### PR TITLE
Replace rate limiter bool flag with RateLimiterKind enum

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -952,6 +952,13 @@ pub enum CollectionError {
     ShardUnavailable { description: String },
 }
 
+/// Which rate limiter rejected an operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RateLimiterKind {
+    Read,
+    Write,
+}
+
 impl CollectionError {
     pub fn timeout(timeout: Duration, operation: impl Into<String>) -> Self {
         Self::Timeout {
@@ -1024,9 +1031,12 @@ impl CollectionError {
     pub fn rate_limit_error(
         rate_limit_error: RateLimitError,
         cost: usize,
-        write_limit_type: bool, // false = read rate limit; true = write rate limit.
+        rate_limiter_kind: RateLimiterKind,
     ) -> Self {
-        let rate_limiter_type = if write_limit_type { "Write" } else { "Read" };
+        let rate_limiter_type = match rate_limiter_kind {
+            RateLimiterKind::Read => "Read",
+            RateLimiterKind::Write => "Write",
+        };
         let (description, retry_after) = match rate_limit_error {
             RateLimitError::AlwaysOverBudget(msg) => {
                 let description = format!("{rate_limiter_type} rate limit exceeded, {msg}",);

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -81,8 +81,8 @@ use crate::config::CollectionConfigInternal;
 use crate::operations::OperationWithClockTag;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::{
-    CollectionError, CollectionResult, OptimizersStatus, ShardInfoInternal, ShardStatus,
-    ShardUpdateQueueInfo,
+    CollectionError, CollectionResult, OptimizersStatus, RateLimiterKind, ShardInfoInternal,
+    ShardStatus, ShardUpdateQueueInfo,
 };
 use crate::optimizers_builder::{OptimizersConfig, build_optimizers, clear_temp_segments};
 use crate::shards::CollectionId;
@@ -1374,7 +1374,7 @@ impl LocalShard {
                 .try_consume(cost as f64)
                 .map_err(|err| {
                     log::debug!("Read rate limit error on {context} with {err:?}");
-                    CollectionError::rate_limit_error(err, cost, false)
+                    CollectionError::rate_limit_error(err, cost, RateLimiterKind::Read)
                 })?;
         }
         Ok(())
@@ -1402,7 +1402,9 @@ impl LocalShard {
             rate_limiter
                 .lock()
                 .try_consume(cost as f64)
-                .map_err(|err| CollectionError::rate_limit_error(err, cost, true))?;
+                .map_err(|err| {
+                    CollectionError::rate_limit_error(err, cost, RateLimiterKind::Write)
+                })?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

`CollectionError::rate_limit_error` took `write_limit_type: bool` whose meaning lived in a trailing comment (`false` = read rate limit, `true` = write rate limit). 

A swapped literal at a call site would compile fine and report the wrong limiter type ("Write rate limit exceeded" on a read path), misdirecting anyone debugging throttling.

This replaces the bool with an explicit enum:

```rust
pub enum RateLimiterKind {
    Read,
    Write,
}
```

Call sites in `check_read_rate_limiter` / `check_write_rate_limiter` now pass `RateLimiterKind::Read` / `RateLimiterKind::Write`, so the intent is visible at the call site and checked at compile time. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)