### PR TITLE
Reset first_voter and prune address book on first-peer --reinit

### DIFF
--- a/lib/storage/src/content_manager/consensus/persistent.rs
+++ b/lib/storage/src/content_manager/consensus/persistent.rs
@@ -149,6 +149,23 @@ impl Persistent {
                 state.state.conf_state.voters = vec![state.this_peer_id];
                 state.state.conf_state.learners = vec![];
                 state.state.hard_state.vote = state.this_peer_id;
+                // If this peer was removed from the old cluster but killed before it
+                // applied `RemoveNode(self)`, `first_voter` and the address book still
+                // describe the old cluster. This peer now starts a brand-new cluster,
+                // of which it is the first voter and the only member. Both values are
+                // served to peers bootstrapping onto this cluster: a stale `first_voter`
+                // seeds their initial `conf_state` with a peer of the old cluster,
+                // permanently corrupting their voter set, and stale addresses make
+                // `/readyz` wait for the commit index of a foreign consensus.
+                // `first_voter` must be reset to this peer rather than cleared:
+                // `recover_first_voter` would re-derive the old first voter from the
+                // retained Raft log.
+                let this_peer_id = state.this_peer_id;
+                state.first_voter = Some(this_peer_id);
+                state
+                    .peer_address_by_id
+                    .write()
+                    .retain(|&peer_id, _| peer_id == this_peer_id);
                 state.save()?;
                 state
             } else {
@@ -468,4 +485,57 @@ struct ConfStateDef {
     voters_outgoing: Vec<u64>,
     learners_next: Vec<u64>,
     auto_leave: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Reinitializing a removed peer as a first peer must drop every trace of the
+    /// old cluster: `conf_state`, `first_voter` and the address book. Peers
+    /// bootstrapping onto the new cluster seed their initial `conf_state` with
+    /// `first_voter` and their address book with the served addresses, so stale
+    /// values corrupt the new cluster's configuration.
+    #[test]
+    fn reinit_first_peer_forgets_old_cluster() {
+        let dir = tempfile::Builder::new()
+            .prefix("consensus_state")
+            .tempdir()
+            .unwrap();
+
+        let this_peer_id = 1;
+        let old_first_peer_id = 2;
+
+        // The peer as a member of the old cluster: it joined via `old_first_peer_id`
+        // and knows both addresses.
+        let mut state =
+            Persistent::load_or_init(dir.path(), false, false, Some(this_peer_id)).unwrap();
+        state
+            .insert_peer(this_peer_id, "http://127.0.0.1:6335".parse().unwrap())
+            .unwrap();
+        state
+            .insert_peer(old_first_peer_id, "http://127.0.0.1:7335".parse().unwrap())
+            .unwrap();
+        state.set_first_voter(old_first_peer_id).unwrap();
+        state
+            .apply_state_update(|state| {
+                state.conf_state.voters = vec![old_first_peer_id, this_peer_id];
+            })
+            .unwrap();
+        drop(state);
+
+        let state = Persistent::load_or_init(dir.path(), true, true, None).unwrap();
+
+        assert_eq!(state.this_peer_id(), this_peer_id);
+        assert_eq!(state.state().conf_state.voters, vec![this_peer_id]);
+        assert_eq!(state.first_voter(), Some(this_peer_id));
+        assert_eq!(
+            state
+                .peer_address_by_id()
+                .keys()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![this_peer_id],
+        );
+    }
 }

--- a/tests/consensus_tests/test_reinit_consensus.py
+++ b/tests/consensus_tests/test_reinit_consensus.py
@@ -80,7 +80,10 @@ def test_reinit_consensus(tmp_path: pathlib.Path):
     peer_urls_new = []
     (bootstrap_api_uri, bootstrap_uri) = start_first_peer(peer_dirs[0], "peer_0_restarted.log", reinit=True)
     peer_urls_new.append(bootstrap_api_uri)
-    leader = wait_peer_added(bootstrap_api_uri, expected_size=2)
+    # `--reinit` founds a fresh single-member cluster: the old peers (and their
+    # old addresses) are dropped from the address book, the other peers re-join
+    # below and re-register their new addresses.
+    leader = wait_peer_added(bootstrap_api_uri, expected_size=1)
     for i in range(1, len(peer_dirs)):
         peer_urls_new.append(start_peer(peer_dirs[i], f"peer_{i}_restarted.log", bootstrap_uri, reinit=True))
     wait_for_uniform_cluster_status(peer_urls_new, leader)

--- a/tests/consensus_tests/test_reinit_removed_peer.py
+++ b/tests/consensus_tests/test_reinit_removed_peer.py
@@ -17,6 +17,13 @@ def test_reinit_removed_peer(tmp_path: pathlib.Path):
     entry it gets replayed on top of the reset single-voter config on startup,
     and consensus initialization panics with "removed all voters", so the node
     can never come back.
+
+    Also covers `--reinit` dropping the stale `first_voter` and address book
+    of the old cluster (simulating the peer being killed before it applied
+    `RemoveNode(self)`, which would have pruned the addresses): both leak into
+    peers that later bootstrap onto the reinitialized cluster, and a stale
+    `first_voter` corrupts their voter set so they never become ready. The old
+    first peer stays alive throughout to catch any such leak.
     """
     assert_project_root()
 
@@ -43,6 +50,27 @@ def test_reinit_removed_peer(tmp_path: pathlib.Path):
     removed_peer_process.kill()
     processes.remove(removed_peer_process)
 
+    # Deterministically simulate the peer being killed after `RemoveNode(self)`
+    # was committed (guaranteed to be in its WAL, see above) but before it
+    # applied *any* of the old cluster's log: the address book still holds the
+    # old first peer, `first_voter` still points at it (nothing resets it on
+    # removal, so it is stale either way), and no entry is applied. `--reinit`
+    # must drop the stale `first_voter` and address book. Both are served to
+    # peers bootstrapping onto the reinitialized cluster; with nothing applied
+    # the reinitialized leader replicates its log as plain entries (no
+    # snapshot), so a stale `first_voter` seeds the joining peer's initial
+    # `conf_state` with a peer of the *old* cluster and permanently corrupts
+    # its voter set - its `/readyz` then waits for the old cluster's commit
+    # index, which its own consensus never reaches.
+    first_peer_id = get_cluster_info(peer_api_uris[0])["peer_id"]
+    raft_state_path = removed_peer_dir / "storage" / "raft_state.json"
+    raft_state = json.loads(raft_state_path.read_text())
+    raft_state["peer_address_by_id"][str(first_peer_id)] = bootstrap_uri
+    raft_state["first_voter"] = first_peer_id
+    raft_state["apply_progress_queue"] = None
+    raft_state["state"]["hard_state"]["commit"] = 0
+    raft_state_path.write_text(json.dumps(raft_state))
+
     # Reinitialize the removed peer as a fresh first peer, reusing its data
     # directory. Before the fix this panicked on startup with:
     #   Can't initialize consensus: Failed to apply configuration change entry
@@ -58,6 +86,10 @@ def test_reinit_removed_peer(tmp_path: pathlib.Path):
     wait_for(leader_is_defined, reinit_api_uri)
     leader = get_leader(reinit_api_uri)
 
+    # The old cluster's peers are not part of the reinitialized cluster: the
+    # stale address injected above must have been dropped by `--reinit`.
+    assert check_cluster_size(reinit_api_uri, 1)
+
     # It must also still be usable as a cluster seed: a fresh peer can bootstrap
     # onto it, which requires the reinitialized peer to serve a snapshot (the
     # entry at the commit index is kept as the snapshot anchor by the fix).
@@ -69,22 +101,20 @@ def test_reinit_removed_peer(tmp_path: pathlib.Path):
 
 def test_reinit_removed_peer_readyz_ignores_old_cluster(tmp_path: pathlib.Path):
     """
-    Regression test for `/readyz` of a reinitialized peer racing against the
-    old cluster.
+    Regression test for `/readyz` treating a stale address-book entry as a
+    cluster member.
 
-    Applying `RemoveNode(self)` prunes all other peers from the removed peer's
-    persisted address book. But the peer may be killed after the removal is
-    committed and *before it applied the entry* - then the old first peer's
-    address survives in `raft_state.json`. After `--reinit` the health checker
-    used to treat every address-book entry as a cluster member and would wait
-    for the reinitialized peer to reach the *old* cluster's commit index - a
-    foreign consensus it can never catch up with, so `/readyz` never passed.
+    `peer_address_by_id` can hold addresses of peers that are not part of this
+    peer's consensus. The health checker used to treat every address-book
+    entry as a cluster member and would wait for this peer to reach the
+    *foreign* peer's commit index, which its own consensus can never catch up
+    with, so `/readyz` never passed. It must rely on `conf_state` membership
+    instead and ignore the foreign peer.
 
-    The kill-before-apply race is simulated by putting the old first peer's
-    address back into the killed peer's persisted state, and the old cluster's
-    commit index is pushed ahead so the reinitialized single-voter consensus
-    stays behind it. `/readyz` must rely on `conf_state` (reset to a single
-    voter by `--reinit`) and ignore the old peer.
+    Since `--reinit` itself now prunes the address book, the stale address is
+    injected on a plain restart (no `--reinit`) of a previously reinitialized
+    single-voter peer, and the foreign (old) cluster's commit index is pushed
+    ahead so this peer's consensus stays behind it.
     """
     assert_project_root()
 
@@ -103,16 +133,30 @@ def test_reinit_removed_peer_readyz_ignores_old_cluster(tmp_path: pathlib.Path):
     removed_peer_process.kill()
     processes.remove(removed_peer_process)
 
-    # Simulate the killed peer not having applied `RemoveNode(self)` yet: the
-    # old first peer's address is still in its persisted address book.
+    # Reinitialize the removed peer as a fresh single-voter first peer.
+    reinit_api_uri, _reinit_bootstrap_uri = start_first_peer(
+        removed_peer_dir, "removed_peer_reinit.log", reinit=True,
+    )
+    wait_for_peer_online(reinit_api_uri)
+
+    # Stop it again to inject the stale address below.
+    reinit_peer_process = processes[1]
+    reinit_peer_process.kill()
+    processes.remove(reinit_peer_process)
+
+    # Put the old first peer's address into the persisted address book, while
+    # `conf_state` remains this peer only. It doesn't matter how a real
+    # cluster ends up in this state (e.g. a peer killed mid-removal and
+    # restarted without `--reinit`) - `/readyz` must not treat address-book
+    # entries outside `conf_state` as cluster members.
     raft_state_path = removed_peer_dir / "storage" / "raft_state.json"
     raft_state = json.loads(raft_state_path.read_text())
     raft_state["peer_address_by_id"][str(first_peer_id)] = bootstrap_uri
     raft_state_path.write_text(json.dumps(raft_state))
 
-    # Push the old cluster's commit index well ahead of anything the removed
-    # peer has in its WAL. Each collection creation commits several consensus
-    # entries on the (now single-node) old cluster.
+    # Push the old cluster's commit index well ahead of anything the
+    # single-voter peer has in its WAL. Each collection creation commits
+    # several consensus entries on the (now single-node) old cluster.
     for i in range(3):
         res = requests.put(
             f"{peer_api_uris[0]}/collections/ahead_{i}?timeout=60",
@@ -122,16 +166,17 @@ def test_reinit_removed_peer_readyz_ignores_old_cluster(tmp_path: pathlib.Path):
 
     old_commit = get_cluster_info(peer_api_uris[0])["raft_info"]["commit"]
 
-    # Reinitialize the removed peer as a fresh first peer, with the old first
-    # peer still alive and reachable. Its own single-voter consensus can never
-    # reach `old_commit`, so `/readyz` must not depend on it.
-    reinit_api_uri, _reinit_bootstrap_uri = start_first_peer(
-        removed_peer_dir, "removed_peer_reinit.log", reinit=True,
+    # Restart the single-voter peer (no `--reinit`), with the old first peer
+    # still alive and reachable at the injected address. This peer's own
+    # consensus can never reach `old_commit`, so `/readyz` must not depend
+    # on it.
+    restart_api_uri, _restart_bootstrap_uri = start_first_peer(
+        removed_peer_dir, "removed_peer_restart.log",
     )
 
-    wait_for_peer_online(reinit_api_uri)
+    wait_for_peer_online(restart_api_uri)
 
-    # The readiness race is only exercised while the reinitialized peer's own
-    # commit index stays behind the old cluster's.
-    reinit_commit = get_cluster_info(reinit_api_uri)["raft_info"]["commit"]
-    assert reinit_commit < old_commit
+    # The readiness race is only exercised while this peer's own commit index
+    # stays behind the old cluster's.
+    restart_commit = get_cluster_info(restart_api_uri)["raft_info"]["commit"]
+    assert restart_commit < old_commit


### PR DESCRIPTION
## Problem

`tests/consensus_tests/test_reinit_removed_peer.py::test_reinit_removed_peer` kept flaking on CI with `Timeout waiting for condition peer_is_online` — the third failure mode of the same underlying state, after #9688 and #9774.

A peer removed from consensus and killed after `RemoveNode(self)` was **committed** but before it was **applied** keeps the old cluster's `first_voter` and peer addresses in `raft_state.json`. First-peer `--reinit` resets `conf_state` to a single voter (itself) but left both untouched (`first_voter` is in fact never reset, even when the removal is applied normally).

Both values are served to peers bootstrapping onto the reinitialized cluster. A joining peer seeds its initial `conf_state` with the advertised `first_voter` (`Consensus::bootstrap`), and Raft conf-changes are deltas on top of that base — so a stale `first_voter` **permanently corrupts the joining peer's voter set**: it ends up with `{old first peer, itself}`, missing its actual leader. Its `/readyz` then treats the still-alive old peer as a cluster member and waits for the *old* cluster's commit index, which its own consensus never reaches.

The corruption only *manifests* when the reinitialized leader replicates its log as plain entries (nothing applied before the kill ⇒ log anchor at index 0). When the leader sends a snapshot instead, the snapshot's full `conf_state` heals the corrupted seed — which is why the test only failed sporadically.

## Fix

Make first-peer `--reinit` behave like founding a fresh cluster (matching `Persistent::init` for a first peer):

- reset `first_voter` to this peer — to `Some(self)`, not `None`, or `recover_first_voter` would re-derive the old first voter from the retained Raft log;
- prune `peer_address_by_id` to this peer only.

This composes with (does not replace) #9688's `conf_state` membership filter and #9774's non-member bootstrap exception in the health checker: with only the `first_voter` reset, the stale address would still leak to joining peers and #9774's all-addresses fallback could latch the foreign commit index during the bootstrap window.

## Tests

- New unit test `reinit_first_peer_forgets_old_cluster` in `persistent.rs`.
- `test_reinit_removed_peer` now injects the CI-observed kill-before-apply state (stale address, stale `first_voter`, commit 0, nothing applied) deterministically, and asserts the reinitialized cluster contains only itself. Against the unfixed binary this reproduces the exact CI failure (30s `peer_is_online` timeout on the joining peer, voter set `{old first peer, itself}`); with the fix it passes.
- Since `--reinit` now prunes the address book, the stale-address injection in `test_reinit_removed_peer_readyz_ignores_old_cluster` moved to a restart *without* `--reinit`, so it keeps exercising the `/readyz` `conf_state` membership filter from #9688.

🤖 Generated with [Claude Code](https://claude.com/claude-code)