### PR TITLE
Implement `ReadOnlyRoaringFlags::preopen`

### DIFF
--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -6,7 +6,7 @@ use common::sorted_slice::SortedSlice;
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    OkNotFound, OpenOptions, Populate, TypedStorage, UniversalRead, UniversalReadFs,
+    CachedReadFs, OkNotFound, OpenOptions, Populate, TypedStorage, UniversalRead, UniversalReadFs,
 };
 use roaring::RoaringBitmap;
 
@@ -89,6 +89,29 @@ fn open_flags_storage<S: UniversalRead>(
 }
 
 impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
+    /// Schedule background prefetch of the two files [`open`](Self::open) reads,
+    /// with the same open options it will use, so the prefetch pool can serve
+    /// them.
+    ///
+    /// Returns whether the flag directory exists, probed — as in [`Self::open`]
+    /// — through the status file: `false` means [`Self::open`] would return
+    /// [`Ok(None)`], and the flags file is then not scheduled.
+    pub fn preopen(fs: &impl CachedReadFs<File = S>, directory: &Path) -> OperationResult<bool> {
+        // Status file. A missing one means the index isn't present on disk.
+        if fs
+            .schedule_prefetch(&status_file(directory), Some(READ_ONLY_OPTIONS), None)
+            .ok_not_found()?
+            .is_none()
+        {
+            return Ok(false);
+        }
+
+        // Flags bitslice. `open` scans it end to end to build the bitmap.
+        fs.schedule_prefetch(&directory.join(FLAGS_FILE), Some(READ_ONLY_OPTIONS), None)?;
+
+        Ok(true)
+    }
+
     /// Open persisted flags read-only and materialize them into an in-memory
     /// roaring bitmap, retaining the bitslice handle for [`LiveReload`].
     ///

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use common::universal_io::UniversalReadFs;
+use common::universal_io::{CachedReadFs, UniversalReadFs};
 
 use super::super::mutable_bool_index::{FALSES_DIRNAME, TRUES_DIRNAME};
 use super::{ReadOnlyBoolIndex, ReadOnlyStorage};
