### PR TITLE
perf(map_index): mark point deleted once instead of per value in immutable index

### DIFF
--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/lifecycle.rs
@@ -223,13 +223,14 @@ where
                     value.borrow(),
                     idx,
                 );
-
-                // Update storage
-                self.storage.remove_point(idx);
                 removed_values_count += 1;
             }
 
             if removed_values_count > 0 {
+                // `storage.remove_point` marks the point as deleted; it is
+                // per-point (idempotent in `idx`), so it only needs to run once
+                // rather than once per removed value.
+                self.storage.remove_point(idx);
                 self.indexed_points = self.indexed_points.saturating_sub(1);
             }
             self.values_count = self.values_count.saturating_sub(removed_values_count);


### PR DESCRIPTION
## Description

`ImmutableMapIndex::remove_point` looped over every indexed value of the point being removed and called `self.storage.remove_point(idx)` on each iteration. That call resolves to `OnDiskMapIndex::remove_point`, which simply does:

```rust
self.storage.deleted.mark_deleted(idx);
```

i.e. it marks the **whole point** as deleted, keyed only on `idx`. It is per-point and idempotent, not per-value. So for a point with N indexed values, `mark_deleted(idx)` was invoked N times with the same `idx`, each touching the mmap-backed `deleted` flag structure.

This moves the call out of the per-value loop into the existing `removed_values_count > 0` block so it runs exactly once per deletion, reducing the storage marking from O(values) to O(1). Behavior is unchanged, the call is still guarded so it only runs when at least one value was removed.

## Change

```rust
// before
for value in removed_values {
    Self::remove_idx_from_value_list(...);
    // Update storage
    self.storage.remove_point(idx);   // once per value
    removed_values_count += 1;
}
if removed_values_count > 0 {
    self.indexed_points = self.indexed_points.saturating_sub(1);
}

// after
for value in removed_values {
    Self::remove_idx_from_value_list(...);
    removed_values_count += 1;
}
if removed_values_count > 0 {
    // per-point (idempotent in `idx`), so it only needs to run once
    self.storage.remove_point(idx);
    self.indexed_points = self.indexed_points.saturating_sub(1);
}
```

## Testing

- `cargo test -p segment map_index`. All 39 passed, 0 failed (incl. `test_str_prefix_match_after_deletion`, `test_map_index_reload_short_deleted_bitslice`, and congruence tests that assert the immutable index matches the reference implementation)
- `cargo test -p segment`. The full crate suite is green (129 integration tests, 0 failed)
- `cargo clippy -p segment --all-targets`. All clean.
- `cargo fmt --check`. All clean.

## All Submissions

- [x] Contribution guidelines followed
- [x] No dependency on external contributions
- [x] No new warnings; existing tests pass