### PR TITLE
Refactor: add DeletedBitVec

### DIFF
--- a/lib/common/common/src/bitvec.rs
+++ b/lib/common/common/src/bitvec.rs
@@ -38,3 +38,46 @@ impl<T: BitStore, O: BitOrder> BitSliceExt for bitvec::slice::BitSlice<T, O> {
         self.get(index).as_deref().copied()
     }
 }
+
+/// Wrapper around [BitVec] with following assumptions:
+/// - Out-of-range points are considered deleted/not active.
+/// - The bitvec never grows.
+pub struct DeletedBitVec {
+    bits: BitVec,
+    count: usize,
+}
+
+impl DeletedBitVec {
+    pub fn new(deleted: BitVec) -> Self {
+        Self {
+            count: deleted.count_ones(),
+            bits: deleted,
+        }
+    }
+
+    #[inline]
+    pub fn is_active(&self, point_id: PointOffsetType) -> bool {
+        self.bits.get_bit(point_id as usize) == Some(false)
+    }
+
+    pub fn mark_deleted(&mut self, point_id: PointOffsetType) -> bool {
+        let newly_marked = self.is_active(point_id);
+        if newly_marked {
+            self.bits.set(point_id as usize, true);
+            self.count += 1;
+        }
+        newly_marked
+    }
+
+    pub fn deleted_count(&self) -> usize {
+        self.count
+    }
+
+    pub fn active_count(&self) -> usize {
+        self.bits.len() - self.count
+    }
+
+    pub fn ram_usage_bytes(&self) -> usize {
+        self.bits.capacity().div_ceil(u8::BITS as usize)
+    }
+}

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/immutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/immutable_inverted_index.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 
 use ahash::AHashMap;
