### PR TITLE
docs(segment): fix mislabeled doc comments in index

### DIFF
--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -14,7 +14,7 @@ use crate::types::{GeoBoundingBox, GeoPoint, GeoPolygon, GeoRadius};
 ///
 /// Geohash string is a base32 encoded string.
 /// It means that each character can be represented with 5 bits.
-/// Also, the length of the string is encoded as 4 bits (because max size is [`GeoHash::MAX_LENGTH`] = 12).
+/// Also, the length of the string is encoded as 4 bits (because max size is `GeoHash::MAX_LEN` = 12).
 /// So, the packed representation is 64 bits long: 5bits * 12chars + 4bits = 64 bits.
 ///
 /// Characters are stored in reverse order to keep lexicographical order.
@@ -35,7 +35,7 @@ pub struct GeoHash(u64);
 
 /// Variation of [`GeoHash`] to serialize/deserialize without validation.
 ///
-/// Unlike [`GeoHash`], it might contain invalid bit patterns, e.g. `length > GeoHash::MAX_LENGTH`,
+/// Unlike [`GeoHash`], it might contain invalid bit patterns, e.g. `length > GeoHash::MAX_LEN`,
 /// or non-zeroed unused bits in characters.
 #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]

--- a/lib/segment/src/index/hnsw_index/config.rs
+++ b/lib/segment/src/index/hnsw_index/config.rs
@@ -10,12 +10,13 @@ pub const HNSW_INDEX_CONFIG_FILE: &str = "hnsw_config.json";
 
 #[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq)]
 pub struct HnswGraphConfig {
-    pub m: usize,
     /// Requested M
-    pub m0: usize,
+    pub m: usize,
     /// Actual M on level 0
-    pub ef_construct: usize,
+    pub m0: usize,
     /// Number of neighbours to search on construction
+    pub ef_construct: usize,
+    /// Number of neighbours to hold in the candidate list during search (initialized to `ef_construct`)
     pub ef: usize,
     /// We prefer a full scan search upto (excluding) this number of vectors.
     ///

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -18,7 +18,7 @@ use crate::types::{Condition, Filter, MinShould};
 ///
 /// * `estimation` - cardinality estimations of number of points selected by payload filter
 /// * `available_vectors` - number of available vectors for the named vector storage
-/// * `total_vectors` - total number of points in the segment
+/// * `available_points` - number of available (non-deleted) points in the segment
 ///
 /// # Result
 ///


### PR DESCRIPTION
Three doc comments in the segment index reference the wrong thing. Documentation only, no code change.

- `geo_hash.rs`: referenced `GeoHash::MAX_LENGTH`; the constant is `MAX_LEN` (private, so plain inline code rather than an intra-doc link).
- `hnsw_index/config.rs`: the field doc comments on `HnswGraphConfig` were each shifted by one, mislabeling `m`, `m0`, `ef_construct`, and `ef`. Realigned them (the constructor confirms `m0 = m * 2` and `ef = ef_construct`) and added a doc for `ef`.
- `query_estimator.rs`: the `adjust_to_available_vectors` docs named a `total_vectors` argument that does not exist; the parameter is `available_points`.

`cargo doc -p segment` reports no warnings for these files and `cargo +nightly fmt` passes.

Closes #9793

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### AI disclosure (per CONTRIBUTING.md)

Commits:
- [AI] docs(segment): fix mislabeled doc comments in index

Prompt/intent: audit the segment index doc comments for correctness against the actual code and fix any that reference the wrong name, field, or parameter.
