### PR TITLE
Replace flush_all sync bool with FlushMode enum

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -38,8 +38,8 @@ mod tests {
     };
     use shard::operations::optimization::OptimizerThresholds;
     use shard::optimizers::segment_optimizer::SegmentOptimizer;
-    use shard::segment_holder::SegmentId;
     use shard::segment_holder::locked::LockedSegmentHolder;
+    use shard::segment_holder::{FlushMode, SegmentId};
     use shard::update::{process_field_index_operation, process_point_operation};
     use tempfile::Builder;
 
@@ -578,7 +578,7 @@ mod tests {
         // `SegmentHolder::register_post_flush_action`). Flush to run the action before counting dirs.
         locked_holder
             .read()
-            .flush_all(true, true)
+            .flush_all(FlushMode::Sync, true)
             .expect("failed to flush segment holder");
 
         let segment_dirs = fs::read_dir(segments_dir.path()).unwrap().collect_vec();

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -43,6 +43,7 @@ mod tests {
     use shard::operations::optimization::OptimizerThresholds;
     use shard::optimizers::config::{DenseVectorOptimizerConfig, SegmentOptimizerConfig};
     use shard::optimizers::segment_optimizer::SegmentOptimizer;
+    use shard::segment_holder::FlushMode;
     use shard::segment_holder::locked::LockedSegmentHolder;
     use tempfile::Builder;
 
@@ -202,7 +203,7 @@ mod tests {
         // `SegmentHolder::register_post_flush_action`). Flush to run the action before asserting.
         locked_holder
             .read()
-            .flush_all(true, true)
+            .flush_all(FlushMode::Sync, true)
             .expect("failed to flush segment holder");
 
         // Check if optimized segments removed from disk

--- a/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/vacuum_optimizer.rs
@@ -32,6 +32,7 @@ mod tests {
     use shard::locked_segment::LockedSegment;
     use shard::operations::optimization::OptimizerThresholds;
     use shard::optimizers::segment_optimizer::SegmentOptimizer;
+    use shard::segment_holder::FlushMode;
     use shard::segment_holder::locked::LockedSegmentHolder;
     use tempfile::Builder;
 
@@ -242,7 +243,7 @@ mod tests {
         drop(holder_guard);
         locked_holder
             .read()
-            .flush_all(true, true)
+            .flush_all(FlushMode::Sync, true)
             .expect("failed to flush segment holder");
 
         // Check old segment data is removed from disk

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -58,6 +58,7 @@ use shard::files::{NEWEST_CLOCKS_PATH, OLDEST_CLOCKS_PATH, ShardDataFiles};
 use shard::operations::CollectionUpdateOperations;
 use shard::operations::optimization::{OptimizationSegmentInfo, PendingOptimization};
 use shard::operations::point_ops::{PointInsertOperationsInternal, PointOperations};
+use shard::segment_holder::FlushMode;
 use shard::segment_holder::locked::LockedSegmentHolder;
 use shard::wal::SerdeWal;
 use tokio::runtime::Handle;
@@ -897,7 +898,7 @@ impl LocalShard {
             // Force a flush after re-applying WAL operations, to ensure we maintain on-disk data
             // consistency, if we happened to only apply *past* operations to a segment with newer
             // version.
-            segments.flush_all(true, true)?;
+            segments.flush_all(FlushMode::Sync, true)?;
         }
 
         bar.finish();

--- a/lib/collection/src/shards/local_shard/snapshot.rs
+++ b/lib/collection/src/shards/local_shard/snapshot.rs
@@ -16,8 +16,8 @@ use shard::files::{APPLIED_SEQ_FILE, SEGMENT_MANIFEST_FILE, SEGMENTS_PATH, WAL_P
 use shard::locked_segment::LockedSegment;
 use shard::operations::OperationWithClockTag;
 use shard::payload_index_schema::PayloadIndexSchema;
-use shard::segment_holder::SegmentHolder;
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::segment_holder::{FlushMode, SegmentHolder};
 use shard::snapshots::snapshot_manifest::SnapshotManifest;
 use shard::snapshots::snapshot_utils::SnapshotUtils;
 use shard::wal::SerdeWal;
@@ -420,7 +420,7 @@ where
     )?;
 
     // Flush all pending changes of each segment, now wrapped segments won't change anymore
-    segments_lock.flush_all(true, true)?;
+    segments_lock.flush_all(FlushMode::Sync, true)?;
 
     // Apply provided function
     log::trace!("Applying function on all proxied shard segments");

--- a/lib/collection/src/shards/local_shard/testing.rs
+++ b/lib/collection/src/shards/local_shard/testing.rs
@@ -1,4 +1,5 @@
 use segment::id_tracker::IdTracker;
+use shard::segment_holder::FlushMode;
 
 use crate::shards::local_shard::LocalShard;
 
@@ -15,6 +16,6 @@ impl LocalShard {
 
     pub fn full_flush(&self) {
         let segments = self.segments.read();
-        segments.flush_all(true, true).unwrap();
+        segments.flush_all(FlushMode::Sync, true).unwrap();
     }
 }

--- a/lib/collection/src/update_workers/flush_workers.rs
+++ b/lib/collection/src/update_workers/flush_workers.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use common::panic;
 use segment::common::operation_error::OperationResult;
 use segment::types::SeqNumberType;
+use shard::segment_holder::FlushMode;
 use shard::segment_holder::locked::LockedSegmentHolder;
 use shard::wal::WalError;
 use tokio::sync::oneshot;
@@ -22,7 +23,7 @@ impl UpdateWorkers {
     /// Returns an error on flush failure
     fn flush_segments(segments: LockedSegmentHolder) -> OperationResult<SeqNumberType> {
         let read_segments = segments.read();
-        let flushed_version = read_segments.flush_all(false, false)?;
+        let flushed_version = read_segments.flush_all(FlushMode::Background, false)?;
         Ok(match read_segments.failed_operation.iter().cloned().min() {
             None => flushed_version,
             Some(failed_operation) => min(failed_operation, flushed_version),

--- a/lib/edge/src/lib.rs
+++ b/lib/edge/src/lib.rs
@@ -41,8 +41,8 @@ use segment::entry::ReadSegmentEntry as _;
 use segment::segment_constructor::{load_segment, normalize_segment_dir};
 use shard::files::{PAYLOAD_INDEX_CONFIG_FILE, SEGMENTS_PATH, segment_manifest_path};
 use shard::operations::CollectionUpdateOperations;
-use shard::segment_holder::SegmentHolder;
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::segment_holder::{FlushMode, SegmentHolder};
 use shard::segment_manifest::SegmentsManifest;
 use shard::wal::SerdeWal;
 use uuid::Uuid;
@@ -245,7 +245,7 @@ impl EdgeShard {
         self.segments
             .try_read()
             .expect("segment holder lock acquired")
-            .flush_all(true, true)
+            .flush_all(FlushMode::Sync, true)
             .expect("segments flushed");
     }
 }

--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -11,6 +11,16 @@ use segment::types::SeqNumberType;
 
 use crate::segment_holder::{SegmentHolder, SegmentId};
 
+/// How [`SegmentHolder::flush_all`] performs the flush.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FlushMode {
+    /// Flush all segments on the current thread and wait for completion.
+    Sync,
+    /// Spawn a background flush thread. If one is already running, skip this pass and return the
+    /// current persisted version.
+    Background,
+}
+
 impl SegmentHolder {
     /// Flushes all segments and returns maximum version to persist
     ///
@@ -19,7 +29,8 @@ impl SegmentHolder {
     ///
     /// If there are unsaved changes after flush - detects lowest unsaved change version.
     /// If all changes are saved - returns max version.
-    pub fn flush_all(&self, sync: bool, force: bool) -> OperationResult<SeqNumberType> {
+    pub fn flush_all(&self, mode: FlushMode, force: bool) -> OperationResult<SeqNumberType> {
+        let sync = mode == FlushMode::Sync;
         let lock_order: Vec<_> = self.non_appendable_then_appendable_segments_ids().collect();
 
         // Grab and keep to segment RwLock's until the end of this function

--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -30,7 +30,10 @@ impl SegmentHolder {
     /// If there are unsaved changes after flush - detects lowest unsaved change version.
     /// If all changes are saved - returns max version.
     pub fn flush_all(&self, mode: FlushMode, force: bool) -> OperationResult<SeqNumberType> {
-        let sync = mode == FlushMode::Sync;
+        let sync = match mode {
+            FlushMode::Sync => true,
+            FlushMode::Background => false,
+        };
         let lock_order: Vec<_> = self.non_appendable_then_appendable_segments_ids().collect();
 
         // Grab and keep to segment RwLock's until the end of this function

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -1,5 +1,6 @@
 mod flush;
 pub mod locked;
+pub use flush::FlushMode;
 pub mod read_points;
 mod snapshot;
 #[cfg(test)]

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -1554,17 +1554,17 @@ fn test_post_flush_action_retry_keeps_ack_pin() {
     });
 
     // While the action is pending, the ack pin caps the returned version.
-    let version = holder.flush_all(true, true).unwrap();
+    let version = holder.flush_all(FlushMode::Sync, true).unwrap();
     assert_eq!(version, ACK_PIN, "ack pin must cap the WAL acknowledge");
     assert_eq!(runs.load(Ordering::SeqCst), 1);
 
     // Still pending after the second retry: the pin remains in effect.
-    let version = holder.flush_all(true, true).unwrap();
+    let version = holder.flush_all(FlushMode::Sync, true).unwrap();
     assert_eq!(version, ACK_PIN);
     assert_eq!(runs.load(Ordering::SeqCst), 2);
 
     // The third flush completes the action, lifting the cap.
-    let version = holder.flush_all(true, true).unwrap();
+    let version = holder.flush_all(FlushMode::Sync, true).unwrap();
     assert_eq!(
         version, WATERLINE,
         "cap is lifted once the action completes"
@@ -1572,7 +1572,7 @@ fn test_post_flush_action_retry_keeps_ack_pin() {
     assert_eq!(runs.load(Ordering::SeqCst), 3);
 
     // The completed action is gone and is not run again.
-    let version = holder.flush_all(true, true).unwrap();
+    let version = holder.flush_all(FlushMode::Sync, true).unwrap();
     assert_eq!(version, WATERLINE);
     assert_eq!(runs.load(Ordering::SeqCst), 3);
 }
@@ -1601,7 +1601,7 @@ fn test_post_flush_action_in_flight_pin_stays_visible() {
         Ok(PostFlushOutcome::Done)
     });
 
-    let version = holder.flush_all(true, true).unwrap();
+    let version = holder.flush_all(FlushMode::Sync, true).unwrap();
 
     assert_eq!(
         *observed.lock(),
@@ -1628,11 +1628,11 @@ fn test_post_flush_action_hard_failure_is_dropped() {
     holder.register_post_flush_action(0, 5, move || Err(OperationError::service_error("boom")));
 
     // The flush surfaces the action's error.
-    let err = holder.flush_all(true, true).unwrap_err();
+    let err = holder.flush_all(FlushMode::Sync, true).unwrap_err();
     assert!(format!("{err}").contains("boom"));
 
     // The failed action is gone, so the next flush is clean and uncapped.
-    let version = holder.flush_all(true, true).unwrap();
+    let version = holder.flush_all(FlushMode::Sync, true).unwrap();
     assert_eq!(version, WATERLINE);
 }
 

--- a/lib/shard/src/update.rs
+++ b/lib/shard/src/update.rs
@@ -1139,7 +1139,7 @@ mod test {
     use crate::fixtures::{
         build_segment_1, build_segment_2, empty_segment, empty_segment_with_deferred,
     };
-    use crate::segment_holder::SegmentHolder;
+    use crate::segment_holder::{FlushMode, SegmentHolder};
     use crate::update::{
         clear_payload_by_filter, delete_payload_by_filter, delete_points_by_filter,
         delete_vectors_by_filter, overwrite_payload_by_filter, set_payload_by_filter,
@@ -1168,7 +1168,7 @@ mod test {
         );
 
         let old_version = holder
-            .flush_all(true, false)
+            .flush_all(FlushMode::Sync, false)
             .expect("Failed to flush test segment holder");
 
         let segments = Arc::new(RwLock::new(holder));
@@ -1187,7 +1187,7 @@ mod test {
 
         let new_version = segments
             .read()
-            .flush_all(true, false)
+            .flush_all(FlushMode::Sync, false)
             .expect("Failed to flush test segment holder");
 
         // Flushing again inrceases by 1 and is now equal to `DELETE_OP_NUM` as we want to acknowledge the empty


### PR DESCRIPTION
## Summary

`SegmentHolder::flush_all(sync: bool, force: bool)` took two adjacent same-typed bools, and call sites read as bare literal pairs: `flush_all(true, true)`, `flush_all(true, false)`, `flush_all(false, false)` all exist in production. 

Transposing the arguments compiles and silently changes flush semantics: `sync=false` early-returns without flushing when a background flush is running, so a swapped pair at e.g. the snapshot site would make snapshots skip the flush entirely.

This replaces the first parameter with an explicit enum:

```rust
pub enum FlushMode {
    /// Flush all segments on the current thread and wait for completion.
    Sync,
    /// Spawn a background flush thread. If one is already running, skip this pass and return the
    /// current persisted version.
    Background,
}
```

With one argument typed, the pair can no longer be transposed, and the flush behavior is named at every call site.

## Notes

- No behavior change: the function body derives its internal `sync` flag from the mode, control flow is untouched.
- `force` intentionally stays a `bool`: it flows into the `SegmentEntry::flusher(force)` trait in lib/segment with many implementors, so converting it would balloon the diff without adding safety now that the arguments can't be swapped.
- Call sites converted mechanically across shard, collection, and edge: all `sync=true` sites become `FlushMode::Sync`, the flush worker's `(false, false)` becomes `FlushMode::Background`.

## Verification

- `cargo check` / `cargo clippy --all-targets` clean on shard, edge, collection
- `cargo test -p shard segment_holder`: 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)