@@ -10,6 +10,19 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::UniversalReadExt;
 
 impl<S: UniversalReadExt> ReadOnlyBoolIndex<S> {
+    /// Schedule background prefetch of the files [`open`](Self::open) reads, in
+    /// both flag directories.
+    ///
+    /// Returns whether the index exists on disk. Mirrors [`Self::open`]'s
+    /// absence check: only a missing *pair* of flag directories means no index,
+    /// so a half-present (corrupt) layout is reported as existing here and left
+    /// for `open` to reject.
+    pub fn preopen(fs: &impl CachedReadFs<File = S>, path: &Path) -> OperationResult<bool> {
+        let trues = ReadOnlyRoaringFlags::<S>::preopen(fs, &path.join(TRUES_DIRNAME))?;
+        let falses = ReadOnlyRoaringFlags::<S>::preopen(fs, &path.join(FALSES_DIRNAME))?;
+        Ok(trues || falses)
+    }
+
     /// Open a read-only bool index at `path`, threading every file open through
     /// the filesystem handle `fs`.
     ///

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
@@ -70,7 +70,9 @@ mod tests {
     use common::counter::hardware_accumulator::HwMeasurementAcc;
     use common::counter::hardware_counter::HardwareCounterCell;
     use common::sorted_slice::SortedSlice;
-    use common::universal_io::{MmapFile, ReadOnly, UniversalRead, UniversalReadFileOps};
+    use common::universal_io::{
+        CachedFs, CachedReadFs, MmapFile, ReadOnly, UniversalRead, UniversalReadFileOps,
+    };
     use itertools::Itertools as _;
     use serde_json::json;
     use tempfile::TempDir;
@@ -306,5 +308,79 @@ mod tests {
         let dir = build();
         fs_err::remove_dir_all(dir.path().join(TRUES_DIRNAME)).unwrap();
         assert!(ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path()).is_err());
+    }
+
+    /// `preopen` must schedule exactly the files `open` goes on to consume.
+    ///
+    /// Merely opening after a `preopen` proves nothing: `CachedFs` falls back to
+    /// a plain inner open for any path that was never scheduled, so a
+    /// scheduled-vs-opened path mismatch would still yield a correct index. To
+    /// make the prefetch pool the *only* possible source, the flag files are
+    /// unlinked between `preopen` and `open`: the already-open handles parked in
+    /// the pool stay readable, while any fallback open hits `NotFound`.
+    #[test]
+    fn preopen_then_open_through_cached_fs() {
+        let dir = TempDir::with_prefix("read_only_bool_index_preopen").unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        // Points 0..=2: true, false, both.
+        let fixture = [json!(true), json!(false), json!([true, false])];
+        let mut builder = MutableBoolIndex::builder(dir.path()).unwrap();
+        for (i, value) in fixture.iter().enumerate() {
+            builder.add_point(i as u32, &[value], &hw_counter).unwrap();
+        }
+        let index = builder.finalize().unwrap();
+        index.flusher()().unwrap();
+        drop(index);
+
+        type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
+        let fs = RoFs::from_context(Default::default()).unwrap();
+
+        // Same order as the segment open path: snapshot, then preopen, then open.
+        let mut cached_fs = CachedFs::new(fs.clone(), dir.path()).unwrap();
+        cached_fs.cache_file_info().unwrap();
+        assert!(ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::preopen(&cached_fs, dir.path()).unwrap());
+
+        // Everything `open` reads must now come from the prefetch pool.
+        fs_err::remove_dir_all(dir.path().join(TRUES_DIRNAME)).unwrap();
+        fs_err::remove_dir_all(dir.path().join(FALSES_DIRNAME)).unwrap();
+
+        let index = ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&cached_fs, dir.path())
+            .unwrap()
+            .unwrap();
+
+        let hw_acc = HwMeasurementAcc::new();
+        let hw_counter = hw_acc.get_counter_cell();
+        assert_eq!(
+            index
+                .filter(&match_bool(true), &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![0, 2],
+        );
+        assert_eq!(
+            index
+                .filter(&match_bool(false), &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec(),
+            vec![1, 2],
+        );
+        assert_eq!(index.count_indexed_points(), 3);
+
+        // An absent index: `preopen` reports it rather than erroring on the
+        // missing status file, and schedules nothing for `open` to consume.
+        let empty = TempDir::with_prefix("read_only_bool_index_preopen_empty").unwrap();
+        let mut empty_fs = CachedFs::new(fs, empty.path()).unwrap();
+        empty_fs.cache_file_info().unwrap();
+        assert!(
+            !ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::preopen(&empty_fs, empty.path()).unwrap()
+        );
+        assert!(
+            ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&empty_fs, empty.path())
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
@@ -143,11 +143,15 @@ impl<S: UniversalReadExt> ReadOnlyFieldIndex<S> {
                 ReadMode::Appendable => false,
                 ReadMode::Immutable { is_on_disk: _ } => false,
             },
-            // Bool and null are roaring-flag backed: a single read-only `open`
+            // Bool and null are roaring-flag backed: a single read-only `preopen`
             // serves both modes (neither consumes the immutable-only
             // `is_on_disk` / `deleted_points`).
-            PayloadIndexType::BoolIndex => false,
-            PayloadIndexType::NullIndex => false,
+            PayloadIndexType::BoolIndex => {
+                ReadOnlyBoolIndex::<S>::preopen(fs, &bool_dir(dir, field))?
+            }
+            PayloadIndexType::NullIndex => {
+                ReadOnlyNullIndex::<S>::preopen(fs, &null_dir(dir, field))?
+            }
         };
 
         Ok(preopened)

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use common::universal_io::{UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
 
 use super::super::mutable_null_index::{HAS_VALUES_DIRNAME, IS_NULL_DIRNAME};
 use super::{ReadOnlyNullIndex, ReadOnlyStorage};
@@ -8,6 +8,19 @@ use crate::common::flags::read_only_roaring_flags::ReadOnlyRoaringFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 
 impl<S: UniversalRead> ReadOnlyNullIndex<S> {
+    /// Schedule background prefetch of the files [`open`](Self::open) reads, in
+    /// both flag directories.
+    ///
+    /// Returns whether the index exists on disk. Mirrors [`Self::open`]'s
+    /// absence check: only a missing *pair* of flag directories means no index,
+    /// so a half-present (corrupt) layout is reported as existing here and left
+    /// for `open` to reject.
+    pub fn preopen(fs: &impl CachedReadFs<File = S>, path: &Path) -> OperationResult<bool> {
+        let has_values = ReadOnlyRoaringFlags::<S>::preopen(fs, &path.join(HAS_VALUES_DIRNAME))?;
+        let is_null = ReadOnlyRoaringFlags::<S>::preopen(fs, &path.join(IS_NULL_DIRNAME))?;
+        Ok(has_values || is_null)
+    }
+
     /// Open a read-only null index at `path`, threading every file open through
     /// the filesystem handle `fs`.
     ///


### PR DESCRIPTION
## What

`ReadOnlyRoaringFlags` had no `preopen`, so its two files were opened cold on the read-only segment open path.

- **`ReadOnlyRoaringFlags::preopen`** schedules background prefetch of the status file and the flags bitslice, with the same `READ_ONLY_OPTIONS` that `open` uses. It probes existence through the status file exactly as `open` does: a missing one returns `false` and the flags file is not scheduled, mirroring `open`'s `Ok(None)`.
- **`ReadOnlyBoolIndex::preopen` / `ReadOnlyNullIndex::preopen`** cover their two flag directories, returning `trues || falses` (resp. `has_values || is_null`) to match `open`'s rule that only a missing *pair* means "no index" — a half-present, corrupt layout is reported as existing and left for `open` to reject.
- The `BoolIndex` and `NullIndex` arms of `ReadOnlyFieldIndex::preopen` were hardcoded `false` placeholders; they now dispatch to the leaves above. Every field index carries a null index alongside it, so this is what puts the flags on the live segment-open prefetch path.

## Note on `populate`

`CachedFs::schedule_prefetch` overwrites `open_options.populate` with `Populate::PreferBackground` unconditionally (`cached_fs/mod.rs:173`), so the `populate` knob in the options passed here is decorative. The flags file is scanned end to end by `open`, so background population is the right behavior anyway — `preopen` just doesn't get to choose it. The options are still passed explicitly to keep the prefetched handle's remaining knobs (`writeable`, `advice`) identical to the ones `open` asks for.

## Test plan

New `preopen_then_open_through_cached_fs` in the bool index test module.

Note that the obvious version of this test — preopen through a `CachedFs`, then open, then assert the index is correct — is worthless: `CachedFs` silently falls back to a plain inner open for any path that was never scheduled (the listing snapshot only returns `NotFound` for paths absent from the *listing*, not for un-prefetched ones). Sabotaging `preopen` to never schedule the flags file still passed that version.

So the test unlinks both flag directories between `preopen` and `open`, making the prefetch pool the only possible source of data: the already-open handles parked in the pool stay readable, while any fallback open hits `NotFound`. Re-running the same sabotage against the committed test fails it, so it has teeth.

- `cargo test -p segment --lib read_only` — 58 passed, 0 failed
- `cargo clippy -p segment --lib --tests` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)