### PR TITLE
Batched ConditionChecker

### DIFF
--- a/lib/common/common/src/condition_checker.rs
+++ b/lib/common/common/src/condition_checker.rs
@@ -91,6 +91,14 @@ impl Select {
     }
 }
 
+impl Rest {
+    /// Helper for sequencing checks.
+    #[inline(always)]
+    pub const fn keep_if(self, more_checks_follow: bool) -> Rest {
+        if more_checks_follow { Rest::Keep } else { self }
+    }
+}
+
 /// The default implementation of [`ConditionChecker::check_batched`].
 pub fn default_check_batched<K: CheckItem, E>(
     items: &mut [K],

--- a/lib/common/common/src/condition_checker.rs
+++ b/lib/common/common/src/condition_checker.rs
@@ -37,7 +37,7 @@ pub trait ConditionChecker {
     ///                   ↑ partition point
     /// ```
     fn check_batched<K: CheckItem>(
-        &mut self,
+        &self,
         items: &mut [K],
         select: Select,
         rest: Rest,
@@ -175,7 +175,7 @@ impl<E> ConditionChecker for ConstantConditionChecker<E> {
     }
 
     fn check_batched<K: CheckItem>(
-        &mut self,
+        &self,
         ids: &mut [K],
         select: Select,
         _rest: Rest,
@@ -333,7 +333,7 @@ impl<T: Copy> Iterator for PartitionerIter<'_, T> {
 /// Assert that [`ConditionChecker::check_batched`] returns the same values as
 /// [`ConditionChecker::check`].
 #[cfg(feature = "testing")]
-pub fn assert_congruence<C>(checker: &mut C, num_points: usize, rng: &mut StdRng)
+pub fn assert_congruence<C>(checker: &C, num_points: usize, rng: &mut StdRng)
 where
     C: ConditionChecker<Error: std::fmt::Debug>,
 {
@@ -344,7 +344,7 @@ where
         false => far_ids[rng.random_range(0..far_ids.len())],
     };
 
-    let mut check = |mut input: Vec<PointOffsetType>| {
+    let check = |mut input: Vec<PointOffsetType>| {
         input.sort_unstable();
 
         for select in [Select::Matches, Select::NonMatches] {

--- a/lib/common/common/src/condition_checker.rs
+++ b/lib/common/common/src/condition_checker.rs
@@ -92,7 +92,10 @@ pub enum Rest {
 impl Select {
     #[inline(always)]
     pub const fn is_match(self) -> bool {
-        matches!(self, Select::Matches)
+        match self {
+            Select::Matches => true,
+            Select::NonMatches => false,
+        }
     }
 }
 
@@ -115,19 +118,23 @@ pub fn default_check_batched<K: CheckItem, E>(
         Rest::Keep => {
             let mut lo = 0;
             let mut hi = items.len();
-            loop {
-                while lo < hi && pred(items[lo].point_id())? == select.is_match() {
+            'outer: while lo < hi {
+                if pred(items[lo].point_id())? == select.is_match() {
                     lo += 1;
+                    continue;
                 }
-                while lo < hi && pred(items[hi - 1].point_id())? != select.is_match() {
+                // items[lo] doesn't belong on the left: scan down for one that does.
+                loop {
                     hi -= 1;
+                    if lo == hi {
+                        break 'outer;
+                    }
+                    if pred(items[hi].point_id())? == select.is_match() {
+                        break;
+                    }
                 }
-                if lo >= hi {
-                    break;
-                }
-                items.swap(lo, hi - 1);
+                items.swap(lo, hi);
                 lo += 1;
-                hi -= 1;
             }
             Ok(lo)
         }
@@ -174,10 +181,9 @@ impl<E> ConditionChecker for ConstantConditionChecker<E> {
         _rest: Rest,
     ) -> Result<usize, E> {
         // Every id is on the same side, so no rearrangement is needed.
-        Ok(if self.0 == select.is_match() {
-            ids.len()
-        } else {
-            0
+        Ok(match self.0 == select.is_match() {
+            true => ids.len(),
+            false => 0,
         })
     }
 }
@@ -252,10 +258,7 @@ impl<'a, T: Copy> Partitioner<'a, T> {
     ///
     /// Panics if you try to write more than was read.
     pub fn write(&self, value: T, is_left: bool) {
-        if self.left_end.get() >= self.unread_start.get() {
-            debug_assert!(false);
-            return;
-        }
+        assert!(self.left_end.get() < self.unread_start.get());
         if is_left {
             // Writing to the left side moves `left_end` forward.
             //
@@ -306,8 +309,8 @@ impl<'a, T: Copy> Partitioner<'a, T> {
     ///
     /// Panics if you haven't read/written all the elements yet.
     pub fn finish(&self) -> usize {
-        debug_assert_eq!(self.left_end.get(), self.unread_start.get());
-        debug_assert_eq!(self.unread_start.get(), self.right_start.get());
+        assert_eq!(self.left_end.get(), self.unread_start.get());
+        assert_eq!(self.unread_start.get(), self.right_start.get());
         self.left_end.get()
     }
 }

--- a/lib/common/common/src/condition_checker.rs
+++ b/lib/common/common/src/condition_checker.rs
@@ -43,10 +43,7 @@ pub trait ConditionChecker {
         rest: Rest,
     ) -> Result<usize, Self::Error>
     where
-        Self: Sized,
-    {
-        default_check_batched(items, select, rest, |id| self.check(id))
-    }
+        Self: Sized;
 }
 
 /// See [`ConditionChecker::check_batched`].

--- a/lib/common/common/src/condition_checker.rs
+++ b/lib/common/common/src/condition_checker.rs
@@ -1,6 +1,8 @@
+use std::cell::Cell;
+use std::fmt;
 use std::marker::PhantomData;
 
-use crate::types::PointOffsetType;
+use crate::types::{PointOffsetType, ScoredPointOffset};
 
 /// A check that tests whether points satisfy a condition.
 pub trait ConditionChecker {
@@ -16,6 +18,119 @@ pub trait ConditionChecker {
         //
         // TODO(uio): remove this method and handle errors properly.
         self.check(point_id).unwrap_or(false)
+    }
+
+    /// Rearranges items in-place, separating those that satisfy the condition
+    /// from those that don't.
+    ///
+    /// Returns the partition point (aka the length of the left side).
+    ///
+    /// ```text
+    /// Input:   ○ ○ ● ○ ○ ○ ● ○ ● ○ ● ● ○
+    /// Output:  ● ● ● ● ● ○ ○ ○ ○ ○ ○ ○ ○
+    ///         └─────────┴───────────────┘
+    ///                   ↑ partition point
+    /// ```
+    fn check_batched<K: CheckItem>(
+        &mut self,
+        items: &mut [K],
+        select: Select,
+        rest: Rest,
+    ) -> Result<usize, Self::Error>
+    where
+        Self: Sized,
+    {
+        default_check_batched(items, select, rest, |id| self.check(id))
+    }
+}
+
+/// See [`ConditionChecker::check_batched`].
+pub trait CheckItem: Copy + fmt::Debug {
+    fn point_id(self) -> PointOffsetType;
+}
+
+impl CheckItem for PointOffsetType {
+    fn point_id(self) -> PointOffsetType {
+        self
+    }
+}
+
+impl CheckItem for ScoredPointOffset {
+    fn point_id(self) -> PointOffsetType {
+        self.idx
+    }
+}
+
+/// Parameter for [`ConditionChecker::check_batched`].
+///
+/// Controls whether the left side should contain the matching or non-matching
+/// items.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Select {
+    /// `● ● ● ● ● ○ ○ ○ ○ ○ ○ ○ ○` - Left are matches.
+    Matches,
+    /// `○ ○ ○ ○ ○ ○ ○ ○ ● ● ● ● ●` - Left are non-matches.
+    NonMatches,
+}
+
+/// Parameter for [`ConditionChecker::check_batched`].
+///
+/// An optimization hint: whether the caller needs the right part.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Rest {
+    /// `● ● ● ● ● ○ ○ ○ ○ ○ ○ ○ ○` - Right side should be written.
+    Keep,
+    /// `● ● ● ● ● # # # # # # # #` - Right side might contain garbage.
+    Discard,
+}
+
+impl Select {
+    #[inline(always)]
+    pub const fn is_match(self) -> bool {
+        matches!(self, Select::Matches)
+    }
+}
+
+/// The default implementation of [`ConditionChecker::check_batched`].
+pub fn default_check_batched<K: CheckItem, E>(
+    items: &mut [K],
+    select: Select,
+    rest: Rest,
+    mut pred: impl FnMut(PointOffsetType) -> Result<bool, E>,
+) -> Result<usize, E> {
+    match rest {
+        Rest::Keep => {
+            let mut lo = 0;
+            let mut hi = items.len();
+            loop {
+                while lo < hi && pred(items[lo].point_id())? == select.is_match() {
+                    lo += 1;
+                }
+                while lo < hi && pred(items[hi - 1].point_id())? != select.is_match() {
+                    hi -= 1;
+                }
+                if lo >= hi {
+                    break;
+                }
+                items.swap(lo, hi - 1);
+                lo += 1;
+                hi -= 1;
+            }
+            Ok(lo)
+        }
+        Rest::Discard => {
+            let mut w = 0;
+            for i in 0..items.len() {
+                let id = items[i];
+                if pred(id.point_id())? == select.is_match() {
+                    if w != i {
+                        items[w] = id;
+                    }
+                    w += 1;
+                }
+            }
+            Ok(w)
+        }
     }
 }
 
@@ -37,5 +152,164 @@ impl<E> ConditionChecker for ConstantConditionChecker<E> {
 
     fn check(&self, _point_id: PointOffsetType) -> Result<bool, E> {
         Ok(self.0)
+    }
+
+    fn check_batched<K: CheckItem>(
+        &mut self,
+        ids: &mut [K],
+        select: Select,
+        _rest: Rest,
+    ) -> Result<usize, E> {
+        // Every id is on the same side, so no rearrangement is needed.
+        Ok(if self.0 == select.is_match() {
+            ids.len()
+        } else {
+            0
+        })
+    }
+}
+
+/// A helper struct to use in [`ConditionChecker::check_batched`] impls.
+///
+/// Lets you partition a slice in-place.
+///
+/// # Implementation
+///
+/// Using three pointers (`left_end`, `unread_start`, `right_start`),
+/// we split the slice into four parts:
+/// - left, right: already written values
+/// - vacant: empty slots (free to be written to)
+/// - unread: values that haven't been read yet
+///
+/// Pointer invariant:
+/// 0 ≤ `left_end` ≤ `unread_start` ≤ `right_start` ≤ `data.len()`.
+///
+/// ```text
+///  left    vacant  unread  right
+/// │● ● ● ●│# # # #│? ? ? ?│○ ○ ○ ○│       
+/// ├───────┼───────┼───────┼───────┤
+/// ↑       ↑       ↑       ↑       ↑
+/// 0       │  unread_start │   data.len()
+///      left_end       right_start
+/// ```
+pub struct Partitioner<'a, T> {
+    data: &'a [Cell<T>],
+    /// How many values have been written to the left side.
+    left_end: Cell<usize>,
+    /// Index of the first unread value.
+    unread_start: Cell<usize>,
+    /// Index of the first value on the right side.
+    right_start: Cell<usize>,
+}
+
+impl<'a, T: Copy> Partitioner<'a, T> {
+    pub fn new(data: &'a mut [T]) -> Self {
+        // The initial state is all items are unread, and left/right/vacant
+        // parts are empty.
+        //
+        // │? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ?│
+        // ├───────────────────────────────┤
+        // ↑                               ↑
+        // 0 = left_end = unread_start     right_start = data.len()
+        let len = data.len();
+        Self {
+            data: Cell::from_mut(data).as_slice_of_cells(),
+            left_end: Cell::new(0),
+            unread_start: Cell::new(0),
+            right_start: Cell::new(len),
+        }
+    }
+
+    /// Reads a single element by moving `unread_start` forward.
+    pub fn read(&self) -> Option<T> {
+        // │● ● ● ●│# # # #│? ? ? ?│○ ○ ○ ○│    (before reading)
+        //
+        // │● ● ● ●│# # # # #│? ? ?│○ ○ ○ ○│    (after reading)
+        //                  ↑ this value is returned
+        if self.unread_start.get() < self.right_start.get() {
+            let value = self.data[self.unread_start.get()].get();
+            self.unread_start.set(self.unread_start.get() + 1);
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    /// Writes a single element to either the left or right side.
+    ///
+    /// Panics if you try to write more than was read.
+    pub fn write(&self, value: T, is_left: bool) {
+        if self.left_end.get() >= self.unread_start.get() {
+            debug_assert!(false);
+            return;
+        }
+        if is_left {
+            // Writing to the left side moves `left_end` forward.
+            //
+            // │● ● ● ●│# # # #│? ? ? ?│○ ○ ○ ○│    (before)
+            //
+            // │● ● ● ● ●│# # #│? ? ? ?│○ ○ ○ ○│    (after write)
+            //          ↑ we just wrote that value
+            self.data[self.left_end.get()].set(value);
+            self.left_end.set(self.left_end.get() + 1);
+        } else {
+            if self.unread_start.get() < self.right_start.get() {
+                // Writing to the right side if there are unread values left:
+                //                swap these
+                //                ↓       ↓
+                // │● ● ● ●│# # # #│? ? ? ?│○ ○ ○ ○│    (before swap)
+                //
+                // │● ● ● ●│# # #│? ? ? ? #│○ ○ ○ ○│    (after swap)
+                //
+                // │● ● ● ●│# # #│? ? ? ?│○ ○ ○ ○ ○│    (after write)
+                //                        ↑ we just wrote that value
+                // ```
+                let last_unread = self.data[self.right_start.get() - 1].get();
+                self.data[self.unread_start.get() - 1].set(last_unread);
+                self.unread_start.set(self.unread_start.get() - 1);
+                self.data[self.right_start.get() - 1].set(value);
+                self.right_start.set(self.right_start.get() - 1);
+            } else {
+                // Writing to the right side if there are no unread values:
+                // │● ● ● ●│# # # # # # # #│○ ○ ○ ○│    (before)
+                //
+                // │● ● ● ●│# # # # # # #│○ ○ ○ ○ ○│    (after write)
+                //                        ↑ we just wrote that value
+                // ```
+                self.data[self.unread_start.get() - 1].set(value);
+                self.unread_start.set(self.unread_start.get() - 1);
+                self.right_start.set(self.right_start.get() - 1);
+            }
+        }
+    }
+
+    /// A convenience adapter - returns an iterator that calls [`Self::read()`]
+    /// on each iteration.
+    pub fn iter(&self) -> PartitionerIter<'_, T> {
+        PartitionerIter(self)
+    }
+
+    /// "I'm done reading. Where is the partition point?"
+    ///
+    /// Panics if you haven't read/written all the elements yet.
+    pub fn finish(&self) -> usize {
+        debug_assert_eq!(self.left_end.get(), self.unread_start.get());
+        debug_assert_eq!(self.unread_start.get(), self.right_start.get());
+        self.left_end.get()
+    }
+}
+
+pub struct PartitionerIter<'a, T>(&'a Partitioner<'a, T>);
+
+impl<T: Copy> Iterator for PartitionerIter<'_, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.read()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let unread = self.0.right_start.get() - self.0.unread_start.get();
+        (unread, Some(unread))
     }
 }

--- a/lib/common/common/src/condition_checker.rs
+++ b/lib/common/common/src/condition_checker.rs
@@ -2,6 +2,11 @@ use std::cell::Cell;
 use std::fmt;
 use std::marker::PhantomData;
 
+#[cfg(feature = "testing")]
+use rand::RngExt;
+#[cfg(feature = "testing")]
+use rand::rngs::StdRng;
+
 use crate::types::{PointOffsetType, ScoredPointOffset};
 
 /// A check that tests whether points satisfy a condition.
@@ -319,5 +324,52 @@ impl<T: Copy> Iterator for PartitionerIter<'_, T> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         let unread = self.0.right_start.get() - self.0.unread_start.get();
         (unread, Some(unread))
+    }
+}
+
+/// Assert that [`ConditionChecker::check_batched`] returns the same values as
+/// [`ConditionChecker::check`].
+#[cfg(feature = "testing")]
+pub fn assert_congruence<C>(checker: &mut C, num_points: usize, rng: &mut StdRng)
+where
+    C: ConditionChecker<Error: std::fmt::Debug>,
+{
+    let num_points = num_points as u32;
+    let far_ids = [num_points, num_points + 100, u32::MAX / 2, u32::MAX - 1];
+    let rand_id = |rng: &mut StdRng| match rng.random_bool(0.9) {
+        true => rng.random_range(0..num_points.max(1)),
+        false => far_ids[rng.random_range(0..far_ids.len())],
+    };
+
+    let mut check = |mut input: Vec<PointOffsetType>| {
+        input.sort_unstable();
+
+        for select in [Select::Matches, Select::NonMatches] {
+            let want = input
+                .iter()
+                .copied()
+                .filter(|&id| checker.check(id).unwrap() == select.is_match())
+                .collect::<Vec<_>>();
+
+            for rest in [Rest::Keep, Rest::Discard] {
+                let mut buf = input.clone();
+                let split = checker.check_batched(&mut buf, select, rest).unwrap();
+                buf[..split].sort_unstable();
+                assert_eq!(&buf[..split], want, "left, {select:?} {rest:?}");
+                if rest == Rest::Keep {
+                    buf.sort_unstable();
+                    assert_eq!(&buf, &input, "kept, {select:?}");
+                }
+            }
+        }
+    };
+
+    check(vec![]);
+    check(vec![rng.random_range(0..num_points.max(1))]);
+    check((0..num_points).chain(far_ids).collect());
+    check((0..2048).map(|_| rand_id(rng)).collect());
+    for _ in 0..5 {
+        let len = rng.random_range(0..300);
+        check((0..len).map(|_| rand_id(rng)).collect());
     }
 }

--- a/lib/segment/src/index/condition_checker.rs
+++ b/lib/segment/src/index/condition_checker.rs
@@ -1,4 +1,6 @@
-use common::condition_checker::{ConditionChecker, ConstantConditionChecker};
+use common::condition_checker::{
+    CheckItem, ConditionChecker, ConstantConditionChecker, Rest, Select, default_check_batched,
+};
 use common::types::PointOffsetType;
 #[cfg(target_os = "linux")]
 use common::universal_io::IoUringFile;
@@ -119,6 +121,73 @@ pub enum ConditionCheckerEnum<'a> {
 
 impl ConditionChecker for ConditionCheckerEnum<'_> {
     type Error = OperationError;
+
+    fn check_batched<K: CheckItem>(
+        &mut self,
+        ids: &mut [K],
+        select: Select,
+        rest: Rest,
+    ) -> OperationResult<usize> {
+        match self {
+            Self::Dyn(c) => default_check_batched(ids, select, rest, |id| c.check(id)),
+            Self::Build(c) => c.check_batched(ids, select, rest),
+            Self::Constant(c) => c.check_batched(ids, select, rest),
+            Self::Filter(c) => c.check_batched(ids, select, rest),
+            Self::Ids(c) => c.check_batched(ids, select, rest),
+            #[cfg(feature = "testing")]
+            Self::Plain(c) => c.check_batched(ids, select, rest),
+            Self::BoolImmutable(c) => c.check_batched(ids, select, rest),
+            Self::BoolMutable(c) => c.check_batched(ids, select, rest),
+            #[cfg(target_os = "linux")]
+            Self::BoolRoIoUring(c) => c.check_batched(ids, select, rest),
+            Self::BoolRoMmap(c) => c.check_batched(ids, select, rest),
+            Self::NullImmutable(c) => c.check_batched(ids, select, rest),
+            Self::NullMutable(c) => c.check_batched(ids, select, rest),
+            #[cfg(target_os = "linux")]
+            Self::NullRoIoUring(c) => c.check_batched(ids, select, rest),
+            Self::NullRoMmap(c) => c.check_batched(ids, select, rest),
+            Self::GeoRadiusWritable(c) => c.check_batched(ids, select, rest),
+            Self::GeoBoundingBoxWritable(c) => c.check_batched(ids, select, rest),
+            Self::GeoPolygonWritable(c) => c.check_batched(ids, select, rest),
+            #[cfg(target_os = "linux")]
+            Self::GeoRadiusRoIoUring(c) => c.check_batched(ids, select, rest),
+            #[cfg(target_os = "linux")]
+            Self::GeoBoundingBoxRoIoUring(c) => c.check_batched(ids, select, rest),
+            #[cfg(target_os = "linux")]
+            Self::GeoPolygonRoIoUring(c) => c.check_batched(ids, select, rest),
+            Self::GeoRadiusRoMmap(c) => c.check_batched(ids, select, rest),
+            Self::GeoBoundingBoxRoMmap(c) => c.check_batched(ids, select, rest),
+            Self::GeoPolygonRoMmap(c) => c.check_batched(ids, select, rest),
+            Self::NumericFloatWritable(c) => c.check_batched(ids, select, rest),
+            Self::NumericIntWritable(c) => c.check_batched(ids, select, rest),
+            Self::NumericUuidWritable(c) => c.check_batched(ids, select, rest),
+            #[cfg(target_os = "linux")]
+            Self::NumericFloatRoIoUring(c) => c.check_batched(ids, select, rest),
+            #[cfg(target_os = "linux")]
+            Self::NumericIntRoIoUring(c) => c.check_batched(ids, select, rest),
+            #[cfg(target_os = "linux")]
+            Self::NumericUuidRoIoUring(c) => c.check_batched(ids, select, rest),
+            Self::NumericFloatRoMmap(c) => c.check_batched(ids, select, rest),
+            Self::NumericIntRoMmap(c) => c.check_batched(ids, select, rest),
+            Self::NumericUuidRoMmap(c) => c.check_batched(ids, select, rest),
+            Self::FullTextWritable(c) => c.check_batched(ids, select, rest),
+            #[cfg(target_os = "linux")]
+            Self::FullTextRoIoUring(c) => c.check_batched(ids, select, rest),
+            Self::FullTextRoMmap(c) => c.check_batched(ids, select, rest),
+            Self::MapIntWritable(c) => c.check_batched(ids, select, rest),
+            Self::MapStrWritable(c) => c.check_batched(ids, select, rest),
+            Self::MapUuidWritable(c) => c.check_batched(ids, select, rest),
+            #[cfg(target_os = "linux")]
+            Self::MapIntRoIoUring(c) => c.check_batched(ids, select, rest),
+            #[cfg(target_os = "linux")]
+            Self::MapStrRoIoUring(c) => c.check_batched(ids, select, rest),
+            #[cfg(target_os = "linux")]
+            Self::MapUuidRoIoUring(c) => c.check_batched(ids, select, rest),
+            Self::MapIntRoMmap(c) => c.check_batched(ids, select, rest),
+            Self::MapStrRoMmap(c) => c.check_batched(ids, select, rest),
+            Self::MapUuidRoMmap(c) => c.check_batched(ids, select, rest),
+        }
+    }
 
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         match self {

--- a/lib/segment/src/index/condition_checker.rs
+++ b/lib/segment/src/index/condition_checker.rs
@@ -49,6 +49,8 @@ pub enum ConditionCheckerEnum<'a> {
     Ids(IdsConditionChecker),
     #[cfg(feature = "testing")]
     Plain(PlainFilterContext<'a>),
+    #[cfg(feature = "testing")]
+    TestBitOfId(TestBitOfId),
 
     // bool index
     BoolImmutable(BoolCC<'a, ImmutableBoolIndex>),
@@ -136,6 +138,8 @@ impl ConditionChecker for ConditionCheckerEnum<'_> {
             Self::Ids(c) => c.check_batched(ids, select, rest),
             #[cfg(feature = "testing")]
             Self::Plain(c) => c.check_batched(ids, select, rest),
+            #[cfg(feature = "testing")]
+            Self::TestBitOfId(c) => c.check_batched(ids, select, rest),
             Self::BoolImmutable(c) => c.check_batched(ids, select, rest),
             Self::BoolMutable(c) => c.check_batched(ids, select, rest),
             #[cfg(target_os = "linux")]
@@ -198,6 +202,8 @@ impl ConditionChecker for ConditionCheckerEnum<'_> {
             Self::Ids(c) => c.check(point_id),
             #[cfg(feature = "testing")]
             Self::Plain(c) => c.check(point_id),
+            #[cfg(feature = "testing")]
+            Self::TestBitOfId(c) => c.check(point_id),
             Self::BoolImmutable(c) => c.check(point_id),
             Self::BoolMutable(c) => c.check(point_id),
             #[cfg(target_os = "linux")]
@@ -260,6 +266,8 @@ impl ConditionChecker for ConditionCheckerEnum<'_> {
             Self::Ids(c) => c.check_infallible(point_id),
             #[cfg(feature = "testing")]
             Self::Plain(c) => c.check_infallible(point_id),
+            #[cfg(feature = "testing")]
+            Self::TestBitOfId(c) => c.check_infallible(point_id),
             Self::BoolImmutable(c) => c.check_infallible(point_id),
             Self::BoolMutable(c) => c.check_infallible(point_id),
             #[cfg(target_os = "linux")]
@@ -311,5 +319,40 @@ impl ConditionChecker for ConditionCheckerEnum<'_> {
             Self::MapStrRoMmap(c) => c.check_infallible(point_id),
             Self::MapUuidRoMmap(c) => c.check_infallible(point_id),
         }
+    }
+}
+
+/// Point matches when its ID has specified bit set.
+#[cfg(feature = "testing")]
+pub struct TestBitOfId(pub u32);
+
+#[cfg(feature = "testing")]
+impl ConditionChecker for TestBitOfId {
+    type Error = OperationError;
+
+    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
+        Ok(point_id >> self.0 & 1 == 1)
+    }
+
+    fn check_batched<K: CheckItem>(
+        &mut self,
+        ids: &mut [K],
+        select: Select,
+        rest: Rest,
+    ) -> OperationResult<usize> {
+        let (mut left, mut right): (Vec<K>, Vec<K>) = ids
+            .iter()
+            .copied()
+            .partition(|item| (item.point_id() >> self.0 & 1 == 1) == select.is_match());
+        left.reverse();
+        right.reverse();
+        if rest == Rest::Discard
+            && let Some(&poison) = left.first().or(right.first())
+        {
+            right.fill(poison);
+        }
+        ids[..left.len()].copy_from_slice(&left);
+        ids[left.len()..].copy_from_slice(&right);
+        Ok(left.len())
     }
 }

--- a/lib/segment/src/index/condition_checker.rs
+++ b/lib/segment/src/index/condition_checker.rs
@@ -125,7 +125,7 @@ impl ConditionChecker for ConditionCheckerEnum<'_> {
     type Error = OperationError;
 
     fn check_batched<K: CheckItem>(
-        &mut self,
+        &self,
         ids: &mut [K],
         select: Select,
         rest: Rest,
@@ -335,7 +335,7 @@ impl ConditionChecker for TestBitOfId {
     }
 
     fn check_batched<K: CheckItem>(
-        &mut self,
+        &self,
         ids: &mut [K],
         select: Select,
         rest: Rest,

--- a/lib/segment/src/index/field_index/bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_ops.rs
@@ -18,7 +18,7 @@
 
 use std::path::PathBuf;
 
-use common::condition_checker::ConditionChecker;
+use common::condition_checker::{CheckItem, ConditionChecker, Rest, Select, default_check_batched};
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
@@ -343,6 +343,13 @@ impl<N: BoolIndexRead> ConditionChecker for BoolConditionChecker<'_, N> {
 
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         self.idx.check_values_any(point_id, self.is_true)
+    }
+
+    fn check_batched<K>(&self, ids: &mut [K], select: Select, rest: Rest) -> OperationResult<usize>
+    where
+        K: CheckItem,
+    {
+        default_check_batched(ids, select, rest, |id| self.check(id))
     }
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/full_text_index_read.rs
+++ b/lib/segment/src/index/field_index/full_text_index/full_text_index_read.rs
@@ -80,6 +80,18 @@ pub trait FullTextIndexRead {
 
     fn check_match(&self, query: &ParsedQuery, point_id: PointOffsetType) -> OperationResult<bool>;
 
+    fn check_match_batch<U: UserData>(
+        &self,
+        query: &ParsedQuery,
+        items: impl Iterator<Item = (U, PointOffsetType)>,
+        mut on_match: impl FnMut(U, bool),
+    ) -> OperationResult<()> {
+        for (tag, point_id) in items {
+            on_match(tag, self.check_match(query, point_id)?);
+        }
+        Ok(())
+    }
+
     /// Walk the inverted-index vocab and emit one [`PayloadBlockCondition`] per
     /// token with at least `threshold` postings. Used to seed payload-block
     /// scans for full-text indexes.

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
@@ -302,19 +302,17 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
             tokens: TokenSet,
             filter: impl Fn(PointOffsetType) -> bool,
         ) -> OperationResult<Vec<PointOffsetType>> {
-            let result =
-                postings.with_all_or_none_postings(tokens.tokens(), |posting_readers| {
-                    if posting_readers.is_empty() {
-                        return Ok(Vec::new());
-                    }
-                    let posting_readers = posting_readers
-                        .into_iter()
-                        .map(|(_token_id, posting_list_view)| posting_list_view)
-                        .collect();
-                    Ok(intersect_compressed_postings_iterator(posting_readers, filter).collect())
-                })?;
-            // Some token has no posting list -> no matches
-            Ok(result.unwrap_or_default())
+            postings.with_all_or_none_postings(tokens.tokens(), |posting_readers| {
+                // Empty query, or a missing token -> no matches
+                let Some(posting_readers) = posting_readers.filter(|r| !r.is_empty()) else {
+                    return Ok(Vec::new());
+                };
+                let posting_readers = posting_readers
+                    .into_iter()
+                    .map(|(_token_id, posting_list_view)| posting_list_view)
+                    .collect();
+                Ok(intersect_compressed_postings_iterator(posting_readers, filter).collect())
+            })
         }
 
         match &self.storage.postings {
@@ -371,13 +369,14 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
             tokens: &TokenSet,
             point_id: PointOffsetType,
         ) -> OperationResult<bool> {
-            let result = postings.with_all_or_none_postings(tokens.tokens(), |all_postings| {
-                Ok(all_postings
-                    .into_iter()
-                    .all(|(_token_id, posting)| posting.visitor().contains(point_id)))
-            })?;
-            // Some token has no posting list -> no match
-            Ok(result.unwrap_or(false))
+            postings.with_all_or_none_postings(tokens.tokens(), |all_postings| {
+                // Some token has no posting list -> no match
+                Ok(all_postings.is_some_and(|all_postings| {
+                    all_postings
+                        .into_iter()
+                        .all(|(_token_id, posting)| posting.visitor().contains(point_id))
+                }))
+            })
         }
 
         match &self.storage.postings {
@@ -427,19 +426,18 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
                 // not fetch the same posting list twice, otherwise positions get
                 // added twice in `phrase_in_all_postings`.
                 let unique_tokens = phrase.to_token_set();
-                let result = postings.with_all_or_none_postings(
-                    unique_tokens.tokens(),
-                    |selected_postings| {
-                        Ok(intersect_compressed_postings_phrase_iterator(
-                            phrase,
-                            selected_postings,
-                            is_active,
-                        )
-                        .collect())
-                    },
-                )?;
-                // Some token has no posting list -> no matches
-                Ok(result.unwrap_or_default())
+                postings.with_all_or_none_postings(unique_tokens.tokens(), |selected_postings| {
+                    // Some token has no posting list -> no matches
+                    let Some(selected_postings) = selected_postings else {
+                        return Ok(Vec::new());
+                    };
+                    Ok(intersect_compressed_postings_phrase_iterator(
+                        phrase,
+                        selected_postings,
+                        is_active,
+                    )
+                    .collect())
+                })
             }
             // cannot do phrase matching if there's no positional information
             OnDiskPostingsEnum::Ids(_postings) => Ok(Vec::new()),
@@ -459,22 +457,171 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
         match &self.storage.postings {
             OnDiskPostingsEnum::WithPositions(postings) => {
                 let unique_tokens = phrase.to_token_set();
-                let result = postings.with_all_or_none_postings(
-                    unique_tokens.tokens(),
-                    |selected_postings| {
-                        Ok(check_compressed_postings_phrase(
-                            phrase,
-                            point_id,
-                            selected_postings,
-                        ))
-                    },
-                )?;
-                // Some token has no posting list -> no match
-                Ok(result.unwrap_or(false))
+                postings.with_all_or_none_postings(unique_tokens.tokens(), |selected_postings| {
+                    // Some token has no posting list -> no match
+                    Ok(selected_postings.is_some_and(|selected_postings| {
+                        check_compressed_postings_phrase(phrase, point_id, selected_postings)
+                    }))
+                })
             }
             // cannot do phrase matching if there's no positional information
             OnDiskPostingsEnum::Ids(_postings) => Ok(false),
         }
+    }
+
+    /// Batched counterpart of [`InvertedIndex::check_match`].
+    pub fn check_match_batch<U: UserData>(
+        &self,
+        query: &ParsedQuery,
+        items: impl Iterator<Item = (U, PointOffsetType)>,
+        on_match: impl FnMut(U, bool),
+    ) -> OperationResult<()> {
+        match query {
+            ParsedQuery::AllTokens(tokens) => self.check_has_subset_batch(tokens, items, on_match),
+            ParsedQuery::AnyTokens(tokens) => self.check_has_any_batch(tokens, items, on_match),
+            ParsedQuery::Phrase(phrase) => self.check_has_phrase_batch(phrase, items, on_match),
+        }
+    }
+
+    fn check_has_subset_batch<U: UserData>(
+        &self,
+        tokens: &TokenSet,
+        items: impl Iterator<Item = (U, PointOffsetType)>,
+        mut on_match: impl FnMut(U, bool),
+    ) -> OperationResult<()> {
+        // An empty query matches nothing. Guard it here: the `all()` below would
+        // otherwise be vacuously true.
+        if tokens.is_empty() {
+            for (tag, _) in items {
+                on_match(tag, false);
+            }
+            return Ok(());
+        }
+
+        fn run<V, S, I, M, U>(
+            index: &OnDiskInvertedIndex<S>,
+            postings: &OnDiskPostings<V, S>,
+            tokens: &TokenSet,
+            items: I,
+            on_match: &mut M,
+        ) -> OperationResult<()>
+        where
+            V: ZerocopyPostingValue,
+            S: UniversalRead,
+            U: UserData,
+            I: Iterator<Item = (U, PointOffsetType)>,
+            M: FnMut(U, bool),
+        {
+            // `None` (some token has no posting list) means nothing matches, so
+            // every item reports `false`.
+            postings.with_all_or_none_postings(tokens.tokens(), |maybe_postings| {
+                let mut visitors = maybe_postings.map(|postings| {
+                    postings
+                        .into_iter()
+                        .map(|(_, posting)| posting.visitor())
+                        .collect::<Vec<_>>()
+                });
+                for (tag, point_id) in items {
+                    let matched = visitors.as_mut().is_some_and(|visitors| {
+                        index.is_active(point_id)
+                            && visitors.iter_mut().all(|v| v.contains(point_id))
+                    });
+                    on_match(tag, matched);
+                }
+                Ok(())
+            })
+        }
+
+        match &self.storage.postings {
+            OnDiskPostingsEnum::Ids(postings) => run(self, postings, tokens, items, &mut on_match),
+            OnDiskPostingsEnum::WithPositions(postings) => {
+                run(self, postings, tokens, items, &mut on_match)
+            }
+        }
+    }
+
+    fn check_has_any_batch<U: UserData>(
+        &self,
+        tokens: &TokenSet,
+        items: impl Iterator<Item = (U, PointOffsetType)>,
+        mut on_match: impl FnMut(U, bool),
+    ) -> OperationResult<()> {
+        if tokens.is_empty() {
+            // No tokens means nothing matches; report every item as a non-match.
+            for (tag, _) in items {
+                on_match(tag, false);
+            }
+            return Ok(());
+        }
+
+        fn check_any<V, S, I, M, U>(
+            index: &OnDiskInvertedIndex<S>,
+            postings: &OnDiskPostings<V, S>,
+            tokens: &TokenSet,
+            items: I,
+            on_match: &mut M,
+        ) -> OperationResult<()>
+        where
+            V: ZerocopyPostingValue,
+            S: UniversalRead,
+            U: UserData,
+            I: Iterator<Item = (U, PointOffsetType)>,
+            M: FnMut(U, bool),
+        {
+            postings.with_existing_postings(tokens.tokens(), |all_postings| {
+                let mut visitors: Vec<_> = all_postings
+                    .into_iter()
+                    .map(|(_, posting)| posting.visitor())
+                    .collect();
+                for (tag, point_id) in items {
+                    let matched = index.is_active(point_id)
+                        && visitors.iter_mut().any(|v| v.contains(point_id));
+                    on_match(tag, matched);
+                }
+                Ok(())
+            })
+        }
+
+        match &self.storage.postings {
+            OnDiskPostingsEnum::Ids(postings) => {
+                check_any(self, postings, tokens, items, &mut on_match)
+            }
+            OnDiskPostingsEnum::WithPositions(postings) => {
+                check_any(self, postings, tokens, items, &mut on_match)
+            }
+        }
+    }
+
+    fn check_has_phrase_batch<U: UserData>(
+        &self,
+        phrase: &Document,
+        items: impl Iterator<Item = (U, PointOffsetType)>,
+        mut on_match: impl FnMut(U, bool),
+    ) -> OperationResult<()> {
+        // Phrase matching needs positional information; without it nothing matches.
+        let OnDiskPostingsEnum::WithPositions(postings) = &self.storage.postings else {
+            for (tag, _) in items {
+                on_match(tag, false);
+            }
+            return Ok(());
+        };
+
+        let unique_tokens = phrase.to_token_set();
+        // `None` (some token has no posting list) means nothing matches, so every
+        // item reports `false`.
+        postings.with_all_or_none_postings(unique_tokens.tokens(), |selected_postings| {
+            for (tag, point_id) in items {
+                let matched = selected_postings.as_ref().is_some_and(|selected| {
+                    // `PostingListView` is a set of slice refs, so the per-point
+                    // clone only copies references; the postings were loaded once
+                    // above.
+                    self.is_active(point_id)
+                        && check_compressed_postings_phrase(phrase, point_id, selected.clone())
+                });
+                on_match(tag, matched);
+            }
+            Ok(())
+        })
     }
 
     pub fn files(&self) -> Vec<PathBuf> {

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
@@ -227,21 +227,24 @@ impl<V: ZerocopyPostingValue, S: UniversalRead> OnDiskPostings<V, S> {
         callback(views)
     }
 
-    /// Fetch posting lists for the given token ids and hand them to `callback`.
-    /// If any of posting lists is not found - return `None`.
+    /// Fetch posting lists for the given token ids and hand them to `callback`,
+    /// which is *always* invoked: with `Some(views)` when every token has a
+    /// posting list, or `None` when at least one is missing (i.e. nothing can
+    /// match). Always running lets batch callers iterate their items in a single
+    /// pass, reporting a non-match for the `None` case, instead of a separate
+    /// fallback loop.
     pub fn with_all_or_none_postings<T>(
         &self,
         token_ids: &[TokenId],
-        callback: impl FnOnce(Vec<(TokenId, PostingListView<'_, V>)>) -> OperationResult<T>,
-    ) -> OperationResult<Option<T>> {
+        callback: impl FnOnce(Option<Vec<(TokenId, PostingListView<'_, V>)>>) -> OperationResult<T>,
+    ) -> OperationResult<T> {
         let HeadersBatch { headers, missing } = self.headers_iter(token_ids)?;
 
         if !missing.is_empty() {
-            return Ok(None);
+            return callback(None);
         }
 
-        self.with_posting_views(headers, token_ids.len(), callback)
-            .map(Some)
+        self.with_posting_views(headers, token_ids.len(), |views| callback(Some(views)))
     }
 
     /// Fetch all existing posting lists for the given token ids and hand them

--- a/lib/segment/src/index/field_index/full_text_index/on_disk_text_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/full_text_index/on_disk_text_index/read_ops.rs
@@ -63,6 +63,16 @@ impl<S: UniversalRead> FullTextIndexRead for OnDiskFullTextIndex<S> {
         self.inverted_index.check_match(query, point_id)
     }
 
+    fn check_match_batch<U: UserData>(
+        &self,
+        query: &ParsedQuery,
+        items: impl Iterator<Item = (U, PointOffsetType)>,
+        on_match: impl FnMut(U, bool),
+    ) -> OperationResult<()> {
+        self.inverted_index
+            .check_match_batch(query, items, on_match)
+    }
+
     fn for_each_payload_block_inner(
         &self,
         threshold: usize,

--- a/lib/segment/src/index/field_index/full_text_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/read_ops.rs
@@ -116,6 +116,23 @@ impl<S: UniversalRead> FullTextIndexRead for ReadOnlyFullTextIndex<S> {
         }
     }
 
+    fn check_match_batch<U: UserData>(
+        &self,
+        query: &ParsedQuery,
+        items: impl Iterator<Item = (U, PointOffsetType)>,
+        on_match: impl FnMut(U, bool),
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyFullTextIndex::Appendable(index) => {
+                index.check_match_batch(query, items, on_match)
+            }
+            ReadOnlyFullTextIndex::OnDisk(index) => index.check_match_batch(query, items, on_match),
+            ReadOnlyFullTextIndex::Immutable(index) => {
+                index.check_match_batch(query, items, on_match)
+            }
+        }
+    }
+
     fn for_each_payload_block_inner(
         &self,
         threshold: usize,

--- a/lib/segment/src/index/field_index/full_text_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_ops.rs
@@ -1,4 +1,6 @@
-use common::condition_checker::{ConditionChecker, ConstantConditionChecker};
+use common::condition_checker::{
+    CheckItem, ConditionChecker, ConstantConditionChecker, Partitioner, Rest, Select,
+};
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
@@ -106,6 +108,19 @@ impl FullTextIndexRead for FullTextIndex {
             Self::Mutable(index) => index.check_match(query, point_id),
             Self::Immutable(index) => index.check_match(query, point_id),
             Self::OnDisk(index) => index.check_match(query, point_id),
+        }
+    }
+
+    fn check_match_batch<U: UserData>(
+        &self,
+        query: &ParsedQuery,
+        items: impl Iterator<Item = (U, PointOffsetType)>,
+        on_match: impl FnMut(U, bool),
+    ) -> OperationResult<()> {
+        match self {
+            Self::Mutable(index) => index.check_match_batch(query, items, on_match),
+            Self::Immutable(index) => index.check_match_batch(query, items, on_match),
+            Self::OnDisk(index) => index.check_match_batch(query, items, on_match),
         }
     }
 
@@ -352,6 +367,21 @@ impl<T: FullTextIndexRead> ConditionChecker for FullTextConditionChecker<'_, T> 
 
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         self.index.check_match(&self.parsed_query, point_id)
+    }
+
+    fn check_batched<K: CheckItem>(
+        &mut self,
+        ids: &mut [K],
+        select: Select,
+        _rest: Rest,
+    ) -> OperationResult<usize> {
+        let p = Partitioner::new(ids);
+        self.index.check_match_batch(
+            &self.parsed_query,
+            p.iter().map(|item| (item, item.point_id())),
+            |item, matched| p.write(item, matched == select.is_match()),
+        )?;
+        Ok(p.finish())
     }
 }
 

--- a/lib/segment/src/index/field_index/full_text_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_ops.rs
@@ -370,7 +370,7 @@ impl<T: FullTextIndexRead> ConditionChecker for FullTextConditionChecker<'_, T> 
     }
 
     fn check_batched<K: CheckItem>(
-        &mut self,
+        &self,
         ids: &mut [K],
         select: Select,
         _rest: Rest,

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
@@ -13,7 +13,7 @@ use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::types::PointOffsetType;
 use common::universal_io::{
     CachedReadFs, MmapFile, OkNotFound, OpenOptions, Populate, ReadRange, SortedBlockIndex,
-    TypedStorage, UniversalRead, UniversalReadFs, read_json_via,
+    TypedStorage, UniversalRead, UniversalReadFs, UserData, read_json_via,
 };
 use fs_err as fs;
 use memmap2::MmapMut;
@@ -287,6 +287,28 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         } else {
             Ok(false)
         }
+    }
+
+    /// Batched counterpart of [`Self::check_values_any`].
+    pub fn for_each_matching_value<I, F, M, U>(
+        &self,
+        items: I,
+        hw_counter: &HardwareCounterCell,
+        check_fn: F,
+        mut on_match: M,
+    ) -> OperationResult<()>
+    where
+        U: UserData,
+        I: Iterator<Item = (U, PointOffsetType)>,
+        F: Fn(&GeoPoint) -> bool,
+        M: FnMut(U, bool),
+    {
+        self.storage.point_to_values.values_iter_batch(
+            items,
+            &self.storage.deleted,
+            ConditionedCounter::always(hw_counter),
+            |tag, mut values| on_match(tag, values.any(|value| check_fn(&value))),
+        )
     }
 
     pub fn get_values(&self, idx: u32) -> Option<impl Iterator<Item = GeoPoint> + '_> {

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/read_ops.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UserData};
 
 use super::super::read_ops::GeoIndexRead;
 use super::OnDiskGeoIndex;
@@ -47,6 +47,22 @@ impl<S: UniversalRead> GeoIndexRead for OnDiskGeoIndex<S> {
         check_fn: &dyn Fn(&GeoPoint) -> bool,
     ) -> OperationResult<bool> {
         OnDiskGeoIndex::check_values_any(self, idx, hw_counter, |p| check_fn(p))
+    }
+
+    fn for_each_matching_value<I, F, M, U>(
+        &self,
+        items: I,
+        hw_counter: &HardwareCounterCell,
+        check_fn: F,
+        on_match: M,
+    ) -> OperationResult<()>
+    where
+        U: UserData,
+        I: Iterator<Item = (U, PointOffsetType)>,
+        F: Fn(&GeoPoint) -> bool,
+        M: FnMut(U, bool),
+    {
+        OnDiskGeoIndex::for_each_matching_value(self, items, hw_counter, check_fn, on_match)
     }
 
     fn values_count(&self, idx: PointOffsetType) -> usize {

--- a/lib/segment/src/index/field_index/geo_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/read_ops.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UserData};
 
 use super::super::read_ops::{self, GeoConditionChecker, GeoIndexRead};
 use super::ReadOnlyGeoIndex;
@@ -97,6 +97,32 @@ impl<S: UniversalRead> GeoIndexRead for ReadOnlyGeoIndex<S> {
             }
             ReadOnlyGeoIndex::OnDisk(index) => {
                 GeoIndexRead::check_values_any(index, idx, hw_counter, check_fn)
+            }
+        }
+    }
+
+    fn for_each_matching_value<I, F, M, U>(
+        &self,
+        items: I,
+        hw_counter: &HardwareCounterCell,
+        check_fn: F,
+        on_match: M,
+    ) -> OperationResult<()>
+    where
+        U: UserData,
+        I: Iterator<Item = (U, PointOffsetType)>,
+        F: Fn(&GeoPoint) -> bool,
+        M: FnMut(U, bool),
+    {
+        match self {
+            ReadOnlyGeoIndex::Appendable(index) => {
+                index.for_each_matching_value(items, hw_counter, check_fn, on_match)
+            }
+            ReadOnlyGeoIndex::Immutable(index) => {
+                index.for_each_matching_value(items, hw_counter, check_fn, on_match)
+            }
+            ReadOnlyGeoIndex::OnDisk(index) => {
+                index.for_each_matching_value(items, hw_counter, check_fn, on_match)
             }
         }
     }

--- a/lib/segment/src/index/field_index/geo_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_ops.rs
@@ -375,7 +375,7 @@ where
     }
 
     fn check_batched<K: CheckItem>(
-        &mut self,
+        &self,
         ids: &mut [K],
         select: Select,
         _rest: Rest,

--- a/lib/segment/src/index/field_index/geo_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_ops.rs
@@ -18,9 +18,10 @@
 use std::cmp::{max, min};
 use std::path::PathBuf;
 
-use common::condition_checker::ConditionChecker;
+use common::condition_checker::{CheckItem, ConditionChecker, Partitioner, Rest, Select};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UserData;
 
 use super::GEO_QUERY_MAX_REGION;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -66,6 +67,26 @@ pub trait GeoIndexRead {
         hw_counter: &HardwareCounterCell,
         check_fn: &dyn Fn(&GeoPoint) -> bool,
     ) -> OperationResult<bool>;
+
+    /// Batched counterpart of [`Self::check_values_any`].
+    fn for_each_matching_value<I, F, M, U>(
+        &self,
+        items: I,
+        hw_counter: &HardwareCounterCell,
+        check_fn: F,
+        mut on_match: M,
+    ) -> OperationResult<()>
+    where
+        U: UserData,
+        I: Iterator<Item = (U, PointOffsetType)>,
+        F: Fn(&GeoPoint) -> bool,
+        M: FnMut(U, bool),
+    {
+        for (tag, idx) in items {
+            on_match(tag, self.check_values_any(idx, hw_counter, &check_fn)?);
+        }
+        Ok(())
+    }
 
     fn values_count(&self, idx: PointOffsetType) -> usize;
 
@@ -351,5 +372,21 @@ where
             .check_values_any(point_id, &self.hw_counter, &|value| {
                 self.filter.check_point(value)
             })
+    }
+
+    fn check_batched<K: CheckItem>(
+        &mut self,
+        ids: &mut [K],
+        select: Select,
+        _rest: Rest,
+    ) -> OperationResult<usize> {
+        let p = Partitioner::new(ids);
+        self.geo.for_each_matching_value(
+            p.iter().map(|item| (item, item.point_id())),
+            &self.hw_counter,
+            |value| self.filter.check_point(value),
+            |item, matched| p.write(item, matched == select.is_match()),
+        )?;
+        Ok(p.finish())
     }
 }

--- a/lib/segment/src/index/field_index/geo_index/tests.rs
+++ b/lib/segment/src/index/field_index/geo_index/tests.rs
@@ -19,7 +19,9 @@ use super::on_disk_geo_index::OnDiskGeoIndex;
 use super::read_ops::GeoIndexRead;
 use super::{GEO_QUERY_MAX_REGION, GeoIndex};
 use crate::fixtures::payload_fixtures::random_geo_payload;
-use crate::index::field_index::geo_hash::{GeoHash, circle_hashes, polygon_hashes};
+use crate::index::field_index::geo_hash::{
+    GeoHash, circle_hashes, encode_max_precision, polygon_hashes,
+};
 use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadFieldIndex, PayloadFieldIndexRead,
     ValueIndexer,
@@ -599,6 +601,50 @@ fn same_geo_index_between_points_test(#[case] index_type: IndexType) {
     assert_eq!(new_index.points_count(), 1);
     if index_type != IndexType::OnDisk {
         assert_eq!(new_index.points_values_count(), 2);
+    }
+}
+
+#[rstest]
+#[case(IndexType::Mutable)]
+#[case(IndexType::OnDisk)]
+#[case(IndexType::Immutable)]
+fn same_geo_index_between_points_with_dups_test(#[case] index_type: IndexType) {
+    let temp_dir = {
+        let (mut builder, temp_dir, _) = create_builder(index_type);
+
+        let geo_values = json!([BERLIN, BERLIN, POTSDAM]); // Berlin twice
+        let hw_counter = HardwareCounterCell::new();
+        let payload = [&geo_values];
+        builder.add_point(1, &payload, &hw_counter).unwrap();
+        builder.add_point(2, &payload, &hw_counter).unwrap();
+        let mut index = builder.finalize().unwrap();
+
+        index.remove_point(1).unwrap();
+        index.flusher()().unwrap();
+
+        assert_eq!(index.points_count(), 1);
+        if index_type != IndexType::OnDisk {
+            assert_eq!(index.points_values_count(), 3);
+        }
+        drop(index);
+        temp_dir
+    };
+
+    let new_index = reload_index(index_type, &temp_dir, &deleted_with(&[1]));
+    assert_eq!(new_index.points_count(), 1);
+    if index_type != IndexType::OnDisk {
+        assert_eq!(new_index.points_values_count(), 3);
+
+        let hw_counter = HardwareCounterCell::disposable();
+        let berlin_hash = encode_max_precision(BERLIN.lon.0, BERLIN.lat.0).unwrap();
+        assert_eq!(
+            new_index.values_of_hash(berlin_hash, &hw_counter).unwrap(),
+            2
+        );
+        assert_eq!(
+            new_index.points_of_hash(berlin_hash, &hw_counter).unwrap(),
+            1
+        );
     }
 }
 

--- a/lib/segment/src/index/field_index/map_index/key.rs
+++ b/lib/segment/src/index/field_index/map_index/key.rs
@@ -11,7 +11,7 @@ use crate::data_types::facets::FacetValue;
 use crate::index::field_index::on_disk_point_to_values::StoredValue;
 use crate::types::{IntPayloadType, UuidIntType};
 
-pub trait MapIndexKey: Key + StoredValue + Eq + Display + Debug {
+pub trait MapIndexKey: Key + StoredValue + Eq + Display + Debug + 'static {
     type Owned: Borrow<Self> + Hash + Eq + Ord + Clone + FromStr + Default + 'static;
 
     fn to_owned(&self) -> <Self as MapIndexKey>::Owned;

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/read_ops.rs
@@ -282,14 +282,12 @@ impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> OnDiskMapIndex<N, S> {
         hw_counter: &HardwareCounterCell,
         f: impl FnMut(PointOffsetType, ValuesIter<'_, N>),
     ) -> OperationResult<()> {
-        let hw_counter = ConditionedCounter::always(hw_counter);
-
-        // Skip deleted points
-        let points = points.filter(|&idx| self.storage.deleted.is_active(idx));
-
-        self.storage
-            .point_to_values
-            .values_iter_batch(points, hw_counter, f)
+        self.storage.point_to_values.values_iter_batch(
+            points.map(|point_id| (point_id, point_id)),
+            &self.storage.deleted,
+            ConditionedCounter::always(hw_counter),
+            f,
+        )
     }
 
     pub fn is_on_disk(&self) -> bool {

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/read_ops.rs
@@ -6,7 +6,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::persisted_hashmap::{Key, READ_ENTRY_OVERHEAD};
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UserData};
 use itertools::Itertools;
 use roaring::RoaringBitmap;
 
@@ -40,6 +40,27 @@ impl<'a, N: MapIndexKey + Key + ?Sized + 'a, S: UniversalRead> MapIndexRead<'a, 
         self.storage
             .point_to_values
             .check_values_any(idx, |v| check_fn(v), &hw_counter)
+    }
+
+    fn for_each_matching_value<I, F, M, U>(
+        &self,
+        items: I,
+        hw_counter: &HardwareCounterCell,
+        check_fn: F,
+        mut on_match: M,
+    ) -> OperationResult<()>
+    where
+        U: UserData,
+        I: Iterator<Item = (U, PointOffsetType)>,
+        F: Fn(&N) -> bool,
+        M: FnMut(U, bool),
+    {
+        self.storage.point_to_values.values_iter_batch(
+            items,
+            &self.storage.deleted,
+            ConditionedCounter::always(hw_counter),
+            |tag, mut values| on_match(tag, values.any(|value| check_fn(&value))),
+        )
     }
 
     fn get_values(

--- a/lib/segment/src/index/field_index/map_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_only/read_ops.rs
@@ -3,7 +3,7 @@ use std::borrow::{Borrow, Cow};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::persisted_hashmap::Key;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UserData};
 use gridstore::Blob;
 
 use super::super::read_ops::MapIndexRead;
@@ -34,6 +34,32 @@ where
             }
             ReadOnlyMapIndex::Immutable(index) => index.check_values_any(idx, hw_counter, check_fn),
             ReadOnlyMapIndex::OnDisk(index) => index.check_values_any(idx, hw_counter, check_fn),
+        }
+    }
+
+    fn for_each_matching_value<I, F, M, U>(
+        &self,
+        items: I,
+        hw_counter: &HardwareCounterCell,
+        check_fn: F,
+        on_match: M,
+    ) -> OperationResult<()>
+    where
+        U: UserData,
+        I: Iterator<Item = (U, PointOffsetType)>,
+        F: Fn(&N) -> bool,
+        M: FnMut(U, bool),
+    {
+        match self {
+            ReadOnlyMapIndex::Appendable(index) => {
+                index.for_each_matching_value(items, hw_counter, check_fn, on_match)
+            }
+            ReadOnlyMapIndex::Immutable(index) => {
+                index.for_each_matching_value(items, hw_counter, check_fn, on_match)
+            }
+            ReadOnlyMapIndex::OnDisk(index) => {
+                index.for_each_matching_value(items, hw_counter, check_fn, on_match)
+            }
         }
     }
 

