### PR TITLE
Fix payload index inconsistency after restart: flush-before-build (alternative to #9737)

### DIFF
--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -564,20 +564,42 @@ impl IndexSelector<'_> {
     }
 }
 
+impl PayloadIndexType {
+    /// The on-disk directory where an index of this type stores `field`'s data,
+    /// under the payload index root `dir`.
+    ///
+    /// This is the single source of truth for [`wipe_field_dirs`]. The match is
+    /// deliberately exhaustive: a new index type does not compile until its storage
+    /// directory is declared here, and it is then wiped on rebuilds automatically.
+    pub(crate) fn storage_dir(&self, dir: &Path, field: &JsonPath) -> PathBuf {
+        match self {
+            PayloadIndexType::IntIndex
+            | PayloadIndexType::DatetimeIndex
+            | PayloadIndexType::FloatIndex => numeric_dir(dir, field),
+            PayloadIndexType::IntMapIndex
+            | PayloadIndexType::KeywordIndex
+            | PayloadIndexType::GeoIndex
+            | PayloadIndexType::UuidIndex
+            | PayloadIndexType::UuidMapIndex => map_dir(dir, field),
+            PayloadIndexType::FullTextIndex => text_dir(dir, field),
+            PayloadIndexType::BoolIndex => bool_dir(dir, field),
+            PayloadIndexType::NullIndex => null_dir(dir, field),
+        }
+    }
+}
+
 /// Remove all on-disk leftovers of `field`'s indexes under the payload index root `dir`.
 ///
 /// A full rebuild must start from a clean slate: files can be left behind by a build
 /// that crashed before its config entry was written, or by an index that failed to
 /// load. Appendable builders open existing storages, so leftovers would leak stale
 /// postings into the fresh build.
