### PR TITLE
[UIO] implement `VectorStorageReadEnum::preopen`

### DIFF
--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -163,14 +163,12 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
             return Ok(());
         }
 
-        let mut open_options = open_arguments.unwrap_or(OpenOptions {
+        let open_options = open_arguments.unwrap_or(OpenOptions {
             writeable: false,
             need_sequential: false,
             populate: Populate::PreferBackground,
             advice: AdviceSetting::Global,
         });
-
-        open_options.populate = Populate::PreferBackground;
 
         let mut open_extra = open_extra.unwrap_or_default();
         if let Some(info) = self.file_info(path) {

--- a/lib/segment/src/common/flags/in_memory_bitvec_flags.rs
+++ b/lib/segment/src/common/flags/in_memory_bitvec_flags.rs
@@ -4,7 +4,9 @@ use common::bitvec::{BitSlice, BitVec};
 use common::mmap::AdviceSetting;
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{OpenOptions, Populate, TypedStorage, UniversalRead, UniversalReadFs};
+use common::universal_io::{
+    CachedReadFs, OpenOptions, Populate, TypedStorage, UniversalRead, UniversalReadFs,
+};
 
 use super::dynamic_stored_flags::{DynamicFlagsStatus, FLAGS_FILE, status_file};
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -35,6 +37,13 @@ const READ_ONLY_OPTIONS: OpenOptions = OpenOptions {
 
 #[allow(dead_code)] // pending: read-only vector storages will use these
 impl InMemoryBitvecFlags {
+    /// Schedule background prefetch of the two files [`Self::open`] reads.
+    pub fn preopen(fs: &impl CachedReadFs, directory: &Path) -> OperationResult<()> {
+        fs.schedule_prefetch(&status_file(directory), Some(READ_ONLY_OPTIONS), None)?;
+        fs.schedule_prefetch(&directory.join(FLAGS_FILE), Some(READ_ONLY_OPTIONS), None)?;
+        Ok(())
+    }
+
     /// Open persisted flags read-only into an owned `BitVec`; creates and writes
     /// nothing. The flags file is padded past the logical length (held in the
     /// status file), so the bitvec is truncated to it and `count` is exact.

--- a/lib/segment/src/common/flags/in_memory_bitvec_flags.rs
+++ b/lib/segment/src/common/flags/in_memory_bitvec_flags.rs
@@ -28,19 +28,31 @@ pub struct InMemoryBitvecFlags {
 }
 
 /// Read-only mmap options: never writable, lazily paged, nothing populated.
-const READ_ONLY_OPTIONS: OpenOptions = OpenOptions {
-    writeable: false,
-    need_sequential: false,
-    populate: Populate::No,
-    advice: AdviceSetting::Global,
-};
+fn bitslice_open_options(populate: Populate) -> OpenOptions {
+    OpenOptions {
+        writeable: false,
+        need_sequential: false,
+        populate,
+        advice: AdviceSetting::Global,
+    }
+}
 
-#[allow(dead_code)] // pending: read-only vector storages will use these
 impl InMemoryBitvecFlags {
     /// Schedule background prefetch of the two files [`Self::open`] reads.
     pub fn preopen(fs: &impl CachedReadFs, directory: &Path) -> OperationResult<()> {
-        fs.schedule_prefetch(&status_file(directory), Some(READ_ONLY_OPTIONS), None)?;
-        fs.schedule_prefetch(&directory.join(FLAGS_FILE), Some(READ_ONLY_OPTIONS), None)?;
+        // Status file
+        fs.schedule_prefetch(
+            &status_file(directory),
+            Some(bitslice_open_options(Populate::PreferBackground)),
+            None,
+        )?;
+
+        // Bitslice
+        fs.schedule_prefetch(
+            &directory.join(FLAGS_FILE),
+            Some(bitslice_open_options(Populate::PreferBackground)),
+            None,
+        )?;
         Ok(())
     }
 
@@ -54,7 +66,7 @@ impl InMemoryBitvecFlags {
         // Length via TypedStorage; StoredStruct is write-bound.
         let status = TypedStorage::<S, DynamicFlagsStatus>::new(fs.open(
             status_file(directory),
-            READ_ONLY_OPTIONS,
+            bitslice_open_options(Populate::No),
             Default::default(),
         )?);
         let len = status
@@ -63,8 +75,12 @@ impl InMemoryBitvecFlags {
             .map_or(0, DynamicFlagsStatus::len);
 
         let flags_path = directory.join(FLAGS_FILE);
-        let flags =
-            StoredBitSlice::<S>::open(fs, &flags_path, READ_ONLY_OPTIONS, Default::default())?;
+        let flags = StoredBitSlice::<S>::open(
+            fs,
+            &flags_path,
+            bitslice_open_options(Populate::No),
+            Default::default(),
+        )?;
         let bits = flags.read_all()?;
         let bitvec = bits.get(..len).map(BitVec::from_bitslice).ok_or_else(|| {
             OperationError::service_error(format!(

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -114,6 +114,16 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         // Id tracker
         ReadOnlyIdTrackerEnum::preopen(fs, segment_path)?;
 
+        // Vector storages
+        for (vector_name, vector_config) in &config.vector_data {
+            let path = get_vector_storage_path(segment_path, vector_name);
+            VectorStorageReadEnum::<S>::preopen(fs, vector_config, &path)?;
+        }
+        for vector_name in config.sparse_vector_data.keys() {
+            let path = get_vector_storage_path(segment_path, vector_name);
+            ReadOnlySparseVectorStorage::<S>::preopen(fs, &path)?;
+        }
+
         // Payload indexes
         let payload_config =
             ReadOnlyStructPayloadIndex::preopen(fs, &get_payload_index_path(segment_path))?;

--- a/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/chunks.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use ahash::AHashMap;
 use common::mmap::{AdviceSetting, MULTI_MMAP_IS_SUPPORTED, create_and_ensure_length};
 use common::universal_io::{
-    OpenOptions, Populate, TypedStorage, UniversalIoError, UniversalRead, UniversalReadFs,
-    UniversalWrite,
+    CachedReadFs, OpenOptions, Populate, TypedStorage, UniversalIoError, UniversalRead,
+    UniversalReadFs, UniversalWrite,
 };
 
 use super::config::{MMAP_CHUNKS_PATTERN_END, MMAP_CHUNKS_PATTERN_START};
@@ -16,6 +16,46 @@ fn check_mmap_file_name_pattern(file_name: &str) -> Option<usize> {
         .strip_prefix(MMAP_CHUNKS_PATTERN_START)
         .and_then(|file_name| file_name.strip_suffix(MMAP_CHUNKS_PATTERN_END))
         .and_then(|file_name| file_name.parse::<usize>().ok())
+}
+
+pub fn chunk_open_options(
+    advice: AdviceSetting,
+    populate: Populate,
+    writeable: bool,
+) -> OpenOptions {
+    OpenOptions {
+        writeable,
+        need_sequential: *MULTI_MMAP_IS_SUPPORTED,
+        populate,
+        advice,
+    }
+}
+
+/// Schedule background prefetch of every chunk file [`read_chunks`] will open.
+pub fn preopen_chunks(
+    fs: &impl CachedReadFs,
+    directory: &Path,
+    advice: AdviceSetting,
+    populate: Populate,
+) -> Result<(), UniversalIoError> {
+    let chunks_prefix = directory.join(MMAP_CHUNKS_PATTERN_START);
+    for listed in fs.list_files(&chunks_prefix)? {
+        let is_chunk = listed
+            .path
+            .file_name()
+            .and_then(|file_name| file_name.to_str())
+            .and_then(check_mmap_file_name_pattern)
+            .is_some();
+
+        if is_chunk {
+            fs.schedule_prefetch(
+                &listed.path,
+                Some(chunk_open_options(advice, populate, false)),
+                None,
+            )?;
+        }
+    }
+    Ok(())
 }
 
 pub fn read_chunks<T: bytemuck::Pod + Send, S: UniversalRead>(
@@ -66,12 +106,7 @@ pub fn read_chunks_from<T: bytemuck::Pod + Send, S: UniversalRead>(
         let chunk = TypedStorage::open(
             fs,
             &chunk_path,
-            OpenOptions {
-                writeable,
-                need_sequential: *MULTI_MMAP_IS_SUPPORTED,
-                populate,
-                advice,
-            },
+            chunk_open_options(advice, populate, writeable),
             Default::default(),
         )?;
 

--- a/lib/segment/src/vector_storage/chunked_vectors/read.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read.rs
@@ -7,12 +7,12 @@ use common::maybe_uninit::maybe_uninit_fill_from;
 use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    Populate, ReadPipeline, ReadRange, TypedStorage, UniversalIoError, UniversalRead,
+    CachedReadFs, Populate, ReadPipeline, ReadRange, TypedStorage, UniversalIoError, UniversalRead,
     UniversalReadFs, UserData, read_json_via, read_whole_via,
 };
 use num_traits::AsPrimitive;
 
-use super::chunks::{chunk_name, read_chunks};
+use super::chunks::{chunk_name, preopen_chunks, read_chunks};
 use super::config::{CONFIG_FILE_NAME, ChunkedVectorsConfig, STATUS_FILE_NAME};
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::vector_storage::common::{PAGE_SIZE_BYTES, VECTOR_READ_BATCH_SIZE};
@@ -57,6 +57,19 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
             Err(UniversalIoError::NotFound { .. }) => Ok(None),
             Err(e) => Err(e.into()),
         }
+    }
+
+    /// Schedule background prefetch of every file [`Self::open`] will read.
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        directory: &Path,
+        advice: AdviceSetting,
+        populate: Populate,
+    ) -> OperationResult<()> {
+        fs.schedule_prefetch(&Self::config_file(directory), None, None)?;
+        fs.schedule_prefetch(&Self::status_file(directory), None, None)?;
+        preopen_chunks(fs, directory, advice, populate)?;
+        Ok(())
     }
 
     /// Open an existing chunked-vectors directory in read-only mode.

--- a/lib/segment/src/vector_storage/chunked_vectors/read.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read.rs
@@ -66,8 +66,13 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
         advice: AdviceSetting,
         populate: Populate,
     ) -> OperationResult<()> {
+        // Config file
         fs.schedule_prefetch(&Self::config_file(directory), None, None)?;
+
+        // Status file
         fs.schedule_prefetch(&Self::status_file(directory), None, None)?;
+
+        // Chunks
         preopen_chunks(fs, directory, advice, populate)?;
         Ok(())
     }

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -57,7 +57,9 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectorData<T, S>
         vectors_path: &Path,
         populate: Populate,
     ) -> OperationResult<()> {
+        // Vector data
         fs.schedule_prefetch(vectors_path, Some(Self::open_options(populate)), None)?;
+
         Ok(())
     }
 

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -11,8 +11,8 @@ use common::mmap;
 use common::mmap::{AdviceSetting, MmapBitSlice, MmapFlusher};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    MmapFile, OpenOptions as UniversalOpenOptions, Populate, ReadOnly, ReadRange, TypedStorage,
-    UniversalRead, UniversalReadFs,
+    CachedReadFs, MmapFile, OpenOptions as UniversalOpenOptions, Populate, ReadOnly, ReadRange,
+    TypedStorage, UniversalRead, UniversalReadFs,
 };
 use fs_err::{File, OpenOptions};
 
@@ -42,6 +42,25 @@ where
 }
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectorData<T, S> {
+    fn open_options(populate: Populate) -> UniversalOpenOptions {
+        UniversalOpenOptions {
+            writeable: false,
+            need_sequential: true,
+            populate,
+            advice: AdviceSetting::Global,
+        }
+    }
+
+    /// Schedule background prefetch of the vector blob [`Self::open`] reads.
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        vectors_path: &Path,
+        populate: Populate,
+    ) -> OperationResult<()> {
+        fs.schedule_prefetch(vectors_path, Some(Self::open_options(populate)), None)?;
+        Ok(())
+    }
+
     /// Open the immutable vector blob read-only through `fs`. The file must
     /// already exist (the writer creates it); nothing is created here.
     pub fn open(
@@ -50,12 +69,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectorData<T, S>
         dim: usize,
         populate: Populate,
     ) -> OperationResult<Self> {
-        let options = UniversalOpenOptions {
-            writeable: false,
-            need_sequential: true,
-            populate,
-            advice: AdviceSetting::Global,
-        };
+        let options = Self::open_options(populate);
         let read_only =
             ReadOnly::open(fs, vectors_path, options, Default::default()).map_err(|e| {
                 crate::common::operation_error::OperationError::service_error(format!(

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/lifecycle.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/lifecycle.rs
@@ -3,9 +3,7 @@ use std::path::Path;
 use common::bitvec::BitVec;
 use common::mmap::AdviceSetting;
 use common::stored_bitslice::StoredBitSlice;
-use common::universal_io::{
-    CachedReadFs, OkNotFound, OpenOptions, Populate, UniversalRead, UniversalReadFs,
-};
+use common::universal_io::{CachedReadFs, OpenOptions, Populate, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyImmutableDenseVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
@@ -18,12 +16,14 @@ use crate::vector_storage::dense::immutable_dense_vectors::{
 };
 
 /// Read-only mmap options: never writable, lazily paged, nothing populated.
-const READ_ONLY_OPTIONS: OpenOptions = OpenOptions {
-    writeable: false,
-    need_sequential: false,
-    populate: Populate::No,
-    advice: AdviceSetting::Global,
-};
+fn bitslice_open_options(populate: Populate) -> OpenOptions {
+    OpenOptions {
+        writeable: false,
+        need_sequential: false,
+        populate,
+        advice: AdviceSetting::Global,
+    }
+}
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyImmutableDenseVectorStorage<T, S> {
     /// Schedule background prefetch of the files [`Self::open`] will read.
@@ -35,10 +35,16 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyImmutableDenseVectorSt
         path: &Path,
         populate: Populate,
     ) -> OperationResult<()> {
-        ImmutableDenseVectorData::<T, S>::preopen(fs, &path.join(VECTORS_PATH), populate)
-            .ok_not_found()?;
-        fs.schedule_prefetch(&path.join(DELETED_PATH), Some(READ_ONLY_OPTIONS), None)
-            .ok_not_found()?;
+        // Vectors
+        ImmutableDenseVectorData::<T, S>::preopen(fs, &path.join(VECTORS_PATH), populate)?;
+
+        // Deleted flags
+        fs.schedule_prefetch(
+            &path.join(DELETED_PATH),
+            Some(bitslice_open_options(Populate::PreferBackground)),
+            None,
+        )?;
+
         Ok(())
     }
 
@@ -73,8 +79,12 @@ fn open_deleted_flags<S: UniversalRead>(
     deleted_path: &Path,
     num_vectors: usize,
 ) -> OperationResult<InMemoryBitvecFlags> {
-    let stored =
-        StoredBitSlice::<S>::open(fs, deleted_path, READ_ONLY_OPTIONS, Default::default())?;
+    let stored = StoredBitSlice::<S>::open(
+        fs,
+        deleted_path,
+        bitslice_open_options(Populate::No),
+        Default::default(),
+    )?;
     let all = stored.read_all()?;
 
     let start = deleted_mmap_data_start() * 8;

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/lifecycle.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/lifecycle.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 use common::bitvec::BitVec;
 use common::mmap::AdviceSetting;
 use common::stored_bitslice::StoredBitSlice;
-use common::universal_io::{OpenOptions, Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{
+    CachedReadFs, OkNotFound, OpenOptions, Populate, UniversalRead, UniversalReadFs,
+};
 
 use super::ReadOnlyImmutableDenseVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
@@ -24,6 +26,22 @@ const READ_ONLY_OPTIONS: OpenOptions = OpenOptions {
 };
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyImmutableDenseVectorStorage<T, S> {
+    /// Schedule background prefetch of the files [`Self::open`] will read.
+    ///
+    /// Absent files are skipped rather than reported: the subsequent open is
+    /// the one to produce the error.
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        path: &Path,
+        populate: Populate,
+    ) -> OperationResult<()> {
+        ImmutableDenseVectorData::<T, S>::preopen(fs, &path.join(VECTORS_PATH), populate)
+            .ok_not_found()?;
+        fs.schedule_prefetch(&path.join(DELETED_PATH), Some(READ_ONLY_OPTIONS), None)
+            .ok_not_found()?;
+        Ok(())
+    }
+
     /// Open the read-only counterpart of the immutable dense storage at `path`,
     /// threading every file open through `fs`; reads the existing layout but
     /// creates and writes nothing. `populate` warms the vector data.

--- a/lib/segment/src/vector_storage/dense/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use common::mmap::AdviceSetting;
-use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, OkNotFound, Populate, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyChunkedDenseVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
@@ -14,6 +14,22 @@ use crate::vector_storage::dense::appendable_dense_vector_storage::{
 };
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedDenseVectorStorage<T, S> {
+    /// Schedule background prefetch of the files [`Self::open`] will read.
+    ///
+    /// Absent files are skipped rather than reported: the subsequent open is
+    /// the one to produce the error.
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        path: &Path,
+        advice: AdviceSetting,
+        populate: Populate,
+    ) -> OperationResult<()> {
+        ChunkedVectorsRead::<T, S>::preopen(fs, &path.join(VECTORS_DIR_PATH), advice, populate)
+            .ok_not_found()?;
+        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_DIR_PATH)).ok_not_found()?;
+        Ok(())
+    }
+
     /// Open the read-only counterpart of the appendable dense storage at `path`,
     /// threading every file open through `fs`; reads the existing layout but
     /// creates and writes nothing. `populate` warms the vector chunks.

--- a/lib/segment/src/vector_storage/dense/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use common::mmap::AdviceSetting;
-use common::universal_io::{CachedReadFs, OkNotFound, Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyChunkedDenseVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
@@ -24,9 +24,12 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedDenseVectorStor
         advice: AdviceSetting,
         populate: Populate,
     ) -> OperationResult<()> {
-        ChunkedVectorsRead::<T, S>::preopen(fs, &path.join(VECTORS_DIR_PATH), advice, populate)
-            .ok_not_found()?;
-        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_DIR_PATH)).ok_not_found()?;
+        // Vectors
+        ChunkedVectorsRead::<T, S>::preopen(fs, &path.join(VECTORS_DIR_PATH), advice, populate)?;
+
+        // Deleted flags
+        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_DIR_PATH))?;
+
         Ok(())
     }
 

--- a/lib/segment/src/vector_storage/multi_dense/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use common::mmap::AdviceSetting;
-use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, OkNotFound, Populate, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
@@ -10,10 +10,33 @@ use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::types::{Distance, MultiVectorConfig};
 use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::{
-    DELETED_DIR_PATH, OFFSETS_DIR_PATH, VECTORS_DIR_PATH,
+    DELETED_DIR_PATH, MultivectorMmapOffset, OFFSETS_DIR_PATH, VECTORS_DIR_PATH,
 };
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedMultiDenseVectorStorage<T, S> {
+    /// Schedule background prefetch of the files [`Self::open`] will read.
+    ///
+    /// Absent files are skipped rather than reported: the subsequent open is
+    /// the one to produce the error.
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        path: &Path,
+        advice: AdviceSetting,
+        populate: Populate,
+    ) -> OperationResult<()> {
+        ChunkedVectorsRead::<T, S>::preopen(fs, &path.join(VECTORS_DIR_PATH), advice, populate)
+            .ok_not_found()?;
+        ChunkedVectorsRead::<MultivectorMmapOffset, S>::preopen(
+            fs,
+            &path.join(OFFSETS_DIR_PATH),
+            advice,
+            populate,
+        )
+        .ok_not_found()?;
+        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_DIR_PATH)).ok_not_found()?;
+        Ok(())
+    }
+
     /// Open the read-only counterpart of the appendable multi-dense storage at
     /// `path`, threading every file open through `fs`; reads the existing layout
     /// but creates and writes nothing. `populate` warms the vector and offset

--- a/lib/segment/src/vector_storage/multi_dense/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/lifecycle.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use common::mmap::AdviceSetting;
-use common::universal_io::{CachedReadFs, OkNotFound, Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
@@ -24,16 +24,20 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedMultiDenseVecto
         advice: AdviceSetting,
         populate: Populate,
     ) -> OperationResult<()> {
-        ChunkedVectorsRead::<T, S>::preopen(fs, &path.join(VECTORS_DIR_PATH), advice, populate)
-            .ok_not_found()?;
+        // Vectors
+        ChunkedVectorsRead::<T, S>::preopen(fs, &path.join(VECTORS_DIR_PATH), advice, populate)?;
+
+        // Offsets
         ChunkedVectorsRead::<MultivectorMmapOffset, S>::preopen(
             fs,
             &path.join(OFFSETS_DIR_PATH),
             advice,
             populate,
-        )
-        .ok_not_found()?;
-        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_DIR_PATH)).ok_not_found()?;
+        )?;
+
+        // Deleted flags
+        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_DIR_PATH))?;
+
         Ok(())
     }
 

--- a/lib/segment/src/vector_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/read_only/lifecycle.rs
@@ -1,17 +1,124 @@
 use std::path::Path;
 
 use common::mmap::{Advice, AdviceSetting};
-use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs};
 
 use super::VectorStorageReadEnum;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
 use crate::types::{VectorDataConfig, VectorStorageDatatype, VectorStorageType};
 use crate::vector_storage::dense::read_only::{
     ReadOnlyChunkedDenseVectorStorage, ReadOnlyImmutableDenseVectorStorage,
 };
 use crate::vector_storage::multi_dense::read_only::ReadOnlyChunkedMultiDenseVectorStorage;
 
