### PR TITLE
[UIO] Preopen `GridstoreReader`

### DIFF
--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -149,7 +149,7 @@ where
     /// Uses the bitmask to infer page count for consistency with the write path.
     pub fn open(fs: S::Fs, base_path: PathBuf, populate: Populate) -> Result<Self> {
         // Writable store: open pages and tracker writable so it can append.
-        let (config, tracker) = reader::read_config_and_tracker(&fs, &base_path, true)?;
+        let (config, tracker) = reader::read_config_and_tracker(&fs, &base_path, populate, true)?;
         let bitmask = Bitmask::open(&fs, &base_path, config.clone())?;
         let num_pages = bitmask.infer_num_pages();
 

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -5,7 +5,9 @@ use common::counter::counter_cell::CounterCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::referenced_counter::HwMetricRefCounter;
 use common::generic_consts::{AccessPattern, Sequential};
-use common::universal_io::{Populate, UniversalRead, UniversalReadFs, UserData, read_json_via};
+use common::universal_io::{
+    CachedReadFs, Populate, UniversalRead, UniversalReadFs, UserData, read_json_via,
+};
 
 use super::view::GridstoreView;
 use crate::Result;
@@ -58,6 +60,22 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
         self.view().max_point_offset()
     }
 
+    pub fn preopen<Fs: CachedReadFs<File = S>>(
+        fs: &Fs,
+        base_path: PathBuf,
+        populate: Populate,
+    ) -> Result<()> {
+        // schedule config file
+        let config_path = base_path.join(CONFIG_FILENAME);
+        fs.schedule_prefetch(&config_path, None, None)?;
+
+        // schedule tracker
+        Tracker::<S>::preopen(fs, &base_path, populate)?;
+
+        // schedule pages
+        Pages::preopen(fs, &base_path, populate)
+    }
+
     /// Open an existing read-only storage at the given path.
     ///
     /// Infers page count by scanning for page files on disk.
@@ -74,7 +92,7 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
         // A reader only reads, so open pages and tracker non-writable. This
         // lets the backend be write-enforced (e.g. `ReadOnly<MmapFile>`); the
         // writable `Gridstore` opens these same files writable instead.
-        let (config, tracker) = read_config_and_tracker(fs, &base_path, false)?;
+        let (config, tracker) = read_config_and_tracker(fs, &base_path, populate, false)?;
 
         let pages = Pages::<S>::open(fs, &base_path, false, populate)?;
 
@@ -214,6 +232,7 @@ impl<V, S: UniversalRead> GridstoreReader<V, S> {
 pub(super) fn read_config_and_tracker<Fs, S>(
     fs: &Fs,
     base_path: &std::path::Path,
+    populate: Populate,
     writeable: bool,
 ) -> Result<(StorageConfig, Tracker<S>)>
 where
@@ -224,7 +243,7 @@ where
     let config: StorageConfig =
         read_json_via::<Fs, StorageConfig>(fs, &config_path).map_err(GridstoreError::from)?;
 
-    let tracker = Tracker::<S>::open(fs, base_path, writeable)?;
+    let tracker = Tracker::<S>::open(fs, base_path, populate, writeable)?;
 
     Ok((config, tracker))
 }

--- a/lib/gridstore/src/pages.rs
+++ b/lib/gridstore/src/pages.rs
@@ -8,8 +8,8 @@ use common::generic_consts::AccessPattern;
 use common::maybe_uninit::assume_init_vec;
 use common::mmap::{Advice, AdviceSetting};
 use common::universal_io::{
-    FileIndex, Flusher, OpenOptions, Populate, ReadPipeline, ReadRange, UniversalRead,
-    UniversalReadFileOps, UniversalReadFs, UniversalWrite, UserData,
+    CachedReadFs, FileIndex, Flusher, OpenOptions, Populate, ReadPipeline, ReadRange,
+    UniversalRead, UniversalReadFileOps, UniversalReadFs, UniversalWrite, UserData,
 };
 use itertools::Either;
 
@@ -20,6 +20,15 @@ use crate::tracker::{PageId, ValuePointer};
 
 pub fn page_path(base_path: &Path, page_id: PageId) -> PathBuf {
     base_path.join(format!("page_{page_id}.dat"))
+}
+
+pub fn page_open_options(populate: Populate, writeable: bool) -> OpenOptions {
+    OpenOptions {
+        writeable,
+        need_sequential: true,
+        populate,
+        advice: AdviceSetting::Advice(Advice::Random),
+    }
 }
 
 #[derive(Debug)]
