### PR TITLE
Fix `Transfer::Restart`

### DIFF
--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -66,6 +66,36 @@ impl Collection {
             .unwrap_or(ShardTransferMethod::Snapshot)
     }
 
+    /// The initial replica state of a transfer's destination for the given
+    /// transfer `method`. For resharding transfers this depends on the current
+    /// resharding direction (up -> `Resharding`, down -> `ReshardingScaleDown`),
+    /// so it errors if no resharding is in progress.
+    async fn initial_replica_state_for_transfer(
+        &self,
+        method: ShardTransferMethod,
+    ) -> CollectionResult<ReplicaState> {
+        let initial_state = match method {
+            ShardTransferMethod::StreamRecords => ReplicaState::Partial,
+            ShardTransferMethod::Snapshot | ShardTransferMethod::WalDelta => ReplicaState::Recovery,
+            ShardTransferMethod::ReshardingStreamRecords => {
+                let direction = self.resharding_state().await.map(|state| state.direction);
+
+                let Some(direction) = direction else {
+                    return Err(CollectionError::bad_input(
+                        "can't start resharding transfer, because resharding is not in progress",
+                    ));
+                };
+
+                match direction {
+                    ReshardingDirection::Up => ReplicaState::Resharding,
+                    ReshardingDirection::Down => ReplicaState::ReshardingScaleDown,
+                }
+            }
+        };
+
+        Ok(initial_state)
+    }
+
     pub async fn start_shard_transfer<T, F>(
         &self,
         mut shard_transfer: ShardTransfer,
@@ -136,28 +166,9 @@ impl Collection {
             // Checked at the top of the function — the method is always set by the
             // peer that submitted this transfer to consensus.
             let transfer_method = shard_transfer.method.expect("transfer method must be set");
-            let initial_state = match transfer_method {
-                ShardTransferMethod::StreamRecords => ReplicaState::Partial,
-
-                ShardTransferMethod::Snapshot | ShardTransferMethod::WalDelta => {
-                    ReplicaState::Recovery
-                }
-
-                ShardTransferMethod::ReshardingStreamRecords => {
-                    let direction = self.resharding_state().await.map(|state| state.direction);
-
-                    let Some(direction) = direction else {
-                        return Err(CollectionError::bad_input(
-                            "can't start resharding transfer, because resharding is not in progress",
-                        ));
-                    };
-
-                    match direction {
-                        ReshardingDirection::Up => ReplicaState::Resharding,
-                        ReshardingDirection::Down => ReplicaState::ReshardingScaleDown,
-                    }
-                }
-            };
+            let initial_state = self
+                .initial_replica_state_for_transfer(transfer_method)
+                .await?;
 
             // Create local shard if it does not exist on receiver, or simply set replica state otherwise
             // (on all peers, regardless if shard is local or remote on that peer).

--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -279,6 +279,121 @@ impl Collection {
         );
     }
 
+    /// Restart a shard transfer with new method, updating transfer record in place
+    /// instead of aborting and re-starting it.
+    ///
+    /// `transfer_key` identifies the existing record; `new_transfer` is replacement,
+    /// with new method and old record's `sync` flag preserved.
+    ///
+    /// Every step is individually idempotent, and record's method update
+    /// (`register_restart_transfer`) is the *last* durable write, so it gates the
+    /// whole operation:
+    ///
+    /// - If we crash *before* the method update, on replay the record still carries
+    ///   the old method, so every step re-runs and converges.
+    /// - If we crash *after*, on replay the record carries the new method, and the
+    ///   check below returns an idempotent no-op.
+    ///
+    /// The record is never removed at any point, so a replay always finds it.
+    /// If it is missing, this is a stale duplicate restart and is rejected.
+    pub async fn restart_shard_transfer<T, F>(
+        &self,
+        transfer_key: ShardTransferKey,
+        new_transfer: ShardTransfer,
+        consensus: Box<dyn ShardTransferConsensus>,
+        temp_dir: PathBuf,
+        on_finish: T,
+        on_error: F,
+    ) -> CollectionResult<()>
+    where
+        T: Future<Output = ()> + Send + 'static,
+        F: Future<Output = ()> + Send + 'static,
+    {
+        let new_method = new_transfer
+            .method
+            .expect("restart transfer method must be set");
+
+        // 1. Proceed only if the record exists and still carries the old method.
+        //    The record is never removed during a restart, so a missing record means
+        //    a stale duplicate restart (reject it), and a record already carrying the
+        //    new method means this restart already applied (idempotent no-op).
+        {
+            let shard_holder = self.shards_holder.read().await;
+            let Some(existing) = shard_holder.get_transfer(&transfer_key) else {
+                return Err(CollectionError::bad_request(format!(
+                    "There is no transfer for shard {} from {} to {}",
+                    transfer_key.shard_id, transfer_key.from, transfer_key.to,
+                )));
+            };
+            if existing.method == Some(new_method) {
+                log::warn!(
+                    "Restart of shard transfer {transfer_key:?} to method {new_method:?} \
+                     was already applied, treating as idempotent no-op",
+                );
+                return Ok(());
+            }
+        }
+
+        let this_peer_id = consensus.this_peer_id();
+        let is_sender = this_peer_id == new_transfer.from;
+        let is_receiver = this_peer_id == new_transfer.to;
+        let dest_shard_id = new_transfer.to_shard_id.unwrap_or(new_transfer.shard_id);
+
+        let initial_state = self.initial_replica_state_for_transfer(new_method).await?;
+
+        // 2. Stop the running transfer task for the old record.
+        let _ = self
+            .transfer_tasks
+            .lock()
+            .await
+            .stop_task(&transfer_key)
+            .await;
+
+        {
+            let shard_holder = self.shards_holder.read().await;
+
+            // 3. Sender: revert the queue/proxy back to a plain local shard.
+            if is_sender {
+                transfer::driver::revert_proxy_shard_to_local(&shard_holder, new_transfer.shard_id)
+                    .await?;
+            }
+
+            // The destination replica set exists on every peer (remote elsewhere,
+            // local on the receiver).
+            let Some(dest_replica_set) = shard_holder.get_shard(dest_shard_id) else {
+                return Err(CollectionError::bad_request(format!(
+                    "Shard {dest_shard_id} doesn't exist"
+                )));
+            };
+
+            // 4. Receiver: reset the destination local shard to empty, discarding
+            //    any partially-transferred data. Safe because a restart is only ever
+            //    proposed as a WAL-delta transfer fallback (never resharding), and the
+            //    fallback method fully re-populates the destination.
+            if is_receiver {
+                dest_replica_set.init_empty_local_shard().await?;
+            }
+
+            // 5. All peers: set the destination replica to the new method's
+            //    initial state.
+            dest_replica_set
+                .ensure_replica_with_state(new_transfer.to, initial_state)
+                .await?;
+
+            // 6. Update the record's method in place. This is the last durable
+            //    write, so it gates the whole operation on replay (see the doc comment).
+            shard_holder.register_restart_transfer(&transfer_key, new_method)?;
+        }
+
+        // 7. Sender: (re)spawn the transfer driver for the new transfer.
+        if is_sender {
+            self.send_shard(new_transfer, consensus, temp_dir, on_finish, on_error)
+                .await;
+        }
+
+        Ok(())
+    }
+
     /// Handles finishing of the shard transfer.
     ///
     /// Returns true if state was changed, false otherwise.

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1662,3 +1662,116 @@ pub(crate) enum ShardTransferChange {
 pub fn shard_not_found_error(shard_id: ShardId) -> CollectionError {
     CollectionError::not_found(format!("shard {shard_id}"))
 }
+
+/// `register_restart_transfer` is the last durable write of a shard-transfer
+/// restart (finding E). These tests pin its replay-safety: the record is never
+/// removed, so a replay after the method-updating write reports the record
+/// (rather than "no transfer"), and the update is value-idempotent.
+#[cfg(test)]
+mod restart_transfer_tests {
+    use super::*;
+
+    fn make_holder() -> (tempfile::TempDir, ShardHolder) {
+        let dir = tempfile::tempdir().unwrap();
+        let holder = ShardHolder::new(dir.path(), ShardingMethod::Auto).unwrap();
+        (dir, holder)
+    }
+
+    // A wal-delta transfer, the only shape that gets restarted.
+    //
+    // `sync: false` and `filter: Some(..)` are chosen so the assertions below
+    // fail if restart hardcodes `sync: true` or keeps the old `filter`.
+    //
+    // `to_shard_id` must stay `None`: it is part of `ShardTransferKey`, so
+    // restart resetting a `Some` value would change the record's identity.
+    fn wal_delta_transfer() -> ShardTransfer {
+        ShardTransfer {
+            shard_id: 1,
+            to_shard_id: None,
+            from: 10,
+            to: 20,
+            sync: false,
+            method: Some(ShardTransferMethod::WalDelta),
+            filter: Some(segment::types::Filter::default()),
+        }
+    }
+
+    #[test]
+    fn test_register_restart_transfer_absent_is_none() {
+        let (_dir, holder) = make_holder();
+        let key = wal_delta_transfer().key();
+
+        // No record: a restart of a transfer that isn't registered is a
+        // stale-duplicate signal, reported as None.
+        let result = holder
+            .register_restart_transfer(&key, ShardTransferMethod::Snapshot)
+            .unwrap();
+        assert_eq!(
+            result, None,
+            "restart of an absent transfer must return None"
+        );
+    }
+
+    #[test]
+    fn test_register_restart_transfer_updates_method_in_place() {
+        let (_dir, holder) = make_holder();
+        let transfer = wal_delta_transfer();
+        let key = transfer.key();
+        holder
+            .register_start_shard_transfer(transfer.clone())
+            .unwrap();
+
+        let updated = holder
+            .register_restart_transfer(&key, ShardTransferMethod::Snapshot)
+            .unwrap()
+            .expect("restart must return the updated record");
+
+        assert_eq!(updated.method, Some(ShardTransferMethod::Snapshot));
+        assert_eq!(updated.sync, transfer.sync, "sync flag must be preserved");
+        assert_eq!(updated.to_shard_id, None);
+        assert_eq!(updated.filter, None, "filter must be reset");
+        assert_eq!(updated.from, transfer.from);
+        assert_eq!(updated.to, transfer.to);
+        assert_eq!(updated.shard_id, transfer.shard_id);
+
+        // The record is replaced in place — still exactly one transfer, now with
+        // the new method (never removed, so a replay can always find it).
+        let transfers = holder.shard_transfers.read();
+        assert_eq!(transfers.len(), 1);
+        assert_eq!(
+            transfers.iter().next().unwrap().method,
+            Some(ShardTransferMethod::Snapshot),
+        );
+    }
+
+    #[test]
+    fn test_register_restart_transfer_replay_is_noop() {
+        let (dir, holder) = make_holder();
+        let transfer = wal_delta_transfer();
+        let key = transfer.key();
+        holder
+            .register_start_shard_transfer(transfer.clone())
+            .unwrap();
+
+        // Apply the restart, then replay it (as a crash after the method write
+        // would). The replay must report the record (not None) and leave the set
+        // unchanged — a single, idempotent no-op.
+        holder
+            .register_restart_transfer(&key, ShardTransferMethod::Snapshot)
+            .unwrap();
+
+        // Reopen the holder from disk, as a crash-restart would, so the replay
+        // runs against the reloaded state rather than the same in-memory value.
+        drop(holder);
+        let holder = ShardHolder::new(dir.path(), ShardingMethod::Auto).unwrap();
+
+        let replay = holder
+            .register_restart_transfer(&key, ShardTransferMethod::Snapshot)
+            .unwrap()
+            .expect("replay must still find the record, not treat it as absent");
+
+        assert_eq!(replay.method, Some(ShardTransferMethod::Snapshot));
+        assert_eq!(replay.sync, transfer.sync);
+        assert_eq!(holder.shard_transfers.read().len(), 1);
+    }
+}

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -62,7 +62,7 @@ use crate::shards::shard_config::ShardConfig;
 use crate::shards::shard_holder::recovery_guard::{
     ActiveRecoveries, RecoveryProgressHandle, ShardRecoveryGuard,
 };
-use crate::shards::transfer::{ShardTransfer, ShardTransferKey};
+use crate::shards::transfer::{ShardTransfer, ShardTransferKey, ShardTransferMethod};
 use crate::shards::{CollectionId, check_shard_path, shard_initializing_flag_path};
 
 const SHARD_TRANSFERS_FILE: &str = "shard_transfers";
@@ -481,6 +481,70 @@ impl ShardHolder {
             .shard_transfer_changes
             .send(ShardTransferChange::Start(transfer));
         Ok(changed)
+    }
+
+    /// Update an existing transfer record's method in place, preserving its `sync` flag.
+    /// This is the last durable write of a shard-transfer restart.
+    ///
+    /// The record is updated in place, never removed and re-inserted, so it is
+    /// always present. A restart replayed after a crash can therefore always find
+    /// the record and re-run.
+    ///
+    /// Returns the resulting record:
+    /// - No matching record: returns `None`. The record is never removed during a
+    ///   restart, so this is a stale duplicate restart (the caller dismisses it).
+    /// - Method already updated: returns the record unchanged, without writing.
+    ///   This is a replay whose method update already landed.
+    /// - Otherwise: replaces the method (resetting `to_shard_id` and `filter`) and
+    ///   returns the updated record.
+    pub fn register_restart_transfer(
+        &self,
+        key: &ShardTransferKey,
+        new_method: ShardTransferMethod,
+    ) -> CollectionResult<Option<ShardTransfer>> {
+        let mut updated = None;
+
+        self.shard_transfers.write_optional(|transfers| {
+            let existing = transfers.iter().find(|transfer| key.check(transfer))?;
+
+            // Replay: the method was already updated on a previous apply. Return
+            // the record without rewriting the file.
+            if existing.method == Some(new_method) {
+                updated = Some(existing.clone());
+                return None;
+            }
+
+            let new_transfer = ShardTransfer {
+                shard_id: existing.shard_id,
+                to_shard_id: None,
+                from: existing.from,
+                to: existing.to,
+                // Preserve the sync flag from the old transfer
+                sync: existing.sync,
+                method: Some(new_method),
+                filter: None,
+            };
+
+            let mut transfers = transfers.clone();
+            transfers.retain(|transfer| !key.check(transfer));
+            transfers.insert(new_transfer.clone());
+            updated = Some(new_transfer);
+            Some(transfers)
+        })?;
+
+        // A restart is semantically the old transfer aborted and a new one
+        // started; notify watchers as that pair (there is no dedicated Restart
+        // change variant).
+        if let Some(transfer) = &updated {
+            let _ = self
+                .shard_transfer_changes
+                .send(ShardTransferChange::Abort(*key));
+            let _ = self
+                .shard_transfer_changes
+                .send(ShardTransferChange::Start(transfer.clone()));
+        }
+
+        Ok(updated)
     }
 
     pub fn register_finish_transfer(&self, key: &ShardTransferKey) -> CollectionResult<bool> {

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -537,6 +537,10 @@ impl TableOfContent {
 
                 let transfer_key = transfer_restart.key();
 
+                // The record must exist. A restart updates the record in place, never
+                // removing it, so a missing record means a stale duplicate restart —
+                // reject it. A restart to an unchanged method is not rejected here; it
+                // is an idempotent no-op inside `restart_shard_transfer`.
                 let Some(old_transfer) = transfer::helpers::get_transfer(&transfer_key, &transfers)
                 else {
                     return Err(StorageError::bad_request(format!(
@@ -545,40 +549,68 @@ impl TableOfContent {
                     )));
                 };
 
-                if old_transfer.method == Some(transfer_restart.method) {
-                    return Err(StorageError::bad_request(format!(
-                        "Cannot restart transfer for shard {} from {} to {}, its configuration did not change",
-                        transfer_restart.shard_id, transfer_restart.from, transfer_restart.to,
-                    )));
-                }
-
-                // Abort and start transfer
-                Box::pin(self.handle_transfer(
-                    collection_id.clone(),
-                    ShardTransferOperations::Abort {
-                        transfer: transfer_restart.key(),
-                        reason: "restart transfer".into(),
-                    },
-                ))
-                .await?;
-
+                // The replacement record: preserve the old sync flag, drop
+                // to_shard_id and any filter, switch to the new method.
                 let new_transfer = ShardTransfer {
                     shard_id: transfer_restart.shard_id,
                     to_shard_id: None,
                     from: transfer_restart.from,
                     to: transfer_restart.to,
-                    sync: old_transfer.sync, // Preserve sync flag from the old transfer
+                    sync: old_transfer.sync,
                     method: Some(transfer_restart.method),
                     filter: None,
                 };
 
-                Box::pin(
-                    self.handle_transfer(
-                        collection_id,
-                        ShardTransferOperations::Start(new_transfer),
-                    ),
-                )
-                .await?;
+                let on_finish = {
+                    let collection_id = collection_id.clone();
+                    let transfer = new_transfer.clone();
+                    let proposal_sender = proposal_sender.clone();
+                    async move {
+                        let operation =
+                            ConsensusOperations::finish_transfer(collection_id, transfer);
+
+                        if let Err(error) = proposal_sender.send(operation) {
+                            log::error!("Can't report transfer progress to consensus: {error}");
+                        };
+                    }
+                };
+
+                let on_failure = {
+                    let collection_id = collection_id.clone();
+                    let transfer = new_transfer.clone();
+                    async move {
+                        if let Err(error) =
+                            proposal_sender.send(ConsensusOperations::abort_transfer(
+                                collection_id,
+                                transfer,
+                                "transmission failed",
+                            ))
+                        {
+                            log::error!("Can't report transfer progress to consensus: {error}");
+                        };
+                    }
+                };
+
+                let shard_consensus = match self.toc_dispatcher.lock().as_ref() {
+                    Some(consensus) => Box::new(consensus.clone()),
+                    None => {
+                        return Err(StorageError::service_error(
+                            "Can't handle transfer, this is a single node deployment",
+                        ));
+                    }
+                };
+
+                let temp_dir = self.optional_temp_or_storage_temp_path()?;
+                collection
+                    .restart_shard_transfer(
+                        transfer_key,
+                        new_transfer,
+                        shard_consensus,
+                        temp_dir,
+                        on_finish,
+                        on_failure,
+                    )
+                    .await?;
             }
             ShardTransferOperations::Finish(transfer) => {
                 // Validate transfer exists to prevent double handling


### PR DESCRIPTION
`Transfer::Restart` has failure similar to #9760. It is composed as independent `Abort` + `Start`, and *each* writes state to disk.

If we crash after `Abort`, but before `Start`, operation will be "skipped" with an error when we reapply it after restart (because shard transfer simply does not exist anymore).

Fix is also similar to #9760. Restructure, so that each step is idempotent and we write on-disk state once, at the end of operation.

Targets #9760, but it's mostly independent, could be rebased on #9695 or maybe even `dev`.

### All Submissions:

* [ ] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
