### PR TITLE
Preserve configured temp root during CLI snapshot recovery

### DIFF
--- a/src/snapshots.rs
+++ b/src/snapshots.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use collection::collection::Collection;
 use collection::shards::shard::PeerId;
-use common::fs::safe_delete_in_tmp;
+use common::fs::{move_dir, safe_delete_in_tmp};
 use common::tar_unpack::tar_unpack_file;
 use fs_err as fs;
 use fs_err::File;
@@ -85,6 +85,7 @@ fn recover_snapshot_mappings(
     is_distributed: bool,
 ) -> Vec<String> {
     let collection_dir_path = storage_dir.join(COLLECTIONS_DIR);
+    fs::create_dir_all(&collection_dir_path).unwrap();
     let mut recovered_collections: Vec<String> = vec![];
 
     for SnapshotMapping {
@@ -112,15 +113,25 @@ fn recover_snapshot_mappings(
             }
             info!("Overwriting collection {collection_name}");
         }
-        let collection_temp_path =
-            temp_dir.map_or_else(|| collection_path.with_extension("tmp"), PathBuf::from);
+        let collection_temp_path = collection_path.with_extension("tmp");
+        if collection_temp_path.exists() {
+            fs::remove_dir_all(&collection_temp_path).unwrap();
+        }
+        let collection_recovery_temp =
+            temp_dir.map(|temp_dir| snapshot_recovery_temp_dir(Some(temp_dir), storage_dir));
+        let collection_recovery_path = collection_recovery_temp
+            .as_ref()
+            .map_or(collection_temp_path.as_path(), |temp_dir| temp_dir.path());
         if let Err(err) = Collection::restore_snapshot(
             snapshot_data,
-            &collection_temp_path,
+            collection_recovery_path,
             this_peer_id,
             is_distributed,
         ) {
             panic!("Failed to recover snapshot {collection_name}: {err}");
+        }
+        if let Some(collection_recovery_temp) = collection_recovery_temp {
+            move_dir(collection_recovery_temp.path(), &collection_temp_path).unwrap();
         }
         // Remove collection_path directory if exists
         if collection_path.exists()
@@ -134,6 +145,18 @@ fn recover_snapshot_mappings(
     recovered_collections
 }
 
+fn snapshot_recovery_temp_dir(temp_dir: Option<&Path>, storage_dir: &Path) -> tempfile::TempDir {
+    let temp_base = temp_dir
+        .map(|path| path.join("tmp"))
+        .unwrap_or_else(|| storage_dir.to_path_buf());
+    fs::create_dir_all(&temp_base).unwrap();
+
+    tempfile::Builder::new()
+        .prefix("snapshots-recovery-")
+        .tempdir_in(temp_base)
+        .unwrap()
+}
+
 pub fn recover_full_snapshot(
     temp_dir: Option<&Path>,
     snapshot_path: &str,
@@ -142,13 +165,11 @@ pub fn recover_full_snapshot(
     this_peer_id: PeerId,
     is_distributed: bool,
 ) -> Vec<String> {
-    let snapshot_temp_path = temp_dir
-        .map(PathBuf::from)
-        .unwrap_or_else(|| storage_dir.join("snapshots_recovery_tmp"));
-    fs::create_dir_all(&snapshot_temp_path).unwrap();
+    let snapshot_temp_dir = snapshot_recovery_temp_dir(temp_dir, storage_dir);
+    let snapshot_temp_path = snapshot_temp_dir.path();
 
     // Un-tar snapshot into temporary directory
-    tar_unpack_file(Path::new(snapshot_path), &snapshot_temp_path).unwrap();
+    tar_unpack_file(Path::new(snapshot_path), snapshot_temp_path).unwrap();
 
     // Read configuration file with snapshot-to-collection mapping
     let config_path = snapshot_temp_path.join("config.json");
@@ -184,8 +205,7 @@ pub fn recover_full_snapshot(
         alias_persistence.insert(alias, collection_name).unwrap();
     }
 
-    // Remove temporary directory
-    fs::remove_dir_all(&snapshot_temp_path).unwrap();
+    snapshot_temp_dir.close().unwrap();
     recovered_collection
 }
 
@@ -193,7 +213,9 @@ pub fn recover_full_snapshot(
 mod tests {
     use std::path::PathBuf;
 
-    use super::SnapshotMapping;
+    use fs_err as fs;
+
+    use super::{SnapshotMapping, snapshot_recovery_temp_dir};
 
     #[test]
     fn snapshot_mapping_absolute_paths() {
@@ -255,6 +277,27 @@ mod tests {
     #[should_panic(expected = "Collection name is missing")]
     fn snapshot_mapping_rejects_empty_collection_name() {
         SnapshotMapping::from_cli_arg("collection.snapshot:");
+    }
+
+    #[test]
+    fn snapshot_recovery_uses_owned_temp_subdirectory() {
+        let configured_temp = tempfile::tempdir().unwrap();
+        let storage_dir = tempfile::tempdir().unwrap();
+        let sentinel_path = configured_temp.path().join("sentinel.txt");
+        fs::write(&sentinel_path, "keep").unwrap();
+
+        let recovery_temp =
+            snapshot_recovery_temp_dir(Some(configured_temp.path()), storage_dir.path());
+        let recovery_temp_path = recovery_temp.path().to_path_buf();
+
+        assert!(recovery_temp_path.starts_with(configured_temp.path().join("tmp")));
+        assert_ne!(recovery_temp_path, configured_temp.path());
+
+        recovery_temp.close().unwrap();
+
+        assert!(configured_temp.path().exists());
+        assert!(sentinel_path.exists());
+        assert!(!recovery_temp_path.exists());
     }
 
     #[test]


### PR DESCRIPTION
CLI snapshot recovery currently treats the configured `storage.temp_path` itself as an operation-owned workspace. This can consume a shared configuration root and can prevent normal collection or full-storage snapshot recovery from completing.

### All Submissions:

> ** PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

## What Problem This Solves

`storage.temp_path` is a configured parent directory that may be shared with other temporary operations or contain unrelated files. The CLI snapshot recovery path instead used that root directory directly as both an extraction workspace and a collection staging directory.

For a regular `--snapshot` recovery, `recover_snapshot_mappings()` passed the configured root directly to `Collection::restore_snapshot()`, then attempted to rename that whole root into `storage/collections/<collection>`. A normal recovery with `storage.temp_path` configured could therefore move the shared temp root or fail during the final rename.

For `--storage-snapshot`, `recover_full_snapshot()` first unpacked the full archive into the configured root. Each collection was then restored into that same directory. The first collection recovery mixed its output with the unpacked `config.json` and remaining collection snapshots, and a successful rename or cleanup could consume files required by later collections.

In other words, the configured directory was being treated as if it were a disposable operation-specific directory. The configuration provides the parking area; recovery should allocate and clean up its own parking space rather than moving or deleting the whole area.

## Change

This PR gives each recovery operation ownership of a unique temporary subdirectory:

The core production change is:

```diff
-        let collection_temp_path =
-            temp_dir.map_or_else(|| collection_path.with_extension("tmp"), PathBuf::from);
+        let collection_temp_path = collection_path.with_extension("tmp");
+        let collection_recovery_temp =
+            temp_dir.map(|temp_dir| snapshot_recovery_temp_dir(Some(temp_dir), storage_dir));
+        let collection_recovery_path = collection_recovery_temp
+            .as_ref()
+            .map_or(collection_temp_path.as_path(), |temp_dir| temp_dir.path());

         if let Err(err) = Collection::restore_snapshot(
             snapshot_data,
-            &collection_temp_path,
+            collection_recovery_path,
             this_peer_id,
             is_distributed,
         ) {
             panic!("Failed to recover snapshot {collection_name}: {err}");
         }
+        if let Some(collection_recovery_temp) = collection_recovery_temp {
+            move_dir(collection_recovery_temp.path(), &collection_temp_path).unwrap();
+        }

+fn snapshot_recovery_temp_dir(temp_dir: Option<&Path>, storage_dir: &Path) -> tempfile::TempDir {
+    let temp_base = temp_dir
+        .map(|path| path.join("tmp"))
+        .unwrap_or_else(|| storage_dir.to_path_buf());
+    fs::create_dir_all(&temp_base).unwrap();
+
+    tempfile::Builder::new()
+        .prefix("snapshots-recovery-")
+        .tempdir_in(temp_base)
+        .unwrap()
+}

-    let snapshot_temp_path = temp_dir
-        .map(PathBuf::from)
-        .unwrap_or_else(|| storage_dir.join("snapshots_recovery_tmp"));
-    fs::create_dir_all(&snapshot_temp_path).unwrap();
+    let snapshot_temp_dir = snapshot_recovery_temp_dir(temp_dir, storage_dir);
+    let snapshot_temp_path = snapshot_temp_dir.path();
```


- full-storage snapshots are unpacked into a unique `TempDir` under `<storage.temp_path>/tmp`
- each collection is restored into its own unique recovery `TempDir`
- the restored collection is moved to `storage/collections/<name>.tmp` with the existing `common::fs::move_dir()` helper
- the final `<name>.tmp -> <name>` rename happens inside the storage filesystem
- stale collection `.tmp` directories are removed before reuse
- the configured temp root and unrelated files inside it are never renamed or deleted

The two-stage move preserves support for putting `storage.temp_path` on a different filesystem. Recovery can use the external temporary filesystem for its working data, while the final atomic rename remains local to the storage filesystem.

When no `storage.temp_path` is configured, recovery continues to use storage-local temporary directories. Alias restoration, force-overwrite behavior, distributed recovery flags, snapshot parsing, and online REST/gRPC snapshot recovery are unchanged.

## Evidence

The baseline was reproduced with a configured temp root containing a sentinel file.

Before this change:

```text
--storage-snapshot with two collections
process exit code: 101
failure: the first collection was restored into the full-snapshot extraction root

--snapshot with one collection
process exit code: 101
failure: the final rename of the configured temp root failed
```

After this change, both CLI paths completed and preserved the configured root:

```json
{"case":"final-full-recovery","ready":true,"collections":["collection_a","collection_b"],"sentinel_exists":true,"temp_root_exists":true,"recovery_workspaces_left":0,"collection_tmp_dirs":[]}
{"case":"final-single-recovery","ready":true,"collections":["collection_a"],"sentinel_exists":true,"temp_root_exists":true,"recovery_workspaces_left":0,"collection_tmp_dirs":[]}
```

The added focused test verifies that the recovery workspace is created below `<storage.temp_path>/tmp`, is distinct from the configured root, is cleaned after use, and does not remove a sentinel file from the root.

## Possible call chain / impact

Regular collection snapshot recovery:

```text
qdrant --snapshot <snapshot>:<collection>
  -> recover_snapshots(...)
  -> recover_snapshot_mappings(...)
  -> snapshot_recovery_temp_dir(...)
  -> Collection::restore_snapshot(...)
  -> move_dir(recovery workspace, collections/<name>.tmp)
  -> rename(collections/<name>.tmp, collections/<name>)
```

Full-storage snapshot recovery:

```text
qdrant --storage-snapshot <snapshot>
  -> recover_full_snapshot(...)
  -> unpack into an operation-owned TempDir
  -> recover_snapshot_mappings(...)
  -> one operation-owned TempDir per collection
  -> storage-local .tmp staging and final rename
```

This affects only CLI startup recovery for collection and full-storage snapshots. It does not change snapshot creation, remote snapshot download, shard transfer, online recovery APIs, checksum handling, scoring, payload data, or collection runtime behavior.

## Validation

Passed locally:

- `cargo build --bin qdrant --locked -j 1`
- `cargo test --bin qdrant snapshots::tests --locked -j 1` - 8 passed
- `cargo test --bin qdrant --locked -j 1` - 155 passed
- `cargo clippy -p qdrant --bin qdrant --tests --no-deps --locked -j 1 -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- manual `--snapshot` before/after recovery
- manual two-collection `--storage-snapshot` before/after recovery


### AI assistance

AI-generated commit:

- `[AI] Preserve temp root during CLI snapshot recovery`

Initial prompt:

> Fix CLI snapshot recovery so configured `storage.temp_path` is treated as a parent directory and is not moved or deleted. Preserve support for external temporary filesystems and cover both collection and full snapshot recovery.



