### PR TITLE
[UIO] Add and use `Populate::Partial` variant

### DIFF
--- a/lib/common/common/src/persisted_hashmap/uio/mod.rs
+++ b/lib/common/common/src/persisted_hashmap/uio/mod.rs
@@ -20,6 +20,8 @@ mod random_reader;
 /// If entries are smaller than that, it's likely more efficient to read them sequentially.
 const SEQUENTIAL_READ_THRESHOLD: u64 = 8 * 1024;
 
+const HEADER_AND_BASIC_PHF_SIZE: u64 = size_of::<Header>() as u64 + 16 * 1024; // header + 16KB
+
 /// On-disk hash map accessed via [`UniversalRead`].
 pub struct UniversalHashMap<K, V, S>
 where
@@ -47,9 +49,12 @@ where
     pub fn preopen<Fs: CachedReadFs<File = S>>(
         fs: &Fs,
         path: impl AsRef<Path>,
-        options: OpenOptions,
+        mut options: OpenOptions,
     ) -> Result<()> {
-        // TODO(uio): Turn `Populate::No` into `Populate::BackgroundPartial(0..header + phf)
+        // Default a lazy open to partially populating the header + a slice of
+        // the perfect-hash table, so the map can be opened without a full read.
+        options.populate = options.populate.or_partial(0..HEADER_AND_BASIC_PHF_SIZE);
+
         fs.schedule_prefetch(path.as_ref(), Some(options), None)
     }
 

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -110,6 +110,7 @@ impl MmapFile {
 
         let populate = match populate {
             Populate::Auto => Self::populate_auto(),
+            Populate::Partial(_) | // mmap does not support partial populate
             Populate::No => false,
             Populate::PreferBackground | // mmap does not yet implement background populate
             Populate::Blocking => true,

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
@@ -1,5 +1,6 @@
 //! Lazy first-use initialization of a [`DiskCache`]'s [`State`].
 
+use std::ops::Range;
 use std::sync::atomic::Ordering;
 
 use super::{DiskCache, State};
@@ -57,6 +58,9 @@ where
             State::OpenPrefill { pipeline } => self.init_from_open_prefill(pipeline)?,
             State::ReopenPrefill { pipeline, local } => {
                 self.init_from_reopen_prefill(pipeline, local)?
+            }
+            State::PartialPrefill { pipeline, len } => {
+                self.init_from_partial_prefill(pipeline, len)?
             }
             State::Ready { .. } => {
                 unreachable!("We just observed `!ready` while holding the mutex lock")
@@ -119,6 +123,33 @@ where
             }
             // There is nothing to apply.
             // TODO: double check that the remote didn't shrink?
+            Some(_) | None => {}
+        }
+
+        Ok((pipeline.into_inner(), local))
+    }
+
+    /// Resolve a [`State::PartialPrefill`] read: size the mirror from `len` and
+    /// write only the fetched (block-aligned) range; the remainder faults in
+    /// lazily on later reads. See [`Populate::Partial`].
+    ///
+    /// [`Populate::Partial`]: crate::universal_io::Populate::Partial
+    pub(super) fn init_from_partial_prefill(
+        &self,
+        mut pipeline: OwnedPipeline<R, Range<u32>>,
+        len: u64,
+    ) -> Result<(R, LocalState)> {
+        let local = LocalState::new(&self.local_path, len, self.open_options)?;
+
+        match pipeline.wait()? {
+            Some((blocks_range, bytes)) if !bytes.is_empty() => {
+                // SAFETY: `start` is block-aligned and `bytes` covers
+                // `blocks_range` exactly (up to EOF), and the remote is
+                // immutable, so the mmap range is filled once with correct data.
+                unsafe { local.write_mmap_bytes(&bytes, blocks_range) };
+            }
+            // Nothing was scheduled (empty range) or the read came back empty:
+            // leave the mirror empty and fault blocks in lazily.
             Some(_) | None => {}
         }
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
@@ -1,5 +1,6 @@
 //! [`DiskCache`]: a lazily-populated local mirror of an immutable remote file.
 
+use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
@@ -67,6 +68,11 @@ pub(crate) enum State<R: UniversalRead + 'static> {
         pipeline: OwnedPipeline<R, u64>,
         local: LocalState,
     },