--- a/lib/segment/src/index/field_index/map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_ops.rs
@@ -1,9 +1,10 @@
 use std::borrow::{Borrow, Cow};
 use std::hash::{BuildHasher, Hash};
 
-use common::condition_checker::ConditionChecker;
+use common::condition_checker::{CheckItem, ConditionChecker, Partitioner, Rest, Select};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UserData;
 use fnv::FnvBuildHasher;
 use gridstore::Blob;
 use indexmap::IndexSet;
@@ -34,6 +35,26 @@ pub trait MapIndexRead<'a, N: MapIndexKey + ?Sized + 'a>: Sized {
         hw_counter: &HardwareCounterCell,
         check_fn: impl Fn(&N) -> bool,
     ) -> OperationResult<bool>;
+
+    /// Batched counterpart of [`Self::check_values_any`].
+    fn for_each_matching_value<I, F, M, U>(
+        &self,
+        items: I,
+        hw_counter: &HardwareCounterCell,
+        check_fn: F,
+        mut on_match: M,
+    ) -> OperationResult<()>
+    where
+        U: UserData,
+        I: Iterator<Item = (U, PointOffsetType)>,
+        F: Fn(&N) -> bool,
+        M: FnMut(U, bool),
+    {
+        for (tag, idx) in items {
+            on_match(tag, self.check_values_any(idx, hw_counter, &check_fn)?);
+        }
+        Ok(())
+    }
 
     fn get_values(
         &'a self,
@@ -563,15 +584,36 @@ where
 
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         self.index
-            .check_values_any(point_id, &self.hw_counter, |value| match &self.predicate {
-                MapPredicate::Value(expected) => value == expected.borrow(),
-                MapPredicate::Prefix(prefix) => {
-                    <N as MapIndexKey>::starts_with(value, prefix.borrow())
-                }
-                MapPredicate::AnyScan { list, negate } => {
-                    list.iter().any(|key| key.borrow() == value) != *negate
-                }
-                MapPredicate::AnyProbe { list, negate } => list.contains(value) != *negate,
-            })
+            .check_values_any(point_id, &self.hw_counter, |value| self.matches(value))
+    }
+
+    fn check_batched<K: CheckItem>(
+        &mut self,
+        ids: &mut [K],
+        select: Select,
+        _rest: Rest,
+    ) -> OperationResult<usize> {
+        let p = Partitioner::new(ids);
+        self.index.for_each_matching_value(
+            p.iter().map(|item| (item, item.point_id())),
+            &self.hw_counter,
+            |value| self.matches(value),
+            |item, matched| p.write(item, matched == select.is_match()),
+        )?;
+        Ok(p.finish())
+    }
+}
+
+impl<'a, N: MapIndexKey + ?Sized + 'a, T> MapConditionChecker<'a, N, T> {
+    /// Whether a single indexed `value` satisfies this checker's predicate.
+    fn matches(&self, value: &N) -> bool {
+        match &self.predicate {
+            MapPredicate::Value(expected) => value == expected.borrow(),
+            MapPredicate::Prefix(prefix) => N::starts_with(value, prefix.borrow()),
+            MapPredicate::AnyScan { list, negate } => {
+                list.iter().any(|key| key.borrow() == value) != *negate
+            }
+            MapPredicate::AnyProbe { list, negate } => list.contains(value) != *negate,
+        }
     }
 }

