### PR TITLE
feat: support S3 Express One Zone buckets in the S3 bridge

### DIFF
--- a/lib/common/io_bridge_object_store/src/backends/aws.rs
+++ b/lib/common/io_bridge_object_store/src/backends/aws.rs
@@ -17,6 +17,8 @@ pub struct AwsConfig {
     /// Custom endpoint URL — set this for MinIO / RustFS / LocalStack.
     /// `with_allow_http(true)` is enabled when this is set.
     pub endpoint: Option<String>,
+    /// Enable S3 Express One Zone (`*--x-s3` directory buckets).
+    pub s3_express: bool,
     /// How to authenticate to S3.
     pub credentials: AwsCredentials,
 }
@@ -55,7 +57,9 @@ impl BlobBackend for AmazonS3 {
                 b
             }
         };
-        builder = builder.with_bucket_name(&config.bucket);
+        builder = builder
+            .with_bucket_name(&config.bucket)
+            .with_s3_express(config.s3_express);
         if let Some(region) = &config.region {
             builder = builder.with_region(region);
         }

--- a/lib/common/io_bridge_object_store/src/tests/rustfs.rs
+++ b/lib/common/io_bridge_object_store/src/tests/rustfs.rs
@@ -26,6 +26,7 @@ pub fn rustfs_aws_config() -> AwsConfig {
         bucket: rustfs_bucket(),
         region: Some("us-east-1".into()),
         endpoint: Some(rustfs_endpoint()),
+        s3_express: false,
         credentials: AwsCredentials::Static {
             access_key_id: env::var("RUSTFS_ACCESS_KEY").unwrap_or_else(|_| "rustfsadmin".into()),
             secret_access_key: env::var("RUSTFS_SECRET_KEY")

--- a/lib/edge/tools/shard_query/src/main.rs
+++ b/lib/edge/tools/shard_query/src/main.rs
@@ -127,6 +127,10 @@ struct ConnectionArgs {
     #[arg(long, env = "S3_SESSION_TOKEN")]
     session_token: Option<String>,
 
+    /// [AWS] Use S3 Express One Zone (directory buckets, named `*--x-s3`).
+    #[arg(long, env = "S3_EXPRESS")]
+    s3_express: bool,
+
     /// [GCS] Path to a service-account JSON key file. Takes precedence over
     /// `--gcs-service-account-key`; if neither is set, application default
     /// credentials (ADC) are used.
@@ -351,6 +355,7 @@ fn build_aws_config(conn: &ConnectionArgs) -> Result<AwsConfig> {
         bucket: conn.bucket.clone(),
         region: conn.region.clone(),
         endpoint: conn.endpoint.clone(),
+        s3_express: conn.s3_express,
         credentials,
     })
 }

--- a/lib/segment/src/segment/read_only/tests.rs
+++ b/lib/segment/src/segment/read_only/tests.rs
@@ -253,6 +253,7 @@ fn read_only_segment_over_s3() {
         endpoint: Some(
             std::env::var("RUSTFS_ENDPOINT").unwrap_or_else(|_| "http://localhost:9000".into()),
         ),
+        s3_express: false,
         credentials: AwsCredentials::Static {
             access_key_id: std::env::var("RUSTFS_ACCESS_KEY")
                 .unwrap_or_else(|_| "rustfsadmin".into()),


### PR DESCRIPTION
`object_store` supports S3 Express One Zone (directory buckets, named `*--x-s3`) only when `s3_express` is enabled explicitly — it does not infer this from the bucket name. Without it, reads against a directory bucket hit the regional `s3.<region>.amazonaws.com` endpoint and fail with `NotFound`.

This threads an `s3_express` flag through `io_bridge_object_store`'s `AwsConfig` into `AmazonS3Builder::with_s3_express`, and exposes it on the `edge-shard-query` tool as `--s3-express` (env `S3_EXPRESS`). Test fixtures (RustFS / localhost) keep it `false`.
