### PR TITLE
Read SegmentState and PayloadConfig once per read-only segment open

### DIFF
--- a/lib/segment/src/index/struct_payload_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/lifecycle.rs
@@ -40,23 +40,17 @@ impl<S: UniversalReadExt> ReadOnlyStructPayloadIndex<S> {
         Ok(config)
     }
 
-    /// Read-only mirror of `StructPayloadIndex::open`: loads the payload config
-    /// and each persisted field index through `fs` (never builds/migrates/writes).
+    /// Read-only mirror of `StructPayloadIndex::open`: loads each persisted field
+    /// index through `fs` (never builds/migrates/writes). `config` is the one
+    /// [`preopen`](Self::preopen) already read.
     pub fn open(
         fs: &impl UniversalReadFs<File = S>,
         payload: Arc<AtomicRefCell<ReadOnlyPayloadStorage<S>>>,
         id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
         vector_storages: HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageReadEnum<S>>>>,
         path: &Path,
+        config: PayloadConfig,
     ) -> OperationResult<Self> {
-        let config_path = PayloadConfig::get_config_path(path);
-        let config = PayloadConfig::load_universal(fs, &config_path)?.ok_or_else(|| {
-            OperationError::service_error(format!(
-                "Read-only payload index missing config at {}",
-                config_path.display()
-            ))
-        })?;
-
         let field_indexes = {
             let id_tracker = id_tracker.borrow();
             let total_point_count = id_tracker.total_point_count();

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -63,6 +63,14 @@ fn build_cached_fs<Fs: UniversalReadFs>(
     Ok(cached_fs)
 }
 
+/// How the payload storage of a segment with `config` is brought into memory.
+fn payload_populate(config: &SegmentConfig) -> Populate {
+    match config.payload_storage_type {
+        PayloadStorageType::InRamMmap => Populate::PreferBackground,
+        PayloadStorageType::Mmap => Populate::No,
+    }
+}
+
 impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     /// Open the segment over a per-segment [`CachedReadFs`]: known files are
     /// prefetched before the listing snapshot is taken (see
@@ -75,14 +83,25 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         deferred_internal_id: Option<PointOffsetType>,
     ) -> OperationResult<Self> {
         let cached_fs = build_cached_fs(fs, segment_path)?;
-        Self::first_preopen(&cached_fs, segment_path)?;
-        Self::open_via(&cached_fs, fs, segment_path, uuid, deferred_internal_id)
+        let (segment_config, payload_config) = Self::first_preopen(&cached_fs, segment_path)?;
+        Self::open_via(
+            &cached_fs,
+            fs,
+            segment_path,
+            segment_config,
+            payload_config,
+            uuid,
+            deferred_internal_id,
+        )
     }
 
+    /// Schedule the prefetch of every file the segment's components will open,
+    /// returning the configs parsed along the way so [`open_via`](Self::open_via)
+    /// does not have to read them a second time.
     fn first_preopen(
         fs: &impl CachedReadFs<File = S>,
         segment_path: &Path,
-    ) -> OperationResult<PayloadConfig> {
+    ) -> OperationResult<(SegmentConfig, PayloadConfig)> {
         let SegmentState {
             initial_version: _,
             version: _,
@@ -90,20 +109,16 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         } = read_json_via(fs, segment_path.join(SEGMENT_STATE_FILE))?;
 
         // Payload storage
-        let payload_populate = match config.payload_storage_type {
-            PayloadStorageType::InRamMmap => Populate::PreferBackground,
-            PayloadStorageType::Mmap => Populate::No,
-        };
-        ReadOnlyPayloadStorage::preopen(fs, segment_path.to_path_buf(), payload_populate)?;
+        ReadOnlyPayloadStorage::preopen(fs, segment_path.to_path_buf(), payload_populate(&config))?;
 
         // Id tracker
         ReadOnlyIdTrackerEnum::preopen(fs, segment_path)?;
 
         // Payload indexes
-        let payload_index_config =
+        let payload_config =
             ReadOnlyStructPayloadIndex::preopen(fs, &get_payload_index_path(segment_path))?;
 
-        Ok(payload_index_config)
+        Ok((config, payload_config))
     }
 
     /// Read-only mirror of `load_segment`: assembles every read-only component
@@ -114,10 +129,15 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     /// pool. `raw_fs` is the canonical backend, for the one component that
     /// stores a filesystem handle to re-open appended files later (the
     /// appendable id tracker): a caching wrapper's snapshot would go stale.
+    ///
+    /// `config` and `payload_config` are the ones [`first_preopen`](Self::first_preopen)
+    /// already parsed off `fs`.
     pub(crate) fn open_via(
         fs: &impl CachedReadFs<File = S>,
         raw_fs: &S::Fs,
         segment_path: &Path,
+        config: SegmentConfig,
+        payload_config: PayloadConfig,
         uuid: Uuid,
         deferred_internal_id: Option<PointOffsetType>,
     ) -> OperationResult<Self> {
@@ -128,23 +148,13 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
             )));
         }
 
-        let SegmentState {
-            initial_version: _,
-            version: _,
-            config,
-        } = read_json_via(fs, segment_path.join(SEGMENT_STATE_FILE))?;
-
         let is_appendable = config.is_appendable();
         let deferred_internal_id = deferred_internal_id.filter(|_| is_appendable);
 
-        let payload_populate = match config.payload_storage_type {
-            PayloadStorageType::InRamMmap => Populate::PreferBackground,
-            PayloadStorageType::Mmap => Populate::No,
-        };
         let payload_storage = Arc::new(AtomicRefCell::new(ReadOnlyPayloadStorage::open(
             fs,
             segment_path.to_path_buf(),
-            payload_populate,
+            payload_populate(&config),
         )?));
 
         // Detect the persisted format by attempting each format's open (no
@@ -185,6 +195,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
             id_tracker.clone(),
             vector_storages.clone(),
             &get_payload_index_path(segment_path),
+            payload_config,
         )?));
 
         let mut vector_data = HashMap::new();


### PR DESCRIPTION
## What

The read-only segment open path parsed two config files twice each:

- `ReadOnlySegment::first_preopen` and `ReadOnlySegment::open_via` both read `segment_state.json`.
- `ReadOnlyStructPayloadIndex::preopen` and `::open` both read the payload index `config.json` — `preopen` even *returned* the parsed `PayloadConfig`, which `ReadOnlySegment::open` then dropped on the floor.

Now the preopen pass hands both configs to the open pass:

- `first_preopen` returns `(SegmentConfig, PayloadConfig)`.
- `open_via` takes them as parameters instead of re-reading `segment_state.json`.
- `ReadOnlyStructPayloadIndex::open` takes `config: PayloadConfig` instead of re-reading `config.json`.

Each of the four functions had exactly one caller, so no other call sites changed.

Also folds the `PayloadStorageType -> Populate` match — which was duplicated verbatim in `first_preopen` and `open_via` — into a `payload_populate(&SegmentConfig)` helper.

## Effect

Per read-only segment open: one fewer `CachedReadFs` prefetch-pool hit and one fewer JSON deserialize for each of the two files. No behavior change.

## Test plan

- `cargo check -p segment --lib` — clean
- `cargo clippy -p segment --lib` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)