--- a/lib/segment/src/index/field_index/map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_ops.rs
@@ -588,7 +588,7 @@ where
     }
 
     fn check_batched<K: CheckItem>(
-        &mut self,
+        &self,
         ids: &mut [K],
         select: Select,
         _rest: Rest,

--- a/lib/segment/src/index/field_index/null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/read_ops.rs
@@ -18,7 +18,7 @@
 
 use std::path::PathBuf;
 
-use common::condition_checker::ConditionChecker;
+use common::condition_checker::{CheckItem, ConditionChecker, Rest, Select, default_check_batched};
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::types::PointOffsetType;
 
@@ -280,5 +280,12 @@ impl<N: NullIndexRead> ConditionChecker for NullConditionChecker<'_, N> {
             CheckKind::IsNull => self.null_index.values_is_null(point_id)?,
         };
         Ok(actual == self.expected)
+    }
+
+    fn check_batched<K>(&self, ids: &mut [K], select: Select, rest: Rest) -> OperationResult<usize>
+    where
+        K: CheckItem,
+    {
+        default_check_batched(ids, select, rest, |id| self.check(id))
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/numeric_index_read.rs
+++ b/lib/segment/src/index/field_index/numeric_index/numeric_index_read.rs
@@ -2,6 +2,7 @@ use std::ops::Bound;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
+use common::universal_io::UserData;
 
 use super::Encodable;
 use crate::common::operation_error::OperationResult;
@@ -33,6 +34,26 @@ pub trait NumericIndexRead<T: Encodable + Numericable + Default + StoredValue> {
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
     ) -> bool;
+
+    /// Batched counterpart of [`Self::check_values_any`].
+    fn for_each_matching_value<I, F, M, U>(
+        &self,
+        items: I,
+        hw_counter: &HardwareCounterCell,
+        check_fn: F,
+        mut on_match: M,
+    ) -> OperationResult<()>
+    where
+        U: UserData,
+        I: Iterator<Item = (U, PointOffsetType)>,
+        F: Fn(&T) -> bool,
+        M: FnMut(U, bool),
+    {
+        for (tag, idx) in items {
+            on_match(tag, self.check_values_any(idx, &check_fn, hw_counter));
+        }
+        Ok(())
+    }
 
     fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>>;
 

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/read_ops.rs
@@ -6,7 +6,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::counter::iterator_hw_measurement::HwMeasurementIteratorExt;
 use common::generic_consts::Random;
 use common::types::PointOffsetType;
-use common::universal_io::{ReadRange, UniversalRead};
+use common::universal_io::{ReadRange, UniversalRead, UserData};
 use itertools::Either;
 
 use super::super::Encodable;
@@ -39,6 +39,27 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
         } else {
             false
         }
