### PR TITLE
Resolve vanished segments against the manifest in ReadOnlyEdgeShard refresh

### DIFF
--- a/lib/edge/src/read_only/holder.rs
+++ b/lib/edge/src/read_only/holder.rs
@@ -67,6 +67,12 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegmentHolder<S> {
         self.by_uuid.retain(|uuid, _| on_disk.contains_key(uuid));
     }
 
+    /// Drop a single segment (e.g. one whose files vanished mid-reload and whose removal was
+    /// confirmed against the manifest). Same handle-only semantics as [`Self::remove_missing`].
+    pub(crate) fn remove(&mut self, uuid: &Uuid) {
+        self.by_uuid.remove(uuid);
+    }
+
     pub(crate) fn segment_arc(&self, uuid: &Uuid) -> Option<Arc<RwLock<ReadOnlySegment<S>>>> {
         self.by_uuid.get(uuid).map(|slot| slot.segment.clone())
     }

--- a/lib/edge/src/read_only/lifecycle.rs
+++ b/lib/edge/src/read_only/lifecycle.rs
@@ -10,7 +10,6 @@ use crate::EdgeConfig;
 use crate::read_only::ReadOnlyEdgeShard;
 use crate::read_only::enumerate::{ManifestSegmentEnumerator, SegmentEnumerator};
 use crate::read_only::holder::ReadOnlySegmentHolder;
-use crate::read_only::load::load_segments_parallel;
 
 impl ReadOnlyEdgeShard<MmapFile> {
     /// Open a read-only follower over local memory-mapped files, discovering segments from the
@@ -62,9 +61,10 @@ impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
     /// Internal seam: [`open`](Self::open) always discovers via the manifest, but tests inject other
     /// discovery strategies (e.g. a directory scan) here.
     ///
-    /// Every segment reported by the enumerator is opened read-only. The manifest is superset-biased,
-    /// so segments that cannot be loaded (not yet finalized, already deleted, or appendable) are
-    /// skipped rather than failing the open.
+    /// The initial load is a [`refresh`](Self::refresh) over an empty shard: same discovery, same
+    /// parallel load, same handling of segments that change while being loaded. The manifest is
+    /// superset-biased, so segments that cannot be loaded (not yet finalized, already deleted, or
+    /// appendable) are skipped rather than failing the open.
     pub(crate) fn open_with_enumerator(
         fs: S::Fs,
         path: &Path,
@@ -80,37 +80,25 @@ impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
         // config alone: the CPU-derived default unless explicitly set.
         let search_pool = crate::pool::build_search_pool(provided_config.search_thread_count())?;
 
-        let mut loaded =
-            load_segments_parallel::<S>(&search_pool, &fs, enumerator.list_segments()?);
-        // Fold the derived config in UUID order so the derivation is deterministic.
-        loaded.sort_unstable_by_key(|(uuid, _)| *uuid);
-        let mut holder = ReadOnlySegmentHolder::default();
-        let mut segments_config: Option<EdgeConfig> = None;
-        for (uuid, segment) in loaded {
-            // Derive the shard config from the segments' own configs: folded over all of them, so
-            // a segment carrying no information about a parameter (e.g. a plain appendable one
-            // says nothing about HNSW) never masks one that does.
-            segments_config = Some(EdgeConfig::fold_from_segment_config(
-                segments_config,
-                &segment.segment_config,
-            ));
-            let appendable = segment.segment_config.is_appendable();
-            holder.insert(uuid, appendable, Arc::new(RwLock::new(segment)));
-        }
-
-        let config = match segments_config {
-            Some(derived) => merge_follower_config(provided_config, derived),
-            // Empty shard: no segments to derive from yet, refresh re-derives once they appear.
-            None => provided_config,
-        };
-
-        Ok(Self {
+        let shard = Self {
             path: path.to_path_buf(),
             fs,
-            config: RwLock::new(Arc::new(config)),
-            segments: RwLock::new(holder),
+            config: RwLock::new(Arc::new(provided_config.clone())),
+            segments: RwLock::new(ReadOnlySegmentHolder::default()),
             enumerator: Box::new(enumerator),
             search_pool,
-        })
+        };
+        shard.refresh()?;
+
+        // Open-only config overlay: caller-provided tunables win over the segment-derived ones
+        // (`refresh` re-derives from the segments alone — see the `config` field docs). For an
+        // empty shard the refresh left the provided config in place, and the overlay is a no-op.
+        let derived = shard.config.read().clone();
+        *shard.config.write() = Arc::new(merge_follower_config(
+            provided_config,
+            EdgeConfig::clone(&derived),
+        ));
+
+        Ok(shard)
     }
 }

--- a/lib/edge/src/read_only/refresh.rs
+++ b/lib/edge/src/read_only/refresh.rs
@@ -2,8 +2,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::universal_io::IsNotFound as _;
 use parking_lot::RwLock;
