### PR TITLE
fix(cli): parse Windows snapshot mappings

### DIFF
--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -13,6 +13,33 @@ use storage::content_manager::alias_mapping::AliasPersistence;
 use storage::content_manager::snapshots::SnapshotConfig;
 use storage::content_manager::toc::{ALIASES_PATH, COLLECTIONS_DIR};
 
+struct SnapshotMapping {
+    snapshot_path: PathBuf,
+    collection_name: String,
+}
+
+impl SnapshotMapping {
+    fn from_cli_arg(snapshot_params: &str) -> Self {
+        let (path, collection_name) = snapshot_params
+            .rsplit_once(':')
+            .unwrap_or_else(|| panic!("Collection name is missing: {snapshot_params}"));
+
+        assert!(
+            !path.is_empty(),
+            "Snapshot path is missing: {snapshot_params}"
+        );
+        assert!(
+            !collection_name.is_empty(),
+            "Collection name is missing: {snapshot_params}"
+        );
+
+        Self {
+            snapshot_path: PathBuf::from(path),
+            collection_name: collection_name.to_string(),
+        }
+    }
+}
+
 /// Recover snapshots from the given arguments
 ///
 /// # Arguments
@@ -31,30 +58,47 @@ pub fn recover_snapshots(
     this_peer_id: PeerId,
     is_distributed: bool,
 ) -> Vec<String> {
+    let mappings = mapping
+        .iter()
+        .map(|snapshot_params| SnapshotMapping::from_cli_arg(snapshot_params));
+
+    recover_snapshot_mappings(
+        mappings,
+        force,
+        temp_dir,
+        storage_dir,
+        this_peer_id,
+        is_distributed,
+    )
+}
+
+fn recover_snapshot_mappings(
+    mapping: impl IntoIterator<Item = SnapshotMapping>,
+    force: bool,
+    temp_dir: Option<&Path>,
+    storage_dir: &Path,
+    this_peer_id: PeerId,
+    is_distributed: bool,
+) -> Vec<String> {
     let collection_dir_path = storage_dir.join(COLLECTIONS_DIR);
     let mut recovered_collections: Vec<String> = vec![];
 
-    for snapshot_params in mapping {
-        let mut split = snapshot_params.split(':');
-        let path = split
-            .next()
-            .unwrap_or_else(|| panic!("Snapshot path is missing: {snapshot_params}"));
+    for SnapshotMapping {
+        snapshot_path,
+        collection_name,
+    } in mapping
+    {
+        let snapshot_data = SnapshotData::new_packed_persistent(&snapshot_path);
 
-        let snapshot_data = SnapshotData::new_packed_persistent(path);
-
-        let collection_name = split
-            .next()
-            .unwrap_or_else(|| panic!("Collection name is missing: {snapshot_params}"));
-        recovered_collections.push(collection_name.to_string());
-        assert!(
-            split.next().is_none(),
-            "Too many parts in snapshot mapping: {snapshot_params}"
+        recovered_collections.push(collection_name.clone());
+        info!(
+            "Recovering snapshot {collection_name} from {}",
+            snapshot_path.display()
         );
-        info!("Recovering snapshot {collection_name} from {path}");
         // check if collection already exists
         // if it does, we need to check if we want to overwrite it
         // if not, we need to abort
-        let collection_path = collection_dir_path.join(collection_name);
+        let collection_path = collection_dir_path.join(&collection_name);
         info!("Collection path: {}", collection_path.display());
         if collection_path.exists() {
             if !force {
@@ -108,20 +152,17 @@ pub fn recover_full_snapshot(
     let config_json: SnapshotConfig = serde_json::from_reader(config_file).unwrap();
 
     // Create mapping from the configuration file
-    let mapping: Vec<String> = config_json
+    let mapping = config_json
         .collections_mapping
         .iter()
-        .map(|(collection_name, snapshot_file)| {
-            format!(
-                "{}:{collection_name}",
-                snapshot_temp_path.join(snapshot_file).display(),
-            )
-        })
-        .collect();
+        .map(|(collection_name, snapshot_file)| SnapshotMapping {
+            snapshot_path: snapshot_temp_path.join(snapshot_file),
+            collection_name: collection_name.clone(),
+        });
 
     // Launch regular recovery of snapshots
-    let recovered_collection = recover_snapshots(
-        &mapping,
+    let recovered_collection = recover_snapshot_mappings(
+        mapping,
         force,
         temp_dir,
         storage_dir,
@@ -142,4 +183,70 @@ pub fn recover_full_snapshot(
     // Remove temporary directory
     fs::remove_dir_all(&snapshot_temp_path).unwrap();
     recovered_collection
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::SnapshotMapping;
+
+    #[test]
+    fn snapshot_mapping_accepts_windows_absolute_path() {
+        let mapping = SnapshotMapping::from_cli_arg(r"C:\tmp\collection.snapshot:test_collection");
+
+        assert_eq!(
+            mapping.snapshot_path,
+            PathBuf::from(r"C:\tmp\collection.snapshot")
+        );
+        assert_eq!(mapping.collection_name, "test_collection");
+    }
+
+    #[test]
+    fn snapshot_mapping_accepts_posix_absolute_path() {
+        let mapping = SnapshotMapping::from_cli_arg("/tmp/collection.snapshot:test_collection");
+
+        assert_eq!(
+            mapping.snapshot_path,
+            PathBuf::from("/tmp/collection.snapshot")
+        );
+        assert_eq!(mapping.collection_name, "test_collection");
+    }
+
+    #[test]
+    fn snapshot_mapping_accepts_relative_path() {
+        let mapping = SnapshotMapping::from_cli_arg("collection.snapshot:test_collection");
+
+        assert_eq!(mapping.snapshot_path, PathBuf::from("collection.snapshot"));
+        assert_eq!(mapping.collection_name, "test_collection");
+    }
+
+    #[test]
+    fn snapshot_mapping_splits_on_last_colon() {
+        let mapping = SnapshotMapping::from_cli_arg("/tmp/snapshots/a:b.snapshot:test_collection");
+
+        assert_eq!(
+            mapping.snapshot_path,
+            PathBuf::from("/tmp/snapshots/a:b.snapshot")
+        );
+        assert_eq!(mapping.collection_name, "test_collection");
+    }
+
+    #[test]
+    #[should_panic(expected = "Collection name is missing")]
+    fn snapshot_mapping_rejects_missing_separator() {
+        SnapshotMapping::from_cli_arg("collection.snapshot");
+    }
+
+    #[test]
+    #[should_panic(expected = "Snapshot path is missing")]
+    fn snapshot_mapping_rejects_empty_path() {
+        SnapshotMapping::from_cli_arg(":test_collection");
+    }
+
+    #[test]
+    #[should_panic(expected = "Collection name is missing")]
+    fn snapshot_mapping_rejects_empty_collection_name() {
+        SnapshotMapping::from_cli_arg("collection.snapshot:");
+    }
 }

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -32,6 +32,10 @@ impl SnapshotMapping {
             !collection_name.is_empty(),
             "Collection name is missing: {snapshot_params}"
         );
+        assert!(
+            !collection_name.contains(['/', '\\']),
+            "Collection name is missing: {snapshot_params}"
+        );
 
         Self {
             snapshot_path: PathBuf::from(path),
@@ -248,5 +252,11 @@ mod tests {
     #[should_panic(expected = "Collection name is missing")]
     fn snapshot_mapping_rejects_empty_collection_name() {
         SnapshotMapping::from_cli_arg("collection.snapshot:");
+    }
+
+    #[test]
+    #[should_panic(expected = "Collection name is missing")]
+    fn snapshot_mapping_rejects_windows_path_without_collection_name() {
+        SnapshotMapping::from_cli_arg(r"C:\tmp\collection.snapshot");
     }
 }

--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -26,15 +26,15 @@ impl SnapshotMapping {
 
         assert!(
             !path.is_empty(),
-            "Snapshot path is missing: {snapshot_params}"
+            "Snapshot path is missing: {snapshot_params}",
         );
         assert!(
             !collection_name.is_empty(),
-            "Collection name is missing: {snapshot_params}"
+            "Collection name is missing: {snapshot_params}",
         );
         assert!(
             !collection_name.contains(['/', '\\']),
-            "Collection name is missing: {snapshot_params}"
+            "Collection name must not contain slashes: {snapshot_params}",
         );
 
         Self {
@@ -196,42 +196,45 @@ mod tests {
     use super::SnapshotMapping;
 
     #[test]
-    fn snapshot_mapping_accepts_windows_absolute_path() {
-        let mapping = SnapshotMapping::from_cli_arg(r"C:\tmp\collection.snapshot:test_collection");
-
-        assert_eq!(
-            mapping.snapshot_path,
-            PathBuf::from(r"C:\tmp\collection.snapshot")
-        );
-        assert_eq!(mapping.collection_name, "test_collection");
-    }
-
-    #[test]
-    fn snapshot_mapping_accepts_posix_absolute_path() {
+    fn snapshot_mapping_absolute_paths() {
+        // Unix path
         let mapping = SnapshotMapping::from_cli_arg("/tmp/collection.snapshot:test_collection");
-
         assert_eq!(
             mapping.snapshot_path,
-            PathBuf::from("/tmp/collection.snapshot")
+            PathBuf::from("/tmp/collection.snapshot"),
+        );
+        assert_eq!(mapping.collection_name, "test_collection");
+
+        // Windows path
+        // See: <https://github.com/qdrant/qdrant/pull/9723>
+        let mapping = SnapshotMapping::from_cli_arg(r"C:\tmp\collection.snapshot:test_collection");
+        assert_eq!(
+            mapping.snapshot_path,
+            PathBuf::from(r"C:\tmp\collection.snapshot"),
         );
         assert_eq!(mapping.collection_name, "test_collection");
     }
 
     #[test]
-    fn snapshot_mapping_accepts_relative_path() {
+    fn snapshot_mapping_relative_path() {
         let mapping = SnapshotMapping::from_cli_arg("collection.snapshot:test_collection");
-
         assert_eq!(mapping.snapshot_path, PathBuf::from("collection.snapshot"));
+        assert_eq!(mapping.collection_name, "test_collection");
+
+        let mapping = SnapshotMapping::from_cli_arg("./collection.snapshot:test_collection");
+        assert_eq!(
+            mapping.snapshot_path,
+            PathBuf::from("./collection.snapshot")
+        );
         assert_eq!(mapping.collection_name, "test_collection");
     }
 
     #[test]
     fn snapshot_mapping_splits_on_last_colon() {
         let mapping = SnapshotMapping::from_cli_arg("/tmp/snapshots/a:b.snapshot:test_collection");
-
         assert_eq!(
             mapping.snapshot_path,
-            PathBuf::from("/tmp/snapshots/a:b.snapshot")
+            PathBuf::from("/tmp/snapshots/a:b.snapshot"),
         );
         assert_eq!(mapping.collection_name, "test_collection");
     }
@@ -255,7 +258,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Collection name is missing")]
+    #[should_panic(
+        expected = "Collection name must not contain slashes: C:\\tmp\\collection.snapshot"
+    )]
     fn snapshot_mapping_rejects_windows_path_without_collection_name() {
         SnapshotMapping::from_cli_arg(r"C:\tmp\collection.snapshot");
     }


### PR DESCRIPTION
Windows probably is not where most people deploy Qdrant, so I see this as a small edge case rather than an urgent production issue. I opened the PR because the CLI already accepts `PATH:NAME`, and valid Windows drive-letter paths currently do not fit that parser. I think either accepting or declining this PR would be reasonable, or it can at least serve as an issue to discuss this edge case.

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### What changed

#### What Problem This Solves

CLI snapshot recovery accepts mappings in the documented `<snapshot_file_path>:<target_collection_name>` shape. That convention is straightforward for POSIX paths such as `/tmp/collection.snapshot:test_collection` and for relative paths such as `collection.snapshot:test_collection`, because the only colon is the separator between the snapshot path and the target collection name.

Windows absolute paths are different. A valid Windows path can contain a drive-letter prefix, so a normal mapping can look like this:

```text
C:\tmp\collection.snapshot:test_collection
```

In that string, the first colon belongs to the path itself (`C:`), while the final colon is the actual mapping separator before `test_collection`.

Before this change, `recover_snapshots()` used `split(':')`, which treats every colon as a separator. For the Windows example above, the parser did not see one path and one collection name. It saw three pieces instead:

```text
C
\tmp\collection.snapshot
test_collection
```

That means `C` was incorrectly treated as the snapshot path, `\tmp\collection.snapshot` was incorrectly treated as the collection name, and `test_collection` became an unexpected third part. Because of that third part, the parser rejected the mapping with `Too many parts in snapshot mapping` before snapshot recovery could start.

So the issue is not that the Windows path is invalid. The path is valid, but the CLI mapping parser consumes the drive-letter colon as if it were part of the `PATH:NAME` protocol. This makes a valid Windows snapshot path impossible to express through the documented CLI mapping format.

#### Changes

This PR moves snapshot mapping parsing into a small internal `SnapshotMapping` type and parses CLI mappings from the final colon. Earlier colons stay with the snapshot path, so Windows drive-letter paths keep their drive prefix while the documented `PATH:NAME` shape remains unchanged.

It also avoids the same string-protocol round trip in full-storage snapshot recovery. `recover_full_snapshot()` already reads structured snapshot configuration, so it now builds `SnapshotMapping` values directly instead of formatting unpacked snapshot paths back into `PATH:NAME` strings and parsing them again.

#### Evidence

The focused tests cover the old failing shape and the nearby parser boundaries:

```text
C:\tmp\collection.snapshot:test_collection
```

Before this change, that mapping could be split into `C`, `\tmp\collection.snapshot`, and `test_collection`, which hit `Too many parts in snapshot mapping`. After this change, the parser returns:

```text
snapshot path: C:\tmp\collection.snapshot
collection:    test_collection
```

The test suite also covers POSIX absolute paths, relative paths, paths with earlier colons, missing separators, empty paths, and empty collection names.

#### Possible call chain / impact

```text
qdrant --snapshot <PATH:NAME>
  -> recover_collections_from_snapshot_args(...)
  -> recover_snapshots(...)
  -> SnapshotMapping::from_cli_arg(...)
  -> Collection::restore_snapshot(...)
```

```text
qdrant --storage-snapshot <PATH>
  -> recover_full_snapshot(...)
  -> SnapshotConfig.collections_mapping
  -> SnapshotMapping { snapshot_path, collection_name }
  -> recover_snapshot_mappings(...)
```

This only changes startup CLI snapshot mapping parsing and the internal full-storage snapshot mapping handoff. It does not change CLI flag names, collection restore behavior after parsing, REST/gRPC snapshot recovery APIs, or snapshot storage formats.

### Scope

Affected:
- `--snapshot PATH:NAME`
- `--collection-snapshot PATH:NAME`
- internal full-storage snapshot recovery mapping construction

Unchanged:
- CLI flag names and documented `PATH:NAME` shape
- collection restore behavior after a mapping has been parsed
- REST and gRPC snapshot recovery APIs
- snapshot storage formats

### Validation

- `cargo +nightly fmt --all --check`
- `git diff --check`
- `cargo test -p qdrant snapshot_mapping -- --nocapture`

Focused test result:

```text
running 8 tests
test snapshots::tests::snapshot_mapping_accepts_relative_path ... ok
test snapshots::tests::snapshot_mapping_accepts_windows_absolute_path ... ok
test snapshots::tests::snapshot_mapping_accepts_posix_absolute_path ... ok
test snapshots::tests::snapshot_mapping_rejects_empty_collection_name - should panic ... ok
test snapshots::tests::snapshot_mapping_rejects_missing_separator - should panic ... ok
test snapshots::tests::snapshot_mapping_rejects_windows_path_without_collection_name - should panic ... ok
test snapshots::tests::snapshot_mapping_rejects_empty_path - should panic ... ok
test snapshots::tests::snapshot_mapping_splits_on_last_colon ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 147 filtered out; finished in 0.00s
```

### AI disclosure

Commit `97dd739c497f200e8be92d198dca9ffa18a7055e` was prepared with AI assistance. Initial prompt intent: fix Qdrant CLI snapshot mapping parsing so Windows drive-letter paths are not split at the drive colon.