+    }
+
+    fn for_each_matching_value<I, F, M, U>(
+        &self,
+        items: I,
+        hw_counter: &HardwareCounterCell,
+        check_fn: F,
+        mut on_match: M,
+    ) -> OperationResult<()>
+    where
+        U: UserData,
+        I: Iterator<Item = (U, PointOffsetType)>,
+        F: Fn(&T) -> bool,
+        M: FnMut(U, bool),
+    {
+        self.storage.point_to_values.values_iter_batch(
+            items,
+            &self.storage.deleted,
+            ConditionedCounter::always(hw_counter),
+            |tag, mut values| on_match(tag, values.any(|value| check_fn(&value))),
+        )
     }
 
     fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {

--- a/lib/segment/src/index/field_index/numeric_index/query.rs
+++ b/lib/segment/src/index/field_index/numeric_index/query.rs
@@ -12,7 +12,7 @@ use std::ops::Bound;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::str::FromStr;
 
-use common::condition_checker::ConditionChecker;
+use common::condition_checker::{CheckItem, ConditionChecker, Partitioner, Rest, Select};
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
@@ -367,6 +367,22 @@ where
             |value| self.typed_range.check_range(*value),
             &self.hw_counter,
         ))
+    }
+
+    fn check_batched<K: CheckItem>(
+        &mut self,
+        ids: &mut [K],
+        select: Select,
+        _rest: Rest,
+    ) -> OperationResult<usize> {
+        let p = Partitioner::new(ids);
+        self.index.for_each_matching_value(
+            p.iter().map(|item| (item, item.point_id())),
+            &self.hw_counter,
+            |value| self.typed_range.check_range(*value),
+            |item, matched| p.write(item, matched == select.is_match()),
+        )?;
+        Ok(p.finish())
     }
 }
 

