### PR TITLE
[UIO] implement `ReadOnlyFullTextIndex::preopen`

### DIFF
--- a/lib/common/common/src/persisted_hashmap/uio/mod.rs
+++ b/lib/common/common/src/persisted_hashmap/uio/mod.rs
@@ -11,8 +11,8 @@ use crate::aligned_buf::AlignedBuf;
 use crate::generic_consts::Sequential;
 use crate::iterator_ext::ordering_iterator::OrderingIterator;
 use crate::universal_io::{
-    OpenOptions, ReadRange, Result, TypedStorage, UniversalIoError, UniversalRead, UniversalReadFs,
-    UserData,
+    CachedReadFs, OpenOptions, ReadRange, Result, TypedStorage, UniversalIoError, UniversalRead,
+    UniversalReadFs, UserData,
 };
 
 mod random_reader;
@@ -42,6 +42,17 @@ where
     V: Sized + Copy + FromBytes + Immutable + IntoBytes + KnownLayout,
     S: UniversalRead,
 {
+    /// Schedule background prefetch of the backing file, ahead of
+    /// [`Self::open`].
+    pub fn preopen<Fs: CachedReadFs<File = S>>(
+        fs: &Fs,
+        path: impl AsRef<Path>,
+        options: OpenOptions,
+    ) -> Result<()> {
+        // TODO(uio): Turn `Populate::No` into `Populate::BackgroundPartial(0..header + phf)
+        fs.schedule_prefetch(path.as_ref(), Some(options), None)
+    }
+
     /// Load the hash map from file.
     pub fn open<Fs: UniversalReadFs<File = S>>(
         fs: &Fs,

--- a/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
@@ -144,8 +144,16 @@ impl<S: UniversalReadExt> ReadOnlyFieldIndex<S> {
                 }
             },
             PayloadIndexType::FullTextIndex => match mode {
-                ReadMode::Appendable => false,
-                ReadMode::Immutable { is_on_disk: _ } => false,
+                ReadMode::Appendable => {
+                    ReadOnlyFullTextIndex::<S>::preopen_appendable(fs, text_dir(dir, field))?
+                }
+                ReadMode::Immutable { is_on_disk } => {
+                    ReadOnlyFullTextIndex::<S>::preopen_immutable(
+                        fs,
+                        &text_dir(dir, field),
+                        is_on_disk,
+                    )?
+                }
             },
             // Bool and null are roaring-flag backed: a single read-only `preopen`
             // serves both modes (neither consumes the immutable-only

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::ops::BitOrAssign;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use common::bitvec::{BitSlice, BitVec, DeletedBitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -11,8 +11,8 @@ use common::persisted_hashmap::{READ_ENTRY_OVERHEAD, UniversalHashMap, serialize
 use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    MmapFile, MmapFs, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead,
-    UniversalReadFs, UserData,
+    CachedReadFs, MmapFile, MmapFs, OkNotFound, OpenOptions, Populate, ReadRange, TypedStorage,
+    UniversalRead, UniversalReadFs, UserData,
 };
 use on_disk_postings::OnDiskPostings;
 use types::ZerocopyPostingValue;
@@ -151,6 +151,68 @@ impl OnDiskInvertedIndex<MmapFile> {
 }
 
 impl<S: UniversalRead> OnDiskInvertedIndex<S> {
+    fn open_options(populate: Populate, advice: AdviceSetting) -> OpenOptions {
+        OpenOptions {
+            writeable: false,
+            need_sequential: false,
+            populate,
+            advice,
+        }
+    }
+
+    /// Schedule background prefetch of every file [`open`](Self::open) will read.
+    ///
+    /// Returns `false` when the index is not in the on-disk format.
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        path: &Path,
+        populate: Populate,
+    ) -> OperationResult<bool> {
+        // Postings.
+        let postings_path = path.join(POSTINGS_FILE);
+        if fs
+            .schedule_prefetch(
+                &postings_path,
+                Some(Self::open_options(
+                    populate,
+                    AdviceSetting::Advice(Advice::Normal),
+                )),
+                None,
+            )
+            .ok_not_found()?
+            .is_none()
+        {
+            // If postings don't exist, assume the index doesn't exist on disk
+            return Ok(false);
+        }
+
+        // Vocabulary
+        UniversalHashMap::<str, TokenId, S>::preopen(
+            fs,
+            &path.join(VOCAB_FILE),
+            Self::open_options(populate, AdviceSetting::Global),
+        )?;
+
+        // Point to tokens count
+        fs.schedule_prefetch(
+            &path.join(POINT_TO_TOKENS_COUNT_FILE),
+            Some(Self::open_options(populate, AdviceSetting::Global)),
+            None,
+        )?;
+
+        // Deleted points
+        fs.schedule_prefetch(
+            &path.join(DELETED_POINTS_FILE),
+            Some(Self::open_options(
+                Populate::PreferBackground,
+                AdviceSetting::Global,
+            )),
+            None,
+        )?;
+
+        Ok(true)
+    }
+
     pub fn open(
         fs: &impl UniversalReadFs<File = S>,
         path: PathBuf,
@@ -163,12 +225,8 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
         let point_to_tokens_count_path = path.join(POINT_TO_TOKENS_COUNT_FILE);
         let deleted_points_path = path.join(DELETED_POINTS_FILE);
 
-        let postings_open_options = OpenOptions {
-            writeable: false,
-            need_sequential: false,
-            populate,
-            advice: AdviceSetting::Advice(Advice::Normal),
-        };
+        let postings_open_options =
+            Self::open_options(populate, AdviceSetting::Advice(Advice::Normal));
 
         let Some(postings) = (match has_positions {
             false => OnDiskPostings::<(), S>::open(
@@ -192,35 +250,20 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
         let vocab = UniversalHashMap::<str, TokenId, S>::open(
             fs,
             &vocab_path,
-            OpenOptions {
-                writeable: false,
-                need_sequential: false,
-                populate,
-                advice: AdviceSetting::Global,
-            },
+            Self::open_options(populate, AdviceSetting::Global),
             Default::default(),
         )?;
 
         let point_to_tokens_count = TypedStorage::<S, usize>::new(fs.open(
             &point_to_tokens_count_path,
-            OpenOptions {
-                writeable: false,
-                need_sequential: false,
-                populate,
-                advice: AdviceSetting::Global,
-            },
+            Self::open_options(populate, AdviceSetting::Global),
             Default::default(),
         )?);
 
         let deleted_payload_mmap = StoredBitSlice::<S>::open(
             fs,
             &deleted_points_path,
-            OpenOptions {
-                writeable: false,
-                need_sequential: false,
-                populate,
-                advice: AdviceSetting::Global,
-            },
+            Self::open_options(populate, AdviceSetting::Global),
             Default::default(),
         )?;
         let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::universal_io::{OkNotFound, Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, OkNotFound, Populate, UniversalRead, UniversalReadFs};
 use gridstore::GridstoreReader;
 
 use super::super::inner::MutableFullTextIndexInner;
@@ -13,6 +13,19 @@ use crate::index::field_index::full_text_index::inverted_index::mutable_inverted
 use crate::index::field_index::full_text_index::tokenizers::Tokenizer;
 
 impl<S: UniversalRead> ReadOnlyAppendableFullTextIndex<S> {
+    /// Schedule background prefetch of the Gridstore files [`open`](Self::open)
+    /// will read.
+    ///
+    /// Returns whether the on-disk directory exists.
+    pub fn preopen(fs: &impl CachedReadFs<File = S>, dir: PathBuf) -> OperationResult<bool> {
+        // Gridstore reader
+        Ok(
+            GridstoreReader::<Vec<u8>, S>::preopen(fs, dir, Populate::PreferBackground)
+                .ok_not_found()?
+                .is_some(),
+        )
+    }
+
     /// Open the appendable (Gridstore) full-text index read-only, threading
     /// every file open through the filesystem handle `fs`.
     ///

--- a/lib/segment/src/index/field_index/full_text_index/on_disk_text_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/on_disk_text_index/lifecycle.rs
@@ -1,9 +1,9 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFs, Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, MmapFs, Populate, UniversalRead, UniversalReadFs};
 use fs_err as fs;
 use serde_json::Value;
 
@@ -21,6 +21,18 @@ use crate::data_types::index::TextIndexParams;
 use crate::index::field_index::{FieldIndexBuilderTrait, ValueIndexer};
 
 impl<S: UniversalRead> OnDiskFullTextIndex<S> {
+    /// Schedule background prefetch of every file [`open`](Self::open) will read.
+    ///
+    /// Returns `false` when the index is not in the on-disk format.
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        path: &Path,
+        populate: Populate,
+    ) -> OperationResult<bool> {
+        // Inverted index
+        OnDiskInvertedIndex::<S>::preopen(fs, path, populate)
+    }
+
     pub fn open(
         fs: &impl UniversalReadFs<File = S>,
         path: PathBuf,

--- a/lib/segment/src/index/field_index/full_text_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use common::bitvec::BitSlice;
-use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs};
 
 use super::super::mutable_text_index::read_only::ReadOnlyAppendableFullTextIndex;
 use super::super::on_disk_text_index::OnDiskFullTextIndex;
@@ -12,6 +12,16 @@ use crate::index::field_index::full_text_index::immutable_text_index::ImmutableF
 use crate::index::payload_config::IndexMutability;
 
 impl<S: UniversalRead> ReadOnlyFullTextIndex<S> {
+    /// Schedule background prefetch for the appendable (Gridstore) format.
+    ///
+    /// Returns `false` when nothing was scheduled (directory absent).
+    pub fn preopen_appendable(
+        fs: &impl CachedReadFs<File = S>,
+        dir: PathBuf,
+    ) -> OperationResult<bool> {
+        ReadOnlyAppendableFullTextIndex::preopen(fs, dir)
+    }
+
     /// Read-only mirror of [`FullTextIndex::new_gridstore`][1]: open the
     /// appendable (Gridstore-backed) full-text index read-only, threading
     /// every file open through the filesystem handle `fs`.
@@ -29,6 +39,25 @@ impl<S: UniversalRead> ReadOnlyFullTextIndex<S> {
         config: TextIndexParams,
     ) -> OperationResult<Option<Self>> {
         Ok(ReadOnlyAppendableFullTextIndex::open(fs, dir, config)?.map(Self::Appendable))
+    }
+
+    /// Schedule background prefetch for the immutable (mmap) format.
+    ///
+    /// Returns `false` when the on-disk index doesn't exist.
+    pub fn preopen_immutable(
+        fs: &impl CachedReadFs<File = S>,
+        path: &Path,
+        is_on_disk: bool,
+    ) -> OperationResult<bool> {
+        let effective_is_on_disk =
+            is_on_disk || common::low_memory::low_memory_mode().prefer_disk();
+
+        let populate = match effective_is_on_disk {
+            true => Populate::No,
+            false => Populate::PreferBackground,
+        };
+
+        OnDiskFullTextIndex::preopen(fs, path, populate)
     }
 
     /// Read-only mirror of [`FullTextIndex::new_mmap`][1]: open the immutable

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
@@ -56,7 +56,11 @@ where
 
         // Value to points
         let hashmap_path = path.join(HASHMAP_PATH);
-        fs.schedule_prefetch(&hashmap_path, Some(Self::open_options(populate)), None)?;
+        UniversalHashMap::<N, PointOffsetType, S>::preopen(
+            fs,
+            &hashmap_path,
+            Self::open_options(populate),
+        )?;
 
         // Point to values
         OnDiskPointToValues::<N, S>::preopen(fs, path, populate)?;


### PR DESCRIPTION
Builds on top of #9744 

Implements preopen functionality for full text index. Also flags the on-disk hashmap as a candidate for partial background populate.