### PR TITLE
feat: skip unloadable segments in read-only follower open

### DIFF
--- a/lib/edge/src/read_only/lifecycle.rs
+++ b/lib/edge/src/read_only/lifecycle.rs
@@ -62,8 +62,9 @@ impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
     /// Internal seam: [`open`](Self::open) always discovers via the manifest, but tests inject other
     /// discovery strategies (e.g. a directory scan) here.
     ///
-    /// Every segment reported by the enumerator is opened read-only; the enumerator only reports
-    /// segments the leader considers ready, so a failure to open one is a genuine error.
+    /// Every segment reported by the enumerator is opened read-only. The manifest is superset-biased,
+    /// so segments that cannot be loaded (not yet finalized, already deleted, or appendable) are
+    /// skipped rather than failing the open.
     pub(crate) fn open_with_enumerator(
         fs: S::Fs,
         path: &Path,
@@ -80,7 +81,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
         let search_pool = crate::pool::build_search_pool(provided_config.search_thread_count())?;
 
         let mut loaded =
-            load_segments_parallel::<S>(&search_pool, &fs, enumerator.list_segments()?)?;
+            load_segments_parallel::<S>(&search_pool, &fs, enumerator.list_segments()?);
         // Fold the derived config in UUID order so the derivation is deterministic.
         loaded.sort_unstable_by_key(|(uuid, _)| *uuid);
         let mut holder = ReadOnlySegmentHolder::default();

--- a/lib/edge/src/read_only/load.rs
+++ b/lib/edge/src/read_only/load.rs
@@ -2,20 +2,24 @@ use std::path::PathBuf;
 
 use rayon::ThreadPool;
 use rayon::prelude::*;
-use segment::common::operation_error::OperationResult;
 use segment::index::UniversalReadExt;
 use segment::segment::read_only::ReadOnlySegment;
 use uuid::Uuid;
 
-/// Open the given segments in parallel on `pool` and return them in input order.
+/// Open the given segments in parallel on `pool` and return the ones that loaded, in input order.
 ///
 /// Reuses the shard's long-lived search thread pool instead of spawning a fresh OS thread per
 /// segment, bounding concurrency to the pool size.
+///
+/// The segment manifest is superset-biased, so it may list segments a read-only follower cannot
+/// load — a not-yet-finalized segment, one already deleted, or an appendable write-buffer segment
+/// that has no disk-resident id tracker. Per the manifest's reader contract these are skipped (with
+/// a warning) instead of failing the whole open.
 pub(crate) fn load_segments_parallel<S>(
     pool: &ThreadPool,
     fs: &S::Fs,
     segments: impl IntoIterator<Item = (Uuid, PathBuf)>,
-) -> OperationResult<Vec<(Uuid, ReadOnlySegment<S>)>>
+) -> Vec<(Uuid, ReadOnlySegment<S>)>
 where
     S: UniversalReadExt + 'static,
     S::Fs: Send + Sync + Clone + 'static,
@@ -25,9 +29,14 @@ where
     pool.install(|| {
         segments
             .into_par_iter()
-            .map(|(uuid, segment_path)| {
-                let segment = ReadOnlySegment::<S>::open(fs, &segment_path, uuid, None)?;
-                Ok((uuid, segment))
+            .filter_map(|(uuid, segment_path)| {
+                match ReadOnlySegment::<S>::open(fs, &segment_path, uuid, None) {
+                    Ok(segment) => Some((uuid, segment)),
+                    Err(err) => {
+                        log::warn!("read-only open: skipping unloadable segment {uuid}: {err}");
+                        None
+                    }
+                }
             })
             .collect()
     })

--- a/lib/edge/src/read_only/refresh.rs
+++ b/lib/edge/src/read_only/refresh.rs
@@ -47,7 +47,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
                 .map(|(uuid, segment_path)| (*uuid, segment_path.clone()))
                 .collect()
         };
-        let loaded = load_segments_parallel::<S>(&self.search_pool, &self.fs, new_segments)?;
+        let loaded = load_segments_parallel::<S>(&self.search_pool, &self.fs, new_segments);
 
         let survivors: Vec<(Uuid, Arc<RwLock<ReadOnlySegment<S>>>)> = {
             let mut holder = self.segments.write();


### PR DESCRIPTION
The segment manifest is superset-biased (see its module doc): a read-only follower may be handed segments it cannot load — one not yet finalized, one already deleted, or an appendable write-buffer segment that has no disk-resident id tracker. The manifest's reader contract says such segments must be tolerated and skipped, but `load_segments_parallel` propagated the open error and failed the whole shard open.

This skips segments that fail to open (logging a warning) instead of erroring, aligning the follower with the manifest's documented reader contract. `load_segments_parallel` no longer returns a `Result` (it can no longer fail); the two callers are updated accordingly.