--- a/lib/segment/src/index/field_index/numeric_index/query.rs
+++ b/lib/segment/src/index/field_index/numeric_index/query.rs
@@ -370,7 +370,7 @@ where
     }
 
     fn check_batched<K: CheckItem>(
-        &mut self,
+        &self,
         ids: &mut [K],
         select: Select,
         _rest: Rest,

--- a/lib/segment/src/index/field_index/numeric_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_only/read_ops.rs
@@ -6,7 +6,7 @@ use std::ops::Bound;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UserData};
 use gridstore::Blob;
 
 use super::super::numeric_index_read::NumericIndexRead;
@@ -36,6 +36,23 @@ where
         hw_counter: &HardwareCounterCell,
     ) -> bool {
         self.inner.check_values_any(idx, check_fn, hw_counter)
+    }
+
+    fn for_each_matching_value<I, F, M, U>(
+        &self,
+        items: I,
+        hw_counter: &HardwareCounterCell,
+        check_fn: F,
+        on_match: M,
+    ) -> OperationResult<()>
+    where
+        U: UserData,
+        I: Iterator<Item = (U, PointOffsetType)>,
+        F: Fn(&T) -> bool,
+        M: FnMut(U, bool),
+    {
+        self.inner
+            .for_each_matching_value(items, hw_counter, check_fn, on_match)
     }
 
     fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/read_ops.rs
@@ -9,7 +9,7 @@ use std::ops::Bound;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UserData};
 use gridstore::Blob;
 
 use super::super::super::numeric_index_read::NumericIndexRead;
@@ -42,6 +42,32 @@ where
             }
             ReadOnlyNumericIndexInner::OnDisk(index) => {
                 index.check_values_any(idx, check_fn, hw_counter)
+            }
+        }
+    }
+
+    fn for_each_matching_value<I, F, M, U>(
+        &self,
+        items: I,
+        hw_counter: &HardwareCounterCell,
+        check_fn: F,
+        on_match: M,
+    ) -> OperationResult<()>
+    where
+        U: UserData,
+        I: Iterator<Item = (U, PointOffsetType)>,
+        F: Fn(&T) -> bool,
+        M: FnMut(U, bool),
+    {
+        match self {
+            ReadOnlyNumericIndexInner::Appendable(index) => {
+                index.for_each_matching_value(items, hw_counter, check_fn, on_match)
+            }
+            ReadOnlyNumericIndexInner::Immutable(index) => {
+                index.for_each_matching_value(items, hw_counter, check_fn, on_match)
+            }
+            ReadOnlyNumericIndexInner::OnDisk(index) => {
+                index.for_each_matching_value(items, hw_counter, check_fn, on_match)
             }
         }
     }

--- a/lib/segment/src/index/field_index/on_disk_point_to_values.rs
+++ b/lib/segment/src/index/field_index/on_disk_point_to_values.rs
@@ -3,6 +3,7 @@ use std::cmp::max;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 
+use common::bitvec::{BitVec, DeletedBitVec};
 use common::counter::conditioned_counter::ConditionedCounter;
 use common::ext::ResultOptionExt;
 use common::generic_consts::Random;
@@ -10,6 +11,7 @@ use common::mmap::{AdviceSetting, create_and_ensure_length, open_write_mmap};
 use common::types::PointOffsetType;
 use common::universal_io::{
     self, CachedReadFs, OpenOptions, Populate, ReadOnly, ReadRange, UniversalRead, UniversalReadFs,
+    UserData,
 };
 use zerocopy::IntoBytes;
 
@@ -270,14 +272,15 @@ where
         Ok(Some(iter))
     }
 
-    /// Batched counterpart of [`values_iter`](Self::values_iter).
+    /// Batched counterpart of [`Self::values_iter`].
     ///
