### PR TITLE
[CachedFs] Refactor into extension trait

### DIFF
--- a/lib/common/common/src/persisted_hashmap/uio/mod.rs
+++ b/lib/common/common/src/persisted_hashmap/uio/mod.rs
@@ -43,11 +43,11 @@ where
     S: UniversalRead,
 {
     /// Load the hash map from file.
-    pub fn open(
-        fs: &S::Fs,
+    pub fn open<Fs: UniversalReadFs<File = S>>(
+        fs: &Fs,
         path: impl AsRef<Path>,
         options: OpenOptions,
-        extra: <S::Fs as UniversalReadFs>::OpenExtra,
+        extra: Fs::OpenExtra,
     ) -> Result<Self> {
         Self::from_file(fs.open(path, options, extra)?)
     }

--- a/lib/common/common/src/stored_bitslice.rs
+++ b/lib/common/common/src/stored_bitslice.rs
@@ -65,11 +65,11 @@ pub struct StoredBitSlice<S> {
 
 impl<S: UniversalRead> StoredBitSlice<S> {
     /// Open a bitslice storage from the given path using backend `S`.
-    pub fn open(
-        fs: &S::Fs,
+    pub fn open<Fs: UniversalReadFs<File = S>>(
+        fs: &Fs,
         path: impl AsRef<Path>,
         options: OpenOptions,
-        extra: <S::Fs as UniversalReadFs>::OpenExtra,
+        extra: Fs::OpenExtra,
     ) -> Result<Self> {
         let storage = TypedStorage::open(fs, path, options, extra)?;
         let element_len = storage.len()?;
@@ -79,8 +79,7 @@ impl<S: UniversalRead> StoredBitSlice<S> {
         })
     }
 
-    /// Wrap an already-opened backend file (e.g. taken from a
-    /// [`CachedReadFs`](crate::universal_io::CachedReadFs) prefetch pool).
+    /// Wrap an already-opened backend file.
     pub fn from_file(file: S) -> Result<Self> {
         let storage = TypedStorage::new(file);
         let element_len = storage.len()?;

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -1,20 +1,14 @@
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
-use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use bytemuck::TransparentWrapper;
 use parking_lot::Mutex;
 
-use crate::ext::aligned_vec::ACow;
-use crate::generic_consts::AccessPattern;
 use crate::mmap::AdviceSetting;
-use crate::universal_io::wrappers::WrappedReadPipeline;
 use crate::universal_io::{
-    Item, ListedFile, OpenOptions, Populate, ReadBytesItem, ReadRange, Result, UniversalIoError,
-    UniversalKind, UniversalRead, UniversalReadFileOps, UniversalReadFs, UserData,
+    ListedFile, OpenOptions, Populate, Result, UniversalIoError, UniversalReadFileOps,
+    UniversalReadFs,
 };
 
 #[derive(Clone, Debug)]
@@ -23,20 +17,50 @@ pub struct FileInfo {
     pub size: u64,
 }
 
-/// Read-only filesystem wrapper that snapshots the file listing and serves
-/// opens from explicitly prefetched handles.
+/// Capability extension over [`UniversalReadFs`]: a filesystem that snapshots
+/// its file listing and serves opens from explicitly prefetched handles.
 ///
-/// Until [`Self::cache_file_info`] takes the listing snapshot, the wrapper is
-/// a passthrough: listing, existence checks and opens forward to the inner
-/// filesystem unchanged (prefetched handles are still consumed first).
+/// Component-level preload helpers bound on `impl CachedFs<File = S>` are
+/// only callable when the caller opens through a caching filesystem;
+/// plain-`UniversalReadFs` open paths never see these methods.
+pub trait CachedFs: UniversalReadFs {
+    /// Take the file listing snapshot. From this point on, listing and
+    /// existence checks are answered locally and opens of unlisted paths
+    /// fail with `NotFound` without touching the underlying filesystem.
+    fn cache_file_info(&mut self) -> Result<()>;
+
+    /// Open `path` in the background and park the handle in the prefetch
+    /// pool, to be consumed by a later [`UniversalReadFs::open`] of the same
+    /// path. Idempotent per path while the handle is unconsumed.
+    fn schedule_prefetch(
+        &self,
+        path: &Path,
+        open_arguments: Option<OpenOptions>,
+        open_extra: Option<Self::OpenExtra>,
+    ) -> Result<()>;
+}
+
+/// Read-only filesystem wrapper that snapshots the file listing and serves
+/// opens from explicitly prefetched handles. The only [`CachedFs`]
+/// implementation.
+///
+/// Opens produce the *wrapped* backend's file type (`Fs::File`), so
+/// components generic over `impl UniversalReadFs<File = S>` accept a raw
+/// backend and this wrapper interchangeably, and stored handle types never
+/// mention the wrapper.
+///
+/// Until [`CachedFs::cache_file_info`] takes the listing snapshot, the
+/// wrapper is a passthrough: listing, existence checks and opens forward to
+/// the inner filesystem unchanged (prefetched handles are still consumed
+/// first).
 ///
 /// Once the snapshot is taken, listing and existence checks are answered
 /// from it without touching the inner filesystem, and opens of paths absent
 /// from the snapshot fail with `NotFound` locally — probing for optional
 /// files is free. Opens are expected to hit a handle registered via
-/// [`Self::schedule_prefetch`]; a miss on a path the snapshot does contain
-/// is currently `todo!` (unreachable: the open path prefetches every listed
-/// file, and each file is opened at most once).
+/// [`CachedFs::schedule_prefetch`]; a miss on a path the snapshot does
+/// contain falls back to an inner open (the open path prefetches every
+/// listed file, so this indicates a not-yet-optimized call site).
 ///
 /// Prefetched handles are take-once: [`UniversalReadFs::open`] removes the
 /// handle from the pool and returns it owned. The pool is shared across
@@ -44,8 +68,8 @@ pub struct FileInfo {
 pub struct CachedReadFs<Fs: UniversalReadFs> {
     fs: Fs,
     prefix_path: PathBuf,
-    /// `None` until [`Self::cache_file_info`] takes the listing snapshot;
-    /// the wrapper forwards to `fs` until then.
+    /// `None` until [`CachedFs::cache_file_info`] takes the listing
+    /// snapshot; the wrapper forwards to `fs` until then.
     files_info: Option<HashMap<PathBuf, FileInfo>>,
     files_prefetched: Arc<Mutex<HashMap<PathBuf, Fs::File>>>,
 }
@@ -80,23 +104,6 @@ impl<Fs: UniversalReadFs> CachedReadFs<Fs> {
         })
     }
 
-    pub fn cache_file_info(&mut self) -> Result<()> {
-        // List all files
-        let list = self.fs.list_files(&self.prefix_path)?;
-
-        let files_info: HashMap<_, _> = list
-            .into_iter()
-            .map(|ListedFile { path, size }| {
-                let info = FileInfo { size };
-                (path, info)
-            })
-            .collect();
-
-        self.files_info = Some(files_info);
-
-        Ok(())
-    }
-
     /// The wrapped inner filesystem.
     ///
     /// Components that keep a filesystem handle for *later* opens (e.g. live
@@ -107,12 +114,12 @@ impl<Fs: UniversalReadFs> CachedReadFs<Fs> {
         &self.fs
     }
 
-    /// File info from the snapshot; `None` before [`Self::cache_file_info`].
+    /// File info from the snapshot; `None` before [`CachedFs::cache_file_info`].
     pub fn file_info(&self, path: &Path) -> Option<&FileInfo> {
         self.files_info.as_ref()?.get(path)
     }
 
-    /// Files from the snapshot; empty before [`Self::cache_file_info`].
+    /// Files from the snapshot; empty before [`CachedFs::cache_file_info`].
     ///
     /// A path matches when its component at the prefix's final position
     /// starts with the prefix's final component (`dir/chunk_` matches
@@ -147,66 +154,33 @@ impl<Fs: UniversalReadFs> CachedReadFs<Fs> {
             .collect()
     }
 
-    /// Existence per the snapshot; `false` before [`Self::cache_file_info`].
+    /// Existence per the snapshot; `false` before [`CachedFs::cache_file_info`].
     pub fn exists(&self, path: &Path) -> bool {
         self.files_info
             .as_ref()
             .is_some_and(|files_info| files_info.contains_key(path))
     }
+}
 
-    /// Take a raw inner file handle, bypassing the [`UniversalReadFs`] trait.
-    ///
-    /// Cache-aware callers that *store* handles long-term use this so their
-    /// stored type stays `Fs::File` — the [`CachedFile`] wrapper the trait
-    /// impl returns is only meant for transient open-read-discard access
-    /// (e.g. [`read_json_via`](crate::universal_io::read_json_via)).
-    ///
-    /// Semantics match the trait open: prefetched handles are taken from the
-    /// pool first; without a snapshot the call passes through to the inner
-    /// filesystem; with one, unlisted paths fail `NotFound` locally and a
-    /// listed-but-not-prefetched path is currently `todo!` (unreachable; see
-    /// the type-level docs).
-    pub fn take_file(
-        &self,
-        path: &Path,
-        options: OpenOptions,
-        extra: Fs::OpenExtra,
-    ) -> Result<Fs::File> {
-        if options.writeable {
-            return Err(UniversalIoError::Uninitialized {
-                description:
-                    "CachedReadFs only supports read-only files, writeable option is not allowed"
-                        .to_string(),
-            });
-        }
+impl<Fs: UniversalReadFs> CachedFs for CachedReadFs<Fs> {
+    fn cache_file_info(&mut self) -> Result<()> {
+        // List all files
+        let list = self.fs.list_files(&self.prefix_path)?;
 
-        if let Some(file) = self.files_prefetched.lock().remove(path) {
-            return Ok(file);
-        }
+        let files_info: HashMap<_, _> = list
+            .into_iter()
+            .map(|ListedFile { path, size }| {
+                let info = FileInfo { size };
+                (path, info)
+            })
+            .collect();
 
-        let Some(files_info) = &self.files_info else {
-            // Fallback to cache bypass.
-            // If we are here, that means open path is not optimized enough.
-            // After read-only read path is refactored, this should be protected
-            // by debug assertion
-            return self.fs.open(path, options, extra);
-        };
+        self.files_info = Some(files_info);
 
-        match files_info.get(path) {
-            None => Err(UniversalIoError::NotFound {
-                path: path.to_path_buf(),
-            }),
-            Some(_file_info) => {
-                // Fallback to cache bypass.
-                // If we are here, that means open path is not optimized enough.
-                // After read-only read path is refactored, this should be protected
-                // by debug assertion
-                self.fs.open(path, options, extra)
-            }
-        }
+        Ok(())
     }
 
-    pub fn schedule_prefetch(
+    fn schedule_prefetch(
         &self,
         path: &Path,
         open_arguments: Option<OpenOptions>,
@@ -285,7 +259,10 @@ impl<Fs: UniversalReadFs> Debug for CachedReadFs<Fs> {
 }
 
 impl<Fs: UniversalReadFs> UniversalReadFs for CachedReadFs<Fs> {
-    type File = CachedFile<Fs::File>;
+    /// The *wrapped* backend's file type: opening through the cache hands
+    /// out the very handles the inner filesystem produced (prefetched or
+    /// fallback-opened), so the wrapper never appears in stored types.
+    type File = Fs::File;
     type OpenExtra = Fs::OpenExtra;
 
     fn open(
@@ -293,116 +270,40 @@ impl<Fs: UniversalReadFs> UniversalReadFs for CachedReadFs<Fs> {
         path: impl AsRef<Path>,
         options: OpenOptions,
         extra: Self::OpenExtra,
-    ) -> Result<Self::File> {
-        Ok(CachedFile(self.take_file(path.as_ref(), options, extra)?))
-    }
-}
+    ) -> Result<Fs::File> {
+        let path = path.as_ref();
 
-/// File handle produced by the [`UniversalReadFs`] impl of
-/// [`CachedReadFs`]: the prefetched inner handle taken out of the pool (or
-/// a direct fallback open).
-///
-/// Exists purely to satisfy the bidirectional
-/// `UniversalReadFs<File = Self>` constraint on [`UniversalRead::Fs`]; all
-/// operations delegate to the wrapped inner file. Meant for transient
-/// open-read-discard helpers (e.g.
-/// [`read_json_via`](crate::universal_io::read_json_via)) that never leak
-/// the handle; code that stores handles long-term takes the raw inner file
-/// via [`CachedReadFs::take_file`] instead, so `CachedFile` never spreads
-/// into stored types.
-#[derive(Debug, TransparentWrapper)]
-#[repr(transparent)]
-pub struct CachedFile<S>(S);
+        if options.writeable {
+            return Err(UniversalIoError::Uninitialized {
+                description:
+                    "CachedReadFs only supports read-only files, writeable option is not allowed"
+                        .to_string(),
+            });
+        }
 
-impl<S: UniversalRead> UniversalRead for CachedFile<S> {
-    type Fs = CachedReadFs<S::Fs>;
+        if let Some(file) = self.files_prefetched.lock().remove(path) {
+            return Ok(file);
+        }
 
-    type ReadPipeline<'file, U>
-        = WrappedReadPipeline<Self, S::ReadPipeline<'file, U>>
-    where
-        Self: 'file,
-        U: UserData;
+        let Some(files_info) = &self.files_info else {
+            // Fallback to cache bypass.
+            // If we are here, that means open path is not optimized enough.
+            // After read-only read path is refactored, this should be protected
+            // by debug assertion
+            return self.fs.open(path, options, extra);
+        };
 
-    #[inline]
-    fn reopen(&mut self) -> Result<()> {
-        self.0.reopen()
-    }
-
-    #[inline]
-    fn read<P: AccessPattern, T: Item>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
-        self.0.read::<P, T>(range)
-    }
-
-    #[inline]
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> Result<ACow<'_>> {
-        self.0.read_bytes::<P>(range, align)
-    }
-
-    #[inline]
-    fn read_whole<T: Item>(&self) -> Result<Cow<'_, [T]>> {
-        self.0.read_whole()
-    }
-
-    #[inline]
-    fn read_batch<P, T, U>(
-        &self,
-        ranges: impl IntoIterator<Item = (U, ReadRange)>,
-        callback: impl FnMut(U, &[T]) -> Result<()>,
-    ) -> Result<()>
-    where
-        P: AccessPattern,
-        T: Item,
-        U: UserData,
-    {
-        self.0.read_batch::<P, T, U>(ranges, callback)
-    }
-
-    #[inline]
-    fn read_iter<P, T, U>(
-        &self,
-        ranges: impl IntoIterator<Item = (U, ReadRange)>,
-    ) -> Result<impl Iterator<Item = Result<(U, Cow<'_, [T]>)>>>
-    where
-        P: AccessPattern,
-        T: Item,
-        U: UserData,
-    {
-        self.0.read_iter::<P, T, U>(ranges)
-    }
-
-    #[inline]
-    fn read_bytes_iter<P, U>(
-        &self,
-        ranges: impl IntoIterator<Item = ReadBytesItem<U>>,
-    ) -> Result<impl Iterator<Item = Result<(U, ACow<'_>)>>>
-    where
-        P: AccessPattern,
-        U: UserData,
-    {
-        self.0.read_bytes_iter::<P, U>(ranges)
-    }
-
-    #[inline]
-    fn len<T>(&self) -> Result<u64> {
-        self.0.len::<T>()
-    }
-
-    #[inline]
-    fn populate(&self) -> Result<()> {
-        self.0.populate()
-    }
-
-    #[inline]
-    fn populate_auto() -> bool {
-        S::populate_auto()
-    }
-
-    #[inline]
-    fn clear_ram_cache(&self) -> Result<()> {
-        self.0.clear_ram_cache()
-    }
-
-    fn kind() -> UniversalKind {
-        S::kind()
+        match files_info.get(path) {
+            None => Err(UniversalIoError::NotFound {
+                path: path.to_path_buf(),
+            }),
+            Some(_file_info) => {
+                // Fallback to cache bypass.
+                // If we are here, that means open path is not optimized enough.
+                // After read-only read path is refactored, this should be protected
+                // by debug assertion
+                self.fs.open(path, options, extra)
+            }
+        }
     }
 }

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -13,7 +13,7 @@ mod traits;
 mod types;
 mod wrappers;
 
-pub use self::cached_fs::{CachedFile, CachedReadFs, CachedReadFsContext, FileInfo};
+pub use self::cached_fs::{CachedFs, CachedReadFs, CachedReadFsContext, FileInfo};
 pub use self::error::{IsNotFound, OkNotFound, UniversalIoError};
 #[cfg(target_os = "linux")]
 pub use self::io_uring::{IoUringFile, IoUringFs, IoUringOpenExtra};

--- a/lib/common/common/src/universal_io/oneshot.rs
+++ b/lib/common/common/src/universal_io/oneshot.rs
@@ -21,7 +21,7 @@ pub struct OneshotFile<S: UniversalRead> {
 
 impl<S: UniversalRead> OneshotFile<S> {
     /// Open `path` read-only through `fs` for a single sequential read.
-    pub fn open(fs: &S::Fs, path: impl AsRef<Path>) -> Result<Self> {
+    pub fn open<Fs: UniversalReadFs<File = S>>(fs: &Fs, path: impl AsRef<Path>) -> Result<Self> {
         let inner = fs.open(
             path,
             OpenOptions {

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -87,7 +87,16 @@ pub trait UniversalWriteFileOps: UniversalReadFileOps {
 /// a single file handle implementing [`UniversalRead`].
 pub trait UniversalReadFs: UniversalReadFileOps {
     /// File handle type produced by [`Self::open`].
-    type File: UniversalRead<Fs = Self>;
+    ///
+    /// Deliberately NOT pinned back to `Self` (no `Fs = Self` bound):
+    /// several filesystems may produce the same file type. The canonical
+    /// backend for a file type is still unique — [`UniversalRead::Fs`]
+    /// names it — but wrappers like
+    /// [`CachedReadFs`](crate::universal_io::CachedReadFs) reuse the
+    /// wrapped backend's file type, so generic code bounded on
+    /// `UniversalReadFs<File = S>` accepts the raw backend and any such
+    /// wrapper interchangeably.
+    type File: UniversalRead;
 
     /// Backend-specific per-open knobs.
     ///

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -33,13 +33,17 @@ use crate::universal_io::{ReadBytesItem, ReadRange, Result, UniversalKind};
 ///   enough for the majority of types.
 #[expect(clippy::len_without_is_empty)]
 pub trait UniversalRead: Sized + Debug + Send + Sync {
-    /// Filesystem handle type that opens `Self`-typed file handles via
-    /// [`UniversalReadFs::open`](UniversalReadFs::open).
+    /// The canonical filesystem handle type that opens `Self`-typed file
+    /// handles via [`UniversalReadFs::open`](UniversalReadFs::open).
     ///
-    /// Bidirectionally pinned: `Self::Fs::File = Self`. Wrappers such as
-    /// `ReadOnly<S>` declare a phantom `ReadOnlyFs<S::Fs>` to satisfy this
-    /// constraint at the type level, while their inherent `open`
-    /// constructor still accepts the unwrapped inner `S::Fs`.
+    /// Pinned in this direction only (`Self::Fs::File = Self`): every file
+    /// type names exactly one canonical backend, but other filesystems may
+    /// produce the same file type (e.g.
+    /// [`CachedReadFs`](crate::universal_io::CachedReadFs) opens the
+    /// wrapped backend's files). Code that should accept any of them takes
+    /// `&impl UniversalReadFs<File = S>` instead of `&S::Fs`. Wrappers such
+    /// as `ReadOnly<S>` declare a phantom `ReadOnlyFs<S::Fs>` to satisfy
+    /// this constraint at the type level.
     type Fs: UniversalReadFs<File = Self>;
 
     /// Read-pipeline implementation for this backend.

--- a/lib/common/common/src/universal_io/wrappers/mod.rs
+++ b/lib/common/common/src/universal_io/wrappers/mod.rs
@@ -8,4 +8,4 @@ pub use buffered_update::SliceBufferedUpdateWrapper;
 pub use read_only::ReadOnly;
 pub use stored_struct::StoredStruct;
 pub use typed::TypedStorage;
-pub(crate) use wrapped_pipeline::WrappedReadPipeline;
+use wrapped_pipeline::WrappedReadPipeline;

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -20,9 +20,8 @@ pub struct ReadOnly<S>(S);
 
 /// Phantom filesystem handle whose `File` type is `ReadOnly<F::File>`.
 ///
-/// Exists purely to satisfy the bidirectional
-/// `UniversalReadFs<File = Self>` constraint on `UniversalRead::Fs` for
-/// the `ReadOnly<S>` wrapper. It wraps an inner `F: UniversalReadFs`
+/// Exists purely to satisfy the `UniversalReadFs<File = Self>` constraint
+/// on `UniversalRead::Fs` for the `ReadOnly<S>` wrapper. It wraps an inner `F: UniversalReadFs`
 /// and asserts read-only semantics on `open`. In practice this Fs is
 /// rarely instantiated; callers use [`ReadOnly::open`] with the
 /// underlying `&S::Fs` directly.
@@ -79,25 +78,26 @@ impl<S> ReadOnly<S>
 where
     S: UniversalRead,
 {
-    /// Open a read-only file through the given filesystem handle.
+    /// Open a read-only file through the given filesystem handle — the
+    /// canonical `S::Fs` or any other filesystem producing `S`-typed
+    /// handles (e.g. [`CachedReadFs`](crate::universal_io::CachedReadFs)).
     ///
     /// Asserts the request is read-only (panics in debug builds on a writeable
     /// `OpenOptions`); the wrapper itself does not enforce write protection
     /// beyond not exposing `UniversalWrite`.
     #[inline]
-    pub fn open(
-        fs: &S::Fs,
+    pub fn open<Fs: UniversalReadFs<File = S>>(
+        fs: &Fs,
         path: impl AsRef<Path>,
         options: OpenOptions,
-        extra: <S::Fs as UniversalReadFs>::OpenExtra,
+        extra: Fs::OpenExtra,
     ) -> Result<Self> {
         debug_assert!(!options.writeable);
         let io = fs.open(path, options, extra)?;
         Ok(Self(io))
     }
 
-    /// Wrap an already-opened backend file (e.g. taken from a
-    /// [`CachedReadFs`](crate::universal_io::CachedReadFs) prefetch pool).
+    /// Wrap an already-opened backend file.
     #[inline]
     pub fn from_file(file: S) -> Self {
         Self(file)

--- a/lib/common/common/src/universal_io/wrappers/stored_struct.rs
+++ b/lib/common/common/src/universal_io/wrappers/stored_struct.rs
@@ -24,11 +24,11 @@ where
     T: bytemuck::Pod + Send,
     S: UniversalWrite + Send + 'static,
 {
-    pub fn open(
-        fs: &S::Fs,
+    pub fn open<Fs: UniversalReadFs<File = S>>(
+        fs: &Fs,
         path: impl AsRef<Path>,
         options: OpenOptions,
-        extra: <S::Fs as UniversalReadFs>::OpenExtra,
+        extra: Fs::OpenExtra,
     ) -> universal_io::Result<Self> {
         let storage = TypedStorage::<S, T>::open(fs, path, options, extra)?;
         let inner = storage.read_whole()?[0];

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -57,11 +57,11 @@ where
 
     /// Open through the provided filesystem handle and wrap the result.
     #[inline]
-    pub fn open(
-        fs: &S::Fs,
+    pub fn open<Fs: UniversalReadFs<File = S>>(
+        fs: &Fs,
         path: impl AsRef<Path>,
         options: OpenOptions,
-        extra: <S::Fs as UniversalReadFs>::OpenExtra,
+        extra: Fs::OpenExtra,
     ) -> Result<Self> {
         fs.open(path, options, extra).map(Self::new)
     }

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -5,9 +5,7 @@ use common::counter::counter_cell::CounterCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::referenced_counter::HwMetricRefCounter;
 use common::generic_consts::{AccessPattern, Sequential};
-use common::universal_io::{
-    CachedReadFs, Populate, UniversalRead, UniversalReadFs, UserData, read_json_via,
-};
+use common::universal_io::{Populate, UniversalRead, UniversalReadFs, UserData, read_json_via};
 
 use super::view::GridstoreView;
 use crate::Result;
@@ -64,21 +62,21 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
     ///
     /// Infers page count by scanning for page files on disk.
     ///
-    /// Stored handles (tracker, pages) are taken from the [`CachedReadFs`]
-    /// prefetch pool, so the reader's storage type stays plain `S`. Live
-    /// reload keeps taking a raw `&S::Fs` — the snapshot behind `fs` goes
-    /// stale the moment the leader writes.
-    pub fn open(fs: &CachedReadFs<S::Fs>, base_path: PathBuf, populate: Populate) -> Result<Self> {
+    /// `fs` may be the raw backend or a caching wrapper producing the same
+    /// `S`-typed handles (e.g. `CachedReadFs`). Live reload keeps taking a
+    /// raw `&S::Fs` — a caching wrapper's snapshot goes stale the moment
+    /// the leader writes.
+    pub fn open<Fs: UniversalReadFs<File = S>>(
+        fs: &Fs,
+        base_path: PathBuf,
+        populate: Populate,
+    ) -> Result<Self> {
         // A reader only reads, so open pages and tracker non-writable. This
         // lets the backend be write-enforced (e.g. `ReadOnly<MmapFile>`); the
         // writable `Gridstore` opens these same files writable instead.
-        let config_path = base_path.join(CONFIG_FILENAME);
-        let config: StorageConfig =
-            read_json_via(fs, &config_path).map_err(GridstoreError::from)?;
+        let (config, tracker) = read_config_and_tracker(fs, &base_path, false)?;
 
-        let tracker = Tracker::<S>::open_cached(fs, &base_path)?;
-
-        let pages = Pages::<S>::open_cached(fs, &base_path, populate)?;
+        let pages = Pages::<S>::open(fs, &base_path, false, populate)?;
 
         Ok(Self {
             tracker,
@@ -220,7 +218,7 @@ pub(super) fn read_config_and_tracker<Fs, S>(
 ) -> Result<(StorageConfig, Tracker<S>)>
 where
     Fs: UniversalReadFs<File = S>,
-    S: UniversalRead<Fs = Fs>,
+    S: UniversalRead,
 {
     let config_path = base_path.join(CONFIG_FILENAME);
     let config: StorageConfig =

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{Random, Sequential};
-use common::universal_io::{CachedReadFs, MmapFs};
+use common::universal_io::MmapFs;
 use fs_err as fs;
 use fs_err::File;
 use itertools::Itertools;
@@ -1131,12 +1131,8 @@ fn test_live_reload() {
     storage.flusher()().unwrap();
 
     // Step 2: Open a reader
-    let mut reader = GridstoreReader::<Payload, MmapFile>::open(
-        &CachedReadFs::new(MmapFs, &path).unwrap(),
-        path.clone(),
-        Populate::No,
-    )
-    .unwrap();
+    let mut reader =
+        GridstoreReader::<Payload, MmapFile>::open(&MmapFs, path.clone(), Populate::No).unwrap();
     assert_eq!(reader.max_point_offset(), 2);
 
     // Step 3: Verify reader sees initial data
@@ -1212,12 +1208,8 @@ fn test_live_reload_across_pages() {
     let initial_pages = storage.pages.read().num_pages();
 
     // Open reader
-    let mut reader = GridstoreReader::<Payload, MmapFile>::open(
-        &CachedReadFs::new(MmapFs, &path).unwrap(),
-        path.clone(),
-        Populate::No,
-    )
-    .unwrap();
+    let mut reader =
+        GridstoreReader::<Payload, MmapFile>::open(&MmapFs, path.clone(), Populate::No).unwrap();
     assert_eq!(reader.max_point_offset(), first_batch);
 
     // Verify reader can read all initial data
@@ -1518,7 +1510,7 @@ fn read_only_reader_over_write_enforced_backend() {
     type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
     let fs = RoFs::from_context(Default::default()).unwrap();
     let reader = GridstoreReader::<Payload, ReadOnly<MmapFile>>::open(
-        &CachedReadFs::new(fs, dir.path()).unwrap(),
+        &fs,
         dir.path().to_path_buf(),
         Populate::No,
     )

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -8,8 +8,8 @@ use common::generic_consts::AccessPattern;
 use common::maybe_uninit::assume_init_vec;
 use common::mmap::{Advice, AdviceSetting};
 use common::universal_io::{
-    CachedReadFs, FileIndex, Flusher, OpenOptions, Populate, ReadPipeline, ReadRange,
-    UniversalRead, UniversalReadFileOps, UniversalReadFs, UniversalWrite, UserData,
+    FileIndex, Flusher, OpenOptions, Populate, ReadPipeline, ReadRange, UniversalRead,
+    UniversalReadFileOps, UniversalReadFs, UniversalWrite, UserData,
 };
 use itertools::Either;
 
@@ -52,7 +52,12 @@ impl<S: UniversalRead> Pages<S> {
         }
     }
 
-    pub fn open(fs: &S::Fs, dir: &Path, writeable: bool, populate: Populate) -> Result<Self> {
+    pub fn open<Fs: UniversalReadFs<File = S>>(
+        fs: &Fs,
+        dir: &Path,
+        writeable: bool,
+        populate: Populate,
+    ) -> Result<Self> {
         let mut pages = Self::new(dir.to_path_buf(), writeable);
 
         let page_files: HashSet<_> = fs
@@ -72,34 +77,12 @@ impl<S: UniversalRead> Pages<S> {
         Ok(pages)
     }
 
-    /// Read-only [`Self::open`] taking page handles from a [`CachedReadFs`]
-    /// prefetch pool. Listing goes through the trait so a snapshot-less
-    /// (passthrough) wrapper behaves like the plain open.
-    pub fn open_cached(fs: &CachedReadFs<S::Fs>, dir: &Path, populate: Populate) -> Result<Self> {
-        let mut pages = Self::new(dir.to_path_buf(), false);
-
-        let page_files: HashSet<_> = UniversalReadFileOps::list_files(fs, &dir.join("page_"))?
-            .into_iter()
-            .map(|listed| listed.path)
-            .collect();
-
-        for page_id in 0.. {
-            let page_path = pages.page_path(page_id);
-            if !page_files.contains(&page_path) {
-                break;
-            }
-            let page = fs.take_file(
-                &page_path,
-                pages.page_open_options(populate),
-                Default::default(),
-            )?;
-            pages.attach_file(page);
-        }
-
-        Ok(pages)
-    }
-
-    pub fn attach_page(&mut self, fs: &S::Fs, path: &Path, populate: Populate) -> Result<()> {
+    pub fn attach_page<Fs: UniversalReadFs<File = S>>(
+        &mut self,
+        fs: &Fs,
+        path: &Path,
+        populate: Populate,
+    ) -> Result<()> {
         let page = fs.open(path, self.page_open_options(populate), Default::default())?;
         self.attach_file(page);
         Ok(())

--- a/lib/gridstore/src/tracker/mod.rs
+++ b/lib/gridstore/src/tracker/mod.rs
@@ -9,8 +9,8 @@ use ahash::{AHashMap, AHashSet};
 use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting, create_and_ensure_length};
 use common::universal_io::{
-    CachedReadFs, OpenOptions, Populate, ReadRange, UniversalIoError, UniversalRead,
-    UniversalReadFs, UniversalWrite, UserData,
+    OpenOptions, Populate, ReadRange, UniversalIoError, UniversalRead, UniversalReadFs,
+    UniversalWrite, UserData,
 };
 use smallvec::SmallVec;
 
@@ -275,27 +275,13 @@ impl<S> Tracker<S> {
 impl<S: UniversalRead> Tracker<S> {
     /// Open an existing PageTracker at the given path
     /// If the file does not exist, return an error
-    pub fn open(fs: &S::Fs, path: &Path, writeable: bool) -> Result<Self> {
+    pub fn open<Fs: UniversalReadFs<File = S>>(
+        fs: &Fs,
+        path: &Path,
+        writeable: bool,
+    ) -> Result<Self> {
         let path = Self::tracker_file_name(path);
         let storage = Self::open_storage(fs, &path, writeable)?;
-        Self::from_storage(path, storage)
-    }
-
-    /// Open the tracker read-only, taking its storage from a
-    /// [`CachedReadFs`] prefetch pool.
-    pub fn open_cached(fs: &CachedReadFs<S::Fs>, path: &Path) -> Result<Self> {
-        let path = Self::tracker_file_name(path);
-        let storage = match fs.take_file(&path, tracker_open_options(false), Default::default()) {
-            Err(UniversalIoError::NotFound { .. }) => {
-                // If config exists and storage doesn't,
-                // it should be treated as inconsistent storage rather than a missing one
-                return Err(GridstoreError::service_error(format!(
-                    "Tracker file does not exist: {}",
-                    path.display()
-                )));
-            }
-            other => other?,
-        };
         Self::from_storage(path, storage)
     }
 
@@ -318,7 +304,11 @@ impl<S: UniversalRead> Tracker<S> {
         Ok(header)
     }
 
-    fn open_storage(fs: &S::Fs, path: &Path, writeable: bool) -> Result<S> {
+    fn open_storage<Fs: UniversalReadFs<File = S>>(
+        fs: &Fs,
+        path: &Path,
+        writeable: bool,
+    ) -> Result<S> {
         let storage = match fs.open(path, tracker_open_options(writeable), Default::default()) {
             Err(UniversalIoError::NotFound { .. }) => {
                 // If config exists and storage doesn't,

--- a/lib/segment/src/common/flags/in_memory_bitvec_flags.rs
+++ b/lib/segment/src/common/flags/in_memory_bitvec_flags.rs
@@ -4,7 +4,7 @@ use common::bitvec::{BitSlice, BitVec};
 use common::mmap::AdviceSetting;
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, OpenOptions, Populate, TypedStorage, UniversalRead};
+use common::universal_io::{OpenOptions, Populate, TypedStorage, UniversalRead, UniversalReadFs};
 
 use super::dynamic_stored_flags::{DynamicFlagsStatus, FLAGS_FILE, status_file};
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -39,12 +39,12 @@ impl InMemoryBitvecFlags {
     /// nothing. The flags file is padded past the logical length (held in the
     /// status file), so the bitvec is truncated to it and `count` is exact.
     pub fn open<S: UniversalRead>(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         directory: &Path,
     ) -> OperationResult<Self> {
         // Length via TypedStorage; StoredStruct is write-bound.
-        let status = TypedStorage::<S, DynamicFlagsStatus>::new(fs.take_file(
-            &status_file(directory),
+        let status = TypedStorage::<S, DynamicFlagsStatus>::new(fs.open(
+            status_file(directory),
             READ_ONLY_OPTIONS,
             Default::default(),
         )?);
@@ -54,7 +54,7 @@ impl InMemoryBitvecFlags {
             .map_or(0, DynamicFlagsStatus::len);
 
         let flags_path = directory.join(FLAGS_FILE);
-        let flags = StoredBitSlice::<S>::from_file(fs.take_file(
+        let flags = StoredBitSlice::<S>::from_file(fs.open(
             &flags_path,
             READ_ONLY_OPTIONS,
             Default::default(),
@@ -150,11 +150,7 @@ mod tests_mod {
 
         persist(&Fs::default(), dir.path(), &random_flags);
 
-        let flags = InMemoryBitvecFlags::open::<S>(
-            &common::universal_io::CachedReadFs::new(Fs::default(), dir.path()).unwrap(),
-            dir.path(),
-        )
-        .unwrap();
+        let flags = InMemoryBitvecFlags::open::<S>(&Fs::default(), dir.path()).unwrap();
 
         let expected_count = random_flags.iter().filter(|flag| **flag).count();
         assert_eq!(flags.count(), expected_count);
@@ -171,11 +167,7 @@ mod tests_mod {
         let random_flags: Vec<bool> = iter::repeat_with(|| rng.random()).take(num_flags).collect();
 
         persist(&Fs::default(), dir.path(), &random_flags);
-        let mut flags = InMemoryBitvecFlags::open::<S>(
-            &common::universal_io::CachedReadFs::new(Fs::default(), dir.path()).unwrap(),
-            dir.path(),
-        )
-        .unwrap();
+        let mut flags = InMemoryBitvecFlags::open::<S>(&Fs::default(), dir.path()).unwrap();
         let base_count = flags.count();
 
         // One offset already set, one unset in range, one past the end (grows).

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -6,7 +6,7 @@ use common::sorted_slice::SortedSlice;
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, OkNotFound, OpenOptions, Populate, TypedStorage, UniversalRead,
+    OkNotFound, OpenOptions, Populate, TypedStorage, UniversalRead, UniversalReadFs,
 };
 use roaring::RoaringBitmap;
 
@@ -57,12 +57,12 @@ const READ_ONLY_OPTIONS: OpenOptions = OpenOptions {
 /// `TypedStorage`. Returns `Ok(None)` when the status file is absent — the flag
 /// directory doesn't exist — matching the read path's never-create contract.
 fn read_status_len<S: UniversalRead>(
-    fs: &CachedReadFs<S::Fs>,
+    fs: &impl UniversalReadFs<File = S>,
     directory: &Path,
 ) -> OperationResult<Option<usize>> {
     let Some(file) = fs
-        .take_file(
-            &status_file(directory),
+        .open(
+            status_file(directory),
             READ_ONLY_OPTIONS,
             Default::default(),
         )
@@ -77,11 +77,11 @@ fn read_status_len<S: UniversalRead>(
 /// Open the flags bitslice read-only for [`ReadOnlyRoaringFlags::open`]'s full
 /// scan into a fresh bitmap. `live_reload` instead reopens the retained handle.
 fn open_flags_storage<S: UniversalRead>(
-    fs: &CachedReadFs<S::Fs>,
+    fs: &impl UniversalReadFs<File = S>,
     directory: &Path,
 ) -> OperationResult<StoredBitSlice<S>> {
-    Ok(StoredBitSlice::<S>::from_file(fs.take_file(
-        &directory.join(FLAGS_FILE),
+    Ok(StoredBitSlice::<S>::from_file(fs.open(
+        directory.join(FLAGS_FILE),
         READ_ONLY_OPTIONS,
         Default::default(),
     )?)?)
@@ -101,7 +101,10 @@ impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
     /// file is absent), matching the read path's never-create contract.
     ///
     /// [1]: super::roaring_flags::RoaringFlags::new
-    pub fn open(fs: &CachedReadFs<S::Fs>, directory: &Path) -> OperationResult<Option<Self>> {
+    pub fn open(
+        fs: &impl UniversalReadFs<File = S>,
+        directory: &Path,
+    ) -> OperationResult<Option<Self>> {
         // A missing status file means the index isn't present on disk.
         let Some(len) = read_status_len::<S>(fs, directory)? else {
             return Ok(None);
@@ -171,10 +174,7 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
 
         // The logical length grows as points are appended; refresh it so
         // length-driven readers (the null index's `iter_falses`) stay correct.
-        // `read_status_len` takes a `CachedReadFs`; snapshot-less it is a
-        // passthrough to the raw backend.
-        let reload_fs = CachedReadFs::new(fs.clone(), &self.directory)?;
-        if let Some(len) = read_status_len::<S>(&reload_fs, &self.directory)? {
+        if let Some(len) = read_status_len::<S>(fs, &self.directory)? {
             self.len = len;
         }
 

--- a/lib/segment/src/id_tracker/disk_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/mod.rs
@@ -32,7 +32,7 @@ use common::mmap::{AdviceSetting, create_and_ensure_length};
 use common::stored_bitslice::StoredBitSlice;
 use common::types::{DeferredBehavior, PointOffsetType};
 use common::universal_io::{
-    CachedReadFs, OpenOptions, Populate, SliceBufferedUpdateWrapper, TypedStorage, UniversalWrite,
+    OpenOptions, Populate, SliceBufferedUpdateWrapper, TypedStorage, UniversalWrite,
 };
 use fs_err::File;
 
@@ -136,10 +136,7 @@ where
         let internal_to_version_wrapper =
             SliceBufferedUpdateWrapper::new(internal_to_version_file.inner)?;
 
-        // `DiskMappingReader::open` takes a `CachedReadFs`; snapshot-less it is
-        // a passthrough to the raw backend.
-        let reader =
-            DiskMappingReader::open(&CachedReadFs::new(fs.clone(), segment_path)?, segment_path)?;
+        let reader = DiskMappingReader::open(fs, segment_path)?;
 
         Ok(Self {
             path: segment_path.to_path_buf(),
@@ -225,9 +222,7 @@ where
         deleted_wrapper.flusher()()?;
         internal_to_version_wrapper.flusher()()?;
 
-        // `DiskMappingReader::open` takes a `CachedReadFs`; snapshot-less it is
-        // a passthrough to the raw backend.
-        let reader = DiskMappingReader::open(&CachedReadFs::new(fs.clone(), path)?, path)?;
+        let reader = DiskMappingReader::open(fs, path)?;
 
         Ok(Self {
             path: path.to_path_buf(),

--- a/lib/segment/src/id_tracker/disk_id_tracker/read_only.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/read_only.rs
@@ -22,7 +22,7 @@ use common::mmap::AdviceSetting;
 use common::stored_bitslice::StoredBitSlice;
 use common::types::{DeferredBehavior, PointOffsetType};
 use common::universal_io::{
-    CachedReadFs, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead,
+    OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead, UniversalReadFs,
 };
 
 use super::mappings::{DiskMappingsSource, log_lookup_err};
@@ -59,7 +59,7 @@ impl<S: UniversalRead> ReadOnlyDiskIdTracker<S> {
     ///
     /// Errors if the segment is not in the on-disk format; use
     /// [`try_open`](Self::try_open) to probe without erroring.
-    pub fn open(fs: &CachedReadFs<S::Fs>, segment_path: &Path) -> OperationResult<Self> {
+    pub fn open(fs: &impl UniversalReadFs<File = S>, segment_path: &Path) -> OperationResult<Self> {
         Self::try_open(fs, segment_path)?.ok_or_else(|| {
             OperationError::service_error(format!(
                 "on-disk id tracker not found in segment {}",
@@ -72,7 +72,7 @@ impl<S: UniversalRead> ReadOnlyDiskIdTracker<S> {
     /// in the on-disk format (`i2e` absent). Probing happens by opening the
     /// mapping directly, so no separate existence check is issued.
     pub fn try_open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         segment_path: &Path,
     ) -> OperationResult<Option<Self>> {
         let Some(reader) = DiskMappingReader::try_open(fs, segment_path)? else {
@@ -85,15 +85,15 @@ impl<S: UniversalRead> ReadOnlyDiskIdTracker<S> {
             populate: Populate::No,
             advice: AdviceSetting::Global,
         };
-        let versions = TypedStorage::<S, SeqNumberType>::new(fs.take_file(
-            &version_mapping_path(segment_path),
+        let versions = TypedStorage::<S, SeqNumberType>::new(fs.open(
+            version_mapping_path(segment_path),
             options,
             Default::default(),
         )?);
         let versions_len = versions.len()?;
 
-        let deleted_file = StoredBitSlice::from_file(fs.take_file(
-            &deleted_path(segment_path),
+        let deleted_file = StoredBitSlice::from_file(fs.open(
+            deleted_path(segment_path),
             options,
             Default::default(),
         )?)?;

--- a/lib/segment/src/id_tracker/disk_id_tracker/reader.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/reader.rs
@@ -20,7 +20,7 @@ use common::bitvec::{BitSlice, BitSliceExt as _};
 use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, OkNotFound, OpenOptions, Populate, ReadRange, UniversalRead,
+    OkNotFound, OpenOptions, Populate, ReadRange, UniversalRead, UniversalReadFs,
 };
 use itertools::Itertools as _;
 use rand::distr::{Distribution as _, Uniform};
@@ -54,7 +54,7 @@ impl<S: UniversalRead> DiskMappingReader<S> {
     ///
     /// Errors if the segment is not in the on-disk format (`i2e` absent). Use
     /// [`try_open`](Self::try_open) to probe without erroring.
-    pub fn open(fs: &CachedReadFs<S::Fs>, segment_path: &Path) -> OperationResult<Self> {
+    pub fn open(fs: &impl UniversalReadFs<File = S>, segment_path: &Path) -> OperationResult<Self> {
         Self::try_open(fs, segment_path)?.ok_or_else(|| {
             OperationError::service_error(format!(
                 "on-disk id tracker mapping ({}) not found",
@@ -68,7 +68,7 @@ impl<S: UniversalRead> DiskMappingReader<S> {
     /// missing/corrupt file is a hard error. Opening the `i2e` handle also serves
     /// as the format probe, so no separate existence check is issued.
     pub fn try_open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         segment_path: &Path,
     ) -> OperationResult<Option<Self>> {
         let options = OpenOptions {
@@ -79,7 +79,7 @@ impl<S: UniversalRead> DiskMappingReader<S> {
         };
 
         let Some(i2e) = fs
-            .take_file(&i2e_path(segment_path), options, Default::default())
+            .open(i2e_path(segment_path), options, Default::default())
             .ok_not_found()?
         else {
             return Ok(None);
@@ -90,7 +90,7 @@ impl<S: UniversalRead> DiskMappingReader<S> {
         })?;
         let i2e_header = I2eHeader::parse(i2e_header_bytes.as_ref())?;
 
-        let e2i = fs.take_file(&e2i_path(segment_path), options, Default::default())?;
+        let e2i = fs.open(e2i_path(segment_path), options, Default::default())?;
         let e2i_header_bytes = e2i.read::<common::generic_consts::Random, u8>(ReadRange {
             byte_offset: 0,
             length: E2I_HEADER_SIZE,

--- a/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
@@ -96,11 +96,7 @@ fn read_only_matches_immutable() {
     // Writing the files also validates the on-disk format round-trips.
     let _disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
 
-    let read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        dir.path(),
-    )
-    .unwrap();
+    let read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
     assert_read_parity(&immutable, &read_only);
 }
 
@@ -135,12 +131,9 @@ fn detect_and_load_selects_disk_format() {
     let disk_dir = Builder::new().prefix("disk").tempdir().unwrap();
     let _disk =
         DiskIdTracker::<MmapFile>::new(&MmapFs, disk_dir.path(), &versions, mappings).unwrap();
-    let loaded = ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        disk_dir.path(),
-        None,
-    )
-    .unwrap();
+    let loaded =
+        ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(&MmapFs, &MmapFs, disk_dir.path(), None)
+            .unwrap();
     assert_eq!(loaded.name(), "read-only disk id tracker");
     assert_read_parity(&immutable, &loaded);
 
@@ -149,18 +142,16 @@ fn detect_and_load_selects_disk_format() {
     let imm_dir = Builder::new().prefix("imm").tempdir().unwrap();
     let _imm = ImmutableIdTracker::<MmapFile>::new(&MmapFs, imm_dir.path(), &versions2, mappings2)
         .unwrap();
-    let loaded = ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        imm_dir.path(),
-        None,
-    )
-    .unwrap();
+    let loaded =
+        ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(&MmapFs, &MmapFs, imm_dir.path(), None)
+            .unwrap();
     assert_eq!(loaded.name(), "read-only immutable id tracker");
 
     // An empty segment (no mapping files) falls back to the appendable reader.
     let empty_dir = Builder::new().prefix("empty").tempdir().unwrap();
     let loaded = ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+        &MmapFs,
+        &MmapFs,
         empty_dir.path(),
         None,
     )
@@ -204,11 +195,7 @@ fn read_by_id_does_not_materialize_deleted_set() {
         disk.point_mappings().iter_from(None).collect()
     };
 
-    let read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        dir.path(),
-    )
-    .unwrap();
+    let read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
 
     // Point lookups must not trigger the full deleted-set materialization.
     for (external_id, offset) in live.iter().take(200) {
@@ -238,11 +225,7 @@ fn deletion_and_live_reload() {
         DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
 
     // A reader opened before the deletions; it will pick them up via live_reload.
-    let mut read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        dir.path(),
-    )
-    .unwrap();
+    let mut read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
     // Establish the diff baseline (a search-style access) so the next reload
     // reports only the incremental deletions, not every build-time deletion.
     let _ = read_only.deleted_point_bitslice();

--- a/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, UniversalRead};
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::disk_id_tracker::ReadOnlyDiskIdTracker;
@@ -34,8 +34,12 @@ impl<S: UniversalRead> ReadOnlyIdTrackerEnum<S> {
     ///
     /// The attempts are sequential for now; they are independent and can be
     /// issued concurrently later (the slow-path being remote opens).
+    /// `raw_fs` is the canonical backend for the appendable tracker, which
+    /// stores a filesystem handle to re-open the append-only files on later
+    /// reloads — a caching wrapper's snapshot would go stale.
     pub fn detect_and_load(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
+        raw_fs: &S::Fs,
         segment_path: &Path,
         deferred_internal_id: Option<PointOffsetType>,
     ) -> OperationResult<Self> {
@@ -46,7 +50,7 @@ impl<S: UniversalRead> ReadOnlyIdTrackerEnum<S> {
             return Ok(Self::Immutable(tracker));
         }
         Ok(Self::Appendable(ReadOnlyAppendableIdTracker::open(
-            fs,
+            raw_fs,
             segment_path,
             deferred_internal_id,
         )?))

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/lifecycle.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/lifecycle.rs
@@ -6,8 +6,8 @@ use common::generic_consts::Sequential;
 use common::mmap::AdviceSetting;
 use common::stored_bitslice::StoredBitSlice;
 use common::universal_io::{
-    CachedReadFs, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead,
-    UniversalReadFileOps,
+    OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead, UniversalReadFileOps,
+    UniversalReadFs,
 };
 
 use super::ReadOnlyImmutableIdTracker;
@@ -29,11 +29,11 @@ impl<S: UniversalRead> ReadOnlyImmutableIdTracker<S> {
     ///
     /// Returns `Ok(None)` when the defining `id_tracker.mappings` file is absent
     /// (i.e. the segment is not in the immutable format). The probe uses
-    /// `exists`, answered from the `CachedReadFs` listing snapshot — a
+    /// `exists`, which a caching `fs` answers from its listing snapshot — a
     /// probe-by-open would consume the file's prefetched take-once handle
     /// that [`Self::open`] needs right after.
     pub fn try_open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         segment_path: &Path,
     ) -> OperationResult<Option<Self>> {
         if !UniversalReadFileOps::exists(fs, &mappings_path(segment_path))? {
@@ -42,7 +42,7 @@ impl<S: UniversalRead> ReadOnlyImmutableIdTracker<S> {
         Ok(Some(Self::open(fs, segment_path)?))
     }
 
-    pub fn open(fs: &CachedReadFs<S::Fs>, segment_path: &Path) -> OperationResult<Self> {
+    pub fn open(fs: &impl UniversalReadFs<File = S>, segment_path: &Path) -> OperationResult<Self> {
         let options = OpenOptions {
             writeable: false,
             need_sequential: false,
@@ -50,24 +50,23 @@ impl<S: UniversalRead> ReadOnlyImmutableIdTracker<S> {
             advice: AdviceSetting::Global,
         };
 
-        let deleted = StoredBitSlice::from_file(fs.take_file(
-            &deleted_path(segment_path),
+        let deleted = StoredBitSlice::from_file(fs.open(
+            deleted_path(segment_path),
             options,
             Default::default(),
         )?)?;
         let mut deleted_bitvec = BitVec::new();
         deleted_bitvec.extend_from_bitslice(deleted.read_all()?.as_ref());
 
-        let internal_to_version_file = TypedStorage::<S, SeqNumberType>::new(fs.take_file(
-            &version_mapping_path(segment_path),
+        let internal_to_version_file = TypedStorage::<S, SeqNumberType>::new(fs.open(
+            version_mapping_path(segment_path),
             options,
             Default::default(),
         )?);
         let internal_to_version =
             CompressedVersions::from_slice(&internal_to_version_file.read_whole()?);
 
-        let mappings_file =
-            fs.take_file(&mappings_path(segment_path), options, Default::default())?;
+        let mappings_file = fs.open(mappings_path(segment_path), options, Default::default())?;
         let mappings_bytes = mappings_file.read::<Sequential, u8>(ReadRange {
             byte_offset: 0,
             length: mappings_file.len::<u8>()?,

--- a/lib/segment/src/id_tracker/mutable_id_tracker/read_only/lifecycle.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/read_only/lifecycle.rs
@@ -3,9 +3,7 @@ use std::path::{Path, PathBuf};
 use common::mmap::Advice::Normal;
 use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
-use common::universal_io::{
-    CachedReadFs, OkNotFound, OpenOptions, Populate, UniversalRead, UniversalReadFs,
-};
+use common::universal_io::{OkNotFound, OpenOptions, Populate, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyAppendableIdTracker;
 use crate::common::operation_error::OperationResult;
@@ -26,18 +24,18 @@ impl<S: UniversalRead> ReadOnlyAppendableIdTracker<S> {
     /// mappings log and versions file are consumed, applying only committed points (a partial
     /// trailing entry is simply not consumed and picked up on a later reload).
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &S::Fs,
         segment_path: impl Into<PathBuf>,
         deferred_internal_id: Option<PointOffsetType>,
     ) -> OperationResult<Self> {
         // The tracker keeps a filesystem handle to re-open the append-only
-        // files on later reloads, so it must retain the *raw* backend — the
-        // `CachedReadFs` snapshot goes stale as soon as the writer appends.
-        // The bootstrap below consequently opens through the raw fs too,
-        // bypassing the prefetch pool (its handles are simply dropped).
+        // files on later reloads, so it must retain the *raw* backend — a
+        // caching wrapper's snapshot goes stale as soon as the writer
+        // appends. The bootstrap below consequently opens through the raw
+        // fs too, bypassing any prefetch pool.
         let mut tracker = Self {
             segment_path: segment_path.into(),
-            fs: fs.inner().clone(),
+            fs: fs.clone(),
             internal_to_version: Vec::new(),
             mappings: PointMappings::new(
                 Default::default(),

--- a/lib/segment/src/id_tracker/mutable_id_tracker/read_only/tests.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/read_only/tests.rs
@@ -75,12 +75,7 @@ fn test_open_matches_mutable_tracker() {
     mutable.drop(200.into()).unwrap();
     flush(&mutable);
 
-    let read_only = ReadOnlyTracker::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        segment_dir.path(),
-        None,
-    )
-    .unwrap();
+    let read_only = ReadOnlyTracker::open(&MmapFs, segment_dir.path(), None).unwrap();
     assert_in_sync(&read_only, &mutable);
 
     // Spot check resolved ids
@@ -103,12 +98,7 @@ fn test_open_without_storage_is_empty() {
 
     // No storage exists yet: the files are absent while empty, so a read-only view opens as an
     // empty tracker (matching `MutableIdTracker::open`) rather than erroring.
-    let read_only = ReadOnlyTracker::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        segment_dir.path(),
-        None,
-    )
-    .unwrap();
+    let read_only = ReadOnlyTracker::open(&MmapFs, segment_dir.path(), None).unwrap();
     assert_eq!(read_only.available_point_count(), 0);
     assert_eq!(read_only.total_point_count(), 0);
 }
@@ -125,12 +115,7 @@ fn test_open_with_missing_versions_is_empty() {
 
     // With no versions file no point is committed (a point becomes visible only once its version is
     // present), so the read-only view opens empty instead of erroring.
-    let read_only = ReadOnlyTracker::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        segment_dir.path(),
-        None,
-    )
-    .unwrap();
+    let read_only = ReadOnlyTracker::open(&MmapFs, segment_dir.path(), None).unwrap();
     assert_eq!(read_only.available_point_count(), 0);
 }
 
@@ -145,12 +130,7 @@ fn test_live_reload_reports_inserts_and_deletes() {
     insert(&mut mutable, 300.into(), 2, 12);
     flush(&mutable);
 
-    let mut read_only = ReadOnlyTracker::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        segment_dir.path(),
-        None,
-    )
-    .unwrap();
+    let mut read_only = ReadOnlyTracker::open(&MmapFs, segment_dir.path(), None).unwrap();
     assert_in_sync(&read_only, &mutable);
 
     // A reload with no new changes reports nothing
@@ -186,12 +166,7 @@ fn test_live_reload_insert_then_delete_within_batch() {
     insert(&mut mutable, 100.into(), 0, 10);
     flush(&mutable);
 
-    let mut read_only = ReadOnlyTracker::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        segment_dir.path(),
-        None,
-    )
-    .unwrap();
+    let mut read_only = ReadOnlyTracker::open(&MmapFs, segment_dir.path(), None).unwrap();
 
     // Insert a brand-new point and delete it again, all before the read-only view reloads.
     insert(&mut mutable, 200.into(), 1, 11);
@@ -223,12 +198,7 @@ fn test_live_reload_upsert_relinks_to_new_offset() {
     insert(&mut mutable, 100.into(), 0, 10);
     flush(&mutable);
 
-    let mut read_only = ReadOnlyTracker::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        segment_dir.path(),
-        None,
-    )
-    .unwrap();
+    let mut read_only = ReadOnlyTracker::open(&MmapFs, segment_dir.path(), None).unwrap();
     assert_eq!(
         read_only
             .internal_id_with_behavior(100.into(), common::types::DeferredBehavior::VisibleOnly),
@@ -266,12 +236,7 @@ fn test_live_reload_withholds_insert_until_version_present() {
     insert(&mut mutable, 100.into(), 0, 10);
     flush(&mutable);
 
-    let mut read_only = ReadOnlyTracker::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        segment_dir.path(),
-        None,
-    )
-    .unwrap();
+    let mut read_only = ReadOnlyTracker::open(&MmapFs, segment_dir.path(), None).unwrap();
 
     // Insert a point but flush *only* the mapping, mimicking observing storage mid-flush-cycle.
     insert(&mut mutable, 200.into(), 1, 11);
@@ -316,12 +281,7 @@ fn test_live_reload_ignores_partial_trailing_mapping_entry() {
     insert(&mut mutable, 200.into(), 1, 11);
     flush(&mutable);
 
-    let mut read_only = ReadOnlyTracker::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        segment_dir.path(),
-        None,
-    )
-    .unwrap();
+    let mut read_only = ReadOnlyTracker::open(&MmapFs, segment_dir.path(), None).unwrap();
     assert_in_sync(&read_only, &mutable);
 
     // Byte offset of the last fully-consumed mapping entry, the position we expect to resume from.
@@ -385,12 +345,7 @@ fn test_open_and_reload_ignore_partial_trailing_version() {
     }
 
     // Open ignores the partial trailing bytes, versions match the complete entries.
-    let read_only = ReadOnlyTracker::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        segment_dir.path(),
-        None,
-    )
-    .unwrap();
+    let read_only = ReadOnlyTracker::open(&MmapFs, segment_dir.path(), None).unwrap();
     assert_eq!(read_only.internal_version(0), Some(10));
     assert_eq!(read_only.internal_version(1), Some(11));
     assert_in_sync(&read_only, &mutable);
@@ -407,12 +362,7 @@ fn test_live_reload_withholds_partially_written_version() {
     insert(&mut mutable, 200.into(), 1, 11);
     flush(&mutable);
 
-    let mut read_only = ReadOnlyTracker::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        segment_dir.path(),
-        None,
-    )
-    .unwrap();
+    let mut read_only = ReadOnlyTracker::open(&MmapFs, segment_dir.path(), None).unwrap();
 
     // Insert a third point and flush its mapping, then simulate a torn version flush by appending
     // only part of its 8-byte version entry.

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use common::universal_io::CachedReadFs;
+use common::universal_io::UniversalReadFs;
 
 use super::super::mutable_bool_index::{FALSES_DIRNAME, TRUES_DIRNAME};
 use super::{ReadOnlyBoolIndex, ReadOnlyStorage};
@@ -26,7 +26,7 @@ impl<S: UniversalReadExt> ReadOnlyBoolIndex<S> {
     /// index that would drop the persisted postings of the present half.
     ///
     /// [1]: super::super::mutable_bool_index::MutableBoolIndex::open
-    pub fn open(fs: &CachedReadFs<S::Fs>, path: &Path) -> OperationResult<Option<Self>> {
+    pub fn open(fs: &impl UniversalReadFs<File = S>, path: &Path) -> OperationResult<Option<Self>> {
         // Open both directories first so a partial layout can be distinguished
         // from a genuinely absent index, regardless of which half is missing.
         let trues_flags = ReadOnlyRoaringFlags::<S>::open(fs, &path.join(TRUES_DIRNAME))?;

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
@@ -131,13 +131,9 @@ mod tests {
         type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
         let fs = RoFs::from_context(Default::default()).unwrap();
 
-        let index = ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(
-            &common::universal_io::CachedReadFs::new(fs.clone(), std::path::Path::new("."))
-                .unwrap(),
-            dir.path(),
-        )
-        .unwrap()
-        .unwrap();
+        let index = ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path())
+            .unwrap()
+            .unwrap();
 
         let hw_acc = HwMeasurementAcc::new();
         let hw_counter = hw_acc.get_counter_cell();
@@ -201,13 +197,9 @@ mod tests {
         let fs = RoFs::from_context(Default::default()).unwrap();
 
         // Read-only view of points 0..=5, taken before the writer continues.
-        let mut reloaded = ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(
-            &common::universal_io::CachedReadFs::new(fs.clone(), std::path::Path::new("."))
-                .unwrap(),
-            dir.path(),
-        )
-        .unwrap()
-        .unwrap();
+        let mut reloaded = ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path())
+            .unwrap()
+            .unwrap();
 
         // Writer's append-only delta: retire points 1 (false) and 2 (both), then
         // append fresh offsets 6 (true), 7 (false) and 1100 (true). Offset 1100
@@ -229,13 +221,9 @@ mod tests {
             )
             .unwrap();
 
-        let fresh = ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(
-            &common::universal_io::CachedReadFs::new(fs.clone(), std::path::Path::new("."))
-                .unwrap(),
-            dir.path(),
-        )
-        .unwrap()
-        .unwrap();
+        let fresh = ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path())
+            .unwrap()
+            .unwrap();
 
         let hw_acc = HwMeasurementAcc::new();
         let hw = hw_acc.get_counter_cell();
@@ -312,25 +300,11 @@ mod tests {
         // `trues` present, `falses` removed.
         let dir = build();
         fs_err::remove_dir_all(dir.path().join(FALSES_DIRNAME)).unwrap();
-        assert!(
-            ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(
-                &common::universal_io::CachedReadFs::new(fs.clone(), std::path::Path::new("."))
-                    .unwrap(),
-                dir.path()
-            )
-            .is_err()
-        );
+        assert!(ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path()).is_err());
 
         // `falses` present, `trues` removed.
         let dir = build();
         fs_err::remove_dir_all(dir.path().join(TRUES_DIRNAME)).unwrap();
-        assert!(
-            ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(
-                &common::universal_io::CachedReadFs::new(fs.clone(), std::path::Path::new("."))
-                    .unwrap(),
-                dir.path()
-            )
-            .is_err()
-        );
+        assert!(ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path()).is_err());
     }
 }

--- a/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use common::bitvec::BitSlice;
-use common::universal_io::CachedReadFs;
+use common::universal_io::UniversalReadFs;
 
 use super::ReadOnlyFieldIndex;
 use crate::common::operation_error::OperationResult;
@@ -57,7 +57,7 @@ impl<S: UniversalReadExt> ReadOnlyFieldIndex<S> {
     ///
     /// [1]: crate::index::field_index::index_selector::IndexSelector::new_index_with_type
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         dir: &Path,
         field: &JsonPath,
         payload_schema: &PayloadFieldSchema,

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
@@ -563,7 +563,7 @@ mod tests {
         OnDiskInvertedIndex::create(mmap_dir.path().into(), &immutable).unwrap();
         let empty_deleted = BitVec::new();
         let mmap: OnDiskInvertedIndex = OnDiskInvertedIndex::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+            &MmapFs,
             mmap_dir.path().into(),
             Populate::No,
             phrase_matching,
@@ -644,7 +644,7 @@ mod tests {
         OnDiskInvertedIndex::create(mmap_dir.path().into(), &immutable).unwrap();
         let empty_deleted = BitVec::new();
         let mut mmap_index = OnDiskInvertedIndex::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+            &MmapFs,
             mmap_dir.path().into(),
             Populate::No,
             phrase_matching,

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
@@ -11,8 +11,8 @@ use common::persisted_hashmap::{READ_ENTRY_OVERHEAD, UniversalHashMap, serialize
 use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFile, MmapFs, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead,
-    UserData,
+    MmapFile, MmapFs, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead,
+    UniversalReadFs, UserData,
 };
 use on_disk_postings::OnDiskPostings;
 use types::ZerocopyPostingValue;
@@ -154,7 +154,7 @@ impl OnDiskInvertedIndex<MmapFile> {
 
 impl<S: UniversalRead> OnDiskInvertedIndex<S> {
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: PathBuf,
         populate: Populate,
         has_positions: bool,
@@ -191,7 +191,7 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
             // If postings don't exist, assume the index doesn't exist on disk
             return Ok(None);
         };
-        let vocab = UniversalHashMap::<str, TokenId, S>::from_file(fs.take_file(
+        let vocab = UniversalHashMap::<str, TokenId, S>::from_file(fs.open(
             &vocab_path,
             OpenOptions {
                 writeable: false,
@@ -202,7 +202,7 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
             Default::default(),
         )?)?;
 
-        let point_to_tokens_count = TypedStorage::<S, usize>::new(fs.take_file(
+        let point_to_tokens_count = TypedStorage::<S, usize>::new(fs.open(
             &point_to_tokens_count_path,
             OpenOptions {
                 writeable: false,
@@ -213,7 +213,7 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
             Default::default(),
         )?);
 
-        let deleted_payload_mmap = StoredBitSlice::<S>::from_file(fs.take_file(
+        let deleted_payload_mmap = StoredBitSlice::<S>::from_file(fs.open(
             &deleted_points_path,
             OpenOptions {
                 writeable: false,

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
@@ -3,10 +3,7 @@ use std::marker::PhantomData;
 use std::path::PathBuf;
 
 use common::generic_consts::{Random, Sequential};
-use common::universal_io::{
-    CachedReadFs, OkNotFound, OpenOptions, ReadRange, UniversalIoError, UniversalRead,
-    UniversalReadFs,
-};
+use common::universal_io::{OkNotFound, OpenOptions, ReadRange, UniversalIoError, UniversalRead, UniversalReadFs};
 use posting_list::{PostingList, PostingListView};
 use zerocopy::FromBytes;
 
@@ -46,14 +43,14 @@ impl<V: ZerocopyPostingValue, S: UniversalRead> OnDiskPostings<V, S> {
     /// Open the postings file at `path` via the `S` storage backend.
     ///
     /// Returns `Ok(None)` if the file is not found
-    pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+    pub fn open<Fs: UniversalReadFs<File = S>>(
+        fs: &Fs,
         path: impl Into<PathBuf>,
         options: OpenOptions,
-        extra: <S::Fs as UniversalReadFs>::OpenExtra,
+        extra: Fs::OpenExtra,
     ) -> OperationResult<Option<Self>> {
         let path = path.into();
-        let Some(storage) = fs.take_file(&path, options, extra).ok_not_found()? else {
+        let Some(storage) = fs.open(&path, options, extra).ok_not_found()? else {
             return Ok(None);
         };
 

--- a/lib/segment/src/index/field_index/full_text_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/lifecycle.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, MmapFs, Populate};
+use common::universal_io::{MmapFs, Populate};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -32,13 +32,8 @@ impl FullTextIndex {
         let memory = memory.clamp_to_low_memory();
 
         let populate = Populate::from(memory.populate_on_open());
-        let Some(on_disk_index) = OnDiskFullTextIndex::open(
-            &CachedReadFs::new(MmapFs, &path)?,
-            path,
-            config,
-            populate,
-            deleted_points,
-        )?
+        let Some(on_disk_index) =
+            OnDiskFullTextIndex::open(&MmapFs, path, config, populate, deleted_points)?
         else {
             return Ok(None);
         };

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::universal_io::{CachedReadFs, OkNotFound, Populate, UniversalRead};
+use common::universal_io::{OkNotFound, Populate, UniversalRead, UniversalReadFs};
 use gridstore::GridstoreReader;
 
 use super::super::inner::MutableFullTextIndexInner;
@@ -30,7 +30,7 @@ impl<S: UniversalRead> ReadOnlyAppendableFullTextIndex<S> {
     ///
     /// [1]: super::super::MutableFullTextIndex::open_gridstore
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: PathBuf,
         config: TextIndexParams,
     ) -> OperationResult<Option<Self>> {

--- a/lib/segment/src/index/field_index/full_text_index/on_disk_text_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/on_disk_text_index/lifecycle.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, MmapFs, Populate, UniversalRead};
+use common::universal_io::{MmapFs, Populate, UniversalRead, UniversalReadFs};
 use fs_err as fs;
 use serde_json::Value;
 
@@ -22,7 +22,7 @@ use crate::index::field_index::{FieldIndexBuilderTrait, ValueIndexer};
 
 impl<S: UniversalRead> OnDiskFullTextIndex<S> {
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: PathBuf,
         config: TextIndexParams,
         populate: Populate,
@@ -191,18 +191,13 @@ impl FieldIndexBuilderTrait for FullTextMmapIndexBuilder {
 
         let populate = Populate::from(!is_on_disk);
         let has_positions = config.phrase_matching.unwrap_or_default();
-        let inverted_index = OnDiskInvertedIndex::open(
-            &CachedReadFs::new(MmapFs, &path)?,
-            path,
-            populate,
-            has_positions,
-            &deleted_points,
-        )?
-        .ok_or_else(|| {
-            OperationError::service_error(
-                "Failed to open OnDiskInvertedIndex that was just created",
-            )
-        })?;
+        let inverted_index =
+            OnDiskInvertedIndex::open(&MmapFs, path, populate, has_positions, &deleted_points)?
+                .ok_or_else(|| {
+                    OperationError::service_error(
+                        "Failed to open OnDiskInvertedIndex that was just created",
+                    )
+                })?;
 
         let on_disk_index = OnDiskFullTextIndex {
             inverted_index,

--- a/lib/segment/src/index/field_index/full_text_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use common::bitvec::BitSlice;
-use common::universal_io::{CachedReadFs, Populate, UniversalRead};
+use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
 
 use super::super::mutable_text_index::read_only::ReadOnlyAppendableFullTextIndex;
 use super::super::on_disk_text_index::OnDiskFullTextIndex;
@@ -24,7 +24,7 @@ impl<S: UniversalRead> ReadOnlyFullTextIndex<S> {
     ///
     /// [1]: super::super::FullTextIndex::new_gridstore
     pub fn open_appendable(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         dir: PathBuf,
         config: TextIndexParams,
     ) -> OperationResult<Option<Self>> {
@@ -44,7 +44,7 @@ impl<S: UniversalRead> ReadOnlyFullTextIndex<S> {
     ///
     /// [1]: super::super::FullTextIndex::new_mmap
     pub fn open_immutable(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: PathBuf,
         config: TextIndexParams,
         is_on_disk: bool,

--- a/lib/segment/src/index/field_index/full_text_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/mod.rs
@@ -112,13 +112,9 @@ mod tests {
         type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
         let fs = RoFs::from_context(Default::default()).unwrap();
         let index: ReadOnlyFullTextIndex<ReadOnly<MmapFile>> =
-            ReadOnlyFullTextIndex::open_appendable(
-                &common::universal_io::CachedReadFs::new(fs, std::path::Path::new(".")).unwrap(),
-                dir.path().to_path_buf(),
-                config,
-            )
-            .unwrap()
-            .unwrap();
+            ReadOnlyFullTextIndex::open_appendable(&fs, dir.path().to_path_buf(), config)
+                .unwrap()
+                .unwrap();
 
         // Dispatcher wraps the leaf into the right variant.
         assert!(matches!(index, ReadOnlyFullTextIndex::Appendable(_)));

--- a/lib/segment/src/index/field_index/geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mod.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, MmapFile, MmapFs, Populate};
+use common::universal_io::{MmapFile, MmapFs, Populate};
 use mutable_geo_index::InMemoryGeoIndex;
 
 pub use self::builders::{GeoIndexGridstoreBuilder, GeoIndexMmapBuilder};
@@ -52,12 +52,7 @@ impl GeoIndex {
         let memory = memory.clamp_to_low_memory();
 
         let populate = Populate::from(memory.populate_on_open());
-        let Some(on_disk_index) = OnDiskGeoIndex::open(
-            &CachedReadFs::new(MmapFs, path)?,
-            path,
-            populate,
-            deleted_points,
-        )?
+        let Some(on_disk_index) = OnDiskGeoIndex::open(&MmapFs, path, populate, deleted_points)?
         else {
             return Ok(None);
         };

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::universal_io::{CachedReadFs, OkNotFound, Populate, UniversalRead};
+use common::universal_io::{OkNotFound, Populate, UniversalRead, UniversalReadFs};
 use gridstore::GridstoreReader;
 
 use super::super::inner::InMemoryGeoIndex;
@@ -25,7 +25,10 @@ impl<S: UniversalRead> ReadOnlyAppendableGeoIndex<S> {
     /// the read path never creates.
     ///
     /// [1]: super::super::MutableGeoIndex::open_gridstore
-    pub fn open(fs: &CachedReadFs<S::Fs>, path: PathBuf) -> OperationResult<Option<Self>> {
+    pub fn open(
+        fs: &impl UniversalReadFs<File = S>,
+        path: PathBuf,
+    ) -> OperationResult<Option<Self>> {
         let Some(storage) =
             GridstoreReader::<Vec<RawGeoPoint>, S>::open(fs, path, Populate::Blocking)
                 .ok_not_found()?

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/mod.rs
@@ -77,12 +77,9 @@ mod tests {
         type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
         let fs = RoFs::from_context(Default::default()).unwrap();
         let index: ReadOnlyAppendableGeoIndex<ReadOnly<MmapFile>> =
-            ReadOnlyAppendableGeoIndex::open(
-                &common::universal_io::CachedReadFs::new(fs, std::path::Path::new(".")).unwrap(),
-                dir.path().to_path_buf(),
-            )
-            .unwrap()
-            .unwrap();
+            ReadOnlyAppendableGeoIndex::open(&fs, dir.path().to_path_buf())
+                .unwrap()
+                .unwrap();
 
         // Counts reconstructed from the Gridstore on open.
         assert_eq!(index.points_count(), 3);

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
@@ -14,8 +14,8 @@ use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFile, MmapFs, OkNotFound, OpenOptions, Populate, ReadRange, TypedStorage,
-    UniversalRead, read_json_via,
+    MmapFile, MmapFs, OkNotFound, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead,
+    UniversalReadFs, read_json_via,
 };
 use fs_err as fs;
 use memmap2::MmapMut;
@@ -155,19 +155,13 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
             },
         )?;
 
-        Self::open(
-            &CachedReadFs::new(fs.clone(), path)?,
-            path,
-            populate,
-            deleted_points,
-        )?
-        .ok_or_else(|| {
+        Self::open(fs, path, populate, deleted_points)?.ok_or_else(|| {
             OperationError::service_error("Failed to open OnDiskGeoIndex after building it")
         })
     }
 
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         populate: Populate,
         deleted_points: &BitSlice,
@@ -191,23 +185,17 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
             advice: AdviceSetting::Global,
         };
 
-        let counts_per_hash = TypedStorage::new(fs.take_file(
-            &counts_per_hash_path,
-            open_options,
-            Default::default(),
-        )?);
+        let counts_per_hash =
+            TypedStorage::new(fs.open(&counts_per_hash_path, open_options, Default::default())?);
         let points_map =
-            TypedStorage::new(fs.take_file(&points_map_path, open_options, Default::default())?);
-        let points_map_ids = TypedStorage::new(fs.take_file(
-            &points_map_ids_path,
-            open_options,
-            Default::default(),
-        )?);
+            TypedStorage::new(fs.open(&points_map_path, open_options, Default::default())?);
+        let points_map_ids =
+            TypedStorage::new(fs.open(&points_map_ids_path, open_options, Default::default())?);
         let point_to_values = OnDiskPointToValues::open(fs, path, populate)?;
 
         let mut deleted = deleted_points.to_owned();
 
-        let deleted_payload_mmap = StoredBitSlice::<S>::from_file(fs.take_file(
+        let deleted_payload_mmap = StoredBitSlice::<S>::from_file(fs.open(
             &deleted_path,
             OpenOptions {
                 writeable: false,

--- a/lib/segment/src/index/field_index/geo_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
-use common::universal_io::{CachedReadFs, Populate, UniversalRead};
+use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
 
 use super::super::mutable_geo_index::read_only::ReadOnlyAppendableGeoIndex;
 use super::super::on_disk_geo_index::OnDiskGeoIndex;
@@ -20,7 +20,7 @@ impl<S: UniversalRead> ReadOnlyGeoIndex<S> {
     ///
     /// [1]: super::super::GeoIndex::new_mutable
     pub fn open_appendable(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         dir: PathBuf,
     ) -> OperationResult<Option<Self>> {
         Ok(ReadOnlyAppendableGeoIndex::open(fs, dir)?.map(Self::Appendable))
@@ -45,7 +45,7 @@ impl<S: UniversalRead> ReadOnlyGeoIndex<S> {
     /// [2]: common::universal_io::MmapFile
     /// [3]: common::universal_io::ReadOnly
     pub fn open_immutable(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         is_on_disk: bool,
         deleted_points: &BitSlice,

--- a/lib/segment/src/index/field_index/geo_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/mod.rs
@@ -130,12 +130,10 @@ mod tests {
 
         type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
         let fs = RoFs::from_context(Default::default()).unwrap();
-        let index: ReadOnlyGeoIndex<ReadOnly<MmapFile>> = ReadOnlyGeoIndex::open_appendable(
-            &common::universal_io::CachedReadFs::new(fs, std::path::Path::new(".")).unwrap(),
-            dir.path().to_path_buf(),
-        )
-        .unwrap()
-        .unwrap();
+        let index: ReadOnlyGeoIndex<ReadOnly<MmapFile>> =
+            ReadOnlyGeoIndex::open_appendable(&fs, dir.path().to_path_buf())
+                .unwrap()
+                .unwrap();
 
         // Dispatcher wraps the leaf into the right variant.
         assert!(matches!(index, ReadOnlyGeoIndex::Appendable(_)));

--- a/lib/segment/src/index/field_index/map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/lifecycle.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, MmapFs, Populate};
+use common::universal_io::{MmapFs, Populate};
 use gridstore::Blob;
 
 use super::MapIndex;
@@ -31,12 +31,7 @@ where
         let memory = memory.clamp_to_low_memory();
 
         let populate = Populate::from(memory.populate_on_open());
-        let Some(on_disk_index) = OnDiskMapIndex::open(
-            &CachedReadFs::new(MmapFs, path)?,
-            path,
-            populate,
-            deleted_points,
-        )?
+        let Some(on_disk_index) = OnDiskMapIndex::open(&MmapFs, path, populate, deleted_points)?
         else {
             return Ok(None);
         };

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::universal_io::{CachedReadFs, OkNotFound, Populate, UniversalRead};
+use common::universal_io::{OkNotFound, Populate, UniversalRead, UniversalReadFs};
 use gridstore::error::GridstoreError;
 use gridstore::{Blob, GridstoreReader};
 
@@ -29,7 +29,10 @@ where
     /// the read path never creates.
     ///
     /// [1]: super::super::MutableMapIndex::open_gridstore
-    pub fn open(fs: &CachedReadFs<S::Fs>, path: PathBuf) -> OperationResult<Option<Self>> {
+    pub fn open(
+        fs: &impl UniversalReadFs<File = S>,
+        path: PathBuf,
+    ) -> OperationResult<Option<Self>> {
         let Some(storage) = GridstoreReader::<Vec<<N as MapIndexKey>::Owned>, S>::open(
             fs,
             path,

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
@@ -10,7 +10,7 @@ use common::persisted_hashmap::{Key, UniversalHashMap, serialize_hashmap};
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFile, OkNotFound, OpenOptions, Populate, UniversalRead, UniversalWrite,
+    MmapFile, OkNotFound, OpenOptions, Populate, UniversalRead, UniversalReadFs, UniversalWrite,
     read_json_via,
 };
 use fs_err as fs;
@@ -31,7 +31,7 @@ where
 {
     /// Open and load mmap map index from the given path
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         populate: Populate,
         deleted_points: &BitSlice,
@@ -47,7 +47,7 @@ where
             return Ok(None);
         };
 
-        let value_to_points = UniversalHashMap::from_file(fs.take_file(
+        let value_to_points = UniversalHashMap::from_file(fs.open(
             &hashmap_path,
             OpenOptions {
                 writeable: false,
@@ -62,7 +62,7 @@ where
 
         let mut deleted = deleted_points.to_owned();
 
-        let deleted_payload_mmap = StoredBitSlice::<S>::from_file(fs.take_file(
+        let deleted_payload_mmap = StoredBitSlice::<S>::from_file(fs.open(
             &deleted_path,
             OpenOptions {
                 writeable: false,
@@ -270,13 +270,7 @@ where
             deleted.flusher()()?;
         }
 
-        Self::open(
-            &CachedReadFs::new(fs.clone(), path)?,
-            path,
-            populate,
-            deleted_points,
-        )?
-        .ok_or_else(|| {
+        Self::open(fs, path, populate, deleted_points)?.ok_or_else(|| {
             OperationError::service_error("Failed to open UniversalMapIndex after building it")
         })
     }

--- a/lib/segment/src/index/field_index/map_index/prefix_index/reader.rs
+++ b/lib/segment/src/index/field_index/map_index/prefix_index/reader.rs
@@ -8,7 +8,8 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::mmap::AdviceSetting;
 use common::universal_io::{
-    CachedReadFs, MmapFile, OpenOptions, Populate, ReadRange, UniversalRead, UniversalReadFileOps,
+    MmapFile, OpenOptions, Populate, ReadRange, UniversalRead, UniversalReadFileOps,
+    UniversalReadFs,
 };
 
 use super::PREFIX_INDEX_PATH;
@@ -55,7 +56,7 @@ impl<S: UniversalRead> PrefixIndex<S> {
     /// Open the prefix index if its file exists; `Ok(None)` when the backing
     /// map index was built without prefix support.
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         populate: Populate,
     ) -> OperationResult<Option<Self>> {
@@ -64,7 +65,7 @@ impl<S: UniversalRead> PrefixIndex<S> {
             return Ok(None);
         }
 
-        let storage = fs.take_file(
+        let storage = fs.open(
             &file_path,
             OpenOptions {
                 writeable: false,

--- a/lib/segment/src/index/field_index/map_index/prefix_index/tests.rs
+++ b/lib/segment/src/index/field_index/map_index/prefix_index/tests.rs
@@ -17,13 +17,9 @@ fn build_and_open(entries: &BTreeMap<Vec<u8>, usize>) -> (TempDir, PrefixIndex) 
         entries.iter().map(|(key, &count)| (key.as_slice(), count)),
     )
     .unwrap();
-    let index = PrefixIndex::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        dir.path(),
-        Populate::Blocking,
-    )
-    .unwrap()
-    .unwrap();
+    let index = PrefixIndex::open(&MmapFs, dir.path(), Populate::Blocking)
+        .unwrap()
+        .unwrap();
     (dir, index)
 }
 
@@ -64,12 +60,7 @@ fn check_prefix(index: &PrefixIndex, entries: &BTreeMap<Vec<u8>, usize>, prefix:
 #[test]
 fn missing_file_opens_as_none() {
     let dir = TempDir::with_prefix("prefix_index").unwrap();
-    let index = PrefixIndex::<MmapFile>::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-        dir.path(),
-        Populate::Blocking,
-    )
-    .unwrap();
+    let index = PrefixIndex::<MmapFile>::open(&MmapFs, dir.path(), Populate::Blocking).unwrap();
     assert!(index.is_none());
 }
 

--- a/lib/segment/src/index/field_index/map_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
-use common::universal_io::{CachedReadFs, Populate, UniversalRead};
+use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
 use gridstore::Blob;
 
 use super::super::MapIndexKey;
@@ -28,7 +28,7 @@ where
     ///
     /// [1]: super::super::MapIndex::new_gridstore
     pub fn open_appendable(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         dir: PathBuf,
     ) -> OperationResult<Option<Self>> {
         Ok(ReadOnlyAppendableMapIndex::open(fs, dir)?.map(Self::Appendable))
@@ -47,7 +47,7 @@ where
     ///
     /// [1]: super::super::MapIndex::new_mmap
     pub fn open_immutable(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         is_on_disk: bool,
         deleted_points: &BitSlice,

--- a/lib/segment/src/index/field_index/map_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/read_only/mod.rs
@@ -87,12 +87,10 @@ mod tests {
         // The read-only filesystem context is `Default`.
         type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
         let fs = RoFs::from_context(Default::default()).unwrap();
-        let index: ReadOnlyMapIndex<str, ReadOnly<MmapFile>> = ReadOnlyMapIndex::open_appendable(
-            &common::universal_io::CachedReadFs::new(fs, std::path::Path::new(".")).unwrap(),
-            dir.path().to_path_buf(),
-        )
-        .unwrap()
-        .unwrap();
+        let index: ReadOnlyMapIndex<str, ReadOnly<MmapFile>> =
+            ReadOnlyMapIndex::open_appendable(&fs, dir.path().to_path_buf())
+                .unwrap()
+                .unwrap();
 
         // Dispatcher wraps the leaf into the right variant.
         assert!(matches!(index, ReadOnlyMapIndex::Appendable(_)));

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use common::universal_io::{CachedReadFs, UniversalRead};
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::super::mutable_null_index::{HAS_VALUES_DIRNAME, IS_NULL_DIRNAME};
 use super::{ReadOnlyNullIndex, ReadOnlyStorage};
@@ -25,7 +25,7 @@ impl<S: UniversalRead> ReadOnlyNullIndex<S> {
     ///
     /// [1]: super::super::mutable_null_index::MutableNullIndex::open
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         total_point_count: usize,
     ) -> OperationResult<Option<Self>> {

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/mod.rs
@@ -103,14 +103,9 @@ mod tests {
         type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
         let fs = RoFs::from_context(Default::default()).unwrap();
 
-        let index = ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(
-            &common::universal_io::CachedReadFs::new(fs.clone(), std::path::Path::new("."))
-                .unwrap(),
-            dir.path(),
-            total,
-        )
-        .unwrap()
-        .unwrap();
+        let index = ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path(), total)
+            .unwrap()
+            .unwrap();
 
         let key = JsonPath::new("test");
         let is_null = FieldCondition::new_is_null(key.clone(), true);
@@ -205,14 +200,9 @@ mod tests {
         let fs = RoFs::from_context(Default::default()).unwrap();
 
         // Read-only view of points 0..=3, taken before the writer continues.
-        let mut reloaded = ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(
-            &common::universal_io::CachedReadFs::new(fs.clone(), std::path::Path::new("."))
-                .unwrap(),
-            dir.path(),
-            4,
-        )
-        .unwrap()
-        .unwrap();
+        let mut reloaded = ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path(), 4)
+            .unwrap()
+            .unwrap();
 
         // Writer's delta: drop point 1, flip point 2 (empty -> value), append a
         // null point 4 (which grows `total_point_count` to 5).
@@ -231,14 +221,9 @@ mod tests {
             )
             .unwrap();
 
-        let fresh = ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(
-            &common::universal_io::CachedReadFs::new(fs.clone(), std::path::Path::new("."))
-                .unwrap(),
-            dir.path(),
-            total,
-        )
-        .unwrap()
-        .unwrap();
+        let fresh = ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path(), total)
+            .unwrap()
+            .unwrap();
 
         let key = JsonPath::new("test");
         let is_null = FieldCondition::new_is_null(key.clone(), true);
@@ -335,27 +320,11 @@ mod tests {
         // `has_values` present, `is_null` removed.
         let dir = build();
         fs_err::remove_dir_all(dir.path().join(IS_NULL_DIRNAME)).unwrap();
-        assert!(
-            ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(
-                &common::universal_io::CachedReadFs::new(fs.clone(), std::path::Path::new("."))
-                    .unwrap(),
-                dir.path(),
-                1
-            )
-            .is_err()
-        );
+        assert!(ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path(), 1).is_err());
 
         // `is_null` present, `has_values` removed.
         let dir = build();
         fs_err::remove_dir_all(dir.path().join(HAS_VALUES_DIRNAME)).unwrap();
-        assert!(
-            ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(
-                &common::universal_io::CachedReadFs::new(fs.clone(), std::path::Path::new("."))
-                    .unwrap(),
-                dir.path(),
-                1
-            )
-            .is_err()
-        );
+        assert!(ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path(), 1).is_err());
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::universal_io::{CachedReadFs, OkNotFound, Populate, UniversalRead};
+use common::universal_io::{OkNotFound, Populate, UniversalRead, UniversalReadFs};
 use gridstore::{Blob, GridstoreReader};
 
 use super::super::InMemoryNumericIndex;
@@ -30,7 +30,10 @@ where
     /// the read path never creates.
     ///
     /// [1]: super::super::MutableNumericIndex::open_gridstore
-    pub fn open(fs: &CachedReadFs<S::Fs>, path: PathBuf) -> OperationResult<Option<Self>> {
+    pub fn open(
+        fs: &impl UniversalReadFs<File = S>,
+        path: PathBuf,
+    ) -> OperationResult<Option<Self>> {
         let Some(storage) =
             GridstoreReader::<Vec<T>, S>::open(fs, path, Populate::Blocking).ok_not_found()?
         else {

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/mod.rs
@@ -76,12 +76,9 @@ mod tests {
         type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
         let fs = RoFs::from_context(Default::default()).unwrap();
         let index: ReadOnlyAppendableNumericIndex<FloatPayloadType, ReadOnly<MmapFile>> =
-            ReadOnlyAppendableNumericIndex::open(
-                &common::universal_io::CachedReadFs::new(fs, std::path::Path::new(".")).unwrap(),
-                dir.path().to_path_buf(),
-            )
-            .unwrap()
-            .unwrap();
+            ReadOnlyAppendableNumericIndex::open(&fs, dir.path().to_path_buf())
+                .unwrap()
+                .unwrap();
 
         assert_eq!(index.get_points_count(), 3);
         assert_eq!(index.get_max_values_per_point(), 2);

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
@@ -8,7 +8,7 @@ use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFs, OkNotFound, OpenOptions, Populate, TypedStorage, UniversalRead,
+    MmapFs, OkNotFound, OpenOptions, Populate, TypedStorage, UniversalRead, UniversalReadFs,
     read_json_via,
 };
 use fs_err as fs;
@@ -109,20 +109,14 @@ where
             deleted.flusher()()?;
         }
 
-        Self::open(
-            &CachedReadFs::new(fs.clone(), path)?,
-            path,
-            populate,
-            deleted_points,
-        )?
-        .ok_or_else(|| {
+        Self::open(fs, path, populate, deleted_points)?.ok_or_else(|| {
             OperationError::service_error("Failed to open UniversalNumericIndex after building it")
         })
     }
 
     /// Open and load mmap numeric index from the given path
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         populate: Populate,
         deleted_points: &BitSlice,
@@ -146,13 +140,12 @@ where
             populate,
             advice: AdviceSetting::Global,
         };
-        let pairs =
-            TypedStorage::new(fs.take_file(&pairs_path, pairs_options, Default::default())?);
+        let pairs = TypedStorage::new(fs.open(&pairs_path, pairs_options, Default::default())?);
 
         let point_to_values = OnDiskPointToValues::open(fs, path, populate)?;
         let mut deleted = deleted_points.to_owned();
 
-        let deleted_payload_mmap = StoredBitSlice::<S>::from_file(fs.take_file(
+        let deleted_payload_mmap = StoredBitSlice::<S>::from_file(fs.open(
             &deleted_path,
             OpenOptions {
                 writeable: false,

--- a/lib/segment/src/index/field_index/numeric_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_only/lifecycle.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
-use common::universal_io::{CachedReadFs, UniversalRead};
+use common::universal_io::{UniversalRead, UniversalReadFs};
 use gridstore::Blob;
 
 use super::super::Encodable;
@@ -24,7 +24,7 @@ where
     ///
     /// [1]: super::super::NumericIndex::new_gridstore
     pub fn open_appendable(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         dir: PathBuf,
     ) -> OperationResult<Option<Self>> {
         Ok(
@@ -42,7 +42,7 @@ where
     ///
     /// [1]: super::super::NumericIndex::new_mmap
     pub fn open_immutable(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         is_on_disk: bool,
         deleted_points: &BitSlice,

--- a/lib/segment/src/index/field_index/numeric_index/storage/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/lifecycle.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, MmapFs, Populate};
+use common::universal_io::{MmapFs, Populate};
 use gridstore::Blob;
 
 use super::super::Encodable;
@@ -35,12 +35,8 @@ where
         let memory = memory.clamp_to_low_memory();
 
         let populate = Populate::from(memory.populate_on_open());
-        let Some(on_disk_index) = OnDiskNumericIndex::open(
-            &CachedReadFs::new(MmapFs, path)?,
-            path,
-            populate,
-            deleted_points,
-        )?
+        let Some(on_disk_index) =
+            OnDiskNumericIndex::open(&MmapFs, path, populate, deleted_points)?
         else {
             // Files don't exist, cannot load
             return Ok(None);

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
-use common::universal_io::{CachedReadFs, Populate, UniversalRead};
+use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
 use gridstore::Blob;
 
 use super::super::super::Encodable;
@@ -29,7 +29,7 @@ where
     ///
     /// [1]: super::super::NumericIndexInner::new_gridstore
     pub fn open_appendable(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         dir: PathBuf,
     ) -> OperationResult<Option<Self>> {
         Ok(ReadOnlyAppendableNumericIndex::open(fs, dir)?.map(Self::Appendable))
@@ -49,7 +49,7 @@ where
     ///
     /// [1]: super::super::NumericIndexInner::new_mmap
     pub fn open_immutable(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         is_on_disk: bool,
         deleted_points: &BitSlice,

--- a/lib/segment/src/index/field_index/on_disk_point_to_values.rs
+++ b/lib/segment/src/index/field_index/on_disk_point_to_values.rs
@@ -8,7 +8,7 @@ use common::ext::ResultOptionExt;
 use common::generic_consts::Random;
 use common::mmap::{AdviceSetting, create_and_ensure_length, open_write_mmap};
 use common::types::PointOffsetType;
-use common::universal_io::{self, CachedReadFs, Populate, ReadOnly, ReadRange, UniversalRead};
+use common::universal_io::{self, Populate, ReadOnly, ReadRange, UniversalRead, UniversalReadFs};
 use zerocopy::IntoBytes;
 
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -162,7 +162,7 @@ where
     }
 
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         populate: Populate,
     ) -> OperationResult<Self> {
@@ -175,8 +175,7 @@ where
             advice: AdviceSetting::Global,
         };
 
-        let store =
-            ReadOnly::from_file(fs.take_file(&file_name, open_options, Default::default())?);
+        let store = ReadOnly::from_file(fs.open(&file_name, open_options, Default::default())?);
 
         let header = store.read::<Random, Header>(ReadRange::one(0))?[0];
 
@@ -510,12 +509,8 @@ mod tests {
                 .map(|(id, values)| (id as PointOffsetType, values.iter().map(|s| s.as_str()))),
         )
         .unwrap();
-        let point_to_values = OnDiskPointToValues::<str, MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-            dir.path(),
-            Populate::No,
-        )
-        .unwrap();
+        let point_to_values =
+            OnDiskPointToValues::<str, MmapFile>::open(&MmapFs, dir.path(), Populate::No).unwrap();
 
         for (idx, values) in values.iter().enumerate() {
             let v = point_to_values
@@ -574,12 +569,9 @@ mod tests {
                 .map(|(id, values)| (id as PointOffsetType, values.iter())),
         )
         .unwrap();
-        let point_to_values = OnDiskPointToValues::<GeoPoint, MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-            dir.path(),
-            Populate::No,
-        )
-        .unwrap();
+        let point_to_values =
+            OnDiskPointToValues::<GeoPoint, MmapFile>::open(&MmapFs, dir.path(), Populate::No)
+                .unwrap();
 
         for (idx, values) in values.iter().enumerate() {
             let iter = point_to_values

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::universal_io::CachedReadFs;
+use common::universal_io::UniversalReadFs;
 
 use super::read_view::HNSWIndexReadView;
 use super::telemetry::HNSWSearchesTelemetry;
@@ -70,7 +70,7 @@ type ReadView<'a, S> = HNSWIndexReadView<
 impl<S: UniversalReadExt> ReadOnlyHNSWIndex<S> {
     /// Read-only mirror of `HNSWIndex::open`: loads the graph through `fs`.
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
         vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,

--- a/lib/segment/src/index/read_only/mod.rs
+++ b/lib/segment/src/index/read_only/mod.rs
@@ -8,7 +8,7 @@ use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::low_memory::low_memory_mode;
 use common::types::{ScoredPointOffset, TelemetryDetail};
-use common::universal_io::CachedReadFs;
+use common::universal_io::UniversalReadFs;
 use half::f16;
 use sparse::common::types::{DimId, QuantizedU8};
 use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::InvertedIndexCompressedImmutableRam;
@@ -62,8 +62,12 @@ pub enum VectorIndexReadEnum<S: UniversalReadExt + 'static> {
 }
 
 /// Shared read-only backends plus the `fs`/`path` an index opens its files from.
-pub struct ReadOnlyVectorIndexOpenArgs<'a, S: UniversalReadExt + 'static> {
-    pub fs: &'a CachedReadFs<S::Fs>,
+pub struct ReadOnlyVectorIndexOpenArgs<
+    'a,
+    S: UniversalReadExt + 'static,
+    Fs: UniversalReadFs<File = S>,
+> {
+    pub fs: &'a Fs,
     pub path: &'a Path,
     pub id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
     pub vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
@@ -73,9 +77,9 @@ pub struct ReadOnlyVectorIndexOpenArgs<'a, S: UniversalReadExt + 'static> {
 
 impl<S: UniversalReadExt + 'static> VectorIndexReadEnum<S> {
     /// Open the read-only dense vector index from its config (sparse: follow-up).
-    pub fn open(
+    pub fn open<Fs: UniversalReadFs<File = S>>(
         vector_config: &VectorDataConfig,
-        args: ReadOnlyVectorIndexOpenArgs<'_, S>,
+        args: ReadOnlyVectorIndexOpenArgs<'_, S, Fs>,
     ) -> OperationResult<Self>
     where
         // The HNSW graph keeps its universal-IO storage handle alive behind a
@@ -112,7 +116,9 @@ impl<S: UniversalReadExt + 'static> VectorIndexReadEnum<S> {
     /// Open the read-only sparse vector index from its persisted [`SparseIndexConfig`],
     /// mirroring `create_sparse_vector_index`'s `(index_type, datatype)` selection.
     /// `MutableRam` has no read-only representation.
-    pub fn open_sparse(args: ReadOnlyVectorIndexOpenArgs<'_, S>) -> OperationResult<Self> {
+    pub fn open_sparse<Fs: UniversalReadFs<File = S>>(
+        args: ReadOnlyVectorIndexOpenArgs<'_, S, Fs>,
+    ) -> OperationResult<Self> {
         let ReadOnlyVectorIndexOpenArgs {
             fs,
             path,
@@ -144,9 +150,14 @@ impl<S: UniversalReadExt + 'static> VectorIndexReadEnum<S> {
             path,
         };
 
-        fn open<S: UniversalReadExt + 'static, TInvertedIndex: InvertedIndexReadOnly<S>>(
-            args: ReadOnlySparseVectorIndexOpenArgs<'_, S>,
-        ) -> OperationResult<Box<ReadOnlySparseVectorIndex<S, TInvertedIndex>>> {
+        fn open<S, Fs, TInvertedIndex>(
+            args: ReadOnlySparseVectorIndexOpenArgs<'_, S, Fs>,
+        ) -> OperationResult<Box<ReadOnlySparseVectorIndex<S, TInvertedIndex>>>
+        where
+            S: UniversalReadExt + 'static,
+            Fs: UniversalReadFs<File = S>,
+            TInvertedIndex: InvertedIndexReadOnly<S>,
+        {
             Ok(Box::new(ReadOnlySparseVectorIndex::open(args)?))
         }
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use common::storage_version::StorageVersion as _;
-use common::universal_io::CachedReadFs;
+use common::universal_io::UniversalReadFs;
 use sparse::SearchScratchPool;
 use sparse::index::inverted_index::{InvertedIndex, InvertedIndexReadOnly};
 
@@ -55,8 +55,9 @@ type ReadView<'a, S, TInvertedIndex> = SparseVectorIndexReadView<
     TInvertedIndex,
 >;
 
-pub struct ReadOnlySparseVectorIndexOpenArgs<'a, S: UniversalReadExt> {
-    pub fs: &'a CachedReadFs<S::Fs>,
+pub struct ReadOnlySparseVectorIndexOpenArgs<'a, S: UniversalReadExt, Fs: UniversalReadFs<File = S>>
+{
+    pub fs: &'a Fs,
     pub config: SparseIndexConfig,
     pub id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
     pub vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
@@ -68,7 +69,9 @@ impl<S: UniversalReadExt, TInvertedIndex: InvertedIndex>
     ReadOnlySparseVectorIndex<S, TInvertedIndex>
 {
     /// Similar to [`super::SparseVectorIndex::open`].
-    pub fn open(args: ReadOnlySparseVectorIndexOpenArgs<S>) -> OperationResult<Self>
+    pub fn open<Fs: UniversalReadFs<File = S>>(
+        args: ReadOnlySparseVectorIndexOpenArgs<S, Fs>,
+    ) -> OperationResult<Self>
     where
         TInvertedIndex: InvertedIndexReadOnly<S>,
     {
@@ -81,7 +84,7 @@ impl<S: UniversalReadExt, TInvertedIndex: InvertedIndex>
             path,
         } = args;
 
-        let inverted_index = TInvertedIndex::open_ro::<S>(fs, path)?;
+        let inverted_index = TInvertedIndex::open_ro(fs, path)?;
 
         let stored_version = TInvertedIndex::Version::load_universal(fs, path)?;
         if stored_version != Some(TInvertedIndex::Version::current()) {

--- a/lib/segment/src/index/struct_payload_index/read_only/config_reload.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/config_reload.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::universal_io::CachedReadFs;
+use common::universal_io::UniversalReadFs;
 
 use super::{ReadOnlyIndexesMap, ReadOnlyStructPayloadIndex};
 use crate::common::operation_error::OperationResult;
@@ -52,7 +52,7 @@ impl<S: UniversalReadExt> ReadOnlyStructPayloadIndex<S> {
     /// entry on apply.
     pub fn config_reload_diff(
         &self,
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         new_config: PayloadConfig,
     ) -> OperationResult<PayloadIndexReloadDiff<S>> {
         let mut added: ReadOnlyIndexesMap<S> = HashMap::new();

--- a/lib/segment/src/index/struct_payload_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/lifecycle.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::universal_io::CachedReadFs;
+use common::universal_io::UniversalReadFs;
 
 use super::{ReadOnlyIndexesMap, ReadOnlyStructPayloadIndex};
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -20,7 +20,7 @@ impl<S: UniversalReadExt> ReadOnlyStructPayloadIndex<S> {
     /// Read-only mirror of `StructPayloadIndex::open`: loads the payload config
     /// and each persisted field index through `fs` (never builds/migrates/writes).
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         payload: Arc<AtomicRefCell<ReadOnlyPayloadStorage<S>>>,
         id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
         vector_storages: HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageReadEnum<S>>>>,

--- a/lib/segment/src/payload_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/payload_storage/read_only/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use common::universal_io::{CachedReadFs, Populate, UniversalRead};
+use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
 use gridstore::GridstoreReader;
 
 use super::ReadOnlyPayloadStorage;
@@ -14,7 +14,7 @@ impl<S: UniversalRead> ReadOnlyPayloadStorage<S> {
     ///
     /// [1]: crate::payload_storage::payload_storage_impl::PayloadStorageImpl::open_or_create
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: PathBuf,
         populate: Populate,
     ) -> OperationResult<Self> {

--- a/lib/segment/src/payload_storage/read_only/mod.rs
+++ b/lib/segment/src/payload_storage/read_only/mod.rs
@@ -61,12 +61,8 @@ mod tests {
         // read-only.
         type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
         let fs = RoFs::from_context(Default::default()).unwrap();
-        let storage: ReadOnlyPayloadStorage<ReadOnly<MmapFile>> = ReadOnlyPayloadStorage::open(
-            &common::universal_io::CachedReadFs::new(fs, std::path::Path::new(".")).unwrap(),
-            dir.path().to_path_buf(),
-            populate,
-        )
-        .unwrap();
+        let storage: ReadOnlyPayloadStorage<ReadOnly<MmapFile>> =
+            ReadOnlyPayloadStorage::open(&fs, dir.path().to_path_buf(), populate).unwrap();
 
         assert_eq!(storage.is_on_disk(), !populate.to_bool::<MmapFile>());
         for i in 0..5 {

--- a/lib/segment/src/segment/read_only/config_reload.rs
+++ b/lib/segment/src/segment/read_only/config_reload.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use common::storage_version::StorageVersion;
-use common::universal_io::{CachedReadFs, read_json_via};
+use common::universal_io::{UniversalReadFs, read_json_via};
 
 use super::{ReadOnlySegment, ReadOnlyVectorData};
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -90,14 +90,11 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     /// Covers added/removed dense vectors, sparse vectors and payload field
     /// indexes. Vectors whose config changed are reloaded (drop + load).
     pub fn config_reload_diff(&self, fs: &S::Fs) -> OperationResult<SegmentConfigReloadDiff<S>> {
-        // Component opens go through a `CachedReadFs`; snapshot-less it is a
-        // passthrough to the raw backend — per-reload snapshots/prefetch are
-        // a later iteration.
-        let cached_fs = CachedReadFs::new(fs.clone(), &self.segment_path)?;
-
+        // Component opens go straight to the raw backend — per-reload
+        // caching/prefetch is a later iteration.
         let new_config = self.read_new_config(fs)?;
-        let (added_vectors, removed_vectors) = self.diff_vectors(&cached_fs, &new_config)?;
-        let payload = self.diff_payload(&cached_fs)?;
+        let (added_vectors, removed_vectors) = self.diff_vectors(fs, &new_config)?;
+        let payload = self.diff_payload(fs)?;
 
         Ok(SegmentConfigReloadDiff {
             new_config,
@@ -129,7 +126,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     /// loading every new or changed vector. Returns `(added, removed)`.
     fn diff_vectors(
         &self,
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         new_config: &SegmentConfig,
     ) -> OperationResult<(AddedVectors<S>, Vec<VectorNameBuf>)> {
         let mut added = HashMap::new();
@@ -160,7 +157,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     /// Open one dense vector's storage, index and quantized vectors from disk.
     fn load_dense_vector(
         &self,
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         name: &VectorName,
         config: &VectorDataConfig,
         new_config: &SegmentConfig,
@@ -187,7 +184,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     /// Open one sparse vector's storage and index from disk (never quantized).
     fn load_sparse_vector(
         &self,
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         name: &VectorName,
     ) -> OperationResult<ReadOnlyVectorData<S>> {
         let path = get_vector_storage_path(&self.segment_path, name);
@@ -206,7 +203,10 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
 
     /// Load the payload field-index diff (delegates to the payload index, which
     /// loads its own new/changed field indexes under a shared borrow).
-    fn diff_payload(&self, fs: &CachedReadFs<S::Fs>) -> OperationResult<PayloadIndexReloadDiff<S>> {
+    fn diff_payload(
+        &self,
+        fs: &impl UniversalReadFs<File = S>,
+    ) -> OperationResult<PayloadIndexReloadDiff<S>> {
         let payload_index_path = get_payload_index_path(&self.segment_path);
         let payload_config_path = PayloadConfig::get_config_path(&payload_index_path);
         let new_payload_config = PayloadConfig::load_universal(fs, &payload_config_path)?

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 use common::storage_version::{StorageVersion, VERSION_FILE};
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, OkNotFound, Populate, UniversalReadFs, read_json_via};
+use common::universal_io::{
+    CachedFs, CachedReadFs, OkNotFound, Populate, UniversalReadFs, read_json_via,
+};
 use uuid::Uuid;
 
 use super::{ReadOnlySegment, ReadOnlyVectorData};
@@ -69,18 +71,20 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         deferred_internal_id: Option<PointOffsetType>,
     ) -> OperationResult<Self> {
         let cached_fs = build_cached_fs(fs, segment_path)?;
-        Self::open_via(&cached_fs, segment_path, uuid, deferred_internal_id)
+        Self::open_via(&cached_fs, fs, segment_path, uuid, deferred_internal_id)
     }
 
     /// Read-only mirror of `load_segment`: assembles every read-only component
     /// from `fs` (id tracker, payload storage+index, per-vector storage/index). No writes.
     ///
-    /// Stored handles are taken from the [`CachedReadFs`] pool via
-    /// [`CachedReadFs::take_file`], so component types stay over plain `S`;
-    /// transient reads (state/config JSON) go through its `UniversalReadFs`
-    /// impl and never leak the wrapper.
+    /// `fs` is any filesystem producing `S`-typed handles — in production the
+    /// per-segment [`CachedReadFs`], whose opens are served from its prefetch
+    /// pool. `raw_fs` is the canonical backend, for the one component that
+    /// stores a filesystem handle to re-open appended files later (the
+    /// appendable id tracker): a caching wrapper's snapshot would go stale.
     pub(crate) fn open_via(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
+        raw_fs: &S::Fs,
         segment_path: &Path,
         uuid: Uuid,
         deferred_internal_id: Option<PointOffsetType>,
@@ -115,6 +119,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         // per-file `exists` round-trips — important for object-storage backends).
         let id_tracker = Arc::new(AtomicRefCell::new(ReadOnlyIdTrackerEnum::detect_and_load(
             fs,
+            raw_fs,
             segment_path,
             deferred_internal_id,
         )?));
@@ -203,7 +208,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlyVectorData<S> {
     /// `open_dense_vector_data`. No `prefill`: read-only never writes.
     #[allow(clippy::too_many_arguments)]
     pub(super) fn open_dense(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         segment_path: &Path,
         vector_name: &VectorName,
         vector_config: &VectorDataConfig,
@@ -255,7 +260,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlyVectorData<S> {
     /// Open one sparse vector's index over `fs`, mirroring
     /// `open_sparse_vector_data`. Sparse vectors are never quantized.
     pub(super) fn open_sparse(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         segment_path: &Path,
         vector_name: &VectorName,
         id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,

--- a/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use ahash::AHashMap;
 use common::mmap::{AdviceSetting, MULTI_MMAP_IS_SUPPORTED, create_and_ensure_length};
 use common::universal_io::{
-    CachedReadFs, OpenOptions, Populate, TypedStorage, UniversalIoError, UniversalRead,
-    UniversalReadFileOps, UniversalWrite,
+    OpenOptions, Populate, TypedStorage, UniversalIoError, UniversalRead, UniversalReadFs,
+    UniversalWrite,
 };
 
 use super::config::{MMAP_CHUNKS_PATTERN_END, MMAP_CHUNKS_PATTERN_START};
@@ -19,7 +19,7 @@ fn check_mmap_file_name_pattern(file_name: &str) -> Option<usize> {
 }
 
 pub fn read_chunks<T: bytemuck::Pod + Send, S: UniversalRead>(
-    fs: &S::Fs,
+    fs: &impl UniversalReadFs<File = S>,
     directory: &Path,
     advice: AdviceSetting,
     populate: Populate,
@@ -28,58 +28,9 @@ pub fn read_chunks<T: bytemuck::Pod + Send, S: UniversalRead>(
     read_chunks_from(fs, directory, 0, advice, populate, writeable)
 }
 
-/// Read-only [`read_chunks`] taking chunk handles from a [`CachedReadFs`]
-/// prefetch pool. Listing goes through the trait so a snapshot-less
-/// (passthrough) wrapper behaves like the plain variant.
-pub fn read_chunks_cached<T: bytemuck::Pod + Send, S: UniversalRead>(
-    fs: &CachedReadFs<S::Fs>,
-    directory: &Path,
-    advice: AdviceSetting,
-    populate: Populate,
-) -> Result<Vec<TypedStorage<S, T>>, UniversalIoError> {
-    let chunks_prefix = directory.join(MMAP_CHUNKS_PATTERN_START);
-    let mut chunks_files: AHashMap<usize, _> = AHashMap::new();
-    for listed in UniversalReadFileOps::list_files(fs, &chunks_prefix)? {
-        let path = listed.path;
-        let chunk_id = path
-            .file_name()
-            .and_then(|file_name| file_name.to_str())
-            .and_then(check_mmap_file_name_pattern);
-
-        if let Some(chunk_id) = chunk_id {
-            chunks_files.insert(chunk_id, path);
-        }
-    }
-
-    let num_chunks = chunks_files.len();
-    let mut result = Vec::with_capacity(num_chunks);
-    for chunk_id in 0..num_chunks {
-        let chunk_path = chunks_files.remove(&chunk_id).ok_or_else(|| {
-            UniversalIoError::Io(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("Missing chunk {chunk_id} in {}", directory.display(),),
-            ))
-        })?;
-
-        let chunk = TypedStorage::new(fs.take_file(
-            &chunk_path,
-            OpenOptions {
-                writeable: false,
-                need_sequential: *MULTI_MMAP_IS_SUPPORTED,
-                populate,
-                advice,
-            },
-            Default::default(),
-        )?);
-
-        result.push(chunk);
-    }
-    Ok(result)
-}
-
 /// Open chunk files with id `>= start_chunk_id`, in ascending order.
 pub fn read_chunks_from<T: bytemuck::Pod + Send, S: UniversalRead>(
-    fs: &S::Fs,
+    fs: &impl UniversalReadFs<File = S>,
     directory: &Path,
     start_chunk_id: usize,
     advice: AdviceSetting,

--- a/lib/segment/src/vector_storage/chunked_vectors/read.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read.rs
@@ -7,12 +7,12 @@ use common::maybe_uninit::maybe_uninit_fill_from;
 use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, Populate, ReadPipeline, ReadRange, TypedStorage, UniversalIoError, UniversalRead,
+    Populate, ReadPipeline, ReadRange, TypedStorage, UniversalIoError, UniversalRead,
     UniversalReadFs, UserData, read_json_via, read_whole_via,
 };
 use num_traits::AsPrimitive;
 
-use super::chunks::{chunk_name, read_chunks_cached};
+use super::chunks::{chunk_name, read_chunks};
 use super::config::{CONFIG_FILE_NAME, ChunkedVectorsConfig, STATUS_FILE_NAME};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::vector_storage::common::{PAGE_SIZE_BYTES, VECTOR_READ_BATCH_SIZE};
@@ -64,7 +64,7 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
     /// Both `config.json` and `status.dat` must already exist; this function
     /// will not create them.
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         directory: &Path,
         dim: usize,
         advice: AdviceSetting,
@@ -86,7 +86,7 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
         }
 
         let len = read_status_len(fs, &Self::status_file(directory))?;
-        let chunks = read_chunks_cached(fs, directory, advice, populate)?;
+        let chunks = read_chunks(fs, directory, advice, populate, false)?;
 
         Ok(Self {
             config,
@@ -403,7 +403,7 @@ mod tests {
         writer.flusher()().unwrap();
 
         let mut reader = ChunkedVectorsRead::<f32, MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+            &MmapFs,
             dir.path(),
             DIM,
             AdviceSetting::Global,
@@ -453,7 +453,7 @@ mod tests {
         writer.flusher()().unwrap();
 
         let mut reader = ChunkedVectorsRead::<f32, MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+            &MmapFs,
             dir.path(),
             DIM,
             AdviceSetting::Global,

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -13,7 +13,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::mmap;
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, MmapFile, MmapFs, Populate, UniversalRead};
+use common::universal_io::{MmapFile, MmapFs, Populate, UniversalRead};
 use fs_err::{File, OpenOptions};
 
 use crate::common::Flusher;
@@ -201,10 +201,8 @@ where
     let vectors_path = path.join(VECTORS_PATH);
     let deleted_path = path.join(DELETED_PATH);
 
-    // `ImmutableDenseVectors::open` takes a `CachedReadFs`; snapshot-less it
-    // is a passthrough to the raw backend.
     let vectors = ImmutableDenseVectors::open(
-        &CachedReadFs::new(fs.clone(), path)?,
+        &fs,
         &vectors_path,
         &deleted_path,
         dim,
@@ -290,7 +288,7 @@ where
 
         // Load store with updated files
         self.vectors.replace(ImmutableDenseVectors::open(
-            &CachedReadFs::new(self.fs.clone(), &self.vectors_path)?,
+            &self.fs,
             &self.vectors_path,
             &self.deleted_path,
             dim,

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -11,8 +11,8 @@ use common::mmap;
 use common::mmap::{AdviceSetting, MmapBitSlice, MmapFlusher};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFile, OpenOptions as UniversalOpenOptions, Populate, ReadOnly, ReadRange,
-    TypedStorage, UniversalRead,
+    MmapFile, OpenOptions as UniversalOpenOptions, Populate, ReadOnly, ReadRange, TypedStorage,
+    UniversalRead, UniversalReadFs,
 };
 use fs_err::{File, OpenOptions};
 
@@ -45,7 +45,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectorData<T, S>
     /// Open the immutable vector blob read-only through `fs`. The file must
     /// already exist (the writer creates it); nothing is created here.
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         vectors_path: &Path,
         dim: usize,
         populate: Populate,
@@ -57,7 +57,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectorData<T, S>
             advice: AdviceSetting::Global,
         };
         let read_only = fs
-            .take_file(vectors_path, options, Default::default())
+            .open(vectors_path, options, Default::default())
             .map(ReadOnly::from_file)
             .map_err(|e| {
                 crate::common::operation_error::OperationError::service_error(format!(
@@ -224,7 +224,7 @@ where
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectors<T, S> {
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         vectors_path: &Path,
         deleted_path: &Path,
         dim: usize,

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/lifecycle.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/lifecycle.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use common::bitvec::BitVec;
 use common::mmap::AdviceSetting;
 use common::stored_bitslice::StoredBitSlice;
-use common::universal_io::{CachedReadFs, OpenOptions, Populate, UniversalRead};
+use common::universal_io::{OpenOptions, Populate, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyImmutableDenseVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
@@ -28,7 +28,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyImmutableDenseVectorSt
     /// threading every file open through `fs`; reads the existing layout but
     /// creates and writes nothing. `populate` warms the vector data.
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         dim: usize,
         distance: Distance,
@@ -51,11 +51,11 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyImmutableDenseVectorSt
 /// followed by the deletion `BitSlice`; the leading header bits are dropped and
 /// `num_vectors` deletion flags are kept.
 fn open_deleted_flags<S: UniversalRead>(
-    fs: &CachedReadFs<S::Fs>,
+    fs: &impl UniversalReadFs<File = S>,
     deleted_path: &Path,
     num_vectors: usize,
 ) -> OperationResult<InMemoryBitvecFlags> {
-    let stored = StoredBitSlice::<S>::from_file(fs.take_file(
+    let stored = StoredBitSlice::<S>::from_file(fs.open(
         deleted_path,
         READ_ONLY_OPTIONS,
         Default::default(),

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/mod.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/mod.rs
@@ -84,7 +84,7 @@ mod tests {
         }
 
         let storage = ReadOnlyImmutableDenseVectorStorage::<VectorElementType, MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+            &MmapFs,
             dir.path(),
             DIM,
             Distance::Dot,
@@ -137,7 +137,7 @@ mod tests {
         }
 
         let mut reader = ReadOnlyImmutableDenseVectorStorage::<VectorElementType, MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+            &MmapFs,
             dir.path(),
             DIM,
             Distance::Dot,

--- a/lib/segment/src/vector_storage/dense/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use common::mmap::AdviceSetting;
-use common::universal_io::{CachedReadFs, Populate, UniversalRead};
+use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyChunkedDenseVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
@@ -19,7 +19,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedDenseVectorStor
     /// creates and writes nothing. `populate` warms the vector chunks.
     #[allow(dead_code)] // pending: read-only vector storage enum will use this
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         dim: usize,
         distance: Distance,

--- a/lib/segment/src/vector_storage/dense/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/mod.rs
@@ -82,7 +82,7 @@ mod tests {
         }
 
         let storage = ReadOnlyChunkedDenseVectorStorage::<VectorElementType, MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+            &MmapFs,
             dir.path(),
             DIM,
             Distance::Dot,
@@ -139,7 +139,7 @@ mod tests {
         writer.flusher()().unwrap();
 
         let mut reader = ReadOnlyChunkedDenseVectorStorage::<VectorElementType, MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+            &MmapFs,
             dir.path(),
             DIM,
             Distance::Dot,

--- a/lib/segment/src/vector_storage/multi_dense/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use common::mmap::AdviceSetting;
-use common::universal_io::{CachedReadFs, Populate, UniversalRead};
+use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
@@ -20,7 +20,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedMultiDenseVecto
     /// chunks.
     #[allow(dead_code)] // pending: read-only vector storage enum will use this
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         dim: usize,
         distance: Distance,

--- a/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/mod.rs
@@ -136,7 +136,7 @@ mod tests {
         }
 
         let storage = ReadOnlyChunkedMultiDenseVectorStorage::<VectorElementType, MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+            &MmapFs,
             dir.path(),
             DIM,
             Distance::Dot,
@@ -205,8 +205,7 @@ mod tests {
 
         let mut reader =
             ReadOnlyChunkedMultiDenseVectorStorage::<VectorElementType, MmapFile>::open(
-                &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new("."))
-                    .unwrap(),
+                &MmapFs,
                 dir.path(),
                 DIM,
                 Distance::Dot,

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_only.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_only.rs
@@ -5,7 +5,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::mmap::{AdviceSetting, MmapFlusher};
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, Populate, UniversalRead};
+use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
 
 use crate::common::operation_error::OperationResult;
 use crate::vector_storage::VectorOffsetType;
@@ -23,7 +23,7 @@ pub struct QuantizedChunkedStorageRead<S: UniversalRead> {
 
 impl<S: UniversalRead> QuantizedChunkedStorageRead<S> {
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         quantized_vector_size: usize,
     ) -> OperationResult<Self> {

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
@@ -6,8 +6,8 @@ use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting, MmapFlusher, MmapSlice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFile, MmapFs, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead,
-    UniversalWrite,
+    MmapFile, MmapFs, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead,
+    UniversalReadFs, UniversalWrite,
 };
 use fs_err as fs;
 use memmap2::MmapMut;
@@ -50,8 +50,11 @@ impl MultivectorOffsetsStorageRam {
     /// performing no writes.
     ///
     /// Read-only counterpart of [`Self::load`] used by read-only storages.
-    pub fn open<S: UniversalRead>(fs: &CachedReadFs<S::Fs>, path: &Path) -> OperationResult<Self> {
-        let offsets = TypedStorage::<S, MultivectorOffset>::new(fs.take_file(
+    pub fn open<S: UniversalRead>(
+        fs: &impl UniversalReadFs<File = S>,
+        path: &Path,
+    ) -> OperationResult<Self> {
+        let offsets = TypedStorage::<S, MultivectorOffset>::new(fs.open(
             path,
             OpenOptions {
                 writeable: false,
@@ -138,7 +141,7 @@ impl MultivectorOffsetsStorageMmap<MmapFile> {
     }
 
     pub fn load(path: &Path) -> OperationResult<Self> {
-        Self::open(&CachedReadFs::new(MmapFs, path)?, path)
+        Self::open(&MmapFs, path)
     }
 }
 
@@ -146,8 +149,8 @@ impl<S: UniversalRead> MultivectorOffsetsStorageMmap<S> {
     /// Open the offsets file read-only through the provided [`UniversalRead`] filesystem.
     ///
     /// Performs no writes, making this the entry point used by read-only storages.
-    pub fn open(fs: &CachedReadFs<S::Fs>, path: &Path) -> OperationResult<Self> {
-        let offsets = TypedStorage::<S, MultivectorOffset>::new(fs.take_file(
+    pub fn open(fs: &impl UniversalReadFs<File = S>, path: &Path) -> OperationResult<Self> {
+        let offsets = TypedStorage::<S, MultivectorOffset>::new(fs.open(
             path,
             OpenOptions {
                 writeable: false,
@@ -372,7 +375,7 @@ pub struct MultivectorOffsetsStorageChunkedRead<S: UniversalRead> {
 }
 
 impl<S: UniversalRead> MultivectorOffsetsStorageChunkedRead<S> {
-    pub fn open(fs: &CachedReadFs<S::Fs>, path: &Path) -> OperationResult<Self> {
+    pub fn open(fs: &impl UniversalReadFs<File = S>, path: &Path) -> OperationResult<Self> {
         let data = ChunkedVectorsRead::open(
             fs,
             path,

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap::{Advice, AdviceSetting, MmapFlusher};
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, OneshotFile, OpenOptions, Populate, UniversalRead};
+use common::universal_io::{OneshotFile, OpenOptions, Populate, UniversalRead, UniversalReadFs};
 use fs_err as fs;
 use fs_err::File;
 
@@ -28,7 +28,7 @@ impl QuantizedRamStorage {
     /// object storage, …) and evicted from the RAM/page cache afterwards via
     /// [`OneshotFile`], since we keep our own heap copy.
     pub fn from_file<S: UniversalRead>(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         quantized_vector_size: usize,
     ) -> OperationResult<Self> {
@@ -38,7 +38,7 @@ impl QuantizedRamStorage {
             ));
         }
 
-        let storage = OneshotFile::new(fs.take_file(
+        let storage = OneshotFile::new(fs.open(
             path,
             OpenOptions {
                 writeable: false,
@@ -189,12 +189,7 @@ mod tests {
         let path = dir.path().join("quantized.bin");
         fs::write(&path, [1, 2, 3, 4]).unwrap();
 
-        let err = QuantizedRamStorage::from_file::<MmapFile>(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-            &path,
-            0,
-        )
-        .unwrap_err();
+        let err = QuantizedRamStorage::from_file::<MmapFile>(&MmapFs, &path, 0).unwrap_err();
 
         assert!(matches!(
             err,
@@ -209,12 +204,7 @@ mod tests {
         let path = dir.path().join("quantized.bin");
         fs::write(&path, [1, 2, 3, 4, 5]).unwrap();
 
-        let err = QuantizedRamStorage::from_file::<MmapFile>(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-            &path,
-            2,
-        )
-        .unwrap_err();
+        let err = QuantizedRamStorage::from_file::<MmapFile>(&MmapFs, &path, 2).unwrap_err();
 
         assert!(matches!(
             err,
@@ -231,12 +221,7 @@ mod tests {
         let path = dir.path().join("quantized.bin");
         fs::write(&path, [1, 2, 3, 4]).unwrap();
 
-        let storage = QuantizedRamStorage::from_file::<MmapFile>(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-            &path,
-            2,
-        )
-        .unwrap();
+        let storage = QuantizedRamStorage::from_file::<MmapFile>(&MmapFs, &path, 2).unwrap();
 
         assert_eq!(storage.vectors_count(), 2);
         assert_eq!(storage.get_vector_data(0).as_ref(), [1, 2]);

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -9,7 +9,7 @@ use common::generic_consts::Random;
 use common::mmap::{AdviceSetting, MmapFlusher, advice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFile, MmapFs, OpenOptions, Populate, ReadOnly, ReadRange, UniversalRead,
+    MmapFile, MmapFs, OpenOptions, Populate, ReadOnly, ReadRange, UniversalRead, UniversalReadFs,
 };
 use fs_err as fs;
 use memmap2::MmapMut;
@@ -51,11 +51,7 @@ impl QuantizedStorage<MmapFile> {
     /// Re-mmap after the file grew so reads observe appended vectors. Build-time only.
     pub(crate) fn reload(&mut self) -> OperationResult<()> {
         let path = self.path.clone();
-        *self = Self::from_file(
-            &CachedReadFs::new(MmapFs, &path)?,
-            &path,
-            self.quantized_vector_size.get(),
-        )?;
+        *self = Self::from_file(&MmapFs, &path, self.quantized_vector_size.get())?;
         Ok(())
     }
 }
@@ -84,12 +80,12 @@ impl<S: UniversalRead> QuantizedStorage<S> {
     }
 
     pub fn from_file(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         quantized_vector_size: usize,
     ) -> OperationResult<QuantizedStorage<S>> {
         let storage =
-            ReadOnly::from_file(fs.take_file(path, Self::open_options(), Default::default())?);
+            ReadOnly::from_file(fs.open(path, Self::open_options(), Default::default())?);
 
         let quantized_vector_size = NonZeroUsize::new(quantized_vector_size).ok_or_else(|| {
             std::io::Error::new(
@@ -129,11 +125,7 @@ impl<S: UniversalRead> QuantizedStorage<S> {
             .truncate(false)
             .open(path)?;
 
-        let storage = Self::from_file(
-            &CachedReadFs::new(fs.clone(), path)?,
-            path,
-            quantized_vector_size,
-        )?;
+        let storage = Self::from_file(fs, path, quantized_vector_size)?;
 
         if prefault {
             storage.populate();
@@ -207,21 +199,14 @@ impl<S: UniversalRead> quantization::EncodedStorage for QuantizedStorage<S> {
     }
 }
 
-impl<S: UniversalRead<Fs = common::universal_io::MmapFs>> quantization::EncodedStorageBuilder
-    for QuantizedStorageBuilder<S>
-{
-    type Storage = QuantizedStorage<S>;
+impl quantization::EncodedStorageBuilder for QuantizedStorageBuilder<MmapFile> {
+    type Storage = QuantizedStorage<MmapFile>;
     type Error = OperationError;
 
-    fn build(self) -> OperationResult<QuantizedStorage<S>> {
+    fn build(self) -> OperationResult<QuantizedStorage<MmapFile>> {
         self.mmap.flush()?;
 
-        let storage = ReadOnly::open(
-            &common::universal_io::MmapFs,
-            &self.path,
-            Self::Storage::open_options(),
-            (),
-        )?;
+        let storage = ReadOnly::open(&MmapFs, &self.path, Self::Storage::open_options(), ())?;
 
         Ok(QuantizedStorage {
             storage,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/load.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/load.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 use std::sync::atomic::AtomicBool;
 
 use common::fs::read_json;
-use common::universal_io::CachedReadFs;
 use quantization::EncodedVectorsPQ;
 use quantization::encoded_vectors_binary::EncodedVectorsBin;
 use quantization::encoded_vectors_tq::EncodedVectorsTQ;
@@ -113,12 +112,9 @@ impl QuantizedVectors {
         let in_ram = config.is_ram(on_disk_vector_storage);
 
         // Open the flat (RAM / mmap) or appendable chunked storage selected for this config.
-        // `from_file` takes a `CachedReadFs`; snapshot-less it is a passthrough
-        // to the raw backend.
-        let read_fs = CachedReadFs::new(READ_FS, data_path.as_path())?;
         let ram =
-            || QuantizedRamStorage::from_file::<ReadFile>(&read_fs, data_path.as_path(), size);
-        let mmap = || QuantizedStorage::from_file(&read_fs, data_path.as_path(), size);
+            || QuantizedRamStorage::from_file::<ReadFile>(&READ_FS, data_path.as_path(), size);
+        let mmap = || QuantizedStorage::from_file(&READ_FS, data_path.as_path(), size);
         let chunked =
             || QuantizedChunkedStorage::<ReadFile>::new(READ_FS, data_path.as_path(), size, in_ram);
 
@@ -173,12 +169,9 @@ impl QuantizedVectors {
 
         // Open the inner quantized storage and the matching offsets storage for the
         // selected backend.
-        // `from_file` takes a `CachedReadFs`; snapshot-less it is a passthrough
-        // to the raw backend.
-        let read_fs = CachedReadFs::new(READ_FS, data_path.as_path())?;
         let ram =
-            || QuantizedRamStorage::from_file::<ReadFile>(&read_fs, data_path.as_path(), size);
-        let mmap = || QuantizedStorage::from_file(&read_fs, data_path.as_path(), size);
+            || QuantizedRamStorage::from_file::<ReadFile>(&READ_FS, data_path.as_path(), size);
+        let mmap = || QuantizedStorage::from_file(&READ_FS, data_path.as_path(), size);
         let chunked =
             || QuantizedChunkedStorage::<ReadFile>::new(READ_FS, data_path.as_path(), size, in_ram);
         let ram_offsets = || MultivectorOffsetsStorageRam::load(&offsets_path);

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use common::universal_io::{CachedReadFs, OkNotFound, UniversalRead, read_json_via};
+use common::universal_io::{OkNotFound, UniversalRead, UniversalReadFs, read_json_via};
 use quantization::EncodedVectorsPQ;
 use quantization::encoded_vectors_binary::EncodedVectorsBin;
 use quantization::encoded_vectors_tq::EncodedVectorsTQ;
@@ -34,7 +34,7 @@ impl<S: UniversalRead> ReadOnlyQuantizedVectors<S> {
     /// `distance`, `datatype`, `multivector_config` and `on_disk_vector_storage` describe
     /// the original (source) vector storage this quantization was built for.
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         distance: Distance,
         datatype: VectorStorageDatatype,
@@ -69,7 +69,7 @@ impl<S: UniversalRead> ReadOnlyQuantizedVectors<S> {
     }
 
     fn open_single(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         config: &QuantizedVectorsConfig,
         on_disk_vector_storage: bool,
@@ -119,7 +119,7 @@ impl<S: UniversalRead> ReadOnlyQuantizedVectors<S> {
     }
 
     fn open_multi(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         path: &Path,
         config: &QuantizedVectorsConfig,
         multivector_config: &MultiVectorConfig,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
@@ -124,7 +124,7 @@ fn read_only_matches_read_write(
     .unwrap();
 
     let ro = ReadOnlyQuantizedVectors::<MmapFile>::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+        &MmapFs,
         quant_dir.path(),
         storage.distance(),
         storage.datatype(),
@@ -206,7 +206,7 @@ fn read_only_matches_read_write_multivector(
     .unwrap();
 
     let ro = ReadOnlyQuantizedVectors::<MmapFile>::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+        &MmapFs,
         quant_dir.path(),
         storage.distance(),
         storage.datatype(),
@@ -289,7 +289,7 @@ fn live_reload_chunked_preserves_scores() {
     .unwrap();
 
     let mut ro = ReadOnlyQuantizedVectors::<MmapFile>::open(
-        &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+        &MmapFs,
         quant_dir.path(),
         storage.distance(),
         storage.datatype(),

--- a/lib/segment/src/vector_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use common::mmap::{Advice, AdviceSetting};
-use common::universal_io::{CachedReadFs, Populate, UniversalRead};
+use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
 
 use super::VectorStorageReadEnum;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -16,7 +16,7 @@ impl<S: UniversalRead> VectorStorageReadEnum<S> {
     /// `VectorDataConfig`, mirroring `open_vector_storage`. Sparse storages are
     /// opened separately via `ReadOnlySparseVectorStorage::open`.
     pub fn open(
-        fs: &CachedReadFs<S::Fs>,
+        fs: &impl UniversalReadFs<File = S>,
         vector_config: &VectorDataConfig,
         path: &Path,
     ) -> OperationResult<Option<Self>> {

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -131,8 +131,7 @@ mod tests {
         let dir = Builder::new().prefix("disp_noop").tempdir().unwrap();
         for storage_type in [VectorStorageType::Memory, VectorStorageType::Empty] {
             let opened = VectorStorageReadEnum::<MmapFile>::open(
-                &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new("."))
-                    .unwrap(),
+                &MmapFs,
                 &dense_config(storage_type, None),
                 dir.path(),
             )
@@ -167,7 +166,7 @@ mod tests {
         }
 
         let storage = VectorStorageReadEnum::<MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+            &MmapFs,
             &dense_config(VectorStorageType::ChunkedMmap, None),
             dir.path(),
         )
@@ -208,7 +207,7 @@ mod tests {
         }
 
         let storage = VectorStorageReadEnum::<MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+            &MmapFs,
             &dense_config(VectorStorageType::Mmap, None),
             dir.path(),
         )
@@ -261,7 +260,7 @@ mod tests {
         }
 
         let storage = VectorStorageReadEnum::<MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+            &MmapFs,
             &dense_config(
                 VectorStorageType::ChunkedMmap,
                 Some(MultiVectorConfig::default()),
@@ -307,7 +306,7 @@ mod tests {
         writer.flusher()().unwrap();
 
         let mut storage = VectorStorageReadEnum::<MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
+            &MmapFs,
             &dense_config(VectorStorageType::ChunkedMmap, None),
             dir.path(),
         )

--- a/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use common::universal_io::{CachedReadFs, Populate, UniversalRead};
+use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
 use gridstore::GridstoreReader;
 
 use super::ReadOnlySparseVectorStorage;
@@ -15,7 +15,7 @@ impl<S: UniversalRead> ReadOnlySparseVectorStorage<S> {
     /// creates and writes nothing. `next_point_offset` is reconstructed like the
     /// writable storage on reopen: the highest deleted id or the Gridstore
     /// pointer count, whichever is larger.
-    pub fn open(fs: &CachedReadFs<S::Fs>, path: &Path) -> OperationResult<Self> {
+    pub fn open(fs: &impl UniversalReadFs<File = S>, path: &Path) -> OperationResult<Self> {
         // Sparse vector storage is not used during search
         let populate = Populate::No;
         let storage = GridstoreReader::<StoredSparseVector, S>::open(

--- a/lib/segment/src/vector_storage/sparse/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/mod.rs
@@ -69,11 +69,7 @@ mod tests {
             storage.flusher()().unwrap();
         }
 
-        let storage = ReadOnlySparseVectorStorage::<MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-            dir.path(),
-        )
-        .unwrap();
+        let storage = ReadOnlySparseVectorStorage::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
 
         assert_eq!(storage.total_vector_count(), POINT_COUNT as usize);
         assert_eq!(storage.distance(), SPARSE_VECTOR_DISTANCE);
@@ -124,11 +120,8 @@ mod tests {
         }
         writer.flusher()().unwrap();
 
-        let mut reader = ReadOnlySparseVectorStorage::<MmapFile>::open(
-            &common::universal_io::CachedReadFs::new(MmapFs, std::path::Path::new(".")).unwrap(),
-            dir.path(),
-        )
-        .unwrap();
+        let mut reader =
+            ReadOnlySparseVectorStorage::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
         assert_eq!(reader.total_vector_count(), first.len());
 
         for (offset, vector) in second.iter().enumerate() {

--- a/lib/sparse/benches/search.rs
+++ b/lib/sparse/benches/search.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, MmapFile, MmapFs};
+use common::universal_io::{MmapFile, MmapFs};
 use criterion::measurement::Measurement;
 use criterion::{Criterion, criterion_group, criterion_main};
 use dataset::Dataset;
@@ -156,22 +156,16 @@ pub fn run_bench(
 
             run_bench2(
                 c.benchmark_group(format!("search/ram_{}/{name}", $name)),
-                &InvertedIndexCompressedImmutableRam::<$type>::open_ro::<MmapFile>(
-                    &CachedReadFs::new(MmapFs, &index_path).unwrap(),
-                    &index_path,
-                )
-                .unwrap(),
+                &InvertedIndexCompressedImmutableRam::<$type>::open_ro(&MmapFs, &index_path)
+                    .unwrap(),
                 query_vectors,
                 &hottest_query_vectors,
             );
 
             run_bench2(
                 c.benchmark_group(format!("search/mmap_{}/{name}", $name)),
-                &InvertedIndexCompressedMmap::<$type, MmapFile>::open_ro(
-                    &CachedReadFs::new(MmapFs, &index_path).unwrap(),
-                    &index_path,
-                )
-                .unwrap(),
+                &InvertedIndexCompressedMmap::<$type, MmapFile>::open_ro(&MmapFs, &index_path)
+                    .unwrap(),
                 query_vectors,
                 &hottest_query_vectors,
             );

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
@@ -5,7 +5,9 @@ use blink_alloc::Blink;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::ext::VecExt;
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, MmapFs, Result, UniversalRead, UniversalWrite, UserData};
+use common::universal_io::{
+    MmapFs, Result, UniversalRead, UniversalReadFs, UniversalWrite, UserData,
+};
 
 use super::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
 use super::inverted_index_ram::InvertedIndexRam;
@@ -31,7 +33,7 @@ type Storage = common::universal_io::MmapFile;
 impl<W: Weight, S: UniversalRead + 'static> InvertedIndexReadOnly<S>
     for InvertedIndexCompressedImmutableRam<W>
 {
-    fn open_ro_impl(fs: &CachedReadFs<S::Fs>, path: &Path) -> Result<Self> {
+    fn open_ro_impl<Fs: UniversalReadFs<File = S>>(fs: &Fs, path: &Path) -> Result<Self> {
         let mmap_inverted_index = InvertedIndexCompressedMmap::<W, S>::open_ro(fs, path)?;
         Self::from_mmap_index(mmap_inverted_index)
     }
@@ -247,11 +249,8 @@ mod tests {
             .unwrap();
 
         let loaded_inverted_index =
-            InvertedIndexCompressedImmutableRam::<W>::open_ro::<common::universal_io::MmapFile>(
-                &CachedReadFs::new(MmapFs, tmp_dir_path.path()).unwrap(),
-                tmp_dir_path.path(),
-            )
-            .unwrap();
+            InvertedIndexCompressedImmutableRam::<W>::open_ro(&MmapFs, tmp_dir_path.path())
+                .unwrap();
         assert_eq!(inverted_index_immutable_ram, loaded_inverted_index);
     }
 }

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -16,8 +16,8 @@ use common::mmap::{transmute_to_u8, transmute_to_u8_slice};
 use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFs, OpenOptions, Populate, ReadBytesItem, Result, UniversalRead,
-    UniversalReadFs, UniversalWrite, UserData, read_json_via,
+    MmapFs, OpenOptions, Populate, ReadBytesItem, Result, UniversalRead, UniversalReadFs,
+    UniversalWrite, UserData, read_json_via,
 };
 use serde::{Deserialize, Serialize};
 use zerocopy::{FromBytes, Immutable, KnownLayout};
@@ -46,12 +46,12 @@ impl StorageVersion for Version {
 impl<W: Weight, S: UniversalRead + 'static> InvertedIndexReadOnly<S>
     for InvertedIndexCompressedMmap<W, S>
 {
-    fn open_ro_impl(fs: &CachedReadFs<S::Fs>, path: &Path) -> Result<Self> {
+    fn open_ro_impl<Fs: UniversalReadFs<File = S>>(fs: &Fs, path: &Path) -> Result<Self> {
         let file_header: InvertedIndexFileHeader =
             read_json_via(fs, Self::index_config_file_path(path))?;
 
-        let storage = fs.take_file(
-            &Self::index_file_path(path),
+        let storage = fs.open(
+            Self::index_file_path(path),
             OpenOptions {
                 writeable: false,
                 need_sequential: false,
@@ -622,11 +622,8 @@ mod tests {
 
             compare_indexes(&inverted_index_ram, &inverted_index_mmap);
         }
-        let index = InvertedIndexCompressedMmap::<W, MmapFile>::open_ro(
-            &CachedReadFs::new(MmapFs, tmp_dir_path.path()).unwrap(),
-            tmp_dir_path.path(),
-        )
-        .unwrap();
+        let index =
+            InvertedIndexCompressedMmap::<W, _>::open_ro(&MmapFs, tmp_dir_path.path()).unwrap();
         // posting_count: 0th entry is always empty + 1st + 2nd + 3rd + 4th empty + 5th
         assert_eq!(index.file_header.posting_count, 6);
         assert_eq!(index.file_header.vector_count, 9);

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -7,8 +7,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, Result, UniversalIoError, UniversalRead, UniversalReadFs, UniversalWrite,
-    UserData,
+    Result, UniversalIoError, UniversalRead, UniversalReadFs, UniversalWrite, UserData,
 };
 
 use super::posting_list_common::PostingListIter;
@@ -29,10 +28,7 @@ pub const INDEX_FILE_NAME: &str = "inverted_index.dat";
 
 pub trait InvertedIndexReadOnly<S: UniversalRead>: InvertedIndex {
     /// See [`InvertedIndex::open_ro`].
-    ///
-    /// Takes a [`CachedReadFs`] so stored handles come from its prefetch
-    /// pool (via `take_file`) and the index type stays over plain `S`.
-    fn open_ro_impl(fs: &CachedReadFs<S::Fs>, path: &Path) -> Result<Self>;
+    fn open_ro_impl<Fs: UniversalReadFs<File = S>>(fs: &Fs, path: &Path) -> Result<Self>;
 }
 
 pub trait InvertedIndexReadWrite<S: UniversalWrite>: InvertedIndex {
@@ -57,9 +53,9 @@ pub trait InvertedIndex: Sized + Debug + 'static {
     fn is_on_disk(&self) -> bool;
 
     /// Open existing index based on path.
-    fn open_ro<S: UniversalRead>(fs: &CachedReadFs<S::Fs>, path: &Path) -> Result<Self>
+    fn open_ro<Fs: UniversalReadFs>(fs: &Fs, path: &Path) -> Result<Self>
     where
-        Self: InvertedIndexReadOnly<S>,
+        Self: InvertedIndexReadOnly<Fs::File>,
     {
         Self::open_ro_impl(fs, path)
     }


### PR DESCRIPTION
This PR suggests to add an extension trait to mitigate the intrusiveness of adding a wrapper in #9712 

Essentially it changes 2 things:
- relaxes the `File`<->`Fs` strict relationship, so we can have this new `CachedFs` return some other inner `File`.
  ```rust
  pub trait UniversalReadFs: UniversalReadFileOps {
     // before, it was:
     // type File: UniversalRead<Fs = Self>
     // now:
     type File: UniversalRead;
  // ..
  }
  ```
- Introduces a new `CachedReadFs` extension trait.
   ```rust
    pub trait CachedReadFs: UniversalReadFs {
        fn cache_file_info(&mut self) -> Result<()>;
    
        fn schedule_prefetch(
            &self,
            path: &Path,
            open_arguments: Option<OpenOptions>,
            open_extra: Option<Self::OpenExtra>,
        ) -> Result<()>;
    }
    ```
