### PR TITLE
Advance newest clocks for WAL-replay tail on load + model-test clock durability check

### DIFF
--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -345,6 +345,10 @@ pub async fn run(
             // the task ends — and reopening the same dir with the old collection still open is
             // unsafe.
             drain_snapshot(&collection, &snapshots_dir, &mut pending_snapshot, i).await;
+            // Newest-clocks recovery point must survive the close+reopen exactly; captured here
+            // (snapshot drained, op loop idle) and compared after the reload below. See
+            // [`verify::assert_clocks_match`] for why both mismatch directions are bugs.
+            let pre_clocks = verify::collect_clock_ticks(&collection).await;
             collection.stop_gracefully().await;
             // `into_inner` makes the invariant checked, not assumed: if any background task still
             // holds an `Arc` clone here, panic loudly instead of reopening the same dir while the
@@ -362,6 +366,12 @@ pub async fn run(
             verify::wait_for_pending_updates(&collection).await;
             let live = verify::collect_model_from_collection(&collection).await;
             verify::assert_matches_model(&live, &model, &format!("restart at op:{i}"));
+            // Clock check AFTER the model check: a lost WAL tail trips both, and the model diff
+            // (extra/missing ids) is the established postmortem signature for that class — keep
+            // it first so known failures keep their signature. A clocks-only mismatch (data
+            // intact, clock state wrong) then surfaces distinctly here.
+            let post_clocks = verify::collect_clock_ticks(&collection).await;
+            verify::assert_clocks_match(&pre_clocks, &post_clocks, &format!("restart at op:{i}"));
             eprintln!();
             bar.set_draw_target(ProgressDrawTarget::stderr());
         } else {
@@ -461,6 +471,8 @@ pub async fn run(
     // Finish any background snapshot before closing (it holds an `Arc` clone — see the restart
     // path), then close and reopen and re-verify — mirrors gridstore tests.rs:488-516.
     drain_snapshot(&collection, &snapshots_dir, &mut pending_snapshot, applied).await;
+    // Same clock-durability capture as the mid-run restart path, for the final reload.
+    let pre_clocks = verify::collect_clock_ticks(&collection).await;
     collection.stop_gracefully().await;
     // Checked close-before-reopen, same as the mid-run restart path.
     drop(
@@ -481,6 +493,9 @@ pub async fn run(
         &reload_missing,
     );
     verify::assert_matches_model(&reloaded, &model, "reloaded");
+    // After the model check, same as the restart path (see the comment there for ordering).
+    let post_clocks = verify::collect_clock_ticks(&collection).await;
+    verify::assert_clocks_match(&pre_clocks, &post_clocks, "reloaded");
 }
 
 /// Upper bound on how long we wait for a background snapshot to finish when draining it, so a hung

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -367,8 +367,8 @@ pub async fn run(
             let live = verify::collect_model_from_collection(&collection).await;
             verify::assert_matches_model(&live, &model, &format!("restart at op:{i}"));
             // Clock check AFTER the model check: a lost WAL tail trips both, and the model diff
-            // (extra/missing ids) is the established postmortem signature for that class — keep
-            // it first so known failures keep their signature. A clocks-only mismatch (data
+            // (extra/missing ids) is the established postmortem signature for that class, so it
+            // stays first and known failures keep their signature. A clocks-only mismatch (data
             // intact, clock state wrong) then surfaces distinctly here.
             let post_clocks = verify::collect_clock_ticks(&collection).await;
             verify::assert_clocks_match(&pre_clocks, &post_clocks, &format!("restart at op:{i}"));

--- a/lib/collection/src/model_testing/verify.rs
+++ b/lib/collection/src/model_testing/verify.rs
@@ -11,6 +11,7 @@ use super::op::{canonical_sparse, dense_diff, dense_matches};
 use super::{Model, ModelEntry, VectorValue};
 use crate::collection::Collection;
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
+use crate::shards::shard::{PeerId, ShardId};
 
 pub(super) async fn collect_model_from_collection(collection: &Collection) -> Model {
     let scroll = collection
@@ -121,6 +122,58 @@ pub(super) fn assert_matches_model(actual: &Model, expected: &Model, ctx: &str) 
             "{ctx}: payload mismatch for id {id:?}",
         );
     }
+}
+
+/// Per-shard newest-clocks recovery point, flattened to `(peer_id, clock_id) -> tick`.
+///
+/// Captured on both sides of a close+reopen boundary (see [`collect_clock_ticks`] /
+/// [`assert_clocks_match`]). Tokens are deliberately dropped: the tick is the semantic content
+/// of a clock, tokens only disambiguate same-tick echoes. `BTreeMap`s keep the
+/// `assert_clocks_match` panic output deterministically ordered.
+pub(super) type ClockTicks = BTreeMap<ShardId, BTreeMap<(PeerId, u32), u64>>;
+
+/// Snapshot every local shard's newest-clocks recovery point.
+///
+/// Only meaningful at a quiescent boundary (op loop idle, background snapshot drained, and,
+/// post-reload, background WAL-tail updates plunged): clock ticks advance synchronously at update
+/// submit, so with no op in flight the recovery point is stable.
+///
+/// Note: the recovery point is derived from the clocks *snapshot* when one is set
+/// (`ClockMap::to_recovery_point`), but only the WAL-less shard-transfer flow sets one — never
+/// this harness — so this always reads the live clocks.
+pub(super) async fn collect_clock_ticks(collection: &Collection) -> ClockTicks {
+    let holder = collection.shards_holder.read().await;
+    let mut out = ClockTicks::new();
+    for (shard_id, replica_set) in holder.get_shards() {
+        let recovery_point = replica_set
+            .shard_recovery_point()
+            .await
+            .expect("shard_recovery_point failed");
+        let ticks = recovery_point
+            .iter_as_clock_tags()
+            .map(|tag| ((tag.peer_id, tag.clock_id), tag.clock_tick))
+            .collect();
+        out.insert(shard_id, ticks);
+    }
+    out
+}
+
+/// Assert the newest-clocks recovery point survived a graceful close+reopen *exactly*.
+///
+/// The reopened shard reconstructs it from the persisted clock-map file plus WAL replay, and
+/// both directions of a mismatch are bugs:
+/// - a tick **lost** across reload means clock durability broke (the tick reached neither the
+///   stored clock map nor a replayable WAL entry), so the node would under-report what it has
+///   seen when negotiating a WAL delta;
+/// - a tick **gained** means the reload path over-advanced a clock, claiming ops this node never
+///   applied, so a future WAL-delta transfer would silently skip them.
+pub(super) fn assert_clocks_match(pre: &ClockTicks, post: &ClockTicks, ctx: &str) {
+    assert_eq!(
+        pre, post,
+        "{ctx}: newest-clocks recovery point changed across close+reopen \
+         (left = pre-close, right = post-reload, keyed shard_id -> (peer_id, clock_id) -> tick); \
+         lost ticks = clock durability broke, gained ticks = replay over-advanced a clock",
+    );
 }
 
 /// Returns `(segment_count, total_optimized_points)` summed across every local shard.

--- a/lib/collection/src/model_testing/verify.rs
+++ b/lib/collection/src/model_testing/verify.rs
@@ -139,8 +139,8 @@ pub(super) type ClockTicks = BTreeMap<ShardId, BTreeMap<(PeerId, u32), u64>>;
 /// submit, so with no op in flight the recovery point is stable.
 ///
 /// Note: the recovery point is derived from the clocks *snapshot* when one is set
-/// (`ClockMap::to_recovery_point`), but only the WAL-less shard-transfer flow sets one — never
-/// this harness — so this always reads the live clocks.
+/// (`ClockMap::to_recovery_point`), but only the WAL-less shard-transfer flow sets one (never
+/// this harness), so this always reads the live clocks.
 pub(super) async fn collect_clock_ticks(collection: &Collection) -> ClockTicks {
     let holder = collection.shards_holder.read().await;
     let mut out = ClockTicks::new();

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -914,6 +914,31 @@ impl LocalShard {
 
         // Send remaining pending WAL elements to the update channel
         if to < last_wal_index {
+            // The update worker applies these queued tail entries but discards their clock tags
+            // (it deserializes only the operation), so advance the newest clocks here, exactly
+            // like the synchronous replay above. These operations are durably in the WAL, which
+            // is what the recovery point tracks; skipping them would let the recovery point
+            // regress across a restart, and the first post-restart updates would then reuse
+            // clock ticks that earlier WAL entries already carry for different operations.
+            //
+            // This tail is queued whenever the persisted `applied_seq` lags the WAL end, so it
+            // runs independently of the `prevent_unoptimized` flag's value: the flag only gates
+            // the worker's deferred-points wait, not whether the tail is queued here.
+            //
+            // `last_wal_index` is one past the last entry (`first_index + len`), so this range is
+            // end-*exclusive* (`..`) even though the send loop below is `..=`: `read_range` errors
+            // on a missing index, and `..=last_wal_index` would try to read that non-existent entry.
+            for entry in wal.read_range(to..last_wal_index) {
+                let (_op_num, update) = entry.map_err(|e| {
+                    CollectionError::service_error(format!(
+                        "Failed to read WAL tail during recovery of {}: {e}",
+                        self.path.display(),
+                    ))
+                })?;
+                if let Some(clock_tag) = update.clock_tag {
+                    newest_clocks.advance_clock(clock_tag);
+                }
+            }
             log::info!(
                 "Loading remaining {} WAL entries from:{to} into update queue",
                 last_wal_index - to

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -925,18 +925,25 @@ impl LocalShard {
             // runs independently of the `prevent_unoptimized` flag's value: the flag only gates
             // the worker's deferred-points wait, not whether the tail is queued here.
             //
-            // `last_wal_index` is one past the last entry (`first_index + len`), so this range is
-            // end-*exclusive* (`..`) even though the send loop below is `..=`: `read_range` errors
-            // on a missing index, and `..=last_wal_index` would try to read that non-existent entry.
+            // An unreadable entry is logged and skipped (its clock tag is lost, but its op_num is
+            // still enqueued below): the worker re-reads it and tolerates the same failure by
+            // log-and-skip, and failing the whole shard load here would turn a single bad tail
+            // entry into a node that cannot start.
+            //
+            // Two passes because the `read_range` iterator borrows the WAL and is not `Send`,
+            // so it cannot be held across the channel-send await below. The range end is
+            // `last_wal_index` *exclusive*: it is one past the last entry (`first_index + len`).
             for entry in wal.read_range(to..last_wal_index) {
-                let (_op_num, update) = entry.map_err(|e| {
-                    CollectionError::service_error(format!(
-                        "Failed to read WAL tail during recovery of {}: {e}",
+                match entry {
+                    Ok((_op_num, update)) => {
+                        if let Some(clock_tag) = update.clock_tag {
+                            newest_clocks.advance_clock(clock_tag);
+                        }
+                    }
+                    Err(err) => log::error!(
+                        "Failed to read WAL tail entry during recovery of {}: {err}",
                         self.path.display(),
-                    ))
-                })?;
-                if let Some(clock_tag) = update.clock_tag {
-                    newest_clocks.advance_clock(clock_tag);
+                    ),
                 }
             }
             log::info!(
@@ -946,7 +953,7 @@ impl LocalShard {
             let update_sender = self.update_sender.load();
             // TODO use proper collection's hardware measurement
             let hw_measurements = HwMeasurementAcc::disposable();
-            for op_num in to..=last_wal_index {
+            for op_num in to..last_wal_index {
                 update_sender
                     .send(UpdateSignal::Operation(OperationData {
                         op_num,

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -10,6 +10,7 @@ use shard::operations::CollectionUpdateOperations;
 use shard::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted,
 };
+use shard::wal::{SerdeWal, WalRawRecord};
 use tempfile::Builder;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
@@ -577,6 +578,140 @@ async fn test_wal_replay_loads_pending_to_queue() {
     assert_eq!(
         points_count, total_ops as usize,
         "All {total_ops} points should be present after WAL replay and update queue processing",
+    );
+
+    shard.stop_gracefully().await;
+}
+
+/// A deferred-tail WAL entry that fails deserialization must not fail shard load.
+///
+/// `load_from_wal` reads the tail past `applied_seq` to advance the newest clocks before
+/// queueing it to the update worker. That pass must log-and-skip an unreadable entry (the
+/// worker tolerates the same failure when it re-reads the entry), not propagate it: failing
+/// there turns one bad tail record into a shard, and by default a node, that cannot start.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_wal_replay_tolerates_corrupt_tail_entry() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+
+    let config = create_collection_config();
+
+    let collection_name = "test".to_string();
+
+    let update_runtime = Handle::current();
+    let current_runtime: AdaptiveSearchHandle = AdaptiveSearchHandle::current_for_tests();
+
+    let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+    let payload_index_schema =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
+    let shared_storage_config = Arc::new(SharedStorageConfig {
+        update_queue_size: 10_000,
+        ..Default::default()
+    });
+
+    // We need WAL length > applied_seq + 65 to trigger the queue loading path
+    let total_ops = 500u64;
+
+    let shard = LocalShard::build(
+        0,
+        collection_name.clone(),
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        shared_storage_config.clone(),
+        payload_index_schema.clone(),
+        update_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+        config.optimizer_config.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Stop flush worker to prevent automatic WAL truncation.
+    shard.stop_flush_worker().await;
+
+    let hw_acc = HwMeasurementAcc::new();
+
+    // Insert all operations
+    for i in 0..total_ops {
+        let point = PointStructPersisted {
+            id: i.into(),
+            vector: VectorStructInternal::from(vec![1.0, 2.0, 3.0, 4.0]).into(),
+            payload: None,
+        };
+        let op = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+            PointInsertOperationsInternal::PointsList(vec![point]),
+        ));
+        shard
+            .update(op.into(), WaitUntil::Visible, None, hw_acc.clone())
+            .await
+            .unwrap();
+    }
+
+    // Stop the shard without flush to preserve WAL.
+    shard.stop_gracefully().await;
+
+    // Lower applied_seq (as in `test_wal_replay_loads_pending_to_queue`) so the entries past it
+    // are deferred to the update queue instead of replayed synchronously.
+    let applied_seq_handler = AppliedSeqHandler::load_or_init(collection_dir.path(), total_ops);
+    let current_applied_seq = applied_seq_handler.op_num().unwrap_or(0);
+    let low_applied_seq = total_ops.saturating_sub(100);
+    if current_applied_seq > low_applied_seq {
+        applied_seq_handler
+            .force_set_and_persist(low_applied_seq)
+            .unwrap();
+    }
+
+    // Append a record that fails `OperationWithClockTag` deserialization into the deferred tail:
+    // a CBOR-encoded string gets valid WAL framing, but decodes as neither of the record codecs.
+    {
+        let wal_path = LocalShard::wal_path(collection_dir.path());
+        let mut raw_wal: SerdeWal<String> =
+            SerdeWal::new(&wal_path, (&config.wal_config).into()).unwrap();
+        raw_wal
+            .write(&WalRawRecord::new(&"not an operation".to_string()).unwrap())
+            .unwrap();
+    }
+
+    // Shard load must survive the corrupt tail entry.
+    let shard = LocalShard::load(
+        0,
+        collection_name,
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        config.optimizer_config.clone(),
+        shared_storage_config,
+        payload_index_schema,
+        false,
+        update_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+    )
+    .await
+    .expect("shard load must tolerate a corrupt WAL entry in the deferred tail");
+
+    // The update worker must drain the queued tail past the corrupt entry (it skips it the same
+    // way: log and continue).
+    let timeout = std::time::Duration::from_secs(2);
+    let start = std::time::Instant::now();
+    let poll_interval = std::time::Duration::from_millis(10);
+
+    while shard.local_update_queue_info().await.length > 0 {
+        assert!(
+            start.elapsed() <= timeout,
+            "Timeout waiting for update queue to empty"
+        );
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    // Every readable operation around the corrupt entry is applied.
+    let info = shard.info().await.unwrap();
+    let points_count = info.points_count.unwrap_or(0);
+    assert_eq!(
+        points_count, total_ops as usize,
+        "All {total_ops} points should be present after WAL replay with a corrupt tail entry",
     );
 
     shard.stop_gracefully().await;


### PR DESCRIPTION
## Summary

`load_from_wal` advances `newest_clocks` from every synchronously replayed entry, but not from the tail it queues to the update worker: the worker deserializes only the operation and drops the clock tag. 

The newest-clocks recovery point could therefore regress across a graceful restart by up to the update-queue size, even though those operations are durably in the WAL (exactly what the recovery point tracks). 

The first post-restart updates would then be assigned clock ticks that earlier WAL entries already carry for different operations, corrupting WAL-delta resolution in a cluster. The fix advances `newest_clocks` over the queued tail during load, mirroring the synchronous replay. Regression dates to #8008, which narrowed synchronous replay to `[from, to)`.

The model testing harness now captures each shard's newest-clocks recovery point on both sides of every close+reopen and asserts exact equality: a lost tick means clock durability broke, a gained tick means the reload path over-advanced a clock. This is the check that caught the regression. It runs after the model check so a lost WAL tail keeps its established extra/missing-id postmortem signature.

Review follow-up (last commit): the tail pass logs and skips an unreadable entry instead of failing shard load (the update worker tolerates the same failure when it re-reads it), with a regression test injecting an undeserializable record into the deferred tail; also fixes a pre-existing off-by-one that enqueued a phantom op_num past the WAL end.

## Testing

Before the fix, the no-optimizer restart variants of the harness failed with the post-reload recovery point ~20 ticks short of pre-close. After: 20 fresh-seed `model_testing` gate runs green, full `collection` suite green, clippy and nightly fmt clean.

Draft: the engine fix would benefit from a second pair of eyes on the cluster WAL-delta implications before merge.