### PR TITLE
fix(segment): count trailing deleted offset on mmap sparse reload

### DIFF
--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -78,6 +78,7 @@ impl MmapSparseVectorStorage {
         let next_point_offset = deleted
             .get_bitslice()
             .last_one()
+            .map(|i| i + 1)
             .max(Some(storage.max_point_offset() as usize))
             .unwrap_or_default();
 
@@ -449,6 +450,42 @@ mod test {
         let storage_files = storage.files().into_iter().collect::<HashSet<_>>();
 
         assert_eq!(storage_files, existing_files);
+    }
+
+    #[test]
+    fn test_reload_counts_trailing_deleted_offset() {
+        use std::borrow::Cow;
+        use std::sync::atomic::AtomicBool;
+
+        let temp_dir = tempfile::Builder::new()
+            .prefix("test_storage_trailing_deleted")
+            .tempdir()
+            .unwrap();
+
+        let vector = sparse_vector::SparseVector {
+            indices: vec![1, 2, 3],
+            values: vec![0.1, 0.2, 0.3],
+        };
+        {
+            let mut storage = MmapSparseVectorStorage::open_or_create(temp_dir.path()).unwrap();
+            let stopped = AtomicBool::new(false);
+
+            let mut entries = vec![
+                (Cow::Owned(vector.clone()), false),
+                (Cow::Owned(vector.clone()), true),
+            ]
+            .into_iter();
+            storage.update_from(&mut entries, &stopped).unwrap();
+            assert_eq!(storage.total_vector_count(), 2); // correct in-session
+            storage.flusher()().unwrap();
+        }
+        // On reload it must still be 2 (it returned 1 before the fix)
+        let storage = MmapSparseVectorStorage::open(temp_dir.path()).unwrap();
+        assert_eq!(
+            storage.total_vector_count(),
+            2,
+            "reload must count the trailing deleted-only offset"
+        );
     }
 
     #[test]

--- a/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
@@ -57,6 +57,7 @@ impl<S: UniversalRead> ReadOnlySparseVectorStorage<S> {
         let next_point_offset = deleted
             .as_bitslice()
             .last_one()
+            .map(|i| i + 1)
             .max(Some(storage.max_point_offset()? as usize))
             .unwrap_or_default();
 

--- a/lib/segment/src/vector_storage/sparse/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/live_reload.rs
@@ -27,6 +27,7 @@ impl<S: UniversalRead> LiveReload for ReadOnlySparseVectorStorage<S> {
             .deleted
             .as_bitslice()
             .last_one()
+            .map(|i| i + 1)
             .max(Some(self.storage.max_point_offset()? as usize))
             .unwrap_or_default();
 


### PR DESCRIPTION
Closes #9796.

On reload, `next_point_offset` was computed as `max(last_one(), max_point_offset())`, which mixes an **index** (`last_one()`, the highest deleted flag) with a **count** (`max_point_offset()`, gridstore's pointer count). When the highest offset is a vector that was flagged deleted but never stored (a trailing deleted point carried by a merge), gridstore's `pointer_count` never advances past it, so the reload computes one less than the real slot count. Consequences: `total_vector_count()` under-reports by one, and the next append reuses that slot, colliding with the still-deleted point.

Fix: normalize the deleted index to a count with `.map(|i| i + 1)` before the `max`, at all three sites that share the pattern:

- `lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs`
- `lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs`
- `lib/segment/src/vector_storage/sparse/read_only/live_reload.rs`

Added a regression test (`test_reload_counts_trailing_deleted_offset`) that appends a trailing deleted-only vector, reopens the storage, and asserts `total_vector_count() == 2` (it returned `1` before the fix). Locally `cargo test -p segment` (sparse storage) passes and `cargo clippy -p segment` is clean.

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### AI disclosure (per CONTRIBUTING.md)

The fix and the regression test were written by me; the bug analysis and a review pass (which caught a couple of compile-time slips) were AI-assisted.