-    /// Non-existing points, or points without values will be skipped.
-    pub fn values_iter_batch(
+    /// Calls `f` exactly once per input item, even for deleted/missing points.
+    pub fn values_iter_batch<U: UserData>(
         &self,
-        points: impl Iterator<Item = PointOffsetType>,
+        items: impl Iterator<Item = (U, PointOffsetType)>,
+        deleted: &DeletedBitVec,
         hw_counter: ConditionedCounter,
-        mut callback: impl FnMut(PointOffsetType, ValuesIter<'_, T>),
+        mut f: impl FnMut(U, ValuesIter<'_, T>),
     ) -> OperationResult<()> {
         let hw_cell = hw_counter.payload_index_io_read_counter();
 
@@ -286,9 +289,10 @@ where
         let file_len = self.store.len::<u8>()?;
 
         // Batch 1: Resolve each values' range and count
-        let mut value_reads = Vec::with_capacity(points.size_hint().0.min(10_000));
-        let range_reads = points.filter_map(|point_id| {
-            if point_id >= points_count {
+        let mut value_reads = Vec::with_capacity(items.size_hint().0.min(10_000));
+        let range_reads = items.filter_map(|(user_data, point_id)| {
+            if point_id >= points_count || !deleted.is_active(point_id) {
+                f(user_data, ValuesIter::empty());
                 return None;
             }
 
@@ -297,10 +301,10 @@ where
             // Fetch 2 `MmapRange` entries per id, so we can get range start..end.
             // In case of being the last entry, we will do start..file_len
             let length = if point_id + 1 < points_count { 2 } else { 1 };
-            Some((point_id, ReadRange::new(byte_offset, length)))
+            Some((user_data, ReadRange::new(byte_offset, length)))
         });
         self.store
-            .read_batch::<Random, MmapRange, _>(range_reads, |point_id, ranges| {
+            .read_batch::<Random, MmapRange, _>(range_reads, |user_data, ranges| {
                 let MmapRange { start, count } = ranges[0];
 
                 // Use next point's start as end offset for this one.
@@ -311,19 +315,23 @@ where
                 // plus the length of the values.
                 hw_cell.incr_delta(MMAP_PTV_ACCESS_OVERHEAD + length as usize);
 
-                if count > 0 {
-                    value_reads.push((point_id, count as usize, ReadRange::new(start, length)));
-                }
+                // Note: if `count == 0`, we'd better call `f` right away, but
+                // `f` is already mut-borrowed in the iterator above. So,
+                // instead we schedule redundant 0-length read. These 0-length
+                // reads are unlikely to happen in hot loops since empty points
+                // usually marked in `deleted`.
+                value_reads.push((user_data, count as usize, ReadRange::new(start, length)));
+
                 Ok(())
             })?;
 
         // Batch 2: Read and pass the values to the callback as `ValuesIter`s.
         let value_reads = value_reads
             .into_iter()
-            .map(|(point_id, count, range)| ((point_id, count), range));
+            .map(|(user_data, count, range)| ((user_data, count), range));
         self.store
-            .read_batch::<Random, u8, _>(value_reads, |(point_id, count), bytes| {
-                callback(point_id, ValuesIter::new(Cow::Borrowed(bytes), count));
+            .read_batch::<Random, u8, _>(value_reads, |(user_data, count), bytes| {
+                f(user_data, ValuesIter::new(Cow::Borrowed(bytes), count));
                 Ok(())
             })?;
 
@@ -402,18 +410,22 @@ where
 
     /// Read every point's values in batches, invoking `f` once per point that
     /// has at least one value.
-    ///
-    /// The callback may be invoked in any order, since batched reads can
-    /// complete out of order. Points without values are not reported.
     pub fn for_all_points_values(
         &self,
-        callback: impl FnMut(PointOffsetType, ValuesIter<'_, T>),
+        mut f: impl FnMut(PointOffsetType, ValuesIter<'_, T>),
     ) -> OperationResult<()> {
+        // Report deleted points with values too.
+        let blank_bitmask = DeletedBitVec::new(BitVec::repeat(false, self.len()));
         // TODO: Propagate counter upwards
         self.values_iter_batch(
-            0..self.len() as PointOffsetType,
+            (0..self.len() as PointOffsetType).map(|point_id| (point_id, point_id)),
+            &blank_bitmask,
             ConditionedCounter::never(),
-            callback,
+            |point_id, values| {
+                if values.count > 0 {
+                    f(point_id, values);
+                }
+            },
         )
     }
 }
@@ -426,6 +438,15 @@ pub struct ValuesIter<'a, T: ?Sized> {
 }
 
 impl<'a, T: StoredValue + ?Sized + 'a> ValuesIter<'a, T> {
+    fn empty() -> Self {
+        Self {
+            bytes: Cow::Borrowed(&[]),
+            start: 0,
+            count: 0,
+            _type: std::marker::PhantomData,
+        }
+    }
+
     fn new(bytes: Cow<'a, [u8]>, count: usize) -> Self {
         Self {
             bytes,
@@ -550,6 +571,42 @@ mod tests {
                 .map(Cow::into_owned)
                 .collect_vec();
             assert_eq!(&v, values, "roundtrip check");
+        }
+
+        // `values_iter_batch` check
+        {
+            // The callback should be called with an empty iterator even in
+            // these edge cases:
+            // 1. Point deleted via bitvec.
+            let deleted_id = values.iter().position(|vals| !vals.is_empty()).unwrap();
+            // 2. Non-deleted point with no values. (just assert that it exists in the input)
+            let _empty_id = values.iter().position(|vals| vals.is_empty()).unwrap();
+            // 3. Large ID. (out-of-range)
+            let large_id = values.len() + 100;
+
+            let mut deleted = DeletedBitVec::new(BitVec::repeat(false, values.len()));
+            deleted.mark_deleted(deleted_id as PointOffsetType);
+
+            // Run `values_iter_batch` and store its results into
+            let mut reported = Vec::new();
+            ppv.values_iter_batch(
+                (0..values.len()).chain([large_id]).map(|id| (id, id as _)),
+                &deleted,
+                ConditionedCounter::never(),
+                |id, vals| reported.push((id, vals.map(Cow::into_owned).collect_vec())),
+            )
+            .unwrap();
+            reported.sort_unstable_by_key(|&(id, _)| id);
+
+            // Compare with expected
+            let mut expected = Vec::new();
+            for (id, vals) in values.iter().enumerate() {
+                let vals = vals.iter().map(|v| v.borrow().to_owned()).collect_vec();
+                expected.push((id, vals));
+            }
+            expected[deleted_id].1.clear();
+            expected.push((large_id, vec![]));
+            assert_eq!(reported, expected);
         }
     }
 }

--- a/lib/segment/src/index/field_index/on_disk_point_to_values.rs
+++ b/lib/segment/src/index/field_index/on_disk_point_to_values.rs
@@ -286,6 +286,7 @@ where
         let file_len = self.store.len::<u8>()?;
 
         // Batch 1: Resolve each values' range and count
+        let mut value_reads = Vec::with_capacity(points.size_hint().0.min(10_000));
         let range_reads = points.filter_map(|point_id| {
             if point_id >= points_count {
                 return None;
@@ -298,7 +299,6 @@ where
             let length = if point_id + 1 < points_count { 2 } else { 1 };
             Some((point_id, ReadRange::new(byte_offset, length)))
         });
-        let mut value_reads = Vec::new();
         self.store
             .read_batch::<Random, MmapRange, _>(range_reads, |point_id, ranges| {
                 let MmapRange { start, count } = ranges[0];

--- a/lib/segment/src/index/field_index/tests/check_batched_tests.rs
+++ b/lib/segment/src/index/field_index/tests/check_batched_tests.rs
@@ -1,0 +1,248 @@
+use common::bitvec::BitVec;
+use common::condition_checker::{ConditionChecker, assert_congruence};
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::counter::hardware_counter::HardwareCounterCell;
+#[cfg(target_os = "linux")]
+use common::universal_io::IoUringFs;
+use common::universal_io::MmapFs;
+use itertools::Itertools;
+use ordered_float::OrderedFloat;
+use rand::prelude::*;
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::data_types::index::TextIndexParams;
+use crate::index::field_index::index_selector::IndexSelector;
+use crate::index::field_index::{
+    FieldIndexBuilderTrait, PayloadFieldIndexRead, ReadOnlyFieldIndex,
+};
+use crate::json_path::JsonPath;
+use crate::types::{
+    AnyVariants, FieldCondition, GeoPoint, GeoRadius, Match, MatchPhrase, MatchTextAny, Memory,
+    PayloadFieldSchema, PayloadSchemaParams, PayloadSchemaType, Range,
+};
+
+const KEY: &str = "field";
+
+#[test]
+fn geo() {
+    let geo = |lon, lat| GeoPoint::new_unchecked(lon, lat);
+    check_index(
+        &PayloadFieldSchema::FieldType(PayloadSchemaType::Geo),
+        &FieldCondition::new_geo_radius(
+            JsonPath::new(KEY),
+            GeoRadius {
+                center: GeoPoint::new_unchecked(0.0, 0.0),
+                radius: OrderedFloat(6_000_000.0),
+            },
+        ),
+        &[
+            vec![geo(0.0, 0.0)],
+            vec![geo(-8.0, 7.5)],
+            vec![geo(8.0, -8.0), geo(150.0, 0.0)],
+        ],
+        &[
+            vec![],
+            vec![geo(150.0, 0.0)],
+            vec![geo(165.0, -8.0), geo(155.0, 8.0)],
+        ],
+    );
+}
+
+#[test]
+fn numeric() {
+    let range = Range {
+        lt: Some(OrderedFloat(75.0)),
+        gt: None,
+        gte: Some(OrderedFloat(25.0)),
+        lte: None,
+    };
+    check_index(
+        &PayloadFieldSchema::FieldType(PayloadSchemaType::Float),
+        &FieldCondition::new_range(JsonPath::new(KEY), range),
+        &[vec![25.0], vec![74.9], vec![50.0, 100.0]],
+        &[vec![], vec![24.9], vec![75.0, 100.0]],
+    );
+}
+
+#[test]
+fn map_keyword() {
+    check_index(
+        &PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword),
+        &FieldCondition::new_match(JsonPath::new(KEY), "red".to_string().into()),
+        &[vec!["red"], vec!["red", "blue"], vec!["b", "red"]],
+        &[
+            vec![],
+            vec![""],
+            vec!["b", "blue"],
+            vec!["a-rather-long-keyword-to-vary-the-value-length"],
+        ],
+    );
+}
+
+#[test]
+fn map_except() {
+    check_index(
+        &PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword),
+        &FieldCondition::new_match(
+            JsonPath::new(KEY),
+            Match::new_except(AnyVariants::Strings(
+                ["red".to_string(), "green".to_string()]
+                    .into_iter()
+                    .collect(),
+            )),
+        ),
+        &[vec!["outsider"], vec!["red", "outsider"]],
+        &[vec![], vec!["red"], vec!["green", "red"]],
+    );
+}
+
+#[test]
+fn text_match() {
+    check_index(
+        &PayloadFieldSchema::FieldParams(PayloadSchemaParams::Text(TextIndexParams::default())),
+        &FieldCondition::new_match(JsonPath::new(KEY), Match::new_text("alpha beta")),
+        &[
+            vec!["gamma alpha beta"],
+            vec!["beta alpha"],
+            vec!["alpha", "delta beta"],
+        ],
+        &[
+            vec![],
+            vec!["alpha gamma"],
+            vec!["beta", "delta beta"],
+            vec!["gamma", "delta"],
+        ],
+    );
+}
+
+#[test]
+fn text_any() {
+    check_index(
+        &PayloadFieldSchema::FieldParams(PayloadSchemaParams::Text(TextIndexParams::default())),
+        &FieldCondition::new_match(
+            JsonPath::new(KEY),
+            Match::TextAny(MatchTextAny {
+                text_any: "alpha beta".into(),
+            }),
+        ),
+        &[
+            vec!["alpha"],
+            vec!["gamma beta"],
+            vec!["delta", "beta alpha"],
+        ],
+        &[vec![], vec!["gamma"], vec!["delta gamma", "delta"]],
+    );
+}
+
+#[test]
+fn text_phrase() {
+    check_index(
+        &PayloadFieldSchema::FieldParams(PayloadSchemaParams::Text(TextIndexParams {
+            phrase_matching: Some(true),
+            ..Default::default()
+        })),
+        &FieldCondition::new_match(
+            JsonPath::new(KEY),
+            Match::Phrase(MatchPhrase {
+                phrase: "alpha beta".into(),
+            }),
+        ),
+        &[
+            vec!["alpha beta"],
+            vec!["gamma alpha beta delta"],
+            vec!["gamma", "alpha beta"],
+        ],
+        &[
+            vec![],
+            vec!["alpha gamma beta"],
+            vec!["beta alpha"],
+            vec!["gamma alpha", "beta delta"],
+        ],
+    );
+}
+
+fn check_index<T: Serialize>(
+    schema: &PayloadFieldSchema,
+    condition: &FieldCondition,
+    yes: &[Vec<T>],
+    no: &[Vec<T>],
+) {
+    let mut rng = StdRng::seed_from_u64(0);
+    let field = JsonPath::new(KEY);
+
+    let mut points: Vec<(Vec<Value>, bool, bool, bool)> = Vec::new(); // (row, baked, removed, expected)
+    for (rows, matched) in [(yes, true), (no, false)] {
+        for row in rows {
+            let row: Vec<Value> = row
+                .iter()
+                .map(|v| serde_json::to_value(v).unwrap())
+                .collect();
+            points.push((row.clone(), false, false, matched));
+            points.push((row.clone(), false, true, false));
+            points.push((row.clone(), true, false, false));
+            points.push((row.clone(), true, true, false));
+        }
+    }
+    points.shuffle(&mut rng);
+
+    for points in [&points[..0], &points[..]] {
+        let n = points.len();
+        let baked: BitVec = points.iter().map(|&(_, baked, _, _)| baked).collect();
+        let deleted: BitVec = points
+            .iter()
+            .map(|&(_, baked, removed, _)| baked || removed)
+            .collect();
+
+        for memory in [Memory::Pinned, Memory::Cold] {
+            let dir = tempfile::tempdir().unwrap();
+            let dir = dir.path();
+
+            // Build index
+            let mut builders = IndexSelector::NonAppendable { dir, memory }
+                .index_builder(&field, schema, &baked)
+                .unwrap();
+            assert_eq!(builders.len(), 1);
+            let mut builder = builders.pop().unwrap();
+            builder.init().unwrap();
+            for (id, (row, _, _, _)) in (0u32..).zip(points) {
+                builder
+                    .add_point(id, &row.iter().collect_vec(), &HardwareCounterCell::new())
+                    .unwrap();
+            }
+            let mut index = builder.finalize().unwrap();
+            for (id, &(_, _, removed, _)) in (0u32..).zip(points) {
+                if removed {
+                    index.remove_point(id).unwrap();
+                }
+            }
+
+            // Sanity check: `check()` is the same as `expected`
+            let checker = index.condition_checker(condition, HwMeasurementAcc::new());
+            let mut checker = checker.unwrap().unwrap();
+            for (id, &(_, _, _, expected)) in (0u32..).zip(points) {
+                assert_eq!(checker.check(id).unwrap(), expected, "{id}");
+            }
+
+            assert_congruence(&mut checker, n, &mut rng);
+
+            let r#type = index.get_full_index_type();
+
+            let index =
+                ReadOnlyFieldIndex::open(&MmapFs, dir, &field, schema, &r#type, n, &deleted, None);
+            let index = index.unwrap().unwrap();
+            let checker = index.condition_checker(condition, HwMeasurementAcc::new());
+            assert_congruence(&mut checker.unwrap().unwrap(), n as _, &mut rng);
+
+            #[cfg(target_os = "linux")]
+            {
+                let index = ReadOnlyFieldIndex::open(
+                    &IoUringFs, dir, &field, schema, &r#type, n, &deleted, None,
+                );
+                let index = index.unwrap().unwrap();
+                let checker = index.condition_checker(condition, HwMeasurementAcc::new());
+                assert_congruence(&mut checker.unwrap().unwrap(), n, &mut rng);
+            }
+        }
+    }
+}

--- a/lib/segment/src/index/field_index/tests/check_batched_tests.rs
+++ b/lib/segment/src/index/field_index/tests/check_batched_tests.rs
@@ -219,12 +219,12 @@ fn check_index<T: Serialize>(
 
             // Sanity check: `check()` is the same as `expected`
             let checker = index.condition_checker(condition, HwMeasurementAcc::new());
-            let mut checker = checker.unwrap().unwrap();
+            let checker = checker.unwrap().unwrap();
             for (id, &(_, _, _, expected)) in (0u32..).zip(points) {
                 assert_eq!(checker.check(id).unwrap(), expected, "{id}");
             }
 
-            assert_congruence(&mut checker, n, &mut rng);
+            assert_congruence(&checker, n, &mut rng);
 
             let r#type = index.get_full_index_type();
 
@@ -232,7 +232,7 @@ fn check_index<T: Serialize>(
                 ReadOnlyFieldIndex::open(&MmapFs, dir, &field, schema, &r#type, n, &deleted, None);
             let index = index.unwrap().unwrap();
             let checker = index.condition_checker(condition, HwMeasurementAcc::new());
-            assert_congruence(&mut checker.unwrap().unwrap(), n as _, &mut rng);
+            assert_congruence(&checker.unwrap().unwrap(), n as _, &mut rng);
 
             #[cfg(target_os = "linux")]
             {
@@ -241,7 +241,7 @@ fn check_index<T: Serialize>(
                 );
                 let index = index.unwrap().unwrap();
                 let checker = index.condition_checker(condition, HwMeasurementAcc::new());
-                assert_congruence(&mut checker.unwrap().unwrap(), n, &mut rng);
+                assert_congruence(&checker.unwrap().unwrap(), n, &mut rng);
             }
         }
     }

--- a/lib/segment/src/index/field_index/tests/mod.rs
+++ b/lib/segment/src/index/field_index/tests/mod.rs
@@ -1,3 +1,4 @@
+mod check_batched_tests;
 mod histogram_i64_tests;
 mod histogram_test_utils;
 mod histogram_tests;

--- a/lib/segment/src/index/hnsw_index/build_condition_checker.rs
+++ b/lib/segment/src/index/hnsw_index/build_condition_checker.rs
@@ -1,4 +1,4 @@
-use common::condition_checker::ConditionChecker;
+use common::condition_checker::{CheckItem, ConditionChecker, Rest, Select, default_check_batched};
 use common::types::PointOffsetType;
 
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -17,5 +17,12 @@ impl ConditionChecker for BuildConditionChecker<'_> {
             return Ok(false); // Do not match current point while inserting it (second time)
         }
         Ok(self.filter_list.check(point_id))
+    }
+
+    fn check_batched<K>(&self, ids: &mut [K], select: Select, rest: Rest) -> OperationResult<usize>
+    where
+        K: CheckItem,
+    {
+        default_check_batched(ids, select, rest, |id| self.check(id))
     }
 }

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::AtomicBool;
 
 use ahash::AHashMap;
 use atomic_refcell::AtomicRefCell;
-use common::condition_checker::ConditionChecker;
+use common::condition_checker::{CheckItem, ConditionChecker, Rest, Select, default_check_batched};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::iterator_ext::IteratorExt;
@@ -344,5 +344,12 @@ impl ConditionChecker for PlainFilterContext<'_> {
 
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         Ok(self.condition_checker.check(point_id, self.filter))
+    }
+
+    fn check_batched<K>(&self, ids: &mut [K], select: Select, rest: Rest) -> OperationResult<usize>
+    where
+        K: CheckItem,
+    {
+        default_check_batched(ids, select, rest, |id| self.check(id))
     }
 }

--- a/lib/segment/src/index/query_optimization/optimized_filter.rs
+++ b/lib/segment/src/index/query_optimization/optimized_filter.rs
@@ -1,6 +1,7 @@
 use common::condition_checker::{CheckItem, ConditionChecker, Rest, Select};
 use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
+use smallvec::SmallVec;
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::condition_checker::ConditionCheckerEnum;
@@ -15,8 +16,6 @@ pub struct OptimizedFilter<'a> {
     must: Vec<ConditionCheckerEnum<'a>>,
     /// All conditions must NOT match
     must_not: Vec<ConditionCheckerEnum<'a>>,
-
-    scratch: Vec<usize>,
 }
 
 impl<'a> OptimizedFilter<'a> {
@@ -33,7 +32,6 @@ impl<'a> OptimizedFilter<'a> {
             min_should_count,
             must,
             must_not,
-            scratch: Vec::new(),
         }
     }
 
@@ -53,7 +51,6 @@ impl ConditionChecker for OptimizedFilter<'_> {
             min_should_count,
             must,
             must_not,
-            scratch: _,
         } = self;
 
         // `should`: at least one matches, if not empty.
@@ -96,7 +93,7 @@ impl ConditionChecker for OptimizedFilter<'_> {
     }
 
     fn check_batched<K: CheckItem>(
-        &mut self,
+        &self,
         ids: &mut [K],
         select: Select,
         rest: Rest,
@@ -107,7 +104,6 @@ impl ConditionChecker for OptimizedFilter<'_> {
             min_should_count,
             must,
             must_not,
-            scratch,
         } = self;
         match select {
             Select::Matches => {
@@ -125,7 +121,6 @@ impl ConditionChecker for OptimizedFilter<'_> {
                     *min_should_count,
                     Select::Matches,
                     rest,
-                    scratch,
                 )?;
                 Ok(n)
             }
@@ -149,7 +144,6 @@ impl ConditionChecker for OptimizedFilter<'_> {
                     threshold,
                     Select::NonMatches,
                     min_should_rest,
-                    scratch,
                 )?;
                 Ok(n)
             }
@@ -159,7 +153,7 @@ impl ConditionChecker for OptimizedFilter<'_> {
 
 /// Select ids that satisfy all of the conditions.
 fn all_of<C: ConditionChecker, K: CheckItem>(
-    conditions: &mut [C],
+    conditions: &[C],
     ids: &mut [K],
     select: Select,
     rest: Rest,
@@ -187,7 +181,7 @@ fn all_of<C: ConditionChecker, K: CheckItem>(
 
 /// Select ids that satisfy any of the conditions.
 fn any_of<C: ConditionChecker, K: CheckItem>(
-    conditions: &mut [C],
+    conditions: &[C],
     ids: &mut [K],
     select: Select,
     rest: Rest,
@@ -208,7 +202,7 @@ fn any_of<C: ConditionChecker, K: CheckItem>(
     //        └────────────────────────────────────────────┘
     let mut n = 0;
     let last = conditions.len().wrapping_sub(1);
-    for (i, condition) in conditions.iter_mut().enumerate() {
+    for (i, condition) in conditions.iter().enumerate() {
         // Only the last conditions's rejects are final.
         let condition_rest = rest.keep_if(i != last);
         n += condition.check_batched(&mut ids[n..], select, condition_rest)?;
@@ -218,12 +212,11 @@ fn any_of<C: ConditionChecker, K: CheckItem>(
 
 /// Selects ids that satisfy at least `threshold` conditions.
 fn at_least<C: ConditionChecker, K: CheckItem>(
-    conditions: &mut [C],
+    conditions: &[C],
     ids: &mut [K],
     threshold: usize,
     select: Select,
     rest: Rest,
-    scratch: &mut Vec<usize>,
 ) -> Result<usize, C::Error> {
     if threshold == 0 {
         return Ok(ids.len());
@@ -233,23 +226,22 @@ fn at_least<C: ConditionChecker, K: CheckItem>(
     }
 
     // Counting sort: ids are kept in blocks by descending number of satisfied
-    // children; `ids[..scratch[0]]` satisfy at least `threshold` of them,
-    // `ids[scratch[i - 1]..scratch[i]]` satisfy exactly `threshold - i`.
+    // children; `ids[..counts[0]]` satisfy at least `threshold` of them,
+    // `ids[counts[i - 1]..counts[i]]` satisfy exactly `threshold - i`.
     // A satisfied id moves to the front of its block, joining the block above.
     let m = ids.len();
-    scratch.clear();
-    scratch.resize(threshold, 0);
+    let mut counts = SmallVec::<[usize; 16]>::from_elem(0, threshold);
     let last = conditions.len() - 1;
-    for (c, condition) in conditions.iter_mut().enumerate() {
+    for (c, condition) in conditions.iter().enumerate() {
         // Only the last condition's rejects are final (see `any_of`).
         let child_rest = rest.keep_if(c != last);
         for i in 0..threshold {
-            let start = scratch[i];
-            let end = if i + 1 < threshold { scratch[i + 1] } else { m };
-            scratch[i] += condition.check_batched(&mut ids[start..end], select, child_rest)?;
+            let start = counts[i];
+            let end = if i + 1 < threshold { counts[i + 1] } else { m };
+            counts[i] += condition.check_batched(&mut ids[start..end], select, child_rest)?;
         }
     }
-    Ok(scratch[0])
+    Ok(counts[0])
 }
 
 #[cfg(test)]
@@ -272,14 +264,14 @@ mod tests {
                     total += 1;
                     ConditionCheckerEnum::TestBitOfId(TestBitOfId(total - 1))
                 };
-                let mut filter = OptimizedFilter::new(
+                let filter = OptimizedFilter::new(
                     (0..should).map(|_| next()).collect(),
                     (0..min_should).map(|_| next()).collect(),
                     min_should_count,
                     (0..must).map(|_| next()).collect(),
                     (0..must_not).map(|_| next()).collect(),
                 );
-                assert_congruence(&mut filter, 1 << total, &mut rng);
+                assert_congruence(&filter, 1 << total, &mut rng);
             }
         }
     }
@@ -289,8 +281,8 @@ mod tests {
         for seed in 0..20 {
             let mut rng = StdRng::seed_from_u64(seed);
             let mut bits = 0;
-            let mut filter = generate(&mut rng, 3, &mut bits);
-            assert_congruence(&mut filter, 1 << bits, &mut rng);
+            let filter = generate(&mut rng, 3, &mut bits);
+            assert_congruence(&filter, 1 << bits, &mut rng);
         }
 
         fn generate(rng: &mut StdRng, depth: usize, bits: &mut u32) -> OptimizedFilter<'static> {

--- a/lib/segment/src/index/query_optimization/optimized_filter.rs
+++ b/lib/segment/src/index/query_optimization/optimized_filter.rs
@@ -1,4 +1,4 @@
-use common::condition_checker::ConditionChecker;
+use common::condition_checker::{CheckItem, ConditionChecker, Rest, Select};
 use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
 
@@ -7,26 +7,39 @@ use crate::index::condition_checker::ConditionCheckerEnum;
 
 pub struct OptimizedFilter<'a> {
     /// At least one of those conditions should match, if not empty.
-    pub should: Vec<ConditionCheckerEnum<'a>>,
+    should: Vec<ConditionCheckerEnum<'a>>,
     /// At least minimum amount of given conditions should match
-    pub min_should: Vec<ConditionCheckerEnum<'a>>,
-    pub min_should_count: usize,
+    min_should: Vec<ConditionCheckerEnum<'a>>,
+    min_should_count: usize,
     /// All conditions must match
-    pub must: Vec<ConditionCheckerEnum<'a>>,
+    must: Vec<ConditionCheckerEnum<'a>>,
     /// All conditions must NOT match
-    pub must_not: Vec<ConditionCheckerEnum<'a>>,
+    must_not: Vec<ConditionCheckerEnum<'a>>,
+
+    scratch: Vec<usize>,
 }
 
 impl<'a> OptimizedFilter<'a> {
+    pub fn new(
+        should: Vec<ConditionCheckerEnum<'a>>,
+        min_should: Vec<ConditionCheckerEnum<'a>>,
+        min_should_count: usize,
+        must: Vec<ConditionCheckerEnum<'a>>,
+        must_not: Vec<ConditionCheckerEnum<'a>>,
+    ) -> Self {
+        OptimizedFilter {
+            should,
+            min_should,
+            min_should_count,
+            must,
+            must_not,
+            scratch: Vec::new(),
+        }
+    }
+
     /// A filter that matches a point iff the single given checker matches it.
     pub fn from_checker(checker: ConditionCheckerEnum<'a>) -> Self {
-        OptimizedFilter {
-            should: Vec::new(),
-            min_should: Vec::new(),
-            min_should_count: 0,
-            must: vec![checker],
-            must_not: Vec::new(),
-        }
+        Self::new(Vec::new(), Vec::new(), 0, vec![checker], Vec::new())
     }
 }
 
@@ -40,6 +53,7 @@ impl ConditionChecker for OptimizedFilter<'_> {
             min_should_count,
             must,
             must_not,
+            scratch: _,
         } = self;
 
         // `should`: at least one matches, if not empty.
@@ -80,4 +94,160 @@ impl ConditionChecker for OptimizedFilter<'_> {
 
         Ok(true)
     }
+
+    fn check_batched<K: CheckItem>(
+        &mut self,
+        ids: &mut [K],
+        select: Select,
+        rest: Rest,
+    ) -> OperationResult<usize> {
+        let OptimizedFilter {
+            should,
+            min_should,
+            min_should_count,
+            must,
+            must_not,
+            scratch,
+        } = self;
+        match select {
+            Select::Matches => {
+                // must ∩ must_not ∩ should ∩ min_should
+
+                let mut n = all_of(must, ids, Select::Matches, rest)?;
+                n = all_of(must_not, &mut ids[..n], Select::NonMatches, rest)?;
+                if !should.is_empty() {
+                    // Empty `should` means "no constraint", not an empty disjunction.
+                    n = any_of(should, &mut ids[..n], Select::Matches, rest)?;
+                }
+                n = at_least(
+                    min_should,
+                    &mut ids[..n],
+                    *min_should_count,
+                    Select::Matches,
+                    rest,
+                    scratch,
+                )?;
+                Ok(n)
+            }
+            Select::NonMatches => {
+                // ¬must ∪ ¬must_not ∪ ¬should ∪ ¬min_should
+
+                let min_should_rest = rest;
+                let should_rest = min_should_rest.keep_if(*min_should_count > 0);
+                let must_not_rest = should_rest.keep_if(!should.is_empty());
+                let must_rest = must_not_rest.keep_if(!must_not.is_empty());
+
+                let mut n = any_of(must, ids, Select::NonMatches, must_rest)?;
+                n += any_of(must_not, &mut ids[n..], Select::Matches, must_not_rest)?;
+                if !should.is_empty() {
+                    n += all_of(should, &mut ids[n..], Select::NonMatches, should_rest)?;
+                }
+                let threshold = (min_should.len() + 1).saturating_sub(*min_should_count);
+                n += at_least(
+                    min_should,
+                    &mut ids[n..],
+                    threshold,
+                    Select::NonMatches,
+                    min_should_rest,
+                    scratch,
+                )?;
+                Ok(n)
+            }
+        }
+    }
+}
+
+/// Select ids that satisfy all of the conditions.
+fn all_of<C: ConditionChecker, K: CheckItem>(
+    conditions: &mut [C],
+    ids: &mut [K],
+    select: Select,
+    rest: Rest,
+) -> Result<usize, C::Error> {
+    // Each step narrows the matching (left) zone.
+    //
+    // Input  │                                                                │
+    //        └────────────────────────────────────────────────────────────────┘
+    // Step A │ A                                                    │ ¬A      │
+    //        └──────────────────────────────────────────────────────┴─────────┘
+    // Step B │ A ∩ B                                       │ A ∩ ¬B │
+    //        └─────────────────────────────────────────────┴────────┘
+    // Step C │ A ∩ B ∩ C                      │ A ∩ B ∩ ¬C │
+    //        └────────────────────────────────┴────────────┘
+    // Step D │ A ∩ B ∩ C ∩ D │ A ∩ B ∩ C ∩ ¬D │
+    //        └───────────────┴────────────────┘
+    // Result │ A ∩ B ∩ C ∩ D │
+    //        └───────────────┘
+    let mut n = ids.len();
+    for condition in conditions {
+        n = condition.check_batched(&mut ids[..n], select, rest)?;
+    }
+    Ok(n)
+}
+
+/// Select ids that satisfy any of the conditions.
+fn any_of<C: ConditionChecker, K: CheckItem>(
+    conditions: &mut [C],
+    ids: &mut [K],
+    select: Select,
+    rest: Rest,
+) -> Result<usize, C::Error> {
+    // Each step scans only the ids rejected by the previous step.
+    //
+    // Input  │                                                                │
+    //        └────────────────────────────────────────────────────────────────┘
+    // Step A │ A │ ¬A                                                         │
+    //        └───┴────────────────────────────────────────────────────────────┘
+    // Step B     │ ¬A ∩ B │ ¬A ∩ ¬B                                           │
+    //            └────────┴───────────────────────────────────────────────────┘
+    // Step C              │ ¬A ∩ ¬B ∩ C │ ¬A ∩ ¬B ∩ ¬C                        │
+    //                     └─────────────┴─────────────────────────────────────┘
+    // Step D                            │¬A ∩ ¬B ∩ ¬C ∩ D │ ¬A ∩ ¬B ∩ ¬C ∩ ¬D │
+    //                                   └─────────────────┴───────────────────┘
+    // Output │ A ∪ B ∪ C ∪ D                              │
+    //        └────────────────────────────────────────────┘
+    let mut n = 0;
+    let last = conditions.len().wrapping_sub(1);
+    for (i, condition) in conditions.iter_mut().enumerate() {
+        // Only the last conditions's rejects are final.
+        let condition_rest = rest.keep_if(i != last);
+        n += condition.check_batched(&mut ids[n..], select, condition_rest)?;
+    }
+    Ok(n)
+}
+
+/// Selects ids that satisfy at least `threshold` conditions.
+fn at_least<C: ConditionChecker, K: CheckItem>(
+    conditions: &mut [C],
+    ids: &mut [K],
+    threshold: usize,
+    select: Select,
+    rest: Rest,
+    scratch: &mut Vec<usize>,
+) -> Result<usize, C::Error> {
+    if threshold == 0 {
+        return Ok(ids.len());
+    }
+    if threshold > conditions.len() {
+        return Ok(0);
+    }
+
+    // Counting sort: ids are kept in blocks by descending number of satisfied
+    // children; `ids[..scratch[0]]` satisfy at least `threshold` of them,
+    // `ids[scratch[i - 1]..scratch[i]]` satisfy exactly `threshold - i`.
+    // A satisfied id moves to the front of its block, joining the block above.
+    let m = ids.len();
+    scratch.clear();
+    scratch.resize(threshold, 0);
+    let last = conditions.len() - 1;
+    for (c, condition) in conditions.iter_mut().enumerate() {
+        // Only the last condition's rejects are final (see `any_of`).
+        let child_rest = rest.keep_if(c != last);
+        for i in 0..threshold {
+            let start = scratch[i];
+            let end = if i + 1 < threshold { scratch[i + 1] } else { m };
+            scratch[i] += condition.check_batched(&mut ids[start..end], select, child_rest)?;
+        }
+    }
+    Ok(scratch[0])
 }

--- a/lib/segment/src/index/query_optimization/optimized_filter.rs
+++ b/lib/segment/src/index/query_optimization/optimized_filter.rs
@@ -251,3 +251,76 @@ fn at_least<C: ConditionChecker, K: CheckItem>(
     }
     Ok(scratch[0])
 }
+
+#[cfg(test)]
+mod tests {
+    use common::condition_checker::assert_congruence;
+    use itertools::iproduct;
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+
+    use super::*;
+    use crate::index::condition_checker::{ConditionCheckerEnum, TestBitOfId};
+
+    #[test]
+    fn flat() {
+        let mut rng = StdRng::seed_from_u64(1);
+        for (should, min_should, must, must_not) in iproduct!(0..=3, 0..=3usize, 0..=3, 0..=3) {
+            for min_should_count in 0..=min_should + 1 {
+                let mut total = 0;
+                let mut next = || {
+                    total += 1;
+                    ConditionCheckerEnum::TestBitOfId(TestBitOfId(total - 1))
+                };
+                let mut filter = OptimizedFilter::new(
+                    (0..should).map(|_| next()).collect(),
+                    (0..min_should).map(|_| next()).collect(),
+                    min_should_count,
+                    (0..must).map(|_| next()).collect(),
+                    (0..must_not).map(|_| next()).collect(),
+                );
+                assert_congruence(&mut filter, 1 << total, &mut rng);
+            }
+        }
+    }
+
+    #[test]
+    fn nested() {
+        for seed in 0..20 {
+            let mut rng = StdRng::seed_from_u64(seed);
+            let mut bits = 0;
+            let mut filter = generate(&mut rng, 3, &mut bits);
+            assert_congruence(&mut filter, 1 << bits, &mut rng);
+        }
+
+        fn generate(rng: &mut StdRng, depth: usize, bits: &mut u32) -> OptimizedFilter<'static> {
+            let mut gen_clause = || -> Vec<ConditionCheckerEnum<'static>> {
+                (0..rng.random_range(0..=2))
+                    .map(|_| {
+                        if depth > 0 && rng.random_bool(0.4) {
+                            return ConditionCheckerEnum::Filter(generate(rng, depth - 1, bits));
+                        }
+                        // Reuse bits once 8 are claimed: keeps the universe small, and
+                        // repeated bits add correlated-leaf coverage.
+                        let bit = match *bits < 8 {
+                            true => {
+                                *bits += 1;
+                                *bits - 1
+                            }
+                            false => rng.random_range(0..8),
+                        };
+                        ConditionCheckerEnum::TestBitOfId(TestBitOfId(bit))
+                    })
+                    .collect()
+            };
+
+            let should = gen_clause();
+            let min_should = gen_clause();
+            let must = gen_clause();
+            let must_not = gen_clause();
+
+            let count = rng.random_range(0..=min_should.len() + 1);
+            OptimizedFilter::new(should, min_should, count, must, must_not)
+        }
+    }
+}

--- a/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 
 use ahash::{AHashMap, AHashSet};
 use atomic_refcell::AtomicRefCell;
-use common::condition_checker::{ConditionChecker, ConstantConditionChecker};
+use common::condition_checker::{
+    CheckItem, ConditionChecker, ConstantConditionChecker, Rest, Select, default_check_batched,
+};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{DeferredBehavior, PointOffsetType};
 use serde_json::Value;
@@ -230,6 +232,13 @@ where
             &self.hw_counter,
         )
     }
+
+    fn check_batched<K>(&self, ids: &mut [K], select: Select, rest: Rest) -> OperationResult<usize>
+    where
+        K: CheckItem,
+    {
+        default_check_batched(ids, select, rest, |id| self.check(id))
+    }
 }
 
 /// For [`Condition::HasId`] and [`Condition::CustomIdChecker`].
@@ -240,6 +249,13 @@ impl ConditionChecker for IdsConditionChecker {
 
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         Ok(self.0.contains(&point_id))
+    }
+
+    fn check_batched<K>(&self, ids: &mut [K], select: Select, rest: Rest) -> OperationResult<usize>
+    where
+        K: CheckItem,
+    {
+        default_check_batched(ids, select, rest, |id| self.check(id))
     }
 }
 
@@ -260,6 +276,13 @@ impl<I: IdTrackerRead> ConditionChecker for SliceConditionChecker<'_, I> {
             .external_id(point_id)
             .is_some_and(|external_id| self.slice.check(external_id)))
     }