+/// How the [`VectorStorageType`] maps onto the read-only open path: mmap
+/// advice, whether the storage is populated on open, and whether it uses the
+/// appendable chunked layout. `None` for the storage types with no on-disk
+/// data to open.
+fn storage_type_params(storage_type: VectorStorageType) -> Option<(AdviceSetting, Populate, bool)> {
+    let (advice, populate, chunked) = match storage_type {
+        VectorStorageType::Mmap => (AdviceSetting::Global, false, false),
+        VectorStorageType::InRamMmap => (AdviceSetting::from(Advice::Normal), true, false),
+        VectorStorageType::ChunkedMmap => (AdviceSetting::Global, false, true),
+        VectorStorageType::InRamChunkedMmap => (AdviceSetting::from(Advice::Normal), true, true),
+        VectorStorageType::Memory | VectorStorageType::Empty => return None,
+    };
+
+    let populate = match populate {
+        true => Populate::PreferBackground,
+        false => Populate::No,
+    };
+
+    Some((advice, populate, chunked))
+}
+
 impl<S: UniversalRead> VectorStorageReadEnum<S> {
+    /// Schedule background prefetch of every file [`Self::open`] will read,
+    /// dispatching on `vector_config` the same way.
+    ///
+    /// Absent files are skipped rather than reported: the subsequent open is
+    /// the one to produce the error.
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        vector_config: &VectorDataConfig,
+        path: &Path,
+    ) -> OperationResult<()> {
+        let datatype = vector_config.datatype.unwrap_or_default();
+
+        // No on-disk data to prefetch for these storage types: no-op.
+        let Some((advice, populate, chunked)) = storage_type_params(vector_config.storage_type)
+        else {
+            return Ok(());
+        };
+
+        // Multivectors always use the appendable chunked layout.
+        if vector_config.multivector_config.is_some() {
+            return match datatype {
+                VectorStorageDatatype::Float32 => {
+                    ReadOnlyChunkedMultiDenseVectorStorage::<VectorElementType, S>::preopen(
+                        fs, path, advice, populate,
+                    )
+                }
+                VectorStorageDatatype::Uint8 => {
+                    ReadOnlyChunkedMultiDenseVectorStorage::<VectorElementTypeByte, S>::preopen(
+                        fs, path, advice, populate,
+                    )
+                }
+                VectorStorageDatatype::Float16 => {
+                    ReadOnlyChunkedMultiDenseVectorStorage::<VectorElementTypeHalf, S>::preopen(
+                        fs, path, advice, populate,
+                    )
+                }
+                VectorStorageDatatype::Turbo4 => Err(OperationError::service_error(
+                    "Turbo4 datatype storage is not yet supported",
+                )),
+            };
+        }
+
+        // chunked-mmap is appendable; plain mmap is the immutable storage.
+        if chunked {
+            match datatype {
+                VectorStorageDatatype::Float32 => {
+                    ReadOnlyChunkedDenseVectorStorage::<VectorElementType, S>::preopen(
+                        fs, path, advice, populate,
+                    )
+                }
+                VectorStorageDatatype::Uint8 => {
+                    ReadOnlyChunkedDenseVectorStorage::<VectorElementTypeByte, S>::preopen(
+                        fs, path, advice, populate,
+                    )
+                }
+                VectorStorageDatatype::Float16 => {
+                    ReadOnlyChunkedDenseVectorStorage::<VectorElementTypeHalf, S>::preopen(
+                        fs, path, advice, populate,
+                    )
+                }
+                VectorStorageDatatype::Turbo4 => Err(OperationError::service_error(
+                    "Turbo4 datatype storage is not yet supported",
+                )),
+            }
+        } else {
+            match datatype {
+                VectorStorageDatatype::Float32 => ReadOnlyImmutableDenseVectorStorage::<
+                    VectorElementType,
+                    S,
+                >::preopen(fs, path, populate),
+                VectorStorageDatatype::Uint8 => ReadOnlyImmutableDenseVectorStorage::<
+                    VectorElementTypeByte,
+                    S,
+                >::preopen(fs, path, populate),
+                VectorStorageDatatype::Float16 => ReadOnlyImmutableDenseVectorStorage::<
+                    VectorElementTypeHalf,
+                    S,
+                >::preopen(fs, path, populate),
+                VectorStorageDatatype::Turbo4 => Err(OperationError::service_error(
+                    "Turbo4 datatype storage is not yet supported",
+                )),
+            }
+        }
+    }
+
     /// Open the read-only counterpart of a dense vector storage from its
     /// `VectorDataConfig`, mirroring `open_vector_storage`. Sparse storages are
     /// opened separately via `ReadOnlySparseVectorStorage::open`.
