### PR TITLE
Lazy roaring flags bitmap and bool index counts

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -183,7 +183,7 @@ mod tests {
         let infos = locked_holder
             .read()
             .iter()
-            .map(|(_sid, segment)| segment.get().read().info())
+            .map(|(_sid, segment)| segment.get().read().info().unwrap())
             .collect_vec();
         let configs = locked_holder
             .read()
@@ -367,7 +367,7 @@ mod tests {
         let infos = locked_holder
             .read()
             .iter()
-            .map(|(_sid, segment)| segment.get().read().info())
+            .map(|(_sid, segment)| segment.get().read().info().unwrap())
             .collect_vec();
         assert!(
             infos
@@ -547,7 +547,7 @@ mod tests {
         let infos = locked_holder
             .read()
             .iter()
-            .map(|(_sid, segment)| segment.get().read().info())
+            .map(|(_sid, segment)| segment.get().read().info().unwrap())
             .collect_vec();
         let configs = locked_holder
             .read()
@@ -638,7 +638,7 @@ mod tests {
         let new_infos = locked_holder
             .read()
             .iter()
-            .map(|(_sid, segment)| segment.get().read().info())
+            .map(|(_sid, segment)| segment.get().read().info().unwrap())
             .collect_vec();
         let new_smallest_size = new_infos
             .iter()
@@ -666,7 +666,7 @@ mod tests {
         let new_infos2 = locked_holder
             .read()
             .iter()
-            .map(|(_sid, segment)| segment.get().read().info())
+            .map(|(_sid, segment)| segment.get().read().info().unwrap())
             .collect_vec();
 
         let mut has_empty = false;

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1120,7 +1120,8 @@ impl LocalShard {
                 // TODO: snapshotting also creates temp proxy segments. should differentiate.
                 let has_special_segment = segments
                     .iter()
-                    .map(|(_, segment)| segment.get().read().info().segment_type)
+                    // `size_info` carries `segment_type` and cannot fail.
+                    .map(|(_, segment)| segment.get().read().size_info().segment_type)
                     .any(|segment_type| segment_type == SegmentType::Special);
                 if has_special_segment {
                     Some((ShardStatus::Yellow, OptimizersStatus::Ok))
@@ -1190,7 +1191,7 @@ impl LocalShard {
                 for segment in segments {
                     segments_count += 1;
 
-                    let segment_info = segment.get().read().info();
+                    let segment_info = segment.get().read().info()?;
 
                     indexed_vectors_count += segment_info.num_indexed_vectors;
                     points_count += segment_info.num_points;
@@ -1201,9 +1202,14 @@ impl LocalShard {
                             .or_insert(val);
                     }
                 }
-                (schema, indexed_vectors_count, points_count, segments_count)
+                OperationResult::Ok((schema, indexed_vectors_count, points_count, segments_count))
             })
             .await;
+
+        // Flatten the join error and the per-segment info error into one.
+        let segment_info = segment_info
+            .map_err(CollectionError::from)
+            .and_then(|info| info.map_err(CollectionError::from));
 
         if let Err(err) = &segment_info {
             log::error!("Failed to get local shard info: {err}");

--- a/lib/collection/src/shards/local_shard/telemetry.rs
+++ b/lib/collection/src/shards/local_shard/telemetry.rs
@@ -50,7 +50,7 @@ impl LocalShard {
                         return Err(CollectionError::timeout(timeout, "shard telemetry"));
                     };
 
-                    segments_telemetry.push(segment_guard.get_telemetry_data(detail))
+                    segments_telemetry.push(segment_guard.get_telemetry_data(detail)?)
                 }
 
                 let collection_config = locked_collection_config.blocking_read();
@@ -155,7 +155,9 @@ impl LocalShard {
             } = SizeStats::default();
 
             for (_, segment) in segments.iter() {
-                let info = segment.get().read().info();
+                // `size_info`, not `info`: only size fields are read here, and it
+                // does not materialize the lazily-built payload index bitmaps.
+                let info = segment.get().read().size_info();
                 num_points += info.num_points;
                 num_vectors += info.num_vectors;
                 vectors_size_bytes += info.vectors_size_bytes;

--- a/lib/edge/publish/examples/src/bin/add-named-vector.rs
+++ b/lib/edge/publish/examples/src/bin/add-named-vector.rs
@@ -59,7 +59,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         ])),
     ))?;
 
-    println!("Points after initial insert: {}", shard.info().points_count);
+    println!(
+        "Points after initial insert: {}",
+        shard.info()?.points_count
+    );
 
     // Verify search works on the default vector
     let results = shard.query(QueryRequest {
@@ -126,7 +129,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         ])),
     ))?;
 
-    println!("Points after adding v2: {}", shard.info().points_count);
+    println!("Points after adding v2: {}", shard.info()?.points_count);
 
     // Search on the new vector - only points 4 and 5 have 'v2'
     let results = shard.query(QueryRequest {
@@ -181,7 +184,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!(
         "Points after adding keywords: {}",
-        shard.info().points_count
+        shard.info()?.points_count
     );
 
     // Search on sparse vector
@@ -213,7 +216,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }),
     ))?;
 
