### PR TITLE
fix: prevent receiver shard slot from becoming None on gRPC timeout

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -582,11 +582,24 @@ impl ShardReplicaSet {
         }
     }
 
-    /// Clears the local shard data and loads an empty local shard
+    /// Clears the local shard data and loads an empty local shard.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe: a `DummyShard` placeholder is installed before any
+    /// await point, so `self.local` always remains populated and interrupted
+    /// initialization can later be detected and retried.
     pub async fn init_empty_local_shard(&self) -> CollectionResult<()> {
-        let mut local = self.local.write().await;
+        let current_shard = {
+            let mut local = self.local.write().await;
+            local.replace(Shard::Dummy(DummyShard::new(
+                "Initializing empty local shard for incoming shard transfer",
+            )))
+        };
 
-        let current_shard = local.take();
+        #[cfg(test)]
+        wait_after_local_replace().await;
+
         if let Some(current_shard) = current_shard {
             current_shard.stop_gracefully().await;
         }
@@ -606,6 +619,7 @@ impl ShardReplicaSet {
         )
         .await;
 
+        let mut local = self.local.write().await;
         match local_shard_res {
             Ok(local_shard) => {
                 *local = Some(Shard::Local(local_shard));
@@ -1524,4 +1538,190 @@ impl ShardReplicaSet {
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]
 pub enum Change {
     Remove(ShardId, PeerId),
+}
+
+#[cfg(test)]
+static INIT_EMPTY_LOCAL_SHARD_AFTER_REPLACE_HOOK: std::sync::Mutex<
+    Option<(
+        tokio::sync::oneshot::Sender<()>,
+        tokio::sync::oneshot::Receiver<()>,
+    )>,
+> = std::sync::Mutex::new(None);
+
+#[cfg(test)]
+async fn wait_after_local_replace() {
+    let hook = INIT_EMPTY_LOCAL_SHARD_AFTER_REPLACE_HOOK
+        .lock()
+        .unwrap()
+        .take();
+
+    if let Some((reached, release)) = hook {
+        let _ = reached.send(());
+        let _ = release.await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use common::budget::ResourceBudget;
+    use common::save_on_disk::SaveOnDisk;
+    use segment::types::Distance;
+    use tempfile::{Builder, TempDir};
+    use tokio::runtime::Handle;
+    use tokio::sync::RwLock;
+    use tokio::sync::oneshot;
+
+    use super::*;
+    use crate::collection::payload_index_schema::PayloadIndexSchema;
+    use crate::common::adaptive_handle::AdaptiveSearchHandle;
+    use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
+    use crate::operations::shared_storage_config::SharedStorageConfig;
+    use crate::operations::types::VectorsConfig;
+    use crate::operations::vector_params_builder::VectorParamsBuilder;
+    use crate::optimizers_builder::OptimizersConfig;
+    use crate::shards::channel_service::ChannelService;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cancel_init_empty_local_shard_preserves_receiver_slot() {
+        let collection_dir = Builder::new()
+            .prefix("init-empty-local-cancel")
+            .tempdir()
+            .unwrap();
+        let replica_set = new_dummy_receiver_replica_set(&collection_dir).await;
+
+        assert!(
+            replica_set.has_local_shard().await,
+            "test fixture must start with a local receiver slot"
+        );
+        assert!(
+            replica_set.is_dummy().await,
+            "test fixture must start with a dummy receiver shard"
+        );
+        replica_set
+            .wait_for_local(Duration::from_secs(1))
+            .await
+            .expect("test fixture metadata must mark this peer as local");
+
+        let (reached_tx, reached_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        install_init_empty_local_shard_after_replace_hook(reached_tx, release_rx);
+
+        let mut init_empty_local_shard = Box::pin(replica_set.init_empty_local_shard());
+
+        tokio::select! {
+            _ = reached_rx => {}
+            result = &mut init_empty_local_shard => {
+                panic!("empty local shard initialization completed before the cancellation window: {result:?}");
+            }
+        }
+
+        drop(init_empty_local_shard);
+        drop(release_tx);
+
+        assert!(
+            replica_set.has_local_shard().await,
+            "receiver initialization cancellation must not leave the local shard slot empty"
+        );
+        assert!(
+            replica_set.is_dummy().await,
+            "cancelling receiver initialization should leave a retry-visible dummy receiver state"
+        );
+        replica_set
+            .wait_for_local(Duration::from_secs(1))
+            .await
+            .expect("replica metadata still says this peer is local");
+    }
+
+    fn install_init_empty_local_shard_after_replace_hook(
+        reached: oneshot::Sender<()>,
+        release: oneshot::Receiver<()>,
+    ) {
+        let mut hook = INIT_EMPTY_LOCAL_SHARD_AFTER_REPLACE_HOOK.lock().unwrap();
+        assert!(
+            hook.is_none(),
+            "init-empty-local-shard test hook is already installed"
+        );
+        *hook = Some((reached, release));
+    }
+
+    async fn new_dummy_receiver_replica_set(collection_dir: &TempDir) -> ShardReplicaSet {
+        let update_runtime = Handle::current();
+        let search_runtime = AdaptiveSearchHandle::current_for_tests();
+
+        let wal_config = WalConfig {
+            wal_capacity_mb: 1,
+            wal_segments_ahead: 0,
+            wal_retain_closed: 1,
+        };
+
+        let collection_params = CollectionParams {
+            vectors: VectorsConfig::Single(VectorParamsBuilder::new(4, Distance::Dot).build()),
+            shard_number: NonZeroU32::new(1).unwrap(),
+            replication_factor: NonZeroU32::new(1).unwrap(),
+            write_consistency_factor: NonZeroU32::new(1).unwrap(),
+            ..CollectionParams::empty()
+        };
+
+        let optimizers_config = OptimizersConfig::fixture();
+        let config = CollectionConfigInternal {
+            params: collection_params,
+            optimizer_config: optimizers_config.clone(),
+            wal_config,
+            hnsw_config: Default::default(),
+            quantization_config: None,
+            strict_mode_config: None,
+            uuid: None,
+            metadata: None,
+        };
+
+        let payload_index_schema_file = collection_dir.path().join("payload-schema.json");
+        let payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>> = Arc::new(
+            SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap(),
+        );
+        let shared_config = Arc::new(RwLock::new(config));
+
+        let replica_set = ShardReplicaSet::build(
+            1,
+            None,
+            "test_collection".to_string(),
+            1,
+            true,
+            HashSet::new(),
+            dummy_on_replica_failure(),
+            dummy_abort_shard_transfer(),
+            collection_dir.path(),
+            shared_config,
+            optimizers_config,
+            Arc::new(SharedStorageConfig::default()),
+            payload_index_schema,
+            ChannelService::default(),
+            update_runtime,
+            search_runtime,
+            ResourceBudget::default(),
+            Some(ReplicaState::Partial),
+        )
+        .await
+        .unwrap();
+
+        {
+            let mut local = replica_set.local.write().await;
+            *local = Some(Shard::Dummy(DummyShard::new(
+                "dummy receiver awaiting shard transfer",
+            )));
+        }
+
+        replica_set
+    }
+
+    fn dummy_on_replica_failure() -> ChangePeerFromState {
+        Arc::new(move |_peer_id, _shard_id, _from_state| {})
+    }
+
+    fn dummy_abort_shard_transfer() -> AbortShardTransfer {
+        Arc::new(|_shard_transfer, _reason| {})
+    }
 }


### PR DESCRIPTION
## What

Fixes a cancel-safety bug in `ShardReplicaSet::init_empty_local_shard()` that can leave the local shard slot as `None` when the internal gRPC request future is cancelled by tonic's timeout wrapper.

## Why

During receiver-side shard transfer setup, `init_empty_local_shard()` held a `tokio::RwLockWriteGuard` across three async boundaries:

1. `current_shard.stop_gracefully().await`
2. `LocalShard::clear(&self.shard_path).await`
3. `LocalShard::build(...).await`

The method started with `local.take()` which set `self.local = None`, then awaited all three operations before assigning back `Some(Shard::Local(...))` or `Some(Shard::Dummy(...))`.

If tonic's `GrpcTimeout` wrapper won the race against the inner service future, the timeout error was returned and the unfinished inner future (containing the entire `initiate -> initiate_receiving_shard -> initiate_shard_transfer -> init_empty_local_shard` chain) was dropped. Dropping the future released the RwLock write guard, but ordinary lock release does not restore the protected value.

This left the replica set in an unmodeled state:

- `self.local == None` (no local shard object)
- `replica_state.is_local == true` (metadata still says peer is local)
- `is_dummy() == false` (because the slot is None, not Some(Dummy))
- `is_proxy() == false` (because the slot is None, not Some(Proxy))
- `wait_for_local() == Ok` (reads from metadata, not the slot)

The retry path could then pass `wait_for_local()`, skip both the dummy-repair and proxy-cleanup branches because None is neither, and return Ok without ever recreating a local receiver slot.

## How

**Before** (vulnerable):
```rust
let mut local = self.local.write().await;
let current_shard = local.take();          // self.local = None
// ... await stop_gracefully, clear, build ...
*local = Some(Shard::Local(local_shard));  // commit under same guard
```

**After** (cancel-safe):
```rust
let current_shard = {
    let mut local = self.local.write().await;
    local.replace(Shard::Dummy(DummyShard::new(
        "Initializing empty local shard for incoming shard transfer",
    )))
    // write lock dropped here
};
// ... await stop_gracefully, clear, build (no lock held) ...
let mut local = self.local.write().await;  // re-acquire for commit
match local_shard_res {
    Ok(local_shard) => *local = Some(Shard::Local(local_shard)),
    Err(err) => *local = Some(Shard::Dummy(DummyShard::new(error))),
}
```

Three changes:

1. **Scoped write lock** — `self.local` is written to a `DummyShard` placeholder immediately, then the lock is dropped
2. **Async work outside the lock** — `stop_gracefully`, `clear`, and `build` all run without holding the write guard
3. **Commit under a new write lock** — the fully-built `LocalShard` (or error `DummyShard`) is installed under a fresh lock acquisition

This guarantees `self.local` is never `None` at any await boundary. If the future is cancelled at any point, the replica set retains a valid `DummyShard` state that retry/recovery logic can detect and handle.

## Where

`lib/collection/src/shards/replica_set/mod.rs:586` — `ShardReplicaSet::init_empty_local_shard()`

Called from `lib/collection/src/collection/shard_transfer.rs:584` — `Collection::initiate_shard_transfer()` when the target replica is a dummy receiver.

The cancellation source is tonic's `GrpcTimeout` wrapper in `tonic/transport/service/grpc_timeout.rs`, triggered by the `grpc-timeout` metadata set by `PoolInterceptor` in `lib/api/src/grpc/transport_channel_pool.rs:98`.

## Before / After

| Scenario | Before | After |
|---|---|---|
| Timeout after `local.take()` | `self.local == None`, metadata says local, retry skips repair | `self.local == Some(Dummy)`, retry enters repair branch |
| Successful build | `Some(Local)` installed | `Some(Local)` installed (unchanged) |
| Build failure | `Some(Dummy)` with error message | `Some(Dummy)` with error message (unchanged) |

## Regression test

Added a whitebox test that deterministically pauses the future after the DummyShard placeholder is installed (via a test-only hook), drops the future, and asserts:

```rust
assert!(replica_set.has_local_shard().await);       // slot is not None
assert!(replica_set.is_dummy().await);               // DummyShard is installed
replica_set.wait_for_local(Duration::from_secs(1)).await.expect("..."); // metadata consistent
```

All 12 existing replica_set tests pass plus the new regression test.