### PR TITLE
[UIO] Better populate of bool and null indexes

### DIFF
--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -50,22 +50,18 @@ pub struct ReadOnlyRoaringFlags<S: UniversalRead> {
     directory: PathBuf,
 }
 
-/// Read-only open options shared by every file this storage maps: never
-/// writable, lazily paged under the global mmap advice, nothing populated up
-/// front. `OpenOptions` has no general constructor by design (callers spell the
-/// knobs out), so this one value keeps the read path's opens identical.
-const READ_ONLY_OPTIONS: OpenOptions = OpenOptions {
-    writeable: false,
-    need_sequential: false,
-    populate: Populate::No,
-    advice: AdviceSetting::Global,
-};
+fn open_options(populate: Populate) -> OpenOptions {
+    OpenOptions {
+        writeable: false,
+        need_sequential: false,
+        populate,
+        advice: AdviceSetting::Global,
+    }
+}
 
 /// Read the logical flag length from the status struct, opened read-only.
 ///
-/// `StoredStruct` is write-bound, so the read goes through the read-only
-/// `TypedStorage`. Returns `Ok(None)` when the status file is absent — the flag
-/// directory doesn't exist — matching the read path's never-create contract.
+/// Returns `Ok(None)` when the status file is absent
 fn read_status_len<S: UniversalRead>(
     fs: &impl UniversalReadFs<File = S>,
     directory: &Path,
@@ -73,7 +69,7 @@ fn read_status_len<S: UniversalRead>(
     let Some(file) = fs
         .open(
             status_file(directory),
-            READ_ONLY_OPTIONS,
+            open_options(Populate::No),
             Default::default(),
         )
         .ok_not_found()?
@@ -84,53 +80,40 @@ fn read_status_len<S: UniversalRead>(
     Ok(Some(status.read_whole()?[0].len()))
 }
 
-/// Open the flags bitslice read-only. The handle is retained, not read: the
-/// bitmap scan happens lazily in [`ReadOnlyRoaringFlags::bitmap`], and
-/// `live_reload` reopens this same handle.
-fn open_flags_storage<S: UniversalRead>(
-    fs: &impl UniversalReadFs<File = S>,
-    directory: &Path,
-) -> OperationResult<StoredBitSlice<S>> {
-    Ok(StoredBitSlice::<S>::open(
-        fs,
-        directory.join(FLAGS_FILE),
-        READ_ONLY_OPTIONS,
-        Default::default(),
-    )?)
-}
-
 impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
-    /// Schedule background prefetch of the two files this storage reads, with
-    /// the same open options they will use, so the prefetch pool can serve them.
+    /// Schedule background prefetch of the two files this storage reads.
     ///
-    /// Returns whether the flag directory exists, probed — as in [`Self::open`]
-    /// — through the status file: `false` means [`Self::open`] would return
-    /// [`Ok(None)`], and the flags file is then not scheduled.
-    pub fn preopen(fs: &impl CachedReadFs<File = S>, directory: &Path) -> OperationResult<bool> {
-        // Status file. A missing one means the index isn't present on disk.
+    /// Returns whether the flag directory exists.
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        directory: &Path,
+        populate: Populate,
+    ) -> OperationResult<bool> {
+        // Status file.
         if fs
-            .schedule_prefetch(&status_file(directory), Some(READ_ONLY_OPTIONS), None)
+            .schedule_prefetch(
+                &status_file(directory),
+                Some(open_options(Populate::PreferBackground)),
+                None,
+            )
             .ok_not_found()?
             .is_none()
         {
             return Ok(false);
         }
 
-        // Flags bitslice. `open` does not read it — [`Self::bitmap`] scans it end
-        // to end on first use — so this warms the pages that scan will need.
-        fs.schedule_prefetch(&directory.join(FLAGS_FILE), Some(READ_ONLY_OPTIONS), None)?;
+        // Bitslice
+        fs.schedule_prefetch(
+            &directory.join(FLAGS_FILE),
+            Some(open_options(populate)),
+            None,
+        )?;
 
         Ok(true)
     }
 
     /// Open persisted flags read-only, retaining the bitslice handle for
     /// [`Self::bitmap`] and [`LiveReload`].
-    ///
-    /// Read-only counterpart of [`RoaringFlags::new`][1]: every file is opened
-    /// through `fs` non-writable, nothing is created and nothing is written.
-    /// The logical length comes from the status file (the flags file is padded
-    /// past it). Unlike the writable path, the flags file itself is *not* read
-    /// here — see [`Self::bitmap`]; opening touches only the status file.
     ///
     /// Returns [`Ok(None)`] when the flag directory doesn't exist (the status
     /// file is absent), matching the read path's never-create contract.
@@ -145,9 +128,12 @@ impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
             return Ok(None);
         };
 
-        // The bitslice handle is opened but not read: the bitmap is built on
-        // first use, and `live_reload` reopens this handle to see appended points.
-        let storage = open_flags_storage::<S>(fs, directory)?;
+        let storage = StoredBitSlice::<S>::open(
+            fs,
+            directory.join(FLAGS_FILE),
+            open_options(Populate::No),
+            Default::default(),
+        )?;
 
         Ok(Some(Self {
             bitmap: OnceLock::new(),

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::OnceLock;
 
-use common::universal_io::{CachedReadFs, UniversalReadFs};
+use common::universal_io::{CachedReadFs, Populate, UniversalReadFs};
 
 use super::super::mutable_bool_index::{FALSES_DIRNAME, TRUES_DIRNAME};
 use super::{ReadOnlyBoolIndex, ReadOnlyStorage};
@@ -17,9 +17,13 @@ impl<S: UniversalReadExt> ReadOnlyBoolIndex<S> {
     /// absence check: only a missing *pair* of flag directories means no index,
     /// so a half-present (corrupt) layout is reported as existing here and left
     /// for `open` to reject.
-    pub fn preopen(fs: &impl CachedReadFs<File = S>, path: &Path) -> OperationResult<bool> {
-        let trues = ReadOnlyRoaringFlags::<S>::preopen(fs, &path.join(TRUES_DIRNAME))?;
-        let falses = ReadOnlyRoaringFlags::<S>::preopen(fs, &path.join(FALSES_DIRNAME))?;
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        path: &Path,
+        populate: Populate,
+    ) -> OperationResult<bool> {
+        let trues = ReadOnlyRoaringFlags::<S>::preopen(fs, &path.join(TRUES_DIRNAME), populate)?;
+        let falses = ReadOnlyRoaringFlags::<S>::preopen(fs, &path.join(FALSES_DIRNAME), populate)?;
         Ok(trues || falses)
     }
 

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
@@ -109,25 +109,7 @@ impl<S: UniversalReadExt> ReadOnlyBoolIndex<S> {
         Ok(())
     }
 
-    /// Reports the on-disk format's mutability, mirroring
-    /// [`BoolIndex::get_mutability_type`][1].
-    ///
-    /// [`MutableBoolIndex`][2] and [`ImmutableBoolIndex`][3] share the same
-    /// on-disk roaring-flags layout — the writable [`BoolIndex::Mmap`][1]
-    /// arm itself "can be both mutable and immutable, so we pick mutable",
-    /// per the writable enum's comment. The read path cannot distinguish
-    /// them from the files alone, and the read-only wrapper denies mutation
-    /// either way, so it conservatively reports
-    /// [`IndexMutability::Immutable`]. If a future caller needs to preserve
-    /// the writable-side label exactly (e.g. for round-tripping
-    /// [`FullPayloadIndexType`][4] against the persisted schema), the
-    /// mutability should be threaded through [`Self::open`] and stored on
-    /// the struct.
-    ///
-    /// [1]: super::super::BoolIndex::get_mutability_type
-    /// [2]: super::super::mutable_bool_index::MutableBoolIndex
-    /// [3]: super::super::immutable_bool_index::ImmutableBoolIndex
-    /// [4]: crate::index::payload_config::FullPayloadIndexType
+    /// Reports the on-disk format's mutability
     pub fn get_mutability_type(&self) -> IndexMutability {
         IndexMutability::Immutable
     }
@@ -487,7 +469,14 @@ mod tests {
         // Same order as the segment open path: snapshot, then preopen, then open.
         let mut cached_fs = CachedFs::new(fs.clone(), dir.path()).unwrap();
         cached_fs.cache_file_info().unwrap();
-        assert!(ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::preopen(&cached_fs, dir.path()).unwrap());
+        assert!(
+            ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::preopen(
+                &cached_fs,
+                dir.path(),
+                Populate::PreferBackground
+            )
+            .unwrap()
+        );
 
         // Everything `open` reads must now come from the prefetch pool.
         fs_err::remove_dir_all(dir.path().join(TRUES_DIRNAME)).unwrap();
@@ -523,7 +512,12 @@ mod tests {
         let mut empty_fs = CachedFs::new(fs, empty.path()).unwrap();
         empty_fs.cache_file_info().unwrap();
         assert!(
-            !ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::preopen(&empty_fs, empty.path()).unwrap()
+            !ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::preopen(
+                &empty_fs,
+                empty.path(),
+                Populate::PreferBackground
+            )
+            .unwrap()
         );
         assert!(
             ReadOnlyBoolIndex::<ReadOnly<MmapFile>>::open(&empty_fs, empty.path())

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
@@ -121,7 +121,7 @@ mod tests {
     use common::counter::hardware_counter::HardwareCounterCell;
     use common::sorted_slice::SortedSlice;
     use common::universal_io::{
-        CachedFs, CachedReadFs, MmapFile, ReadOnly, UniversalRead, UniversalReadFileOps,
+        CachedFs, CachedReadFs, MmapFile, Populate, ReadOnly, UniversalRead, UniversalReadFileOps,
     };
     use itertools::Itertools as _;
     use serde_json::json;

--- a/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use common::bitvec::BitSlice;
-use common::universal_io::{CachedReadFs, UniversalReadFs};
+use common::universal_io::{CachedReadFs, Populate, UniversalReadFs};
 
 use super::ReadOnlyFieldIndex;
 use crate::common::operation_error::OperationResult;
@@ -143,14 +143,23 @@ impl<S: UniversalReadExt> ReadOnlyFieldIndex<S> {
                 ReadMode::Appendable => false,
                 ReadMode::Immutable { is_on_disk: _ } => false,
             },
-            // Bool and null are roaring-flag backed: a single read-only `preopen`
-            // serves both modes (neither consumes the immutable-only
-            // `is_on_disk` / `deleted_points`).
             PayloadIndexType::BoolIndex => {
-                ReadOnlyBoolIndex::<S>::preopen(fs, &bool_dir(dir, field))?
+                let populate = match mode {
+                    ReadMode::Immutable { is_on_disk: false } | ReadMode::Appendable => {
+                        Populate::PreferBackground
+                    }
+                    ReadMode::Immutable { is_on_disk: true } => Populate::No,
+                };
+                ReadOnlyBoolIndex::<S>::preopen(fs, &bool_dir(dir, field), populate)?
             }
             PayloadIndexType::NullIndex => {
-                ReadOnlyNullIndex::<S>::preopen(fs, &null_dir(dir, field))?
+                let populate = match mode {
+                    ReadMode::Immutable { is_on_disk: false } | ReadMode::Appendable => {
+                        Populate::PreferBackground
+                    }
+                    ReadMode::Immutable { is_on_disk: true } => Populate::No,
+                };
+                ReadOnlyNullIndex::<S>::preopen(fs, &null_dir(dir, field), populate)?
             }
         };
 

--- a/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
@@ -42,11 +42,21 @@ impl<S: UniversalReadExt> ReadOnlyFieldIndex<S> {
         fs: &impl CachedReadFs<File = S>,
         dir: &Path,
         field: &JsonPath,
+        payload_schema: &PayloadFieldSchema,
         index_type: &FullPayloadIndexType,
     ) -> OperationResult<bool> {
         let mode = match index_type.storage_type {
             StorageType::Gridstore => ReadMode::Appendable,
             StorageType::Mmap { is_on_disk } => ReadMode::Immutable { is_on_disk },
+        };
+
+        // Derive whether how to populate from the payload schema
+        let schema_populate = || {
+            if payload_schema.memory_placement().populate_on_open() {
+                Populate::PreferBackground
+            } else {
+                Populate::No
+            }
         };
 
         let preopened = match index_type.index_type {
@@ -143,22 +153,14 @@ impl<S: UniversalReadExt> ReadOnlyFieldIndex<S> {
                 ReadMode::Appendable => false,
                 ReadMode::Immutable { is_on_disk: _ } => false,
             },
+            // Bool and null keep a single roaring-flag format, but we can choose populate
+            // param based on schema placement.
             PayloadIndexType::BoolIndex => {
-                let populate = match mode {
-                    ReadMode::Immutable { is_on_disk: false } | ReadMode::Appendable => {
-                        Populate::PreferBackground
-                    }
-                    ReadMode::Immutable { is_on_disk: true } => Populate::No,
-                };
+                let populate = schema_populate();
                 ReadOnlyBoolIndex::<S>::preopen(fs, &bool_dir(dir, field), populate)?
             }
             PayloadIndexType::NullIndex => {
-                let populate = match mode {
-                    ReadMode::Immutable { is_on_disk: false } | ReadMode::Appendable => {
-                        Populate::PreferBackground
-                    }
-                    ReadMode::Immutable { is_on_disk: true } => Populate::No,
-                };
+                let populate = schema_populate();
                 ReadOnlyNullIndex::<S>::preopen(fs, &null_dir(dir, field), populate)?
             }
         };
@@ -176,7 +178,7 @@ impl<S: UniversalReadExt> ReadOnlyFieldIndex<S> {
     /// [`UniversalRead`](common::universal_io::UniversalRead) handle `fs` (the map, numeric, geo and full-text leaves
     /// are all fs-generic), so the dispatcher needn't fix a concrete backend.
     ///
-    /// `payload_schema` is consulted only by the full-text arm (it carries the
+    /// `` is consulted only by the full-text arm (it carries the
     /// [`TextIndexParams`] the leaf open needs) and `total_point_count` only by
     /// the null arm (it is segment-wide, not recoverable from the index files);
     /// the other arms ignore both, mirroring the writable selector.

--- a/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/lifecycle.rs
@@ -178,7 +178,7 @@ impl<S: UniversalReadExt> ReadOnlyFieldIndex<S> {
     /// [`UniversalRead`](common::universal_io::UniversalRead) handle `fs` (the map, numeric, geo and full-text leaves
     /// are all fs-generic), so the dispatcher needn't fix a concrete backend.
     ///
-    /// `` is consulted only by the full-text arm (it carries the
+    /// `payload_schema` is consulted only by the full-text arm (it carries the
     /// [`TextIndexParams`] the leaf open needs) and `total_point_count` only by
     /// the null arm (it is segment-wide, not recoverable from the index files);
     /// the other arms ignore both, mirroring the writable selector.

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs};
 
 use super::super::mutable_null_index::{HAS_VALUES_DIRNAME, IS_NULL_DIRNAME};
 use super::{ReadOnlyNullIndex, ReadOnlyStorage};

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/lifecycle.rs
@@ -15,9 +15,15 @@ impl<S: UniversalRead> ReadOnlyNullIndex<S> {
     /// absence check: only a missing *pair* of flag directories means no index,
     /// so a half-present (corrupt) layout is reported as existing here and left
     /// for `open` to reject.
-    pub fn preopen(fs: &impl CachedReadFs<File = S>, path: &Path) -> OperationResult<bool> {
-        let has_values = ReadOnlyRoaringFlags::<S>::preopen(fs, &path.join(HAS_VALUES_DIRNAME))?;
-        let is_null = ReadOnlyRoaringFlags::<S>::preopen(fs, &path.join(IS_NULL_DIRNAME))?;
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        path: &Path,
+        populate: Populate,
+    ) -> OperationResult<bool> {
+        let has_values =
+            ReadOnlyRoaringFlags::<S>::preopen(fs, &path.join(HAS_VALUES_DIRNAME), populate)?;
+        let is_null =
+            ReadOnlyRoaringFlags::<S>::preopen(fs, &path.join(IS_NULL_DIRNAME), populate)?;
         Ok(has_values || is_null)
     }
 

--- a/lib/segment/src/index/struct_payload_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/lifecycle.rs
@@ -33,7 +33,7 @@ impl<S: UniversalReadExt> ReadOnlyStructPayloadIndex<S> {
         // Payload indexes
         for (field, indexed) in config.indices.iter() {
             for index_type in &indexed.types {
-                ReadOnlyFieldIndex::preopen(fs, path, field, index_type)?;
+                ReadOnlyFieldIndex::preopen(fs, path, field, &indexed.schema, index_type)?;
             }
         }
 


### PR DESCRIPTION
Instead of never prefetching the bitslices of `bool` and `null` indexes, we can derive whether we need them from the memory placement of the payload schema. This PR:
- Allows taking `populate` parameter all the way into roaring flags.
- Leverages the user-specified payload schema to choose whether to prefetch these bitslices.