### PR TITLE
perf(geo_index): dedup sub-hashes with AHashSet in immutable index (match mutable variant)

### DIFF
--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index/lifecycle.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::path::PathBuf;
 
 use ahash::AHashSet;
-use common::bitvec::BitSliceExt;
 use common::generic_consts::Random;
 use common::types::PointOffsetType;
 use common::universal_io::{ReadRange, UniversalRead};

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index/lifecycle.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 use std::path::PathBuf;
 
+use ahash::AHashSet;
+use common::bitvec::BitSliceExt;
 use common::generic_consts::Random;
 use common::types::PointOffsetType;
 use common::universal_io::{ReadRange, UniversalRead};
@@ -288,14 +290,13 @@ impl<S: UniversalRead> ImmutableGeoIndex<S> {
     }
 
     pub(super) fn decrement_hash_point_counts(&mut self, geo_hashes: &[GeoHash]) {
-        let mut seen_hashes: Vec<GeoHash> = Vec::new();
+        let mut seen_hashes: AHashSet<GeoHash> = AHashSet::default();
         for geo_hash in geo_hashes {
             for i in 0..=geo_hash.len() {
                 let sub_geo_hash = geo_hash.truncate(i);
-                if seen_hashes.contains(&sub_geo_hash) {
+                if !seen_hashes.insert(sub_geo_hash) {
                     continue;
                 }
-                seen_hashes.push(sub_geo_hash);
                 if let Ok(index) = self
                     .counts_per_hash
                     .binary_search_by(|x| x.hash.cmp(&sub_geo_hash))


### PR DESCRIPTION
## Description

`ImmutableGeoIndex::decrement_hash_point_counts` deduplicated the sub-hashes of a point using a `Vec<GeoHash>` which scanned linearly with `.contains()` inside a nested loop. That makes the dedup **O(k²)** in the number of sub-hashes `k` (≈ `geo_values × precision_levels`, up to ~12 levels per value), so points with many geo values or deep precision pay a quadratic cost on removal.

The **mutable** sibling `InMemoryGeoIndex::decrement_hash_point_counts` already solved this with an `AHashSet<GeoHash>`, using `insert()`'s return value to combine the seen-check and record into a single O(1) step. This change brings the immutable variant in line with that existing pattern:

- dedup is now **O(k)** instead of O(k²)
- removes a redundant `Vec` allocation + `push`
- `GeoHash` is a `Copy` wrapper around a `u64`, so hashing is cheap

This is purely an internal implementation change. The existing behavior is unchanged.

## Change

```rust
// before
let mut seen_hashes: Vec<GeoHash> = Vec::new();
for geo_hash in geo_hashes {
    for i in 0..=geo_hash.len() {
        let sub_geo_hash = geo_hash.truncate(i);
        if seen_hashes.contains(&sub_geo_hash) {
            continue;
        }
        seen_hashes.push(sub_geo_hash);
        ...

// after
let mut seen_hashes: AHashSet<GeoHash> = AHashSet::default();
for geo_hash in geo_hashes {
    for i in 0..=geo_hash.len() {
        let sub_geo_hash = geo_hash.truncate(i);
        if !seen_hashes.insert(sub_geo_hash) {
            continue;
        }
        ...
```

## Testing

Tests suites were executed using`cargo test -p segment geo_index`. All 46 passed, 0 failed. Notably:

- `test_remove_point_with_duplicate_geo_values`
- `test_values_per_hash_drift_on_duplicate_geo_removal`
- `test_congruence` / `test_all_points_congruence` (assert mutable and immutable indexes yield identical results)

## All Submissions

- [x] Contribution guidelines followed
- [x] No dependency on external contributions
- [x] No new warnings; existing tests pass