@@ -24,20 +131,10 @@ impl<S: UniversalRead> VectorStorageReadEnum<S> {
         let distance = vector_config.distance;
         let datatype = vector_config.datatype.unwrap_or_default();
 
-        let (advice, populate, chunked) = match vector_config.storage_type {
-            VectorStorageType::Mmap => (AdviceSetting::Global, false, false),
-            VectorStorageType::InRamMmap => (AdviceSetting::from(Advice::Normal), true, false),
-            VectorStorageType::ChunkedMmap => (AdviceSetting::Global, false, true),
-            VectorStorageType::InRamChunkedMmap => {
-                (AdviceSetting::from(Advice::Normal), true, true)
-            }
-            // No on-disk data to open for these storage types: no-op.
-            VectorStorageType::Memory | VectorStorageType::Empty => return Ok(None),
-        };
-
-        let populate = match populate {
-            true => Populate::PreferBackground,
-            false => Populate::No,
+        // No on-disk data to open for these storage types: no-op.
+        let Some((advice, populate, chunked)) = storage_type_params(vector_config.storage_type)
+        else {
+            return Ok(None);
         };
 
         // Multivectors always use the appendable chunked layout.

--- a/lib/segment/src/vector_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/read_only/lifecycle.rs
@@ -46,9 +46,9 @@ impl<S: UniversalRead> VectorStorageReadEnum<S> {
     ) -> OperationResult<()> {
         let datatype = vector_config.datatype.unwrap_or_default();
 
-        // No on-disk data to prefetch for these storage types: no-op.
         let Some((advice, populate, chunked)) = storage_type_params(vector_config.storage_type)
         else {
+            // No on-disk data to prefetch for these storage types: no-op.
             return Ok(());
         };
 

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -76,12 +76,14 @@ impl<S: UniversalRead> RawScorerBuilder for VectorStorageReadEnum<S> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use common::counter::hardware_counter::HardwareCounterCell;
     use common::generic_consts::Random;
     use common::mmap::AdviceSetting;
     use common::sorted_slice::SortedSlice;
     use common::types::PointOffsetType;
-    use common::universal_io::{MmapFile, MmapFs};
+    use common::universal_io::{CachedFs, CachedReadFs, MmapFile, MmapFs};
     use rand::rngs::StdRng;
     use rand::{RngExt, SeedableRng};
     use tempfile::Builder;
@@ -96,10 +98,14 @@ mod tests {
         Distance, Indexes, MultiVectorConfig, VectorDataConfig, VectorStorageDatatype,
         VectorStorageType,
     };
-    use crate::vector_storage::dense::appendable_dense_vector_storage::open_appendable_memmap_vector_storage_impl;
-    use crate::vector_storage::dense::dense_vector_storage::open_dense_vector_storage;
+    use crate::vector_storage::dense::appendable_dense_vector_storage::{
+        self, open_appendable_memmap_vector_storage_impl,
+    };
+    use crate::vector_storage::dense::dense_vector_storage::{self, open_dense_vector_storage};
     use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
-    use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::open_appendable_memmap_multi_vector_storage_impl;
+    use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::{
+        self, open_appendable_memmap_multi_vector_storage_impl,
+    };
     use crate::vector_storage::{VectorStorage, VectorStorageRead};
 
     const DIM: usize = 16;
@@ -274,6 +280,181 @@ mod tests {
             storage,
             VectorStorageReadEnum::MultiDenseChunked(_)
         ));
+        assert_eq!(storage.total_vector_count(), multis.len());
+        let stored = storage.get_vector::<Random>(5);
+        let multi: TypedMultiDenseVectorRef<VectorElementType> =
+            stored.as_vec_ref().try_into().unwrap();
+        assert_eq!(multi.to_owned(), multis[5]);
+    }
+
+    /// Build a per-directory `CachedFs` with the listing snapshot taken, the
+    /// way the segment open path does before `preopen`.
+    fn snapshot_cached_fs(dir: &Path) -> CachedFs<MmapFs> {
+        let mut cached_fs = CachedFs::new(MmapFs, dir).unwrap();
+        cached_fs.cache_file_info().unwrap();
+        cached_fs
+    }
+
+    /// `preopen` must schedule exactly the files `open` goes on to consume.
+    ///
+    /// Merely opening after a `preopen` proves nothing: `CachedFs` falls back
+    /// to a plain inner open for any path that was never scheduled, so a
+    /// scheduled-vs-opened path mismatch would still yield a correct storage.
+    /// To make the prefetch pool the *only* possible source, the storage files
+    /// are unlinked between `preopen` and `open`: the already-open handles
+    /// parked in the pool stay readable, while any fallback open hits
+    /// `NotFound`.
+    #[test]
+    fn preopen_then_open_chunked_through_cached_fs() {
+        let dir = Builder::new().prefix("preopen_chunked").tempdir().unwrap();
+        let mut rng = StdRng::seed_from_u64(4);
+        let hw = HardwareCounterCell::disposable();
+        let vectors: Vec<DenseVector> = (0..300).map(|_| rand_vec(&mut rng)).collect();
+
+        {
+            let mut storage = open_appendable_memmap_vector_storage_impl::<VectorElementType>(
+                dir.path(),
+                DIM,
+                Distance::Dot,
+                AdviceSetting::Global,
+                false,
+            )
+            .unwrap();
+            for (id, vector) in vectors.iter().enumerate() {
+                storage
+                    .insert_vector(id as PointOffsetType, VectorRef::from(vector), &hw)
+                    .unwrap();
+            }
+            storage.flusher()().unwrap();
+        }
+
+        let config = dense_config(VectorStorageType::ChunkedMmap, None);
+        let cached_fs = snapshot_cached_fs(dir.path());
+        VectorStorageReadEnum::<MmapFile>::preopen(&cached_fs, &config, dir.path()).unwrap();
+
+        // Everything `open` reads must now come from the prefetch pool.
+        for dir_name in [
+            appendable_dense_vector_storage::VECTORS_DIR_PATH,
+            appendable_dense_vector_storage::DELETED_DIR_PATH,
+        ] {
+            fs_err::remove_dir_all(dir.path().join(dir_name)).unwrap();
+        }
+
+        let storage = VectorStorageReadEnum::open(&cached_fs, &config, dir.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(storage.total_vector_count(), vectors.len());
+        let got: DenseVector = storage
+            .get_vector::<Random>(7)
+            .to_owned()
+            .try_into()
+            .unwrap();
+        assert_eq!(got, vectors[7]);
+    }
+
+    /// [`preopen_then_open_chunked_through_cached_fs`], for the immutable
+    /// (plain mmap) dense storage.
+    #[test]
+    fn preopen_then_open_mmap_through_cached_fs() {
+        let dir = Builder::new().prefix("preopen_mmap").tempdir().unwrap();
+        let mut rng = StdRng::seed_from_u64(5);
+        let hw = HardwareCounterCell::disposable();
+        let vectors: Vec<DenseVector> = (0..3).map(|_| rand_vec(&mut rng)).collect();
+
+        {
+            // The immutable mmap storage is built by copying from another storage.
+            let mut storage =
+                open_dense_vector_storage(dir.path(), DIM, Distance::Dot, false).unwrap();
+            let mut staging = new_volatile_dense_vector_storage(DIM, Distance::Dot);
+            for (id, vector) in vectors.iter().enumerate() {
+                staging
+                    .insert_vector(id as PointOffsetType, VectorRef::from(vector), &hw)
+                    .unwrap();
+            }
+            merge_from_single_source(&mut storage, &staging, vectors.len() as PointOffsetType)
+                .unwrap();
+            storage.flusher()().unwrap();
+        }
+
+        let config = dense_config(VectorStorageType::Mmap, None);
+        let cached_fs = snapshot_cached_fs(dir.path());
+        VectorStorageReadEnum::<MmapFile>::preopen(&cached_fs, &config, dir.path()).unwrap();
+
+        // Everything `open` reads must now come from the prefetch pool.
+        for file_name in [
+            dense_vector_storage::VECTORS_PATH,
+            dense_vector_storage::DELETED_PATH,
+        ] {
+            fs_err::remove_file(dir.path().join(file_name)).unwrap();
+        }
+
+        let storage = VectorStorageReadEnum::open(&cached_fs, &config, dir.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(storage.total_vector_count(), vectors.len());
+        let got: DenseVector = storage
+            .get_vector::<Random>(1)
+            .to_owned()
+            .try_into()
+            .unwrap();
+        assert_eq!(got, vectors[1]);
+    }
+
+    /// [`preopen_then_open_chunked_through_cached_fs`], for the chunked
+    /// multi-dense storage (which adds the offsets directory).
+    #[test]
+    fn preopen_then_open_multi_through_cached_fs() {
+        let dir = Builder::new().prefix("preopen_multi").tempdir().unwrap();
+        let mut rng = StdRng::seed_from_u64(6);
+        let hw = HardwareCounterCell::disposable();
+        let multis: Vec<MultiDenseVectorInternal> = (0..200)
+            .map(|_| {
+                let inner = rng.random_range(1..=3);
+                let vectors = std::iter::repeat_with(|| rand_vec(&mut rng))
+                    .take(inner)
+                    .collect::<Vec<_>>();
+                MultiDenseVectorInternal::try_from(vectors).unwrap()
+            })
+            .collect();
+
+        {
+            let mut storage =
+                open_appendable_memmap_multi_vector_storage_impl::<VectorElementType>(
+                    dir.path(),
+                    DIM,
+                    Distance::Dot,
+                    MultiVectorConfig::default(),
+                    AdviceSetting::Global,
+                    false,
+                )
+                .unwrap();
+            for (id, multivec) in multis.iter().enumerate() {
+                storage
+                    .insert_vector(id as PointOffsetType, VectorRef::from(multivec), &hw)
+                    .unwrap();
+            }
+            storage.flusher()().unwrap();
+        }
+
+        let config = dense_config(
+            VectorStorageType::ChunkedMmap,
+            Some(MultiVectorConfig::default()),
+        );
+        let cached_fs = snapshot_cached_fs(dir.path());
+        VectorStorageReadEnum::<MmapFile>::preopen(&cached_fs, &config, dir.path()).unwrap();
+
+        // Everything `open` reads must now come from the prefetch pool.
+        for dir_name in [
+            appendable_mmap_multi_dense_vector_storage::VECTORS_DIR_PATH,
+            appendable_mmap_multi_dense_vector_storage::OFFSETS_DIR_PATH,
+            appendable_mmap_multi_dense_vector_storage::DELETED_DIR_PATH,
+        ] {
+            fs_err::remove_dir_all(dir.path().join(dir_name)).unwrap();
+        }
+
+        let storage = VectorStorageReadEnum::open(&cached_fs, &config, dir.path())
+            .unwrap()
+            .unwrap();
         assert_eq!(storage.total_vector_count(), multis.len());
         let stored = storage.get_vector::<Random>(5);
         let multi: TypedMultiDenseVectorRef<VectorElementType> =

--- a/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use common::universal_io::{CachedReadFs, OkNotFound, Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs};
 use gridstore::GridstoreReader;
 
 use super::ReadOnlySparseVectorStorage;
@@ -15,19 +15,21 @@ impl<S: UniversalRead> ReadOnlySparseVectorStorage<S> {
     /// Absent files are skipped rather than reported: the subsequent open is
     /// the one to produce the error.
     pub fn preopen(fs: &impl CachedReadFs<File = S>, path: &Path) -> OperationResult<()> {
+        // Gridstore reader
         GridstoreReader::<StoredSparseVector, S>::preopen(
             fs,
             path.join(STORAGE_DIRNAME),
             Populate::No,
         )
-        .ok_not_found()
         .map_err(|err| {
             OperationError::service_error(format!(
                 "Failed to preopen read-only sparse vector storage: {err}"
             ))
         })?;
 
-        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_DIRNAME)).ok_not_found()?;
+        // Deleted flags
+        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_DIRNAME))?;
+
         Ok(())
     }
 

--- a/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use common::universal_io::{Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, OkNotFound, Populate, UniversalRead, UniversalReadFs};
 use gridstore::GridstoreReader;
 
 use super::ReadOnlySparseVectorStorage;
@@ -10,6 +10,27 @@ use crate::vector_storage::sparse::mmap_sparse_vector_storage::{DELETED_DIRNAME,
 use crate::vector_storage::sparse::stored_sparse_vectors::StoredSparseVector;
 
 impl<S: UniversalRead> ReadOnlySparseVectorStorage<S> {
+    /// Schedule background prefetch of the files [`Self::open`] will read.
+    ///
+    /// Absent files are skipped rather than reported: the subsequent open is
+    /// the one to produce the error.
+    pub fn preopen(fs: &impl CachedReadFs<File = S>, path: &Path) -> OperationResult<()> {
+        GridstoreReader::<StoredSparseVector, S>::preopen(
+            fs,
+            path.join(STORAGE_DIRNAME),
+            Populate::No,
+        )
+        .ok_not_found()
+        .map_err(|err| {
+            OperationError::service_error(format!(
+                "Failed to preopen read-only sparse vector storage: {err}"
+            ))
+        })?;
+
+        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_DIRNAME)).ok_not_found()?;
+        Ok(())
+    }
+
     /// Open the read-only counterpart of the mmap sparse storage at `path`,
     /// threading every file open through `fs`; reads the existing layout but
     /// creates and writes nothing. `next_point_offset` is reconstructed like the

--- a/lib/segment/src/vector_storage/sparse/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/mod.rs
@@ -22,7 +22,7 @@ mod tests {
     use common::generic_consts::Random;
     use common::sorted_slice::SortedSlice;
     use common::types::PointOffsetType;
-    use common::universal_io::{MmapFile, MmapFs};
+    use common::universal_io::{CachedFs, CachedReadFs, MmapFile, MmapFs};
     use sparse::common::sparse_vector::SparseVector;
     use tempfile::Builder;
 
@@ -31,7 +31,9 @@ mod tests {
     use crate::data_types::named_vectors::CowVector;
     use crate::data_types::vectors::VectorRef;
     use crate::vector_storage::sparse::SPARSE_VECTOR_DISTANCE;
-    use crate::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
+    use crate::vector_storage::sparse::mmap_sparse_vector_storage::{
+        DELETED_DIRNAME, MmapSparseVectorStorage, STORAGE_DIRNAME,
+    };
     use crate::vector_storage::{VectorStorage, VectorStorageRead};
 
     /// Write sparse vectors (deleting some) through the writable mmap storage,
@@ -93,6 +95,70 @@ mod tests {
                 CowVector::Dense(_) | CowVector::MultiDense(_) => {
                     panic!("expected sparse vector for point {id}")
                 }
+            }
+        }
+    }
+
+    /// `preopen` must schedule exactly the files `open` goes on to consume.
+    ///
+    /// Merely opening after a `preopen` proves nothing: `CachedFs` falls back
+    /// to a plain inner open for any path that was never scheduled, so a
+    /// scheduled-vs-opened path mismatch would still yield a correct storage.
+    /// To make the prefetch pool the *only* possible source, the storage
+    /// directories are removed between `preopen` and `open`: the already-open
+    /// handles parked in the pool stay readable, while any fallback open hits
+    /// `NotFound`.
+    #[test]
+    fn preopen_then_open_through_cached_fs() {
+        const POINT_COUNT: PointOffsetType = 500;
+
+        let dir = Builder::new()
+            .prefix("ro_sparse_preopen")
+            .tempdir()
+            .unwrap();
+        let hw = HardwareCounterCell::disposable();
+
+        let sparse_vectors: Vec<SparseVector> = (0..POINT_COUNT)
+            .map(|id| {
+                let value = id as f32;
+                SparseVector {
+                    indices: vec![1, 5, 9],
+                    values: vec![value + 0.1, value + 0.2, value + 0.3],
+                }
+            })
+            .collect();
+
+        {
+            let mut storage = MmapSparseVectorStorage::open_or_create(dir.path()).unwrap();
+            for (id, vector) in sparse_vectors.iter().enumerate() {
+                storage
+                    .insert_vector(id as PointOffsetType, VectorRef::from(vector), &hw)
+                    .unwrap();
+            }
+            storage.flusher()().unwrap();
+        }
+
+        // Same order as the segment open path: snapshot, then preopen, then open.
+        let mut cached_fs = CachedFs::new(MmapFs, dir.path()).unwrap();
+        cached_fs.cache_file_info().unwrap();
+        ReadOnlySparseVectorStorage::<MmapFile>::preopen(&cached_fs, dir.path()).unwrap();
+
+        // Everything `open` reads must now come from the prefetch pool.
+        for dir_name in [STORAGE_DIRNAME, DELETED_DIRNAME] {
+            fs_err::remove_dir_all(dir.path().join(dir_name)).unwrap();
+        }
+
+        let storage =
+            ReadOnlySparseVectorStorage::<MmapFile>::open(&cached_fs, dir.path()).unwrap();
+
+        assert_eq!(storage.total_vector_count(), POINT_COUNT as usize);
+        match storage.get_vector::<Random>(7) {
+            CowVector::Sparse(got) => {
+                assert_eq!(got.indices, sparse_vectors[7].indices);
+                assert_eq!(got.values, sparse_vectors[7].values);
+            }
+            CowVector::Dense(_) | CowVector::MultiDense(_) => {
+                panic!("expected sparse vector for point 7")
             }
         }
     }


### PR DESCRIPTION
Follow-up to #9768 in the preopen series.

Implements preopen for the read-only vector storages, wired into the segment's `first_preopen` between the id tracker and the payload indexes:

- `VectorStorageReadEnum::preopen` mirrors `open`'s dispatch; the storage-type → advice/populate/chunked mapping is extracted into a shared `storage_type_params` so the two can't drift.
- Leaf preopens next to each open: immutable dense (`matrix.dat` + `deleted.dat`), chunked dense (vectors dir + deleted flags), chunked multi-dense (adds the offsets dir), and sparse (Gridstore `store/` + deleted flags).
- New shared building blocks: `ChunkedVectorsRead::preopen` (config, status, chunks — with `preopen_chunks`/`chunk_open_options` mirroring gridstore's `Pages::preopen`/`page_open_options`) and `InMemoryBitvecFlags::preopen`.

Absent files are skipped rather than reported (`ok_not_found`): the subsequent open is the one to produce the error.

Tests: four `preopen`-then-`open`-through-`CachedFs` tests (chunked, immutable mmap, multi-dense, sparse) that unlink the storage files between the two calls, so the prefetch pool is the only possible source and a scheduled-vs-opened path mismatch fails with `NotFound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)