### PR TITLE
Preserve not-found classification on read-only reload/open paths

### DIFF
--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -140,7 +140,8 @@ impl UniversalReadFs for BlockCacheFs {
         } = options;
         debug_assert!(!writeable);
 
-        Ok(CachedSlice::open(&self.controller, path.as_ref())?)
+        CachedSlice::open(&self.controller, path.as_ref())
+            .map_err(|err| UniversalIoError::extract_not_found(err, path.as_ref()))
     }
 }
 
@@ -155,7 +156,8 @@ impl UniversalRead for CachedSlice {
 
     fn reopen(&mut self) -> Result<()> {
         // TODO: revise if this is the best way to reopen
-        *self = CachedSlice::open(&self.controller, &self.path)?;
+        *self = CachedSlice::open(&self.controller, &self.path)
+            .map_err(|err| UniversalIoError::extract_not_found(err, &self.path))?;
         Ok(())
     }
 

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -160,7 +160,10 @@ impl UniversalRead for MmapFile {
 
     fn reopen(&mut self) -> Result<()> {
         let old_len = self.len as u64;
-        let new_len = fs_err::File::open(self.path())?.metadata()?.len();
+        let new_len = fs_err::File::open(self.path())
+            .map_err(|err| UniversalIoError::extract_not_found(err, self.path()))?
+            .metadata()?
+            .len();
         if new_len < old_len {
             return Err(UniversalIoError::Io(io::Error::new(
                 ErrorKind::UnexpectedEof,

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -61,23 +61,20 @@ fn open_options(populate: Populate) -> OpenOptions {
 
 /// Read the logical flag length from the status struct, opened read-only.
 ///
-/// Returns `Ok(None)` when the status file is absent
+/// An absent status file propagates as not-found: whether that is legitimate
+/// depends on the caller — [`ReadOnlyRoaringFlags::open`] masks it (the index
+/// may simply not exist), a reload must not (the file existed before).
 fn read_status_len<S: UniversalRead>(
     fs: &impl UniversalReadFs<File = S>,
     directory: &Path,
-) -> OperationResult<Option<usize>> {
-    let Some(file) = fs
-        .open(
-            status_file(directory),
-            open_options(Populate::No),
-            Default::default(),
-        )
-        .ok_not_found()?
-    else {
-        return Ok(None);
-    };
+) -> OperationResult<usize> {
+    let file = fs.open(
+        status_file(directory),
+        open_options(Populate::No),
+        Default::default(),
+    )?;
     let status = TypedStorage::<S, DynamicFlagsStatus>::new(file);
-    Ok(Some(status.read_whole()?[0].len()))
+    Ok(status.read_whole()?[0].len())
 }
 
 impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
@@ -124,7 +121,7 @@ impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
         directory: &Path,
     ) -> OperationResult<Option<Self>> {
         // A missing status file means the index isn't present on disk.
-        let Some(len) = read_status_len::<S>(fs, directory)? else {
+        let Some(len) = read_status_len::<S>(fs, directory).ok_not_found()? else {
             return Ok(None);
         };
 
@@ -222,9 +219,9 @@ impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
 
         // The logical length grows as points are appended; refresh it so
         // length-driven readers (the null index's `iter_falses`) stay correct.
-        if let Some(len) = read_status_len::<S>(fs, &self.directory)? {
-            self.len = len;
-        }
+        // Once the index exists its status file always does, so absence here is
+        // a genuine not-found (segment removed mid-reload), not a lazy file.
+        self.len = read_status_len::<S>(fs, &self.directory)?;
 
         Ok(())
     }

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -142,10 +142,12 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         deferred_internal_id: Option<PointOffsetType>,
     ) -> OperationResult<Self> {
         if SegmentVersion::load_universal(fs, segment_path)?.is_none() {
-            return Err(OperationError::service_error(format!(
-                "Segment version file not found in segment: {}",
-                segment_path.display(),
-            )));
+            // `FileNotFound`, not a service error: the version file is written last, so
+            // its absence means the segment vanished mid-open (or was never completed) —
+            // a follower resolves that against the segment manifest.
+            return Err(OperationError::FileNotFound {
+                path: segment_path.join(VERSION_FILE),
+            });
         }
 
         let is_appendable = config.is_appendable();

--- a/lib/segment/src/segment/read_only/tests.rs
+++ b/lib/segment/src/segment/read_only/tests.rs
@@ -377,3 +377,43 @@ fn read_only_segment_config_reload_payload_index() {
     }
     assert_query_equivalence(&mutable, &read_only);
 }
+
+/// A follower distinguishes "segment removed by the leader" from corruption by
+/// classifying errors as not-found (see `IsNotFound for OperationError`): both
+/// opening a vanished segment directory and live-reloading a segment whose
+/// directory vanished mid-flight must classify, so the shard-level refresh can
+/// re-check the segment manifest instead of escalating.
+#[test]
+fn vanished_segment_classifies_not_found() {
+    use common::universal_io::IsNotFound as _;
+
+    let segments_dir = Builder::new().prefix("ro_segments").tempdir().unwrap();
+    let temp_dir = Builder::new().prefix("ro_builder").tempdir().unwrap();
+
+    let mutable = build_immutable_segment(segments_dir.path(), temp_dir.path());
+    let segment_path = mutable.data_path();
+    let segment_uuid = mutable.uuid;
+    drop(mutable);
+
+    // Open of a directory that never existed.
+    let Err(err) = ReadOnlySegment::<MmapFile>::open(
+        &MmapFs,
+        &segments_dir.path().join("no-such-segment"),
+        segment_uuid,
+        None,
+    ) else {
+        panic!("open of a missing directory must fail");
+    };
+    assert!(err.is_not_found(), "expected not-found, got: {err}");
+
+    // Live-reload of a segment whose directory vanished after open (the leader
+    // removed it): the first component reopen hits the missing file.
+    let mut read_only =
+        ReadOnlySegment::<MmapFile>::open(&MmapFs, &segment_path, segment_uuid, None)
+            .expect("read-only open");
+    fs_err::remove_dir_all(&segment_path).unwrap();
+    let err = read_only
+        .live_reload(&MmapFs, &HardwareCounterCell::disposable())
+        .expect_err("live_reload over a removed directory must fail");
+    assert!(err.is_not_found(), "expected not-found, got: {err}");
+}


### PR DESCRIPTION
## What

Follow-up to #9763. An audit of every component `live_reload` implementation and the read-only open path found four places where a not-found error lost its structured classification before reaching `OperationError::FileNotFound` — all fixed:

1. **`MmapFile::reopen`** (`universal_io/mmap/mod.rs`) opened the file with a bare `?`, producing unstructured `Io(NotFound)`. This is *the* central call on the local follower's live-reload path — without this fix, no mid-reload segment removal would ever have classified on the mmap backend. Wrapped with `extract_not_found`.
2. **`BlockCacheFs::open` / `CachedSlice::reopen`** (`universal_io/disk_cache/mod.rs`) — same bare-`?` pattern over `CachedSlice::open`'s `io::Result`. Both wrapped.
3. **`ReadOnlySegment::open_via`** hand-rolled a `service_error("Segment version file not found…")`. The version file is written last, so its absence is exactly the vanished-mid-open signal a follower must resolve against the segment manifest; now `FileNotFound { path }`.
4. **`ReadOnlyRoaringFlags`** — `read_status_len` masked NotFound internally, so `live_reload` silently kept a stale `len` if the status file vanished mid-reload. The raw reader now propagates; `open` masks it explicitly with `.ok_not_found()` (works on `OperationResult` since #9763), and `live_reload` requires the file — once the index exists, its status file is essential, not lazy.

## Audited and deliberately unchanged

- All `live_reload.rs` impls: no manual error conversions found.
- Lazily-created files keep masking absence (`ok_not_found`): mutable id tracker mappings/versions, mutable-index gridstore dirs — a leader creates these on first flush, so absence is a valid state.
- Optional-component probes at open (payload/hnsw/quantization configs, on-disk index variant detection, chunked-vectors config).
- Object-store bridge: already maps `object_store::Error::NotFound` → structured `UniversalIoError::NotFound`, with an integration test.
- `gridstore/tracker`'s config-present-but-tracker-missing check at open stays an inconsistent-storage error: that is corruption detection; the mid-reload window is covered by the (now fixed) reopen path.

## Test

`segment::read_only::tests::vanished_segment_classifies_not_found` pins both legs end-to-end: opening a missing segment directory and live-reloading a segment whose directory was removed both classify via `is_not_found()`. The live-reload leg fails without fix 1.

Full suites pass: segment (869), common/universal_io (45), gridstore, edge (60); clippy clean.

## Context

Second step toward the shard-level not-found handling in `ReadOnlyEdgeShard::refresh` ("segment vanished mid-reload → re-check manifest, absorb; anything else → escalate"), which needs errors to classify reliably from every component. The refresh logic itself follows in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)