### PR TITLE
Fix /readyz false-positive on freshly bootstrapped peer

### DIFF
--- a/src/common/health.rs
+++ b/src/common/health.rs
@@ -311,9 +311,13 @@ impl Task {
     /// index of such peers means waiting for the commit index of a foreign consensus, which this
     /// peer may never reach.
     ///
-    /// An empty `conf_state` means this peer doesn't know the cluster configuration yet (e.g. it
-    /// bootstraps and didn't apply any configuration change so far). In this case all known peer
-    /// addresses are considered members.
+    /// The `conf_state` filter only applies if this peer is a member itself. A bootstrapping
+    /// peer seeds `conf_state` with just the first voter of the cluster until it applies the
+    /// configuration change entries of the log. Filtering by that interim `conf_state` would
+    /// leave a single member and misclassify this peer as a single-node cluster, reporting it
+    /// ready before it caught up with the cluster commit index. The same reasoning covers an
+    /// empty `conf_state`: this peer doesn't know the cluster configuration yet, so all known
+    /// peer addresses are considered members.
     fn member_peer_addresses(&self) -> PeerAddressById {
         let persistent = self.consensus_state.persistent.read();
         let conf_state = &persistent.state().conf_state;
@@ -329,7 +333,7 @@ impl Task {
 
         let mut peer_address_by_id = persistent.peer_address_by_id();
 
-        if !members.is_empty() {
+        if members.contains(&persistent.this_peer_id()) {
             peer_address_by_id.retain(|peer_id, _| members.contains(peer_id));
         }
 


### PR DESCRIPTION
## Problem

`test_replace_running_peer_without_shards_same_uri` is flaky on CI: right after `wait_for_peer_online` (which polls `/readyz`), querying `/collections/test_collection/cluster` on a freshly bootstrapped peer returns 404 — the peer hasn't applied the `CreateCollection` Raft entry yet.

From the failing run's logs, `/readyz` passed ~400ms *before* the peer applied any committed entries (applied index 0, cluster commit 12).

## Root cause

A bootstrapping peer manually seeds `conf_state` with just the first voter of the cluster (`Consensus::init`) until it applies the configuration change entries of the log. Since #9688, `member_peer_addresses()` filters known peer addresses by `conf_state` membership. During the catch-up window this leaves a single member, so `cluster_commit_index()` takes the "only 1 node in the cluster" short-circuit, returns `None`, and the health checker latches ready without ever waiting for the cluster commit index.

The window between Raft init and applying the first conf-change entries is normally tens of milliseconds, so `/readyz` polls usually miss it; under CI load with slow fsyncs it stretched to ~800ms and the test hit it.

## Fix

Only apply the `conf_state` filter in `member_peer_addresses()` when this peer is a member itself:

- **Reinit first peer** (the #9688 scenario): `conf_state` is reset to this peer → filter applies → still treated as single-node, ready immediately. Behavior unchanged.
- **Genuine single-node cluster**: this peer is the only voter → unchanged.
- **Freshly bootstrapped peer catching up**: not yet in `conf_state` → falls back to all known peer addresses (pre-#9688 behavior) and properly waits until the local applied index reaches the cluster commit index.

## Testing

- `test_replace_running_peer_without_shards_same_uri` passes
- `test_reinit_removed_peer`, `test_reinit_removed_peer_readyz_ignores_old_cluster`, `test_reinit_consensus` pass (the #9688 regression scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)