### PR TITLE
Fix payload index data inconsistency after restart

### DIFF
--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -564,6 +564,27 @@ impl IndexSelector<'_> {
     }
 }
 
+/// Remove all on-disk leftovers of `field`'s indexes under the payload index root `dir`.
+///
+/// A full rebuild must start from a clean slate: files can be left behind by a build
+/// whose config entry never became durable (config persistence is deferred to the
+/// flush pipeline) or by an index that failed to load. Appendable builders open
+/// existing storages, so leftovers would leak stale postings into the fresh build.
+pub(crate) fn wipe_field_dirs(dir: &Path, field: &JsonPath) -> std::io::Result<()> {
+    for candidate in [
+        map_dir(dir, field),
+        numeric_dir(dir, field),
+        text_dir(dir, field),
+        bool_dir(dir, field),
+        null_dir(dir, field),
+    ] {
+        if candidate.exists() {
+            fs_err::remove_dir_all(&candidate)?;
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn map_dir(dir: &Path, field: &JsonPath) -> PathBuf {
     dir.join(format!("{}-map", field.filename()))
 }

--- a/lib/segment/src/index/struct_payload_index/build.rs
+++ b/lib/segment/src/index/struct_payload_index/build.rs
@@ -5,6 +5,7 @@ use super::StructPayloadIndex;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::BuildIndexResult;
+use crate::index::field_index::index_selector::wipe_field_dirs;
 use crate::index::field_index::{FieldIndex, FieldIndexBuilderTrait as _};
 use crate::payload_storage::PayloadStorageRead;
 use crate::types::{PayloadContainer, PayloadFieldSchema, PayloadKeyTypeRef};
@@ -16,6 +17,12 @@ impl StructPayloadIndex {
         payload_schema: &PayloadFieldSchema,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<FieldIndex>> {
+        // Start from a clean slate: leftover files from a build whose config entry
+        // never became durable (or from an index that failed to load) would be
+        // opened by the appendable builders and leak stale postings into the
+        // fresh build.
+        wipe_field_dirs(&self.path, field)?;
+
         let payload_storage = self.payload.borrow();
         let id_tracker_borrow = self.id_tracker.borrow();
         let selector = self.selector(payload_schema);

--- a/lib/segment/src/index/struct_payload_index/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/mod.rs
@@ -54,6 +54,13 @@ pub struct StructPayloadIndex {
     pub(super) visited_pool: VisitedPool,
     /// Desired storage type for payload indices, used in builder to pick correct type
     storage_type: StorageType,
+    /// Bumped on every in-memory `config` mutation (index created/dropped). Paired with
+    /// [`Self::persisted_config_gen`] so the flusher writes the config file only when it
+    /// changed, and a stale (earlier-captured) flusher never overwrites a newer persisted
+    /// config.
+    config_gen: u64,
+    /// Generation of the config that was last persisted by a flusher.
+    persisted_config_gen: Arc<parking_lot::Mutex<u64>>,
 }
 
 impl StructPayloadIndex {
@@ -64,6 +71,20 @@ impl StructPayloadIndex {
     pub(super) fn save_config(&self) -> OperationResult<()> {
         let config_path = self.config_path();
         self.config.save(&config_path)
+    }
+
+    /// Record an in-memory config mutation (index created or dropped) for deferred
+    /// persistence by the flusher.
+    ///
+    /// The config file must never durably list an index whose data (and the payload
+    /// state it was built from) is not itself durable: WAL replay of `CreateFieldIndex`
+    /// short-circuits on `AlreadyBuilt` when the config lists the field, skipping the
+    /// rebuild that re-derives postings for rows replay resurrects. Persisting the
+    /// config inside the flush pipeline (after the index data, before the segment
+    /// version) keeps config, index data, payload state, and version mutually
+    /// consistent at every crash point.
+    pub(super) fn mark_config_dirty(&mut self) {
+        self.config_gen += 1;
     }
 
     fn load_all_fields(&mut self, create_if_missing: bool) -> OperationResult<()> {
@@ -172,6 +193,9 @@ impl StructPayloadIndex {
         // If index is not properly loaded or when migrating, rebuild indices
         if rebuild {
             log::debug!("Rebuilding payload index for field `{field}`...");
+            // Close any partially-loaded index storages first: the rebuild wipes
+            // their directories before building fresh.
+            indexes.clear();
             indexes = self.build_field_indexes(
                 field,
                 &payload_schema.schema,
@@ -217,6 +241,8 @@ impl StructPayloadIndex {
             path: path.to_owned(),
             visited_pool: Default::default(),
             storage_type,
+            config_gen: 0,
+            persisted_config_gen: Arc::new(parking_lot::Mutex::new(0)),
         };
 
         if !index.config_path().exists() {

--- a/lib/segment/src/index/struct_payload_index/payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index/payload_index.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
@@ -57,7 +58,9 @@ impl PayloadIndex for StructPayloadIndex {
             PayloadFieldSchemaWithIndexType::new(payload_schema, index_types),
         );
 
-        self.save_config()?;
+        // Persistence of the config is deferred to the flush pipeline: see
+        // `mark_config_dirty` for the durability invariant this preserves.
+        self.mark_config_dirty();
 
         Ok(())
     }
@@ -104,7 +107,10 @@ impl PayloadIndex for StructPayloadIndex {
             }
         }
 
-        self.save_config()?;
+        // Deferred to the flush pipeline (see `mark_config_dirty`). If a crash leaves
+        // the durable config still listing this field with its files wiped, the load
+        // path rebuilds it from payload and WAL replay re-applies the drop.
+        self.mark_config_dirty();
 
         Ok(is_removed)
     }
@@ -236,6 +242,15 @@ impl PayloadIndex for StructPayloadIndex {
         }
         let payload_flusher = self.payload.borrow().flusher();
 
+        // Config persistence rides the flush pipeline, after the index data it
+        // describes (see `mark_config_dirty` for the durability invariant). The
+        // snapshot is captured together with the field flushers, so what gets
+        // written always describes data flushed in this (or an earlier) cycle.
+        let config_snapshot = self.config.clone();
+        let config_gen = self.config_gen;
+        let persisted_config_gen = Arc::clone(&self.persisted_config_gen);
+        let config_path = self.config_path();
+
         Box::new(move || {
             for flusher in field_flushers {
                 match flusher() {
@@ -253,6 +268,17 @@ impl PayloadIndex for StructPayloadIndex {
                 }
             }
             payload_flusher()?;
+
+            {
+                let mut persisted_gen = persisted_config_gen.lock();
+                // `>` (not `>=`): skips rewrites when nothing changed and stops a
+                // stale flusher from overwriting a newer persisted config.
+                if config_gen > *persisted_gen {
+                    config_snapshot.save(&config_path)?;
+                    *persisted_gen = config_gen;
+                }
+            }
+
             Ok(())
         })
     }

--- a/lib/segment/src/index/struct_payload_index/tests.rs
+++ b/lib/segment/src/index/struct_payload_index/tests.rs
@@ -10,14 +10,20 @@ use tempfile::Builder;
 use uuid::Uuid;
 
 use crate::data_types::vectors::only_default_vector;
-use crate::entry::{NonAppendableSegmentEntry, SegmentEntry};
+use crate::entry::{
+    NonAppendableSegmentEntry, ReadSegmentEntry, SegmentEntry, StorageSegmentEntry,
+};
+use crate::index::PayloadIndexRead;
 use crate::index::payload_config::{
     FullPayloadIndexType, IndexMutability, PayloadConfig, PayloadIndexType,
 };
 use crate::json_path::JsonPath;
 use crate::segment_constructor::load_segment;
 use crate::segment_constructor::simple_segment_constructor::build_simple_segment;
-use crate::types::{Distance, Payload, PayloadFieldSchema, PayloadSchemaType};
+use crate::types::{
+    Condition, Distance, FieldCondition, Filter, Match, Payload, PayloadFieldSchema,
+    PayloadSchemaType, ValueVariants,
+};
 
 #[test]
 fn test_load_payload_index() {
@@ -53,6 +59,10 @@ fn test_load_payload_index() {
                 &HardwareCounterCell::new(),
             )
             .unwrap();
+
+        // Config persistence is deferred to the flush pipeline; flush so the
+        // on-disk config below lists the freshly created index.
+        segment.flush(true).unwrap();
 
         segment.segment_path.clone()
     };
@@ -94,6 +104,74 @@ fn test_load_payload_index() {
 
     let schema = payload_config.indices.get(&key).unwrap();
     assert!(check_index_types(&schema.types));
+}
+
+/// Failure-direction regression test for the payload index inconsistency fixed by
+/// deferring config persistence into the flush pipeline: an index built while a
+/// payload change was still pending must be rebuilt when `CreateFieldIndex` is
+/// re-applied (WAL replay) after a restart lost that pending change. With the config
+/// saved synchronously at build time, the re-application hit `AlreadyBuilt` and the
+/// resurrected row stayed invisible to filtered reads forever.
+#[test]
+fn create_field_index_replay_covers_rows_resurrected_by_lost_flush() {
+    let dir = Builder::new().prefix("payload_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let key = JsonPath::from_str("name").unwrap();
+    let schema = PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword);
+    let payload: Payload = serde_json::from_str(r#"{ "name": "John Doe" }"#).unwrap();
+
+    let segment_path = {
+        let mut segment = build_simple_segment(dir.path(), 2, Distance::Dot).unwrap();
+        segment
+            .upsert_point(1, 0.into(), only_default_vector(&[1.0, 1.0]), &hw_counter)
+            .unwrap();
+        segment
+            .set_full_payload(2, 0.into(), &payload, &hw_counter)
+            .unwrap();
+        segment.flush(true).unwrap();
+
+        // Pending payload clear: never flushed, lost at the "crash" below.
+        segment.clear_payload(3, 0.into(), &hw_counter).unwrap();
+
+        // The build correctly omits the cleared row.
+        segment
+            .create_field_index(4, &key, Some(&schema), &hw_counter)
+            .unwrap();
+
+        segment.segment_path.clone()
+        // Dropped without a flush: everything after the explicit flush is lost.
+    };
+
+    let mut segment = load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false))
+        .expect("segment must load after simulated crash");
+
+    // The clear was pending only: the durable payload row resurrected.
+    let resurrected = segment.payload(0.into(), &hw_counter).unwrap();
+    assert!(
+        resurrected.0.contains_key("name"),
+        "the unflushed payload clear must be lost on reload",
+    );
+
+    // WAL replay re-applies the CreateFieldIndex op; it must rebuild over the
+    // resurrected row instead of trusting a prematurely persisted config.
+    segment
+        .create_field_index(4, &key, Some(&schema), &hw_counter)
+        .unwrap();
+
+    let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
+        key,
+        Match::new_value(ValueVariants::String("John Doe".to_string())),
+    )));
+    let hits = segment
+        .payload_index
+        .borrow()
+        .with_view(|view| view.query_points(&filter, &hw_counter, &AtomicBool::new(false)))
+        .unwrap();
+    assert_eq!(
+        hits,
+        vec![0],
+        "the field index must cover the resurrected payload row",
+    );
 }
 
 #[test]

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -1381,9 +1381,9 @@ fn test_bool_index_appendable_reopen_accepts_updates() {
             .set_indexed(&field, FieldType(PayloadSchemaType::Bool), &hw_counter)
             .unwrap();
 
-        for field_index in index.field_indexes.get(&field).unwrap() {
-            field_index.flusher()().unwrap();
-        }
+        // The full flusher, not per-field storage flushers: config persistence
+        // (which the reopen below relies on) rides the flush pipeline.
+        index.flusher()().unwrap();
     }
 
     let payload_storage = Arc::new(AtomicRefCell::new(InMemoryPayloadStorage::default().into()));
@@ -1443,9 +1443,9 @@ fn test_null_index_appendable_reopen_loads_and_accepts_updates() {
             .set_indexed(&field, FieldType(Keyword), &hw_counter)
             .unwrap();
 
-        for field_index in index.field_indexes.get(&field).unwrap() {
-            field_index.flusher()().unwrap();
-        }
+        // The full flusher, not per-field storage flushers: config persistence
+        // (which the reopen below relies on) rides the flush pipeline.
+        index.flusher()().unwrap();
     }
 
     // Reopen with a fresh (empty) payload storage — same pattern as the bool


### PR DESCRIPTION
**TL;DR**: after a restart, a field index can describe a newer state than the payload it summarizes, and the saved schema file makes WAL replay skip the rebuild that would repair it. 

Fix: persist the schema in the same flush cycle as the data.

## Example

A `city` keyword index is created while a point deletion is still pending (changes stay buffered in memory until the next flush):

1. Point 7 is inserted with `city: "Berlin"` and flushed to disk.
2. Point 7 is deleted. The deletion is not flushed yet.
3. `CreateFieldIndex(city)` builds the index. Point 7 is deleted right now, so it gets no posting. The build result and the config are written to disk immediately.

A restart before the next flush loses the pending deletion, so point 7 is back, and the durable state contradicts itself:

| component | durable state |
|---|---|
| payload storage | point 7 present, `city: "Berlin"` |
| `city` index | no posting for point 7 |
| config | `city` is indexed |

WAL replay normally reconciles this kind of gap by re-applying operations: a plain deletion would simply delete the row again and storage and index would agree.

But the WAL records logical operations, not their physical side effects, and this deletion was the side effect of an update that relocated the point to another segment under conditions (an in-flight snapshot, a duplicate copy) that no longer hold at replay. 

The re-applied update resolves as a plain in-place write, so the row stays, and `CreateFieldIndex` sees `city` in the config and skips the rebuild as `AlreadyBuilt`.

Point 7 is now permanently invisible to `city` filters while full scans keep returning it. 

With this fix the config only becomes durable at the next flush, so after the restart it does not list `city`, and the replayed `CreateFieldIndex` rebuilds the index and covers point 7.

## Problem

`apply_index`/`drop_index` save the payload index config (`payload_index/config.json`) synchronously. 

The config is already written after the index files, so the index artifact itself is never torn: config present has always meant the index files are complete. 

What that ordering cannot guarantee is that the *payload state the build summarized* is durable too: payload durability is committed by the segment flush cycle, a separate and later commit point.

 A restart in between rewinds the payload but not the index or its config.

WAL replay trusts that schema: when it re-applies `CreateFieldIndex` and finds the field already in the config, it returns `AlreadyBuilt` and skips the rebuild. 

If the segment state reconstructed by replay differs from what the live build saw, the index permanently misses points that are visible in payload storage.

Found by the model testing harness as a CI flake in `harness_no_optimizer_snapshots` (run [28888025708](https://github.com/qdrant/qdrant/actions/runs/28888025708/job/85693129551)); seed `17579323109889096168` reproduces it deterministically.

## Fix

Persist the config as part of the flush pipeline instead, right after the field index and payload data it describes and before the segment version write. 

Now either the whole flush cycle is durable (config, index data, payload, version all consistent) or none of it is, in which case the config does not list the field and replay rebuilds the index from the current payload rows.

Supporting changes:

- A config generation counter avoids rewriting an unchanged config on every flush and keeps a stale-captured flusher from overwriting a newer persisted config.
- Index rebuilds wipe leftover files first (`wipe_field_dirs`): a build whose config entry never became durable leaves orphan storages behind, and reopening them would leak stale postings into the fresh build.

Considered alternative: always rebuild when `CreateFieldIndex` is re-applied. 

Rejected because the segment layer cannot tell a replayed op from a live duplicate call, and clients routinely re-issue `create_field_index` as an idempotent ensure-step; every such call would then trigger a full rebuild. `AlreadyBuilt` stays a no-op; this change just makes the config it trusts truthful.

## Validation

- New regression test `create_field_index_replay_covers_rows_resurrected_by_lost_flush` walks the failure end to end (durable row, pending clear lost at reopen, re-applied `CreateFieldIndex`); it fails on the previous code and passes with this change.

- The failing CI seed: 0/6 runs passed before the fix, 24/24 after.
- All five model-testing gates and 7 fresh-seed snapshot-gate runs green.
- `cargo test -p segment/-p shard` green (lib + integration); three tests adjusted because they asserted the on-disk config right after index creation, which now requires running the flusher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)