### PR TITLE
Bound request snapshots in the slow requests log

### DIFF
--- a/lib/collection/src/operations/loggable.rs
+++ b/lib/collection/src/operations/loggable.rs
@@ -10,6 +10,13 @@ use shard::scroll::ScrollRequestInternal;
 use crate::operations::types::PointRequestInternal;
 use crate::operations::universal_query::shard_query::ShardQueryRequest;
 
+/// Log entries are retained in memory indefinitely, so a snapshot must not keep
+/// unbounded request data alive. E.g. internally generated distance matrix
+/// queries carry `has_id` filters with sample² point ids in total, which blows
+/// up multi-fold when expanded into a JSON tree. Arrays longer than this are
+/// cut down to this many elements plus an omission marker.
+const MAX_LOGGED_ARRAY_LEN: usize = 64;
+
 pub trait Loggable {
     fn to_log_value(&self) -> serde_json::Value;
 
@@ -19,9 +26,41 @@ pub trait Loggable {
     fn request_hash(&self) -> u64;
 }
 
+/// Serialize a request for the slow-requests log, bounding all arrays.
+fn bounded_log_value<T: serde::Serialize>(request: &T) -> Value {
+    let mut value = serde_json::to_value(request).unwrap_or_default();
+    truncate_long_arrays(&mut value);
+    value
+}
+
+fn omission_marker(omitted: usize) -> Value {
+    Value::String(format!("... ({omitted} more items)"))
+}
+
+fn truncate_long_arrays(value: &mut Value) {
+    match value {
+        Value::Array(items) => {
+            if items.len() > MAX_LOGGED_ARRAY_LEN {
+                let omitted = items.len() - MAX_LOGGED_ARRAY_LEN;
+                items.truncate(MAX_LOGGED_ARRAY_LEN);
+                items.push(omission_marker(omitted));
+            }
+            for item in items.iter_mut() {
+                truncate_long_arrays(item);
+            }
+        }
+        Value::Object(map) => {
+            for (_key, item) in map.iter_mut() {
+                truncate_long_arrays(item);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
 impl Loggable for CollectionUpdateOperations {
     fn to_log_value(&self) -> Value {
-        serde_json::to_value(self).unwrap_or_default()
+        bounded_log_value(self)
     }
 
     fn request_name(&self) -> &'static str {
@@ -38,7 +77,19 @@ impl Loggable for CollectionUpdateOperations {
 
 impl Loggable for Vec<ShardQueryRequest> {
     fn to_log_value(&self) -> Value {
-        serde_json::to_value(self).unwrap_or_default()
+        // Serialize requests one by one, only up to the cap: serializing the
+        // whole batch at once would materialize the full JSON tree (gigabytes
+        // for internally generated matrix batches) before truncation could
+        // trim it.
+        let mut items: Vec<Value> = self
+            .iter()
+            .take(MAX_LOGGED_ARRAY_LEN)
+            .map(bounded_log_value)
+            .collect();
+        if self.len() > MAX_LOGGED_ARRAY_LEN {
+            items.push(omission_marker(self.len() - MAX_LOGGED_ARRAY_LEN));
+        }
+        Value::Array(items)
     }
 
     fn request_name(&self) -> &'static str {
@@ -55,7 +106,7 @@ impl Loggable for Vec<ShardQueryRequest> {
 
 impl Loggable for ScrollRequestInternal {
     fn to_log_value(&self) -> Value {
-        serde_json::to_value(self).unwrap_or_default()
+        bounded_log_value(self)
     }
 
     fn request_name(&self) -> &'static str {
@@ -86,7 +137,7 @@ impl<T: Loggable> Loggable for Arc<T> {
 
 impl Loggable for FacetParams {
     fn to_log_value(&self) -> Value {
-        serde_json::to_value(self).unwrap_or_default()
+        bounded_log_value(self)
     }
 
     fn request_name(&self) -> &'static str {
@@ -103,7 +154,7 @@ impl Loggable for FacetParams {
 
 impl Loggable for CountRequestInternal {
     fn to_log_value(&self) -> Value {
-        serde_json::to_value(self).unwrap_or_default()
+        bounded_log_value(self)
     }
 
     fn request_name(&self) -> &'static str {
@@ -120,7 +171,7 @@ impl Loggable for CountRequestInternal {
 
 impl Loggable for PointRequestInternal {
     fn to_log_value(&self) -> Value {
-        serde_json::to_value(self).unwrap_or_default()
+        bounded_log_value(self)
     }
 
     fn request_name(&self) -> &'static str {
@@ -132,5 +183,72 @@ impl Loggable for PointRequestInternal {
         self.request_name().hash(&mut hasher);
         self.hash(&mut hasher);
         hasher.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use segment::types::{Condition, Filter, HasIdCondition, WithPayloadInterface, WithVector};
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_truncate_long_arrays() {
+        let mut value = json!({
+            "short": [1, 2, 3],
+            "long": (0..MAX_LOGGED_ARRAY_LEN + 100).collect::<Vec<_>>(),
+            "nested": {
+                "long": [(0..MAX_LOGGED_ARRAY_LEN + 1).collect::<Vec<_>>()],
+            },
+        });
+
+        truncate_long_arrays(&mut value);
+
+        assert_eq!(value["short"], json!([1, 2, 3]));
+
+        let long = value["long"].as_array().unwrap();
+        assert_eq!(long.len(), MAX_LOGGED_ARRAY_LEN + 1);
+        assert_eq!(long[MAX_LOGGED_ARRAY_LEN], json!("... (100 more items)"));
+
+        let nested = value["nested"]["long"][0].as_array().unwrap();
+        assert_eq!(nested.len(), MAX_LOGGED_ARRAY_LEN + 1);
+        assert_eq!(nested[MAX_LOGGED_ARRAY_LEN], json!("... (1 more items)"));
+    }
+
+    #[test]
+    fn test_query_batch_log_value_is_bounded() {
+        // Mimics an internally generated distance matrix batch: many queries,
+        // each carrying a has_id filter with all sampled point ids.
+        let ids: ahash::AHashSet<_> = (0..MAX_LOGGED_ARRAY_LEN as u64 + 36)
+            .map(segment::types::PointIdType::from)
+            .collect();
+        let filter = Filter::new_must(Condition::HasId(HasIdCondition::from(ids)));
+
+        let request = ShardQueryRequest {
+            prefetches: vec![],
+            query: None,
+            filter: Some(filter),
+            score_threshold: None,
+            limit: 10,
+            offset: 0,
+            params: None,
+            with_vector: WithVector::Bool(false),
+            with_payload: WithPayloadInterface::Bool(false),
+        };
+        let batch = vec![request; MAX_LOGGED_ARRAY_LEN + 100];
+
+        let value = batch.to_log_value();
+
+        let queries = value.as_array().unwrap();
+        assert_eq!(queries.len(), MAX_LOGGED_ARRAY_LEN + 1);
+        assert_eq!(
+            queries[MAX_LOGGED_ARRAY_LEN],
+            json!("... (100 more items)"),
+        );
+
+        let has_id = queries[0]["filter"]["must"][0]["has_id"].as_array().unwrap();
+        assert_eq!(has_id.len(), MAX_LOGGED_ARRAY_LEN + 1);
+        assert_eq!(has_id[MAX_LOGGED_ARRAY_LEN], json!("... (36 more items)"));
     }
 }

--- a/lib/collection/src/operations/loggable.rs
+++ b/lib/collection/src/operations/loggable.rs
@@ -242,12 +242,11 @@ mod tests {
 
         let queries = value.as_array().unwrap();
         assert_eq!(queries.len(), MAX_LOGGED_ARRAY_LEN + 1);
-        assert_eq!(
-            queries[MAX_LOGGED_ARRAY_LEN],
-            json!("... (100 more items)"),
-        );
+        assert_eq!(queries[MAX_LOGGED_ARRAY_LEN], json!("... (100 more items)"));
 
-        let has_id = queries[0]["filter"]["must"][0]["has_id"].as_array().unwrap();
+        let has_id = queries[0]["filter"]["must"][0]["has_id"]
+            .as_array()
+            .unwrap();
         assert_eq!(has_id.len(), MAX_LOGGED_ARRAY_LEN + 1);
         assert_eq!(has_id[MAX_LOGGED_ARRAY_LEN], json!("... (36 more items)"));
     }


### PR DESCRIPTION
## Problem

`POST /collections/{name}/points/search/matrix/{offsets,pairs}` appeared to leak ~2GB of `active_bytes` per request on a small dataset, eventually dying by OOM killer.

It is not a leak in the matrix search itself: any local-shard read slower than 50ms gets its **internal** request snapshotted into the slow requests log (`GET /profiler/slow_requests`) as a fully expanded `serde_json::Value`, retained indefinitely (up to 32 entries per request type, no expiry).

The matrix API internally generates a batch of `sample` queries, each carrying a `has_id` filter with all `sample` sampled ids — `sample²` ids per snapshot, at ~90 bytes per id once expanded into a JSON tree:

- `sample=1000` → ~90MB per log entry
- `sample=5000` → ~2GB per log entry

Since the sampled ids are random, every request has a fresh content hash and adds a new entry, growing memory linearly until the 32-slot queue fills (~2.9GB for `sample=1000`; OOM far earlier for larger samples). Verified with a jemalloc heap-profile diff pinning retention to `serde_json::to_value(ShardQueryRequest)` → `LogEntry::request_body`.

## Fix

Bound every snapshot in `Loggable::to_log_value`:

- Truncate all arrays in logged request bodies to 64 elements, appending a `"... (N more items)"` marker.
- Serialize query batches one element at a time, up to the cap — the full untruncated JSON tree (gigabytes for matrix batches) is never materialized even transiently.
- `request_hash` still hashes the full request, so dedup/counting semantics are unchanged.

## Verification

- Unit tests for plain/nested truncation and the matrix-style batch (both truncation levels + marker text).
- Repro (100k points, `sample=1000, limit=100`): log entries went from ~90MB to ~43KB; `active_bytes` no longer climbs per request; `/profiler/slow_requests` shows markers correctly:

```
batch len: 65 | last elem: "... (936 more items)"
has_id len: 65 | last elem: "... (936 more items)"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)