### PR TITLE
Add time to gRPC responses

### DIFF
--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -1080,6 +1080,8 @@ message CollectionClusterInfoResponse {
   repeated ShardTransferInfo shard_transfers = 5;
   // Resharding operations
   repeated ReshardingInfo resharding_operations = 6;
+  // Time spent to process
+  double time = 7;
 }
 
 message MoveShard {
@@ -1180,6 +1182,8 @@ message UpdateCollectionClusterSetupRequest {
 
 message UpdateCollectionClusterSetupResponse {
   bool result = 1;
+  // Time spent to process
+  double time = 2;
 }
 
 message CreateShardKeyRequest {
@@ -1209,10 +1213,14 @@ message ListShardKeysRequest {
 
 message CreateShardKeyResponse {
   bool result = 1;
+  // Time spent to process
+  double time = 2;
 }
 
 message DeleteShardKeyResponse {
   bool result = 1;
+  // Time spent to process
+  double time = 2;
 }
 
 message ShardKeyDescription {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1951,6 +1951,9 @@ pub struct CollectionClusterInfoResponse {
     /// Resharding operations
     #[prost(message, repeated, tag = "6")]
     pub resharding_operations: ::prost::alloc::vec::Vec<ReshardingInfo>,
+    /// Time spent to process
+    #[prost(double, tag = "7")]
+    pub time: f64,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
@@ -2103,10 +2106,13 @@ pub mod update_collection_cluster_setup_request {
     }
 }
 #[derive(serde::Serialize)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct UpdateCollectionClusterSetupResponse {
     #[prost(bool, tag = "1")]
     pub result: bool,
+    /// Time spent to process
+    #[prost(double, tag = "2")]
+    pub time: f64,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -2145,16 +2151,22 @@ pub struct ListShardKeysRequest {
     pub collection_name: ::prost::alloc::string::String,
 }
 #[derive(serde::Serialize)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct CreateShardKeyResponse {
     #[prost(bool, tag = "1")]
     pub result: bool,
+    /// Time spent to process
+    #[prost(double, tag = "2")]
+    pub time: f64,
 }
 #[derive(serde::Serialize)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct DeleteShardKeyResponse {
     #[prost(bool, tag = "1")]
     pub result: bool,
+    /// Time spent to process
+    #[prost(double, tag = "2")]
+    pub time: f64,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -1607,6 +1607,8 @@ impl From<CollectionClusterInfo> for api::grpc::qdrant::CollectionClusterInfoRes
                 .flatten()
                 .map(ReshardingInfo::into)
                 .collect(),
+            // Overwritten with the real processing time by the API handler
+            time: 0.0,
         }
     }
 }

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -199,19 +199,23 @@ impl Collections for CollectionsService {
         mut request: Request<CollectionClusterInfoRequest>,
     ) -> Result<Response<CollectionClusterInfoResponse>, Status> {
         validate(request.get_ref())?;
+        let timing = Instant::now();
         let auth = extract_auth(&mut request);
 
         // Nothing to verify here.
         let pass = new_unchecked_verification_pass();
 
-        let response = do_get_collection_cluster(
+        let result = do_get_collection_cluster(
             self.dispatcher.toc(&auth, &pass),
             &auth,
             request.into_inner().collection_name.as_str(),
         )
-        .await?
-        .into();
+        .await?;
 
+        let response = CollectionClusterInfoResponse {
+            time: timing.elapsed().as_secs_f64(),
+            ..result.into()
+        };
         Ok(Response::new(response))
     }
 
@@ -220,6 +224,7 @@ impl Collections for CollectionsService {
         mut request: Request<UpdateCollectionClusterSetupRequest>,
     ) -> Result<Response<UpdateCollectionClusterSetupResponse>, Status> {
         validate(request.get_ref())?;
+        let timing = Instant::now();
         let auth = extract_auth(&mut request);
         let UpdateCollectionClusterSetupRequest {
             collection_name,
@@ -239,6 +244,7 @@ impl Collections for CollectionsService {
         .await?;
         Ok(Response::new(UpdateCollectionClusterSetupResponse {
             result,
+            time: timing.elapsed().as_secs_f64(),
         }))
     }
 
@@ -268,6 +274,7 @@ impl Collections for CollectionsService {
         &self,
         mut request: Request<CreateShardKeyRequest>,
     ) -> Result<Response<CreateShardKeyResponse>, Status> {
+        let timing = Instant::now();
         let auth = extract_auth(&mut request);
 
         let CreateShardKeyRequest {
@@ -295,13 +302,17 @@ impl Collections for CollectionsService {
         )
         .await?;
 
-        Ok(Response::new(CreateShardKeyResponse { result }))
+        Ok(Response::new(CreateShardKeyResponse {
+            result,
+            time: timing.elapsed().as_secs_f64(),
+        }))
     }
 
     async fn delete_shard_key(
         &self,
         mut request: Request<DeleteShardKeyRequest>,
     ) -> Result<Response<DeleteShardKeyResponse>, Status> {
+        let timing = Instant::now();
         let auth = extract_auth(&mut request);
 
         let DeleteShardKeyRequest {
@@ -329,7 +340,10 @@ impl Collections for CollectionsService {
         )
         .await?;
 
-        Ok(Response::new(DeleteShardKeyResponse { result }))
+        Ok(Response::new(DeleteShardKeyResponse {
+            result,
+            time: timing.elapsed().as_secs_f64(),
+        }))
     }
 }
 

--- a/src/tonic/api/collections_api.rs
+++ b/src/tonic/api/collections_api.rs
@@ -212,10 +212,9 @@ impl Collections for CollectionsService {
         )
         .await?;
 
-        let response = CollectionClusterInfoResponse {
-            time: timing.elapsed().as_secs_f64(),
-            ..result.into()
-        };
+        let mut response = CollectionClusterInfoResponse::from(result);
+        response.time = timing.elapsed().as_secs_f64();
+
         Ok(Response::new(response))
     }
 


### PR DESCRIPTION
Add API processing time to some gRPC responses.

Adds the time field for the following types:

- `CreateShardKeyResponse` ([rest](https://api.qdrant.tech/v-1-18-x/api-reference/distributed/create-shard-key#response.body.time) counterpart)
- `DeleteShardKeyResponse` ([rest](https://api.qdrant.tech/v-1-18-x/api-reference/distributed/delete-shard-key#response.body.time) counterpart)
- `UpdateCollectionClusterSetupResponse` ([rest](https://api.qdrant.tech/v-1-18-x/api-reference/distributed/update-collection-cluster#response.body.time) counterpart)
- `CollectionClusterInfoResponse` ([rest](https://api.qdrant.tech/v-1-18-x/api-reference/collections/get-collection#response.body.time) counterpart)

This makes the responses consistent with our REST interface.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
