### PR TITLE
Fix use-after-free in u8-quantized vector reads on owning storages

### DIFF
--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -553,6 +553,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
         let data = self.encoded_vectors.get_vector_data(i);
         let (offset, _) = Self::parse_vec_data(&data);
         let dim = self.metadata.actual_dim();
+        debug_assert!(data.len() >= ADDITIONAL_CONSTANT_SIZE + dim);
         // Return the code as a view into `data` itself, so an owned buffer stays alive.
         let code = match data {
             Cow::Borrowed(bytes) => {

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -338,8 +338,9 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
     pub fn score_point_simple(&self, query: &EncodedQueryU8, bytes: &[u8]) -> f32 {
         match &self.metadata {
             Metadata::Int8(metadata) => {
-                let (vector_offset, v_ptr) = Self::parse_vec_data(bytes);
+                let (vector_offset, v_code) = Self::parse_vec_data(bytes);
                 let q_ptr = query.encoded_query.as_ptr();
+                let v_ptr = v_code.as_ptr();
 
                 let score = match metadata.vector_parameters.distance_type {
                     DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => {
@@ -357,8 +358,11 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
     pub fn score_point_simple_internal(&self, i: PointOffsetType, j: PointOffsetType) -> f32 {
         match &self.metadata {
             Metadata::Int8(metadata) => {
-                let (query_offset, q_ptr) = self.get_vec_ptr(i);
-                let (vector_offset, v_ptr) = self.get_vec_ptr(j);
+                let query_data = self.encoded_vectors.get_vector_data(i);
+                let vector_data = self.encoded_vectors.get_vector_data(j);
+                let (query_offset, q_code) = Self::parse_vec_data(&query_data);
+                let (vector_offset, v_code) = Self::parse_vec_data(&vector_data);
+                let (q_ptr, v_ptr) = (q_code.as_ptr(), v_code.as_ptr());
                 let score = match metadata.vector_parameters.distance_type {
                     DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => {
                         impl_score_dot(q_ptr, v_ptr, metadata.actual_dim)
@@ -375,8 +379,9 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
     pub fn score_point_neon(&self, query: &EncodedQueryU8, bytes: &[u8]) -> f32 {
         match &self.metadata {
             Metadata::Int8(metadata) => {
-                let (vector_offset, v_ptr) = Self::parse_vec_data(bytes);
+                let (vector_offset, v_code) = Self::parse_vec_data(bytes);
                 let q_ptr = query.encoded_query.as_ptr();
+                let v_ptr = v_code.as_ptr();
 
                 let score = match metadata.vector_parameters.distance_type {
                     DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => unsafe {
@@ -396,8 +401,11 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
     pub fn score_point_neon_internal(&self, i: PointOffsetType, j: PointOffsetType) -> f32 {
         match &self.metadata {
             Metadata::Int8(metadata) => {
-                let (query_offset, q_ptr) = self.get_vec_ptr(i);
-                let (vector_offset, v_ptr) = self.get_vec_ptr(j);
+                let query_data = self.encoded_vectors.get_vector_data(i);
+                let vector_data = self.encoded_vectors.get_vector_data(j);
+                let (query_offset, q_code) = Self::parse_vec_data(&query_data);
+                let (vector_offset, v_code) = Self::parse_vec_data(&vector_data);
+                let (q_ptr, v_ptr) = (q_code.as_ptr(), v_code.as_ptr());
 
                 let score = match metadata.vector_parameters.distance_type {
                     DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => unsafe {
@@ -417,8 +425,9 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
     pub fn score_point_sse(&self, query: &EncodedQueryU8, bytes: &[u8]) -> f32 {
         match &self.metadata {
             Metadata::Int8(metadata) => {
-                let (vector_offset, v_ptr) = Self::parse_vec_data(bytes);
+                let (vector_offset, v_code) = Self::parse_vec_data(bytes);
                 let q_ptr = query.encoded_query.as_ptr();
+                let v_ptr = v_code.as_ptr();
 
                 let score = match metadata.vector_parameters.distance_type {
                     DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => unsafe {
@@ -438,8 +447,11 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
     pub fn score_point_sse_internal(&self, i: PointOffsetType, j: PointOffsetType) -> f32 {
         match &self.metadata {
             Metadata::Int8(metadata) => {
-                let (query_offset, q_ptr) = self.get_vec_ptr(i);
-                let (vector_offset, v_ptr) = self.get_vec_ptr(j);
+                let query_data = self.encoded_vectors.get_vector_data(i);
+                let vector_data = self.encoded_vectors.get_vector_data(j);
+                let (query_offset, q_code) = Self::parse_vec_data(&query_data);
+                let (vector_offset, v_code) = Self::parse_vec_data(&vector_data);
+                let (q_ptr, v_ptr) = (q_code.as_ptr(), v_code.as_ptr());
 
                 let score = match metadata.vector_parameters.distance_type {
                     DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => unsafe {
@@ -459,8 +471,9 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
     pub fn score_point_avx(&self, query: &EncodedQueryU8, bytes: &[u8]) -> f32 {
         match &self.metadata {
             Metadata::Int8(metadata) => {
-                let (vector_offset, v_ptr) = Self::parse_vec_data(bytes);
+                let (vector_offset, v_code) = Self::parse_vec_data(bytes);
                 let q_ptr = query.encoded_query.as_ptr();
+                let v_ptr = v_code.as_ptr();
 
                 let score = match metadata.vector_parameters.distance_type {
                     DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => unsafe {
@@ -480,8 +493,11 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
     pub fn score_point_avx_internal(&self, i: PointOffsetType, j: PointOffsetType) -> f32 {
         match &self.metadata {
             Metadata::Int8(metadata) => {
-                let (query_offset, q_ptr) = self.get_vec_ptr(i);
-                let (vector_offset, v_ptr) = self.get_vec_ptr(j);
+                let query_data = self.encoded_vectors.get_vector_data(i);
+                let vector_data = self.encoded_vectors.get_vector_data(j);
+                let (query_offset, q_code) = Self::parse_vec_data(&query_data);
+                let (vector_offset, v_code) = Self::parse_vec_data(&vector_data);
+                let (q_ptr, v_ptr) = (q_code.as_ptr(), v_code.as_ptr());
 
                 let score = match metadata.vector_parameters.distance_type {
                     DistanceType::Dot | DistanceType::Cosine | DistanceType::L2 => unsafe {
@@ -510,20 +526,19 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
         (alpha, offset)
     }
 
+    /// Split encoded vector data into the offset constant and the quantized code.
+    ///
+    /// The returned slice borrows `data`, so callers reading from raw pointers derived from it
+    /// must keep the (possibly owned) buffer returned by
+    /// [`EncodedStorage::get_vector_data`] alive for the whole read.
     #[inline]
-    fn parse_vec_data(data: &[u8]) -> (f32, *const u8) {
+    fn parse_vec_data(data: &[u8]) -> (f32, &[u8]) {
         debug_assert!(data.len() >= ADDITIONAL_CONSTANT_SIZE);
         unsafe {
             let offset = data.as_ptr().cast::<f32>().read_unaligned();
-            let v_ptr = data.as_ptr().add(ADDITIONAL_CONSTANT_SIZE);
-            (offset, v_ptr)
+            let code = data.get_unchecked(ADDITIONAL_CONSTANT_SIZE..);
+            (offset, code)
         }
-    }
-
-    #[inline]
-    fn get_vec_ptr(&self, i: PointOffsetType) -> (f32, *const u8) {
-        let data = self.encoded_vectors.get_vector_data(i);
-        Self::parse_vec_data(&data)
     }
 
     pub fn get_quantized_vector(&self, i: PointOffsetType) -> Cow<'_, [u8]> {
@@ -534,10 +549,21 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
         Layout::from_size_align(self.quantized_vector_size(), align_of::<u8>()).unwrap()
     }
 
-    pub fn get_quantized_vector_offset_and_code(&self, i: PointOffsetType) -> (f32, &[u8]) {
-        let (offset, v_ptr) = self.get_vec_ptr(i);
-        let vector_data_size = self.metadata.actual_dim();
-        let code = unsafe { std::slice::from_raw_parts(v_ptr, vector_data_size) };
+    pub fn get_quantized_vector_offset_and_code(&self, i: PointOffsetType) -> (f32, Cow<'_, [u8]>) {
+        let data = self.encoded_vectors.get_vector_data(i);
+        let (offset, _) = Self::parse_vec_data(&data);
+        let dim = self.metadata.actual_dim();
+        // Return the code as a view into `data` itself, so an owned buffer stays alive.
+        let code = match data {
+            Cow::Borrowed(bytes) => {
+                Cow::Borrowed(&bytes[ADDITIONAL_CONSTANT_SIZE..ADDITIONAL_CONSTANT_SIZE + dim])
+            }
+            Cow::Owned(mut bytes) => {
+                bytes.drain(..ADDITIONAL_CONSTANT_SIZE);
+                bytes.truncate(dim);
+                Cow::Owned(bytes)
+            }
+        };
         (offset, code)
     }
 
@@ -688,14 +714,13 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsU8<TStorage> {
     fn encode_internal_vector(&self, id: PointOffsetType) -> Option<EncodedQueryU8> {
         match &self.metadata {
             Metadata::Int8(metadata) => {
-                let (vector_offset, q_ptr) = self.get_vec_ptr(id);
+                let data = self.encoded_vectors.get_vector_data(id);
+                let (vector_offset, code) = Self::parse_vec_data(&data);
                 // Remove shift from offset because encoded query should not have it, it's contained in vector data only.
                 let query_offset = vector_offset - metadata.get_shift();
                 Some(EncodedQueryU8 {
                     offset: query_offset,
-                    encoded_query: unsafe {
-                        std::slice::from_raw_parts(q_ptr, metadata.actual_dim).to_vec()
-                    },
+                    encoded_query: code[..metadata.actual_dim].to_vec(),
                 })
             }
         }

--- a/lib/quantization/tests/integration/main.rs
+++ b/lib/quantization/tests/integration/main.rs
@@ -15,6 +15,8 @@ pub mod test_binary_encodings;
 #[cfg(test)]
 pub mod test_neon;
 #[cfg(test)]
+pub mod test_owned_storage;
+#[cfg(test)]
 pub mod test_pq;
 #[cfg(test)]
 pub mod test_simple;

--- a/lib/quantization/tests/integration/test_owned_storage.rs
+++ b/lib/quantization/tests/integration/test_owned_storage.rs
@@ -1,0 +1,189 @@
+//! Regression tests for storages whose `get_vector_data` returns `Cow::Owned` (e.g. the
+//! disk-cache / uring backends), as opposed to the borrowed views of mmap-based storages.
+//!
+//! `EncodedVectorsU8` used to extract a raw pointer from the returned buffer and drop the
+//! buffer before dereferencing it — a use-after-free on any owning storage. These tests run
+//! the scoring and vector-access paths over an owning storage and check they agree with the
+//! borrowed baseline, so the owned code path stays exercised (and fails under Miri/ASAN if
+//! the buffer lifetime is ever mishandled again).
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+    use std::path::PathBuf;
+    use std::sync::atomic::AtomicBool;
+
+    use common::counter::hardware_counter::HardwareCounterCell;
+    use common::mmap::MmapFlusher;
+    use common::types::PointOffsetType;
+    use quantization::encoded_storage::{
+        EncodedStorage, EncodedStorageBuilder, TestEncodedStorage, TestEncodedStorageBuilder,
+    };
+    use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
+    use quantization::encoded_vectors_u8;
+    use quantization::encoded_vectors_u8::{EncodedVectorsU8, ScalarQuantizationMethod};
+    use rand::{RngExt, SeedableRng};
+
+    /// Wraps a storage so every read returns a freshly allocated `Cow::Owned` buffer.
+    struct OwnedStorage(TestEncodedStorage);
+
+    impl EncodedStorage for OwnedStorage {
+        fn get_vector_data(&self, index: PointOffsetType) -> Cow<'_, [u8]> {
+            let Self(inner) = self;
+            Cow::Owned(inner.get_vector_data(index).into_owned())
+        }
+
+        fn get_vector_data_opt(&self, index: PointOffsetType) -> Option<Cow<'_, [u8]>> {
+            let Self(inner) = self;
+            Some(Cow::Owned(inner.get_vector_data_opt(index)?.into_owned()))
+        }
+
+        fn is_in_ram_or_mmap() -> bool {
+            TestEncodedStorage::is_in_ram_or_mmap()
+        }
+
+        fn is_on_disk(&self) -> bool {
+            let Self(inner) = self;
+            inner.is_on_disk()
+        }
+
+        fn upsert_vector(
+            &mut self,
+            id: PointOffsetType,
+            vector: &[u8],
+            hw_counter: &HardwareCounterCell,
+        ) -> std::io::Result<()> {
+            let Self(inner) = self;
+            inner.upsert_vector(id, vector, hw_counter)
+        }
+
+        fn vectors_count(&self) -> usize {
+            let Self(inner) = self;
+            inner.vectors_count()
+        }
+
+        fn flusher(&self) -> MmapFlusher {
+            let Self(inner) = self;
+            inner.flusher()
+        }
+
+        fn files(&self) -> Vec<PathBuf> {
+            let Self(inner) = self;
+            inner.files()
+        }
+
+        fn immutable_files(&self) -> Vec<PathBuf> {
+            let Self(inner) = self;
+            inner.immutable_files()
+        }
+
+        fn heap_size_bytes(&self) -> usize {
+            let Self(inner) = self;
+            inner.heap_size_bytes()
+        }
+    }
+
+    struct OwnedStorageBuilder(TestEncodedStorageBuilder);
+
+    impl EncodedStorageBuilder for OwnedStorageBuilder {
+        type Storage = OwnedStorage;
+        type Error = std::io::Error;
+
+        fn build(self) -> std::io::Result<Self::Storage> {
+            let Self(inner) = self;
+            Ok(OwnedStorage(inner.build()?))
+        }
+
+        fn push_vector_data(&mut self, other: &[u8]) -> std::io::Result<()> {
+            let Self(inner) = self;
+            inner.push_vector_data(other)
+        }
+    }
+
+    #[test]
+    fn test_u8_owned_storage_matches_borrowed() {
+        let vectors_count = 65;
+        let vector_dim = 65;
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+        let vector_data: Vec<Vec<f32>> = (0..vectors_count)
+            .map(|_| (0..vector_dim).map(|_| rng.random()).collect())
+            .collect();
+        let query: Vec<f32> = (0..vector_dim).map(|_| rng.random()).collect();
+
+        let vector_parameters = VectorParameters {
+            dim: vector_dim,
+            deprecated_count: None,
+            distance_type: DistanceType::Dot,
+            invert: false,
+        };
+        let quantized_vector_size =
+            encoded_vectors_u8::get_quantized_vector_size(&vector_parameters);
+
+        let encoded_owned = EncodedVectorsU8::encode(
+            vector_data.iter(),
+            OwnedStorageBuilder(TestEncodedStorageBuilder::new(None, quantized_vector_size)),
+            &vector_parameters,
+            vectors_count,
+            None,
+            ScalarQuantizationMethod::Int8,
+            None,
+            &AtomicBool::new(false),
+        )
+        .unwrap();
+        let encoded_borrowed = EncodedVectorsU8::encode(
+            vector_data.iter(),
+            TestEncodedStorageBuilder::new(None, quantized_vector_size),
+            &vector_parameters,
+            vectors_count,
+            None,
+            ScalarQuantizationMethod::Int8,
+            None,
+            &AtomicBool::new(false),
+        )
+        .unwrap();
+
+        let counter = HardwareCounterCell::new();
+
+        // Offset + code accessor must return identical data through owning and borrowed
+        // storages, and the code must have the quantized vector size minus the offset constant.
+        let code_size = encoded_borrowed.quantized_vector_size() - size_of::<f32>();
+        for i in 0..vectors_count as PointOffsetType {
+            let (offset_owned, code_owned) = encoded_owned.get_quantized_vector_offset_and_code(i);
+            let (offset_borrowed, code_borrowed) =
+                encoded_borrowed.get_quantized_vector_offset_and_code(i);
+            assert_eq!(offset_owned, offset_borrowed);
+            assert_eq!(code_owned, code_borrowed);
+            assert_eq!(code_owned.len(), code_size);
+        }
+
+        // Internal (point-to-point) scoring reads two vectors at once from the storage.
+        for i in 0..vectors_count as PointOffsetType {
+            let j = (i + 7) % vectors_count as PointOffsetType;
+            assert_eq!(
+                encoded_owned.score_internal(i, j, &counter),
+                encoded_borrowed.score_internal(i, j, &counter),
+            );
+        }
+
+        // Queries encoded from a stored vector must score identically as well.
+        let query_owned = encoded_owned.encode_internal_vector(0).unwrap();
+        let query_borrowed = encoded_borrowed.encode_internal_vector(0).unwrap();
+        for i in 0..vectors_count as PointOffsetType {
+            assert_eq!(
+                encoded_owned.score_point(&query_owned, i, &counter),
+                encoded_borrowed.score_point(&query_borrowed, i, &counter),
+            );
+        }
+
+        // External query scoring by point id.
+        let query_u8_owned = encoded_owned.encode_query(&query);
+        let query_u8_borrowed = encoded_borrowed.encode_query(&query);
+        for i in 0..vectors_count as PointOffsetType {
+            assert_eq!(
+                encoded_owned.score_point(&query_u8_owned, i, &counter),
+                encoded_borrowed.score_point(&query_u8_borrowed, i, &counter),
+            );
+        }
+    }
+}

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -348,7 +348,7 @@ impl GpuVectorStorage {
             (0..quantized_storage.vectors_count()).map(|id| {
                 let (_, vector) =
                     quantized_storage.get_quantized_vector_offset_and_code(id as PointOffsetType);
-                Cow::Borrowed(vector)
+                vector
             }),
             Some(GpuQuantization::new_sq(device, quantized_storage)?),
             multivectors,


### PR DESCRIPTION
## What

Fixes #9799 — `EncodedVectorsU8::get_vec_ptr` extracted a raw pointer from the buffer returned by `EncodedStorage::get_vector_data` and dropped the buffer before the pointer was dereferenced. Sound for `Cow::Borrowed` (mmap) storages, a use-after-free for storages that return `Cow::Owned` (disk-cache misses, uring backends).

The issue reported `get_quantized_vector_offset_and_code` (gpu-only callers), but the same dangling pointer was dereferenced by **every** user of `get_vec_ptr`:

- the internal SIMD scorers (`score_point_{simple,sse,avx,neon}_internal`), reachable via `score_internal`
- `encode_internal_vector`, reachable via `QuantizedQueryScorer` construction from a stored point — no `gpu` feature needed
- `get_quantized_vector_offset_and_code`, which exported the dangling buffer through a safe `&[u8]`

## How

- `parse_vec_data` now returns the code as a slice **borrowing the input**, so the borrow checker forces callers to keep the storage buffer alive while reading it (`get_unchecked` keeps codegen identical to the previous pointer add). `get_vec_ptr` is removed; scoring sites bind the `Cow`s to locals — the same pattern `encoded_vectors_binary.rs` already uses. On the mmap path the `Cow`s are borrowed, so the hot path is unchanged.
- `get_quantized_vector_offset_and_code` returns `(f32, Cow<'_, [u8]>)` — a sub-slice on the borrowed path, a trimmed owned buffer otherwise — matching the sibling `get_quantized_vector`. Its one affected caller (`gpu_vector_storage/mod.rs`) now uses the returned `Cow` directly.
- The vendored copy in `lib/edge/publish` is regenerated from these sources by `amalgamate.py` at release time, so it is intentionally not touched here.

## Verification

New regression test (`test_owned_storage.rs`) drives scoring and vector access through a storage wrapper that always returns `Cow::Owned` and checks results agree with the borrowed baseline. Under Miri it reproduces the bug on the previous code:

```
error: Undefined Behavior: constructing invalid value of type &[u8]:
       encountered a dangling reference (use-after-free)
 --> lib/quantization/src/encoded_vectors_u8.rs:540:28
```

and passes with this fix. Full `cargo test -p quantization` (207 tests) passes; clippy clean.

Credit to @yashs33244 for the report and analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)