+
+    fn check_batched<K>(&self, ids: &mut [K], select: Select, rest: Rest) -> OperationResult<usize>
+    where
+        K: CheckItem,
+    {
+        default_check_batched(ids, select, rest, |id| self.check(id))
+    }
 }
 
 /// For [`Condition::HasVector`].
@@ -270,5 +293,14 @@ impl<V: VectorStorageRead> ConditionChecker for HasVectorConditionChecker<V> {
 
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         Ok(!self.0.borrow().is_deleted_vector(point_id))
+    }
+
+    fn check_batched<K: CheckItem>(
+        &self,
+        ids: &mut [K],
+        select: Select,
+        rest: Rest,
+    ) -> OperationResult<usize> {
+        default_check_batched(ids, select, rest, |id| self.check(id))
     }
 }

--- a/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
@@ -105,13 +105,8 @@ where
         )?;
         filter_estimations.push(estimation);
 
-        let optimized_filter = OptimizedFilter {
-            should,
-            min_should,
-            min_should_count,
-            must,
-            must_not,
-        };
+        let optimized_filter =
+            OptimizedFilter::new(should, min_should, min_should_count, must, must_not);
 
         Ok((
             optimized_filter,


### PR DESCRIPTION
This PR adds `ConditionChecker::check_batched` trait method and implements it for:
- numeric/geo/map/full-text indices
- `OptimizedFilter` (`should`/`min_should`/`must`/`must_not` thingy)

No integration is made in this PR. Integration PRs:
- #9845
- #9846

I suggest to review commit by commit.

# Preamble

An average UIO migration looks like this: we have a method that does some action on a given id…:
```rust
fn something(&self, id: u32) -> R;
```
…, and we implement similar method that performs the same action on multiple IDs at once. Any of these:
```rust
fn something_batched_vec(&self, ids: &[u32]) -> Vec<R>;
fn something_batched_iter(&self, ids: impl Iterator<Item=u32>) -> impl Iterator<Item=R>;
fn something_batched_callback(&self, ids: impl Iterator<Item=u32>, f: impl FnMut(u32, R));
```

It scales well as long as we batch actions of the same type (e.g. reading from the same index type).
But this time we need to combine multiple independent index implementations, e.g.:
```js
filter: {
  must: [
    // numeric index
    { key: "weight_kg",   range: { gte: 4.9 } },
    // keyword/map index
    { key: "category",    match: { value: "laptop" } },
    // full-text index
    { key: "description", match: { text: "ThinkPad W700ds" } },
  ],
}
```

To complicate things more, these conditions can be arbitrarily nested. E.g., `must` inside `min_should` inside `must_not`.

# Goals

There are two contradicting goals for the `ConditionChecker` interface.

- For S3, it should be batched. Network latencies overshadow any other logic, so any naive implementation would work: put IDs into a hashset, allocate on each step, it will be not be noticeable on benchmarks.
- For in-memory case, any allocation or extra branching will hurt. So it should be as simple as possible to keep the performance on par.

An easy way is to provide two implementations: use the existing non-batched for in-memory case, and a separate batched implementation for the S3 case.
But who said that we should take easy ways?
What if we can make an interface that satisfy both goals — be batched AND fast in tight loops at the same time?
I've tried many approaches and found out that this interface is possible (at least for HNSW search).

# The interface

The new interface looks like this (simplified):
````rust
pub trait ConditionChecker {
    /// Rearranges items in-place, separating those that satisfy the condition
    /// from those that don't.
    ///
    /// Returns the partition point (aka the length of the left side).
    ///
    /// ```text
    /// Input:   ○ ○ ● ○ ○ ○ ● ○ ● ○ ● ● ○
    /// Output:  ● ● ● ● ● ○ ○ ○ ○ ○ ○ ○ ○
    ///         └─────────┴───────────────┘
    ///                   ↑ partition point
    /// ```
    fn check_batched(&mut self, items: &mut [PointOffsetType]) -> usize;
}
````

(the actual interface a bit more complicated, see sources)

Why it's good? Rearranging in-place lets us to perform no allocations.
Combining multiple (`must`/`should`/etc) is also [done in-place](https://github.com/qdrant/qdrant/blob/220d3e873c3a834548f7a00a8ff9f7ec3bed897e/lib/segment/src/index/query_optimization/optimized_filter.rs#L160-L217). Single clauses (e.g. `must` with one condition) add no overhead.

Since this interface might be cumberstone to implement, this PR provides two helpers:
- `fn partition_batched` for sync impls
  https://github.com/qdrant/qdrant/blob/220d3e873c3a834548f7a00a8ff9f7ec3bed897e/lib/common/common/src/condition_checker.rs#L48
- `struct Partitioner` for async impls
  https://github.com/qdrant/qdrant/blob/220d3e873c3a834548f7a00a8ff9f7ec3bed897e/lib/segment/src/index/field_index/numeric_index/query.rs#L378-L385

More details in [`condition_checker.rs`](https://github.com/qdrant/qdrant/blob/batched-conditon-checker/lib/common/common/src/condition_checker.rs) and [`optimized_filter.rs`](https://github.com/qdrant/qdrant/blob/batched-conditon-checker/lib/segment/src/index/query_optimization/optimized_filter.rs).

# Benchmarks

Filtered HNSW, best scenario:
- [vector-db-benchmark/arxiv-titles-384-angular-filters](https://github.com/qdrant/vector-db-benchmark/blob/e8fb073a778909a12fc1e8fcade0ee4dd1dd40b0/datasets/datasets.json#L132-L143)
- 2_138_591 points, dim=384
- Payload filters like this (one condition per point):
  ```js
  { must: [{ key: "labels", match: { value: "math.SG" }}]}
  { must: [{ key: "submitter", match: { value: "Keiichi Wada" }}]}
  { must: [{ key: "update_date_ts", range: { gt: 1336998172, lt: 1453451777 }}]}
  ```
- 1 segment, on_disk=false, m=32
- RPS: 3478 (dev) → 3777 (this PR); +8.6%

Other HNSW scenarios show no perf degradation.

On sparse, it's a bit worse sometimes (can explain later why). Perhaps I'll just switch between batched/non-batched based on the uio backend.