+///
+/// Covers every [`PayloadIndexType`] by construction: the candidate set is derived
+/// by iterating the enum through [`PayloadIndexType::storage_dir`].
 pub(crate) fn wipe_field_dirs(dir: &Path, field: &JsonPath) -> std::io::Result<()> {
-    for candidate in [
-        map_dir(dir, field),
-        numeric_dir(dir, field),
-        text_dir(dir, field),
-        bool_dir(dir, field),
-        null_dir(dir, field),
-    ] {
+    for index_type in <PayloadIndexType as strum::IntoEnumIterator>::iter() {
+        let candidate = index_type.storage_dir(dir, field);
         if candidate.exists() {
             fs_err::remove_dir_all(&candidate)?;
         }

--- a/lib/segment/src/index/field_index/index_selector.rs
+++ b/lib/segment/src/index/field_index/index_selector.rs
@@ -564,6 +564,27 @@ impl IndexSelector<'_> {
     }
 }
 
+/// Remove all on-disk leftovers of `field`'s indexes under the payload index root `dir`.
+///
+/// A full rebuild must start from a clean slate: files can be left behind by a build
+/// that crashed before its config entry was written, or by an index that failed to
+/// load. Appendable builders open existing storages, so leftovers would leak stale
+/// postings into the fresh build.
+pub(crate) fn wipe_field_dirs(dir: &Path, field: &JsonPath) -> std::io::Result<()> {
+    for candidate in [
+        map_dir(dir, field),
+        numeric_dir(dir, field),
+        text_dir(dir, field),
+        bool_dir(dir, field),
+        null_dir(dir, field),
+    ] {
+        if candidate.exists() {
+            fs_err::remove_dir_all(&candidate)?;
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn map_dir(dir: &Path, field: &JsonPath) -> PathBuf {
     dir.join(format!("{}-map", field.filename()))
 }

--- a/lib/segment/src/index/payload_config.rs
+++ b/lib/segment/src/index/payload_config.rs
@@ -140,7 +140,7 @@ impl PayloadFieldSchemaWithIndexType {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, strum::EnumIter)]
 #[serde(rename_all = "snake_case")]
 pub enum PayloadIndexType {
     IntIndex,

--- a/lib/segment/src/index/struct_payload_index/build.rs
+++ b/lib/segment/src/index/struct_payload_index/build.rs
@@ -5,6 +5,7 @@ use super::StructPayloadIndex;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerRead;
 use crate::index::BuildIndexResult;
+use crate::index::field_index::index_selector::wipe_field_dirs;
 use crate::index::field_index::{FieldIndex, FieldIndexBuilderTrait as _};
 use crate::payload_storage::PayloadStorageRead;
 use crate::types::{PayloadContainer, PayloadFieldSchema, PayloadKeyTypeRef};
@@ -16,6 +17,19 @@ impl StructPayloadIndex {
         payload_schema: &PayloadFieldSchema,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<FieldIndex>> {
+        // A build must start from a clean slate: files can be left behind by a build
+        // that crashed before its config entry was written, or by an index that
+        // failed to load. Appendable builders open existing storages, so leftovers
+        // would leak stale postings into the fresh build.
+        wipe_field_dirs(&self.path, field)?;
+
+        // Note: durability of the state this build reads (id tracker, payload storage)
+        // is the caller's responsibility. Component flushers must not be invoked here:
+        // flusher executions are serialized end-to-end with their capture by the shard
+        // flush pipeline, and an extra flush run between another flusher's capture and
+        // execution corrupts storage (Gridstore double-frees superseded blocks). The
+        // live update path pins the observed state by flushing the whole segment under
+        // that serialization before building (`shard::update::create_field_index`).
         let payload_storage = self.payload.borrow();
         let id_tracker_borrow = self.id_tracker.borrow();
         let selector = self.selector(payload_schema);

--- a/lib/segment/src/index/struct_payload_index/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/mod.rs
@@ -172,11 +172,23 @@ impl StructPayloadIndex {
         // If index is not properly loaded or when migrating, rebuild indices
         if rebuild {
             log::debug!("Rebuilding payload index for field `{field}`...");
+            // Close any partially-loaded index storages first: the rebuild wipes
+            // their directories before building fresh.
+            indexes.clear();
             indexes = self.build_field_indexes(
                 field,
                 &payload_schema.schema,
                 &HardwareCounterCell::disposable(), // Internal operation
             )?;
+
+            // The durable config keeps listing this field: persist the rebuilt data
+            // now, or a crash before the next flush cycle would leave the config
+            // pointing at empty index storages that silently load as a complete
+            // index. Safe here: the segment is still being opened, so no flush
+            // pipeline capture of these storages can exist yet.
+            for index in &indexes {
+                index.flusher()()?;
+            }
 
             // Persist exact payload index types of newly built indices
             is_dirty = true;

--- a/lib/segment/src/index/struct_payload_index/payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index/payload_index.rs
@@ -46,6 +46,15 @@ impl PayloadIndex for StructPayloadIndex {
         payload_schema: PayloadFieldSchema,
         field_index: Vec<FieldIndex>,
     ) -> OperationResult<()> {
+        // Persist the built index before the config that lists it. The config is the
+        // durable commit marker for the index (loading and WAL replay trust it), while
+        // mutable indexes buffer their postings in memory until flushed. Flushing here
+        // guarantees a crash right after the config write cannot leave a durable
+        // config entry pointing at index data that never reached disk.
+        for index in &field_index {
+            index.flusher()()?;
+        }
+
         let index_types: Vec<_> = field_index
             .iter()
             .map(|i| i.get_full_index_type())

--- a/lib/segment/src/index/struct_payload_index/payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index/payload_index.rs
@@ -46,15 +46,13 @@ impl PayloadIndex for StructPayloadIndex {
         payload_schema: PayloadFieldSchema,
         field_index: Vec<FieldIndex>,
     ) -> OperationResult<()> {
-        // Persist the built index before the config that lists it. The config is the
-        // durable commit marker for the index (loading and WAL replay trust it), while
-        // mutable indexes buffer their postings in memory until flushed. Flushing here
-        // guarantees a crash right after the config write cannot leave a durable
-        // config entry pointing at index data that never reached disk.
-        for index in &field_index {
-            index.flusher()()?;
-        }
-
+        // Contract: `field_index` data must already be durable when this is called —
+        // the config saved below is the durable commit marker the loader and WAL
+        // replay trust, and it must never list an index whose postings only exist in
+        // memory. Live builds persist in `Segment::build_field_index` (build phase,
+        // so no index I/O happens here under the segment write lock); the load-time
+        // rebuild persists in `load_from_db`; `SegmentBuilder` segments are exempt
+        // because they are not loadable until the builder flushes and promotes them.
         let index_types: Vec<_> = field_index
             .iter()
             .map(|i| i.get_full_index_type())

--- a/lib/segment/src/index/struct_payload_index/tests.rs
+++ b/lib/segment/src/index/struct_payload_index/tests.rs
@@ -108,8 +108,9 @@ fn name_filter(key: &JsonPath, value: &str) -> Filter {
 }
 
 /// The durable config must never list an index whose data is still buffered in
-/// memory. `apply_index` flushes the built indexes before saving the config, so a
-/// crash right after `create_field_index` reloads a complete index.
+/// memory. `Segment::build_field_index` flushes the built indexes before
+/// `apply_index` saves the config, so a crash right after `create_field_index`
+/// reloads a complete index.
 ///
 /// Invariant guard rather than a failing-direction regression test: without the
 /// flush, this scenario recovers only by accident — the mutable index files were
@@ -171,6 +172,74 @@ fn create_field_index_persists_index_data_with_config() {
         hits,
         vec![0],
         "the index listed by the durable config must cover the durable payload rows",
+    );
+}
+
+/// Switching a field's index to an incompatible type (keyword → full-text) must
+/// leave a complete, durable new index even across a crash. The ordering that makes
+/// `wipe_field_dirs` safe here: the incompatible keyword index is dropped (config
+/// entry, in-memory index, and files) by `delete_field_index_if_incompatible`
+/// *before* the text build starts, so the wipe never touches a live index's files —
+/// it only clears leftovers for a field the config no longer lists. The rebuilt
+/// index is then flushed before the config commits it.
+#[test]
+fn switch_incompatible_index_type_survives_crash() {
+    let dir = Builder::new().prefix("payload_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let key = JsonPath::from_str("name").unwrap();
+    let keyword_schema = PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword);
+    let text_schema = PayloadFieldSchema::FieldType(PayloadSchemaType::Text);
+    let payload: Payload = serde_json::from_str(r#"{ "name": "John Doe" }"#).unwrap();
+
+    let segment_path = {
+        let mut segment = build_simple_segment(dir.path(), 2, Distance::Dot).unwrap();
+        segment
+            .upsert_point(1, 0.into(), only_default_vector(&[1.0, 1.0]), &hw_counter)
+            .unwrap();
+        segment
+            .set_full_payload(2, 0.into(), &payload, &hw_counter)
+            .unwrap();
+        segment
+            .create_field_index(3, &key, Some(&keyword_schema), &hw_counter)
+            .unwrap();
+        segment.flush(true).unwrap();
+
+        // Incompatible switch: drops the keyword index, then builds full-text.
+        // No flush after this op: its own persistence must be self-contained.
+        segment
+            .create_field_index(4, &key, Some(&text_schema), &hw_counter)
+            .unwrap();
+
+        segment.segment_path.clone()
+        // Dropped without a further flush: simulates a crash right after the op.
+    };
+
+    // The switch committed durably: the config lists the field with the new schema.
+    let payload_config =
+        PayloadConfig::load(&segment_path.join("payload_index/config.json")).unwrap();
+    assert_eq!(
+        payload_config.indices.get(&key).map(|entry| &entry.schema),
+        Some(&text_schema),
+        "the durable config must list the new index schema",
+    );
+
+    let segment = load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false))
+        .expect("segment must load after simulated crash");
+
+    // Queried before any replay on purpose: the new index data must be complete.
+    let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(
+        key,
+        Match::Text("John".into()),
+    )));
+    let hits = segment
+        .payload_index
+        .borrow()
+        .with_view(|view| view.query_points(&filter, &hw_counter, &AtomicBool::new(false)))
+        .unwrap();
+    assert_eq!(
+        hits,
+        vec![0],
+        "the full-text index must be complete after the crash",
     );
 }
 

--- a/lib/segment/src/index/struct_payload_index/tests.rs
+++ b/lib/segment/src/index/struct_payload_index/tests.rs
@@ -10,14 +10,18 @@ use tempfile::Builder;
 use uuid::Uuid;
 
 use crate::data_types::vectors::only_default_vector;
-use crate::entry::{NonAppendableSegmentEntry, SegmentEntry};
+use crate::entry::{NonAppendableSegmentEntry, SegmentEntry, StorageSegmentEntry};
+use crate::index::PayloadIndexRead;
 use crate::index::payload_config::{
     FullPayloadIndexType, IndexMutability, PayloadConfig, PayloadIndexType,
 };
 use crate::json_path::JsonPath;
 use crate::segment_constructor::load_segment;
 use crate::segment_constructor::simple_segment_constructor::build_simple_segment;
-use crate::types::{Distance, Payload, PayloadFieldSchema, PayloadSchemaType};
+use crate::types::{
+    Condition, Distance, FieldCondition, Filter, Match, Payload, PayloadFieldSchema,
+    PayloadSchemaType, ValueVariants,
+};
 
 #[test]
 fn test_load_payload_index() {
@@ -94,6 +98,80 @@ fn test_load_payload_index() {
 
     let schema = payload_config.indices.get(&key).unwrap();
     assert!(check_index_types(&schema.types));
+}
+
+fn name_filter(key: &JsonPath, value: &str) -> Filter {
+    Filter::new_must(Condition::Field(FieldCondition::new_match(
+        key.clone(),
+        Match::new_value(ValueVariants::String(value.to_string())),
+    )))
+}
+
+/// The durable config must never list an index whose data is still buffered in
+/// memory. `apply_index` flushes the built indexes before saving the config, so a
+/// crash right after `create_field_index` reloads a complete index.
+///
+/// Invariant guard rather than a failing-direction regression test: without the
+/// flush, this scenario recovers only by accident — the mutable index files were
+/// never created, so loading fails and triggers a rebuild. Index types whose build
+/// writes files immediately (mmap/on-disk) load "successfully" incomplete instead;
+/// the flush-before-config makes the guarantee structural for all of them.
+#[test]
+fn create_field_index_persists_index_data_with_config() {
+    let dir = Builder::new().prefix("payload_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let key = JsonPath::from_str("name").unwrap();
+    let schema = PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword);
+    let payload: Payload = serde_json::from_str(r#"{ "name": "John Doe" }"#).unwrap();
+
+    let segment_path = {
+        let mut segment = build_simple_segment(dir.path(), 2, Distance::Dot).unwrap();
+        segment
+            .upsert_point(1, 0.into(), only_default_vector(&[1.0, 1.0]), &hw_counter)
+            .unwrap();
+        segment
+            .set_full_payload(2, 0.into(), &payload, &hw_counter)
+            .unwrap();
+        segment.flush(true).unwrap();
+
+        // No flush after this op: its own persistence must be self-contained.
+        segment
+            .create_field_index(4, &key, Some(&schema), &hw_counter)
+            .unwrap();
+
+        segment.segment_path.clone()
+        // Dropped without a further flush: simulates a crash right after the op.
+    };
+
+    // The op committed the index durably: the config lists the field.
+    let payload_config =
+        PayloadConfig::load(&segment_path.join("payload_index/config.json")).unwrap();
+    assert!(
+        payload_config.indices.contains_key(&key),
+        "create_field_index must durably commit the config",
+    );
+
+    let segment = load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false))
+        .expect("segment must load after simulated crash");
+
+    // Queried before any replay on purpose: the index data itself must be complete,
+    // not repaired by re-applied operations.
+    let hits = segment
+        .payload_index
+        .borrow()
+        .with_view(|view| {
+            view.query_points(
+                &name_filter(&key, "John Doe"),
+                &hw_counter,
+                &AtomicBool::new(false),
+            )
+        })
+        .unwrap();
+    assert_eq!(
+        hits,
+        vec![0],
+        "the index listed by the durable config must cover the durable payload rows",
+    );
 }
 
 #[test]

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -666,6 +666,17 @@ impl NonAppendableSegmentEntry for Segment {
             }
         };
 
+        // Persist the built index here, in the build phase, so `apply_index` can
+        // durably list it in the config without doing any I/O under the segment
+        // write lock (builds run under a lock that still admits reads; apply does
+        // not). Safe outside the shard flush serialization: these storages are not
+        // installed yet, so no previously captured flusher can overlap with them.
+        // If the apply never happens, the leftover files are wiped by the next
+        // build of this field.
+        for index in &field_index {
+            index.flusher()()?;
+        }
+
         Ok(BuildFieldIndexResult::Built {
             indexes: field_index,
             schema: field_type.clone(),

--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -181,6 +181,28 @@ impl SegmentHolder {
         final_order
     }
 
+    /// Run `f` serialized with the flush pipeline.
+    ///
+    /// Flusher executions must be serialized end-to-end with their capture: component
+    /// flushers capture pending state by value (e.g. Gridstore clones its pending update
+    /// set) and their execution frees storage superseded by that state. Running an extra
+    /// flush between another flusher's capture and its execution makes the pending sets
+    /// overlap, and the later execution double-frees blocks that may already have been
+    /// reused — corrupting the storage. This joins any in-flight background flush (whose
+    /// flushers were captured earlier) and holds the flush lock while `f` runs, so a
+    /// flush performed inside `f` cannot interleave with a captured-but-unrun pass.
+    ///
+    /// Deadlock note: callers may hold segment locks; `flush_all` acquires segment locks
+    /// before this lock, and flush executions take no segment locks, so the ordering
+    /// [segment locks → flush lock] is consistent.
+    pub fn with_flush_serialized<T>(
+        &self,
+        f: impl FnOnce() -> OperationResult<T>,
+    ) -> OperationResult<T> {
+        let _flush_lock = self.lock_flushing()?;
+        f()
+    }
+
     // Joins flush thread if exists
     // Returns lock to guarantee that there will be no other flush in a different thread
     pub(super) fn lock_flushing(

--- a/lib/shard/src/update.rs
+++ b/lib/shard/src/update.rs
@@ -988,6 +988,26 @@ pub fn create_field_index(
             segment.delete_field_index_if_incompatible(op_num, field_name, field_schema)
         })?;
 
+        // Pin the state the build will observe before the index config durably marks
+        // the index as complete. The build reads the live id tracker and payload
+        // storage, which may hold changes that are not flushed yet; if such a change
+        // were lost in a crash, the durable index (and the config that WAL replay
+        // trusts via `AlreadyBuilt`) would permanently disagree with the durable
+        // payload. Flushing the whole segment first makes every crash outcome
+        // consistent: either the config is not durable yet and replay rebuilds, or
+        // config, index data, and observed state are durable together.
+        //
+        // Serialized with the flush pipeline: an extra flush run between another
+        // flusher's capture and its execution corrupts storage (see
+        // `SegmentHolder::with_flush_serialized`). Skipped for idempotent
+        // ensure-calls (index already present with an identical schema), which must
+        // stay cheap; those resolve to `AlreadyExists` in the build below.
+        let already_indexed =
+            write_segment.get_indexed_fields().get(field_name) == Some(field_schema);
+        if !already_indexed {
+            segments.with_flush_serialized(|| write_segment.flush(true))?;
+        }
+
         let (schema, indexes) =
             match write_segment.build_field_index(op_num, field_name, field_schema, hw_counter)? {
                 BuildFieldIndexResult::SkippedByVersion => {
@@ -1140,8 +1160,9 @@ mod test {
     };
     use crate::segment_holder::{FlushMode, SegmentHolder};
     use crate::update::{
-        clear_payload_by_filter, delete_payload_by_filter, delete_points_by_filter,
-        delete_vectors_by_filter, overwrite_payload_by_filter, set_payload_by_filter,
+        clear_payload_by_filter, create_field_index, delete_payload_by_filter,
+        delete_points_by_filter, delete_vectors_by_filter, overwrite_payload_by_filter,
+        set_payload_by_filter,
     };
 
     #[test]
@@ -1791,5 +1812,92 @@ mod test {
         upsert_points(&holder, 101, [&incoming], &hw_counter).unwrap();
         let segment = holder.get(sid).unwrap().get();
         check(&*segment.read(), "CoW move");
+    }
+
+    /// Failure-direction regression test for the payload index durability fix: an
+    /// index built while a payload change is still pending must not let the durable
+    /// index config outrun the state the build observed. `create_field_index` flushes
+    /// the segment (serialized with the flush pipeline) before building, so the
+    /// pending change becomes durable together with the index: after a crash the
+    /// reloaded segment sees the cleared payload, the re-applied `CreateFieldIndex`
+    /// (WAL replay) stays a truthful no-op (`AlreadyBuilt`), and filtered reads agree
+    /// with full scans.
+    ///
+    /// Without the pre-build flush, the reloaded segment resurrects the cleared
+    /// payload row while the durable index has no posting for it, and the row stays
+    /// invisible to filtered reads forever.
+    #[test]
+    fn create_field_index_pins_pending_payload_state() {
+        use std::sync::atomic::AtomicBool;
+
+        use common::types::DeferredBehavior;
+        use segment::entry::{NonAppendableSegmentEntry as _, StorageSegmentEntry as _};
+        use segment::segment_constructor::load_segment;
+        use segment::types::{PayloadFieldSchema, PayloadSchemaType};
+        use uuid::Uuid;
+
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::new();
+        let key: PayloadKeyType = "city".parse().unwrap();
+        let schema = PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword);
+        let is_stopped = AtomicBool::new(false);
+
+        let mut seg = empty_segment(dir.path());
+        seg.upsert_point(
+            1,
+            0.into(),
+            only_default_vector(&[1.0, 0.0, 0.0, 0.0]),
+            &hw_counter,
+        )
+        .unwrap();
+        let payload: segment::types::Payload = payload_json! {"city": "Berlin"};
+        seg.set_payload(2, 0.into(), &payload, &None, &hw_counter)
+            .unwrap();
+        seg.flush(true).unwrap();
+
+        // Pending payload clear: stays in memory until the next flush cycle.
+        seg.clear_payload(3, 0.into(), &hw_counter).unwrap();
+        let segment_path = seg.segment_path.clone();
+
+        let mut holder = SegmentHolder::default();
+        holder.add_new(seg);
+
+        // The build observes the cleared row and must pin it durably before the
+        // index config becomes durable.
+        create_field_index(&holder, 4, &key, Some(&schema), &hw_counter).unwrap();
+
+        // Simulated crash: dropped without any flush after the op.
+        drop(holder);
+
+        let mut segment = load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false))
+            .expect("segment must load after simulated crash");
+
+        // The pre-build flush persisted the pending clear together with the index.
+        let reloaded = segment.payload(0.into(), &hw_counter).unwrap();
+        assert!(
+            !reloaded.0.contains_key("city"),
+            "the payload state observed by the index build must be durable",
+        );
+
+        // WAL replay re-applies the CreateFieldIndex op; the config is truthful, so
+        // `AlreadyBuilt` is a correct no-op.
+        segment
+            .create_field_index(4, &key, Some(&schema), &hw_counter)
+            .unwrap();
+
+        let hits = segment
+            .read_filtered(
+                None,
+                None,
+                Some(&city_filter("Berlin")),
+                &is_stopped,
+                &hw_counter,
+                DeferredBehavior::VisibleOnly,
+            )
+            .unwrap();
+        assert!(
+            hits.is_empty(),
+            "filtered reads must agree with payload storage: the row was cleared",
+        );
     }
 }


### PR DESCRIPTION
**TL;DR**: alternative implementation of the #9737 fix, for side-by-side comparison (see [discussion](https://github.com/qdrant/qdrant/pull/9737#issuecomment-4928446945)). Same bug, same invariant, opposite mechanism: instead of deferring the index config write into the flush pipeline, make index creation durably self-contained — flush the segment before the build, flush the built index after it, then write the config synchronously as today.

Fair warning up front: the naive version of this design ("just run the component flushers before building") **corrupts data**, and the model-testing harness caught it. The corrected version works — 12/12 green on the #9737 failing seed — but the fix for that hazard is itself an argument in the comparison. Details below.

## The invariant (shared with #9737)

The on-disk payload index config is the commit marker for the index: loading trusts it, and WAL replay of `CreateFieldIndex` short-circuits on `AlreadyBuilt` when the config lists the field. For that marker to be truthful it must never become durable before

1. **the state the build observed** — the build reads the live id tracker and payload storage, which may hold changes not flushed yet (e.g. a deletion propagated by an earlier unproxy). If such a change is lost in a crash, the durable index permanently disagrees with the durable payload, and replay does not repair it.
2. **the built index data itself** — mutable (appendable) indexes buffer postings in memory until flushed, so the config must not durably point at data that never fully reached disk.

#9737 restores truthfulness by deferring the config write into the flush pipeline (generation-guarded). This PR restores it by making the op commit everything it depends on before the config write:

- `shard::update::create_field_index` flushes the whole segment before the build (skipped for idempotent ensure-calls, which short-circuit to `AlreadyExists`),
- `StructPayloadIndex::apply_index` flushes the built field indexes before `save_config`,
- `build_field_indexes` wipes leftover field dirs first (`wipe_field_dirs`, same groundwork as #9737),
- the load-time rebuild path also flushes the rebuilt indexes, since the durable config keeps listing the field (closes a pre-existing corner that #9737 leaves open: a crash after a load-rebuild leaves empty index storages that silently load as a complete index).

Crash before the config write: config doesn't list the field, WAL replay rebuilds from the pinned durable state. Crash after: config, index data, and observed payload state are durable together, so `AlreadyBuilt` is truthful.

The unproxy propagation path needs no flush of its own: snapshots proxy first and then `flush_all`, so at propagation time the wrapped segment's in-memory state equals its durable state by construction.

## The hazard this design has to work around

The first implementation ran the input flush inside `build_field_indexes` by invoking the id-tracker and payload-storage flushers directly. `cargo test -p segment/-p shard` were green, the #9737 regression scenario was fixed — and the model-testing harness failed ~1 in 4 runs on the pinned seed with a Gridstore `LiteralOutOfBounds` panic after a simulated crash, i.e. **durable data corruption**.

Mechanism: component flushers capture pending state by value (Gridstore clones its pending update set at capture, and executing the flush frees the storage blocks superseded by that set). The whole flush pipeline is serialized **end-to-end — capture through execution — by the shard's flush lock** (`SegmentHolder::lock_flushing`), so pending sets of successive passes are disjoint. An ad-hoc flush that runs *between* another pass's capture and its execution makes the sets overlap; the later execution then re-frees blocks that were already freed and reused, two live values end up sharing blocks, and the survivor is garbage. Nothing in the segment layer prevents this — the serialization primitive lives in the shard's `SegmentHolder`.

Consequence for this design: the pre-build flush cannot live at the segment layer at all. It lives in `shard::update::create_field_index`, wrapped in a new `SegmentHolder::with_flush_serialized` (joins any in-flight background flush pass and holds the flush lock while the segment flushes; the lock is held only for the flush, not the build). The `apply_index` and load-rebuild flushes are exempt from the hazard because freshly built storages cannot appear in any previously captured pass.

## Trade-offs vs #9737

Pro:
- Config persistence stays synchronous and local: when `create_field_index` returns, the index is durable. No deferred-persistence state — no generation counter, no stale-flusher guard, no window where `config.json` lags the in-memory schema.
- Existing tests unchanged.
- Also covers the load-rebuild corner (silently-empty index after a crash mid-open) that deferred-config does not.

Con:
- A synchronous whole-segment flush on the op path per actual index build (ensure-calls don't pay; the build itself, a full payload scan under the segment lock, still dominates).
- The input-durability half of the invariant is enforced at the shard funnel, not the segment layer: `Segment::create_field_index` alone remains crash-unsafe, and every current call site is safe for a *reason* rather than by construction — the update path (live + WAL replay) flushes first, the unproxy propagation is safe because snapshots flush after proxying, `SegmentBuilder` is safe because unfinished segments are never loadable. A future caller has to know this. #9737's config-in-the-flusher is violation-proof by construction, at the cost of the generation machinery.
- Index creation can now fail on a flush error of any segment component.

## Validation

- New regression test `update::test::create_field_index_pins_pending_payload_state` (shard level — the layer that owns the fix; same scenario as #9737's test): fails with the flush disabled, passes with it.
- New invariant-guard test `create_field_index_persists_index_data_with_config` (segment level): config listed ⇒ index data complete on reload, no reliance on load-time rebuild-on-failure. (On `dev` this scenario recovers only by accident when the never-flushed index files are entirely absent; index types that write files at build time load "successfully" incomplete.)
- Failing CI seed from #9737 (`17579323109889096168`), `harness_no_optimizer_snapshots` pinned locally: **12/12 green** (the interim unserialized-flush version failed 2/9 with Gridstore corruption; `dev` per #9737 was 0/6).
- `cargo test -p segment` (869 lib + 129 integration) and `cargo test -p shard` (87) green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