+    /// Open-time partial prefill
+    PartialPrefill {
+        pipeline: OwnedPipeline<R, Range<u32>>,
+        len: u64,
+    },
 }
 
 impl<R: UniversalRead + 'static> State<R> {
@@ -74,7 +80,10 @@ impl<R: UniversalRead + 'static> State<R> {
     pub fn is_ready(&self) -> bool {
         match self {
             State::Ready { .. } => true,
-            State::Uninit | State::OpenPrefill { .. } | State::ReopenPrefill { .. } => false,
+            State::Uninit
+            | State::OpenPrefill { .. }
+            | State::ReopenPrefill { .. }
+            | State::PartialPrefill { .. } => false,
         }
     }
 
@@ -82,7 +91,10 @@ impl<R: UniversalRead + 'static> State<R> {
     pub fn is_uninit(&self) -> bool {
         match self {
             State::Uninit => true,
-            State::Ready { .. } | State::OpenPrefill { .. } | State::ReopenPrefill { .. } => false,
+            State::Ready { .. }
+            | State::OpenPrefill { .. }
+            | State::ReopenPrefill { .. }
+            | State::PartialPrefill { .. } => false,
         }
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -26,6 +26,9 @@ where
             State::ReopenPrefill { pipeline, local } => {
                 self.init_from_reopen_prefill(pipeline, local)?
             }
+            State::PartialPrefill { pipeline, len } => {
+                self.init_from_partial_prefill(pipeline, len)?
+            }
         };
         *self.is_ready.get_mut() = false;
 