@@ -50,6 +59,27 @@ impl<S: UniversalRead> Pages<S> {
             pages: Vec::new(),
             writeable,
         }
+    }
+
+    pub fn preopen<Fs: CachedReadFs<File = S>>(
+        fs: &Fs,
+        dir: &Path,
+        populate: Populate,
+    ) -> Result<()> {
+        let page_files: HashSet<_> = fs
+            .list_files(&dir.join("page_"))?
+            .into_iter()
+            .map(|listed| listed.path)
+            .collect();
+
+        for page_id in 0.. {
+            let page_path = page_path(dir, page_id);
+            if !page_files.contains(&page_path) {
+                break;
+            }
+            fs.schedule_prefetch(&page_path, Some(page_open_options(populate, false)), None)?;
+        }
+        Ok(())
     }
 
     pub fn open<Fs: UniversalReadFs<File = S>>(
@@ -83,18 +113,13 @@ impl<S: UniversalRead> Pages<S> {
         path: &Path,
         populate: Populate,
     ) -> Result<()> {
-        let page = fs.open(path, self.page_open_options(populate), Default::default())?;
+        let page = fs.open(
+            path,
+            page_open_options(populate, self.writeable),
+            Default::default(),
+        )?;
         self.pages.push(page);
         Ok(())
-    }
-
-    fn page_open_options(&self, populate: Populate) -> OpenOptions {
-        OpenOptions {
-            writeable: self.writeable,
-            need_sequential: true,
-            populate,
-            advice: AdviceSetting::Advice(Advice::Random),
-        }
     }
 
     pub fn num_pages(&self) -> usize {

--- a/lib/gridstore/src/tracker/mod.rs
+++ b/lib/gridstore/src/tracker/mod.rs
@@ -9,8 +9,8 @@ use ahash::{AHashMap, AHashSet};
 use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting, create_and_ensure_length};
 use common::universal_io::{
-    OpenOptions, Populate, ReadRange, UniversalIoError, UniversalRead, UniversalReadFs,
-    UniversalWrite, UserData,
+    CachedReadFs, OpenOptions, Populate, ReadRange, UniversalIoError, UniversalRead,
+    UniversalReadFs, UniversalWrite, UserData,
 };
 use smallvec::SmallVec;
 
@@ -27,11 +27,11 @@ pub type PageId = u32;
 /// `writeable` is `false` for read-only readers (so the backend may be
 /// write-enforced, e.g. `ReadOnly<MmapFile>`) and `true` for the writable
 /// tracker that appends pointers.
-fn tracker_open_options(writeable: bool) -> OpenOptions {
+fn tracker_open_options(populate: Populate, writeable: bool) -> OpenOptions {
     OpenOptions {
         writeable,
         need_sequential: false,
-        populate: Populate::No,
+        populate,
         advice: AdviceSetting::Advice(Advice::Random),
     }
 }
@@ -273,21 +273,29 @@ impl<S> Tracker<S> {
 
 // Read operations -- only require UniversalRead
 impl<S: UniversalRead> Tracker<S> {
+    pub fn preopen<Fs: CachedReadFs<File = S>>(
+        fs: &Fs,
+        path: &Path,
+        populate: Populate,
+    ) -> Result<()> {
+        let path = Self::tracker_file_name(path);
+        // TODO(uio): use Populate::BackgroundPartial when Populate::No
+        fs.schedule_prefetch(&path, Some(tracker_open_options(populate, false)), None)?;
+        Ok(())
+    }
+
     /// Open an existing PageTracker at the given path
     /// If the file does not exist, return an error
     pub fn open<Fs: UniversalReadFs<File = S>>(
         fs: &Fs,
         path: &Path,
+        populate: Populate,
         writeable: bool,
     ) -> Result<Self> {
         let path = Self::tracker_file_name(path);
-        let storage = Self::open_storage(fs, &path, writeable)?;
-        Self::from_storage(path, storage)
-    }
 
-    /// Build the tracker over an already-opened storage file. `path` must be
-    /// the tracker file path the storage was opened from.
-    fn from_storage(path: PathBuf, storage: S) -> Result<Self> {
+        let storage = Self::open_storage(fs, &path, populate, writeable)?;
+
         let header: TrackerHeader = Self::read_header(&storage)?;
         let pending_updates = AHashMap::new();
         Ok(Self {
@@ -307,9 +315,14 @@ impl<S: UniversalRead> Tracker<S> {
     fn open_storage<Fs: UniversalReadFs<File = S>>(
         fs: &Fs,
         path: &Path,
+        populate: Populate,
         writeable: bool,
     ) -> Result<S> {
-        let storage = match fs.open(path, tracker_open_options(writeable), Default::default()) {
+        let storage = match fs.open(
+            path,
+            tracker_open_options(populate, writeable),
+            Default::default(),
+        ) {
             Err(UniversalIoError::NotFound { .. }) => {
                 // If config exists and storage doesn't,
                 // it should be treated as inconsistent storage rather than a missing one
@@ -424,7 +437,11 @@ where
             "Size hint is too small"
         );
         create_and_ensure_length(&path, size)?;
-        let storage = fs.open(&path, tracker_open_options(true), Default::default())?;
+        let storage = fs.open(
+            &path,
+            tracker_open_options(Populate::No, true),
+            Default::default(),
+        )?;
         let header = TrackerHeader::default();
         let pending_updates = AHashMap::new();
         let mut page_tracker = Self {

--- a/lib/gridstore/src/tracker/tests.rs
+++ b/lib/gridstore/src/tracker/tests.rs
@@ -179,7 +179,7 @@ fn test_persist_and_open_tracker(#[case] initial_tracker_size: usize) {
     drop(tracker);
 
     // reopen the tracker
-    let tracker = TestTracker::open(&MmapFs, path, true).unwrap();
+    let tracker = TestTracker::open(&MmapFs, path, Populate::No, true).unwrap();
     assert_eq!(tracker.mapping_len().unwrap(), value_count / 2);
     assert_eq!(tracker.pointer_count(), value_count as u32 - 1);
 

--- a/lib/segment/src/payload_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/payload_storage/read_only/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs};
 use gridstore::GridstoreReader;
 
 use super::ReadOnlyPayloadStorage;
@@ -9,6 +9,16 @@ use crate::payload_storage::payload_storage_impl::storage_dir;
 use crate::types::Payload;
 
 impl<S: UniversalRead> ReadOnlyPayloadStorage<S> {
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        path: PathBuf,
+        populate: Populate,
+    ) -> OperationResult<()> {
+        let path = storage_dir(path);
+        GridstoreReader::<Payload, S>::preopen(fs, path, populate)?;
+        Ok(())
+    }
+
     /// Open the payload storage read-only over the generic filesystem `fs` —
     /// the read-only counterpart of [`PayloadStorageImpl::open_or_create`][1].
     ///

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -65,7 +65,24 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         deferred_internal_id: Option<PointOffsetType>,
     ) -> OperationResult<Self> {
         let cached_fs = build_cached_fs(fs, segment_path)?;
+        Self::first_preopen(&cached_fs, segment_path)?;
         Self::open_via(&cached_fs, fs, segment_path, uuid, deferred_internal_id)
+    }
+
+    fn first_preopen(fs: &impl CachedReadFs<File = S>, segment_path: &Path) -> OperationResult<()> {
+        let SegmentState {
+            initial_version: _,
+            version: _,
+            config,
+        } = read_json_via(fs, segment_path.join(SEGMENT_STATE_FILE))?;
+
+        let payload_populate = match config.payload_storage_type {
+            PayloadStorageType::InRamMmap => Populate::PreferBackground,
+            PayloadStorageType::Mmap => Populate::No,
+        };
+        ReadOnlyPayloadStorage::preopen(fs, segment_path.to_path_buf(), payload_populate)?;
+
+        Ok(())
     }
 
     /// Read-only mirror of `load_segment`: assembles every read-only component
@@ -77,7 +94,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     /// stores a filesystem handle to re-open appended files later (the
     /// appendable id tracker): a caching wrapper's snapshot would go stale.
     pub(crate) fn open_via(
-        fs: &impl UniversalReadFs<File = S>,
+        fs: &impl CachedReadFs<File = S>,
         raw_fs: &S::Fs,
         segment_path: &Path,
         uuid: Uuid,


### PR DESCRIPTION
Adds `preopen` functions to `GridstoreReader`, so it can be prefetched in parallel with other components and within its own files too.

Additionally, this PR also fixes the propagation of `Populate` for the `Tracker` component of gridstore, it was never being populated before.