### PR TITLE
fix: preserve Euclid order with zero-padding

### DIFF
--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -33,12 +33,29 @@ pub struct EuclidMetric;
 #[derive(Clone)]
 pub struct ManhattanMetric;
 
+#[inline]
+fn trim_common_trailing_zeros<'a>(
+    v1: &'a [VectorElementType],
+    v2: &'a [VectorElementType],
+) -> (&'a [VectorElementType], &'a [VectorElementType]) {
+    debug_assert_eq!(v1.len(), v2.len());
+
+    let mut len = v1.len();
+    while len > 0 && v1[len - 1] == 0.0 && v2[len - 1] == 0.0 {
+        len -= 1;
+    }
+
+    (&v1[..len], &v2[..len])
+}
+
 impl Metric<VectorElementType> for EuclidMetric {
     fn distance() -> Distance {
         Distance::Euclid
     }
 
     fn similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
+        let (v1, v2) = trim_common_trailing_zeros(v1, v2);
+
         #[cfg(target_arch = "x86_64")]
         {
             if is_x86_feature_detected!("avx")
@@ -274,5 +291,104 @@ mod tests {
                 "renormalization is not stable (vector #{attempt})"
             );
         }
+    }
+
+    #[test]
+    fn test_euclid_zero_padding_does_not_change_order_across_simd_boundary() {
+        let query = vec![0.0; 31];
+        let point_1 = vec![
+            -7379.2085,
+            78561.6797,
+            351176.656,
+            -179895.969,
+            -37065.5938,
+            266713.188,
+            403120.125,
+            -2049.87158,
+            -419890.938,
+            35755.168,
+            -313292.0,
+            320771.656,
+            53339.3438,
+            -349924.688,
+            239633.781,
+            310356.625,
+            -279830.062,
+            276455.562,
+            117963.992,
+            -201381.141,
+            -99853.5312,
+            222634.391,
+            -56914.293,
+            -111477.445,
+            102780.82,
+            -25055.0332,
+            -231102.703,
+            -80738.5391,
+            75535.4922,
+            -319243.594,
+            184434.984,
+        ];
+        let point_2 = vec![
+            -7335.02246,
+            78627.1797,
+            351145.281,
+            -179854.953,
+            -37026.6406,
+            266792.688,
+            403092.594,
+            -2089.85986,
+            -419901.125,
+            35719.1875,
+            -313275.938,
+            320861.75,
+            53338.5195,
+            -350038.656,
+            239602.297,
+            310319.875,
+            -279785.062,
+            276427.0,
+            117995.641,
+            -201402.891,
+            -99835.2422,
+            222626.906,
+            -56885.3555,
+            -111412.375,
+            102726.219,
+            -25111.8809,
+            -231136.031,
+            -80752.4141,
+            75534.0859,
+            -319195.75,
+            184394.719,
+        ];
+
+        let base_1 = <EuclidMetric as Metric<VectorElementType>>::similarity(&query, &point_1);
+        let base_2 = <EuclidMetric as Metric<VectorElementType>>::similarity(&query, &point_2);
+
+        let padded_query = pad_zero(query);
+        let padded_point_1 = pad_zero(point_1);
+        let padded_point_2 = pad_zero(point_2);
+
+        let padded_1 =
+            <EuclidMetric as Metric<VectorElementType>>::similarity(&padded_query, &padded_point_1);
+        let padded_2 =
+            <EuclidMetric as Metric<VectorElementType>>::similarity(&padded_query, &padded_point_2);
+
+        assert_eq!(base_1, padded_1);
+        assert_eq!(base_2, padded_2);
+        assert!(
+            base_1 > base_2,
+            "point 1 should be closer before zero padding: {base_1} <= {base_2}"
+        );
+        assert!(
+            padded_1 > padded_2,
+            "point 1 should remain closer after zero padding: {padded_1} <= {padded_2}"
+        );
+    }
+
+    fn pad_zero(mut vector: DenseVector) -> DenseVector {
+        vector.push(0.0);
+        vector
     }
 }


### PR DESCRIPTION
﻿Fixes #9659.

Exact Euclid search can currently choose a different SIMD path after appending a common trailing zero to the query and stored vectors. The extra zero does not change the mathematical distance, but it can change the accumulation path across the 31D/32D boundary and alter the ordering for very close scores.

This trims common trailing zero dimensions before Euclid scoring dispatches to scalar/SSE/AVX. Non-zero dimensions and non-common trailing values are unchanged. A focused regression test covers the vectors from the issue and checks that zero-padding preserves both scores and ordering.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

Validation run locally:

* `cargo +nightly fmt --all` - passed
* `cargo +nightly fmt --all -- --check` - passed
* `git diff --check` - passed
* `cargo test -p segment test_euclid_zero_padding_does_not_change_order_across_simd_boundary -- --nocapture` - blocked locally: Windows MSVC linker/Windows SDK is missing (`link.exe`, `kernel32.lib`, `ntdll.lib`, etc.). WSL is available but does not have Rust/C build tools installed and `sudo` requires a password.

### AI assistance disclosure

Commits:

* [AI] e1bdeda55 fix: preserve euclid order with zero-padding

Initial prompt used for AI assistance:

> Fix qdrant/qdrant#9659 by preserving Euclid exact-search ordering when all compared vectors and the query receive common trailing zero padding across the 31D/32D SIMD boundary. Keep the change narrow and add a focused regression test for the provided vectors.