-use segment::common::operation_error::OperationResult;
+use segment::common::operation_error::{OperationError, OperationResult};
 use segment::index::UniversalReadExt;
 use segment::segment::read_only::ReadOnlySegment;
 use uuid::Uuid;
@@ -12,6 +13,16 @@ use crate::EdgeConfig;
 use crate::read_only::ReadOnlyEdgeShard;
 use crate::read_only::load::load_segments_parallel;
 
+/// How a single [`refresh_attempt`](ReadOnlyEdgeShard::refresh_attempt) ended.
+enum RefreshOutcome {
+    /// The attempt fully converged on its manifest snapshot.
+    Complete,
+    /// Segments vanished benignly mid-attempt (the leader removed them, confirmed
+    /// against a re-read manifest); re-run against the fresh manifest to pick up
+    /// their replacements.
+    ManifestChanged,
+}
+
 impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
     /// Refresh the follower to the leader's current on-disk state.
     ///
@@ -19,6 +30,14 @@ impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
     /// owns the cadence (a timer, an explicit call after a known leader flush, or an FS watch).
     /// Eventually consistent — a point becomes visible once the leader has flushed it to the
     /// segment files and a subsequent `refresh` has run.
+    ///
+    /// Leader-side segment churn is absorbed: a segment whose files vanish while its live-reload
+    /// runs is checked against a re-read manifest, and if the leader indeed removed it, the segment
+    /// is dropped and the refresh re-runs (bounded) to pick up its replacements. `Err` therefore
+    /// means the shard genuinely needs attention: a component failed to reload, or a segment's
+    /// essential files are missing while the manifest still lists it. Either way the shard stays
+    /// consistent — every swap is atomic, a failed segment keeps serving its pre-refresh state,
+    /// and the next refresh replays its unapplied delta (see `pending_reload`).
     pub fn refresh(&self) -> OperationResult<()>
     where
         S::Fs: Send + Sync + Clone + 'static,
@@ -32,13 +51,48 @@ impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
     where
         S::Fs: Send + Sync + Clone + 'static,
     {
+        // A benign mid-attempt segment removal re-runs the attempt against the fresh manifest;
+        // bound the re-runs so a leader churning segments faster than the follower converges
+        // cannot spin this loop forever.
+        const MAX_ATTEMPTS: usize = 3;
+
+        for _ in 0..MAX_ATTEMPTS {
+            match self.refresh_attempt(hw_counter)? {
+                RefreshOutcome::Complete => return Ok(()),
+                RefreshOutcome::ManifestChanged => {}
+            }
+        }
+
+        // Attempts exhausted without converging. The shard is still consistent — every completed
+        // swap was atomic — it just may not reflect the newest segments yet; the next refresh
+        // continues from here.
+        log::warn!(
+            "shard refresh did not converge after {MAX_ATTEMPTS} attempts \
+             (leader keeps replacing segments); serving the state reached so far",
+        );
+        Ok(())
+    }
+
+    /// One refresh pass over a single manifest snapshot.
+    ///
+    /// Completes as much as possible before reporting problems: newly-appeared segments are
+    /// swapped in and every survivor is live-reloaded (they are independent) even when one of
+    /// them fails. Not-found failures are then resolved against a re-read manifest — a segment
+    /// the leader removed mid-attempt is dropped and reported as [`RefreshOutcome::ManifestChanged`]
+    /// so the caller re-runs against the fresh manifest; one whose files are missing while the
+    /// manifest still lists it escalates. Any other reload failure escalates after the loop.
+    fn refresh_attempt(&self, hw_counter: &HardwareCounterCell) -> OperationResult<RefreshOutcome>
+    where
+        S::Fs: Send + Sync + Clone + 'static,
+    {
         // 1. Snapshot the current on-disk segment set (backend-specific; see `SegmentEnumerator`).
         let on_disk = self.enumerator.list_segments()?;
 
         // 2. Load newly-appeared segments in parallel (outside the holder lock), then under the lock
         //    add them and drop removed ones, and collect the survivors to live_reload *after*
         //    releasing the lock — so reads only block during the cheap add/drop, not during load
-        //    or reload.
+        //    or reload. The manifest is superset-biased, so unloadable segments are skipped by
+        //    `load_segments_parallel` and simply retried on the next refresh.
         let new_segments: Vec<(Uuid, PathBuf)> = {
             let holder = self.segments.read();
             on_disk
@@ -98,15 +152,64 @@ impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
         }
 
         // 4. Live-reload survivors to fold in the leader's flushed in-place appends and deletes.
-        //    Newly-added segments are already current, so they are skipped.
+        //    Newly-added segments are already current, so they are skipped. Survivors are
+        //    independent, so a failure does not stop the others from reloading; a failed segment
+        //    keeps serving its pre-refresh state and its unapplied delta is retained in
+        //    `pending_reload`, so a later reload replays the union and nothing is lost.
+        let mut not_found: Vec<(Uuid, OperationError)> = Vec::new();
+        let mut first_hard_error: Option<OperationError> = None;
         for (uuid, segment) in survivors {
-            if let Err(err) = segment.write().live_reload(&self.fs, hw_counter) {
-                // The segment retains the unapplied delta in its `pending_reload`; the next refresh
-                // folds in fresh changes and replays the union, so nothing is lost.
-                log::warn!("live_reload of segment {uuid} failed, will retry next refresh: {err}");
+            match segment.write().live_reload(&self.fs, hw_counter) {
+                Ok(()) => {}
+                // An essential file is gone; whether that is benign (the leader removed the
+                // segment while we reloaded it) is decided against a re-read manifest below.
+                Err(err) if err.is_not_found() => not_found.push((uuid, err)),
+                Err(err) => {
+                    log::error!("live_reload of segment {uuid} failed: {err}");
+                    first_hard_error.get_or_insert(err);
+                }
             }
         }
 
-        Ok(())
+        // 5. Resolve not-found failures against a re-read manifest: gone from the manifest means
+        //    the leader removed the segment mid-attempt — drop it and re-run to pick up its
+        //    replacements; still listed means its essential files are genuinely missing — escalate.
+        let outcome = if not_found.is_empty() {
+            RefreshOutcome::Complete
+        } else {
+            let fresh = self.enumerator.list_segments()?;
+            let mut gone: Vec<Uuid> = Vec::new();
+            let mut still_listed_error: Option<OperationError> = None;
+            for (uuid, err) in not_found {
+                if fresh.contains_key(&uuid) {
+                    log::error!(
+                        "segment {uuid} is listed in the manifest but its files are missing: {err}",
+                    );
+                    still_listed_error.get_or_insert(err);
+                } else {
+                    log::debug!("segment {uuid} was removed by the leader during refresh");
+                    gone.push(uuid);
+                }
+            }
+
+            // Drop the removed segments even when escalating below: they are confirmed gone, so
+            // keeping them would only leave handles to vanished files.
+            if !gone.is_empty() {
+                let mut holder = self.segments.write();
+                for uuid in &gone {
+                    holder.remove(uuid);
+                }
+            }
+
+            if let Some(err) = still_listed_error {
+                return Err(err);
+            }
+            RefreshOutcome::ManifestChanged
+        };
+
+        if let Some(err) = first_hard_error {
+            return Err(err);
+        }
+        Ok(outcome)
     }
 }


