### PR TITLE
Replace load_or_init bool flags with PeerBootstrap and ConsensusInitMode enums

### DIFF
--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -56,6 +56,26 @@ pub struct Persistent {
     pub dirty: AtomicBool,
 }
 
+/// Whether this peer starts a new deployment or joins an existing cluster.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PeerBootstrap {
+    /// First peer of a new deployment (it does not bootstrap from anyone); starts as the sole
+    /// voter.
+    FirstPeer,
+    /// Peer joining an existing cluster; leaves the network topology empty until it joins
+    /// consensus.
+    JoiningCluster,
+}
+
+/// Whether [`Persistent::load_or_init`] loads the existing raft state as-is or re-initializes it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConsensusInitMode {
+    /// Load persisted raft state if present, initialize it otherwise.
+    Load,
+    /// Re-initialize raft state, dropping the known cluster topology (`--reinit`).
+    Reinit,
+}
+
 impl Persistent {
     pub fn state(&self) -> &RaftState {
         &self.state
@@ -114,8 +134,8 @@ impl Persistent {
     /// `peer_id` is used only when raft state is not found.
     pub fn load_or_init(
         storage_path: impl AsRef<Path>,
-        first_peer: bool,
-        reinit: bool,
+        bootstrap: PeerBootstrap,
+        init_mode: ConsensusInitMode,
         peer_id: Option<PeerId>,
     ) -> Result<Self, StorageError> {
         fs::create_dir_all(storage_path.as_ref())?;
@@ -136,11 +156,11 @@ impl Persistent {
             if let Some(peer_id) = peer_id {
                 log::debug!("Using peer ID: {peer_id}");
             };
-            Self::init(path_json.clone(), first_peer, peer_id)?
+            Self::init(path_json.clone(), bootstrap, peer_id)?
         };
 
-        let state = if reinit {
-            if first_peer {
+        let state = if init_mode == ConsensusInitMode::Reinit {
+            if bootstrap == PeerBootstrap::FirstPeer {
                 // Re-initialize consensus of the first peer is different from the rest
                 // Effectively, we should remove all other peers from voters and learners
                 // assuming that other peers would need to join consensus again.
@@ -155,7 +175,7 @@ impl Persistent {
                 // We want to re-initialize consensus while preserve the peer ID
                 // which is needed for migration from one cluster to another
                 let keep_peer_id = state.this_peer_id;
-                Self::init(path_json, first_peer, Some(keep_peer_id))?
+                Self::init(path_json, bootstrap, Some(keep_peer_id))?
             }
         } else {
             state
@@ -319,23 +339,21 @@ impl Persistent {
     /// ## Arguments
     /// `path` - full name of the file where state will be saved
     ///
-    /// `first_peer` - if this is a first peer in a new deployment (e.g. it does not bootstrap from anyone)
-    /// It is `None` if distributed deployment is disabled
+    /// `peer_id` - it is `None` if distributed deployment is disabled
     fn init(
         path: PathBuf,
-        first_peer: bool,
+        bootstrap: PeerBootstrap,
         peer_id: Option<PeerId>,
     ) -> Result<Self, StorageError> {
         // Do not generate too big peer ID, to avoid problems with serialization
         // (especially in json format)
         let this_peer_id = peer_id.unwrap_or_else(|| rand::random::<PeerId>() % (1 << 53) + 1);
-        let voters = if first_peer {
-            vec![this_peer_id]
-        } else {
-            // `Some(false)` - Leave empty the network topology for the peer, if it is not starting a network itself.
+        let voters = match bootstrap {
+            PeerBootstrap::FirstPeer => vec![this_peer_id],
+            // Leave the network topology empty for a peer that is not starting a network itself.
             // This way it will not be able to become a leader and commit data
             // until it joins an existing network.
-            vec![]
+            PeerBootstrap::JoiningCluster => vec![],
         };
         let state = Self {
             state: RaftState {
@@ -345,7 +363,7 @@ impl Persistent {
                 conf_state: ConfState::from((voters, vec![])),
             },
             apply_progress_queue: Default::default(),
-            first_voter: first_peer.then_some(this_peer_id),
+            first_voter: (bootstrap == PeerBootstrap::FirstPeer).then_some(this_peer_id),
             peer_address_by_id: Default::default(),
             peer_metadata_by_id: Default::default(),
             cluster_metadata: Default::default(),

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -1241,12 +1241,20 @@ mod tests {
     use crate::content_manager::consensus::consensus_wal::ConsensusOpWal;
     use crate::content_manager::consensus::entry_queue::EntryApplyProgressQueue;
     use crate::content_manager::consensus::operation_sender::OperationSender;
-    use crate::content_manager::consensus::persistent::Persistent;
+    use crate::content_manager::consensus::persistent::{
+        ConsensusInitMode, PeerBootstrap, Persistent,
+    };
 
     #[test]
     fn update_is_applied() {
         let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
-        let mut state = Persistent::load_or_init(dir.path(), false, false, None).unwrap();
+        let mut state = Persistent::load_or_init(
+            dir.path(),
+            PeerBootstrap::JoiningCluster,
+            ConsensusInitMode::Load,
+            None,
+        )
+        .unwrap();
         assert_eq!(state.state().hard_state.commit, 0);
         state
             .apply_state_update(|state| state.hard_state.commit = 1)
@@ -1270,13 +1278,25 @@ mod tests {
     #[test]
     fn state_is_loaded() {
         let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
-        let mut state = Persistent::load_or_init(dir.path(), false, false, None).unwrap();
+        let mut state = Persistent::load_or_init(
+            dir.path(),
+            PeerBootstrap::JoiningCluster,
+            ConsensusInitMode::Load,
+            None,
+        )
+        .unwrap();
         state
             .apply_state_update(|state| state.hard_state.commit = 1)
             .unwrap();
         assert_eq!(state.state().hard_state.commit, 1);
 
-        let state_loaded = Persistent::load_or_init(dir.path(), false, false, None).unwrap();
+        let state_loaded = Persistent::load_or_init(
+            dir.path(),
+            PeerBootstrap::JoiningCluster,
+            ConsensusInitMode::Load,
+            None,
+        )
+        .unwrap();
         assert_eq!(state_loaded.state().hard_state.commit, 1);
     }
 
@@ -1284,10 +1304,22 @@ mod tests {
     fn default_peer_id_is_persisted() {
         let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
         let peer_id = Some(101);
-        let state = Persistent::load_or_init(dir.path(), false, false, peer_id).unwrap();
+        let state = Persistent::load_or_init(
+            dir.path(),
+            PeerBootstrap::JoiningCluster,
+            ConsensusInitMode::Load,
+            peer_id,
+        )
+        .unwrap();
         assert_eq!(state.this_peer_id, 101);
 
-        let state_loaded = Persistent::load_or_init(dir.path(), false, false, None).unwrap();
+        let state_loaded = Persistent::load_or_init(
+            dir.path(),
+            PeerBootstrap::JoiningCluster,
+            ConsensusInitMode::Load,
+            None,
+        )
+        .unwrap();
         assert_eq!(state_loaded.this_peer_id, 101);
     }
 
@@ -1385,7 +1417,13 @@ mod tests {
         entries: Vec<Entry>,
         path: &std::path::Path,
     ) -> (ConsensusManager<NoCollections>, MemStorage) {
-        let persistent = Persistent::load_or_init(path, true, false, None).unwrap();
+        let persistent = Persistent::load_or_init(
+            path,
+            PeerBootstrap::FirstPeer,
+            ConsensusInitMode::Load,
+            None,
+        )
+        .unwrap();
         let (sender, _) = mpsc::channel();
         let consensus_state = ConsensusManager::new(
             persistent,
@@ -1521,7 +1559,13 @@ mod tests {
         use crate::types::{PeerAddressById, PeerMetadataById};
 
         let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
-        let persistent = Persistent::load_or_init(dir.path(), true, false, None).unwrap();
+        let persistent = Persistent::load_or_init(
+            dir.path(),
+            PeerBootstrap::FirstPeer,
+            ConsensusInitMode::Load,
+            None,
+        )
+        .unwrap();
         let (sender, _) = mpsc::channel();
         let consensus = ConsensusManager::new(
             persistent,
@@ -1598,7 +1642,13 @@ mod tests {
         use crate::types::{PeerAddressById, PeerMetadataById};
 
         let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
-        let persistent = Persistent::load_or_init(dir.path(), true, false, None).unwrap();
+        let persistent = Persistent::load_or_init(
+            dir.path(),
+            PeerBootstrap::FirstPeer,
+            ConsensusInitMode::Load,
+            None,
+        )
+        .unwrap();
         let (sender, _) = mpsc::channel();
         let consensus = ConsensusManager::new(
             persistent,

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1589,7 +1589,9 @@ mod tests {
         CollectionMetaOperations, CreateCollection, CreateCollectionOperation,
     };
     use storage::content_manager::consensus::operation_sender::OperationSender;
-    use storage::content_manager::consensus::persistent::Persistent;
+    use storage::content_manager::consensus::persistent::{
+        ConsensusInitMode, PeerBootstrap, Persistent,
+    };
     use storage::content_manager::consensus_manager::{ConsensusManager, ConsensusStateRef};
     use storage::content_manager::toc::TableOfContent;
     use storage::dispatcher::Dispatcher;
@@ -1607,8 +1609,13 @@ mod tests {
         settings.storage.storage_path = storage_dir.path().to_path_buf();
         tracing_subscriber::fmt::init();
         let (propose_sender, propose_receiver) = std::sync::mpsc::channel();
-        let persistent_state =
-            Persistent::load_or_init(&settings.storage.storage_path, true, false, None).unwrap();
+        let persistent_state = Persistent::load_or_init(
+            &settings.storage.storage_path,
+            PeerBootstrap::FirstPeer,
+            ConsensusInitMode::Load,
+            None,
+        )
+        .unwrap();
         let operation_sender = OperationSender::new(propose_sender);
         let toc = TableOfContent::new(
             &settings.storage,

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,9 @@ use fs_err as fs;
 use slog::Drain;
 use startup::setup_panic_hook;
 use storage::content_manager::consensus::operation_sender::OperationSender;
-use storage::content_manager::consensus::persistent::Persistent;
+use storage::content_manager::consensus::persistent::{
+    ConsensusInitMode, PeerBootstrap, Persistent,
+};
 use storage::content_manager::consensus_manager::{ConsensusManager, ConsensusStateRef};
 use storage::content_manager::toc::TableOfContent;
 use storage::content_manager::toc::dispatcher::TocDispatcher;
@@ -478,10 +480,20 @@ fn main() -> anyhow::Result<()> {
     let bootstrap = resolve_bootstrap_uri(args.bootstrap, args.uri.as_ref());
 
     // Saved state of the consensus.
+    let peer_bootstrap = if bootstrap.is_none() {
+        PeerBootstrap::FirstPeer
+    } else {
+        PeerBootstrap::JoiningCluster
+    };
+    let consensus_init_mode = if args.reinit {
+        ConsensusInitMode::Reinit
+    } else {
+        ConsensusInitMode::Load
+    };
     let persistent_consensus_state = Persistent::load_or_init(
         &settings.storage.storage_path,
-        bootstrap.is_none(),
-        args.reinit,
+        peer_bootstrap,
+        consensus_init_mode,
         settings.cluster.peer_id,
     )?;
 
@@ -831,7 +843,13 @@ mod tests {
     #[test]
     fn empty_api_keys_are_not_forwarded_on_internal_requests() {
         let dir = tempfile::tempdir().unwrap();
-        let persistent = Persistent::load_or_init(dir.path(), true, false, None).unwrap();
+        let persistent = Persistent::load_or_init(
+            dir.path(),
+            PeerBootstrap::FirstPeer,
+            ConsensusInitMode::Load,
+            None,
+        )
+        .unwrap();
         let mut settings = Settings::new(None).unwrap();
 
         settings.service.api_key = Some(String::new());


### PR DESCRIPTION
## Summary

`Persistent::load_or_init(path, first_peer: bool, reinit: bool, peer_id)` took two adjacent same-typed bools, and most call sites passed bare literal pairs (`true, false` in tests, `bootstrap.is_none(), args.reinit` in production). 

Transposing the arguments compiles and is catastrophic: `reinit=true` on the first peer rewrites `conf_state.voters` to just this peer (and on a non-first peer wholesale re-creates raft state), so an accidental swap turns "bootstrap first peer normally" into "wipe consensus state" on startup.

This replaces both parameters with explicit enums:

```rust
pub enum PeerBootstrap {
    /// First peer of a new deployment (it does not bootstrap from anyone); starts as the sole voter.
    FirstPeer,
    /// Peer joining an existing cluster; leaves the network topology empty until it joins consensus.
    JoiningCluster,
}

pub enum ConsensusInitMode {
    /// Load persisted raft state if present, initialize it otherwise.
    Load,
    /// Re-initialize raft state, dropping the known cluster topology (`--reinit`).
    Reinit,
}
```

The production call site in `main.rs` now builds both values as named locals right above the call, so the mapping from `bootstrap.is_none()` / `args.reinit` is visible and checked at compile time.

## Notes

- No behavior change: the private `init` now matches on `PeerBootstrap` to derive the voters list and `first_voter`, control flow is untouched.
- Also fixes the `init` doc comment, which described `peer_id` semantics ("is None if distributed deployment is disabled") under the `first_peer` argument, and drops a stale `Some(false)` comment fragment in the voters logic.
- Test call sites in `main.rs`, `consensus.rs`, and `consensus_manager.rs` converted mechanically.

## Verification

- `cargo clippy -p storage -p qdrant --all-targets` clean
- `cargo test -p storage consensus`: 20 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)