### PR TITLE
Remove unnecessary clippy allow attributes

### DIFF
--- a/lib/collection/src/model_testing/apply/reads.rs
+++ b/lib/collection/src/model_testing/apply/reads.rs
@@ -1196,7 +1196,6 @@ pub(super) async fn apply_scroll_ordered(
     assert_id_sets_eq(&returned_ids, &expected_ids, "ordered scroll");
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(super) async fn apply_recommend(
     collection: &Collection,
     model: &Model,

--- a/lib/collection/src/shards/local_shard/snapshot_tests.rs
+++ b/lib/collection/src/shards/local_shard/snapshot_tests.rs
@@ -81,7 +81,6 @@ fn test_snapshot_all() {
 /// (`segments_manifest.json`, next to the `segments/` directory) listing every snapshotted segment
 /// as `active`.
 #[test]
-#[allow(clippy::field_reassign_with_default)]
 fn test_snapshot_includes_segment_manifest() {
     let mut flags = FeatureFlags::default();
     flags.write_segment_manifest = true;

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -101,7 +101,6 @@ impl QueueProxyShard {
     ///
     /// This fails if the given `version` is not in bounds of our current WAL. If the given
     /// `version` is too old or too new, queue proxy creation is rejected.
-    #[allow(clippy::result_large_err)]
     pub async fn new_from_version(
         wrapped_shard: LocalShard,
         remote_shard: RemoteShard,

--- a/lib/collection/src/tests/segment_manifest.rs
+++ b/lib/collection/src/tests/segment_manifest.rs
@@ -17,7 +17,6 @@ use crate::tests::fixtures::create_collection_config;
 /// With the `write_segment_manifest` flag enabled, building a shard writes `segments_manifest.json`
 /// (next to the `segments/` directory) listing the shard's segments as `active`.
 #[tokio::test]
-#[allow(clippy::field_reassign_with_default)]
 async fn writes_segment_manifest_when_flag_enabled() {
     let mut flags = FeatureFlags::default();
     flags.write_segment_manifest = true;

--- a/lib/edge/src/read_only/tests.rs
+++ b/lib/edge/src/read_only/tests.rs
@@ -458,7 +458,6 @@ fn manifest_enumerator_requires_manifest() {
 /// With the `write_segment_manifest` flag enabled, the leader `EdgeShard` writes a manifest listing
 /// its segments, and a follower opened over the same directory loads through it.
 #[test]
-#[allow(clippy::field_reassign_with_default)]
 fn leader_writes_manifest_and_follower_loads_it() {
     let mut flags = FeatureFlags::default();
     flags.write_segment_manifest = true;

--- a/lib/shard/src/retrieve/retrieve_blocking.rs
+++ b/lib/shard/src/retrieve/retrieve_blocking.rs
@@ -58,7 +58,6 @@ pub fn retrieve_blocking(
 /// Generic over the segment type `R` so callers with a homogeneous snapshot (e.g. a follower's
 /// `ReadOnlySegment<S>`) are monomorphized; the heterogeneous leader instantiates `R = dyn
 /// ReadSegmentEntry`.
-#[allow(clippy::too_many_arguments)]
 pub fn retrieve_over<R: ReadSegmentEntry + ?Sized>(
     segments: Vec<Arc<RwLock<R>>>,
     points: &[PointIdType],

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -772,7 +772,6 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     /// # Errors
     ///
     /// Returns an error if we have diverged commit/term for example.
-    #[allow(clippy::result_unit_err)]
     pub async fn wait_for_consensus_commit(
         &self,
         commit: u64,


### PR DESCRIPTION
Removes 7 `#[allow(clippy::...)]` attributes that no longer suppress any lint. Each was verified to be redundant: the code they annotate is already clippy-clean without them, under all three clippy configurations run in CI (default features, `--all-targets`, and `--all-targets --all-features`).

### Removed

| File | Lint |
|------|------|
| `lib/collection/src/model_testing/apply/reads.rs` | `too_many_arguments` |
| `lib/shard/src/retrieve/retrieve_blocking.rs` | `too_many_arguments` |
| `lib/collection/src/shards/local_shard/snapshot_tests.rs` | `field_reassign_with_default` |
| `lib/collection/src/tests/segment_manifest.rs` | `field_reassign_with_default` |
| `lib/edge/src/read_only/tests.rs` | `field_reassign_with_default` |
| `lib/collection/src/shards/queue_proxy_shard.rs` | `result_large_err` |
| `lib/storage/src/content_manager/consensus_manager.rs` | `result_unit_err` |

No behavior change; attribute-only deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)