### PR DESCRIPTION
## What

Third step of the `ReadOnlyEdgeShard` not-found handling, after #9763 (error classification) and #9777 (classification-preserving reload paths). Implements the shard-level requirement from the live-reload design:

> If during live-reload we find that some essential files of the segment no longer exist, propagate a not-found error back to shard-level live-reload. There, re-read the manifest: if the segment is gone — ignore the error and load new segments again; if it is not gone — escalate.

## How

**`refresh()` is now a bounded retry loop** (3 attempts) over single-manifest-snapshot passes. Within an attempt, every survivor live-reloads even when one fails — they're independent. Failures split by the classification built in #9763/#9777:

- **Not-found** → resolved against a re-read manifest:
  - gone from the manifest → the leader removed the segment mid-reload; drop its handle and **re-run the attempt** against the fresh manifest, so replacement segments appear immediately instead of on the next poll;
  - still listed → essential files are genuinely missing; escalate.
- **Anything else** → escalate after reloading the remaining survivors (first error returned, all logged). This replaces the previous warn-and-swallow, which could hide a corrupted segment indefinitely. Escalation is safe: a failed segment keeps serving its pre-refresh state, and `pending_reload` replays the unapplied delta on the next refresh.

If the attempts run out (leader replacing segments continuously), refresh logs a warning and returns `Ok` — every swap was atomic, so the shard is consistent, just possibly not the newest; the next refresh continues from there. `Err` from refresh now genuinely means "needs attention".

**`open_with_enumerator` reuses the refresh machinery**: empty holder + `refresh()` + the open-only `merge_follower_config` overlay (provided tunables win at open; refresh re-derives from segments alone). Removes the duplicated load/derive logic. At open there are no survivors, so open behavior is unchanged.

**Load-side failures stay as settled by #9762**: the manifest is superset-biased, unloadable listed segments are skipped and retried on every refresh — this PR deliberately does not touch that contract.

## Scope notes

- New `ReadOnlySegmentHolder::remove(&Uuid)` for the confirmed-gone drop (same handle-only semantics as `remove_missing`).
- Failure-scenario tests (scripted stale-then-fresh enumerator, still-listed escalation, hard-error escalation) come in the follow-up PR — the injectable-enumerator seam they need is already in place.

Full edge test suite passes; clippy and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)