### PR TITLE
Fix `SetRepicaState(Dead)`/`Transfer::Abort`/`Resharding::Abort`

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -410,13 +410,40 @@ impl Collection {
         new_state: ReplicaState,
         from_state: Option<ReplicaState>,
     ) -> CollectionResult<()> {
-        let mut replica_set = self
-            .shards_holder
-            .read()
-            .await
-            .get_shard(shard_id)
-            .ok_or_else(|| shard_not_found_error(shard_id))?
-            .clone();
+        let replica_set = self.shards_holder.read().await.get_shard(shard_id).cloned();
+
+        let Some(mut replica_set) = replica_set else {
+            // The shard may not exist.
+            //
+            // If we set replica `Dead`, and resharding targeting this shard is in progress,
+            // then scale-up resharding abort might have dropped the shard (and this replica)
+            // but crashed before clearing resharding state. This is the only code path that
+            // might lead to this state.
+            //
+            // Finish the abort to clear the state, then return: the replica is already gone,
+            // same as the early return below once the abort drops the shard.
+
+            if new_state == ReplicaState::Dead {
+                let reshard_key = self
+                    .shards_holder
+                    .read()
+                    .await
+                    .resharding_state
+                    .read()
+                    .as_ref()
+                    .filter(|state| state.shard_id == shard_id)
+                    .map(|state| state.key());
+
+                if let Some(reshard_key) = reshard_key {
+                    self.abort_resharding(reshard_key, false, AbortReshardingScope::default())
+                        .await?;
+
+                    return Ok(());
+                }
+            }
+
+            return Err(shard_not_found_error(shard_id));
+        };
 
         log::debug!(
             "Changing shard {}:{shard_id} replica state from {:?} to {new_state:?}",
@@ -462,23 +489,21 @@ impl Collection {
             )));
         }
 
-        // Abort resharding *before* persisting the new replica state.
+        // Setting a resharding replica `Dead` aborts the resharding first, then
+        // writes `Dead` last (see `AbortReshardingScope::skip_replica` for why the
+        // abort must leave this replica untouched, and why this ordering converges
+        // on replay).
         //
-        // If we did this after the persist, a crash between the durable
-        // `replica_state.json` write and `abort_resharding` would leave
-        // `resharding_state.json` stuck `Some` on the replaying peer (a
-        // `current_state`-based gate reads `Dead` from disk on replay and
-        // skips the abort). Doing it first means a partial-apply crash
-        // either re-runs the whole entry (replica state still reads as a
-        // resharding state, gate fires, the idempotent abort re-runs) or no
-        // longer needs the abort to fire at all (resharding_state already
-        // cleared by the prior attempt). Either way, every peer converges.
+        // The trigger is the replica's own state (`is_resharding()`), not
+        // `resharding_state` alone, on purpose:
+        // - It stays true across replays: the abort skips this replica, so a crash
+        //   mid-abort re-runs the whole handler and converges.
+        // - A stale duplicate `Dead`, arriving after a new resharding started, reads
+        //   this replica as `Dead` already, so it aborts no unrelated resharding.
         //
