### PR TITLE
Serve known file length from CachedFs snapshot on plain open

### DIFF
--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -269,7 +269,15 @@ impl<Fs: UniversalReadFs> UniversalReadFs for CachedFs<Fs> {
             });
         }
 
-        // Cache bypass: the path was never scheduled, and no snapshot was taken
+        // The path was never scheduled for prefetch. If a snapshot was taken it
+        // still carries the file's size, so thread it into the open as a known
+        // length — this lets the backend skip a remote `len`/HEAD round-trip
+        // (e.g. `DiskCacheFs` opens straight into `State::Ready`). Without a
+        // snapshot this is a plain cache-bypass open.
+        let extra = match self.file_info(path) {
+            Some(info) => extra.with_known_len(info.size),
+            None => extra,
+        };
         self.fs.open(path, options, extra)
     }
 }


### PR DESCRIPTION
## Problem

`CachedFs::cache_file_info` snapshots every file's size from the `list_files` result, but that size was only used on the **prefetch** path (`schedule_prefetch` → `with_known_len`). Files opened directly through the fallback `CachedFs::open` — e.g. segment files the loader opens lazily instead of prefetching — forwarded the caller's `OpenExtra` unchanged, so `known_len` was `None`.

As a result, on blob backends (S3) each such file triggered a separate remote `len`/HEAD round-trip to size it, even though the length was already known from the listing. Observed while loading a shard in `edge-shard-query`:

```
len::<u8>(.../vector_storage/matrix.dat) took 151ms and measured 101376004 bytes
len::<u8>(.../has_values/flags_a.dat)   took 386ms and measured 1048576 bytes
...
```

## Change

Thread the snapshot size into the fallback open too: when a snapshot exists and lists the path, apply `with_known_len(info.size)` before delegating to the inner `open`. This lets `DiskCacheFs::open` go straight to `State::Ready` and skip the remote metadata call.

- No-op when no snapshot was taken (plain cache-bypass open, unchanged).
- No-op for backends where `with_known_len` is meaningless (e.g. `()`).
- The prefetch path is unchanged.

## Effect

Every file opened through a snapshotted `CachedFs` — prefetched or lazily opened — now carries its length from the list snapshot, removing one S3 HEAD per lazily-opened file during shard load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)