### PR TITLE
[DiskCache]  Accept file size in `DiskCacheFs::open`

### DIFF
--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -8,7 +8,7 @@ use parking_lot::Mutex;
 use crate::mmap::AdviceSetting;
 use crate::universal_io::traits::CachedReadFs;
 use crate::universal_io::{
-    ListedFile, OpenOptions, Populate, Result, UniversalIoError, UniversalReadFileOps,
+    ListedFile, OpenExtra, OpenOptions, Populate, Result, UniversalIoError, UniversalReadFileOps,
     UniversalReadFs,
 };
 
@@ -172,7 +172,10 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
 
         open_options.populate = Populate::PreferBackground;
 
-        let open_extra = open_extra.unwrap_or_default();
+        let mut open_extra = open_extra.unwrap_or_default();
+        if let Some(info) = self.file_info(path) {
+            open_extra = open_extra.with_known_len(info.size);
+        }
 
         let file = self.fs.open(path, open_options, open_extra)?;
         files_prefetched.insert(path.to_path_buf(), file);

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -106,6 +106,10 @@ impl OpenExtra for IoUringOpenExtra {
         let Self { prevent_caching: _ } = self;
         Self { prevent_caching }
     }
+
+    fn with_known_len(self, _known_len: u64) -> Self {
+        self
+    }
 }
 
 impl UniversalReadFs for IoUringFs {

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -6,6 +6,7 @@ use super::DiskCacheRemote;
 use super::config::DiskCacheConfig;
 use super::file::{DiskCache, State};
 use crate::mmap::AdviceSetting;
+use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::{
     ListedFile, OpenExtra, OpenOptions, OwnedPipeline, Populate, Result, UniversalIoError,
     UniversalRead, UniversalReadFileOps, UniversalReadFs, UniversalWriteFileOps,
@@ -18,6 +19,27 @@ use crate::universal_io::{
 pub struct DiskCacheFsContext<C> {
     pub config: Arc<DiskCacheConfig>,
     pub remote: C,
+}
+
+#[derive(Default, Debug)]
+pub struct DiskCacheFsOpenExtra<RemoteExtra: OpenExtra> {
+    /// Extra options passed to the remote
+    remote_extra: RemoteExtra,
+    /// The length of the file, if known
+    known_len: Option<u64>,
+}
+
+impl<RemoteExtra: OpenExtra> OpenExtra for DiskCacheFsOpenExtra<RemoteExtra> {
+    fn with_prevent_caching(self, _prevent_caching: bool) -> Self {
+        self
+    }
+
+    fn with_known_len(self, known_len: u64) -> Self {
+        Self {
+            remote_extra: self.remote_extra,
+            known_len: Some(known_len),
+        }
+    }
 }
 
 /// Filesystem handle for the simple disk cache. Carries the remote-side
@@ -61,6 +83,26 @@ where
             .field("config", config)
             .field("remote_fs", remote_fs)
             .finish()
+    }
+}
+
+impl<R: UniversalRead> DiskCacheFs<R> {
+    fn open_remote(
+        &self,
+        path: impl AsRef<Path>,
+        extra: <R::Fs as UniversalReadFs>::OpenExtra,
+    ) -> Result<R> {
+        let extra = extra.with_prevent_caching(true);
+        self.remote_fs.open(
+            path.as_ref(),
+            OpenOptions {
+                writeable: false,
+                need_sequential: true,
+                populate: Populate::No,
+                advice: AdviceSetting::Global,
+            },
+            extra,
+        )
     }
 }
 
@@ -118,7 +160,7 @@ where
     R: DiskCacheRemote,
 {
     type File = DiskCache<R>;
-    type OpenExtra = <R::Fs as UniversalReadFs>::OpenExtra;
+    type OpenExtra = DiskCacheFsOpenExtra<<R::Fs as UniversalReadFs>::OpenExtra>;
 
     fn open(
         &self,
@@ -134,7 +176,7 @@ where
             });
         }
 
-        let extra = extra.with_prevent_caching(true);
+        let remote_extra = extra.remote_extra.with_prevent_caching(true);
         let local_path = self.config.local_path_for(path.as_ref())?;
 
         let populate = if crate::low_memory::low_memory_mode().skip_populate() {
@@ -143,19 +185,19 @@ where
             options.populate
         };
 
-        let state = match populate {
-            Populate::Auto | Populate::No => State::Uninit,
-            Populate::Blocking | Populate::PreferBackground => {
-                let remote = self.remote_fs.open(
-                    path.as_ref(),
-                    OpenOptions {
-                        writeable: false,
-                        need_sequential: true,
-                        populate: Populate::No,
-                        advice: AdviceSetting::Global,
-                    },
-                    extra.clone(),
-                )?;
+        let state = match (extra.known_len, populate) {
+            (None, Populate::Auto | Populate::No) => State::Uninit,
+            // We know file length, initialize local state.
+            (Some(len), Populate::Auto | Populate::No) => {
+                let remote = self.open_remote(path.as_ref(), remote_extra.clone())?;
+
+                let local = LocalState::new(&local_path, len, options)?;
+
+                State::Ready { remote, local }
+            }
+            // Even if we know length, we don't need it to do `schedule_whole`.
+            (None | Some(_), Populate::Blocking | Populate::PreferBackground) => {
+                let remote = self.open_remote(path.as_ref(), remote_extra.clone())?;
 
                 let mut pipeline = OwnedPipeline::new(remote)?;
 
@@ -168,7 +210,7 @@ where
 
         let cache = DiskCache::new(
             self.remote_fs.clone(),
-            extra,
+            remote_extra,
             path.as_ref(),
             local_path,
             options,

--- a/lib/common/common/src/universal_io/traits/open_extra.rs
+++ b/lib/common/common/src/universal_io/traits/open_extra.rs
@@ -15,8 +15,13 @@ pub trait OpenExtra: Default + Debug {
     /// where it's meaningless (mmap, block-cache) treat this as a no-op.
     #[must_use]
     fn with_prevent_caching(self, prevent_caching: bool) -> Self;
+
+    /// Hint about the length of the file.
+    fn with_known_len(self, known_len: u64) -> Self;
 }
 
 impl OpenExtra for () {
     fn with_prevent_caching(self, _prevent_caching: bool) -> Self {}
+
+    fn with_known_len(self, _known_len: u64) -> Self {}
 }

--- a/lib/common/io_bridge/src/tests/whole_read.rs
+++ b/lib/common/io_bridge/src/tests/whole_read.rs
@@ -228,7 +228,7 @@ fn disk_cache_read_whole_skips_remote_len() {
                 populate: Populate::No,
                 ..OpenOptions::new_for_test()
             },
-            (),
+            Default::default(),
         )
         .unwrap();
 
@@ -280,7 +280,7 @@ fn disk_cache_prefill_open_uses_whole_get_without_head() {
                 populate: Populate::Blocking,
                 ..OpenOptions::new_for_test()
             },
-            (),
+            Default::default(),
         )
         .unwrap();
 


### PR DESCRIPTION
Adds a native `DiskCacheFsOpenExtra` structure that accepts the file size, if it was already known. 

This allows the initial listing of the files to pass the sizes to DiskCache, so that it doesn't need an extra `len` call to the remote when the first read is issued under `Populate::No`.