-    println!("Points after deleting v2: {}", shard.info().points_count);
+    println!("Points after deleting v2: {}", shard.info()?.points_count);
 
     // Search on the default vector still works
     let results = shard.query(QueryRequest {
@@ -244,7 +247,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     drop(shard);
     let shard = EdgeShard::load(&path, None)?;
 
-    let info = shard.info();
+    let info = shard.info()?;
     println!("Reopened shard: {} points", info.points_count);
 
     let results = shard.query(QueryRequest {

--- a/lib/edge/publish/examples/src/bin/bm25-search.rs
+++ b/lib/edge/publish/examples/src/bin/bm25-search.rs
@@ -64,7 +64,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         PointOperations::UpsertPoints(PointInsertOperations::PointsList(points)),
     ))?;
     shard.optimize()?;
-    println!("Info: {:?}", shard.info());
+    println!("Info: {:?}", shard.info()?);
 
     let query = bm25.embed_query("clever fox");
     let results = shard.query(QueryRequest {

--- a/lib/edge/publish/examples/src/bin/demo.rs
+++ b/lib/edge/publish/examples/src/bin/demo.rs
@@ -251,7 +251,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("---- Info ----");
 
-    let info = shard.info();
+    let info = shard.info()?;
     println!("{info:?}");
 
     println!("---- Close and reopen shard ----");
@@ -261,7 +261,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let reopened_shard = EdgeShard::load(Path::new(TMP_DIR), None)?;
     println!(
         "Edge shard reopened. Approx Points: {}",
-        reopened_shard.info().points_count
+        reopened_shard.info()?.points_count
     );
 
     Ok(())

--- a/lib/edge/publish/examples/src/bin/facet_test.rs
+++ b/lib/edge/publish/examples/src/bin/facet_test.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("---- Load shard ----");
     let shard = EdgeShard::load(&shard_data, None)?;
-    println!("Shard loaded. Points: {}", shard.info().points_count);
+    println!("Shard loaded. Points: {}", shard.info()?.points_count);
 
     println!("---- Test Facet on 'color' field ----");
     let response = shard.facet(FacetRequest {

--- a/lib/edge/publish/examples/src/bin/restore-snapshot.rs
+++ b/lib/edge/publish/examples/src/bin/restore-snapshot.rs
@@ -65,7 +65,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("{point:?}");
     }
 
-    let info = shard.info();
+    let info = shard.info()?;
 
     println!("{info:?}");
 

--- a/lib/edge/python/src/lib.rs
+++ b/lib/edge/python/src/lib.rs
@@ -182,7 +182,7 @@ impl PyEdgeShard {
     }
 
     pub fn info(&self) -> Result<PyShardInfo> {
-        let info = self.get_shard()?.info();
+        let info = self.get_shard()?.info()?;
         let info = PyShardInfo(info);
         Ok(info)
     }

--- a/lib/edge/src/info.rs
+++ b/lib/edge/src/info.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use segment::common::operation_error::OperationResult;
 use segment::entry::ReadSegmentEntry;
 use segment::types::{PayloadIndexInfo, PayloadKeyType};
 
@@ -22,7 +23,7 @@ pub struct ShardInfo {
 }
 
 impl<H: ReadSegmentHandle> EdgeReadView<H> {
-    pub(crate) fn info(&self) -> ShardInfo {
+    pub(crate) fn info(&self) -> OperationResult<ShardInfo> {
         let mut segments_count = 0;
         let mut points_count = 0;
         let mut indexed_vectors_count = 0;
@@ -31,7 +32,7 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
         for segment in &self.segments {
             segments_count += 1;
 
-            let segment_info = segment.read_segment().info();
+            let segment_info = segment.read_segment().info()?;
 
             points_count += segment_info.num_points;
             indexed_vectors_count += segment_info.num_indexed_vectors;
@@ -44,11 +45,11 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
             }
         }
 
-        ShardInfo {
+        Ok(ShardInfo {
             segments_count,
             points_count,
             indexed_vectors_count,
             payload_schema,
-        }
+        })
     }
 }

--- a/lib/edge/src/optimize.rs
+++ b/lib/edge/src/optimize.rs
@@ -195,11 +195,11 @@ mod tests {
         duplicate_single_segment(dir.path());
 
         let reopened = EdgeShard::load(dir.path(), None).unwrap();
-        assert_eq!(reopened.info().segments_count, 2);
+        assert_eq!(reopened.info().unwrap().segments_count, 2);
 
         let optimized = reopened.optimize().unwrap();
         assert!(!optimized, "optimizer should not force-merge all segments");
-        assert_eq!(reopened.info().segments_count, 2);
+        assert_eq!(reopened.info().unwrap().segments_count, 2);
 
         assert_points_retrievable_with_vectors(&reopened, &[1]);
     }
@@ -257,8 +257,8 @@ mod tests {
 
         let optimized = shard.optimize().unwrap();
         assert!(!optimized, "single clean segment should not be optimized");
-        assert_eq!(shard.info().points_count, 100);
-        assert_eq!(shard.info().segments_count, 1);
+        assert_eq!(shard.info().unwrap().points_count, 100);
+        assert_eq!(shard.info().unwrap().segments_count, 1);
 
         assert_points_retrievable_with_vectors(&shard, &[1, 50, 100]);
     }
@@ -276,7 +276,7 @@ mod tests {
 
         let optimized = shard.optimize().unwrap();
         assert!(!optimized, "empty shard should not trigger optimization");
-        assert_eq!(shard.info().points_count, 0);
+        assert_eq!(shard.info().unwrap().points_count, 0);
     }
 
     /// Creating more segments than `default_segment_number` should trigger
@@ -301,7 +301,7 @@ mod tests {
 
         let reopened = EdgeShard::load(dir.path(), None).unwrap();
         reopened.optimize().unwrap();
-        let info = reopened.info();
+        let info = reopened.info().unwrap();
         assert!(
             info.segments_count <= default_segment_number() + 1,
             "segments should be reduced after merge: got {} segments, \
@@ -348,7 +348,7 @@ mod tests {
         let reopened = EdgeShard::load(dir.path(), None).unwrap();
         // First explicit optimization triggers merge.
         reopened.optimize().unwrap();
-        let segments_after_first = reopened.info().segments_count;
+        let segments_after_first = reopened.info().unwrap().segments_count;
 
         // Second explicit optimization should be a no-op.
         let optimized = reopened.optimize().unwrap();
@@ -356,7 +356,10 @@ mod tests {
             !optimized,
             "second optimization run should be idle after merge"
         );
-        assert_eq!(reopened.info().segments_count, segments_after_first);
+        assert_eq!(
+            reopened.info().unwrap().segments_count,
+            segments_after_first
+        );
 
         assert_points_retrievable_with_vectors(&reopened, &[1]);
     }
@@ -632,7 +635,7 @@ mod tests {
         let reopened = EdgeShard::load(dir.path(), None).unwrap();
         reopened.optimize().unwrap();
 
-        let info = reopened.info();
+        let info = reopened.info().unwrap();
         assert!(
             info.segments_count <= default_segment_number() + 1,
             "excess segments should be merged: got {}",
@@ -748,7 +751,7 @@ mod tests {
             .expect("optimize must prune the deleted vector data, not cancel the merge");
         assert!(optimized, "excess segments should have been merged");
 
-        let info = reopened.info();
+        let info = reopened.info().unwrap();
         assert!(
             info.segments_count <= default_segment_number() + 1,
             "segments should be reduced after merge: got {} segments",

--- a/lib/edge/src/read_view.rs
+++ b/lib/edge/src/read_view.rs
@@ -189,7 +189,7 @@ pub trait EdgeShardRead {
         view(self).facet(request)
     }
 
-    fn info(&self) -> ShardInfo {
+    fn info(&self) -> OperationResult<ShardInfo> {
         view(self).info()
     }
 

--- a/lib/edge/src/shard_read.rs
+++ b/lib/edge/src/shard_read.rs
@@ -89,7 +89,7 @@ impl EdgeShard {
         EdgeShardRead::facet(self, request)
     }
 
-    pub fn info(&self) -> ShardInfo {
+    pub fn info(&self) -> OperationResult<ShardInfo> {
         EdgeShardRead::info(self)
     }
 

--- a/lib/edge/tests/wal_options.rs
+++ b/lib/edge/tests/wal_options.rs
@@ -109,14 +109,14 @@ fn reload_with_smaller_wal_capacity_after_upsert() {
         shard
             .update(PointOperation(UpsertPoints(PointsList(vec![point(42)]))))
             .unwrap();
-        assert_eq!(shard.info().points_count, 1);
+        assert_eq!(shard.info().unwrap().points_count, 1);
         // drop -> flushes WAL + segments.
     }
 
     // Phase 2: reload with custom small 4 MiB WAL (passed via EdgeConfig).
     let shard = EdgeShard::load(dir.path(), Some(config_with_small_wal())).unwrap();
     assert_eq!(
-        shard.info().points_count,
+        shard.info().unwrap().points_count,
         1,
         "point must survive reload with mismatched WAL options"
     );
@@ -125,7 +125,7 @@ fn reload_with_smaller_wal_capacity_after_upsert() {
     shard
         .update(PointOperation(UpsertPoints(PointsList(vec![point(43)]))))
         .unwrap();
-    assert_eq!(shard.info().points_count, 2);
+    assert_eq!(shard.info().unwrap().points_count, 2);
 }
 
 /// Symmetric case: create with custom small 4 MiB, reload with default
@@ -144,7 +144,7 @@ fn reload_with_larger_wal_capacity_after_upsert() {
         shard
             .update(PointOperation(UpsertPoints(PointsList(vec![point(100)]))))
             .unwrap();
-        assert_eq!(shard.info().points_count, 1);
+        assert_eq!(shard.info().unwrap().points_count, 1);
     }
 
     // Phase 2: reload with explicit default 32 MiB WAL options, overwriting the
@@ -161,7 +161,7 @@ fn reload_with_larger_wal_capacity_after_upsert() {
         WalOptions::default().segment_capacity,
     );
     assert_eq!(
-        shard.info().points_count,
+        shard.info().unwrap().points_count,
         1,
         "point must survive reload with default WAL options"
     );
@@ -170,5 +170,5 @@ fn reload_with_larger_wal_capacity_after_upsert() {
     shard
         .update(PointOperation(UpsertPoints(PointsList(vec![point(101)]))))
         .unwrap();
-    assert_eq!(shard.info().points_count, 2);
+    assert_eq!(shard.info().unwrap().points_count, 2);
 }

--- a/lib/segment/benches/range_filtering.rs
+++ b/lib/segment/benches/range_filtering.rs
@@ -95,11 +95,15 @@ fn range_filtering(c: &mut Criterion) {
 
     // make sure all points are indexed
     assert_eq!(
-        index.with_view(|v| v.indexed_points(&FLT_KEY.parse().unwrap())),
+        index
+            .with_view(|v| v.indexed_points(&FLT_KEY.parse().unwrap()))
+            .unwrap(),
         NUM_POINTS,
     );
     assert_eq!(
-        index.with_view(|v| v.indexed_points(&INT_KEY.parse().unwrap())),
+        index
+            .with_view(|v| v.indexed_points(&INT_KEY.parse().unwrap()))
+            .unwrap(),
         NUM_POINTS,
     );
 

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap::AdviceSetting;
@@ -17,11 +18,12 @@ use crate::common::operation_error::OperationResult;
 
 /// Read-only counterpart of [`RoaringFlags`][1].
 ///
-/// Loads the persisted flags into an in-memory roaring bitmap on open and keeps
-/// the backing [`StoredBitSlice`] handle so [`LiveReload::live_reload`] can
-/// reopen it to read the points the writer appended, rather than re-scanning the
-/// whole file. There is no write path: no buffer, no [`BufferedDynamicFlags`][2],
-/// no [`DynamicStoredFlags`][3]. The retained `S` is the one [`Self::open`] was
+/// Materializes the persisted flags into an in-memory roaring bitmap on first
+/// use — *not* on open, unlike the writable variant — and keeps the backing
+/// [`StoredBitSlice`] handle so [`LiveReload::live_reload`] can reopen it to
+/// read the points the writer appended, rather than re-scanning the whole file.
+/// There is no write path: no buffer, no [`BufferedDynamicFlags`][2], no
+/// [`DynamicStoredFlags`][3]. The retained `S` is the one [`Self::open`] was
 /// called with, mirroring the other read-only field indexes, which likewise
 /// hold their backing storage across reloads.
 ///
@@ -30,8 +32,16 @@ use crate::common::operation_error::OperationResult;
 /// [3]: super::dynamic_stored_flags::DynamicStoredFlags
 pub struct ReadOnlyRoaringFlags<S: UniversalRead> {
     /// In-memory bitmap of true flags, materialized from the backing file on
-    /// open and patched in place on [`LiveReload::live_reload`].
-    bitmap: RoaringBitmap,
+    /// first access and patched in place on [`LiveReload::live_reload`].
+    ///
+    /// Lazy so that opening the flags reads only the (tiny) status file: a
+    /// segment open would otherwise scan every flags file end to end, which
+    /// defeats prefetching only the bytes a query actually needs.
+    ///
+    /// [`OnceLock`] rather than a plain cell because the index is queried
+    /// through `&self` from many threads. On a race both threads may build a
+    /// bitmap; the first to finish wins and the loser's copy is dropped.
+    bitmap: OnceLock<RoaringBitmap>,
     /// Backing bitslice. A reload reopens this handle so points the writer
     /// appended become readable, then reads only those new positions.
     storage: StoredBitSlice<S>,
@@ -74,8 +84,9 @@ fn read_status_len<S: UniversalRead>(
     Ok(Some(status.read_whole()?[0].len()))
 }
 
-/// Open the flags bitslice read-only for [`ReadOnlyRoaringFlags::open`]'s full
-/// scan into a fresh bitmap. `live_reload` instead reopens the retained handle.
+/// Open the flags bitslice read-only. The handle is retained, not read: the
+/// bitmap scan happens lazily in [`ReadOnlyRoaringFlags::bitmap`], and
+/// `live_reload` reopens this same handle.
 fn open_flags_storage<S: UniversalRead>(
     fs: &impl UniversalReadFs<File = S>,
     directory: &Path,
@@ -112,14 +123,14 @@ impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
         Ok(true)
     }
 
-    /// Open persisted flags read-only and materialize them into an in-memory
-    /// roaring bitmap, retaining the bitslice handle for [`LiveReload`].
+    /// Open persisted flags read-only, retaining the bitslice handle for
+    /// [`Self::bitmap`] and [`LiveReload`].
     ///
     /// Read-only counterpart of [`RoaringFlags::new`][1]: every file is opened
     /// through `fs` non-writable, nothing is created and nothing is written.
     /// The logical length comes from the status file (the flags file is padded
-    /// past it), and the set positions from the flags file — shared with the
-    /// writable path via [`StoredBitSlice::iter_ones`].
+    /// past it). Unlike the writable path, the flags file itself is *not* read
+    /// here — see [`Self::bitmap`]; opening touches only the status file.
     ///
     /// Returns [`Ok(None)`] when the flag directory doesn't exist (the status
     /// file is absent), matching the read path's never-create contract.
@@ -134,19 +145,39 @@ impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
             return Ok(None);
         };
 
-        // Build the bitmap from the set positions. The bitslice handle is kept
-        // for the live-reload path, which reopens it to read appended points.
+        // The bitslice handle is opened but not read: the bitmap is built on
+        // first use, and `live_reload` reopens this handle to see appended points.
         let storage = open_flags_storage::<S>(fs, directory)?;
-        let bitmap =
-            RoaringBitmap::from_sorted_iter(storage.iter_ones()?.map(|i| i as PointOffsetType))
-                .expect("iter_ones iterates in sorted order");
 
         Ok(Some(Self {
-            bitmap,
+            bitmap: OnceLock::new(),
             storage,
             len,
             directory: directory.to_path_buf(),
         }))
+    }
+
+    /// The in-memory bitmap of set positions, scanning the flags file to build
+    /// it on the first call and returning the cached one afterwards.
+    ///
+    /// This is the whole-file read that [`Self::open`] avoids. It is deferred
+    /// to the first query rather than paid per segment open — many segments
+    /// hold flag indexes (every payload field carries a null index) that no
+    /// query ever touches.
+    fn bitmap(&self) -> OperationResult<&RoaringBitmap> {
+        // `OnceLock::get_or_try_init` is still unstable, so build outside the
+        // lock and let `get_or_init` arbitrate. A racing thread's bitmap is
+        // simply dropped: both are built from the same bytes.
+        if let Some(bitmap) = self.bitmap.get() {
+            return Ok(bitmap);
+        }
+
+        let bitmap = RoaringBitmap::from_sorted_iter(
+            self.storage.iter_ones()?.map(|i| i as PointOffsetType),
+        )
+        .expect("iter_ones iterates in sorted order");
+
+        Ok(self.bitmap.get_or_init(|| bitmap))
     }
 }
 
@@ -165,7 +196,12 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
     ///
     /// `hw_counter` is unused: the per-position reads go through the reopened
     /// [`StoredBitSlice`], which takes no hardware counter — mirroring
-    /// [`Self::open`], which also doesn't account its scan.
+    /// [`Self::bitmap`], which also doesn't account its scan.
+    ///
+    /// While the bitmap is still unmaterialized there is nothing to patch: the
+    /// eventual scan reads the current on-disk flags, which the writer has
+    /// already brought up to date (it clears a retired point's flag). The
+    /// bitslice is still reopened, so that scan sees the grown file.
     fn live_reload(
         &mut self,
         fs: &S::Fs,
@@ -173,8 +209,10 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
         new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        for &point in deleted_points {
-            self.bitmap.remove(point);
+        if let Some(bitmap) = self.bitmap.get_mut() {
+            for &point in deleted_points {
+                bitmap.remove(point);
+            }
         }
 
         // Nothing appended → no on-disk delta to fetch, skip all I/O.
@@ -185,14 +223,14 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
         // Live reload is append-only, so we only need to process the new range of
         // the bitslice.
         self.storage.reopen()?;
-        if let Some(new_range) = new_points.range_u64() {
+        if let (Some(bitmap), Some(new_range)) = (self.bitmap.get_mut(), new_points.range_u64()) {
             let start = new_range.start as usize;
             let bitslice = self.storage.read_bit_range(new_range)?;
             for point in bitslice
                 .iter_ones()
                 .map(|idx| (idx + start) as PointOffsetType)
             {
-                self.bitmap.insert(point);
+                bitmap.insert(point);
             }
         }
 
@@ -211,8 +249,12 @@ impl<S: UniversalRead> RoaringFlagsRead for ReadOnlyRoaringFlags<S> {
         self.len
     }
 
-    fn get_bitmap(&self) -> &RoaringBitmap {
-        &self.bitmap
+    fn get_bitmap(&self) -> OperationResult<&RoaringBitmap> {
+        self.bitmap()
+    }
+
+    fn bitmap_if_materialized(&self) -> Option<&RoaringBitmap> {
+        self.bitmap.get()
     }
 
     fn files(&self) -> Vec<PathBuf> {

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -100,9 +100,8 @@ fn open_flags_storage<S: UniversalRead>(
 }
 
 impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
-    /// Schedule background prefetch of the two files [`open`](Self::open) reads,
-    /// with the same open options it will use, so the prefetch pool can serve
-    /// them.
+    /// Schedule background prefetch of the two files this storage reads, with
+    /// the same open options they will use, so the prefetch pool can serve them.
     ///
     /// Returns whether the flag directory exists, probed — as in [`Self::open`]
     /// — through the status file: `false` means [`Self::open`] would return
@@ -117,7 +116,8 @@ impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
             return Ok(false);
         }
 
-        // Flags bitslice. `open` scans it end to end to build the bitmap.
+        // Flags bitslice. `open` does not read it — [`Self::bitmap`] scans it end
+        // to end on first use — so this warms the pages that scan will need.
         fs.schedule_prefetch(&directory.join(FLAGS_FILE), Some(READ_ONLY_OPTIONS), None)?;
 
         Ok(true)

--- a/lib/segment/src/common/flags/roaring_flags.rs
+++ b/lib/segment/src/common/flags/roaring_flags.rs
@@ -24,31 +24,49 @@ pub trait RoaringFlagsRead {
     }
 
     /// Underlying in-memory roaring bitmap of "true" positions.
-    fn get_bitmap(&self) -> &RoaringBitmap;
+    ///
+    /// Fallible because a read-only variant may only materialize the bitmap on
+    /// first use, by scanning its backing file — see
+    /// [`ReadOnlyRoaringFlags`](super::read_only_roaring_flags::ReadOnlyRoaringFlags).
+    /// Once materialized the bitmap is cached, so repeated calls are free.
+    fn get_bitmap(&self) -> OperationResult<&RoaringBitmap>;
 
-    fn get(&self, index: PointOffsetType) -> bool {
-        self.get_bitmap().contains(index)
+    /// The bitmap if it is already in RAM, without materializing it.
+    ///
+    /// Only for callers that must not pay for (or cannot fail on) a scan —
+    /// [`ram_usage_bytes`][Self::ram_usage_bytes] being the motivating one, for
+    /// which an unmaterialized bitmap genuinely occupies nothing.
+    fn bitmap_if_materialized(&self) -> Option<&RoaringBitmap>;
+
+    fn get(&self, index: PointOffsetType) -> OperationResult<bool> {
+        Ok(self.get_bitmap()?.contains(index))
     }
 
-    fn iter_trues(&self) -> roaring::bitmap::Iter<'_> {
-        self.get_bitmap().iter()
+    fn iter_trues(&self) -> OperationResult<roaring::bitmap::Iter<'_>> {
+        Ok(self.get_bitmap()?.iter())
     }
 
-    fn iter_falses(&self) -> Box<dyn Iterator<Item = PointOffsetType> + '_> {
+    fn iter_falses(&self) -> OperationResult<Box<dyn Iterator<Item = PointOffsetType> + '_>> {
         // potential optimization:
         //      Create custom iterator which leverages bitmap's iterator for knowing ranges where the flags are false.
         //      This will help by not checking the bitmap for indices that are already known to be false.
         let len = self.len() as PointOffsetType;
-        let bitmap = self.get_bitmap();
-        Box::new((0..len).filter(move |i| !bitmap.contains(*i)))
+        let bitmap = self.get_bitmap()?;
+        Ok(Box::new((0..len).filter(move |i| !bitmap.contains(*i))))
     }
 
-    fn count_trues(&self) -> usize {
-        self.get_bitmap().len() as usize
+    fn count_trues(&self) -> OperationResult<usize> {
+        Ok(self.get_bitmap()?.len() as usize)
     }
 
-    fn count_falses(&self) -> usize {
-        self.len().saturating_sub(self.count_trues())
+    fn count_falses(&self) -> OperationResult<usize> {
+        Ok(self.len().saturating_sub(self.count_trues()?))
+    }
+
+    /// RAM held by the in-memory bitmap. Zero while it is not materialized.
+    fn ram_usage_bytes(&self) -> usize {
+        self.bitmap_if_materialized()
+            .map_or(0, |bitmap| bitmap.serialized_size())
     }
 
     /// Fill RAM cache with the backing file pages.
@@ -99,8 +117,13 @@ where
         self.len
     }
 
-    fn get_bitmap(&self) -> &RoaringBitmap {
-        &self.bitmap
+    fn get_bitmap(&self) -> OperationResult<&RoaringBitmap> {
+        Ok(&self.bitmap)
+    }
+
+    fn bitmap_if_materialized(&self) -> Option<&RoaringBitmap> {
+        // The writable variant materializes on construction and never drops it.
+        Some(&self.bitmap)
     }
 
     fn clear_cache(&self) -> OperationResult<()> {
@@ -234,21 +257,21 @@ mod tests_mod {
             let roaring_flags = RoaringFlags::new(Fs::default(), mmap_flags).unwrap();
 
             // Verify iteration consistency after reload
-            let iter_trues: Vec<_> = roaring_flags.iter_trues().collect();
+            let iter_trues: Vec<_> = roaring_flags.iter_trues().unwrap().collect();
 
             // Verify expected values
             assert_eq!(iter_trues, vec![0, 5, 10, 15]);
 
             // Verify count consistency
-            assert_eq!(roaring_flags.count_trues(), 4);
+            assert_eq!(roaring_flags.count_trues().unwrap(), 4);
             assert_eq!(
-                roaring_flags.count_falses(),
-                roaring_flags.len() - roaring_flags.count_trues()
+                roaring_flags.count_falses().unwrap(),
+                roaring_flags.len() - roaring_flags.count_trues().unwrap()
             );
 
             // Verify iteration covers all indices
-            let all_trues: Vec<_> = roaring_flags.iter_trues().collect();
-            let all_falses: Vec<_> = roaring_flags.iter_falses().collect();
+            let all_trues: Vec<_> = roaring_flags.iter_trues().unwrap().collect();
+            let all_falses: Vec<_> = roaring_flags.iter_falses().unwrap().collect();
             let mut all_indices = all_trues;
             all_indices.extend(all_falses);
             all_indices.sort();

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -266,7 +266,7 @@ pub trait ReadSegmentEntry {
     fn segment_type(&self) -> SegmentType;
 
     /// Get current stats of the segment
-    fn info(&self) -> SegmentInfo;
+    fn info(&self) -> OperationResult<SegmentInfo>;
 
     /// Get size related stats of the segment.
     /// This returns `SegmentInfo` with some non size-related data (like `schema`) unset to improve performance.
@@ -285,7 +285,7 @@ pub trait ReadSegmentEntry {
     fn get_indexed_fields(&self) -> HashMap<PayloadKeyType, PayloadFieldSchema>;
 
     // Get collected telemetry data of segment
-    fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry;
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationResult<SegmentTelemetry>;
 
     fn fill_query_context(&self, query_context: &mut QueryContext) -> OperationResult<()>;
 

--- a/lib/segment/src/index/field_index/bool_index/immutable_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/immutable_bool_index/mod.rs
@@ -37,16 +37,16 @@ mod tests {
         builder.add_point(2, &[&json!(false)], &hw_counter).unwrap();
 
         let mut index = builder.finalize().unwrap();
-        assert_eq!(index.get_point_values(1), vec![true; 1]);
-        assert_eq!(index.count_indexed_points(), 3);
+        assert_eq!(index.get_point_values(1).unwrap(), vec![true; 1]);
+        assert_eq!(index.count_indexed_points().unwrap(), 3);
 
         index.remove_point(1).unwrap();
-        assert_eq!(index.get_point_values(1), vec![true; 0]);
-        assert_eq!(index.count_indexed_points(), 2);
+        assert_eq!(index.get_point_values(1).unwrap(), vec![true; 0]);
+        assert_eq!(index.count_indexed_points().unwrap(), 2);
 
         index.remove_point(1).unwrap();
-        assert_eq!(index.get_point_values(1), vec![true; 0]);
-        assert_eq!(index.count_indexed_points(), 2);
+        assert_eq!(index.get_point_values(1).unwrap(), vec![true; 0]);
+        assert_eq!(index.count_indexed_points().unwrap(), 2);
     }
 
     #[test]
@@ -68,7 +68,7 @@ mod tests {
         let opened_index = ImmutableBoolIndex::open(dir.path(), &deleted)
             .unwrap()
             .unwrap();
-        assert_eq!(opened_index.get_point_values(1), vec![true; 0]);
-        assert_eq!(opened_index.count_indexed_points(), 2);
+        assert_eq!(opened_index.get_point_values(1).unwrap(), vec![true; 0]);
+        assert_eq!(opened_index.count_indexed_points().unwrap(), 2);
     }
 }

--- a/lib/segment/src/index/field_index/bool_index/immutable_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/immutable_bool_index/read_ops.rs
@@ -24,7 +24,7 @@ impl BoolIndexRead for ImmutableBoolIndex {
         self.0.falses_flags()
     }
 
-    fn indexed_count(&self) -> usize {
+    fn indexed_count(&self) -> OperationResult<usize> {
         self.0.indexed_count()
     }
 
@@ -32,18 +32,18 @@ impl BoolIndexRead for ImmutableBoolIndex {
         self.0.telemetry_index_type()
     }
 
-    fn trues_count(&self) -> usize {
+    fn trues_count(&self) -> OperationResult<usize> {
         self.0.trues_count()
     }
 
-    fn falses_count(&self) -> usize {
+    fn falses_count(&self) -> OperationResult<usize> {
         self.0.falses_count()
     }
 }
 
 impl PayloadFieldIndexRead for ImmutableBoolIndex {
     #[inline]
-    fn count_indexed_points(&self) -> usize {
+    fn count_indexed_points(&self) -> OperationResult<usize> {
         self.indexed_count()
     }
 
@@ -53,7 +53,7 @@ impl PayloadFieldIndexRead for ImmutableBoolIndex {
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
     ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
-        Ok(read_ops::filter(self, condition, hw_counter))
+        read_ops::filter(self, condition, hw_counter)
     }
 
     #[inline]
@@ -62,7 +62,7 @@ impl PayloadFieldIndexRead for ImmutableBoolIndex {
         condition: &FieldCondition,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<CardinalityEstimation>> {
-        Ok(read_ops::estimate_cardinality(self, condition, hw_counter))
+        read_ops::estimate_cardinality(self, condition, hw_counter)
     }
 
     #[inline]

--- a/lib/segment/src/index/field_index/bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mod.rs
@@ -55,7 +55,7 @@ impl BoolIndex {
     pub fn value_retriever<'a>(
         &'a self,
         hw_counter: &'a HardwareCounterCell,
-    ) -> VariableRetrieverFn<'a> {
+    ) -> OperationResult<VariableRetrieverFn<'a>> {
         read_ops::value_retriever(self, hw_counter)
     }
 }
@@ -77,7 +77,7 @@ impl BoolIndexRead for BoolIndex {
         }
     }
 
-    fn indexed_count(&self) -> usize {
+    fn indexed_count(&self) -> OperationResult<usize> {
         match self {
             BoolIndex::Mutable(index) => index.indexed_count(),
             BoolIndex::Immutable(index) => index.indexed_count(),
@@ -91,14 +91,14 @@ impl BoolIndexRead for BoolIndex {
         }
     }
 
-    fn trues_count(&self) -> usize {
+    fn trues_count(&self) -> OperationResult<usize> {
         match self {
             BoolIndex::Mutable(index) => index.trues_count(),
             BoolIndex::Immutable(index) => index.trues_count(),
         }
     }
 
-    fn falses_count(&self) -> usize {
+    fn falses_count(&self) -> OperationResult<usize> {
         match self {
             BoolIndex::Mutable(index) => index.falses_count(),
             BoolIndex::Immutable(index) => index.falses_count(),
@@ -107,7 +107,7 @@ impl BoolIndexRead for BoolIndex {
 }
 
 impl PayloadFieldIndexRead for BoolIndex {
-    fn count_indexed_points(&self) -> usize {
+    fn count_indexed_points(&self) -> OperationResult<usize> {
         self.indexed_count()
     }
 
@@ -116,7 +116,7 @@ impl PayloadFieldIndexRead for BoolIndex {
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
     ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
-        Ok(read_ops::filter(self, condition, hw_counter))
+        read_ops::filter(self, condition, hw_counter)
     }
 
     fn estimate_cardinality(
@@ -124,7 +124,7 @@ impl PayloadFieldIndexRead for BoolIndex {
         condition: &FieldCondition,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<super::CardinalityEstimation>> {
-        Ok(read_ops::estimate_cardinality(self, condition, hw_counter))
+        read_ops::estimate_cardinality(self, condition, hw_counter)
     }
 
     fn for_each_payload_block(
@@ -190,10 +190,10 @@ impl FacetIndex for BoolIndex {
         _hw_counter: &HardwareCounterCell,
         mut f: impl FnMut(PointOffsetType, &mut dyn Iterator<Item = FacetValueRef<'_>>),
     ) -> OperationResult<()> {
-        points.for_each(|point_id| {
-            let values = self.get_point_values(point_id);
+        for point_id in points {
+            let values = self.get_point_values(point_id)?;
             f(point_id, &mut values.into_iter().map(FacetValueRef::Bool));
-        });
+        }
         Ok(())
     }
 
@@ -201,7 +201,7 @@ impl FacetIndex for BoolIndex {
         &self,
         mut f: impl FnMut(FacetValueRef<'_>) -> OperationResult<()>,
     ) -> OperationResult<()> {
-        BoolIndexRead::iter_values(self).try_for_each(|v| f(FacetValueRef::Bool(v)))
+        BoolIndexRead::iter_values(self)?.try_for_each(|v| f(FacetValueRef::Bool(v)))
     }
 
     fn for_each_value_map(
@@ -478,7 +478,7 @@ mod tests {
             .collect_vec();
         assert_eq!(point_offsets, vec![0, 2, 3, 4, 6, 11]);
 
-        assert_eq!(new_index.count_indexed_points(), 9);
+        assert_eq!(new_index.count_indexed_points().unwrap(), 9);
     }
 
     #[rstest]
@@ -552,7 +552,7 @@ mod tests {
 
         let index = builder.finalize().unwrap();
 
-        assert_eq!(index.count_indexed_points(), 9);
+        assert_eq!(index.count_indexed_points().unwrap(), 9);
     }
 
     #[test]

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index/lifecycle.rs
@@ -56,11 +56,13 @@ impl MutableBoolIndex {
         let falses_slice = DynamicStoredFlags::open(&MmapFs, &falses_path, Populate::No)?;
         let falses_flags = RoaringFlags::new(MmapFs, falses_slice)?;
 
-        let trues_count = trues_flags.count_trues();
-        let falses_count = falses_flags.count_trues();
+        // Infallible for the writable variant: its bitmaps are materialized by
+        // `RoaringFlags::new` above.
+        let trues_count = trues_flags.count_trues()?;
+        let falses_count = falses_flags.count_trues()?;
         let indexed_count = {
-            let trues = trues_flags.get_bitmap();
-            let falses = falses_flags.get_bitmap();
+            let trues = trues_flags.get_bitmap()?;
+            let falses = falses_flags.get_bitmap()?;
             trues.union_len(falses) as usize
         };
 

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index/read_ops.rs
@@ -24,8 +24,8 @@ impl BoolIndexRead for MutableBoolIndex {
         &self.storage.falses_flags
     }
 
-    fn indexed_count(&self) -> usize {
-        self.indexed_count
+    fn indexed_count(&self) -> OperationResult<usize> {
+        Ok(self.indexed_count)
     }
 
     fn telemetry_index_type(&self) -> &'static str {
@@ -34,17 +34,17 @@ impl BoolIndexRead for MutableBoolIndex {
 
     // Override the default impls to use precomputed counts maintained by the
     // write path, avoiding a bitmap scan on every read.
-    fn trues_count(&self) -> usize {
-        self.trues_count
+    fn trues_count(&self) -> OperationResult<usize> {
+        Ok(self.trues_count)
     }
 
-    fn falses_count(&self) -> usize {
-        self.falses_count
+    fn falses_count(&self) -> OperationResult<usize> {
+        Ok(self.falses_count)
     }
 }
 
 impl PayloadFieldIndexRead for MutableBoolIndex {
-    fn count_indexed_points(&self) -> usize {
+    fn count_indexed_points(&self) -> OperationResult<usize> {
         self.indexed_count()
     }
 
@@ -53,7 +53,7 @@ impl PayloadFieldIndexRead for MutableBoolIndex {
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
     ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
-        Ok(read_ops::filter(self, condition, hw_counter))
+        read_ops::filter(self, condition, hw_counter)
     }
 
     fn estimate_cardinality(
@@ -61,7 +61,7 @@ impl PayloadFieldIndexRead for MutableBoolIndex {
         condition: &FieldCondition,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<CardinalityEstimation>> {
-        Ok(read_ops::estimate_cardinality(self, condition, hw_counter))
+        read_ops::estimate_cardinality(self, condition, hw_counter)
     }
 
     fn for_each_payload_block(

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/lifecycle.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
+use std::sync::OnceLock;
 
 use common::universal_io::{CachedReadFs, UniversalReadFs};
 
 use super::super::mutable_bool_index::{FALSES_DIRNAME, TRUES_DIRNAME};
 use super::{ReadOnlyBoolIndex, ReadOnlyStorage};
 use crate::common::flags::read_only_roaring_flags::ReadOnlyRoaringFlags;
-use crate::common::flags::roaring_flags::RoaringFlagsRead;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::UniversalReadExt;
 
@@ -28,10 +28,10 @@ impl<S: UniversalReadExt> ReadOnlyBoolIndex<S> {
     ///
     /// `fs` is the generic filesystem object (e.g. `ReadOnlyFs<MmapFs>`): the
     /// index never touches the local filesystem directly, it opens all of its
-    /// files — the `trues` and `falses` flag directories — through `fs`. Like
-    /// the writable [`MutableBoolIndex::open`][1], `indexed_count`
-    /// (`|trues ∪ falses|`) is derived from the two bitmaps, so `open` takes
-    /// only `fs` and the directory.
+    /// files — the `trues` and `falses` flag directories — through `fs`. Unlike
+    /// the writable [`MutableBoolIndex::open`][1], the counts (`indexed_count`
+    /// and friends) are *not* derived here: doing so would scan both flags
+    /// files. They are computed on first use — see [`Self::counts`].
     ///
     /// Returns [`Ok(None)`] only when both flag directories are absent. If
     /// exactly one of `trues` / `falses` exists, the on-disk layout is
@@ -48,25 +48,14 @@ impl<S: UniversalReadExt> ReadOnlyBoolIndex<S> {
         match (trues_flags, falses_flags) {
             // Neither directory exists: the index isn't present on disk.
             (None, None) => Ok(None),
-            (Some(trues_flags), Some(falses_flags)) => {
-                let indexed_count = trues_flags
-                    .get_bitmap()
-                    .union_len(falses_flags.get_bitmap())
-                    as usize;
-                let trues_count = trues_flags.count_trues();
-                let falses_count = falses_flags.count_trues();
-
-                Ok(Some(Self {
-                    _base_dir: path.to_path_buf(),
-                    storage: ReadOnlyStorage {
-                        trues_flags,
-                        falses_flags,
-                    },
-                    indexed_count,
-                    trues_count,
-                    falses_count,
-                }))
-            }
+            (Some(trues_flags), Some(falses_flags)) => Ok(Some(Self {
+                _base_dir: path.to_path_buf(),
+                storage: ReadOnlyStorage {
+                    trues_flags,
+                    falses_flags,
+                },
+                counts: OnceLock::new(),
+            })),
             // Exactly one directory exists: partial/corrupt storage.
             (trues, falses) => Err(OperationError::service_error(format!(
                 "inconsistent bool index at {path:?}: exactly one flag directory exists \

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
@@ -3,7 +3,6 @@ use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 
 use super::ReadOnlyBoolIndex;
-use crate::common::flags::roaring_flags::RoaringFlagsRead;
 use crate::common::operation_error::OperationResult;
 use crate::index::UniversalReadExt;
 use crate::index::field_index::LiveReload;
@@ -26,19 +25,13 @@ impl<S: UniversalReadExt> LiveReload for ReadOnlyBoolIndex<S> {
             .falses_flags
             .live_reload(fs, deleted_points, new_points, hw_counter)?;
 
-        // Refresh the derived counts from the reloaded bitmaps, as `open` does.
+        // Re-derive the counts from the just-reloaded bitmaps, but only if they
+        // were computed before: an untouched index must not pay for the bitmap
+        // scan that deriving them would force.
         //
         // possible opt: update this using deleted_points and new_points separately,
         //               so we only process the delta
-        self.indexed_count =
-            self.storage
-                .trues_flags
-                .get_bitmap()
-                .union_len(self.storage.falses_flags.get_bitmap()) as usize;
-
-        // possible opt: track num_trues within `RoaringFlags`.
-        self.trues_count = self.storage.trues_flags.count_trues();
-        self.falses_count = self.storage.falses_flags.count_trues();
+        self.refresh_counts()?;
 
         Ok(())
     }

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
@@ -1,6 +1,11 @@
 use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use roaring::RoaringBitmap;
 
 use crate::common::flags::read_only_roaring_flags::ReadOnlyRoaringFlags;
+use crate::common::flags::roaring_flags::RoaringFlagsRead;
+use crate::common::operation_error::OperationResult;
 use crate::index::UniversalReadExt;
 use crate::index::payload_config::IndexMutability;
 
@@ -10,9 +15,9 @@ mod read_ops;
 
 /// Read-only counterpart of [`MutableBoolIndex`][1] / [`ImmutableBoolIndex`][2].
 ///
-/// All flags are loaded into in-memory roaring bitmaps on open. The backing
-/// storage is bound to [`UniversalRead`][3] only — no buffer, no flusher,
-/// no write path. Query logic (filter / cardinality / payload blocks /
+/// Flags are materialized into in-memory roaring bitmaps on first use, not on
+/// open. The backing storage is bound to [`UniversalRead`][3] only — no buffer,
+/// no flusher, no write path. Query logic (filter / cardinality / payload blocks /
 /// condition checker / faceting) is shared with the writable variants via
 /// [`BoolIndexRead`][4].
 ///
@@ -28,9 +33,28 @@ mod read_ops;
 pub struct ReadOnlyBoolIndex<S: UniversalReadExt> {
     pub(super) _base_dir: PathBuf,
     pub(super) storage: ReadOnlyStorage<S>,
-    pub(super) indexed_count: usize,
-    pub(super) trues_count: usize,
-    pub(super) falses_count: usize,
+    /// Counts derived from both bitmaps, computed on first use and cached.
+    ///
+    /// Deriving them eagerly would force both bitmaps to materialize at open,
+    /// scanning each flags file end to end — exactly what the lazy
+    /// [`ReadOnlyRoaringFlags`] bitmap exists to avoid. [`LiveReload`][1]
+    /// refreshes them in place if they are present, and leaves them unset
+    /// otherwise.
+    ///
+    /// [1]: crate::index::field_index::LiveReload
+    pub(super) counts: OnceLock<BoolCounts>,
+}
+
+/// The three point counts the bool index reports, all derived from the same
+/// pair of bitmaps and therefore computed together in one pass.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct BoolCounts {
+    /// `|trues ∪ falses|` — points with at least one indexed bool value.
+    pub indexed: usize,
+    /// Points with at least one `true` value.
+    pub trues: usize,
+    /// Points with at least one `false` value.
+    pub falses: usize,
 }
 
 pub(super) struct ReadOnlyStorage<S: UniversalReadExt> {
@@ -41,6 +65,50 @@ pub(super) struct ReadOnlyStorage<S: UniversalReadExt> {
 }
 
 impl<S: UniversalReadExt> ReadOnlyBoolIndex<S> {
+    /// The cached counts, materializing both bitmaps to derive them on the
+    /// first call.
+    pub(super) fn counts(&self) -> OperationResult<&BoolCounts> {
+        if let Some(counts) = self.counts.get() {
+            return Ok(counts);
+        }
+
+        let counts = Self::derive_counts(&self.storage)?;
+
+        Ok(self.counts.get_or_init(|| counts))
+    }
+
+    /// Recompute the counts straight from the bitmaps, materializing them.
+    fn derive_counts(storage: &ReadOnlyStorage<S>) -> OperationResult<BoolCounts> {
+        let trues: &RoaringBitmap = storage.trues_flags.get_bitmap()?;
+        let falses: &RoaringBitmap = storage.falses_flags.get_bitmap()?;
+
+        Ok(BoolCounts {
+            indexed: trues.union_len(falses) as usize,
+            trues: trues.len() as usize,
+            falses: falses.len() as usize,
+        })
+    }
+
+    /// Bring the cached counts back in line with the bitmaps after a reload.
+    ///
+    /// A no-op while the counts are unset: recomputing them would materialize
+    /// both bitmaps, and a reload must not force work no query has asked for.
+    /// When they *are* set the bitmaps are materialized too (deriving the
+    /// counts is what materialized them), so this rereads them for free.
+    pub(super) fn refresh_counts(&mut self) -> OperationResult<()> {
+        if self.counts.get().is_none() {
+            return Ok(());
+        }
+
+        let counts = Self::derive_counts(&self.storage)?;
+        *self
+            .counts
+            .get_mut()
+            .expect("counts are set, just checked above") = counts;
+
+        Ok(())
+    }
+
     /// Reports the on-disk format's mutability, mirroring
     /// [`BoolIndex::get_mutability_type`][1].
     ///
@@ -78,7 +146,9 @@ mod tests {
     use tempfile::TempDir;
 
     use super::super::mutable_bool_index::{FALSES_DIRNAME, MutableBoolIndex, TRUES_DIRNAME};
+    use super::super::read_ops::BoolIndexRead;
     use super::ReadOnlyBoolIndex;
+    use crate::common::flags::roaring_flags::RoaringFlagsRead;
     use crate::index::field_index::{
         FieldIndexBuilderTrait, LiveReload, PayloadFieldIndex, PayloadFieldIndexRead, ValueIndexer,
     };
@@ -157,7 +227,7 @@ mod tests {
             vec![0, 2, 3, 4, 6, 11],
         );
         // `indexed_count = |trues ∪ falses|`, derived from the two bitmaps on open.
-        assert_eq!(index.count_indexed_points(), 9);
+        assert_eq!(index.count_indexed_points().unwrap(), 9);
     }
 
     /// The incremental `LiveReload` path must land on exactly the same in-memory
@@ -174,8 +244,21 @@ mod tests {
     /// Offset 1100 lands past the 128-byte minimum mmap (1024 flags), growing the
     /// flags file, so it is observed only because `live_reload` reopens the
     /// bitslice — a stale mapping cannot see the grown region.
+    /// The bitmaps are lazy, so `live_reload` has two distinct paths: patch the
+    /// in-memory bitmap in place, or — when nothing has materialized it yet —
+    /// leave it alone and let the eventual scan read the updated file. Both must
+    /// land on the same state, so both are exercised.
     #[test]
-    fn live_reload_matches_fresh_open() {
+    fn live_reload_matches_fresh_open_materialized() {
+        live_reload_matches_fresh_open(true);
+    }
+
+    #[test]
+    fn live_reload_matches_fresh_open_lazy() {
+        live_reload_matches_fresh_open(false);
+    }
+
+    fn live_reload_matches_fresh_open(materialize_before_reload: bool) {
         let dir = TempDir::with_prefix("read_only_bool_index_live_reload").unwrap();
         let hw_counter = HardwareCounterCell::new();
 
@@ -203,6 +286,16 @@ mod tests {
             .unwrap()
             .unwrap();
 
+        if materialize_before_reload {
+            // Pull both bitmaps into memory, so the reload below takes its
+            // in-place delta path rather than deferring to a later scan. This
+            // also populates the counts cache.
+            reloaded.count_indexed_points().unwrap();
+            assert!(reloaded.counts.get().is_some());
+        } else {
+            assert!(reloaded.counts.get().is_none());
+        }
+
         // Writer's append-only delta: retire points 1 (false) and 2 (both), then
         // append fresh offsets 6 (true), 7 (false) and 1100 (true). Offset 1100
         // grows the flags file past its 128-byte minimum, so the reload sees it
@@ -222,6 +315,10 @@ mod tests {
                 &hw_counter,
             )
             .unwrap();
+
+        // Counts already computed are refreshed in place, never invalidated;
+        // counts never computed stay that way, so the reload forced no scan.
+        assert_eq!(reloaded.counts.get().is_some(), materialize_before_reload);
 
         let fresh = ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path())
             .unwrap()
@@ -264,8 +361,8 @@ mod tests {
         assert_eq!(reloaded_true, fresh_true);
         assert_eq!(reloaded_false, fresh_false);
         assert_eq!(
-            reloaded.count_indexed_points(),
-            fresh.count_indexed_points()
+            reloaded.count_indexed_points().unwrap(),
+            fresh.count_indexed_points().unwrap()
         );
         assert_eq!(card(&reloaded, true), card(&fresh, true));
         assert_eq!(card(&reloaded, false), card(&fresh, false));
@@ -275,7 +372,7 @@ mod tests {
         // as `false` — 1100 only via the reopened, freshly-grown bitslice.
         assert_eq!(reloaded_true, vec![0, 3, 5, 6, 1100]);
         assert_eq!(reloaded_false, vec![4, 5, 7]);
-        assert_eq!(reloaded.count_indexed_points(), 7);
+        assert_eq!(reloaded.count_indexed_points().unwrap(), 7);
         assert_eq!(card(&reloaded, true), 5);
         assert_eq!(card(&reloaded, false), 3);
     }
@@ -308,6 +405,57 @@ mod tests {
         let dir = build();
         fs_err::remove_dir_all(dir.path().join(TRUES_DIRNAME)).unwrap();
         assert!(ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path()).is_err());
+    }
+
+    /// Opening must not read the flags files — that whole-file scan is the cost
+    /// laziness exists to defer. Asserted through `ram_usage_bytes`, which is 0
+    /// exactly while no bitmap is materialized, and through the counts cache.
+    ///
+    /// Nothing else in this module would notice an eager `open`: every other
+    /// test reads the index, which materializes the bitmaps anyway.
+    #[test]
+    fn open_does_not_materialize_bitmaps() {
+        let dir = TempDir::with_prefix("read_only_bool_index_lazy").unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        let mut builder = MutableBoolIndex::builder(dir.path()).unwrap();
+        let value = json!(true);
+        builder.add_point(0, &[&value], &hw_counter).unwrap();
+        let index = builder.finalize().unwrap();
+        index.flusher()().unwrap();
+        drop(index);
+
+        type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
+        let fs = RoFs::from_context(Default::default()).unwrap();
+
+        let index = ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path())
+            .unwrap()
+            .unwrap();
+
+        // Neither bitmap is in RAM, and the derived counts are not computed.
+        assert!(index.storage.trues_flags.bitmap_if_materialized().is_none());
+        assert!(
+            index
+                .storage
+                .falses_flags
+                .bitmap_if_materialized()
+                .is_none()
+        );
+        assert_eq!(BoolIndexRead::ram_usage_bytes(&index), 0);
+        assert!(index.counts.get().is_none());
+
+        // The first count materializes both, and caches what it derived.
+        assert_eq!(index.count_indexed_points().unwrap(), 1);
+        assert!(index.storage.trues_flags.bitmap_if_materialized().is_some());
+        assert!(
+            index
+                .storage
+                .falses_flags
+                .bitmap_if_materialized()
+                .is_some()
+        );
+        assert!(BoolIndexRead::ram_usage_bytes(&index) > 0);
+        assert!(index.counts.get().is_some());
     }
 
     /// `preopen` must schedule exactly the files `open` goes on to consume.
@@ -367,7 +515,7 @@ mod tests {
                 .collect_vec(),
             vec![1, 2],
         );
-        assert_eq!(index.count_indexed_points(), 3);
+        assert_eq!(index.count_indexed_points().unwrap(), 3);
 
         // An absent index: `preopen` reports it rather than erroring on the
         // missing status file, and schedules nothing for `open` to consume.

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/read_ops.rs
@@ -22,7 +22,7 @@ impl<S: UniversalReadExt> ReadOnlyBoolIndex<S> {
     pub fn value_retriever<'a>(
         &'a self,
         hw_counter: &'a HardwareCounterCell,
-    ) -> VariableRetrieverFn<'a> {
+    ) -> OperationResult<VariableRetrieverFn<'a>> {
         read_ops::value_retriever(self, hw_counter)
     }
 }
@@ -38,25 +38,25 @@ impl<S: UniversalReadExt> BoolIndexRead for ReadOnlyBoolIndex<S> {
         &self.storage.falses_flags
     }
 
-    fn indexed_count(&self) -> usize {
-        self.indexed_count
+    fn indexed_count(&self) -> OperationResult<usize> {
+        Ok(self.counts()?.indexed)
     }
 
     fn telemetry_index_type(&self) -> &'static str {
         "read_only_bool_index"
     }
 
-    fn trues_count(&self) -> usize {
-        self.trues_count
+    fn trues_count(&self) -> OperationResult<usize> {
+        Ok(self.counts()?.trues)
     }
 
-    fn falses_count(&self) -> usize {
-        self.falses_count
+    fn falses_count(&self) -> OperationResult<usize> {
+        Ok(self.counts()?.falses)
     }
 }
 
 impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyBoolIndex<S> {
-    fn count_indexed_points(&self) -> usize {
+    fn count_indexed_points(&self) -> OperationResult<usize> {
         self.indexed_count()
     }
 
@@ -65,7 +65,7 @@ impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyBoolIndex<S> {
         condition: &'a FieldCondition,
         hw_counter: &'a HardwareCounterCell,
     ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
-        Ok(read_ops::filter(self, condition, hw_counter))
+        read_ops::filter(self, condition, hw_counter)
     }
 
     fn estimate_cardinality(
@@ -73,7 +73,7 @@ impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyBoolIndex<S> {
         condition: &FieldCondition,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<CardinalityEstimation>> {
-        Ok(read_ops::estimate_cardinality(self, condition, hw_counter))
+        read_ops::estimate_cardinality(self, condition, hw_counter)
     }
 
     fn for_each_payload_block(
@@ -110,10 +110,10 @@ impl<S: UniversalReadExt> FacetIndex for ReadOnlyBoolIndex<S> {
         _hw_counter: &HardwareCounterCell,
         mut f: impl FnMut(PointOffsetType, &mut dyn Iterator<Item = FacetValueRef<'_>>),
     ) -> OperationResult<()> {
-        points.for_each(|point_id| {
-            let values = self.get_point_values(point_id);
+        for point_id in points {
+            let values = self.get_point_values(point_id)?;
             f(point_id, &mut values.into_iter().map(FacetValueRef::Bool));
-        });
+        }
         Ok(())
     }
 
@@ -121,7 +121,7 @@ impl<S: UniversalReadExt> FacetIndex for ReadOnlyBoolIndex<S> {
         &self,
         mut f: impl FnMut(FacetValueRef<'_>) -> OperationResult<()>,
     ) -> OperationResult<()> {
-        BoolIndexRead::iter_values(self).try_for_each(|v| f(FacetValueRef::Bool(v)))
+        BoolIndexRead::iter_values(self)?.try_for_each(|v| f(FacetValueRef::Bool(v)))
     }
 
     fn for_each_value_map(

--- a/lib/segment/src/index/field_index/bool_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_ops.rs
@@ -50,22 +50,25 @@ pub trait BoolIndexRead {
 
     /// Number of distinct points with at least one indexed bool value
     /// (i.e. `|trues ∪ falses|`).
-    fn indexed_count(&self) -> usize;
+    ///
+    /// Fallible: the read-only variant derives it from bitmaps it materializes
+    /// on demand. See [`RoaringFlagsRead::get_bitmap`].
+    fn indexed_count(&self) -> OperationResult<usize>;
 
     /// Per-variant telemetry tag (e.g. `"mmap_bool"`).
     fn telemetry_index_type(&self) -> &'static str;
 
-    fn trues_count(&self) -> usize;
+    fn trues_count(&self) -> OperationResult<usize>;
 
-    fn falses_count(&self) -> usize;
+    fn falses_count(&self) -> OperationResult<usize>;
 
-    fn values_count(&self, point_id: PointOffsetType) -> usize {
-        let has_true = self.trues_flags().get(point_id);
-        let has_false = self.falses_flags().get(point_id);
-        usize::from(has_true) + usize::from(has_false)
+    fn values_count(&self, point_id: PointOffsetType) -> OperationResult<usize> {
+        let has_true = self.trues_flags().get(point_id)?;
+        let has_false = self.falses_flags().get(point_id)?;
+        Ok(usize::from(has_true) + usize::from(has_false))
     }
 
-    fn check_values_any(&self, point_id: PointOffsetType, is_true: bool) -> bool {
+    fn check_values_any(&self, point_id: PointOffsetType, is_true: bool) -> OperationResult<bool> {
         if is_true {
             self.trues_flags().get(point_id)
         } else {
@@ -73,29 +76,24 @@ pub trait BoolIndexRead {
         }
     }
 
-    fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
-        !self.trues_flags().get(point_id) && !self.falses_flags().get(point_id)
+    fn values_is_empty(&self, point_id: PointOffsetType) -> OperationResult<bool> {
+        Ok(!self.trues_flags().get(point_id)? && !self.falses_flags().get(point_id)?)
     }
 
-    fn get_point_values(&self, point_id: PointOffsetType) -> Vec<bool> {
-        [
-            self.trues_flags().get(point_id).then_some(true),
-            self.falses_flags().get(point_id).then_some(false),
+    fn get_point_values(&self, point_id: PointOffsetType) -> OperationResult<Vec<bool>> {
+        Ok([
+            self.trues_flags().get(point_id)?.then_some(true),
+            self.falses_flags().get(point_id)?.then_some(false),
         ]
         .into_iter()
         .flatten()
-        .collect()
+        .collect())
     }
 
-    fn iter_values(&self) -> Box<dyn Iterator<Item = bool> + '_> {
-        Box::new(
-            [
-                self.falses_flags().iter_trues().next().map(|_| false),
-                self.trues_flags().iter_trues().next().map(|_| true),
-            ]
-            .into_iter()
-            .flatten(),
-        )
+    fn iter_values(&self) -> OperationResult<Box<dyn Iterator<Item = bool> + '_>> {
+        let has_false = self.falses_flags().iter_trues()?.next().map(|_| false);
+        let has_true = self.trues_flags().iter_trues()?.next().map(|_| true);
+        Ok(Box::new([has_false, has_true].into_iter().flatten()))
     }
 
     fn for_each_value_map<F>(
@@ -106,11 +104,11 @@ pub trait BoolIndexRead {
     where
         F: FnMut(bool, &mut dyn Iterator<Item = PointOffsetType>) -> OperationResult<()>,
     {
-        f(false, &mut self.falses_flags().iter_trues())?;
+        f(false, &mut self.falses_flags().iter_trues()?)?;
         hw_counter
             .payload_index_io_read_counter()
             .incr_delta(u8::BITS as usize);
-        f(true, &mut self.trues_flags().iter_trues())?;
+        f(true, &mut self.trues_flags().iter_trues()?)?;
         hw_counter
             .payload_index_io_read_counter()
             .incr_delta(u8::BITS as usize);
@@ -130,9 +128,9 @@ pub trait BoolIndexRead {
     {
         for is_true in values {
             let mut ids = if is_true {
-                self.trues_flags().iter_trues()
+                self.trues_flags().iter_trues()?
             } else {
-                self.falses_flags().iter_trues()
+                self.falses_flags().iter_trues()?
             };
             hw_counter
                 .payload_index_io_read_counter()
@@ -154,27 +152,28 @@ pub trait BoolIndexRead {
             Some(deferred_internal_id) => {
                 let false_count =
                     self.falses_flags()
-                        .get_bitmap()
+                        .get_bitmap()?
                         .range_cardinality(..deferred_internal_id) as usize;
                 let true_count =
                     self.trues_flags()
-                        .get_bitmap()
+                        .get_bitmap()?
                         .range_cardinality(..deferred_internal_id) as usize;
                 (false_count, true_count)
             }
-            None => (self.falses_count(), self.trues_count()),
+            None => (self.falses_count()?, self.trues_count()?),
         };
         f(false, false_count)?;
         f(true, true_count)
     }
 
+    /// Zero while neither bitmap is materialized — nothing is held in RAM yet.
     fn ram_usage_bytes(&self) -> usize {
-        self.trues_flags().get_bitmap().serialized_size()
-            + self.falses_flags().get_bitmap().serialized_size()
+        self.trues_flags().ram_usage_bytes() + self.falses_flags().ram_usage_bytes()
     }
 
     /// Whether the index keeps its primary data on disk. Default `false` —
-    /// the bitmap is in RAM after open for every current variant.
+    /// every current variant serves reads from an in-RAM bitmap (the read-only
+    /// one materializes it on first use).
     fn is_on_disk(&self) -> bool {
         false
     }
@@ -201,14 +200,16 @@ pub trait BoolIndexRead {
         }
     }
 
-    fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
-        PayloadIndexTelemetry {
+    /// Materializes both bitmaps for its counts, unlike the null index's
+    /// length-driven telemetry.
+    fn get_telemetry_data(&self) -> OperationResult<PayloadIndexTelemetry> {
+        Ok(PayloadIndexTelemetry {
             field_name: None,
-            points_count: self.indexed_count(),
-            points_values_count: self.trues_count() + self.falses_count(),
+            points_count: self.indexed_count()?,
+            points_values_count: self.trues_count()? + self.falses_count()?,
             histogram_bucket_size: None,
             index_type: self.telemetry_index_type(),
-        }
+        })
     }
 }
 
@@ -216,15 +217,15 @@ pub(super) fn filter<'a, N: BoolIndexRead>(
     idx: &'a N,
     condition: &'a FieldCondition,
     hw_counter: &'a HardwareCounterCell,
-) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
+) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
     match &condition.r#match {
         Some(Match::Value(MatchValue {
             value: ValueVariants::Bool(value),
         })) => {
             let bitmap = if *value {
-                idx.trues_flags().get_bitmap()
+                idx.trues_flags().get_bitmap()?
             } else {
-                idx.falses_flags().get_bitmap()
+                idx.falses_flags().get_bitmap()?
             };
             let iter = bitmap
                 .iter()
@@ -234,9 +235,9 @@ pub(super) fn filter<'a, N: BoolIndexRead>(
                     u8::BITS as usize,
                     |i| i.payload_index_io_read_counter(),
                 );
-            Some(Box::new(iter))
+            Ok(Some(Box::new(iter)))
         }
-        _ => None,
+        _ => Ok(None),
     }
 }
 
@@ -244,27 +245,27 @@ pub(super) fn estimate_cardinality<N: BoolIndexRead>(
     idx: &N,
     condition: &FieldCondition,
     hw_counter: &HardwareCounterCell,
-) -> Option<CardinalityEstimation> {
+) -> OperationResult<Option<CardinalityEstimation>> {
     match &condition.r#match {
         Some(Match::Value(MatchValue {
             value: ValueVariants::Bool(value),
         })) => {
             let count = if *value {
-                idx.trues_count()
+                idx.trues_count()?
             } else {
-                idx.falses_count()
+                idx.falses_count()?
             };
 
             hw_counter
                 .payload_index_io_read_counter()
                 .incr_delta(size_of::<usize>());
 
-            Some(
+            Ok(Some(
                 CardinalityEstimation::exact(count)
                     .with_primary_clause(PrimaryCondition::Condition(Box::new(condition.clone()))),
-            )
+            ))
         }
-        _ => None,
+        _ => Ok(None),
     }
 }
 
@@ -285,8 +286,8 @@ pub(super) fn for_each_payload_block<N: BoolIndexRead>(
     };
 
     // just two possible blocks: true and false
-    handle_block(idx.trues_count(), true, key.clone())?;
-    handle_block(idx.falses_count(), false, key)
+    handle_block(idx.trues_count()?, true, key.clone())?;
+    handle_block(idx.falses_count()?, false, key)
 }
 
 pub(super) fn condition_checker<'a, N: BoolIndexRead>(
@@ -341,7 +342,7 @@ impl<N: BoolIndexRead> ConditionChecker for BoolConditionChecker<'_, N> {
     type Error = OperationError;
 
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
-        Ok(self.idx.check_values_any(point_id, self.is_true))
+        self.idx.check_values_any(point_id, self.is_true)
     }
 }
 
@@ -357,11 +358,23 @@ impl<N: BoolIndexRead> ConditionChecker for BoolConditionChecker<'_, N> {
 pub(super) fn value_retriever<'a, N: BoolIndexRead + ?Sized + 'a>(
     idx: &'a N,
     _hw_counter: &'a HardwareCounterCell,
-) -> VariableRetrieverFn<'a> {
-    Box::new(move |point_id: PointOffsetType| -> MultiValue<Value> {
-        idx.get_point_values(point_id)
+) -> OperationResult<VariableRetrieverFn<'a>> {
+    // Materialize both bitmaps here rather than inside the closure: the
+    // retriever is invoked per point and must not fail, so the one scan that
+    // could fail is hoisted to construction time.
+    let trues = idx.trues_flags().get_bitmap()?;
+    let falses = idx.falses_flags().get_bitmap()?;
+
+    Ok(Box::new(
+        move |point_id: PointOffsetType| -> MultiValue<Value> {
+            [
+                trues.contains(point_id).then_some(true),
+                falses.contains(point_id).then_some(false),
+            ]
             .into_iter()
+            .flatten()
             .map(Value::Bool)
             .collect()
-    })
+        },
+    ))
 }

--- a/lib/segment/src/index/field_index/field_index_base/field_index_read.rs
+++ b/lib/segment/src/index/field_index/field_index_base/field_index_read.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 
 use super::payload_field_index::PayloadFieldIndexRead;
+use crate::common::operation_error::OperationResult;
 use crate::index::field_index::facet_index::FacetIndex;
 use crate::index::field_index::numeric_index::NumericFieldIndexRead;
 use crate::index::query_optimization::rescore_formula::value_retriever::VariableRetrieverFn;
@@ -30,13 +31,18 @@ use crate::telemetry::PayloadIndexTelemetry;
 /// [`StructPayloadIndexReadView`]: crate::index::struct_payload_index::StructPayloadIndexReadView
 pub trait FieldIndexRead: PayloadFieldIndexRead {
     /// Per-index telemetry snapshot.
-    fn get_telemetry_data(&self) -> PayloadIndexTelemetry;
+    ///
+    /// Fallible for the same reason as
+    /// [`count_indexed_points`](PayloadFieldIndexRead::count_indexed_points):
+    /// the read-only bool index derives its point counts from bitmaps it
+    /// materializes on demand.
+    fn get_telemetry_data(&self) -> OperationResult<PayloadIndexTelemetry>;
 
     /// Number of values for `point_id`.
-    fn values_count(&self, point_id: PointOffsetType) -> usize;
+    fn values_count(&self, point_id: PointOffsetType) -> OperationResult<usize>;
 
     /// True if `point_id` has zero values in this index.
-    fn values_is_empty(&self, point_id: PointOffsetType) -> bool;
+    fn values_is_empty(&self, point_id: PointOffsetType) -> OperationResult<bool>;
 
     /// Build a closure that extracts this index's values for a given
     /// point as a [`MultiValue<Value>`](crate::common::utils::MultiValue).
@@ -51,7 +57,7 @@ pub trait FieldIndexRead: PayloadFieldIndexRead {
     fn value_retriever<'a, 'q>(
         &'a self,
         hw_counter: &'q HardwareCounterCell,
-    ) -> Option<VariableRetrieverFn<'q>>
+    ) -> OperationResult<Option<VariableRetrieverFn<'q>>>
     where
         'a: 'q;
 

--- a/lib/segment/src/index/field_index/field_index_base/field_index_read_impl.rs
+++ b/lib/segment/src/index/field_index/field_index_base/field_index_read_impl.rs
@@ -20,7 +20,7 @@ use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl PayloadFieldIndexRead for FieldIndex {
-    fn count_indexed_points(&self) -> usize {
+    fn count_indexed_points(&self) -> OperationResult<usize> {
         match self {
             FieldIndex::IntIndex(idx) => idx.count_indexed_points(),
             FieldIndex::DatetimeIndex(idx) => idx.count_indexed_points(),
@@ -162,58 +162,58 @@ impl PayloadFieldIndexRead for FieldIndex {
 }
 
 impl FieldIndexRead for FieldIndex {
-    fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
-        match self {
+    fn get_telemetry_data(&self) -> OperationResult<PayloadIndexTelemetry> {
+        Ok(match self {
             FieldIndex::IntIndex(index) => index.get_telemetry_data(),
             FieldIndex::DatetimeIndex(index) => index.get_telemetry_data(),
             FieldIndex::IntMapIndex(index) => index.get_telemetry_data(),
             FieldIndex::KeywordIndex(index) => index.get_telemetry_data(),
             FieldIndex::FloatIndex(index) => index.get_telemetry_data(),
             FieldIndex::GeoIndex(index) => index.get_telemetry_data(),
-            FieldIndex::BoolIndex(index) => index.get_telemetry_data(),
+            FieldIndex::BoolIndex(index) => index.get_telemetry_data()?,
             FieldIndex::FullTextIndex(index) => index.get_telemetry_data(),
             FieldIndex::UuidIndex(index) => index.get_telemetry_data(),
             FieldIndex::UuidMapIndex(index) => index.get_telemetry_data(),
             FieldIndex::NullIndex(index) => index.get_telemetry_data(),
-        }
+        })
     }
 
-    fn values_count(&self, point_id: PointOffsetType) -> usize {
-        match self {
+    fn values_count(&self, point_id: PointOffsetType) -> OperationResult<usize> {
+        Ok(match self {
             FieldIndex::IntIndex(index) => index.values_count(point_id),
             FieldIndex::DatetimeIndex(index) => index.values_count(point_id),
             FieldIndex::IntMapIndex(index) => index.values_count(point_id),
             FieldIndex::KeywordIndex(index) => index.values_count(point_id),
             FieldIndex::FloatIndex(index) => index.values_count(point_id),
             FieldIndex::GeoIndex(index) => index.values_count(point_id),
-            FieldIndex::BoolIndex(index) => index.values_count(point_id),
+            FieldIndex::BoolIndex(index) => index.values_count(point_id)?,
             FieldIndex::FullTextIndex(index) => index.values_count(point_id),
             FieldIndex::UuidIndex(index) => index.values_count(point_id),
             FieldIndex::UuidMapIndex(index) => index.values_count(point_id),
-            FieldIndex::NullIndex(index) => index.values_count(point_id),
-        }
+            FieldIndex::NullIndex(index) => index.values_count(point_id)?,
+        })
     }
 
-    fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
-        match self {
+    fn values_is_empty(&self, point_id: PointOffsetType) -> OperationResult<bool> {
+        Ok(match self {
             FieldIndex::IntIndex(index) => index.values_is_empty(point_id),
             FieldIndex::DatetimeIndex(index) => index.values_is_empty(point_id),
             FieldIndex::IntMapIndex(index) => index.values_is_empty(point_id),
             FieldIndex::KeywordIndex(index) => index.values_is_empty(point_id),
             FieldIndex::FloatIndex(index) => index.values_is_empty(point_id),
             FieldIndex::GeoIndex(index) => index.values_is_empty(point_id),
-            FieldIndex::BoolIndex(index) => index.values_is_empty(point_id),
+            FieldIndex::BoolIndex(index) => index.values_is_empty(point_id)?,
             FieldIndex::FullTextIndex(index) => index.values_is_empty(point_id),
             FieldIndex::UuidIndex(index) => index.values_is_empty(point_id),
             FieldIndex::UuidMapIndex(index) => index.values_is_empty(point_id),
-            FieldIndex::NullIndex(index) => index.values_is_empty(point_id),
-        }
+            FieldIndex::NullIndex(index) => index.values_is_empty(point_id)?,
+        })
     }
 
     fn value_retriever<'a, 'q>(
         &'a self,
         hw_counter: &'q HardwareCounterCell,
-    ) -> Option<VariableRetrieverFn<'q>>
+    ) -> OperationResult<Option<VariableRetrieverFn<'q>>>
     where
         'a: 'q,
     {
@@ -222,14 +222,14 @@ impl FieldIndexRead for FieldIndex {
         // `NumericIndex<IntPayloadType, DateTimePayloadType>::value_retriever`).
         // This dispatch is mechanical — adding a `FieldIndex` variant
         // forces a compile error here.
-        match self {
+        Ok(match self {
             FieldIndex::IntIndex(index) => Some(index.value_retriever(hw_counter)),
             FieldIndex::DatetimeIndex(index) => Some(index.value_retriever(hw_counter)),
             FieldIndex::IntMapIndex(index) => Some(index.value_retriever(hw_counter)),
             FieldIndex::KeywordIndex(index) => Some(index.value_retriever(hw_counter)),
             FieldIndex::FloatIndex(index) => Some(index.value_retriever(hw_counter)),
             FieldIndex::GeoIndex(index) => Some(index.value_retriever(hw_counter)),
-            FieldIndex::BoolIndex(index) => Some(index.value_retriever(hw_counter)),
+            FieldIndex::BoolIndex(index) => Some(index.value_retriever(hw_counter)?),
             FieldIndex::UuidIndex(index) => Some(index.value_retriever(hw_counter)),
             FieldIndex::UuidMapIndex(index) => Some(index.value_retriever(hw_counter)),
             // FullTextIndex: caller falls back to payload — text values
@@ -239,7 +239,7 @@ impl FieldIndexRead for FieldIndex {
             // NullIndex: no underlying values to return; another index
             // on the same field is expected to provide them.
             FieldIndex::NullIndex(_) => None,
-        }
+        })
     }
 
     fn as_numeric(&self) -> Option<impl NumericFieldIndexRead + '_> {

--- a/lib/segment/src/index/field_index/field_index_base/payload_field_index.rs
+++ b/lib/segment/src/index/field_index/field_index_base/payload_field_index.rs
@@ -21,7 +21,11 @@ use crate::types::{FieldCondition, PayloadKeyType};
 /// `F: FieldIndexRead` consumers get these methods directly.
 pub trait PayloadFieldIndexRead {
     /// Return number of points with at least one value indexed in here
-    fn count_indexed_points(&self) -> usize;
+    ///
+    /// Fallible: an index whose backing data is materialized on demand (the
+    /// read-only bool index) has to read it to count. See
+    /// [`RoaringFlagsRead::get_bitmap`](crate::common::flags::roaring_flags::RoaringFlagsRead::get_bitmap).
+    fn count_indexed_points(&self) -> OperationResult<usize>;
 
     /// Get iterator over points fitting given `condition`
     /// Return `None` if condition does not match the index type

--- a/lib/segment/src/index/field_index/field_index_base/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/read_ops.rs
@@ -23,7 +23,7 @@ use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{FieldCondition, PayloadKeyType};
 
 impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyFieldIndex<S> {
-    fn count_indexed_points(&self) -> usize {
+    fn count_indexed_points(&self) -> OperationResult<usize> {
         match self {
             ReadOnlyFieldIndex::IntIndex(idx) => idx.count_indexed_points(),
             ReadOnlyFieldIndex::DatetimeIndex(idx) => idx.count_indexed_points(),
@@ -173,24 +173,24 @@ impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyFieldIndex<S> {
 }
 
 impl<S: UniversalReadExt> FieldIndexRead for ReadOnlyFieldIndex<S> {
-    fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
-        match self {
+    fn get_telemetry_data(&self) -> OperationResult<PayloadIndexTelemetry> {
+        Ok(match self {
             ReadOnlyFieldIndex::IntIndex(idx) => idx.get_telemetry_data(),
             ReadOnlyFieldIndex::DatetimeIndex(idx) => idx.get_telemetry_data(),
             ReadOnlyFieldIndex::IntMapIndex(idx) => idx.get_telemetry_data(),
             ReadOnlyFieldIndex::KeywordIndex(idx) => idx.get_telemetry_data(),
             ReadOnlyFieldIndex::FloatIndex(idx) => idx.get_telemetry_data(),
-            ReadOnlyFieldIndex::BoolIndex(idx) => idx.get_telemetry_data(),
+            ReadOnlyFieldIndex::BoolIndex(idx) => idx.get_telemetry_data()?,
             ReadOnlyFieldIndex::GeoIndex(idx) => idx.get_telemetry_data(),
             ReadOnlyFieldIndex::UuidIndex(idx) => idx.get_telemetry_data(),
             ReadOnlyFieldIndex::FullTextIndex(idx) => idx.get_telemetry_data(),
             ReadOnlyFieldIndex::UuidMapIndex(idx) => idx.get_telemetry_data(),
             ReadOnlyFieldIndex::NullIndex(idx) => idx.get_telemetry_data(),
-        }
+        })
     }
 
-    fn values_count(&self, point_id: PointOffsetType) -> usize {
-        match self {
+    fn values_count(&self, point_id: PointOffsetType) -> OperationResult<usize> {
+        Ok(match self {
             ReadOnlyFieldIndex::IntIndex(idx) => {
                 NumericIndexRead::values_count(idx, point_id).unwrap_or(0)
             }
@@ -206,7 +206,7 @@ impl<S: UniversalReadExt> FieldIndexRead for ReadOnlyFieldIndex<S> {
             ReadOnlyFieldIndex::FloatIndex(idx) => {
                 NumericIndexRead::values_count(idx, point_id).unwrap_or(0)
             }
-            ReadOnlyFieldIndex::BoolIndex(idx) => BoolIndexRead::values_count(idx, point_id),
+            ReadOnlyFieldIndex::BoolIndex(idx) => BoolIndexRead::values_count(idx, point_id)?,
             ReadOnlyFieldIndex::GeoIndex(idx) => GeoIndexRead::values_count(idx, point_id),
             ReadOnlyFieldIndex::UuidIndex(idx) => {
                 NumericIndexRead::values_count(idx, point_id).unwrap_or(0)
@@ -217,12 +217,12 @@ impl<S: UniversalReadExt> FieldIndexRead for ReadOnlyFieldIndex<S> {
             ReadOnlyFieldIndex::UuidMapIndex(idx) => {
                 MapIndexRead::values_count(idx, point_id).unwrap_or(0)
             }
-            ReadOnlyFieldIndex::NullIndex(idx) => NullIndexRead::values_count(idx, point_id),
-        }
+            ReadOnlyFieldIndex::NullIndex(idx) => NullIndexRead::values_count(idx, point_id)?,
+        })
     }
 
-    fn values_is_empty(&self, point_id: PointOffsetType) -> bool {
-        match self {
+    fn values_is_empty(&self, point_id: PointOffsetType) -> OperationResult<bool> {
+        Ok(match self {
             ReadOnlyFieldIndex::IntIndex(idx) => NumericIndexRead::values_is_empty(idx, point_id),
             ReadOnlyFieldIndex::DatetimeIndex(idx) => {
                 NumericIndexRead::values_is_empty(idx, point_id)
@@ -230,21 +230,21 @@ impl<S: UniversalReadExt> FieldIndexRead for ReadOnlyFieldIndex<S> {
             ReadOnlyFieldIndex::IntMapIndex(idx) => MapIndexRead::values_is_empty(idx, point_id),
             ReadOnlyFieldIndex::KeywordIndex(idx) => MapIndexRead::values_is_empty(idx, point_id),
             ReadOnlyFieldIndex::FloatIndex(idx) => NumericIndexRead::values_is_empty(idx, point_id),
-            ReadOnlyFieldIndex::BoolIndex(idx) => BoolIndexRead::values_is_empty(idx, point_id),
+            ReadOnlyFieldIndex::BoolIndex(idx) => BoolIndexRead::values_is_empty(idx, point_id)?,
             ReadOnlyFieldIndex::GeoIndex(idx) => GeoIndexRead::values_is_empty(idx, point_id),
             ReadOnlyFieldIndex::UuidIndex(idx) => NumericIndexRead::values_is_empty(idx, point_id),
             ReadOnlyFieldIndex::FullTextIndex(idx) => {
                 FullTextIndexRead::values_is_empty(idx, point_id)
             }
             ReadOnlyFieldIndex::UuidMapIndex(idx) => MapIndexRead::values_is_empty(idx, point_id),
-            ReadOnlyFieldIndex::NullIndex(idx) => NullIndexRead::values_is_empty(idx, point_id),
-        }
+            ReadOnlyFieldIndex::NullIndex(idx) => NullIndexRead::values_is_empty(idx, point_id)?,
+        })
     }
 
     fn value_retriever<'a, 'q>(
         &'a self,
         hw_counter: &'q HardwareCounterCell,
-    ) -> Option<VariableRetrieverFn<'q>>
+    ) -> OperationResult<Option<VariableRetrieverFn<'q>>>
     where
         'a: 'q,
     {
@@ -253,18 +253,18 @@ impl<S: UniversalReadExt> FieldIndexRead for ReadOnlyFieldIndex<S> {
         // rather than raw payload values — neither has a value retriever yet.
         // The numeric, map, bool and geo variants build their per-variant
         // closure via an inherent `value_retriever` method.
-        match self {
+        Ok(match self {
             ReadOnlyFieldIndex::IntIndex(idx) => Some(idx.value_retriever(hw_counter)),
             ReadOnlyFieldIndex::DatetimeIndex(idx) => Some(idx.value_retriever(hw_counter)),
             ReadOnlyFieldIndex::IntMapIndex(idx) => Some(idx.value_retriever(hw_counter)),
             ReadOnlyFieldIndex::KeywordIndex(idx) => Some(idx.value_retriever(hw_counter)),
             ReadOnlyFieldIndex::FloatIndex(idx) => Some(idx.value_retriever(hw_counter)),
-            ReadOnlyFieldIndex::BoolIndex(idx) => Some(idx.value_retriever(hw_counter)),
+            ReadOnlyFieldIndex::BoolIndex(idx) => Some(idx.value_retriever(hw_counter)?),
             ReadOnlyFieldIndex::GeoIndex(idx) => Some(idx.value_retriever(hw_counter)),
             ReadOnlyFieldIndex::UuidIndex(idx) => Some(idx.value_retriever(hw_counter)),
             ReadOnlyFieldIndex::UuidMapIndex(idx) => Some(idx.value_retriever(hw_counter)),
             ReadOnlyFieldIndex::FullTextIndex(_) | ReadOnlyFieldIndex::NullIndex(_) => None,
-        }
+        })
     }
 
     fn as_numeric(&self) -> Option<impl NumericFieldIndexRead + '_> {

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/tests.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/tests.rs
@@ -68,7 +68,7 @@ fn test_full_text_indexing() {
                 .unwrap();
         }
 
-        assert_eq!(index.count_indexed_points(), payloads.len());
+        assert_eq!(index.count_indexed_points().unwrap(), payloads.len());
 
         let hw_acc = HwMeasurementAcc::new();
         let hw_counter = hw_acc.get_counter_cell();
@@ -110,7 +110,7 @@ fn test_full_text_indexing() {
                 .is_none()
         );
 
-        assert_eq!(index.count_indexed_points(), payloads.len() - 2);
+        assert_eq!(index.count_indexed_points().unwrap(), payloads.len() - 2);
 
         let payload = serde_json::json!([
             "The last question was asked for the first time, half in jest, on May 21, 2061,",
@@ -123,7 +123,7 @@ fn test_full_text_indexing() {
         ]);
         index.add_point(4, &[&payload], &hw_cell).unwrap();
 
-        assert_eq!(index.count_indexed_points(), payloads.len() - 1);
+        assert_eq!(index.count_indexed_points().unwrap(), payloads.len() - 1);
 
         index.flusher()().unwrap();
     }
@@ -133,7 +133,7 @@ fn test_full_text_indexing() {
             .unwrap()
             .unwrap();
 
-        assert_eq!(index.count_indexed_points(), 4);
+        assert_eq!(index.count_indexed_points().unwrap(), 4);
 
         let hw_acc = HwMeasurementAcc::new();
         let hw_counter = hw_acc.get_counter_cell();
@@ -163,7 +163,7 @@ fn test_full_text_indexing() {
             .unwrap()
             .collect();
         assert!(search_res.is_empty());
-        assert_eq!(index.count_indexed_points(), 3);
+        assert_eq!(index.count_indexed_points().unwrap(), 3);
 
         index.remove_point(3).unwrap();
         let filter_condition = filter_request("the");
@@ -173,10 +173,10 @@ fn test_full_text_indexing() {
             .unwrap()
             .collect();
         assert_eq!(search_res, vec![1, 4]);
-        assert_eq!(index.count_indexed_points(), 2);
+        assert_eq!(index.count_indexed_points().unwrap(), 2);
 
         // check deletion of non-existing point
         index.remove_point(3).unwrap();
-        assert_eq!(index.count_indexed_points(), 2);
+        assert_eq!(index.count_indexed_points().unwrap(), 2);
     }
 }

--- a/lib/segment/src/index/field_index/full_text_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/mod.rs
@@ -122,7 +122,7 @@ mod tests {
         // Trait dispatch on the parent enum forwards into the leaf:
         // every document was indexed (3 points), and `brown` matches the two
         // that contain it while `lazy` matches only the second.
-        assert_eq!(index.count_indexed_points(), payloads.len());
+        assert_eq!(index.count_indexed_points().unwrap(), payloads.len());
 
         let key = JsonPath::new("test");
         let brown = FieldCondition::new_match(key.clone(), Match::new_text("brown"));

--- a/lib/segment/src/index/field_index/full_text_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/read_ops.rs
@@ -161,8 +161,8 @@ impl<S: UniversalRead> FullTextIndexRead for ReadOnlyFullTextIndex<S> {
 }
 
 impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyFullTextIndex<S> {
-    fn count_indexed_points(&self) -> usize {
-        FullTextIndexRead::points_count(self)
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(FullTextIndexRead::points_count(self))
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/full_text_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_ops.rs
@@ -148,8 +148,8 @@ impl FullTextIndexRead for FullTextIndex {
 }
 
 impl PayloadFieldIndexRead for FullTextIndex {
-    fn count_indexed_points(&self) -> usize {
-        FullTextIndexRead::points_count(self)
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(FullTextIndexRead::points_count(self))
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/geo_index/payload_index.rs
+++ b/lib/segment/src/index/field_index/geo_index/payload_index.rs
@@ -111,8 +111,8 @@ impl PayloadFieldIndex for GeoIndex {
 }
 
 impl PayloadFieldIndexRead for GeoIndex {
-    fn count_indexed_points(&self) -> usize {
-        self.points_count()
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(self.points_count())
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/geo_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/read_ops.rs
@@ -211,8 +211,8 @@ impl<S: UniversalRead> GeoIndexRead for ReadOnlyGeoIndex<S> {
 }
 
 impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyGeoIndex<S> {
-    fn count_indexed_points(&self) -> usize {
-        GeoIndexRead::points_count(self)
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(GeoIndexRead::points_count(self))
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/geo_index/tests.rs
+++ b/lib/segment/src/index/field_index/geo_index/tests.rs
@@ -412,7 +412,8 @@ fn geo_indexed_filtering(#[case] index_type: IndexType) {
         let (field_index, _, _) = build_random_index(1000, 5, index_type);
 
         let hw_counter = HardwareCounterCell::new();
-        let mut matched_points = (0..field_index.count_indexed_points() as PointOffsetType)
+        let mut matched_points = (0..field_index.count_indexed_points().unwrap()
+            as PointOffsetType)
             .filter_map(|idx| {
                 if field_index
                     .check_values_any(idx, &hw_counter, &check_fn.clone())

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/int.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/int.rs
@@ -42,8 +42,8 @@ impl PayloadFieldIndex for MapIndex<IntPayloadType> {
 }
 
 impl PayloadFieldIndexRead for MapIndex<IntPayloadType> {
-    fn count_indexed_points(&self) -> usize {
-        MapIndexRead::get_indexed_points(self)
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(MapIndexRead::get_indexed_points(self))
     }
 
     fn filter<'a>(
@@ -85,8 +85,8 @@ impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyMapIndex<IntPayloadT
 where
     Vec<<IntPayloadType as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
-    fn count_indexed_points(&self) -> usize {
-        MapIndexRead::get_indexed_points(self)
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(MapIndexRead::get_indexed_points(self))
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
@@ -48,8 +48,8 @@ impl PayloadFieldIndex for MapIndex<str> {
 }
 
 impl PayloadFieldIndexRead for MapIndex<str> {
-    fn count_indexed_points(&self) -> usize {
-        MapIndexRead::get_indexed_points(self)
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(MapIndexRead::get_indexed_points(self))
     }
 
     fn filter<'a>(
@@ -91,8 +91,8 @@ impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyMapIndex<str, S>
 where
     Vec<<str as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
-    fn count_indexed_points(&self) -> usize {
-        MapIndexRead::get_indexed_points(self)
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(MapIndexRead::get_indexed_points(self))
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/uuid.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/uuid.rs
@@ -46,8 +46,8 @@ impl PayloadFieldIndex for MapIndex<UuidIntType> {
 }
 
 impl PayloadFieldIndexRead for MapIndex<UuidIntType> {
-    fn count_indexed_points(&self) -> usize {
-        MapIndexRead::get_indexed_points(self)
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(MapIndexRead::get_indexed_points(self))
     }
 
     fn filter<'a>(
@@ -89,8 +89,8 @@ impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyMapIndex<UuidIntType
 where
     Vec<<UuidIntType as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
-    fn count_indexed_points(&self) -> usize {
-        MapIndexRead::get_indexed_points(self)
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(MapIndexRead::get_indexed_points(self))
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/map_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/read_only/mod.rs
@@ -98,7 +98,7 @@ mod tests {
         // Trait dispatch on the parent enum forwards into the leaf:
         // every point with at least one value is counted, and `red` matches
         // the two that contain it while `blue` matches only the third.
-        assert_eq!(index.count_indexed_points(), 3);
+        assert_eq!(index.count_indexed_points().unwrap(), 3);
 
         let key = JsonPath::new("color");
         let red = FieldCondition::new_match(key.clone(), Match::from("red".to_string()));

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index/mod.rs
@@ -267,11 +267,11 @@ mod tests {
                 .collect_vec(),
             vec![0, 2],
         );
-        assert_eq!(reopened_index.count_indexed_points(), 3);
+        assert_eq!(reopened_index.count_indexed_points().unwrap(), 3);
 
         // Direct API parity: deleted point reads as empty; live points don't.
-        assert!(reopened_index.values_is_empty(1));
-        assert!(!reopened_index.values_is_empty(0));
-        assert!(!reopened_index.values_is_empty(2));
+        assert!(reopened_index.values_is_empty(1).unwrap());
+        assert!(!reopened_index.values_is_empty(0).unwrap());
+        assert!(!reopened_index.values_is_empty(2).unwrap());
     }
 }

--- a/lib/segment/src/index/field_index/null_index/immutable_null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/immutable_null_index/read_ops.rs
@@ -35,8 +35,8 @@ impl NullIndexRead for ImmutableNullIndex {
 
 impl PayloadFieldIndexRead for ImmutableNullIndex {
     #[inline]
-    fn count_indexed_points(&self) -> usize {
-        self.indexed_points_count()
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(self.indexed_points_count())
     }
 
     #[inline]
@@ -45,7 +45,7 @@ impl PayloadFieldIndexRead for ImmutableNullIndex {
         condition: &'a FieldCondition,
         _hw_counter: &'a HardwareCounterCell,
     ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
-        Ok(read_ops::filter(self, condition))
+        read_ops::filter(self, condition)
     }
 
     #[inline]
@@ -54,7 +54,7 @@ impl PayloadFieldIndexRead for ImmutableNullIndex {
         condition: &FieldCondition,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<CardinalityEstimation>> {
-        Ok(read_ops::estimate_cardinality(self, condition))
+        read_ops::estimate_cardinality(self, condition)
     }
 
     #[inline]

--- a/lib/segment/src/index/field_index/null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/mod.rs
@@ -100,8 +100,8 @@ impl NullIndexRead for NullIndex {
 }
 
 impl PayloadFieldIndexRead for NullIndex {
-    fn count_indexed_points(&self) -> usize {
-        self.indexed_points_count()
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(self.indexed_points_count())
     }
 
     fn filter<'a>(
@@ -109,7 +109,7 @@ impl PayloadFieldIndexRead for NullIndex {
         condition: &'a FieldCondition,
         _hw_counter: &'a HardwareCounterCell,
     ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
-        Ok(read_ops::filter(self, condition))
+        read_ops::filter(self, condition)
     }
 
     fn estimate_cardinality(
@@ -117,7 +117,7 @@ impl PayloadFieldIndexRead for NullIndex {
         condition: &FieldCondition,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<super::CardinalityEstimation>> {
-        Ok(read_ops::estimate_cardinality(self, condition))
+        read_ops::estimate_cardinality(self, condition)
     }
 
     fn for_each_payload_block(

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index/mod.rs
@@ -103,10 +103,10 @@ mod tests {
             .collect();
 
         let is_empty_values: Vec<_> = (0..n)
-            .filter(|&id| null_index.values_is_empty(id))
+            .filter(|&id| null_index.values_is_empty(id).unwrap())
             .collect();
         let not_null_values: Vec<_> = (0..n)
-            .filter(|&id| !null_index.values_is_null(id))
+            .filter(|&id| !null_index.values_is_null(id).unwrap())
             .collect();
 
         for i in 0..n {
@@ -173,8 +173,8 @@ mod tests {
         index.flusher()().unwrap();
 
         for i in 0..10 {
-            assert!(!index.values_is_empty(i as PointOffsetType));
-            assert!(!index.values_is_null(i as PointOffsetType));
+            assert!(!index.values_is_empty(i as PointOffsetType).unwrap());
+            assert!(!index.values_is_null(i as PointOffsetType).unwrap());
         }
     }
 }

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index/read_ops.rs
@@ -34,8 +34,8 @@ impl NullIndexRead for MutableNullIndex {
 }
 
 impl PayloadFieldIndexRead for MutableNullIndex {
-    fn count_indexed_points(&self) -> usize {
-        self.indexed_points_count()
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(self.indexed_points_count())
     }
 
     fn filter<'a>(
@@ -43,7 +43,7 @@ impl PayloadFieldIndexRead for MutableNullIndex {
         condition: &'a FieldCondition,
         _hw_counter: &'a HardwareCounterCell,
     ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
-        Ok(read_ops::filter(self, condition))
+        read_ops::filter(self, condition)
     }
 
     fn estimate_cardinality(
@@ -51,7 +51,7 @@ impl PayloadFieldIndexRead for MutableNullIndex {
         condition: &FieldCondition,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<CardinalityEstimation>> {
-        Ok(read_ops::estimate_cardinality(self, condition))
+        read_ops::estimate_cardinality(self, condition)
     }
 
     fn for_each_payload_block(

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/mod.rs
@@ -11,9 +11,9 @@ mod read_ops;
 
 /// Read-only counterpart of [`MutableNullIndex`][1] / [`ImmutableNullIndex`][2].
 ///
-/// All flags are loaded into in-memory roaring bitmaps on open. The backing
-/// storage is bound to [`UniversalRead`][3] only — no buffer, no flusher,
-/// no write path. Query logic (filter / cardinality / condition checker) is
+/// Flags are materialized into in-memory roaring bitmaps on first use, not on
+/// open — nothing this index needs at open touches them. The backing storage is
+/// bound to [`UniversalRead`][3] only — no buffer, no flusher, no write path. Query logic (filter / cardinality / condition checker) is
 /// shared with the writable variant via the [`NullIndexRead`][4] trait.
 ///
 /// Each [`ReadOnlyRoaringFlags`] retains its backend `S` so a [`LiveReload`][5]
@@ -160,16 +160,16 @@ mod tests {
             vec![0, 2],
         );
         // Length read straight from the status file.
-        assert_eq!(index.count_indexed_points(), 4);
+        assert_eq!(index.count_indexed_points().unwrap(), 4);
 
-        assert!(index.values_is_empty(0));
-        assert!(!index.values_is_empty(1));
-        assert!(index.values_is_empty(2));
-        assert!(!index.values_is_empty(3));
+        assert!(index.values_is_empty(0).unwrap());
+        assert!(!index.values_is_empty(1).unwrap());
+        assert!(index.values_is_empty(2).unwrap());
+        assert!(!index.values_is_empty(3).unwrap());
 
-        assert!(index.values_is_null(0));
-        assert!(index.values_is_null(1));
-        assert!(!index.values_is_null(3));
+        assert!(index.values_is_null(0).unwrap());
+        assert!(index.values_is_null(1).unwrap());
+        assert!(!index.values_is_null(3).unwrap());
     }
 
     /// The incremental `LiveReload` path must land on exactly the same in-memory
@@ -180,8 +180,21 @@ mod tests {
     /// null point is appended. `live_reload` is handed only that delta, yet its
     /// bitmaps and the `total_point_count`-driven `is_empty` results must match
     /// the authoritative re-open.
+    /// The bitmaps are lazy, so `live_reload` has two distinct paths: patch the
+    /// in-memory bitmap in place, or — when nothing has materialized it yet —
+    /// leave it alone and let the eventual scan read the updated file. Both must
+    /// land on the same state, so both are exercised.
     #[test]
-    fn live_reload_matches_fresh_open() {
+    fn live_reload_matches_fresh_open_materialized() {
+        live_reload_matches_fresh_open(true);
+    }
+
+    #[test]
+    fn live_reload_matches_fresh_open_lazy() {
+        live_reload_matches_fresh_open(false);
+    }
+
+    fn live_reload_matches_fresh_open(materialize_before_reload: bool) {
         let dir = TempDir::with_prefix("read_only_null_index_live_reload").unwrap();
         let hw_counter = HardwareCounterCell::new();
 
@@ -203,6 +216,13 @@ mod tests {
         let mut reloaded = ReadOnlyNullIndex::<ReadOnly<MmapFile>>::open(&fs, dir.path(), 4)
             .unwrap()
             .unwrap();
+
+        if materialize_before_reload {
+            // Pull both bitmaps into memory, so the reload below takes its
+            // in-place delta path rather than deferring to a later scan.
+            reloaded.values_is_null(0).unwrap();
+            reloaded.values_is_empty(0).unwrap();
+        }
 
         // Writer's delta: drop point 1, flip point 2 (empty -> value), append a
         // null point 4 (which grows `total_point_count` to 5).
@@ -286,8 +306,8 @@ mod tests {
         assert_eq!(reloaded_not_empty, fresh_not_empty);
         assert_eq!(reloaded_empty, fresh_empty);
         assert_eq!(
-            reloaded.count_indexed_points(),
-            fresh.count_indexed_points()
+            reloaded.count_indexed_points().unwrap(),
+            fresh.count_indexed_points().unwrap()
         );
 
         // … and the concrete expected sets. Point 2's flip moves it from empty
@@ -296,7 +316,7 @@ mod tests {
         assert_eq!(reloaded_null, vec![0, 4]);
         assert_eq!(reloaded_not_empty, vec![2, 3]);
         assert_eq!(reloaded_empty, vec![0, 1, 4]);
-        assert_eq!(reloaded.count_indexed_points(), 5);
+        assert_eq!(reloaded.count_indexed_points().unwrap(), 5);
     }
 
     /// A partial on-disk layout — exactly one of the `has_values` / `is_null`

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/read_ops.rs
@@ -35,8 +35,8 @@ impl<S: UniversalRead> NullIndexRead for ReadOnlyNullIndex<S> {
 }
 
 impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyNullIndex<S> {
-    fn count_indexed_points(&self) -> usize {
-        self.indexed_points_count()
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(self.indexed_points_count())
     }
 
     fn filter<'a>(
@@ -44,7 +44,7 @@ impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyNullIndex<S> {
         condition: &'a FieldCondition,
         _hw_counter: &'a HardwareCounterCell,
     ) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
-        Ok(read_ops::filter(self, condition))
+        read_ops::filter(self, condition)
     }
 
     fn estimate_cardinality(
@@ -52,7 +52,7 @@ impl<S: UniversalReadExt> PayloadFieldIndexRead for ReadOnlyNullIndex<S> {
         condition: &FieldCondition,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Option<CardinalityEstimation>> {
-        Ok(read_ops::estimate_cardinality(self, condition))
+        read_ops::estimate_cardinality(self, condition)
     }
 
     fn for_each_payload_block(

--- a/lib/segment/src/index/field_index/null_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/null_index/read_ops.rs
@@ -44,15 +44,15 @@ pub trait NullIndexRead {
     /// Per-variant telemetry tag (e.g. `"mutable_null_index"`).
     fn telemetry_index_type(&self) -> &'static str;
 
-    fn values_count(&self, id: PointOffsetType) -> usize {
-        usize::from(self.has_values_flags().get(id))
+    fn values_count(&self, id: PointOffsetType) -> OperationResult<usize> {
+        Ok(usize::from(self.has_values_flags().get(id)?))
     }
 
-    fn values_is_empty(&self, id: PointOffsetType) -> bool {
-        !self.has_values_flags().get(id)
+    fn values_is_empty(&self, id: PointOffsetType) -> OperationResult<bool> {
+        Ok(!self.has_values_flags().get(id)?)
     }
 
-    fn values_is_null(&self, id: PointOffsetType) -> bool {
+    fn values_is_null(&self, id: PointOffsetType) -> OperationResult<bool> {
         self.is_null_flags().get(id)
     }
 
@@ -60,13 +60,14 @@ pub trait NullIndexRead {
         self.has_values_flags().len()
     }
 
+    /// Zero while neither bitmap is materialized — nothing is held in RAM yet.
     fn ram_usage_bytes(&self) -> usize {
-        self.has_values_flags().get_bitmap().serialized_size()
-            + self.is_null_flags().get_bitmap().serialized_size()
+        self.has_values_flags().ram_usage_bytes() + self.is_null_flags().ram_usage_bytes()
     }
 
     /// Whether the index keeps its primary data on disk. Default `false` —
-    /// the bitmap is in RAM after open for every current variant.
+    /// every current variant serves reads from an in-RAM bitmap (the read-only
+    /// one materializes it on first use).
     fn is_on_disk(&self) -> bool {
         false
     }
@@ -94,6 +95,8 @@ pub trait NullIndexRead {
     }
 
     fn get_telemetry_data(&self) -> PayloadIndexTelemetry {
+        // `indexed_points_count` is the status file's `len`, so telemetry never
+        // forces a bitmap scan.
         let points_count = self.indexed_points_count();
         PayloadIndexTelemetry {
             field_name: None,
@@ -108,7 +111,7 @@ pub trait NullIndexRead {
 pub(super) fn filter<'a, N: NullIndexRead>(
     null_index: &'a N,
     condition: &'a FieldCondition,
-) -> Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>> {
+) -> OperationResult<Option<Box<dyn Iterator<Item = PointOffsetType> + 'a>>> {
     let FieldCondition {
         key: _,
         r#match: _,
@@ -125,37 +128,39 @@ pub(super) fn filter<'a, N: NullIndexRead>(
     let is_null_flags = null_index.is_null_flags();
     let total_point_count = null_index.total_point_count();
 
-    if let Some(is_empty) = is_empty {
+    let iter: Box<dyn Iterator<Item = PointOffsetType> + 'a> = if let Some(is_empty) = is_empty {
         if *is_empty {
             // Return points that don't have values
-            Some(Box::new(has_values_flags.iter_falses().chain({
+            Box::new(has_values_flags.iter_falses()?.chain({
                 let end = has_values_flags.len() as PointOffsetType;
                 end..total_point_count as u32
-            })))
+            }))
         } else {
             // Return points that have values
-            Some(Box::new(has_values_flags.iter_trues()))
+            Box::new(has_values_flags.iter_trues()?)
         }
     } else if let Some(is_null) = is_null {
         if *is_null {
             // Return points that have null values
-            Some(Box::new(is_null_flags.iter_trues()))
+            Box::new(is_null_flags.iter_trues()?)
         } else {
             // Return points that don't have null values
-            Some(Box::new(is_null_flags.iter_falses().chain({
+            Box::new(is_null_flags.iter_falses()?.chain({
                 let end = is_null_flags.len() as PointOffsetType;
                 end..total_point_count as u32
-            })))
+            }))
         }
     } else {
-        None
-    }
+        return Ok(None);
+    };
+
+    Ok(Some(iter))
 }
 
 pub(super) fn estimate_cardinality<N: NullIndexRead>(
     null_index: &N,
     condition: &FieldCondition,
-) -> Option<CardinalityEstimation> {
+) -> OperationResult<Option<CardinalityEstimation>> {
     let FieldCondition {
         key,
         r#match: _,
@@ -172,12 +177,12 @@ pub(super) fn estimate_cardinality<N: NullIndexRead>(
     let is_null_flags = null_index.is_null_flags();
     let total_point_count = null_index.total_point_count();
 
-    if let Some(is_empty) = is_empty {
+    let estimation = if let Some(is_empty) = is_empty {
         if *is_empty {
-            let has_values_count = has_values_flags.count_trues();
+            let has_values_count = has_values_flags.count_trues()?;
             let estimated = total_point_count.saturating_sub(has_values_count);
 
-            Some(CardinalityEstimation {
+            CardinalityEstimation {
                 min: 0,
                 exp: 2 * estimated / 3, // assuming 1/3 of the points are deleted
                 max: estimated,
@@ -185,28 +190,24 @@ pub(super) fn estimate_cardinality<N: NullIndexRead>(
                     key.clone(),
                     true,
                 ))],
-            })
+            }
         } else {
-            let count = has_values_flags.count_trues();
-            Some(
-                CardinalityEstimation::exact(count).with_primary_clause(PrimaryCondition::from(
-                    FieldCondition::new_is_empty(key.clone(), false),
-                )),
-            )
+            let count = has_values_flags.count_trues()?;
+            CardinalityEstimation::exact(count).with_primary_clause(PrimaryCondition::from(
+                FieldCondition::new_is_empty(key.clone(), false),
+            ))
         }
     } else if let Some(is_null) = is_null {
         if *is_null {
-            let count = is_null_flags.count_trues();
-            Some(
-                CardinalityEstimation::exact(count).with_primary_clause(PrimaryCondition::from(
-                    FieldCondition::new_is_null(key.clone(), true),
-                )),
-            )
+            let count = is_null_flags.count_trues()?;
+            CardinalityEstimation::exact(count).with_primary_clause(PrimaryCondition::from(
+                FieldCondition::new_is_null(key.clone(), true),
+            ))
         } else {
-            let is_null_count = is_null_flags.count_trues();
+            let is_null_count = is_null_flags.count_trues()?;
             let estimated = total_point_count.saturating_sub(is_null_count);
 
-            Some(CardinalityEstimation {
+            CardinalityEstimation {
                 min: 0,
                 exp: 2 * estimated / 3, // assuming 1/3 of the points are deleted
                 max: estimated,
@@ -214,11 +215,13 @@ pub(super) fn estimate_cardinality<N: NullIndexRead>(
                     key.clone(),
                     false,
                 ))],
-            })
+            }
         }
     } else {
-        None
-    }
+        return Ok(None);
+    };
+
+    Ok(Some(estimation))
 }
 
 pub(super) fn condition_checker<'a, N: NullIndexRead>(
@@ -273,8 +276,8 @@ impl<N: NullIndexRead> ConditionChecker for NullConditionChecker<'_, N> {
 
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         let actual = match self.kind {
-            CheckKind::IsEmpty => self.null_index.values_is_empty(point_id),
-            CheckKind::IsNull => self.null_index.values_is_null(point_id),
+            CheckKind::IsEmpty => self.null_index.values_is_empty(point_id)?,
+            CheckKind::IsNull => self.null_index.values_is_null(point_id)?,
         };
         Ok(actual == self.expected)
     }

--- a/lib/segment/src/index/field_index/numeric_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_only/read_ops.rs
@@ -97,7 +97,7 @@ impl<T: NumericIndexValue, P, S: UniversalReadExt> PayloadFieldIndexRead
 where
     Vec<T>: Blob,
 {
-    fn count_indexed_points(&self) -> usize {
+    fn count_indexed_points(&self) -> OperationResult<usize> {
         self.inner.count_indexed_points()
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_ops.rs
@@ -51,7 +51,7 @@ impl<T: NumericIndexValue, P> PayloadFieldIndexRead for NumericIndex<T, P>
 where
     Vec<T>: Blob,
 {
-    fn count_indexed_points(&self) -> usize {
+    fn count_indexed_points(&self) -> OperationResult<usize> {
         self.inner.count_indexed_points()
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/trait_impls.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/trait_impls.rs
@@ -25,8 +25,8 @@ impl<T: NumericIndexValue, S: UniversalReadExt> PayloadFieldIndexRead
 where
     Vec<T>: Blob,
 {
-    fn count_indexed_points(&self) -> usize {
-        self.get_points_count()
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(self.get_points_count())
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/numeric_index/storage/trait_impls.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/trait_impls.rs
@@ -60,8 +60,8 @@ impl<T: NumericIndexValue> PayloadFieldIndexRead for NumericIndexInner<T>
 where
     Vec<T>: Blob,
 {
-    fn count_indexed_points(&self) -> usize {
-        self.get_points_count()
+    fn count_indexed_points(&self) -> OperationResult<usize> {
+        Ok(self.get_points_count())
     }
 
     fn filter<'a>(

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -875,7 +875,7 @@ fn test_remove_reopen() {
     let index = open_index_from_disk(temp_dir.path(), IndexType::RamMmap, &deleted);
 
     // Deletions reflected in the indexed-point count.
-    assert_eq!(index.inner().count_indexed_points(), 2);
+    assert_eq!(index.inner().count_indexed_points().unwrap(), 2);
 
     // Range query covering all four original values returns only the live
     // ones; deleted points must be filtered out by the immutable index.

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -69,7 +69,11 @@ pub trait PayloadIndexRead {
     ) -> OperationResult<Vec<PointOffsetType>>;
 
     /// Return number of points, indexed by this field
-    fn indexed_points(&self, field: PayloadKeyTypeRef) -> usize;
+    ///
+    /// Fallible: see [`PayloadFieldIndexRead::count_indexed_points`].
+    ///
+    /// [`PayloadFieldIndexRead::count_indexed_points`]: crate::index::field_index::PayloadFieldIndexRead::count_indexed_points
+    fn indexed_points(&self, field: PayloadKeyTypeRef) -> OperationResult<usize>;
 
     fn filter_context<'a>(
         &'a self,
@@ -91,7 +95,7 @@ pub trait PayloadIndexRead {
     fn facet_index_for(&self, key: &JsonPath) -> Option<impl FacetIndex + '_>;
 
     /// Per-field-index telemetry data.
-    fn get_telemetry_data(&self) -> Vec<PayloadIndexTelemetry>;
+    fn get_telemetry_data(&self) -> OperationResult<Vec<PayloadIndexTelemetry>>;
 
     /// Build a per-query formula scorer that evaluates the given parsed
     /// formula against this index's payload, using the prefetch scores as

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -126,8 +126,8 @@ impl PayloadIndexRead for PlainPayloadIndex {
             .collect()
     }
 
-    fn indexed_points(&self, _field: PayloadKeyTypeRef) -> usize {
-        0 // No points are indexed in the plain index
+    fn indexed_points(&self, _field: PayloadKeyTypeRef) -> OperationResult<usize> {
+        Ok(0) // No points are indexed in the plain index
     }
 
     fn filter_context<'a>(
@@ -188,9 +188,9 @@ impl PayloadIndexRead for PlainPayloadIndex {
         None::<FacetIndexEnum<'_>>
     }
 
-    fn get_telemetry_data(&self) -> Vec<PayloadIndexTelemetry> {
+    fn get_telemetry_data(&self) -> OperationResult<Vec<PayloadIndexTelemetry>> {
         // Plain index has no field indexes to report telemetry for.
-        Vec::new()
+        Ok(Vec::new())
     }
 
     fn formula_scorer<'q>(

--- a/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
@@ -98,15 +98,11 @@ where
             .and_then(|indexes| indexes.iter().find_map(|index| index.as_numeric()))
     }
 
-    fn get_telemetry_data(&self) -> Vec<PayloadIndexTelemetry> {
+    fn get_telemetry_data(&self) -> OperationResult<Vec<PayloadIndexTelemetry>> {
         self.field_indexes
             .iter()
-            .flat_map(|(name, field)| -> Vec<PayloadIndexTelemetry> {
-                field
-                    .iter()
-                    .map(|field| field.get_telemetry_data().set_name(name.to_string()))
-                    .collect()
-            })
+            .flat_map(|(name, field)| field.iter().map(move |field| (name, field)))
+            .map(|(name, field)| Ok(field.get_telemetry_data()?.set_name(name.to_string())))
             .collect()
     }
 
@@ -129,7 +125,7 @@ where
             formula,
         } = parsed_formula;
 
-        let payload_retrievers = self.retrievers_map(payload_vars.clone(), hw_counter);
+        let payload_retrievers = self.retrievers_map(payload_vars.clone(), hw_counter)?;
 
         let payload_provider = PayloadProvider::new(self.payload.clone());
         let total = self.available_point_count();
@@ -240,17 +236,20 @@ where
         }
     }
 
-    fn indexed_points(&self, field: PayloadKeyTypeRef) -> usize {
-        self.field_indexes.get(field).map_or(0, |indexes| {
-            // Assume that multiple field indexes are applied to the same data type,
-            // so the points indexed with those indexes are the same.
-            // We will return minimal number as a worst case, to highlight possible errors in the index early.
-            indexes
-                .iter()
-                .map(|index| index.count_indexed_points())
-                .min()
-                .unwrap_or(0)
-        })
+    fn indexed_points(&self, field: PayloadKeyTypeRef) -> OperationResult<usize> {
+        let Some(indexes) = self.field_indexes.get(field) else {
+            return Ok(0);
+        };
+
+        // Assume that multiple field indexes are applied to the same data type,
+        // so the points indexed with those indexes are the same.
+        // We will return minimal number as a worst case, to highlight possible errors in the index early.
+        let counts = indexes
+            .iter()
+            .map(|index| index.count_indexed_points())
+            .collect::<OperationResult<Vec<_>>>()?;
+
+        Ok(counts.into_iter().min().unwrap_or(0))
     }
 
     fn filter_context<'b>(

--- a/lib/segment/src/index/struct_payload_index/read_view/value_retriever/helpers.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/value_retriever/helpers.rs
@@ -4,6 +4,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use serde_json::Value;
 
+use crate::common::operation_error::OperationResult;
 use crate::common::utils::MultiValue;
 use crate::index::field_index::FieldIndexRead;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
@@ -17,25 +18,32 @@ pub(super) fn variable_retriever<'a, 'q, P, F>(
     json_path: &JsonPath,
     payload_provider: PayloadProvider<P>,
     hw_counter: &'q HardwareCounterCell,
-) -> VariableRetrieverFn<'q>
+) -> OperationResult<VariableRetrieverFn<'q>>
 where
     P: PayloadStorageRead + 'q,
     F: FieldIndexRead,
     'a: 'q,
 {
-    indices
-        .get(json_path)
-        .and_then(|indices| {
-            indices
-                .iter()
-                .find_map(|index| index.value_retriever(hw_counter))
-        })
-        // TODO(scoreboost): optimize by reusing the same payload for all variables?
-        .unwrap_or_else(|| {
-            // if the variable is not found in the index, try to find it in the payload
-            let key = json_path.clone();
-            payload_variable_retriever(payload_provider, key, hw_counter)
-        })
+    let indexed = match indices.get(json_path) {
+        Some(indices) => {
+            let mut found = None;
+            for index in indices {
+                if let Some(retriever) = index.value_retriever(hw_counter)? {
+                    found = Some(retriever);
+                    break;
+                }
+            }
+            found
+        }
+        None => None,
+    };
+
+    // TODO(scoreboost): optimize by reusing the same payload for all variables?
+    Ok(indexed.unwrap_or_else(|| {
+        // if the variable is not found in the index, try to find it in the payload
+        let key = json_path.clone();
+        payload_variable_retriever(payload_provider, key, hw_counter)
+    }))
 }
 
 fn payload_variable_retriever<'a, P: PayloadStorageRead + 'a>(
@@ -161,7 +169,8 @@ mod tests {
             &"value".try_into().unwrap(),
             payload_provider.clone(),
             &hw_counter,
-        );
+        )
+        .unwrap();
         for id in 0..=3 {
             let value = retriever(id);
             match id {
@@ -179,7 +188,8 @@ mod tests {
             &"location".try_into().unwrap(),
             payload_provider.clone(),
             &hw_counter,
-        );
+        )
+        .unwrap();
         for id in 0..=3 {
             let value = retriever(id);
             match id {
@@ -259,7 +269,8 @@ mod tests {
             &"value".try_into().unwrap(),
             payload_provider.clone(),
             &hw_counter,
-        );
+        )
+        .unwrap();
         for id in 0..=2 {
             let value = retriever(id);
             match id {
@@ -276,7 +287,8 @@ mod tests {
             &"location".try_into().unwrap(),
             payload_provider.clone(),
             &hw_counter,
-        );
+        )
+        .unwrap();
         for id in 0..=2 {
             let value = retriever(id);
             match id {
@@ -293,7 +305,8 @@ mod tests {
             &"creation".try_into().unwrap(),
             payload_provider.clone(),
             &hw_counter,
-        );
+        )
+        .unwrap();
         for id in 0..=2 {
             let value = retriever(id);
             match id {

--- a/lib/segment/src/index/struct_payload_index/read_view/value_retriever/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/value_retriever/mod.rs
@@ -6,6 +6,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 
 use self::helpers::variable_retriever;
 use super::StructPayloadIndexReadView;
+use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::field_index::FieldIndexRead;
 use crate::index::query_optimization::payload_provider::PayloadProvider;
@@ -26,7 +27,7 @@ where
         &'b self,
         variables: HashSet<JsonPath>,
         hw_counter: &'q HardwareCounterCell,
-    ) -> HashMap<JsonPath, VariableRetrieverFn<'q>>
+    ) -> OperationResult<HashMap<JsonPath, VariableRetrieverFn<'q>>>
     where
         'b: 'q,
     {
@@ -42,11 +43,11 @@ where
                 &key,
                 payload_provider.clone(),
                 hw_counter,
-            );
+            )?;
 
             var_retrievers.insert(key, retriever);
         }
 
-        var_retrievers
+        Ok(var_retrievers)
     }
 }

--- a/lib/segment/src/index/struct_payload_index/tests.rs
+++ b/lib/segment/src/index/struct_payload_index/tests.rs
@@ -241,7 +241,7 @@ fn build_index_reloads_in_new_mode_on_on_disk_change() {
         .get(&field)
         .unwrap()
         .iter()
-        .map(|i| i.count_indexed_points())
+        .map(|i| i.count_indexed_points().unwrap())
         .sum();
     assert!(before_count > 0, "fixture should index some integer points");
 
@@ -261,7 +261,10 @@ fn build_index_reloads_in_new_mode_on_on_disk_change() {
                 indexes.iter().any(|i| i.is_on_disk()),
                 "an on_disk-only change must reload the existing index in on-disk mode",
             );
-            let after_count: usize = indexes.iter().map(|i| i.count_indexed_points()).sum();
+            let after_count: usize = indexes
+                .iter()
+                .map(|i| i.count_indexed_points().unwrap())
+                .sum();
             assert_eq!(
                 after_count, before_count,
                 "reloading in the new mode must preserve the indexed points",

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -306,7 +306,7 @@ impl ReadSegmentEntry for Segment {
         })
     }
 
-    fn info(&self) -> SegmentInfo {
+    fn info(&self) -> OperationResult<SegmentInfo> {
         self.with_view(|view| view.build_info(self.uuid, self.segment_type, self.appendable_flag))
     }
 
@@ -327,7 +327,7 @@ impl ReadSegmentEntry for Segment {
         self.vector_data.keys().cloned().collect()
     }
 
-    fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry {
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationResult<SegmentTelemetry> {
         self.with_view(|view| {
             view.build_telemetry(
                 self.uuid,

--- a/lib/segment/src/segment/read_only/read_entry.rs
+++ b/lib/segment/src/segment/read_only/read_entry.rs
@@ -304,7 +304,7 @@ impl<S: UniversalReadExt + 'static> ReadSegmentEntry for ReadOnlySegment<S> {
         self.segment_type
     }
 
-    fn info(&self) -> SegmentInfo {
+    fn info(&self) -> OperationResult<SegmentInfo> {
         // A read-only segment is never appendable.
         self.with_view(|view| view.build_info(self.uuid, self.segment_type, false))
     }
@@ -328,7 +328,7 @@ impl<S: UniversalReadExt + 'static> ReadSegmentEntry for ReadOnlySegment<S> {
             .with_view(|v| v.indexed_fields())
     }
 
-    fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry {
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationResult<SegmentTelemetry> {
         self.with_view(|view| {
             // A read-only segment is never appendable.
             view.build_telemetry(

--- a/lib/segment/src/segment/read_view/info.rs
+++ b/lib/segment/src/segment/read_view/info.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use common::types::TelemetryDetail;
 use uuid::Uuid;
 
+use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::{PayloadIndexRead, VectorIndexRead};
 use crate::payload_storage::PayloadStorageRead;
@@ -102,19 +103,18 @@ where
         uuid: Uuid,
         segment_type: SegmentType,
         is_appendable: bool,
-    ) -> SegmentInfo {
+    ) -> OperationResult<SegmentInfo> {
         let mut info = self.build_size_info(uuid, segment_type, is_appendable);
         info.index_schema = self
             .payload_index
             .indexed_fields()
             .into_iter()
             .map(|(key, index_schema)| {
-                let points_count = self.payload_index.indexed_points(&key);
-                let index_info = PayloadIndexInfo::new(index_schema, points_count);
-                (key, index_info)
+                let points_count = self.payload_index.indexed_points(&key)?;
+                Ok((key, PayloadIndexInfo::new(index_schema, points_count)))
             })
-            .collect();
-        info
+            .collect::<OperationResult<_>>()?;
+        Ok(info)
     }
 
     /// Build the segment-level telemetry payload.
@@ -125,7 +125,7 @@ where
         is_appendable: bool,
         config: &SegmentConfig,
         detail: TelemetryDetail,
-    ) -> SegmentTelemetry {
+    ) -> OperationResult<SegmentTelemetry> {
         let vector_index_searches = self
             .vector_data
             .iter()
@@ -136,11 +136,11 @@ where
             })
             .collect();
 
-        SegmentTelemetry {
-            info: self.build_info(uuid, segment_type, is_appendable),
+        Ok(SegmentTelemetry {
+            info: self.build_info(uuid, segment_type, is_appendable)?,
             config: config.clone(),
             vector_index_searches,
-            payload_field_indices: self.payload_index.get_telemetry_data(),
-        }
+            payload_field_indices: self.payload_index.get_telemetry_data()?,
+        })
     }
 }

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -526,19 +526,19 @@ fn test_point_vector_count() {
     segment
         .upsert_point(101, 6.into(), only_default_vector(&[0.6]), &hw_counter)
         .unwrap();
-    let segment_info = segment.info();
+    let segment_info = segment.info().unwrap();
     assert_eq!(segment_info.num_points, 2);
     assert_eq!(segment_info.num_vectors, 2);
 
     // Delete nonexistent point, counts should remain the same
     segment.delete_point(102, 1.into(), &hw_counter).unwrap();
-    let segment_info = segment.info();
+    let segment_info = segment.info().unwrap();
     assert_eq!(segment_info.num_points, 2);
     assert_eq!(segment_info.num_vectors, 2);
 
     // Delete point 4, counts should decrease by 1
     segment.delete_point(103, 4.into(), &hw_counter).unwrap();
-    let segment_info = segment.info();
+    let segment_info = segment.info().unwrap();
     assert_eq!(segment_info.num_points, 1);
     assert_eq!(segment_info.num_vectors, 2); // We don't propagate deletes to vectors at this time
 
@@ -546,7 +546,7 @@ fn test_point_vector_count() {
     // segment
     //     .delete_vector(104, 6.into(), DEFAULT_VECTOR_NAME)
     //     .unwrap();
-    // let segment_info = segment.info();
+    // let segment_info = segment.info().unwrap();
     // assert_eq!(segment_info.num_points, 1);
     // assert_eq!(segment_info.num_vectors, 1);
 }
@@ -601,31 +601,31 @@ fn test_point_vector_count_multivec() {
             &hw_counter,
         )
         .unwrap();
-    let segment_info = segment.info();
+    let segment_info = segment.info().unwrap();
     assert_eq!(segment_info.num_points, 4);
     assert_eq!(segment_info.num_vectors, 6);
 
     // Delete nonexistent point, counts should remain the same
     segment.delete_point(104, 1.into(), &hw_counter).unwrap();
-    let segment_info = segment.info();
+    let segment_info = segment.info().unwrap();
     assert_eq!(segment_info.num_points, 4);
     assert_eq!(segment_info.num_vectors, 6);
 
     // Delete point 4, counts should decrease by 1
     segment.delete_point(105, 4.into(), &hw_counter).unwrap();
-    let segment_info = segment.info();
+    let segment_info = segment.info().unwrap();
     assert_eq!(segment_info.num_points, 3);
     assert_eq!(segment_info.num_vectors, 6); // We don't propagate deletes to vectors at this time
 
     // Delete vector 'a' of point 6, vector count should decrease by 1
     segment.delete_vector(106, 6.into(), VECTOR1_NAME).unwrap();
-    let segment_info = segment.info();
+    let segment_info = segment.info().unwrap();
     assert_eq!(segment_info.num_points, 3);
     assert_eq!(segment_info.num_vectors, 5);
 
     // Deleting it again shouldn't chain anything
     segment.delete_vector(107, 6.into(), VECTOR1_NAME).unwrap();
-    let segment_info = segment.info();
+    let segment_info = segment.info().unwrap();
     assert_eq!(segment_info.num_points, 3);
     assert_eq!(segment_info.num_vectors, 5);
 
@@ -641,7 +641,7 @@ fn test_point_vector_count_multivec() {
             &hw_counter,
         )
         .unwrap();
-    let segment_info = segment.info();
+    let segment_info = segment.info().unwrap();
     assert_eq!(segment_info.num_points, 3);
     assert_eq!(segment_info.num_vectors, 5);
 
@@ -657,7 +657,7 @@ fn test_point_vector_count_multivec() {
             &hw_counter,
         )
         .unwrap();
-    let segment_info = segment.info();
+    let segment_info = segment.info().unwrap();
     assert_eq!(segment_info.num_points, 3);
     assert_eq!(segment_info.num_vectors, 6);
 }

--- a/lib/segment/tests/integration/payload_index_test.rs
+++ b/lib/segment/tests/integration/payload_index_test.rs
@@ -255,10 +255,10 @@ impl TestSegments {
 
         for (field, indexes) in struct_segment.payload_index.borrow().field_indexes.iter() {
             for index in indexes {
-                assert!(index.count_indexed_points() <= num_points as usize);
+                assert!(index.count_indexed_points().unwrap() <= num_points as usize);
                 if field.to_string() != FLICKING_KEY {
                     assert!(
-                        index.count_indexed_points()
+                        index.count_indexed_points().unwrap()
                             >= (num_points as usize - points_to_delete - points_to_clear)
                     );
                 }
@@ -511,9 +511,9 @@ fn build_test_segments_nested_payload(path_struct: &Path, path_plain: &Path) -> 
 
     for indexes in struct_segment.payload_index.borrow().field_indexes.values() {
         for index in indexes {
-            assert!(index.count_indexed_points() <= num_points as usize);
+            assert!(index.count_indexed_points().unwrap() <= num_points as usize);
             assert!(
-                index.count_indexed_points()
+                index.count_indexed_points().unwrap()
                     > (num_points as usize - points_to_delete - points_to_clear)
             );
         }
@@ -1327,8 +1327,8 @@ fn test_update_payload_index_type() {
         FieldType(Integer)
     );
     let field_index = index.field_indexes.get(&field).unwrap();
-    assert_eq!(field_index[0].count_indexed_points(), point_num);
-    assert_eq!(field_index[1].count_indexed_points(), point_num);
+    assert_eq!(field_index[0].count_indexed_points().unwrap(), point_num);
+    assert_eq!(field_index[1].count_indexed_points().unwrap(), point_num);
 
     // update field to Keyword type
     index.set_indexed(&field, Keyword, &hw_counter).unwrap();
@@ -1337,7 +1337,7 @@ fn test_update_payload_index_type() {
         FieldType(Keyword)
     );
     let field_index = index.field_indexes.get(&field).unwrap();
-    assert_eq!(field_index[0].count_indexed_points(), 0); // only one field index for Keyword
+    assert_eq!(field_index[0].count_indexed_points().unwrap(), 0); // only one field index for Keyword
 
     // set field to Integer type (again)
     index.set_indexed(&field, Integer, &hw_counter).unwrap();
@@ -1346,8 +1346,8 @@ fn test_update_payload_index_type() {
         FieldType(Integer)
     );
     let field_index = index.field_indexes.get(&field).unwrap();
-    assert_eq!(field_index[0].count_indexed_points(), point_num);
-    assert_eq!(field_index[1].count_indexed_points(), point_num);
+    assert_eq!(field_index[0].count_indexed_points().unwrap(), point_num);
+    assert_eq!(field_index[1].count_indexed_points().unwrap(), point_num);
 }
 
 /// An appendable segment with a bool payload index must still accept updates
@@ -1407,7 +1407,7 @@ fn test_bool_index_appendable_reopen_accepts_updates() {
         .iter()
         .find(|fi| matches!(fi, FieldIndex::BoolIndex(_)))
         .expect("bool index present after reopen");
-    assert_eq!(bool_index.count_indexed_points(), 2);
+    assert_eq!(bool_index.count_indexed_points().unwrap(), 2);
 }
 
 /// An appendable segment with a payload field index carries a companion null

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -423,7 +423,7 @@ fn sparse_vector_index_ram_filtered_search() {
 
     let field_indexes = &payload_index.field_indexes;
     let field_index = field_indexes.get(&JsonPath::new(field_name)).unwrap();
-    assert_eq!(field_index[0].count_indexed_points(), 0);
+    assert_eq!(field_index[0].count_indexed_points().unwrap(), 0);
     drop(payload_index);
 
     // add payload on the first half of the points
@@ -442,7 +442,10 @@ fn sparse_vector_index_ram_filtered_search() {
     let payload_index = sparse_vector_index.payload_index().borrow();
     let field_indexes = &payload_index.field_indexes;
     let field_index = field_indexes.get(&JsonPath::new(field_name)).unwrap();
-    assert_eq!(field_index[0].count_indexed_points(), half_indexed_count);
+    assert_eq!(
+        field_index[0].count_indexed_points().unwrap(),
+        half_indexed_count
+    );
     drop(payload_index);
 
     // request all points with payload

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -48,6 +48,80 @@ impl ProxySegment {
             .collect();
         (with_vector, filtered_point_ids)
     }
+
+    /// Restate the wrapped segment's info as the proxy's own: drop stale vector
+    /// data, and net out the points and vectors the proxy has deleted.
+    ///
+    /// Takes the wrapped info rather than fetching it, so both
+    /// [`SegmentEntry::info`] (which needs `index_schema`, and can fail) and
+    /// [`SegmentEntry::size_info`] (which cannot) can share it.
+    fn adjusted_info(&self, wrapped_info: SegmentInfo) -> SegmentInfo {
+        // Remove vector-data entries for names that the proxy has deleted or
+        // superseded with a different schema — their counts and size reflect
+        // the old, stale storage and should not be surfaced.
+        let mut vector_data = wrapped_info.vector_data;
+        let mut removed_num_vectors = 0usize;
+        let mut removed_num_indexed = 0usize;
+        let mut removed_num_deleted = 0usize;
+        vector_data.retain(|name, info| {
+            if self.changed_vector_names.is_wrapped_data_stale(name) {
+                removed_num_vectors += info.num_vectors;
+                removed_num_indexed += info.num_indexed_vectors;
+                removed_num_deleted += info.num_deleted_vectors;
+                false
+            } else {
+                true
+            }
+        });
+
+        let vector_name_count = vector_data.len();
+        let deleted_points_count = self.deleted_points.len();
+
+        // Best estimate: start from wrapped aggregate, subtract what we just
+        // removed (stale vectors) and what the proxy deleted (per-point
+        // deletions × remaining vector names).
+        let num_vectors = wrapped_info
+            .num_vectors
+            .saturating_sub(removed_num_vectors)
+            .saturating_sub(deleted_points_count * vector_name_count);
+
+        let num_indexed_vectors = if wrapped_info.segment_type == SegmentType::Indexed {
+            wrapped_info
+                .num_indexed_vectors
+                .saturating_sub(removed_num_indexed)
+                .saturating_sub(deleted_points_count * vector_name_count)
+        } else {
+            0
+        };
+
+        let num_deleted_vectors = wrapped_info
+            .num_deleted_vectors
+            .saturating_sub(removed_num_deleted)
+            + deleted_points_count * vector_name_count;
+
+        SegmentInfo {
+            uuid: wrapped_info.uuid,
+            segment_type: SegmentType::Special,
+            num_vectors,
+            num_indexed_vectors,
+            num_points: self.available_point_count(),
+            num_deferred_points: Some(self.deferred_point_count()),
+            num_deleted_deferred_points: wrapped_info.num_deleted_deferred_points.map(
+                |num_deleted_deferred_points| {
+                    num_deleted_deferred_points.saturating_add(self.deleted_deferred_count)
+                },
+            ),
+            num_deleted_vectors,
+            vectors_size_bytes: wrapped_info.vectors_size_bytes,
+            payloads_size_bytes: wrapped_info.payloads_size_bytes,
+            ram_usage_bytes: wrapped_info.ram_usage_bytes,
+            disk_usage_bytes: wrapped_info.disk_usage_bytes,
+            is_appendable: false,
+            index_schema: wrapped_info.index_schema,
+            vector_data,
+            deferred_internal_id: wrapped_info.deferred_internal_id,
+        }
+    }
 }
 
 impl ReadSegmentEntry for ProxySegment {
@@ -637,78 +711,15 @@ impl ReadSegmentEntry for ProxySegment {
     }
 
     fn size_info(&self) -> SegmentInfo {
-        // To reduce code complexity for estimations, we use `.info()` directly here.
-        self.info()
+        // Same proxy adjustments as `info`, over the wrapped segment's size
+        // info. Uses `size_info` rather than `info` so it stays infallible:
+        // only `info`'s `index_schema` can fail to compute.
+        self.adjusted_info(self.wrapped_segment.get().read().size_info())
     }
 
-    fn info(&self) -> SegmentInfo {
-        let wrapped_info = self.wrapped_segment.get().read().info();
-
-        // Remove vector-data entries for names that the proxy has deleted or
-        // superseded with a different schema — their counts and size reflect
-        // the old, stale storage and should not be surfaced.
-        let mut vector_data = wrapped_info.vector_data;
-        let mut removed_num_vectors = 0usize;
-        let mut removed_num_indexed = 0usize;
-        let mut removed_num_deleted = 0usize;
-        vector_data.retain(|name, info| {
-            if self.changed_vector_names.is_wrapped_data_stale(name) {
-                removed_num_vectors += info.num_vectors;
-                removed_num_indexed += info.num_indexed_vectors;
-                removed_num_deleted += info.num_deleted_vectors;
-                false
-            } else {
-                true
-            }
-        });
-
-        let vector_name_count = vector_data.len();
-        let deleted_points_count = self.deleted_points.len();
-
-        // Best estimate: start from wrapped aggregate, subtract what we just
-        // removed (stale vectors) and what the proxy deleted (per-point
-        // deletions × remaining vector names).
-        let num_vectors = wrapped_info
-            .num_vectors
-            .saturating_sub(removed_num_vectors)
-            .saturating_sub(deleted_points_count * vector_name_count);
-
-        let num_indexed_vectors = if wrapped_info.segment_type == SegmentType::Indexed {
-            wrapped_info
-                .num_indexed_vectors
-                .saturating_sub(removed_num_indexed)
-                .saturating_sub(deleted_points_count * vector_name_count)
-        } else {
-            0
-        };
-
-        let num_deleted_vectors = wrapped_info
-            .num_deleted_vectors
-            .saturating_sub(removed_num_deleted)
-            + deleted_points_count * vector_name_count;
-
-        SegmentInfo {
-            uuid: wrapped_info.uuid,
-            segment_type: SegmentType::Special,
-            num_vectors,
-            num_indexed_vectors,
-            num_points: self.available_point_count(),
-            num_deferred_points: Some(self.deferred_point_count()),
-            num_deleted_deferred_points: wrapped_info.num_deleted_deferred_points.map(
-                |num_deleted_deferred_points| {
-                    num_deleted_deferred_points.saturating_add(self.deleted_deferred_count)
-                },
-            ),
-            num_deleted_vectors,
-            vectors_size_bytes: wrapped_info.vectors_size_bytes,
-            payloads_size_bytes: wrapped_info.payloads_size_bytes,
-            ram_usage_bytes: wrapped_info.ram_usage_bytes,
-            disk_usage_bytes: wrapped_info.disk_usage_bytes,
-            is_appendable: false,
-            index_schema: wrapped_info.index_schema,
-            vector_data,
-            deferred_internal_id: wrapped_info.deferred_internal_id,
-        }
+    fn info(&self) -> OperationResult<SegmentInfo> {
+        let wrapped_info = self.wrapped_segment.get().read().info()?;
+        Ok(self.adjusted_info(wrapped_info))
     }
 
     fn config(&self) -> &SegmentConfig {
@@ -747,7 +758,7 @@ impl ReadSegmentEntry for ProxySegment {
         self.wrapped_segment.get().read().vector_names()
     }
 
-    fn get_telemetry_data(&self, detail: TelemetryDetail) -> SegmentTelemetry {
+    fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationResult<SegmentTelemetry> {
         self.wrapped_segment.get().read().get_telemetry_data(detail)
     }
 

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -541,7 +541,7 @@ fn test_point_vector_count() {
     let mut proxy_segment = ProxySegment::new(original_segment);
 
     // We have 5 points by default, assert counts
-    let segment_info = proxy_segment.info();
+    let segment_info = proxy_segment.info().unwrap();
     assert_eq!(segment_info.num_points, 5);
     assert_eq!(segment_info.num_vectors, 5);
 
@@ -549,13 +549,13 @@ fn test_point_vector_count() {
     proxy_segment
         .delete_point(101, 99999.into(), &hw_cell)
         .unwrap();
-    let segment_info = proxy_segment.info();
+    let segment_info = proxy_segment.info().unwrap();
     assert_eq!(segment_info.num_points, 5);
     assert_eq!(segment_info.num_vectors, 5);
 
     // Delete point 1, counts should decrease by 1
     proxy_segment.delete_point(102, 4.into(), &hw_cell).unwrap();
-    let segment_info = proxy_segment.info();
+    let segment_info = proxy_segment.info().unwrap();
     assert_eq!(segment_info.num_points, 4);
     assert_eq!(segment_info.num_vectors, 4);
 }
@@ -604,19 +604,19 @@ fn test_point_vector_count_multivec() {
     let mut proxy_segment = ProxySegment::new(original_segment);
 
     // Assert counts from original segment
-    let segment_info = proxy_segment.info();
+    let segment_info = proxy_segment.info().unwrap();
     assert_eq!(segment_info.num_points, 2);
     assert_eq!(segment_info.num_vectors, 4);
 
     // Delete nonexistent point, counts should remain the same
     proxy_segment.delete_point(104, 1.into(), &hw_cell).unwrap();
-    let segment_info = proxy_segment.info();
+    let segment_info = proxy_segment.info().unwrap();
     assert_eq!(segment_info.num_points, 2);
     assert_eq!(segment_info.num_vectors, 4);
 
     // Delete point 4, counts should decrease by 1
     proxy_segment.delete_point(105, 4.into(), &hw_cell).unwrap();
-    let segment_info = proxy_segment.info();
+    let segment_info = proxy_segment.info().unwrap();
     assert_eq!(segment_info.num_points, 1);
     assert_eq!(segment_info.num_vectors, 2);
 }


### PR DESCRIPTION
## What

Opening a read-only segment scanned every flags file end to end. `ReadOnlyRoaringFlags::open` materialized the whole `RoaringBitmap` via `iter_ones()`, and since **every payload field carries a null index**, that cost was paid per field per segment — for bitmaps most queries never touch. It defeats the point of prefetching only the bytes a query needs.

Note the counts were not the culprit: `ReadOnlyNullIndex::open` computes none at all (`indexed_points_count()` is `has_values_flags().len()`, straight from the tiny status file). The eager scan was the bitmap itself, so that is where the laziness had to go.

- `ReadOnlyRoaringFlags::bitmap` is now a `OnceLock<RoaringBitmap>`, filled by a scan on first access. `open` touches only the status file. (`OnceLock` because indexes are queried through `&self` across threads; `get_or_try_init` is still unstable, so a race may build twice and drop the loser.)
- `ReadOnlyBoolIndex`'s three eager count fields collapse into one lazily-derived, cached `BoolCounts`. Its `live_reload` refreshes them **in place** when they are already present, and leaves them unset otherwise — so reloading an index nothing queries stays scan-free. The refresh is free when it runs: counts can only exist if deriving them already materialized both bitmaps, which `live_reload` patches in place.
- `ram_usage_bytes` stays infallible: an unmaterialized bitmap holds no RAM, so it reports 0 via the new `bitmap_if_materialized`.

## Propagation

Materializing on demand can fail, so `Result` propagates from `RoaringFlagsRead::{get_bitmap, get, iter_trues, iter_falses, count_trues, count_falses}` through `PayloadFieldIndexRead::count_indexed_points`, `FieldIndexRead::{get_telemetry_data, values_count, values_is_empty, value_retriever}`, `PayloadIndexRead::{indexed_points, get_telemetry_data}`, `build_info` / `build_telemetry`, and `SegmentEntry::{info, get_telemetry_data}` — out into `shard`, `edge` (including the public `EdgeShardRead::info`) and `collection`. Most consumers were already in `OperationResult` contexts.

`bool_index/read_ops.rs::value_retriever` must return an infallible per-point closure, so both bitmaps are resolved once at construction rather than per point.

Two collection sites read `info()` for size fields only; they now call the infallible `size_info()`. That is strictly better: `/telemetry` no longer forces every bool bitmap into memory.

## Behavior change worth reviewing

`ProxySegment::size_info()` used to delegate to `info()`, so it uniquely returned a populated `index_schema`. To keep it infallible the proxy adjustments moved into `adjusted_info()`, fed by the wrapped segment's `size_info()`, which by contract leaves `index_schema` empty (`read_view/info.rs:27`). The proxy now matches plain `Segment::size_info()`. No caller reads `index_schema` off `size_info()`, but this is a semantic change, not a pure refactor.

## Test plan

The existing `live_reload_matches_fresh_open` tests never read the index before reloading, so once `open` stopped materializing, they stopped covering the in-place delta path entirely — I disabled `live_reload`'s deletes *and* appends and both still passed. Each is now split into `_materialized` / `_lazy` variants; the sabotage fails the `_materialized` pair.

Each half of the new `live_reload` contract is pinned independently, verified by breaking it:
- making `refresh_counts` a no-op (stale counts survive) fails `live_reload_matches_fresh_open_materialized`
- making it always recompute (forcing a scan on an untouched index) fails `live_reload_matches_fresh_open_lazy`

New `open_does_not_materialize_bitmaps` pins the laziness itself — nothing else in the module would notice an eager `open`, since every other test reads the index.

- `cargo test -p segment --lib` — 867 passed, 0 failed
- `cargo test -p collection --lib` — 244 passed, 0 failed
- `cargo test -p shard --lib` / `-p edge --lib` — 35 / 86 passed
- `cargo clippy --workspace --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)