-        // Covers both directions: up (`Resharding`) and down (`ReshardingScaleDown`).
-        // For up, `abort_resharding` drops the shard entirely; we detect the
-        // missing shard below and skip the persist. For down, the shard
-        // stays, abort just reverts the receiver back to `Active`, and the
-        // persist below overwrites that with `Dead`.
+        // Scale-up aborts drop the shard entirely (early return below); scale-down
+        // aborts keep the shard and leave this replica untouched, so `Dead` is
+        // written below.
         if new_state == ReplicaState::Dead && current_state.is_some_and(|s| s.is_resharding()) {
             let reshard_key = self
                 .shards_holder
@@ -493,8 +518,16 @@ impl Collection {
                 // Drop replica set `Arc`, so that `abort_resharding` can drop shard cleanly
                 drop(replica_set);
 
-                self.abort_resharding(reshard_key, false, AbortReshardingScope::default())
-                    .await?;
+                self.abort_resharding(
+                    reshard_key,
+                    false,
+                    AbortReshardingScope {
+                        // The abort must leave this replica untouched (see field doc).
+                        skip_replica: Some((shard_id, peer_id)),
+                        ..Default::default()
+                    },
+                )
+                .await?;
 
                 // Check if shard was dropped (when resharding up), and return early if so
                 let Some(rs) = self.shards_holder.read().await.get_shard(shard_id).cloned() else {

--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -33,6 +33,7 @@ use shard::operations::optimization::{OptimizationsRequestOptions, Optimizations
 use tokio::runtime::Handle;
 use tokio::sync::{Mutex, RwLock};
 
+pub use self::resharding::AbortReshardingScope;
 use crate::collection::collection_ops::ABORT_TRANSFERS_ON_SHARD_DROP_FIX_FROM_VERSION;
 use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection_state::{ShardInfo, State};
@@ -492,7 +493,8 @@ impl Collection {
                 // Drop replica set `Arc`, so that `abort_resharding` can drop shard cleanly
                 drop(replica_set);
 
-                self.abort_resharding(reshard_key, false).await?;
+                self.abort_resharding(reshard_key, false, AbortReshardingScope::default())
+                    .await?;
 
                 // Check if shard was dropped (when resharding up), and return early if so
                 let Some(rs) = self.shards_holder.read().await.get_shard(shard_id).cloned() else {
@@ -685,7 +687,9 @@ impl Collection {
             .filter(|state| state.peer_id == peer_id);
 
         if let Some(state) = resharding_state
-            && let Err(err) = self.abort_resharding(state.key(), true).await
+            && let Err(err) = self
+                .abort_resharding(state.key(), true, AbortReshardingScope::default())
+                .await
         {
             log::error!(
                 "Failed to abort resharding {} while removing peer {peer_id}: {err}",

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -10,7 +10,46 @@ use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::types::CollectionResult;
 use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::resharding::{ReshardKey, ReshardState, ReshardingStage};
-use crate::shards::transfer::ShardTransferConsensus;
+use crate::shards::shard::{PeerId, ShardId};
+use crate::shards::shard_holder::ReshardingCheck;
+use crate::shards::transfer::{ShardTransferConsensus, ShardTransferKey};
+
+/// State updates that `Collection::abort_resharding` must skip,
+/// because the caller performs them itself.
+///
+/// Few different consensus operations might trigger resharding abort:
+/// `Resharding::Abort`, `SetReplicaState(Dead)` and `Transfer::Abort`.
+///
+/// `SetReplicaState(Dead)` and `Transfer::Abort` decide whether to abort
+/// resharding by checking a piece of state (replica state, transfer record)
+/// that resharding abort also updates. If resharding abort updated that state,
+/// and we crashed before the operation completed, on replay the operation
+/// would see the updated state and skip both the resharding abort and its own
+/// remaining steps, leaving them permanently unapplied on this peer.
+///
+/// So these operations must perform such state updates themselves, *last*,
+/// after resharding abort is complete, and resharding abort must leave
+/// the state untouched.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct AbortReshardingScope {
+    /// Replica that the caller updates itself.
+    ///
+    /// `SetReplicaState(Dead)` aborts resharding when the target replica is
+    /// in a resharding state, then marks the replica as `Dead`.
+    /// Resharding abort must not revert this replica to `Active`:
+    /// the replica has to stay in a resharding state until the caller's
+    /// final `Dead` write, so that replay after a crash re-runs the whole operation.
+    pub skip_replica: Option<(ShardId, PeerId)>,
+
+    /// Transfer that the caller aborts itself.
+    ///
+    /// `Transfer::Abort` aborts resharding when the transfer being aborted is
+    /// a resharding transfer, then aborts the transfer itself.
+    /// Resharding abort must not abort this transfer during its own transfer cleanup:
+    /// the transfer has to stay registered until resharding state is cleared,
+    /// so that replay after a crash re-runs the whole operation.
+    pub skip_transfer: Option<ShardTransferKey>,
+}
 
 impl Collection {
     pub async fn resharding_state(&self) -> Option<ReshardState> {
@@ -240,52 +279,100 @@ impl Collection {
         Ok(())
     }
 
+    /// Abort a resharding operation.
+    ///
+    /// Every step is idempotent, and resharding state is cleared *last*,
+    /// so it gates the whole operation:
+    ///
+    /// - If we crash *before* resharding state is cleared, on replay the check
+    ///   finds a matching state and every step re-runs with the same result.
+    /// - If we crash *after*, on replay the check finds no matching state and
+    ///   the whole operation is a no-op.
+    ///
+    /// If current resharding does *not* match `resharding_key`, this means
+    /// another/newer resharding is in progress, so we treat operation as no-op.
+    ///
+    /// `force` skips the pre-check, if resharding must be aborted unconditionally
+    /// (e.g. when removing a peer or dropping a shard key).
     pub async fn abort_resharding(
         &self,
         resharding_key: ReshardKey,
         force: bool,
+        scope: AbortReshardingScope,
     ) -> CollectionResult<()> {
         log::warn!(
             "Invalidating local cleanup tasks and aborting resharding {resharding_key} (force: {force})"
         );
 
-        let shard_holder = self.shards_holder.read().await;
-
-        // Each step below is individually idempotent, so on replay (e.g. after
-        // a crash that applied only part of the abort) we fall through every
-        // step to reconcile any partially-applied state instead of
-        // short-circuiting on the first condition that already holds.
+        // Proceed only if resharding currently in progress matches `resharding_key`.
+        // If it doesn't (the abort was already applied, or a new resharding has
+        // started since), return early: the steps below act unconditionally, without
+        // checking resharding key, so running them here would tear down the current,
+        // unrelated resharding.
         if !force {
-            shard_holder.check_abort_resharding(&resharding_key)?;
+            let check = self
+                .shards_holder
+                .read()
+                .await
+                .check_abort_resharding(&resharding_key)?;
+
+            match check {
+                ReshardingCheck::Proceed => (),
+                ReshardingCheck::NoOp => return Ok(()),
+            }
         } else {
             log::warn!("Force-aborting resharding {resharding_key}");
         }
 
-        // Invalidate clean state for shards we copied new points into
-        // These shards must be cleaned or dropped to ensure they don't contain irrelevant points
-        match resharding_key.direction {
-            // On resharding up: new shard now has invalid points, shard will likely be dropped
-            ReshardingDirection::Up => {
-                self.invalidate_clean_local_shards([resharding_key.shard_id])
-                    .await;
-            }
-            // On resharding down: existing shards may have new points moved
-            // into them. Use the router's node set, which works regardless of
-            // whether the ring has already been rolled back to `Single` on a
-            // replay.
-            ReshardingDirection::Down => {
-                if let Some(ring) = shard_holder.rings.get(&resharding_key.shard_key) {
-                    self.invalidate_clean_local_shards(ring.nodes().clone())
+        // 1. Invalidate clean state for shards affected by (partial) resharding.
+        //    These shards must be cleaned or dropped to ensure they don't contain irrelevant points.
+        {
+            let shard_holder = self.shards_holder.read().await;
+            match resharding_key.direction {
+                // Up: the new shard now has invalid points, and will likely be dropped.
+                ReshardingDirection::Up => {
+                    self.invalidate_clean_local_shards([resharding_key.shard_id])
                         .await;
+                }
+                // Down: existing shards may have new points moved into them. Use
+                // the router's node set, which works regardless of whether the
+                // ring has already been rolled back to `Single` on a replay.
+                ReshardingDirection::Down => {
+                    if let Some(ring) = shard_holder.rings.get(&resharding_key.shard_key) {
+                        self.invalidate_clean_local_shards(ring.nodes().clone())
+                            .await;
+                    }
                 }
             }
         }
 
-        drop(shard_holder); // drop the read lock before acquiring write lock
         let mut shard_holder = self.shards_holder.write().await;
 
-        // Decrement and persist shard count *before* aborting resharding, so crash
-        // doesn't leave `shard_number` pointing at deleted dir, which would panic on startup
+        // 2. Scale-down: revert replicas in `ReshardingScaleDown` state back to `Active`.
+        //    Skip the replica the caller updates itself (see `AbortReshardingScope::skip_replica`).
+        for (shard_id, peer_id) in shard_holder.scale_down_replicas(&resharding_key) {
+            if scope.skip_replica == Some((shard_id, peer_id)) {
+                continue;
+            }
+
+            if let Some(shard) = shard_holder.get_shard(shard_id) {
+                shard
+                    .set_replica_state(peer_id, ReplicaState::Active)
+                    .await?;
+            }
+        }
+
+        // 3. Scale-down: delete points transferred from target shard during resharding
+        shard_holder
+            .scale_down_cleanup_points(&resharding_key)
+            .await?;
+
+        // 4. Roll hash ring back
+        shard_holder.revert_resharding_hashring(&resharding_key);
+
+        // 5. Scale-up: decrement and persist shard count *before* dropping shard directory,
+        //    so crash doesn't leave `shard_number` pointing at deleted dir,
+        //    which would panic on startup
         if resharding_key.direction == ReshardingDirection::Up {
             let mut config = self.collection_config.write().await;
 
@@ -317,33 +404,27 @@ impl Collection {
             }
         }
 
-        // Abort resharding before the related transfers to keep this
-        // idempotent on replay: if we aborted a transfer first and crashed,
-        // on restart the transfer would be gone and we'd no longer detect
-        // it as resharding-related, leaving resharding running.
+        // 6. Scale-up: drop target shard that resharding created
         shard_holder
-            .abort_resharding(resharding_key.clone(), force)
+            .scale_up_drop_target_shard(&resharding_key)
             .await?;
 
         let shard_holder = RwLockWriteGuard::downgrade(shard_holder);
 
-        // Abort all resharding transfer related to this specific resharding operation
-        let resharding_transfers =
-            shard_holder.get_transfers(|t| t.is_related_to_resharding(&resharding_key));
-
-        // Staging-only: pause after clearing resharding state but before aborting the transfer, so a test can kill this peer mid-abort.
-        #[cfg(feature = "staging")]
-        if !resharding_transfers.is_empty()
-            && let Ok(secs) = std::env::var("QDRANT_STAGING_RESHARDING_ABORT_DELAY_SEC")
-            && let Ok(secs) = secs.parse::<f64>()
-        {
-            tokio::time::sleep(std::time::Duration::from_secs_f64(secs)).await;
-        }
+        // 7. Abort all transfers related to this specific resharding operation.
+        //    Skip the transfer the caller aborts itself (see `AbortReshardingScope::skip_transfer`).
+        let resharding_transfers = shard_holder.get_transfers(|transfer| {
+            transfer.is_related_to_resharding(&resharding_key)
+                && scope.skip_transfer != Some(transfer.key())
+        });
 
         for transfer in resharding_transfers {
             self.abort_shard_transfer(transfer, &shard_holder).await?;
         }
-        drop(shard_holder);
+
+        // 8. Clear persisted resharding state. This is the *last* step,
+        //    so a crash at any earlier point replays the whole operation.
+        shard_holder.clear_resharding_state(&resharding_key)?;
 
         Ok(())
     }

--- a/lib/collection/src/collection/resharding.rs
+++ b/lib/collection/src/collection/resharding.rs
@@ -222,15 +222,29 @@ impl Collection {
             .commit_write_hashring(resharding_key)
     }
 
+    /// Finish a resharding operation.
+    ///
+    /// Every step is idempotent, and resharding state is cleared *last*,
+    /// so it gates the whole operation:
+    ///
+    /// - If we crash *before* resharding state is cleared, on replay the check
+    ///   finds a matching state and every step re-runs with the same result.
+    /// - If we crash *after*, on replay the check finds no matching state and
+    ///   the whole operation is a no-op.
+    ///
+    /// If current resharding does *not* match `resharding_key`, this means
+    /// another/newer resharding is in progress, so we return an error.
     pub async fn finish_resharding(&self, resharding_key: ReshardKey) -> CollectionResult<()> {
         let mut shard_holder = self.shards_holder.write().await;
 
-        // Each step below is individually idempotent, so on replay (e.g. after
-        // a crash that applied only part of the operation) we fall through
-        // every step to reconcile any partially-applied state instead of
-        // short-circuiting on the first condition that already holds.
-        shard_holder.check_finish_resharding(&resharding_key)?;
-        shard_holder.finish_resharding_unchecked(&resharding_key)?;
+        // Check that resharding state matches expected key.
+        //
+        // Steps below modify state unconditionally, so running them on mismatched key
+        // would modify unrelated resharding.
+        match shard_holder.check_finish_resharding(&resharding_key)? {
+            ReshardingCheck::Proceed => {}
+            ReshardingCheck::NoOp => return Ok(()),
+        }
 
         if resharding_key.direction == ReshardingDirection::Down {
             // Remove the shard we've now migrated all points out of
@@ -275,6 +289,10 @@ impl Collection {
                 .drop_and_remove_shard(resharding_key.shard_id)
                 .await?;
         }
+
+        // Clear persisted resharding state. This is the *last* step,
+        // so a crash at any earlier point replays the whole operation.
+        shard_holder.clear_resharding_state(&resharding_key)?;
 
         Ok(())
     }

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -10,6 +10,7 @@ use semver::Version;
 use tokio_util::task::AbortOnDropHandle;
 
 use super::Collection;
+use super::resharding::AbortReshardingScope;
 use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::local_shard::LocalShard;
@@ -465,17 +466,48 @@ impl Collection {
             }
         };
 
-        // Abort resharding before the transfer to be idempotent
+        // Abort resharding *before* aborting the transfer.
+        // Exclude this transfer from `abort_resharding` transfer cleanup (`skip_transfer`),
+        // and abort transfer *last*, after resharding state is cleared.
+        //
+        // On replay after a crash:
+        // - transfer registered, resharding state set: re-run the whole operation
+        // - transfer registered, resharding state cleared: skip resharding abort,
+        //   abort the transfer
+        // - transfer not registered: everything already applied, no-op
+
+        #[cfg(feature = "staging")]
+        let is_resharding_abort = resharding_state.is_some();
+
         if let Some(state) = resharding_state {
-            self.abort_resharding(state.key(), false).await?;
+            self.abort_resharding(
+                state.key(),
+                false,
+                AbortReshardingScope {
+                    skip_transfer: Some(transfer_key),
+                    ..Default::default()
+                },
+            )
+            .await?;
         }
 
-        // Resharding may already have aborted the transfer so we check it again
+        // Staging-only: pause after clearing resharding state, but before aborting
+        // transfer, so test can kill this peer mid-abort (resharding state cleared,
+        // transfer still registered) and verify that replay converges.
+        #[cfg(feature = "staging")]
+        if is_resharding_abort
+            && let Ok(secs) = std::env::var("QDRANT_STAGING_RESHARDING_ABORT_DELAY_SEC")
+            && let Ok(secs) = secs.parse::<f64>()
+        {
+            tokio::time::sleep(std::time::Duration::from_secs_f64(secs)).await;
+        }
+
         let shard_holder = self.shards_holder.read().await;
 
-        let Some(transfer) = shard_holder.get_transfer(&transfer_key) else {
-            return Ok(());
-        };
+        // Abort resharding must *not* abort this transfer
+        let transfer = shard_holder
+            .get_transfer(&transfer_key)
+            .expect("shard transfer exists");
 
         self.abort_shard_transfer(transfer, &shard_holder).await
     }

--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::types::ShardKey;
 
-use crate::collection::Collection;
+use crate::collection::{AbortReshardingScope, Collection};
 use crate::config::ShardingMethod;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::{
@@ -186,7 +186,8 @@ impl Collection {
             .filter(|state| state.shard_key.as_ref() == Some(&shard_key));
 
         if let Some(state) = resharding_state {
-            self.abort_resharding(state.key(), true).await?;
+            self.abort_resharding(state.key(), true, AbortReshardingScope::default())
+                .await?;
         }
 
         // Invalidate local shard cleanup tasks

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1,5 +1,6 @@
 pub mod recovery_guard;
 mod resharding;
+pub(crate) use resharding::ReshardingCheck;
 pub(crate) mod shard_mapping;
 pub mod shared_shard_holder;
 

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -889,10 +889,12 @@ mod tests {
         // resharding state is not cleared on this peer while it IS cleared on
         // peers where the operation succeeded.
         let result = holder.check_abort_resharding(&key);
-        assert!(
-            result.is_ok(),
-            "check_abort_resharding must return Ok when no resharding is active \
-             (idempotent: already aborted or never started), got error: {result:?}",
+        assert_eq!(
+            result.ok(),
+            Some(ReshardingCheck::NoOp),
+            "check_abort_resharding must signal NoOp when no resharding is active \
+             (idempotent: already aborted or never started) so the caller does not \
+             fall through to the destructive teardown",
         );
     }
 
@@ -919,10 +921,12 @@ mod tests {
         // the original resharding was already aborted and a new one was started.
         let other_key = make_reshard_key(2);
         let result = holder.check_abort_resharding(&other_key);
-        assert!(
-            result.is_ok(),
-            "check_abort_resharding must return Ok when a different resharding is active \
-             (the one we're aborting was already handled), got error: {result:?}"
+        assert_eq!(
+            result.ok(),
+            Some(ReshardingCheck::NoOp),
+            "check_abort_resharding must signal NoOp when a different resharding is active \
+             (the one we're aborting was already handled, or this is a stale abort \
+             targeting an earlier resharding that a newer one has since replaced)",
         );
     }
 
@@ -970,9 +974,46 @@ mod tests {
         let key = make_reshard_key(1);
 
         let result = holder.check_finish_resharding(&key);
+        assert_eq!(
+            result.ok(),
+            Some(ReshardingCheck::NoOp),
+            "check_finish_resharding must signal NoOp when no resharding is active \
+             (idempotent: already finished) so the caller does not fall through to the \
+             destructive down-branch teardown",
+        );
+    }
+
+    #[test]
+    fn test_finish_check_dismisses_stale_duplicate() {
+        let (_dir, mut holder) = make_holder();
+
+        // A different resharding is active: a stale finish targeting an earlier
+        // resharding that a newer one has since replaced. Finish rejects a
+        // mismatched key with `bad_request`, so the destructive down-branch never
+        // runs against the newer resharding's shard.
+        let active_key = make_reshard_key(1);
+        holder
+            .rings
+            .get_mut(&None)
+            .unwrap()
+            .start_resharding(active_key.shard_id, active_key.direction);
+        holder
+            .resharding_state
+            .write(|state| {
+                *state = Some(ReshardState::new(
+                    active_key.uuid,
+                    active_key.direction,
+                    active_key.peer_id,
+                    active_key.shard_id,
+                    active_key.shard_key.clone(),
+                ));
+            })
+            .unwrap();
+
+        let stale_key = make_reshard_key(2);
         assert!(
-            result.is_ok(),
-            "check_finish_resharding must return Ok when no resharding is active (idempotent: already finished), got error: {result:?}",
+            holder.check_finish_resharding(&stale_key).is_err(),
+            "a stale-duplicate finish (mismatched key) must be dismissed, not proceed",
         );
     }
 
@@ -1150,13 +1191,62 @@ mod tests {
         let result_a = holder_a.check_abort_resharding(&key);
         let result_b = holder_b.check_abort_resharding(&key);
 
-        assert!(
-            result_a.is_ok(),
-            "Peer A (has resharding state) must succeed: {result_a:?}"
+        assert_eq!(
+            result_a.ok(),
+            Some(ReshardingCheck::Proceed),
+            "Peer A (has matching resharding state) must proceed with the abort",
         );
-        assert!(
-            result_b.is_ok(),
-            "Peer B (no resharding state) must also succeed to prevent divergence: {result_b:?}"
+        assert_eq!(
+            result_b.ok(),
+            Some(ReshardingCheck::NoOp),
+            "Peer B (no resharding state) must signal NoOp (not error) to prevent divergence",
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // A stale abort must not touch a newer resharding
+    // ------------------------------------------------------------------
+
+    /// [abort A][start B reusing shard id][stale abort of A]: the stale abort
+    /// of A arrives after a new resharding B has reused the same shard id. It
+    /// must be a complete no-op — the pre-check signals NoOp (so the caller
+    /// never runs the destructive teardown that would drop B's shard) and, even
+    /// if the teardown's last write were reached, `clear_resharding_state`
+    /// refuses to clear B's state because it does not match A.
+    #[test]
+    fn test_stale_duplicate_abort_leaves_newer_resharding_untouched() {
+        let (_dir, holder) = make_holder();
+
+        // Resharding A completed its abort: state is cleared.
+        let key_a = make_reshard_key(1);
+        holder.clear_resharding_state(&key_a).unwrap();
+
+        // Resharding B started, reusing shard id 1.
+        let key_b = make_reshard_key(1);
+        let state_b = ReshardState::new(
+            key_b.uuid,
+            key_b.direction,
+            key_b.peer_id,
+            key_b.shard_id,
+            key_b.shard_key.clone(),
+        );
+        holder
+            .resharding_state
+            .write(|state| *state = Some(state_b.clone()))
+            .unwrap();
+
+        // A stale duplicate abort of A arrives.
+        assert_eq!(
+            holder.check_abort_resharding(&key_a).ok(),
+            Some(ReshardingCheck::NoOp),
+            "stale abort of A must signal NoOp while B is active",
+        );
+        holder.clear_resharding_state(&key_a).unwrap();
+
+        assert_eq!(
+            holder.resharding_state.read().clone(),
+            Some(state_b),
+            "B's resharding state must survive a stale abort of A",
         );
     }
 }

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -16,9 +16,21 @@ use crate::operations::cluster_ops::ReshardingDirection;
 use crate::operations::point_ops::{ConditionalInsertOperationInternal, PointOperations};
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::replica_set::ShardReplicaSet;
-use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::resharding::{ReshardKey, ReshardState, ReshardingStage};
 use crate::shards::shard::{PeerId, ShardId};
+
+/// Outcome of a resharding pre-check: whether caller should run the operation,
+/// or treat it as already-applied no-op.
+///
+/// On `NoOp` caller must return early, *without* modifying resharding state.
+/// Only pre-check compares resharding key, update steps act unconditionally.
+/// So running them for a stale operation targeting an earlier, already
+/// finished/aborted resharding would modify the current, unrelated one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReshardingCheck {
+    Proceed,
+    NoOp,
+}
 
 impl ShardHolder {
     pub fn resharding_state(&self) -> Option<ReshardState> {
@@ -326,32 +338,49 @@ impl ShardHolder {
         Ok(())
     }
 
-    pub fn check_abort_resharding(&self, resharding_key: &ReshardKey) -> CollectionResult<()> {
+    pub fn check_abort_resharding(
+        &self,
+        resharding_key: &ReshardKey,
+    ) -> CollectionResult<ReshardingCheck> {
         let state = self.resharding_state.read();
 
         let Some(state) = state.deref() else {
-            // Idempotent: no resharding in progress means the abort (or finish)
-            // was already applied, or the start was never applied on this node.
-            // Returning an error here would be silently swallowed by apply_entries,
-            // causing permanent state divergence between peers.
+            // Resharding is not in progress.
+            //
+            // Either resharding was never started, or it is already finished,
+            // or it was already aborted.
+            //
+            // Treat as a no-op.
+
             log::warn!(
-                "check_abort_resharding: no resharding in progress for {resharding_key}, treating as already aborted",
+                "check_abort_resharding: \
+                 resharding is not in progress, \
+                 treating resharding {resharding_key} as already aborted",
             );
-            return Ok(());
+
+            return Ok(ReshardingCheck::NoOp);
         };
 
         if !state.matches(resharding_key) {
-            // Idempotent: a different resharding is active, so the one we're
-            // trying to abort was already handled. Same reasoning as above.
+            // A different resharding is in progress.
+            //
+            // Either requested resharding was never started, or it is already finished,
+            // or it was already aborted.
+            //
+            // Treat as a no-op.
+
             log::warn!(
-                "check_abort_resharding: resharding {resharding_key} not found, current resharding has key {}, treating as already aborted",
+                "check_abort_resharding: \
+                 resharding {} is in progress, \
+                 treating resharding {resharding_key} as already aborted",
                 state.key(),
             );
-            return Ok(());
+
+            return Ok(ReshardingCheck::NoOp);
         }
 
         if state.stage < ReshardingStage::ReadHashRingCommitted {
-            return Ok(());
+            return Ok(ReshardingCheck::Proceed);
         }
 
         Err(CollectionError::bad_request(format!(
@@ -511,35 +540,6 @@ impl ShardHolder {
             Some(state) if state.matches(resharding_key) => Some(None),
             _ => None,
         })?;
-
-        Ok(())
-    }
-
-    pub async fn abort_resharding(
-        &mut self,
-        resharding_key: ReshardKey,
-        force: bool,
-    ) -> CollectionResult<()> {
-        log::warn!("Aborting resharding {resharding_key} (force: {force})");
-
-        // Scale-down: revert replicas in `ReshardingScaleDown` state back to `Active`.
-        for (shard_id, peer_id) in self.scale_down_replicas(&resharding_key) {
-            if let Some(shard) = self.shards.get(&shard_id) {
-                shard.set_replica_state(peer_id, ReplicaState::Active).await?;
-            }
-        }
-
-        // Scale-down: delete points transferred from target shard during resharding
-        self.scale_down_cleanup_points(&resharding_key).await?;
-
-        // Roll hash ring back
-        self.revert_resharding_hashring(&resharding_key);
-
-        // Scale-up: drop target shard that resharding created
-        self.scale_up_drop_target_shard(&resharding_key).await?;
-
-        // Clear persisted resharding state
-        self.clear_resharding_state(&resharding_key)?;
 
         Ok(())
     }

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -18,7 +18,7 @@ use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::replica_set::ShardReplicaSet;
 use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::resharding::{ReshardKey, ReshardState, ReshardingStage};
-use crate::shards::shard::ShardId;
+use crate::shards::shard::{PeerId, ShardId};
 
 impl ShardHolder {
     pub fn resharding_state(&self) -> Option<ReshardState> {
@@ -361,14 +361,106 @@ impl ShardHolder {
         )))
     }
 
-    pub async fn abort_resharding(
-        &mut self,
-        resharding_key: ReshardKey,
-        force: bool,
-    ) -> CollectionResult<()> {
-        log::warn!("Aborting resharding {resharding_key} (force: {force})");
+    /// Scale-down resharding only. Returns replicas in `ReshardingScaleDown` state,
+    /// that require cleanup on abort.
+    pub fn scale_down_replicas(&self, resharding_key: &ReshardKey) -> Vec<(ShardId, PeerId)> {
+        if resharding_key.direction != ReshardingDirection::Down {
+            return Vec::new();
+        }
 
-        let ReshardKey {
+        let mut replicas = Vec::new();
+
+        for (&id, shard) in self.shards.iter() {
+            // Skip shards that do not belong to the resharding shard key
+            if self.shard_id_to_key_mapping.get(&id) != resharding_key.shard_key.as_ref() {
+                continue;
+            }
+
+            // Skip target shard
+            if id == resharding_key.shard_id {
+                continue;
+            }
+
+            for (peer, state) in shard.peers() {
+                if state.is_resharding() {
+                    replicas.push((id, peer));
+                }
+            }
+        }
+
+        replicas
+    }
+
+    /// Scale-down resharding only. Delete points that were transferred from target
+    /// shard during scale-down resharding.
+    pub async fn scale_down_cleanup_points(
+        &self,
+        resharding_key: &ReshardKey,
+    ) -> CollectionResult<()> {
+        if resharding_key.direction != ReshardingDirection::Down {
+            return Ok(());
+        }
+
+        for (&id, shard) in self.shards.iter() {
+            // Skip shards that do not belong to the resharding shard key
+            if self.shard_id_to_key_mapping.get(&id) != resharding_key.shard_key.as_ref() {
+                continue;
+            }
+
+            // Skip target shard
+            if id == resharding_key.shard_id {
+                continue;
+            }
+
+            // We only cleanup local shards
+            if !shard.is_local().await {
+                continue;
+            }
+
+            // Remove any points that might have been transferred from target shard
+            // Replica may be dead, so we force the delete operation
+            let filter = self.hash_ring_filter(id).expect("hash ring filter");
+            let filter = Filter::new_must_not(Condition::new_custom(Arc::new(filter)));
+            shard
+                .delete_local_points(
+                    filter,
+                    // Internal operation, no performance tracking needed
+                    HwMeasurementAcc::disposable(),
+                    true,
+                    DeferredBehavior::WithDeferred,
+                )
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Revert resharding hash-ring into regular mode.
+    pub fn revert_resharding_hashring(&mut self, resharding_key: &ReshardKey) {
+        let Some(ring) = self.rings.get_mut(&resharding_key.shard_key) else {
+            log::warn!(
+                "aborting resharding {resharding_key}, \
+                 but {:?} hashring does not exist",
+                resharding_key.shard_key,
+            );
+
+            return;
+        };
+
+        log::debug!(
+            "reverting resharding hashring for shard {}",
+            resharding_key.shard_id,
+        );
+
+        ring.abort_resharding(resharding_key.shard_id, resharding_key.direction);
+    }
+
+    /// Scale-up resharding only. Drop the target shard that scale-up resharding created.
+    pub async fn scale_up_drop_target_shard(
+        &mut self,
+        resharding_key: &ReshardKey,
+    ) -> CollectionResult<()> {
+        let &ReshardKey {
             uuid: _,
             direction,
             peer_id: _,
@@ -376,111 +468,78 @@ impl ShardHolder {
             ref shard_key,
         } = resharding_key;
 
-        // Cleanup existing shards if resharding down
-        if direction == ReshardingDirection::Down {
-            for (&id, shard) in self.shards.iter() {
-                // Skip shards that does not belong to resharding shard key
-                if self.shard_id_to_key_mapping.get(&id) != shard_key.as_ref() {
-                    continue;
-                }
-
-                // Skip target shard
-                if id == shard_id {
-                    continue;
-                }
-
-                // Revert replicas in `Resharding` state back into `Active` state
-                for (peer, state) in shard.peers() {
-                    if state.is_resharding() {
-                        shard.set_replica_state(peer, ReplicaState::Active).await?;
-                    }
-                }
-
-                // We only cleanup local shards
-                if !shard.is_local().await {
-                    continue;
-                }
-
-                // Remove any points that might have been transferred from target shard
-                // Replica may be dead, so we force the delete operation
-                let filter = self.hash_ring_filter(id).expect("hash ring filter");
-                let filter = Filter::new_must_not(Condition::new_custom(Arc::new(filter)));
-                shard
-                    .delete_local_points(
-                        filter,
-                        // Internal operation, no performance tracking needed
-                        HwMeasurementAcc::disposable(),
-                        true,
-                        DeferredBehavior::WithDeferred,
-                    )
-                    .await?;
-            }
+        if direction != ReshardingDirection::Up {
+            return Ok(());
         }
 
-        if let Some(ring) = self.rings.get_mut(shard_key) {
-            log::debug!("reverting resharding hashring for shard {shard_id}");
-            ring.abort_resharding(shard_id, direction);
-        } else {
+        if !self.shards.contains_key(&shard_id) {
             log::warn!(
                 "aborting resharding {resharding_key}, \
-                 but {shard_key:?} hashring does not exist"
+                 but shard holder does not contain {shard_id} replica set",
             );
+
+            return Ok(());
         }
 
-        // Remove new shard if resharding up
-        if direction == ReshardingDirection::Up {
-            if let Some(shard) = self.get_shard(shard_id) {
-                // Remove all replicas from shard
-                for (peer_id, replica_state) in shard.peers() {
-                    log::debug!(
-                        "removing peer {peer_id} with state {replica_state:?} from replica set {shard_id}",
-                    );
-                    shard.remove_peer(peer_id).await?;
+        log::debug!("removing replica set {shard_id}");
+
+        if let Some(shard_key) = shard_key {
+            self.key_mapping.write_optional(|key_mapping| {
+                if !key_mapping.get(shard_key)?.contains(&shard_id) {
+                    return None;
                 }
 
-                debug_assert!(
-                    shard.peers().is_empty(),
-                    "replica set {shard_id} must be empty after removing all peers",
-                );
+                let mut key_mapping = key_mapping.clone();
+                key_mapping.get_mut(shard_key)?.remove(&shard_id);
+                Some(key_mapping)
+            })?;
+        }
 
-                log::debug!("removing replica set {shard_id}");
+        // No need to remove individual replicas from replica set one-by-one,
+        // because replica set directory (and `replica_set.json` that it contains)
+        // would be removed at once
 
-                // Drop the shard
-                if let Some(shard_key) = shard_key {
-                    // Idempotent: only rewrite the mapping if the shard id is
-                    // actually present under this key. A replay after a
-                    // successful abort finds nothing to remove and skips the
-                    // unnecessary disk write.
-                    self.key_mapping.write_optional(|key_mapping| {
-                        let shard_ids = key_mapping.get(shard_key)?;
-                        if !shard_ids.contains(&shard_id) {
-                            return None;
-                        }
+        self.drop_and_remove_shard(shard_id).await?;
+        self.shard_id_to_key_mapping.remove(&shard_id);
 
-                        let mut key_mapping = key_mapping.clone();
-                        key_mapping.get_mut(shard_key).unwrap().remove(&shard_id);
+        Ok(())
+    }
 
-                        Some(key_mapping)
-                    })?;
-                }
+    /// Clear `resharding_state.json` file, if persisted state matches `resharding_key`.
+    pub fn clear_resharding_state(&self, resharding_key: &ReshardKey) -> CollectionResult<()> {
+        self.resharding_state.write_optional(|state| match state {
+            Some(state) if state.matches(resharding_key) => Some(None),
+            _ => None,
+        })?;
 
-                self.drop_and_remove_shard(shard_id).await?;
-                self.shard_id_to_key_mapping.remove(&shard_id);
-            } else {
-                log::warn!(
-                    "aborting resharding {resharding_key}, \
-                     but shard holder does not contain {shard_id} replica set",
-                );
+        Ok(())
+    }
+
+    pub async fn abort_resharding(
+        &mut self,
+        resharding_key: ReshardKey,
+        force: bool,
+    ) -> CollectionResult<()> {
+        log::warn!("Aborting resharding {resharding_key} (force: {force})");
+
+        // Scale-down: revert replicas in `ReshardingScaleDown` state back to `Active`.
+        for (shard_id, peer_id) in self.scale_down_replicas(&resharding_key) {
+            if let Some(shard) = self.shards.get(&shard_id) {
+                shard.set_replica_state(peer_id, ReplicaState::Active).await?;
             }
         }
 
-        // Idempotent: if state is already cleared, or holds a different
-        // resharding (already superseded), leave it alone. Only clear a state
-        // that matches the resharding_key we are aborting.
-        self.resharding_state.write_optional(|state| match state {
-            Some(state) if state.matches(&resharding_key) => Some(None),
-            _ => None,
-        })?;
+        // Scale-down: delete points transferred from target shard during resharding
+        self.scale_down_cleanup_points(&resharding_key).await?;
+
+        // Roll hash ring back
+        self.revert_resharding_hashring(&resharding_key);
+
+        // Scale-up: drop target shard that resharding created
+        self.scale_up_drop_target_shard(&resharding_key).await?;
+
+        // Clear persisted resharding state
+        self.clear_resharding_state(&resharding_key)?;
 
         Ok(())
     }

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -265,13 +265,25 @@ impl ShardHolder {
         Ok(())
     }
 
-    pub fn check_finish_resharding(&mut self, resharding_key: &ReshardKey) -> CollectionResult<()> {
-        // Idempotent: if no resharding is active, finish was already applied.
+    pub fn check_finish_resharding(
+        &mut self,
+        resharding_key: &ReshardKey,
+    ) -> CollectionResult<ReshardingCheck> {
         if self.resharding_state.read().is_none() {
+            // Resharding is not in progress.
+            //
+            // Either it was never started, or it is already finished,
+            // or it was already aborted. Treat as a no-op.
+            //
+            // A *mismatched* state, is rejected with an error by `check_resharding` below.
+
             log::warn!(
-                "check_finish_resharding: no resharding in progress for {resharding_key}, treating as already finished",
+                "check_finish_resharding: \
+                 resharding is not in progress, \
+                 treating resharding {resharding_key} as already finished",
             );
-            return Ok(());
+
+            return Ok(ReshardingCheck::NoOp);
         }
 
         self.check_resharding(
@@ -279,19 +291,7 @@ impl ShardHolder {
             check_stage(ReshardingStage::WriteHashRingCommitted),
         )?;
 
-        Ok(())
-    }
-
-    pub fn finish_resharding_unchecked(&mut self, _: &ReshardKey) -> CollectionResult<()> {
-        // Idempotent: if state is already cleared (replay after a successful
-        // finish/abort), leave it alone so we don't spuriously touch the file.
-        self.resharding_state.write_optional(
-            |state| {
-                if state.is_some() { Some(None) } else { None }
-            },
-        )?;
-
-        Ok(())
+        Ok(ReshardingCheck::Proceed)
     }
 
     fn check_resharding(
@@ -348,9 +348,7 @@ impl ShardHolder {
             // Resharding is not in progress.
             //
             // Either resharding was never started, or it is already finished,
-            // or it was already aborted.
-            //
-            // Treat as a no-op.
+            // or it was already aborted. Treat as a no-op.
 
             log::warn!(
                 "check_abort_resharding: \
@@ -365,9 +363,7 @@ impl ShardHolder {
             // A different resharding is in progress.
             //
             // Either requested resharding was never started, or it is already finished,
-            // or it was already aborted.
-            //
-            // Treat as a no-op.
+            // or it was already aborted. Treat as a no-op.
 
             log::warn!(
                 "check_abort_resharding: \
@@ -1021,25 +1017,56 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // finish_resharding_unchecked idempotency
+    // clear_resharding_state idempotency (the finish/abort last write)
     // ------------------------------------------------------------------
 
     #[test]
-    fn test_finish_unchecked_idempotent_when_no_resharding_active() {
-        let (_dir, mut holder) = make_holder();
+    fn test_clear_resharding_state_idempotent_when_no_resharding_active() {
+        let (_dir, holder) = make_holder();
         let key = make_reshard_key(1);
 
-        // Replay `finish` after the resharding state has already been cleared
-        // (partial apply between the state write and a subsequent step).
-        // The unchecked helper must not panic or error in this case.
-        let result = holder.finish_resharding_unchecked(&key);
+        // Replay `finish`/`abort` after the resharding state has already been
+        // cleared (replay after a successful apply, or crash after the final
+        // clear). The primitive must not panic or error in this case.
+        let result = holder.clear_resharding_state(&key);
         assert!(
             result.is_ok(),
-            "finish_resharding_unchecked must return Ok when no resharding state is present, got error: {result:?}",
+            "clear_resharding_state must return Ok when no resharding state is present, got error: {result:?}",
         );
         assert!(
             holder.resharding_state.read().is_none(),
-            "state must remain cleared after idempotent finish",
+            "state must remain cleared after idempotent clear",
+        );
+    }
+
+    #[test]
+    fn test_clear_resharding_state_leaves_mismatched_state_untouched() {
+        let (_dir, holder) = make_holder();
+
+        // If current resharding does *not* match `resharding_key`, this means
+        // another/newer resharding is in progress, so `clear_resharding_state`
+        // should be a no-op.
+
+        let active_key = make_reshard_key(1);
+        let active_state = ReshardState::new(
+            active_key.uuid,
+            active_key.direction,
+            active_key.peer_id,
+            active_key.shard_id,
+            active_key.shard_key.clone(),
+        );
+        holder
+            .resharding_state
+            .write(|state| *state = Some(active_state.clone()))
+            .unwrap();
+
+        let stale_key = make_reshard_key(2);
+        holder.clear_resharding_state(&stale_key).unwrap();
+
+        assert_eq!(
+            holder.resharding_state.read().clone(),
+            Some(active_state),
+            "a mismatched resharding state must be left untouched by clear_resharding_state",
         );
     }
 

--- a/lib/collection/tests/integration/consensus_idempotency_test.rs
+++ b/lib/collection/tests/integration/consensus_idempotency_test.rs
@@ -1,0 +1,182 @@
+//! Replay/idempotency tests for `Collection::set_shard_replica_state` and the
+//! resharding-abort composition (audit findings B and I, Part 1).
+//!
+//! These exercise the in-process `Collection` API directly. The multi-peer
+//! crash-window scenarios (mid-teardown down crash, post-dir-drop up residue)
+//! live in the Python consensus suite
+//! (`tests/consensus_tests/test_resharding_set_replica_dead_replay.py`,
+//! `test_resharding_down_abort_converges_after_crash.py`,
+//! `test_resharding_replay.py`); here we cover what a single process can drive
+//! deterministically.
+
+use async_trait::async_trait;
+use collection::operations::cluster_ops::ReshardingDirection;
+use collection::operations::types::{CollectionError, CollectionResult};
+use collection::shards::CollectionId;
+use collection::shards::replica_set::replica_set_state::ReplicaState;
+use collection::shards::resharding::ReshardKey;
+use collection::shards::shard::{PeerId, ShardId};
+use collection::shards::transfer::{
+    ShardTransfer, ShardTransferConsensus, ShardTransferKey, ShardTransferMethod,
+};
+use tempfile::Builder;
+use uuid::Uuid;
+
+use crate::common::simple_collection_fixture;
+
+/// `Collection::start_resharding` never touches its `ShardTransferConsensus`
+/// argument (the resharding driver is disabled), so every method can be a stub.
+struct NoopReshardingConsensus;
+
+#[async_trait]
+impl ShardTransferConsensus for NoopReshardingConsensus {
+    fn this_peer_id(&self) -> PeerId {
+        0
+    }
+
+    fn peers(&self) -> Vec<PeerId> {
+        vec![0]
+    }
+
+    fn consensus_commit_term(&self) -> (u64, u64) {
+        (0, 0)
+    }
+
+    fn recovered_switch_to_partial(
+        &self,
+        _transfer_config: &ShardTransfer,
+        _collection_id: CollectionId,
+    ) -> CollectionResult<()> {
+        unimplemented!("not exercised by start_resharding")
+    }
+
+    async fn start_shard_transfer(
+        &self,
+        _transfer_config: ShardTransfer,
+        _collection_id: CollectionId,
+    ) -> CollectionResult<()> {
+        unimplemented!("not exercised by start_resharding")
+    }
+
+    async fn restart_shard_transfer(
+        &self,
+        _transfer_config: ShardTransfer,
+        _collection_id: CollectionId,
+        _default_method: ShardTransferMethod,
+    ) -> CollectionResult<()> {
+        unimplemented!("not exercised by start_resharding")
+    }
+
+    async fn abort_shard_transfer(
+        &self,
+        _transfer: ShardTransferKey,
+        _collection_id: CollectionId,
+        _reason: &str,
+    ) -> CollectionResult<()> {
+        unimplemented!("not exercised by start_resharding")
+    }
+
+    async fn set_shard_replica_set_state(
+        &self,
+        _peer_id: Option<PeerId>,
+        _collection_id: CollectionId,
+        _shard_id: ShardId,
+        _state: ReplicaState,
+        _from_state: Option<ReplicaState>,
+    ) -> CollectionResult<()> {
+        unimplemented!("not exercised by start_resharding")
+    }
+
+    async fn commit_read_hashring(
+        &self,
+        _collection_id: CollectionId,
+        _reshard_key: ReshardKey,
+    ) -> CollectionResult<()> {
+        unimplemented!("not exercised by start_resharding")
+    }
+
+    async fn commit_write_hashring(
+        &self,
+        _collection_id: CollectionId,
+        _reshard_key: ReshardKey,
+    ) -> CollectionResult<()> {
+        unimplemented!("not exercised by start_resharding")
+    }
+}
+
+/// [audit-B] Setting a resharding-*up* replica `Dead` aborts the resharding
+/// first (dropping the shard) and then converges: the shard is gone, the
+/// persisted resharding state is cleared, and re-applying the same entry does
+/// not resurrect the shard or the state.
+#[tokio::test]
+async fn test_set_resharding_up_replica_dead_drops_shard_and_clears_state() {
+    let dir = Builder::new().prefix("collection").tempdir().unwrap();
+    // Auto-sharded collection with shards 0 and 1.
+    let collection = simple_collection_fixture(dir.path(), 2).await;
+
+    // Start resharding *up*: creates shard 2 on peer 0 in `Resharding` state and
+    // persists resharding_state (shard_number -> 3).
+    let key = ReshardKey {
+        uuid: Uuid::new_v4(),
+        direction: ReshardingDirection::Up,
+        peer_id: 0,
+        shard_id: 2,
+        shard_key: None,
+    };
+    collection
+        .start_resharding(
+            key,
+            Box::new(NoopReshardingConsensus),
+            std::future::ready(()),
+            std::future::ready(()),
+        )
+        .await
+        .expect("start_resharding up must succeed");
+
+    assert!(
+        collection.resharding_state().await.is_some(),
+        "resharding must be in progress after start",
+    );
+    assert!(
+        collection.state().await.shards.contains_key(&2),
+        "resharding up must have created shard 2",
+    );
+
+    // Deactivate the resharding replica. This triggers the abort composition
+    // (with skip_replica = (2, 0)): the shard is dropped, so the handler takes
+    // the missing-shard early return after clearing the state.
+    collection
+        .set_shard_replica_state(2, 0, ReplicaState::Dead, Some(ReplicaState::Resharding))
+        .await
+        .expect("deactivating a resharding-up replica must abort resharding and return Ok");
+
+    assert!(
+        collection.resharding_state().await.is_none(),
+        "resharding_state must be cleared after the abort",
+    );
+    assert!(
+        !collection.state().await.shards.contains_key(&2),
+        "shard 2 must be dropped by the resharding-up abort",
+    );
+
+    // Replay the exact same entry. The shard is gone and resharding_state is
+    // None, so the crash-signature re-entry does not fire and the entry is
+    // benignly dismissed (not_found) — critically, nothing is resurrected and
+    // the state stays converged.
+    let replay = collection
+        .set_shard_replica_state(2, 0, ReplicaState::Dead, Some(ReplicaState::Resharding))
+        .await;
+
+    assert!(
+        matches!(replay, Err(CollectionError::NotFound { .. })),
+        "replay after full completion is a benign dismissal (shard already gone)",
+    );
+    assert!(
+        collection.resharding_state().await.is_none(),
+        "resharding_state must stay cleared across the replay",
+    );
+    assert!(
+        !collection.state().await.shards.contains_key(&2),
+        "the dropped shard must not be resurrected by the replay",
+    );
+}

--- a/lib/collection/tests/integration/main.rs
+++ b/lib/collection/tests/integration/main.rs
@@ -1,6 +1,7 @@
 mod collection_restore_test;
 mod collection_test;
 mod common;
+mod consensus_idempotency_test;
 mod continuous_snapshot_test;
 mod create_shard_key_test;
 mod distance_matrix_test;

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::sync::LazyLock;
 
+use collection::collection::AbortReshardingScope;
 use collection::collection_state;
 use collection::config::ShardingMethod;
 use collection::events::{CollectionDeletedEvent, IndexCreatedEvent};
@@ -237,7 +238,9 @@ impl TableOfContent {
         let removed_opt = self.collections.write().await.remove(collection_name);
         if let Some(removed) = removed_opt {
             if let Some(state) = removed.resharding_state().await
-                && let Err(err) = removed.abort_resharding(state.key(), true).await
+                && let Err(err) = removed
+                    .abort_resharding(state.key(), true, AbortReshardingScope::default())
+                    .await
             {
                 log::error!(
                     "Failed to abort resharding {} when deleting collection {collection_name}: \
@@ -415,7 +418,9 @@ impl TableOfContent {
             }
 
             ReshardingOperation::Abort(key) => {
-                collection.abort_resharding(key, false).await?;
+                collection
+                    .abort_resharding(key, false, AbortReshardingScope::default())
+                    .await?;
             }
         }
 


### PR DESCRIPTION
Follow up to #9695
Fixes <https://github.com/qdrant/qdrant/pull/9656>

This PR refactors `set_replica_state`, `abort_transfer` and `abort_resharding`, so that each operation is idempotent and partial-failure safe.

`set_replica_state`, `abort_transfer` and `abort_resharding` each might do all three things:
- `set_replica_state(Dead)` might abort transfers and/or resharding
- `abort_transfer` might abort resharding and set replica state to `Dead`
- and `abort_resharding` might abort transfer(s) and/or change replica state

To make each operation partial-failure safe, we need to ensure that each operation writes its own state **last**:
- `set_replica_state(Dead)` should abort transfers and resharding *before* it writes `replica_state.json`
- `abort_transfer` should abort resharding and set replica state to `Dead` *before* it writes `shard_transfers`
- `abort_resharding` should abort transfers and change replica states *before* it writes `resharding_state.json`

This ensures, that if we crash and re-apply operation after restart, we would retry each step of an operation, and only mark it "completed" by final write.

This is what PR does. We restructure all three operations, so that they "hook" into each other correctly, without accidentally updating state that should not be written yet.

Code changes are not _too bad, 2/3 of the PR are documentation/comments and tests.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