-use common::bitvec::BitSliceExt;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::UserData;
@@ -529,7 +528,11 @@ impl<S: common::universal_io::UniversalRead> TryFrom<&OnDiskInvertedIndex<S>>
             .read_whole()?
             .into_owned();
         for (idx, count) in point_to_tokens_count.iter_mut().enumerate() {
-            if index.storage.deleted_points.get_bit(idx).unwrap_or(false) {
+            if !index
+                .storage
+                .deleted_points
+                .is_active(idx as PointOffsetType)
+            {
                 *count = 0;
             }
         }

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mod.rs
@@ -412,7 +412,7 @@ pub trait InvertedIndex {
 #[cfg(test)]
 mod tests {
 
-    use common::bitvec::{BitSliceExt, BitVec};
+    use common::bitvec::BitVec;
     use common::counter::hardware_counter::HardwareCounterCell;
     use common::universal_io::{MmapFs, Populate};
     use rand::RngExt;
@@ -615,8 +615,8 @@ mod tests {
         for (point_id, count) in immutable.point_to_tokens_count.iter().enumerate() {
             // Check same deleted points
             assert_eq!(
-                mmap.storage.deleted_points.get_bit(point_id).unwrap(),
-                *count == 0,
+                mmap.storage.deleted_points.is_active(point_id as u32),
+                *count != 0,
                 "point_id: {point_id}",
             );
 
@@ -626,7 +626,7 @@ mod tests {
         }
 
         // Check same points count
-        assert_eq!(immutable.points_count, mmap.active_points_count);
+        assert_eq!(immutable.points_count, mmap.points_count());
         assert_eq!(immutable.points_count, imm_mmap.points_count);
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::ops::BitOrAssign;
 use std::path::PathBuf;
 
-use common::bitvec::{BitSlice, BitSliceExt, BitVec};
+use common::bitvec::{BitSlice, BitVec, DeletedBitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::fs::clear_disk_cache;
 use common::generic_consts::Random;
@@ -59,8 +59,6 @@ const DELETED_POINTS_FILE: &str = "deleted_points.dat";
 pub struct OnDiskInvertedIndex<S: UniversalRead = MmapFile> {
     pub(in crate::index::field_index::full_text_index) path: PathBuf,
     pub(in crate::index::field_index::full_text_index) storage: Storage<S>,
-    /// Number of points which are not deleted
-    pub(in crate::index::field_index::full_text_index) active_points_count: usize,
 }
 
 pub(in crate::index::field_index::full_text_index) struct Storage<S: UniversalRead = MmapFile> {
@@ -68,7 +66,7 @@ pub(in crate::index::field_index::full_text_index) struct Storage<S: UniversalRe
     pub(in crate::index::field_index::full_text_index) vocab: UniversalHashMap<str, TokenId, S>,
     pub(in crate::index::field_index::full_text_index) point_to_tokens_count:
         TypedStorage<S, usize>,
-    pub(in crate::index::field_index::full_text_index) deleted_points: BitVec,
+    pub(in crate::index::field_index::full_text_index) deleted_points: DeletedBitVec,
 }
 
 impl<S: UniversalRead> Storage<S> {
@@ -80,7 +78,7 @@ impl<S: UniversalRead> Storage<S> {
             deleted_points,
         } = self;
 
-        deleted_points.capacity().div_ceil(u8::BITS as usize)
+        deleted_points.ram_usage_bytes()
     }
 }
 
@@ -238,8 +236,7 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
         deleted.resize(total_count, false);
         deleted.bitor_assign(deleted_payloads_bitslice.as_ref());
 
-        let num_deleted_points = deleted.count_ones();
-        let points_count = total_count - num_deleted_points;
+        let deleted = DeletedBitVec::new(deleted);
 
         Ok(Some(Self {
             path,
@@ -249,7 +246,6 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
                 point_to_tokens_count,
                 deleted_points: deleted,
             },
-            active_points_count: points_count,
         }))
     }
 
@@ -264,12 +260,7 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
 
     /// Returns whether the point id is valid and active.
     pub fn is_active(&self, point_id: PointOffsetType) -> bool {
-        let is_deleted = self
-            .storage
-            .deleted_points
-            .get_bit(point_id as usize)
-            .unwrap_or(true);
-        !is_deleted
+        self.storage.deleted_points.is_active(point_id)
     }
 
     /// Iterate over point ids whose documents contain all given tokens.
@@ -501,11 +492,7 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
 
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
-        let Self {
-            path,
-            storage,
-            active_points_count: _,
-        } = self;
+        let Self { path, storage } = self;
         let Storage {
             postings,
             vocab,
@@ -548,17 +535,7 @@ impl<S: UniversalRead> InvertedIndex for OnDiskInvertedIndex<S> {
     }
 
     fn remove(&mut self, idx: PointOffsetType) -> bool {
-        let Some(is_deleted) = self.storage.deleted_points.get_bit(idx as usize) else {
-            return false; // Never existed
-        };
-
-        if is_deleted {
-            return false; // Already removed
-        }
-
-        self.storage.deleted_points.set(idx as usize, true);
-        self.active_points_count = self.active_points_count.saturating_sub(1);
-        true
+        self.storage.deleted_points.mark_deleted(idx)
     }
 
     fn filter<'a>(
@@ -608,12 +585,7 @@ impl<S: UniversalRead> InvertedIndex for OnDiskInvertedIndex<S> {
     }
 
     fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
-        if self
-            .storage
-            .deleted_points
-            .get_bit(point_id as usize)
-            .unwrap_or(true)
-        {
+        if !self.storage.deleted_points.is_active(point_id) {
             return true;
         }
         // If the read fails or the point does not exist, treat as empty.
@@ -623,12 +595,7 @@ impl<S: UniversalRead> InvertedIndex for OnDiskInvertedIndex<S> {
     }
 
     fn values_count(&self, point_id: PointOffsetType) -> usize {
-        if self
-            .storage
-            .deleted_points
-            .get_bit(point_id as usize)
-            .unwrap_or(true)
-        {
+        if !self.storage.deleted_points.is_active(point_id) {
             return 0;
         }
 
@@ -637,7 +604,7 @@ impl<S: UniversalRead> InvertedIndex for OnDiskInvertedIndex<S> {
     }
 
     fn points_count(&self) -> usize {
-        self.active_points_count
+        self.storage.deleted_points.active_count()
     }
 
     fn for_each_token_id<'a, U: UserData>(

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index/lifecycle.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::path::PathBuf;
 
-use common::bitvec::BitSliceExt;
 use common::generic_consts::Random;
 use common::types::PointOffsetType;
 use common::universal_io::{ReadRange, UniversalRead};
@@ -46,12 +45,7 @@ impl<S: UniversalRead> ImmutableGeoIndex<S> {
                 points_map_hashes.push(points_map_entries[i].hash.normalize());
                 points_map_offsets.push(points_map_ids.len() as u32);
                 for &id in ids {
-                    if !index
-                        .storage
-                        .deleted
-                        .get_bit(id as usize)
-                        .unwrap_or_default()
-                    {
+                    if index.storage.deleted.is_active(id) {
                         points_map_ids.push(id);
                     }
                 }
@@ -64,7 +58,7 @@ impl<S: UniversalRead> ImmutableGeoIndex<S> {
         // Get point values and filter deleted points
         // Track deleted points to adjust point and value counts after loading
         let mut deleted_points: Vec<(PointOffsetType, Vec<GeoPoint>)> =
-            Vec::with_capacity(index.deleted_count);
+            Vec::with_capacity(index.storage.deleted.deleted_count());
         // Batched reads only report non-empty points and may arrive out of
         // order, so we pre-fill with empty value lists and index by point id.
         let mut point_to_values: Vec<Vec<GeoPoint>> =
@@ -74,12 +68,7 @@ impl<S: UniversalRead> ImmutableGeoIndex<S> {
             .point_to_values
             .for_all_points_values(|id, values| {
                 let geo_points: Vec<GeoPoint> = values.map(Cow::into_owned).collect();
-                let is_deleted = index
-                    .storage
-                    .deleted
-                    .get_bit(id as usize)
-                    .unwrap_or_default();
-                if is_deleted {
+                if !index.storage.deleted.is_active(id) {
                     deleted_points.push((id, geo_points));
                 } else {
                     point_to_values[id as usize] = geo_points;

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use ahash::AHashSet;
 use common::binary_search::binary_search_by;
-use common::bitvec::{BitSlice, BitSliceExt};
+use common::bitvec::{BitSlice, DeletedBitVec};
 use common::counter::conditioned_counter::ConditionedCounter;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::fs::{atomic_save_json, clear_disk_cache};
@@ -216,8 +216,6 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         deleted.resize(point_to_values.len(), false);
         deleted.bitor_assign(deleted_payloads_bitslice.as_ref());
 
-        let deleted_count = deleted.count_ones();
-
         Ok(Some(Self {
             path: path.to_owned(),
             storage: Storage {
@@ -225,9 +223,8 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
                 points_map,
                 points_map_ids,
                 point_to_values,
-                deleted,
+                deleted: DeletedBitVec::new(deleted),
             },
-            deleted_count,
             points_values_count: stats.points_values_count,
             max_values_per_point: stats.max_values_per_point,
         }))
@@ -240,7 +237,7 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         check_fn: impl Fn(&GeoPoint) -> bool,
     ) -> OperationResult<bool> {
         let hw_counter = ConditionedCounter::always(hw_counter);
-        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
+        if self.storage.deleted.is_active(idx) {
             self.storage
                 .point_to_values
                 .check_values_any(idx, |v| check_fn(v), &hw_counter)
@@ -259,7 +256,7 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
     }
 
     pub fn values_count(&self, idx: PointOffsetType) -> usize {
-        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
+        if self.storage.deleted.is_active(idx) {
             self.storage
                 .point_to_values
                 .get_values_count(idx)
@@ -388,11 +385,7 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
     /// Not persisted: on reopen, deletions must be re-supplied via the
     /// `deleted_points` argument to [`Self::open`].
     pub fn remove_point(&mut self, idx: PointOffsetType) {
-        let idx = idx as usize;
-        if idx < self.storage.deleted.len() && !self.storage.deleted.get_bit(idx).unwrap_or(true) {
-            self.storage.deleted.set(idx, true);
-            self.deleted_count += 1;
-        }
+        self.storage.deleted.mark_deleted(idx);
     }
 
     /// Return all unique point IDs which have any of the geo-hash prefixes.
@@ -493,15 +486,11 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         // Step 3: read the collected ranges and accumulate unique,
         // non-deleted point ids.
         let mut points = AHashSet::new();
+        let deleted = &self.storage.deleted;
         self.storage.points_map_ids.read_batch::<Random, _>(
             point_map_ranges.into_iter().enumerate(),
             |_idx, values| {
-                points.extend(
-                    values
-                        .iter()
-                        .copied()
-                        .filter(|&id| !self.storage.deleted.get_bit(id as usize).unwrap_or(true)),
-                );
+                points.extend(values.iter().copied().filter(|&id| deleted.is_active(id)));
                 Ok(())
             },
         )?;
@@ -513,7 +502,7 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         self.storage
             .point_to_values
             .len()
-            .saturating_sub(self.deleted_count)
+            .saturating_sub(self.storage.deleted.deleted_count())
     }
 
     pub fn points_values_count(&self) -> usize {
@@ -539,7 +528,6 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         let Self {
             path,
             storage,
-            deleted_count: _,
             points_values_count: _,
             max_values_per_point: _,
         } = self;

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/mod.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use common::bitvec::BitVec;
+use common::bitvec::DeletedBitVec;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, TypedStorage, UniversalRead};
 use serde::{Deserialize, Serialize};
@@ -64,7 +64,6 @@ pub(in super::super) struct PointKeyValue {
 pub struct OnDiskGeoIndex<S: UniversalRead = MmapFile> {
     pub(super) path: PathBuf,
     pub(in super::super) storage: Storage<S>,
-    pub(in super::super) deleted_count: usize,
     pub(super) points_values_count: usize,
     pub(super) max_values_per_point: usize,
 }
@@ -83,7 +82,7 @@ pub(in super::super) struct Storage<S: UniversalRead = MmapFile> {
     /// In-memory deletion bitmap. Reconstructed at load time as the union of
     /// the build-time empty-payload bits read from `deleted.bin` and the
     /// segment-level deleted bitslice supplied by the id-tracker. Not persisted.
-    pub(in super::super) deleted: BitVec,
+    pub(in super::super) deleted: DeletedBitVec,
 }
 
 impl<S: UniversalRead> Storage<S> {
@@ -100,7 +99,7 @@ impl<S: UniversalRead> Storage<S> {
             + points_map.ram_usage_bytes()
             + points_map_ids.ram_usage_bytes()
             + point_to_values.ram_usage_bytes()
-            + deleted.capacity().div_ceil(u8::BITS as usize)
+            + deleted.ram_usage_bytes()
     }
 }
 

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
@@ -3,7 +3,7 @@ use std::ops::BitOrAssign;
 use std::path::{Path, PathBuf};
 
 use ahash::HashMap;
-use common::bitvec::{BitSlice, BitSliceExt};
+use common::bitvec::{BitSlice, DeletedBitVec};
 use common::fs::{atomic_save_json, clear_disk_cache};
 use common::mmap::{AdviceSetting, create_and_ensure_length};
 use common::persisted_hashmap::{Key, UniversalHashMap, serialize_hashmap};
@@ -85,17 +85,14 @@ where
         deleted.resize(point_to_values.len(), false);
         deleted.bitor_assign(deleted_payloads_bitslice.as_ref());
 
-        let deleted_count = deleted.count_ones();
-
         Ok(Some(Self {
             path: path.to_path_buf(),
             storage: Storage {
                 value_to_points,
                 point_to_values,
-                deleted,
+                deleted: DeletedBitVec::new(deleted),
                 prefix_index,
             },
-            deleted_count,
             total_key_value_pairs: config.total_key_value_pairs,
         }))
     }
@@ -105,11 +102,7 @@ where
     /// Not persisted: on reopen, deletions must be re-supplied via the
     /// `deleted_points` argument to [`Self::open`].
     pub fn remove_point(&mut self, idx: PointOffsetType) {
-        let idx = idx as usize;
-        if idx < self.storage.deleted.len() && !self.storage.deleted.get_bit(idx).unwrap_or(true) {
-            self.storage.deleted.set(idx, true);
-            self.deleted_count += 1;
-        }
+        self.storage.deleted.mark_deleted(idx);
     }
 
     pub fn files(&self) -> Vec<PathBuf> {
@@ -154,7 +147,6 @@ where
         let Self {
             path,
             storage,
-            deleted_count: _,
             total_key_value_pairs: _,
         } = self;
         let Storage {

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/mod.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use common::bitvec::BitVec;
+use common::bitvec::DeletedBitVec;
 use common::persisted_hashmap::{Key, UniversalHashMap};
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, UniversalRead};
@@ -33,7 +33,6 @@ pub(super) const CONFIG_PATH: &str = "mmap_field_index_config.json";
 pub struct OnDiskMapIndex<N: MapIndexKey + Key + ?Sized, S: UniversalRead = MmapFile> {
     pub(super) path: PathBuf,
     pub(super) storage: Storage<N, S>,
-    pub(super) deleted_count: usize,
     pub(super) total_key_value_pairs: usize,
 }
 
@@ -43,7 +42,7 @@ pub(super) struct Storage<N: MapIndexKey + Key + ?Sized, S: UniversalRead = Mmap
     /// In-memory deletion bitmap. Reconstructed at load time as the union of
     /// the build-time empty-payload bits read from `deleted.bin` and the
     /// segment-level deleted bitslice supplied by the id-tracker. Not persisted.
-    pub(super) deleted: BitVec,
+    pub(super) deleted: DeletedBitVec,
     /// Sorted key dictionary for prefix queries. Present only when the index
     /// was built with the `prefix` option (signalled by the presence of its
     /// file on disk).
@@ -61,7 +60,7 @@ impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> Storage<N, S> {
 
         // `value_to_points` is a storage-backed hashmap with no in-memory state.
         point_to_values.ram_usage_bytes()
-            + deleted.capacity().div_ceil(u8::BITS as usize)
+            + deleted.ram_usage_bytes()
             + prefix_index
                 .as_ref()
                 .map_or(0, |prefix_index| prefix_index.ram_usage_bytes())

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/read_ops.rs
@@ -1,7 +1,6 @@
 use std::borrow::{Borrow, Cow};
 use std::iter;
 
-use common::bitvec::BitSliceExt;
 use common::counter::conditioned_counter::ConditionedCounter;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
@@ -34,13 +33,7 @@ impl<'a, N: MapIndexKey + Key + ?Sized + 'a, S: UniversalRead> MapIndexRead<'a, 
             .payload_index_io_read_counter()
             .incr_delta(size_of::<bool>());
 
-        let is_deleted = self
-            .storage
-            .deleted
-            .get_bit(idx as usize)
-            .is_some_and(|b| b);
-
-        if is_deleted {
+        if !self.storage.deleted.is_active(idx) {
             return Ok(false);
         }
 
@@ -59,7 +52,7 @@ impl<'a, N: MapIndexKey + Key + ?Sized + 'a, S: UniversalRead> MapIndexRead<'a, 
         // We can account cost of reading `bool`, but it will likely be more expensive, than
         // actually reading bool itself.
 
-        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
+        if self.storage.deleted.is_active(idx) {
             self.storage
                 .point_to_values
                 .values_iter(idx, hw_counter)
@@ -71,7 +64,7 @@ impl<'a, N: MapIndexKey + Key + ?Sized + 'a, S: UniversalRead> MapIndexRead<'a, 
     }
 
     fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
-        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
+        if self.storage.deleted.is_active(idx) {
             self.storage.point_to_values.get_values_count(idx).ok()?
         } else {
             None
@@ -82,7 +75,7 @@ impl<'a, N: MapIndexKey + Key + ?Sized + 'a, S: UniversalRead> MapIndexRead<'a, 
         self.storage
             .point_to_values
             .len()
-            .saturating_sub(self.deleted_count)
+            .saturating_sub(self.storage.deleted.deleted_count())
     }
 
     /// Returns the number of key-value pairs in the index.
@@ -132,10 +125,11 @@ impl<'a, N: MapIndexKey + Key + ?Sized + 'a, S: UniversalRead> MapIndexRead<'a, 
                     .payload_index_io_read_counter()
                     .incr_delta(size_of_val(values.as_slice()) + READ_ENTRY_OVERHEAD);
 
+                let deleted = &self.storage.deleted;
                 Box::new(
-                    values.into_iter().filter(|idx| {
-                        !self.storage.deleted.get_bit(*idx as usize).unwrap_or(false)
-                    }),
+                    values
+                        .into_iter()
+                        .filter(move |idx| deleted.is_active(*idx)),
                 )
             }
             Ok(None) => {
@@ -186,13 +180,12 @@ impl<'a, N: MapIndexKey + Key + ?Sized + 'a, S: UniversalRead> MapIndexRead<'a, 
                     .payload_index_io_read_counter()
                     .incr_delta(io_read);
 
-                let mut ids = point_ids.unwrap_or(&[]).iter().copied().filter(|point| {
-                    !self
-                        .storage
-                        .deleted
-                        .get_bit(*point as usize)
-                        .unwrap_or(false)
-                });
+                let deleted = &self.storage.deleted;
+                let mut ids = point_ids
+                    .unwrap_or(&[])
+                    .iter()
+                    .copied()
+                    .filter(move |point| deleted.is_active(*point));
 
                 f(key, &mut ids)
             })
@@ -224,11 +217,12 @@ impl<'a, N: MapIndexKey + Key + ?Sized + 'a, S: UniversalRead> MapIndexRead<'a, 
         deferred_internal_id: Option<PointOffsetType>,
         mut f: impl FnMut(&N, usize) -> OperationResult<()>,
     ) -> OperationResult<()> {
+        let deleted = &self.storage.deleted;
         self.storage.value_to_points.for_each_entry(|k, v| {
             let count = v
                 .iter()
                 .filter(|&&idx| {
-                    !self.storage.deleted.get_bit(idx as usize).unwrap_or(true)
+                    deleted.is_active(idx)
 
                     // TODO(deferred): Maybe we can improve this filter and use take_while instead. For this we
                     // need to make sure that `v` is always sorted which we _can_ enforce when finalizing the index.
@@ -257,7 +251,7 @@ impl<'a, N: MapIndexKey + Key + ?Sized + 'a, S: UniversalRead> MapIndexRead<'a, 
             let mut iter = v
                 .iter()
                 .copied()
-                .filter(|idx| !deleted.get_bit(*idx as usize).unwrap_or(true))
+                .filter(|idx| deleted.is_active(*idx))
                 .measure_hw_with_acc(
                     hw_counter.new_accumulator(),
                     size_of::<PointOffsetType>(),
@@ -291,8 +285,7 @@ impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> OnDiskMapIndex<N, S> {
         let hw_counter = ConditionedCounter::always(hw_counter);
 
         // Skip deleted points
-        let points =
-            points.filter(|&idx| self.storage.deleted.get_bit(idx as usize) == Some(false));
+        let points = points.filter(|&idx| self.storage.deleted.is_active(idx));
 
         self.storage
             .point_to_values

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 use std::ops::BitOrAssign;
 use std::path::{Path, PathBuf};
 
-use common::bitvec::{BitSlice, BitSliceExt};
+use common::bitvec::{BitSlice, DeletedBitVec};
 use common::fs::{atomic_save_json, clear_disk_cache};
 use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
@@ -166,17 +166,14 @@ where
         deleted.resize(point_to_values.len(), false);
         deleted.bitor_assign(deleted_payloads_bitslice.as_ref());
 
-        let deleted_count = deleted.count_ones();
-
         Ok(Some(Self {
             path: path.to_path_buf(),
             storage: Storage {
-                deleted,
+                deleted: DeletedBitVec::new(deleted),
                 pairs,
                 point_to_values,
             },
             histogram,
-            deleted_count,
             max_values_per_point: config.max_values_per_point,
         }))
     }
@@ -232,11 +229,7 @@ where
     /// Not persisted: on reopen, deletions must be re-supplied via the
     /// `deleted_points` argument to [`Self::open`].
     pub fn remove_point(&mut self, idx: PointOffsetType) {
-        let idx = idx as usize;
-        if idx < self.storage.deleted.len() && !self.storage.deleted.get_bit(idx).unwrap_or(true) {
-            self.storage.deleted.set(idx, true);
-            self.deleted_count += 1;
-        }
+        self.storage.deleted.mark_deleted(idx);
     }
 
     /// Populate all pages in the mmap.
@@ -253,7 +246,6 @@ where
             path,
             storage,
             histogram: _,
-            deleted_count: _,
             max_values_per_point: _,
         } = self;
         let Storage {
@@ -272,7 +264,6 @@ where
             path: _,
             storage,
             histogram,
-            deleted_count: _,
             max_values_per_point: _,
         } = self;
 

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/mod.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use common::bitvec::BitVec;
+use common::bitvec::DeletedBitVec;
 use common::universal_io::{MmapFile, TypedStorage, UniversalRead};
 
 use super::Encodable;
@@ -35,7 +35,6 @@ pub struct OnDiskNumericIndex<
     pub(super) path: PathBuf,
     pub(super) storage: Storage<T, S>,
     pub(super) histogram: Histogram<T>,
-    pub(super) deleted_count: usize,
     pub(super) max_values_per_point: usize,
 }
 
@@ -43,7 +42,7 @@ pub(in super::super) struct Storage<
     T: Encodable + Numericable + Default + StoredValue + 'static,
     S: UniversalRead = MmapFile,
 > {
-    pub(super) deleted: BitVec,
+    pub(super) deleted: DeletedBitVec,
     // sorted pairs (id + value), sorted by value (by id if values are equal)
     pub(super) pairs: TypedStorage<S, Point<T>>,
     pub(in super::super) point_to_values: OnDiskPointToValues<T, S>,
@@ -57,8 +56,6 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
             point_to_values,
         } = self;
 
-        deleted.capacity().div_ceil(u8::BITS as usize)
-            + pairs.ram_usage_bytes()
-            + point_to_values.ram_usage_bytes()
+        deleted.ram_usage_bytes() + pairs.ram_usage_bytes() + point_to_values.ram_usage_bytes()
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/read_ops.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::ops::Bound;
 
-use common::bitvec::BitSliceExt as _;
 use common::counter::conditioned_counter::ConditionedCounter;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
@@ -32,7 +31,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
         // [`NumericIndexRead::check_values_any`] returns `OperationResult`.
         let hw_counter = ConditionedCounter::always(hw_counter);
 
-        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
+        if self.storage.deleted.is_active(idx) {
             self.storage
                 .point_to_values
                 .check_values_any(idx, |v| check_fn(v), &hw_counter)
@@ -43,7 +42,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
     }
 
     fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {
-        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
+        if self.storage.deleted.is_active(idx) {
             Some(Box::new(
                 self.storage
                     .point_to_values
@@ -58,7 +57,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
     }
 
     fn values_count(&self, idx: PointOffsetType) -> Option<usize> {
-        if self.storage.deleted.get_bit(idx as usize) == Some(false) {
+        if self.storage.deleted.is_active(idx) {
             self.storage.point_to_values.get_values_count(idx).ok()?
         } else {
             None
@@ -118,7 +117,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
     }
 
     fn get_points_count(&self) -> usize {
-        self.storage.point_to_values.len() - self.deleted_count
+        self.storage.point_to_values.len() - self.storage.deleted.deleted_count()
     }
 
     fn get_max_values_per_point(&self) -> usize {
@@ -231,7 +230,7 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
 
         let deleted = &self.storage.deleted;
 
-        Ok(iter.filter(move |point| !deleted.get_bit(point.idx as usize).unwrap_or(true)))
+        Ok(iter.filter(move |point| deleted.is_active(point.idx)))
     }
 
     pub fn is_on_disk(&self) -> bool {


### PR DESCRIPTION
The situation: `deleted_bitslice.get_bit(point_id)` returns `None`. How to interpret that value?
1. Of course the point is alive, since it's not marked as deleted explicitly.
2. The point were never there, so it can not be alive.

These answers contradict each other, so they can't be both correct at once.
There are counterexamples for [the first] and for [the second], so we can't say "at least one answer is correct".
So, the only remaining conclusion is that both answers are incorrect[^1].

[the first]: https://github.com/qdrant/qdrant/blob/f1c14680f3a202ef78d286e2d3ac093fe2cc8363/lib/segment/src/vector_storage/raw_scorer.rs#L592
[the second]: https://github.com/qdrant/qdrant/blob/f1c14680f3a202ef78d286e2d3ac093fe2cc8363/lib/segment/src/vector_storage/raw_scorer.rs#L595

This PR introduces `DeletedBitVec` wrapper for places that consistently prefer the second incorrect option or never call `.get_bit()` beyond the `.len()`. So the decision fatigue (which variant I need to follow when writing new code?) now occurs only once per structure definition, not per each access call-site.

The semantics is expected to be the same. Perhaps not all relevant places are updated; only those that are related for the upcoming batched `ConditionChecker` implementation.

[^1]: deliberate logical fallacy for a dramatic effect