### PR TITLE
[chore] Cleanup after #9712

### DIFF
--- a/lib/common/common/src/persisted_hashmap/uio/mod.rs
+++ b/lib/common/common/src/persisted_hashmap/uio/mod.rs
@@ -49,14 +49,7 @@ where
         options: OpenOptions,
         extra: Fs::OpenExtra,
     ) -> Result<Self> {
-        Self::from_file(fs.open(path, options, extra)?)
-    }
-
-    /// Load the hash map from an already-opened backend file (e.g. taken
-    /// from a [`CachedReadFs`](crate::universal_io::CachedReadFs) prefetch
-    /// pool).
-    pub fn from_file(file: S) -> Result<Self> {
-        let storage = TypedStorage::<S, u8>::new(file);
+        let storage = TypedStorage::<S, u8>::open(fs, path, options, extra)?;
 
         // 1. Read header.
         let header_bytes = storage.read::<Sequential>(ReadRange {

--- a/lib/common/common/src/stored_bitslice.rs
+++ b/lib/common/common/src/stored_bitslice.rs
@@ -79,16 +79,6 @@ impl<S: UniversalRead> StoredBitSlice<S> {
         })
     }
 
-    /// Wrap an already-opened backend file.
-    pub fn from_file(file: S) -> Result<Self> {
-        let storage = TypedStorage::new(file);
-        let element_len = storage.len()?;
-        Ok(Self {
-            storage,
-            element_len,
-        })
-    }
-
     pub fn reopen(&mut self) -> Result<()> {
         self.storage.reopen()?;
         self.element_len = self.storage.len()?;

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use crate::mmap::AdviceSetting;
+use crate::universal_io::traits::CachedReadFs;
 use crate::universal_io::{
     ListedFile, OpenOptions, Populate, Result, UniversalIoError, UniversalReadFileOps,
     UniversalReadFs,
@@ -17,31 +18,8 @@ pub struct FileInfo {
     pub size: u64,
 }
 
-/// Capability extension over [`UniversalReadFs`]: a filesystem that snapshots
-/// its file listing and serves opens from explicitly prefetched handles.
-///
-/// Component-level preload helpers bound on `impl CachedFs<File = S>` are
-/// only callable when the caller opens through a caching filesystem;
-/// plain-`UniversalReadFs` open paths never see these methods.
-pub trait CachedFs: UniversalReadFs {
-    /// Take the file listing snapshot. From this point on, listing and
-    /// existence checks are answered locally and opens of unlisted paths
-    /// fail with `NotFound` without touching the underlying filesystem.
-    fn cache_file_info(&mut self) -> Result<()>;
-
-    /// Open `path` in the background and park the handle in the prefetch
-    /// pool, to be consumed by a later [`UniversalReadFs::open`] of the same
-    /// path. Idempotent per path while the handle is unconsumed.
-    fn schedule_prefetch(
-        &self,
-        path: &Path,
-        open_arguments: Option<OpenOptions>,
-        open_extra: Option<Self::OpenExtra>,
-    ) -> Result<()>;
-}
-
 /// Read-only filesystem wrapper that snapshots the file listing and serves
-/// opens from explicitly prefetched handles. The only [`CachedFs`]
+/// opens from explicitly prefetched handles. The only [`CachedReadFs`]
 /// implementation.
 ///
 /// Opens produce the *wrapped* backend's file type (`Fs::File`), so
@@ -57,15 +35,14 @@ pub trait CachedFs: UniversalReadFs {
 /// Once the snapshot is taken, listing and existence checks are answered
 /// from it without touching the inner filesystem, and opens of paths absent
 /// from the snapshot fail with `NotFound` locally — probing for optional
-/// files is free. Opens are expected to hit a handle registered via
-/// [`CachedFs::schedule_prefetch`]; a miss on a path the snapshot does
-/// contain falls back to an inner open (the open path prefetches every
-/// listed file, so this indicates a not-yet-optimized call site).
+/// files is free. Opens first consume any handle registered via
+/// [`CachedFs::schedule_prefetch`]; opens of listed files that were not
+/// scheduled fall back to a plain inner open.
 ///
 /// Prefetched handles are take-once: [`UniversalReadFs::open`] removes the
 /// handle from the pool and returns it owned. The pool is shared across
 /// clones.
-pub struct CachedReadFs<Fs: UniversalReadFs> {
+pub struct CachedFs<Fs: UniversalReadFs> {
     fs: Fs,
     prefix_path: PathBuf,
     /// `None` until [`CachedFs::cache_file_info`] takes the listing
@@ -77,7 +54,7 @@ pub struct CachedReadFs<Fs: UniversalReadFs> {
 /// Manual impl: `derive(Clone)` would add a spurious `Fs::File: Clone`
 /// bound for the projection in `files_prefetched`, even though the
 /// `Arc` field is unconditionally cloneable (rust-lang/rust#26925).
-impl<Fs: UniversalReadFs> Clone for CachedReadFs<Fs> {
+impl<Fs: UniversalReadFs> Clone for CachedFs<Fs> {
     fn clone(&self) -> Self {
         let Self {
             fs,
@@ -94,7 +71,7 @@ impl<Fs: UniversalReadFs> Clone for CachedReadFs<Fs> {
     }
 }
 
-impl<Fs: UniversalReadFs> CachedReadFs<Fs> {
+impl<Fs: UniversalReadFs> CachedFs<Fs> {
     pub fn new(fs: Fs, prefix_path: &Path) -> Result<Self> {
         Ok(Self {
             fs,
@@ -119,14 +96,15 @@ impl<Fs: UniversalReadFs> CachedReadFs<Fs> {
         self.files_info.as_ref()?.get(path)
     }
 
-    /// Files from the snapshot; empty before [`CachedFs::cache_file_info`].
+    /// Files matching `prefix_path` in the snapshot; empty before
+    /// [`CachedFs::cache_file_info`].
     ///
     /// A path matches when its component at the prefix's final position
     /// starts with the prefix's final component (`dir/chunk_` matches
     /// `dir/chunk_1.dat` and everything under `dir/chunk_extra/`) — the
     /// same name-based matching as the local backends, immune to mixed
     /// `/` and `\` separators on Windows.
-    pub fn list_files(&self, prefix_path: &Path) -> Vec<ListedFile> {
+    fn cached_list_files(&self, prefix_path: &Path) -> Vec<ListedFile> {
         let dir = prefix_path.parent().unwrap_or(Path::new(""));
         let name_prefix = prefix_path
             .file_name()
@@ -153,16 +131,9 @@ impl<Fs: UniversalReadFs> CachedReadFs<Fs> {
             })
             .collect()
     }
-
-    /// Existence per the snapshot; `false` before [`CachedFs::cache_file_info`].
-    pub fn exists(&self, path: &Path) -> bool {
-        self.files_info
-            .as_ref()
-            .is_some_and(|files_info| files_info.contains_key(path))
-    }
 }
 
-impl<Fs: UniversalReadFs> CachedFs for CachedReadFs<Fs> {
+impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
     fn cache_file_info(&mut self) -> Result<()> {
         // List all files
         let list = self.fs.list_files(&self.prefix_path)?;
@@ -218,7 +189,7 @@ pub struct CachedReadFsContext<C> {
     pub prefix_path: PathBuf,
 }
 
-impl<Fs: UniversalReadFs> UniversalReadFileOps for CachedReadFs<Fs> {
+impl<Fs: UniversalReadFs> UniversalReadFileOps for CachedFs<Fs> {
     type ContextConfig = CachedReadFsContext<Fs::ContextConfig>;
 
     fn from_context(context: Self::ContextConfig) -> Result<Self> {
@@ -228,7 +199,7 @@ impl<Fs: UniversalReadFs> UniversalReadFileOps for CachedReadFs<Fs> {
 
     fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
         match &self.files_info {
-            Some(_) => Ok(self.list_files(prefix_path)),
+            Some(_) => Ok(self.cached_list_files(prefix_path)),
             None => self.fs.list_files(prefix_path),
         }
     }
@@ -241,7 +212,7 @@ impl<Fs: UniversalReadFs> UniversalReadFileOps for CachedReadFs<Fs> {
     }
 }
 
-impl<Fs: UniversalReadFs> Debug for CachedReadFs<Fs> {
+impl<Fs: UniversalReadFs> Debug for CachedFs<Fs> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let Self {
             fs,
@@ -258,7 +229,7 @@ impl<Fs: UniversalReadFs> Debug for CachedReadFs<Fs> {
     }
 }
 
-impl<Fs: UniversalReadFs> UniversalReadFs for CachedReadFs<Fs> {
+impl<Fs: UniversalReadFs> UniversalReadFs for CachedFs<Fs> {
     /// The *wrapped* backend's file type: opening through the cache hands
     /// out the very handles the inner filesystem produced (prefetched or
     /// fallback-opened), so the wrapper never appears in stored types.
@@ -285,25 +256,17 @@ impl<Fs: UniversalReadFs> UniversalReadFs for CachedReadFs<Fs> {
             return Ok(file);
         }
 
-        let Some(files_info) = &self.files_info else {
-            // Fallback to cache bypass.
-            // If we are here, that means open path is not optimized enough.
-            // After read-only read path is refactored, this should be protected
-            // by debug assertion
-            return self.fs.open(path, options, extra);
-        };
-
-        match files_info.get(path) {
-            None => Err(UniversalIoError::NotFound {
+        // With a snapshot, unlisted paths fail locally — probing for
+        // optional files never reaches the inner filesystem.
+        if let Some(files_info) = &self.files_info
+            && !files_info.contains_key(path)
+        {
+            return Err(UniversalIoError::NotFound {
                 path: path.to_path_buf(),
-            }),
-            Some(_file_info) => {
-                // Fallback to cache bypass.
-                // If we are here, that means open path is not optimized enough.
-                // After read-only read path is refactored, this should be protected
-                // by debug assertion
-                self.fs.open(path, options, extra)
-            }
+            });
         }
+
+        // Cache bypass: the path was never scheduled, and no snapshot was taken
+        self.fs.open(path, options, extra)
     }
 }

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -13,7 +13,7 @@ mod traits;
 mod types;
 mod wrappers;
 
-pub use self::cached_fs::{CachedFs, CachedReadFs, CachedReadFsContext, FileInfo};
+pub use self::cached_fs::{CachedFs, CachedReadFsContext};
 pub use self::error::{IsNotFound, OkNotFound, UniversalIoError};
 #[cfg(target_os = "linux")]
 pub use self::io_uring::{IoUringFile, IoUringFs, IoUringOpenExtra};
@@ -23,8 +23,8 @@ pub use self::simple_disk_cache::{
     DiskCache, DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, DiskCacheRemote,
 };
 pub use self::traits::{
-    Item, OpenExtra, OwnedPipeline, ReadPipeline, UniversalRead, UniversalReadFileOps,
-    UniversalReadFs, UniversalWrite, UniversalWriteFileOps, UserData,
+    CachedReadFs, Item, OpenExtra, OwnedPipeline, ReadPipeline, UniversalRead,
+    UniversalReadFileOps, UniversalReadFs, UniversalWrite, UniversalWriteFileOps, UserData,
 };
 pub use self::types::{
     ByteOffset, FileIndex, Flusher, ListedFile, OpenOptions, Populate, ReadBytesItem, ReadRange,

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -118,3 +118,26 @@ pub trait UniversalReadFs: UniversalReadFileOps {
         extra: Self::OpenExtra,
     ) -> Result<Self::File>;
 }
+
+/// Capability extension over [`UniversalReadFs`]: a filesystem that snapshots
+/// its file listing and serves opens from explicitly prefetched handles.
+///
+/// Component-level preload helpers bound on `impl CachedFs<File = S>` are
+/// only callable when the caller opens through a caching filesystem;
+/// plain-`UniversalReadFs` open paths never see these methods.
+pub trait CachedReadFs: UniversalReadFs {
+    /// Take the file listing snapshot. From this point on, listing and
+    /// existence checks are answered locally and opens of unlisted paths
+    /// fail with `NotFound` without touching the underlying filesystem.
+    fn cache_file_info(&mut self) -> Result<()>;
+
+    /// Open `path` in the background and park the handle in the prefetch
+    /// pool, to be consumed by a later [`UniversalReadFs::open`] of the same
+    /// path. Idempotent per path while the handle is unconsumed.
+    fn schedule_prefetch(
+        &self,
+        path: &Path,
+        open_arguments: Option<OpenOptions>,
+        open_extra: Option<Self::OpenExtra>,
+    ) -> Result<()>;
+}

--- a/lib/common/common/src/universal_io/traits/mod.rs
+++ b/lib/common/common/src/universal_io/traits/mod.rs
@@ -6,7 +6,7 @@ mod write;
 
 use std::fmt;
 
-pub use file_ops::{UniversalReadFileOps, UniversalReadFs, UniversalWriteFileOps};
+pub use file_ops::{CachedReadFs, UniversalReadFileOps, UniversalReadFs, UniversalWriteFileOps};
 pub use open_extra::OpenExtra;
 pub use pipeline::{OwnedPipeline, ReadPipeline};
 pub use read::UniversalRead;

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -96,12 +96,6 @@ where
         let io = fs.open(path, options, extra)?;
         Ok(Self(io))
     }
-
-    /// Wrap an already-opened backend file.
-    #[inline]
-    pub fn from_file(file: S) -> Self {
-        Self(file)
-    }
 }
 
 impl<S> UniversalRead for ReadOnly<S>

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -84,14 +84,8 @@ impl<S: UniversalRead> Pages<S> {
         populate: Populate,
     ) -> Result<()> {
         let page = fs.open(path, self.page_open_options(populate), Default::default())?;
-        self.attach_file(page);
-        Ok(())
-    }
-
-    /// Attach an already-opened page file. Pages must be attached in page-id
-    /// order, matching what [`Self::page_path`] maps ids to.
-    pub fn attach_file(&mut self, page: S) {
         self.pages.push(page);
+        Ok(())
     }
 
     fn page_open_options(&self, populate: Populate) -> OpenOptions {

--- a/lib/segment/src/common/flags/in_memory_bitvec_flags.rs
+++ b/lib/segment/src/common/flags/in_memory_bitvec_flags.rs
@@ -54,11 +54,8 @@ impl InMemoryBitvecFlags {
             .map_or(0, DynamicFlagsStatus::len);
 
         let flags_path = directory.join(FLAGS_FILE);
-        let flags = StoredBitSlice::<S>::from_file(fs.open(
-            &flags_path,
-            READ_ONLY_OPTIONS,
-            Default::default(),
-        )?)?;
+        let flags =
+            StoredBitSlice::<S>::open(fs, &flags_path, READ_ONLY_OPTIONS, Default::default())?;
         let bits = flags.read_all()?;
         let bitvec = bits.get(..len).map(BitVec::from_bitslice).ok_or_else(|| {
             OperationError::service_error(format!(

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -80,11 +80,12 @@ fn open_flags_storage<S: UniversalRead>(
     fs: &impl UniversalReadFs<File = S>,
     directory: &Path,
 ) -> OperationResult<StoredBitSlice<S>> {
-    Ok(StoredBitSlice::<S>::from_file(fs.open(
+    Ok(StoredBitSlice::<S>::open(
+        fs,
         directory.join(FLAGS_FILE),
         READ_ONLY_OPTIONS,
         Default::default(),
-    )?)?)
+    )?)
 }
 
 impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {

--- a/lib/segment/src/id_tracker/disk_id_tracker/read_only.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/read_only.rs
@@ -92,11 +92,8 @@ impl<S: UniversalRead> ReadOnlyDiskIdTracker<S> {
         )?);
         let versions_len = versions.len()?;
 
-        let deleted_file = StoredBitSlice::from_file(fs.open(
-            deleted_path(segment_path),
-            options,
-            Default::default(),
-        )?)?;
+        let deleted_file =
+            StoredBitSlice::open(fs, deleted_path(segment_path), options, Default::default())?;
 
         Ok(Some(Self {
             path: segment_path.to_path_buf(),

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/lifecycle.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/lifecycle.rs
@@ -50,11 +50,8 @@ impl<S: UniversalRead> ReadOnlyImmutableIdTracker<S> {
             advice: AdviceSetting::Global,
         };
 
-        let deleted = StoredBitSlice::from_file(fs.open(
-            deleted_path(segment_path),
-            options,
-            Default::default(),
-        )?)?;
+        let deleted =
+            StoredBitSlice::open(fs, deleted_path(segment_path), options, Default::default())?;
         let mut deleted_bitvec = BitVec::new();
         deleted_bitvec.extend_from_bitslice(deleted.read_all()?.as_ref());
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
@@ -191,7 +191,8 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
             // If postings don't exist, assume the index doesn't exist on disk
             return Ok(None);
         };
-        let vocab = UniversalHashMap::<str, TokenId, S>::from_file(fs.open(
+        let vocab = UniversalHashMap::<str, TokenId, S>::open(
+            fs,
             &vocab_path,
             OpenOptions {
                 writeable: false,
@@ -200,7 +201,7 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
                 advice: AdviceSetting::Global,
             },
             Default::default(),
-        )?)?;
+        )?;
 
         let point_to_tokens_count = TypedStorage::<S, usize>::new(fs.open(
             &point_to_tokens_count_path,
@@ -213,7 +214,8 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
             Default::default(),
         )?);
 
-        let deleted_payload_mmap = StoredBitSlice::<S>::from_file(fs.open(
+        let deleted_payload_mmap = StoredBitSlice::<S>::open(
+            fs,
             &deleted_points_path,
             OpenOptions {
                 writeable: false,
@@ -222,7 +224,7 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
                 advice: AdviceSetting::Global,
             },
             Default::default(),
-        )?)?;
+        )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
 
         // `deleted` length must match `point_to_tokens_count.len()` because it

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
@@ -195,7 +195,8 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
 
         let mut deleted = deleted_points.to_owned();
 
-        let deleted_payload_mmap = StoredBitSlice::<S>::from_file(fs.open(
+        let deleted_payload_mmap = StoredBitSlice::<S>::open(
+            fs,
             &deleted_path,
             OpenOptions {
                 writeable: false,
@@ -204,7 +205,7 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
                 advice: AdviceSetting::Global,
             },
             Default::default(),
-        )?)?;
+        )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
 
         // `deleted` length must match `point_to_values.len()` because it only

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
@@ -47,7 +47,8 @@ where
             return Ok(None);
         };
 
-        let value_to_points = UniversalHashMap::from_file(fs.open(
+        let value_to_points = UniversalHashMap::open(
+            fs,
             &hashmap_path,
             OpenOptions {
                 writeable: false,
@@ -56,13 +57,14 @@ where
                 advice: AdviceSetting::Global,
             },
             Default::default(),
-        )?)?;
+        )?;
         let point_to_values = OnDiskPointToValues::open(fs, path, populate)?;
         let prefix_index = PrefixIndex::open(fs, path, populate)?;
 
         let mut deleted = deleted_points.to_owned();
 
-        let deleted_payload_mmap = StoredBitSlice::<S>::from_file(fs.open(
+        let deleted_payload_mmap = StoredBitSlice::<S>::open(
+            fs,
             &deleted_path,
             OpenOptions {
                 writeable: false,
@@ -71,7 +73,7 @@ where
                 advice: AdviceSetting::Global,
             },
             Default::default(),
-        )?)?;
+        )?;
 
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
 

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
@@ -145,7 +145,8 @@ where
         let point_to_values = OnDiskPointToValues::open(fs, path, populate)?;
         let mut deleted = deleted_points.to_owned();
 
-        let deleted_payload_mmap = StoredBitSlice::<S>::from_file(fs.open(
+        let deleted_payload_mmap = StoredBitSlice::<S>::open(
+            fs,
             &deleted_path,
             OpenOptions {
                 writeable: false,
@@ -154,7 +155,7 @@ where
                 advice: AdviceSetting::Global,
             },
             Default::default(),
-        )?)?;
+        )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
 
         // `deleted` length must match `point_to_values.len()` because it only

--- a/lib/segment/src/index/field_index/on_disk_point_to_values.rs
+++ b/lib/segment/src/index/field_index/on_disk_point_to_values.rs
@@ -175,7 +175,7 @@ where
             advice: AdviceSetting::Global,
         };
 
-        let store = ReadOnly::from_file(fs.open(&file_name, open_options, Default::default())?);
+        let store = ReadOnly::open(fs, &file_name, open_options, Default::default())?;
 
         let header = store.read::<Random, Header>(ReadRange::one(0))?[0];
 

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -30,21 +30,16 @@ use crate::vector_storage::quantized::quantized_vectors::ReadOnlyQuantizedVector
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 use crate::vector_storage::sparse::read_only::ReadOnlySparseVectorStorage;
 
-/// Build a per-segment [`CachedReadFs`] over `segment_path`, ready to serve
-/// every open of the segment's files from prefetched handles.
+/// Build a per-segment [`CachedReadFs`] over `segment_path`.
 ///
-/// Order matters for object-storage backends: the files whose names are known
-/// in advance (version file, segment state) are scheduled *before* the listing
-/// snapshot is taken, so their fetch overlaps the listing round-trip. Every
-/// remaining listed file is then scheduled too — a read-only segment opens
-/// essentially all of its files, and prefetching them up front runs the
-/// fetches in parallel instead of serializing them inside each component's
-/// open.
+/// The files whose names are known in advance (version file, segment state)
+/// are scheduled *before* the listing snapshot is taken, so on backends with
+/// background population their fetch overlaps the listing round-trip.
 fn build_cached_fs<Fs: UniversalReadFs>(
     fs: &Fs,
     segment_path: &Path,
-) -> OperationResult<CachedReadFs<Fs>> {
-    let mut cached_fs = CachedReadFs::new(fs.clone(), segment_path)?;
+) -> OperationResult<CachedFs<Fs>> {
+    let mut cached_fs = CachedFs::new(fs.clone(), segment_path)?;
 
     // Absence is tolerated here: the subsequent read reports it gracefully.
     for file_name in [VERSION_FILE, SEGMENT_STATE_FILE] {
@@ -60,9 +55,8 @@ fn build_cached_fs<Fs: UniversalReadFs>(
 
 impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     /// Open the segment over a per-segment [`CachedReadFs`]: known files are
-    /// prefetched before the listing snapshot is taken, the rest right after
-    /// it, and every component open below takes its handles from that pool
-    /// (see [`build_cached_fs`]). Probes for optional files resolve against
+    /// prefetched before the listing snapshot is taken (see
+    /// [`build_cached_fs`]), and probes for optional files resolve against
     /// the snapshot, without inner-filesystem round-trips.
     pub fn open(
         fs: &S::Fs,

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -56,10 +56,8 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectorData<T, S>
             populate,
             advice: AdviceSetting::Global,
         };
-        let read_only = fs
-            .open(vectors_path, options, Default::default())
-            .map(ReadOnly::from_file)
-            .map_err(|e| {
+        let read_only =
+            ReadOnly::open(fs, vectors_path, options, Default::default()).map_err(|e| {
                 crate::common::operation_error::OperationError::service_error(format!(
                     "Failed to open vector mmap at {}: {e}",
                     vectors_path.display()

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/lifecycle.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/lifecycle.rs
@@ -55,11 +55,8 @@ fn open_deleted_flags<S: UniversalRead>(
     deleted_path: &Path,
     num_vectors: usize,
 ) -> OperationResult<InMemoryBitvecFlags> {
-    let stored = StoredBitSlice::<S>::from_file(fs.open(
-        deleted_path,
-        READ_ONLY_OPTIONS,
-        Default::default(),
-    )?)?;
+    let stored =
+        StoredBitSlice::<S>::open(fs, deleted_path, READ_ONLY_OPTIONS, Default::default())?;
     let all = stored.read_all()?;
 
     let start = deleted_mmap_data_start() * 8;

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -3,9 +3,9 @@ use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::mmap::{Advice, AdviceSetting, MmapFlusher};
+use common::mmap::MmapFlusher;
 use common::types::PointOffsetType;
-use common::universal_io::{OneshotFile, OpenOptions, Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{OneshotFile, UniversalRead, UniversalReadFs};
 use fs_err as fs;
 use fs_err::File;
 
@@ -38,16 +38,7 @@ impl QuantizedRamStorage {
             ));
         }
 
-        let storage = OneshotFile::new(fs.open(
-            path,
-            OpenOptions {
-                writeable: false,
-                need_sequential: true,
-                populate: Populate::No,
-                advice: AdviceSetting::Advice(Advice::Sequential),
-            },
-            Default::default(),
-        )?);
+        let storage = OneshotFile::open(fs, path)?;
 
         // Read the whole file in a single access and validate against the returned
         // buffer's length, rather than querying `len()` separately. Avoids an extra

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -84,8 +84,7 @@ impl<S: UniversalRead> QuantizedStorage<S> {
         path: &Path,
         quantized_vector_size: usize,
     ) -> OperationResult<QuantizedStorage<S>> {
-        let storage =
-            ReadOnly::from_file(fs.open(path, Self::open_options(), Default::default())?);
+        let storage = ReadOnly::open(fs, path, Self::open_options(), Default::default())?;
 
         let quantized_vector_size = NonZeroUsize::new(quantized_vector_size).ok_or_else(|| {
             std::io::Error::new(


### PR DESCRIPTION
A few cleanups after the merge of #9712 

- get rid of `from_file` abstractions
- renames:
  - `CachedFs` to be the implementation
  - `CachedReadFs` to be the trait
- move `CachedFs` trait into traits module

Assisted by AI