### PR TITLE
Fix shard snapshot checksum file hashing

### DIFF
--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -319,55 +319,6 @@ pub async fn recover_shard_snapshot(
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn hash_materialized_snapshot_uses_materialized_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let storage_path = dir.path().join("storage-key.snapshot");
-        let materialized_file = tempfile::Builder::new()
-            .prefix("materialized")
-            .suffix(".snapshot")
-            .tempfile_in(dir.path())
-            .unwrap()
-            .into_temp_path();
-        let materialized_path = materialized_file.to_path_buf();
-        let snapshot_file = MaybeTempPath::Temporary(materialized_file);
-
-        tokio::fs::write(&storage_path, b"storage bytes")
-            .await
-            .unwrap();
-        tokio::fs::write(&materialized_path, b"materialized bytes")
-            .await
-            .unwrap();
-
-        let actual = hash_materialized_snapshot_if_requested(&snapshot_file, true)
-            .await
-            .unwrap()
-            .unwrap();
-        let storage_hash = sha_256::hash_file(&storage_path).await.unwrap();
-        let materialized_hash = sha_256::hash_file(&materialized_path).await.unwrap();
-
-        assert_ne!(actual, storage_hash);
-        assert_eq!(actual, materialized_hash);
-    }
-
-    #[tokio::test]
-    async fn hash_materialized_snapshot_skips_hash_when_not_requested() {
-        let dir = tempfile::tempdir().unwrap();
-        let missing_path = dir.path().join("missing.snapshot");
-        let snapshot_file = MaybeTempPath::Persistent(missing_path);
-
-        let actual = hash_materialized_snapshot_if_requested(&snapshot_file, false)
-            .await
-            .unwrap();
-
-        assert_eq!(actual, None);
-    }
-}
-
 /// # Cancel safety
 ///
 /// This function is *not* cancel safe.
@@ -495,4 +446,53 @@ pub async fn try_take_partial_snapshot_recovery_lock(
         .await?;
 
     Ok(recovery_lock)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn hash_materialized_snapshot_uses_materialized_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage_path = dir.path().join("storage-key.snapshot");
+        let materialized_file = tempfile::Builder::new()
+            .prefix("materialized")
+            .suffix(".snapshot")
+            .tempfile_in(dir.path())
+            .unwrap()
+            .into_temp_path();
+        let materialized_path = materialized_file.to_path_buf();
+        let snapshot_file = MaybeTempPath::Temporary(materialized_file);
+
+        fs_err::tokio::write(&storage_path, b"storage bytes")
+            .await
+            .unwrap();
+        fs_err::tokio::write(&materialized_path, b"materialized bytes")
+            .await
+            .unwrap();
+
+        let actual = hash_materialized_snapshot_if_requested(&snapshot_file, true)
+            .await
+            .unwrap()
+            .unwrap();
+        let storage_hash = sha_256::hash_file(&storage_path).await.unwrap();
+        let materialized_hash = sha_256::hash_file(&materialized_path).await.unwrap();
+
+        assert_ne!(actual, storage_hash);
+        assert_eq!(actual, materialized_hash);
+    }
+
+    #[tokio::test]
+    async fn hash_materialized_snapshot_skips_hash_when_not_requested() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing_path = dir.path().join("missing.snapshot");
+        let snapshot_file = MaybeTempPath::Persistent(missing_path);
+
+        let actual = hash_materialized_snapshot_if_requested(&snapshot_file, false)
+            .await
+            .unwrap();
+
+        assert_eq!(actual, None);
+    }
 }

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -11,6 +11,7 @@ use collection::shards::replica_set::replica_set_state::ReplicaState;
 use collection::shards::shard::ShardId;
 use collection::shards::shard_holder::recovery_guard::RecoveryProgressHandle;
 use collection::shards::transfer::RecoveryStage;
+use common::tempfile_ext::MaybeTempPath;
 use shard::snapshots::snapshot_data::SnapshotData;
 use shard::snapshots::snapshot_manifest::{RecoveryType, SnapshotManifest};
 use storage::content_manager::errors::StorageError;
@@ -23,6 +24,17 @@ use tokio::sync::OwnedRwLockWriteGuard;
 
 use super::auth::Auth;
 use super::http_client::HttpClient;
+
+async fn hash_materialized_snapshot_if_requested(
+    snapshot_file: &MaybeTempPath,
+    compute_checksum: bool,
+) -> Result<Option<String>, StorageError> {
+    if compute_checksum {
+        Ok(Some(sha_256::hash_file(snapshot_file).await?))
+    } else {
+        Ok(None)
+    }
+}
 
 /// # Cancel safety
 ///