@@ -35,7 +38,7 @@ where
         let local_len = local.mmap().len::<u8>()?;
 
         match self.open_options.populate {
-            Populate::Auto | Populate::No => {
+            Populate::Auto | Populate::No | Populate::Partial(_) => {
                 let remote_len = remote.len::<u8>()?;
 
                 // The remote is assumed to be append-only; a smaller file is unexpected.

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -2,9 +2,11 @@ use std::fmt::Debug;
 use std::path::Path;
 use std::sync::Arc;
 
-use super::DiskCacheRemote;
 use super::config::DiskCacheConfig;
 use super::file::{DiskCache, State};
+use super::pipeline::REMOTE_READ_ALIGNMENT;
+use super::{DiskCacheRemote, block_aligned_fetch};
+use crate::generic_consts::Sequential;
 use crate::mmap::AdviceSetting;
 use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::{
@@ -205,6 +207,40 @@ where
                 pipeline.schedule_whole((), 0)?;
 
                 State::OpenPrefill { pipeline }
+            }
+            // Schedule a partial block-aligned read.
+            (known_len, Populate::Partial(range)) => {
+                let remote = self.open_remote(path.as_ref(), remote_extra.clone())?;
+
+                // `Partial` must create the local file, so we need the length up front.
+                let file_len = match known_len {
+                    Some(len) => len,
+                    None => remote.len::<u8>()?,
+                };
+
+                let mut pipeline = OwnedPipeline::new(remote)?;
+
+                let requested_byte_range = range.into_byte_range::<u8>();
+
+                let (blocks_range, byte_range) =
+                    block_aligned_fetch(requested_byte_range.clone(), file_len).ok_or_else(
+                        || UniversalIoError::OutOfBounds {
+                            start: requested_byte_range.start,
+                            end: requested_byte_range.end,
+                            elements: requested_byte_range
+                                .end
+                                .saturating_sub(requested_byte_range.start)
+                                as usize,
+                        },
+                    )?;
+
+                // FIXME: check `can_schedule` in a loop first
+                pipeline.schedule::<Sequential>(blocks_range, byte_range, REMOTE_READ_ALIGNMENT)?;
+
+                State::PartialPrefill {
+                    pipeline,
+                    len: file_len,
+                }
             }
         };
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -208,6 +208,10 @@ where
 
                 State::OpenPrefill { pipeline }
             }
+            // Special case of no known length and empty range. Don't initialize.
+            (None, Populate::Partial(range)) if range.into_byte_range::<u8>().is_empty() => {
+                State::Uninit
+            }
             // Schedule a partial block-aligned read.
             (known_len, Populate::Partial(range)) => {
                 let remote = self.open_remote(path.as_ref(), remote_extra.clone())?;
@@ -218,28 +222,28 @@ where
                     None => remote.len::<u8>()?,
                 };
 
-                let mut pipeline = OwnedPipeline::new(remote)?;
-
                 let requested_byte_range = range.into_byte_range::<u8>();
 
-                let (blocks_range, byte_range) =
-                    block_aligned_fetch(requested_byte_range.clone(), file_len).ok_or_else(
-                        || UniversalIoError::OutOfBounds {
-                            start: requested_byte_range.start,
-                            end: requested_byte_range.end,
-                            elements: requested_byte_range
-                                .end
-                                .saturating_sub(requested_byte_range.start)
-                                as usize,
-                        },
+                if let Some((blocks_range, byte_range)) =
+                    block_aligned_fetch(requested_byte_range.clone(), file_len)
+                {
+                    let mut pipeline = OwnedPipeline::new(remote)?;
+
+                    // FIXME: check `can_schedule` in a loop first
+                    pipeline.schedule::<Sequential>(
+                        blocks_range,
+                        byte_range,
+                        REMOTE_READ_ALIGNMENT,
                     )?;
 
-                // FIXME: check `can_schedule` in a loop first
-                pipeline.schedule::<Sequential>(blocks_range, byte_range, REMOTE_READ_ALIGNMENT)?;
-
-                State::PartialPrefill {
-                    pipeline,
-                    len: file_len,
+                    State::PartialPrefill {
+                        pipeline,
+                        len: file_len,
+                    }
+                } else {
+                    // empty byte range, just initialize with length.
+                    let local = LocalState::new(&local_path, file_len, options)?;
+                    State::Ready { remote, local }
                 }
             }
         };

--- a/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
@@ -59,8 +59,7 @@ fn to_block_range(byte_range: Range<u64>) -> Range<u32> {
 /// fetched from the remote to cover it, clamped to the file's `len` (EOF).
 ///
 /// Returns the covering block range together with its EOF-clamped byte range,
-/// or `None` when there is nothing to fetch — either `byte_range` is empty, or
-/// it starts at/beyond EOF so the clamped range collapses to empty.
+/// or `None` when `byte_range` is empty.
 fn block_aligned_fetch(byte_range: Range<u64>, file_len: u64) -> Option<(Range<u32>, Range<u64>)> {
     let blocks_range = to_block_range(byte_range);
     if blocks_range.is_empty() {

--- a/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
@@ -21,6 +21,7 @@ pub trait DiskCacheRemote:
         Fs: Clone + Send + Sync + UniversalReadFs<OpenExtra: Clone + Send + Sync>,
         ReadPipeline<'static, ()>: Send,
         ReadPipeline<'static, u64>: Send,
+        ReadPipeline<'static, Range<u32>>: Send,
     > + Clone
     + 'static
 {
@@ -33,6 +34,7 @@ where
     <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
     R::ReadPipeline<'static, ()>: Send,
     R::ReadPipeline<'static, u64>: Send,
+    R::ReadPipeline<'static, Range<u32>>: Send,
 {
 }
 
@@ -51,4 +53,30 @@ fn to_block_range(byte_range: Range<u64>) -> Range<u32> {
     }
     let end = byte_range.end.div_ceil(BLOCK_SIZE as u64) as u32;
     start..end
+}
+
+/// Expand a requested `byte_range` to the block-aligned region that must be
+/// fetched from the remote to cover it, clamped to the file's `len` (EOF).
+///
+/// Returns the covering block range together with its EOF-clamped byte range,
+/// or `None` when there is nothing to fetch — either `byte_range` is empty, or
+/// it starts at/beyond EOF so the clamped range collapses to empty.
+fn block_aligned_fetch(byte_range: Range<u64>, file_len: u64) -> Option<(Range<u32>, Range<u64>)> {
+    let blocks_range = to_block_range(byte_range);
+    if blocks_range.is_empty() {
+        return None;
+    }
+
+    // BLOCK_SIZE aligned, clamped to EOF.
+    let byte_offset = u64::from(blocks_range.start) * BLOCK_SIZE as u64;
+    let fetch_length = blocks_range.len() as u64 * BLOCK_SIZE as u64;
+    let max_length = file_len.saturating_sub(byte_offset);
+    let blocks_byte_range = byte_offset..byte_offset + max_length.min(fetch_length);
+
+    // The first block already starts past EOF: nothing valid to fetch.
+    if blocks_byte_range.is_empty() {
+        return None;
+    }
+
+    Some((blocks_range, blocks_byte_range))
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -6,17 +6,17 @@ use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Random, Sequential};
 use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::simple_disk_cache::{
-    BLOCK_SIZE, DiskCache, DiskCacheRemote, to_block_range,
+    DiskCache, DiskCacheRemote, block_aligned_fetch, to_block_range,
 };
 use crate::universal_io::{self, ReadPipeline, Result, UniversalIoError, UniversalRead, UserData};
 
 #[cfg(target_os = "linux")]
 /// Required alignment when using io_uring with `O_DIRECT` on Linux
-const REMOTE_READ_ALIGNMENT: usize = universal_io::io_uring::KERNEL_PAGE_SIZE;
+pub(super) const REMOTE_READ_ALIGNMENT: usize = universal_io::io_uring::KERNEL_PAGE_SIZE;
 
 #[cfg(not(target_os = "linux"))]
 /// Default alignment on non-Linux platforms
-const REMOTE_READ_ALIGNMENT: usize = 1;
+pub(super) const REMOTE_READ_ALIGNMENT: usize = 1;
 
 struct RemoteMeta<File, U> {
     file: File,
@@ -91,11 +91,10 @@ where
         });
     }
 
-    // BLOCK_SIZE aligned, clamped to EOF.
-    let byte_offset = u64::from(blocks_range.start) * BLOCK_SIZE as u64;
-    let fetch_length = blocks_range.len() as u64 * BLOCK_SIZE as u64;
-    let max_length = local.mmap().len::<u8>()?.saturating_sub(byte_offset);
-    let blocks_byte_range = byte_offset..byte_offset + max_length.min(fetch_length);
+    // BLOCK_SIZE aligned, clamped to EOF. `range` is non-empty here, so the
+    // block range is non-empty and `block_aligned_fetch` yields `Some`.
+    let (blocks_range, blocks_byte_range) = block_aligned_fetch(range, local.mmap().len::<u8>()?)
+        .expect("non-empty range has a non-empty block range");
 
     Ok(Source::Remote {
         blocks_range,

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -81,6 +81,31 @@ impl Scenario {
         .unwrap()
     }
 
+    /// Open with [`Populate::Partial`] over `range`, prefetching just that
+    /// (block-aligned) byte range at open.
+    fn open_partial<R>(&self, range: std::ops::Range<u64>) -> DiskCache<R>
+    where
+        R: DiskCacheRemote,
+        <R::Fs as UniversalReadFileOps>::ContextConfig: Default,
+    {
+        let fs = DiskCacheFs::<R>::from_context(DiskCacheFsContext {
+            config: self.config.clone(),
+            remote: Default::default(),
+        })
+        .unwrap();
+        fs.open(
+            &self.remote_path,
+            OpenOptions {
+                writeable: false,
+                populate: Populate::Partial(ReadRange::new(range.start, range.end - range.start)),
+                need_sequential: false,
+                advice: AdviceSetting::Global,
+            },
+            Default::default(),
+        )
+        .unwrap()
+    }
+
     /// Append `additional_bytes` bytes to the remote file in-place.
     /// Returns the full new remote contents.
     fn grow_remote(&mut self, additional_bytes: usize) -> Vec<u8> {
@@ -379,5 +404,86 @@ mod tests_mod {
             })
             .unwrap();
         assert_eq!(&*bytes, &new_data[BLOCK_SIZE..BLOCK_SIZE * 2]);
+    }
+
+    /// `Populate::Partial` prefetches only the requested (block-aligned) range;
+    /// blocks outside it stay unfetched until read, then fault in lazily.
+    #[test]
+    fn partial_populate_fetches_only_requested_range() {
+        // 4 blocks: 0, 1, 2, and a partial tail block 3.
+        let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
+        // Request blocks 0 and 1 (range spills 50 bytes into block 1).
+        let file = scn.open_partial::<R>(0..(BLOCK_SIZE as u64 + 50));
+
+        // The mirror is materialized lazily; nothing exists before the first read.
+        let expected_local = scn.expected_local_path();
+        assert!(!expected_local.exists());
+        assert!(!file.is_ready());
+
+        // A read within the prefetched range is served from the local mirror.
+        let bytes = file
+            .read::<Sequential, u8>(ReadRange {
+                byte_offset: 10,
+                length: 20,
+            })
+            .unwrap();
+        assert_eq!(&*bytes, &scn.data[10..30]);
+
+        // The mirror now exists, and exactly the requested blocks {0, 1} are
+        // cached — not the whole file, proving the populate was partial.
+        assert!(expected_local.exists());
+        {
+            let local = file.state().unwrap().local;
+            assert!(!local.fully_populated.load(Ordering::Acquire));
+            assert!(local.fetched.lock().contains_range(0..2));
+            assert!(!local.fetched.lock().contains(2));
+            assert!(!local.fetched.lock().contains(3));
+        }
+
+        // A read outside the prefetched range faults its block in on demand.
+        let start = (BLOCK_SIZE * 2) as u64;
+        let bytes = file
+            .read::<Sequential, u8>(ReadRange {
+                byte_offset: start,
+                length: 30,
+            })
+            .unwrap();
+        assert_eq!(&*bytes, &scn.data[start as usize..start as usize + 30]);
+        assert!(file.state().unwrap().local.fetched.lock().contains(2));
+    }
+
+    /// An empty `Populate::Partial` range prefetches nothing but still opens a
+    /// correctly-sized mirror that serves reads by faulting blocks in lazily.
+    #[test]
+    fn partial_populate_empty_range_is_lazy() {
+        let scn = Scenario::new(BLOCK_SIZE * 2 + 100);
+        let file = scn.open_partial::<R>(10..10);
+
+        // Nothing prefetched, so the first read must fault its block in.
+        let bytes = file
+            .read::<Sequential, u8>(ReadRange {
+                byte_offset: 0,
+                length: 16,
+            })
+            .unwrap();
+        assert_eq!(&*bytes, &scn.data[0..16]);
+        assert_eq!(file.len::<u8>().unwrap(), scn.data.len() as u64);
+    }
+
+    /// A `Populate::Partial` range starting past EOF has nothing valid to
+    /// prefetch; the mirror is still sized correctly and serves reads lazily.
+    #[test]
+    fn partial_populate_range_past_eof_is_lazy() {
+        let scn = Scenario::new(100);
+        let file = scn.open_partial::<R>(BLOCK_SIZE as u64 * 4..BLOCK_SIZE as u64 * 5);
+
+        let bytes = file
+            .read::<Sequential, u8>(ReadRange {
+                byte_offset: 0,
+                length: 100,
+            })
+            .unwrap();
+        assert_eq!(&*bytes, &scn.data[..]);
+        assert_eq!(file.len::<u8>().unwrap(), 100);
     }
 }

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -76,6 +76,16 @@ impl Populate {
             Populate::Blocking | Populate::PreferBackground => true,
         }
     }
+
+    /// Default a non-populate (`Auto`/`No`) to partially populating `range`.
+    pub fn or_partial(self, range: Range<u64>) -> Populate {
+        match self {
+            Populate::Auto | Populate::No => {
+                Populate::Partial(ReadRange::new(range.start, range.end - range.start))
+            }
+            Populate::Blocking | Populate::PreferBackground | Populate::Partial(_) => self,
+        }
+    }
 }
 
 /// Options for [`UniversalReadFs::open`].

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -51,6 +51,11 @@ pub enum Populate {
     Blocking,
     /// Populate, but prefer to do it in the background
     PreferBackground,
+    /// Populate only the given range.
+    ///
+    /// Backends that cannot populate a sub-range treat this like
+    /// [`Populate::No`].
+    Partial(ReadRange),
 }
 
 impl From<bool> for Populate {
@@ -67,7 +72,7 @@ impl Populate {
     pub fn to_bool<S: UniversalRead>(self) -> bool {
         match self {
             Populate::Auto => S::populate_auto(),
-            Populate::No => false,
+            Populate::No | Populate::Partial(_) => false,
             Populate::Blocking | Populate::PreferBackground => true,
         }
     }

--- a/lib/gridstore/src/tracker/mod.rs
+++ b/lib/gridstore/src/tracker/mod.rs
@@ -279,7 +279,8 @@ impl<S: UniversalRead> Tracker<S> {
         populate: Populate,
     ) -> Result<()> {
         let path = Self::tracker_file_name(path);
-        // TODO(uio): use Populate::BackgroundPartial when Populate::No
+        // Default a lazy open to partially populating the header.
+        let populate = populate.or_partial(0..size_of::<TrackerHeader>() as u64);
         fs.schedule_prefetch(&path, Some(tracker_open_options(populate, false)), None)?;
         Ok(())
     }

--- a/lib/segment/src/id_tracker/disk_id_tracker/reader.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/reader.rs
@@ -54,8 +54,10 @@ impl<S: UniversalRead> DiskMappingReader<S> {
         OpenOptions {
             writeable: false,
             need_sequential: false,
-            // TODO(uio): files have headers, we should use Populate::BackgroundPartial
-            populate: Populate::No,
+            populate: Populate::Partial(ReadRange::new(
+                0,
+                size_of::<I2eHeader>().max(size_of::<E2iHeader>()) as u64,
+            )),
             advice: AdviceSetting::Global,
         }
     }

--- a/lib/segment/src/index/field_index/map_index/prefix_index/reader.rs
+++ b/lib/segment/src/index/field_index/map_index/prefix_index/reader.rs
@@ -19,6 +19,8 @@ use super::format::{
 };
 use crate::common::operation_error::{OperationError, OperationResult};
 
+const HEADER_AND_BASIC_BLOCK_INDEX_SIZE: u64 = size_of::<Header>() as u64 + 16 * 1024; // Header + 16 KB
+
 /// Per-block metadata, parsed from the block index section and kept resident.
 pub(super) struct BlockMeta {
     /// First key of the block, stored in full. Any valid separator (a string
@@ -53,7 +55,11 @@ pub struct PrefixIndex<S: UniversalRead = MmapFile> {
 }
 
 impl<S: UniversalRead> PrefixIndex<S> {
-    fn open_options(populate: Populate) -> OpenOptions {
+    fn prefix_open_options(populate: Populate) -> OpenOptions {
+        // Default a lazy open to partially populating the header + a slice of
+        // the block index, so the index can be opened without a full read.
+        let populate = populate.or_partial(0..HEADER_AND_BASIC_BLOCK_INDEX_SIZE);
+
         OpenOptions {
             writeable: false,
             need_sequential: false,
@@ -72,8 +78,7 @@ impl<S: UniversalRead> PrefixIndex<S> {
             return Ok(());
         }
 
-        // TODO(uio): Turn Populate::No into Populate::BackgroundPartial(0..header + header.block_index_size)
-        fs.schedule_prefetch(&file_path, Some(Self::open_options(populate)), None)?;
+        fs.schedule_prefetch(&file_path, Some(Self::prefix_open_options(populate)), None)?;
 
         Ok(())
     }
@@ -90,7 +95,11 @@ impl<S: UniversalRead> PrefixIndex<S> {
             return Ok(None);
         }
 
-        let storage = fs.open(&file_path, Self::open_options(populate), Default::default())?;
+        let storage = fs.open(
+            &file_path,
+            Self::prefix_open_options(populate),
+            Default::default(),
+        )?;
 
         let header_size = size_of::<Header>() as u64;
         let header_bytes = storage.read_bytes::<Random>(0..header_size, align_of::<Header>())?;

--- a/lib/segment/src/index/field_index/on_disk_point_to_values.rs
+++ b/lib/segment/src/index/field_index/on_disk_point_to_values.rs
@@ -100,6 +100,9 @@ where
     S: UniversalRead,
 {
     fn open_options(populate: Populate) -> OpenOptions {
+        // Default a lazy open to partially populating the header.
+        let populate = populate.or_partial(0..size_of::<Header>() as u64);
+
         OpenOptions {
             writeable: false,
             need_sequential: false,
@@ -179,7 +182,6 @@ where
     ) -> OperationResult<()> {
         let file_name = dir.join(POINT_TO_VALUES_PATH);
 
-        // TODO(uio): Turn Populate::No into Populate::BackgroundPartial(0..header_size)
         fs.schedule_prefetch(&file_name, Some(Self::open_options(populate)), None)?;
 
         Ok(())


### PR DESCRIPTION
In order to schedule headers for some files appropriately, we need to be able to schedule just a partial part of a file.

This PR:
-  introduces `Populate::Partial(ReadRange)` to solve this.
- Uses it for the structures that already implemented `preopen`, but which `Populate::No` did not provide any prescheduling advantage. Now the opening sequence won't need to read the headers sequentially from the remote.


For reviewers: Please check if universal hashmap and prefix index's partial prefetch is of the right size 🙏.

Assisted by AI.