### PR TITLE
ci: build single edge wheel on dev push, test all stable Pythons on release

### DIFF
--- a/.github/workflows/edge-py-release.yml
+++ b/.github/workflows/edge-py-release.yml
@@ -26,22 +26,20 @@ jobs:
 
     strategy:
       matrix:
-        target: [x86_64, aarch64]
-        manylinux: [manylinux_2_17, manylinux_2_28]
-        python:
-          - python3.10
-          - pypy3.11
+        # On `push` to `dev`, only build the single most popular flavor:
+        # x86_64 manylinux_2_17 (widest glibc compatibility). Thanks to
+        # abi3, that one wheel covers every CPython >= 3.10, including the
+        # latest. The full matrix (aarch64, manylinux_2_28, musl, PyPy)
+        # only runs on manual `workflow_dispatch` releases.
+        target: ${{ github.event_name == 'push' && fromJSON('["x86_64"]') || fromJSON('["x86_64", "aarch64"]') }}
+        manylinux: ${{ github.event_name == 'push' && fromJSON('["manylinux_2_17"]') || fromJSON('["manylinux_2_17", "manylinux_2_28"]') }}
+        python: ${{ github.event_name == 'push' && fromJSON('["python3.10"]') || fromJSON('["python3.10", "pypy3.11"]') }}
 
-        include:
-          - arch: x86_64
-            target: x86_64-unknown-linux-musl
-            manylinux: musllinux_1_2
-            python: python3.10
-
-          - arch: aarch64
-            target: aarch64-unknown-linux-musl
-            manylinux: musllinux_1_2
-            python: python3.10
+        include: >-
+          ${{ github.event_name == 'push' && fromJSON('[]') || fromJSON('[
+          {"arch": "x86_64", "target": "x86_64-unknown-linux-musl", "manylinux": "musllinux_1_2", "python": "python3.10"},
+          {"arch": "aarch64", "target": "aarch64-unknown-linux-musl", "manylinux": "musllinux_1_2", "python": "python3.10"}
+          ]') }}
 
         exclude:
           - target: aarch64
@@ -100,6 +98,10 @@ jobs:
     name: Build Python wheels [macOS]
 
     runs-on: macos-latest
+
+    # Dev pushes only build Linux x86_64; the full platform matrix is
+    # reserved for manual `workflow_dispatch` releases.
+    if: github.event_name != 'push'
 
     strategy:
       matrix:
@@ -162,6 +164,10 @@ jobs:
     name: Build Python wheels [Windows]
 
     runs-on: windows-latest
+
+    # Dev pushes only build Linux x86_64; the full platform matrix is
+    # reserved for manual `workflow_dispatch` releases.
+    if: github.event_name != 'push'
 
     strategy:
       matrix:
@@ -229,17 +235,22 @@ jobs:
       - edge-py-macos
       - edge-py-windows
 
+    # macOS/Windows builds are intentionally skipped on `push`, which by
+    # default would skip this job too — override with `!cancelled()` and
+    # only require the jobs that were supposed to run.
+    if: >-
+      ${{ !cancelled()
+      && needs.edge-py-linux.result == 'success'
+      && (github.event_name == 'push' || (needs.edge-py-macos.result == 'success' && needs.edge-py-windows.result == 'success')) }}
+
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - macos-latest
-          - ubuntu-24.04-arm
-          - ubuntu-latest
-          - windows-latest
-        python:
-          - '3.10'
-          - 'pypy3.11'
+        # Dev pushes test the single x86_64 Linux wheel on the latest
+        # stable Python only. Production releases (workflow_dispatch)
+        # verify the abi3 wheel against every stable CPython plus PyPy.
+        os: ${{ github.event_name == 'push' && fromJSON('["ubuntu-latest"]') || fromJSON('["macos-latest", "ubuntu-24.04-arm", "ubuntu-latest", "windows-latest"]') }}
+        python: ${{ github.event_name == 'push' && fromJSON('["3.14"]') || fromJSON('["3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.11"]') }}
 
     steps:
       - name: Checkout Qdrant
@@ -285,7 +296,9 @@ jobs:
       - edge-py-windows
       - edge-py-test
 
-    if: inputs.publish || github.event_name == 'push'
+    # `!cancelled()` because macOS/Windows builds are skipped on `push`;
+    # `edge-py-test` succeeding already implies every required build passed.
+    if: ${{ !cancelled() && needs.edge-py-test.result == 'success' && (inputs.publish || github.event_name == 'push') }}
 
     steps:
       - name: Merge release artifacts


### PR DESCRIPTION
Building the full `Qdrant Edge Release Build` wheel matrix (15 build jobs + 8 test jobs across Linux/macOS/Windows, glibc/musl, CPython/PyPy) on every push to `dev` is too expensive.

## Dev pushes (cheap path)

- `edge-py-linux` collapses to a single job: **x86_64 / manylinux_2_17 / CPython**. Thanks to `abi3-py310`, that one `cp310-abi3` wheel installs on every CPython >= 3.10, including the latest — no per-version builds needed. `manylinux_2_17` is chosen for widest glibc compatibility of the single dev wheel.
- macOS and Windows builds are skipped entirely.
- `edge-py-test` shrinks to `ubuntu-latest` x Python 3.14, verifying the dev wheel on the latest stable Python.
- Net: 15 build + 8 test jobs → 1 + 1 per dev push. `publish-gcs` behaves as before.

## Production releases (`workflow_dispatch`)

- Full build matrix unchanged (x86_64/aarch64, manylinux 2_17/2_28, musl, PyPy).
- Test matrix **extended to all stable CPythons** (3.10, 3.11, 3.12, 3.13, 3.14) plus PyPy 3.11 on all four OS runners (previously only 3.10 + PyPy). Nothing to extend on the build side: abi3 means one wheel per platform already covers all of them, and `pyproject.toml` has no `requires-python` cap.

## Plumbing

Since macOS/Windows builds are skipped on push, `edge-py-test` and `merge-artifacts` would have been skip-propagated; both now use `!cancelled()`-based conditions that only require the jobs that were supposed to run. `publish` and `publish-gcs` are untouched.

Matrices are switched with `${{ github.event_name == 'push' && fromJSON(...) || fromJSON(...) }}`; YAML and all `fromJSON` literals validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)