@@ -252,11 +264,9 @@ pub async fn recover_shard_snapshot(
                         .get_snapshot_file(&snapshot_path, &download_dir)
                         .await?;
 
-                    let hash = if checksum.is_some() {
-                        Some(sha_256::hash_file(&snapshot_path).await?)
-                    } else {
-                        None
-                    };
+                    let hash =
+                        hash_materialized_snapshot_if_requested(&snapshot_file, checksum.is_some())
+                            .await?;
 
                     DownloadResult {
                         snapshot: SnapshotData::Packed(snapshot_file),
@@ -307,6 +317,55 @@ pub async fn recover_shard_snapshot(
     .await??;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn hash_materialized_snapshot_uses_materialized_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage_path = dir.path().join("storage-key.snapshot");
+        let materialized_file = tempfile::Builder::new()
+            .prefix("materialized")
+            .suffix(".snapshot")
+            .tempfile_in(dir.path())
+            .unwrap()
+            .into_temp_path();
+        let materialized_path = materialized_file.to_path_buf();
+        let snapshot_file = MaybeTempPath::Temporary(materialized_file);
+
+        tokio::fs::write(&storage_path, b"storage bytes")
+            .await
+            .unwrap();
+        tokio::fs::write(&materialized_path, b"materialized bytes")
+            .await
+            .unwrap();
+
+        let actual = hash_materialized_snapshot_if_requested(&snapshot_file, true)
+            .await
+            .unwrap()
+            .unwrap();
+        let storage_hash = sha_256::hash_file(&storage_path).await.unwrap();
+        let materialized_hash = sha_256::hash_file(&materialized_path).await.unwrap();
+
+        assert_ne!(actual, storage_hash);
+        assert_eq!(actual, materialized_hash);
+    }
+
+    #[tokio::test]
+    async fn hash_materialized_snapshot_skips_hash_when_not_requested() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing_path = dir.path().join("missing.snapshot");
+        let snapshot_file = MaybeTempPath::Persistent(missing_path);
+
+        let actual = hash_materialized_snapshot_if_requested(&snapshot_file, false)
+            .await
+            .unwrap();
+
+        assert_eq!(actual, None);
+    }
 }
 
 /// # Cancel safety


### PR DESCRIPTION
﻿﻿### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

## What Problem This Solves

Path-based shard snapshot recovery first resolves a storage path and then materializes the snapshot through `get_snapshot_file(...)`.

For local snapshot storage, those two paths are effectively the same file. For S3-backed snapshot storage, the storage path is an object-store key, while `get_snapshot_file(...)` downloads that object into a local `MaybeTempPath::Temporary` file that is passed to recovery.

Before this change, the checksum branch still hashed the original storage path:

```rust
sha_256::hash_file(&snapshot_path)
```

That means S3-backed shard snapshot recovery with a user-provided checksum could try to verify a non-local object key instead of the downloaded snapshot bytes. In other words, the recovery path had already materialized the snapshot correctly, but checksum verification was still looking back at the storage locator instead of the concrete local file.

## Change

The production change is just to hash the materialized snapshot file returned by `get_snapshot_file(...)`:

```diff
-                        Some(sha_256::hash_file(&snapshot_path).await?)
+                        Some(sha_256::hash_file(&snapshot_file).await?)
```

In the current PR this is wrapped in a small helper so the focused tests can cover both checksum branches directly. The recovery behavior itself stays the same except for the checksum target: verification now uses the same materialized file that is later passed to `SnapshotData::Packed(...)`.

Unchanged paths:

- URL-based shard snapshot recovery still uses `download_snapshot(...)` and its returned hash.
- Local filesystem snapshot recovery still hashes the same underlying file through `MaybeTempPath::Persistent`.
- Shard transfer checksum propagation is not changed here; related open PRs such as #9535 and #8765 touch that separate sender/transfer path.

## Evidence

The focused tests cover the two relevant branches:

- `hash_materialized_snapshot_uses_materialized_file` creates different bytes at a storage path and a materialized snapshot path, then verifies the helper hashes the materialized file.
- `hash_materialized_snapshot_skips_hash_when_not_requested` verifies the path is not opened when no checksum was requested.

Before this change, the path-checksum branch used:

```rust
sha_256::hash_file(&snapshot_path)
```

After this change, it uses the materialized snapshot file:

```rust
hash_materialized_snapshot_if_requested(&snapshot_file, checksum.is_some()).await?
```

## Possible call chain / impact

```text
recover_shard_snapshot(...)
  -> ShardSnapshotLocation::Path { ... }
  -> snapshots_storage_manager.get_snapshot_file(&snapshot_path, &download_dir)
     -> LocalFS: MaybeTempPath::Persistent(snapshot_path)
     -> S3/cloud: MaybeTempPath::Temporary(downloaded_file)
  -> checksum verification
  -> SnapshotData::Packed(snapshot_file)
```

The affected case is path-based shard snapshot recovery with a provided checksum and non-local snapshot storage. The fix aligns checksum verification with the same materialized file that recovery consumes.

## Validation

- `cargo fmt --all`
- `cargo test -p qdrant hash_materialized_snapshot --locked -- --nocapture`
  - `2 passed; 0 failed`
- `git diff --check`
- `cargo clippy -p qdrant --all-targets --locked -- -D warnings`
  - Not fully green locally: it fails on existing `lib/collection/src/common/memory_reporter.rs:222` usage of `std::fs::metadata`, unrelated to this PR. The changed file was still compiled successfully by the focused test command.
- `git push -u origin s3-shard-snapshot-checksum`
  - pre-push hook ran `cargo +nightly fmt --all -- --check` successfully.

## AI disclosure

This PR was prepared with AI assistance. Initial prompt: investigate and fix whether S3-backed shard snapshot recovery with checksum hashes the storage path instead of the materialized downloaded snapshot file.

