### PR TITLE
Allocate a single slot per operation in append-only mutations

### DIFF
--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -450,6 +450,27 @@ pub trait SegmentEntry: NonAppendableSegmentEntry {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<bool>;
 
+    /// Upsert a complete point in a single operation: storage-native raw
+    /// vectors (the [`ReadSegmentEntry::retrieve_raw`] form, same contract as
+    /// [`SegmentEntry::upsert_point_raw`]), decoded vectors overriding them
+    /// name-by-name, and the full payload. Named vectors present in neither
+    /// list are deleted.
+    ///
+    /// This is the copy-on-write move primitive: it is equivalent to
+    /// `upsert_point_raw` + `update_vectors` + `set_full_payload`, but writes
+    /// the point once. On append-only segments each of those steps clones the
+    /// whole point to a fresh internal id, so issuing them separately turns
+    /// one moved point into a chain of immediately-dead slots.
+    fn upsert_moved_point(
+        &mut self,
+        op_num: SeqNumberType,
+        point_id: PointIdType,
+        raw_vectors: &[(VectorNameBuf, Vec<u8>)],
+        updated_vectors: NamedVectors,
+        payload: &Payload,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<bool>;
+
     fn update_vectors(
         &mut self,
         op_num: SeqNumberType,

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::AtomicBool;
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::fs::safe_delete_with_suffix;
-use common::types::{DeferredBehavior, TelemetryDetail};
+use common::types::{DeferredBehavior, PointOffsetType, TelemetryDetail};
 use uuid::Uuid;
 
 use super::Segment;
@@ -819,6 +819,77 @@ impl SegmentEntry for Segment {
                 let new_index =
                     segment.insert_new_vectors_raw(point_id, op_num, vectors, hw_counter)?;
                 Ok((false, Some(new_index)))
+            }),
+        }
+    }
+
+    fn upsert_moved_point(
+        &mut self,
+        op_num: SeqNumberType,
+        point_id: PointIdType,
+        raw_vectors: &[(VectorNameBuf, Vec<u8>)],
+        mut updated_vectors: NamedVectors,
+        payload: &Payload,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<bool> {
+        debug_assert!(self.is_appendable());
+        for (vector_name, _) in raw_vectors {
+            check_vector_name(vector_name, &self.segment_config)?;
+        }
+        check_named_vectors(&updated_vectors, &self.segment_config)?;
+        // Raw bytes are the stored form, already preprocessed on first
+        // ingestion; only the freshly decoded overlay needs preprocessing.
+        updated_vectors.preprocess(|name| self.config().vector_data.get(name).unwrap());
+        let stored_internal_point = self
+            .id_tracker
+            .borrow()
+            .internal_id_with_behavior(point_id, DeferredBehavior::WithDeferred);
+        match stored_internal_point {
+            Some(existing_internal_id) => {
+                let append_only = self.is_append_only();
+                self.handle_point_version_and_failure(
+                    op_num,
+                    point_id,
+                    Some(existing_internal_id),
+                    |segment| {
+                        let internal_id = if append_only {
+                            // The whole point is replaced, so no snapshot of the old
+                            // slot is needed: write the parts at a fresh id and
+                            // repoint last, like `clone_and_replace_point_raw`.
+                            segment.id_tracker.borrow().total_point_count() as PointOffsetType
+                        } else {
+                            existing_internal_id
+                        };
+                        segment.write_point_parts(
+                            internal_id,
+                            op_num,
+                            raw_vectors,
+                            &updated_vectors,
+                            payload,
+                            hw_counter,
+                        )?;
+                        if append_only {
+                            segment
+                                .id_tracker
+                                .borrow_mut()
+                                .set_link(point_id, internal_id)?;
+                        }
+                        Ok((true, Some(internal_id)))
+                    },
+                )
+            }
+            None => self.handle_point_version_and_failure(op_num, point_id, None, |segment| {
+                let new_id = segment.id_tracker.borrow().total_point_count() as PointOffsetType;
+                segment.write_point_parts(
+                    new_id,
+                    op_num,
+                    raw_vectors,
+                    &updated_vectors,
+                    payload,
+                    hw_counter,
+                )?;
+                segment.id_tracker.borrow_mut().set_link(point_id, new_id)?;
+                Ok((false, Some(new_id)))
             }),
         }
     }

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -221,6 +221,52 @@ impl Segment {
         Ok(new_id)
     }
 
+    /// Write a complete point at `internal_id` in one pass: vectors from a
+    /// mix of storage-native bytes and decoded values, then the payload.
+    ///
+    /// Every configured named vector storage gets touched: a name present in
+    /// `updated_vectors` is written from its decoded value, a name present
+    /// only in `raw_vectors` is written from its bytes, and an absent name is
+    /// written as `None` (the slot is grown and marked deleted), matching
+    /// [`Segment::replace_all_vectors_raw`]'s contract. The payload is
+    /// written last — always, even when empty, for the same null-index
+    /// `total_point_count` bump reason as [`Segment::clone_and_mutate_point`].
+    ///
+    /// `internal_id` may be a fresh id one past the current end: the raw
+    /// write paths grow the storages as needed.
+    ///
+    /// # Warning
+    ///
+    /// Available for appendable segments only.
+    pub(super) fn write_point_parts(
+        &mut self,
+        internal_id: PointOffsetType,
+        op_num: SeqNumberType,
+        raw_vectors: &[(VectorNameBuf, Vec<u8>)],
+        updated_vectors: &NamedVectors,
+        payload: &Payload,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        debug_assert!(self.is_appendable());
+        for (vector_name, vector_data) in self.vector_data.iter_mut() {
+            let mut vector_index = vector_data.vector_index.borrow_mut();
+            match updated_vectors.get(vector_name) {
+                Some(vector) => {
+                    vector_index.update_vector(internal_id, Some(vector), hw_counter)?;
+                }
+                None => {
+                    let bytes = find_raw_vector(raw_vectors, vector_name);
+                    vector_index.update_vector_raw(internal_id, bytes, hw_counter)?;
+                }
+            }
+            self.version_tracker.set_vector(vector_name, Some(op_num));
+        }
+        self.payload_index
+            .borrow_mut()
+            .overwrite_payload(internal_id, payload, hw_counter)?;
+        Ok(())
+    }
+
     /// Append-only update: snapshot the point at `old_id` into owned vectors
     /// and payload, hand them to `mutate` for in-memory modification, then
     /// write the result at a fresh internal id and repoint the id tracker.

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -264,6 +264,10 @@ impl Segment {
         self.payload_index
             .borrow_mut()
             .overwrite_payload(internal_id, payload, hw_counter)?;
+        // The overwrite mutated payload storage: stamp it so partial
+        // snapshots re-upload it (the old CoW path bumped this via
+        // `set_full_payload`).
+        self.version_tracker.set_payload(Some(op_num));
         Ok(())
     }
 

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -390,7 +390,10 @@ impl Segment {
     ///   [`Segment::clone_and_mutate_point`] with `snapshot_mutate`, which
     ///   sees an owned snapshot of the point's vectors and payload and
     ///   modifies it in memory; the helper writes the result at a fresh
-    ///   internal id and tombstones the old one.
+    ///   internal id and tombstones the old one. Exception: a slot written
+    ///   by the current operation (its version equals `op_num`) is mutated
+    ///   in place — it is not durable yet, so cloning it would only chain
+    ///   dead slots for multi-step point writes.
     ///
     /// Both closures return the op-specific result bool (e.g. "was anything
     /// deleted"). The version-recording offset is chosen automatically:
@@ -412,7 +415,21 @@ impl Segment {
         InPlace: FnOnce(&mut Segment, PointOffsetType) -> OperationResult<bool>,
         SnapshotMutate: FnOnce(&mut NamedVectors<'static>, &mut Payload) -> OperationResult<bool>,
     {
-        let append_only = self.is_append_only();
+        // A slot whose version already equals `op_num` was written by the
+        // current operation (an earlier step of a multi-step point write,
+        // e.g. the upsert preceding this set_full_payload). It cannot be
+        // durable yet: the segment write lock is held across the whole
+        // operation, so no flush — and hence no read-only follower — can
+        // have observed it, and a crash discards it (versions flush last,
+        // WAL replay re-applies the whole operation). Mutating it in place
+        // is therefore invisible to readers and avoids cloning the point
+        // once per step.
+        let same_op_slot = self
+            .id_tracker
+            .borrow()
+            .internal_version(existing_internal_id)
+            .is_some_and(|slot_version| slot_version == op_num);
+        let append_only = self.is_append_only() && !same_op_slot;
         self.handle_point_version_and_failure(
             op_num,
             point_id,

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -1101,6 +1101,61 @@ fn test_upsert_moved_point_single_slot() {
     assert_eq!(dst.payload(7.into(), &hw_counter).unwrap(), payload2);
 }
 
+/// On an append-only segment, the follow-up steps of a multi-step point
+/// write (e.g. the `set_full_payload` after an `upsert_point`, sharing its
+/// `op_num`) must mutate the slot written by the same operation in place
+/// instead of cloning it: one operation allocates exactly one slot.
+#[test]
+fn test_append_only_same_op_multi_step_single_slot() {
+    use crate::id_tracker::IdTrackerRead as _;
+
+    init_logger();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let dim = 4;
+
+    let mut segment = build_simple_segment(dir.path(), dim, Distance::Dot).unwrap();
+    segment.append_only_mutations = true;
+    let hw_counter = HardwareCounterCell::new();
+
+    // New point: insert + payload at the same op_num — one slot.
+    let vec = vec![1.0_f32, 0.0, 1.0, 0.0];
+    let payload: Payload = serde_json::from_str(r#"{"color": "red"}"#).unwrap();
+    segment
+        .upsert_point(100, 7.into(), only_default_vector(&vec), &hw_counter)
+        .unwrap();
+    segment
+        .set_full_payload(100, 7.into(), &payload, &hw_counter)
+        .unwrap();
+    assert_eq!(segment.id_tracker.borrow().total_point_count(), 1);
+
+    // Update of a committed point: the first step clones to a fresh slot,
+    // the second step mutates that same-op slot in place — one new slot.
+    let vec2 = vec![0.1_f32, 0.2, 0.3, 0.4];
+    let payload2: Payload = serde_json::from_str(r#"{"color": "blue"}"#).unwrap();
+    segment
+        .upsert_point(101, 7.into(), only_default_vector(&vec2), &hw_counter)
+        .unwrap();
+    segment
+        .set_full_payload(101, 7.into(), &payload2, &hw_counter)
+        .unwrap();
+    assert_eq!(segment.id_tracker.borrow().total_point_count(), 2);
+    assert_eq!(
+        segment
+            .vector(DEFAULT_VECTOR_NAME, 7.into(), &hw_counter)
+            .unwrap(),
+        Some(VectorInternal::Dense(vec2)),
+    );
+    assert_eq!(segment.payload(7.into(), &hw_counter).unwrap(), payload2);
+
+    // A later operation still clones: committed slots are never mutated.
+    let payload3: Payload = serde_json::from_str(r#"{"color": "green"}"#).unwrap();
+    segment
+        .set_full_payload(102, 7.into(), &payload3, &hw_counter)
+        .unwrap();
+    assert_eq!(segment.id_tracker.borrow().total_point_count(), 3);
+    assert_eq!(segment.payload(7.into(), &hw_counter).unwrap(), payload3);
+}
+
 /// Multi-dense raw round-trip: the flattened inner-vector blob must survive
 /// `retrieve_raw` → `upsert_point_raw` byte-identically and decode to the
 /// original multivector.

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -1037,6 +1037,70 @@ fn test_append_only_clone_stamps_payload_version() {
     assert_eq!(plain.version_tracker.get_payload(), Some(101));
 }
 
+/// `upsert_moved_point` writes the whole point — raw bytes, decoded overlay,
+/// payload — in one operation, allocating exactly one internal slot where the
+/// separate `upsert_point_raw` + `update_vectors` + `set_full_payload` steps
+/// would clone the point once per step on an append-only segment.
+#[test]
+fn test_upsert_moved_point_single_slot() {
+    use crate::id_tracker::IdTrackerRead as _;
+
+    init_logger();
+    let src_dir = Builder::new().prefix("segment_src").tempdir().unwrap();
+    let dst_dir = Builder::new().prefix("segment_dst").tempdir().unwrap();
+    let dim = 4;
+
+    let mut src = build_simple_segment(src_dir.path(), dim, Distance::Dot).unwrap();
+    let mut dst = build_simple_segment(dst_dir.path(), dim, Distance::Dot).unwrap();
+    dst.append_only_mutations = true;
+    let hw_counter = HardwareCounterCell::new();
+
+    let raw_vec = vec![1.0_f32, 0.0, 1.0, 0.0];
+    src.upsert_point(100, 7.into(), only_default_vector(&raw_vec), &hw_counter)
+        .unwrap();
+    let bytes = retrieve_raw_vector(&src, 7.into(), DEFAULT_VECTOR_NAME);
+    let payload: Payload = serde_json::from_str(r#"{"color": "red"}"#).unwrap();
+
+    // Insert path: raw bytes only, exactly one slot.
+    dst.upsert_moved_point(
+        101,
+        7.into(),
+        &[(DEFAULT_VECTOR_NAME.to_owned(), bytes.clone())],
+        NamedVectors::default(),
+        &payload,
+        &hw_counter,
+    )
+    .unwrap();
+    assert_eq!(dst.id_tracker.borrow().total_point_count(), 1);
+    assert_eq!(
+        dst.vector(DEFAULT_VECTOR_NAME, 7.into(), &hw_counter)
+            .unwrap(),
+        Some(VectorInternal::Dense(raw_vec)),
+    );
+    assert_eq!(dst.payload(7.into(), &hw_counter).unwrap(), payload);
+
+    // Replace path with a decoded overlay shadowing the raw bytes: exactly
+    // one fresh slot (the clone), and the overlay wins over the raw bytes.
+    let new_vec = vec![0.1_f32, 0.2, 0.3, 0.4];
+    let payload2: Payload = serde_json::from_str(r#"{"color": "blue"}"#).unwrap();
+    dst.upsert_moved_point(
+        102,
+        7.into(),
+        &[(DEFAULT_VECTOR_NAME.to_owned(), bytes)],
+        only_default_vector(&new_vec),
+        &payload2,
+        &hw_counter,
+    )
+    .unwrap();
+    assert_eq!(dst.id_tracker.borrow().total_point_count(), 2);
+    assert_eq!(
+        dst.vector(DEFAULT_VECTOR_NAME, 7.into(), &hw_counter)
+            .unwrap(),
+        Some(VectorInternal::Dense(new_vec)),
+    );
+    assert_eq!(dst.payload(7.into(), &hw_counter).unwrap(), payload2);
+}
+
 /// Multi-dense raw round-trip: the flattened inner-vector blob must survive
 /// `retrieve_raw` → `upsert_point_raw` byte-identically and decode to the
 /// original multivector.

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -1078,6 +1078,9 @@ fn test_upsert_moved_point_single_slot() {
         Some(VectorInternal::Dense(raw_vec)),
     );
     assert_eq!(dst.payload(7.into(), &hw_counter).unwrap(), payload);
+    // Payload storage was mutated: its snapshot version stamp must move to
+    // this op, or partial snapshots would skip the changed payload files.
+    assert_eq!(dst.version_tracker.get_payload(), Some(101));
 
     // Replace path with a decoded overlay shadowing the raw bytes: exactly
     // one fresh slot (the clone), and the overlay wins over the raw bytes.
@@ -1099,6 +1102,7 @@ fn test_upsert_moved_point_single_slot() {
         Some(VectorInternal::Dense(new_vec)),
     );
     assert_eq!(dst.payload(7.into(), &hw_counter).unwrap(), payload2);
+    assert_eq!(dst.version_tracker.get_payload(), Some(102));
 }
 
 /// On an append-only segment, the follow-up steps of a multi-step point

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -837,6 +837,20 @@ impl SegmentEntry for ProxySegment {
         )))
     }
 
+    fn upsert_moved_point(
+        &mut self,
+        op_num: SeqNumberType,
+        point_id: PointIdType,
+        _raw_vectors: &[(VectorNameBuf, Vec<u8>)],
+        _updated_vectors: NamedVectors,
+        _payload: &Payload,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<bool> {
+        Err(OperationError::service_error(format!(
+            "Upsert is disabled for proxy segments: operation {op_num} on point {point_id}",
+        )))
+    }
+
     fn update_vectors(
         &mut self,
         op_num: SeqNumberType,

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -1102,22 +1102,17 @@ impl SegmentHolder {
                             "CoW raw move requires encoding-compatible vector configs on source and destination",
                         );
 
-                        appendable_write_segment.upsert_point_raw(
+                        // One fused write: issuing raw vectors, updated vectors and
+                        // payload as separate operations would clone the point once
+                        // per step on append-only destinations.
+                        appendable_write_segment.upsert_moved_point(
                             op_num,
                             point_id,
                             &raw_vectors,
+                            updated_vectors,
+                            &payload,
                             hw_counter,
                         )?;
-                        if !updated_vectors.is_empty() {
-                            appendable_write_segment.update_vectors(
-                                op_num,
-                                point_id,
-                                updated_vectors,
-                                hw_counter,
-                            )?;
-                        }
-                        appendable_write_segment
-                            .set_full_payload(op_num, point_id, &payload, hw_counter)?;
 
                         // Keep the source of the CoW operation as the deferred point is invisible until indexing.
                         if !appendable_write_segment.point_is_deferred(point_id) {

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -300,6 +300,73 @@ fn test_cow_operation() {
     );
 }
 
+/// A CoW move into an append-only destination must allocate exactly one
+/// internal slot: raw vectors, updated vectors and payload travel in one
+/// fused write (`upsert_moved_point`), not one clone per part.
+#[test]
+fn test_cow_move_append_only_single_slot() {
+    use segment::id_tracker::IdTrackerRead as _;
+
+    const PAYLOAD_KEY: &str = "test-value";
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut destination = empty_segment(dir.path());
+    destination.append_only_mutations = true;
+    let destination_id_tracker = destination.id_tracker.clone();
+
+    let mut source = build_segment_1(dir.path());
+    let hw_counter = HardwareCounterCell::new();
+    source
+        .upsert_point(
+            100,
+            123.into(),
+            segment::data_types::vectors::only_default_vector(&[0.0, 1.0, 2.0, 3.0]),
+            &hw_counter,
+        )
+        .unwrap();
+    source.appendable_flag = false;
+
+    let mut holder = SegmentHolder::default();
+    let dst_sid = holder.add_new(destination);
+    holder.add_new(source);
+
+    holder
+        .apply_points_with_conditional_move(
+            1010,
+            &[123.into()],
+            |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
+            |_point_id, _raw_vectors, vectors, payload| {
+                vectors.insert(
+                    DEFAULT_VECTOR_NAME.to_owned(),
+                    VectorInternal::Dense(vec![9.0; 4]),
+                );
+                payload.0.insert(PAYLOAD_KEY.to_string(), 2.into());
+            },
+            &hw_counter,
+        )
+        .unwrap();
+
+    // The moved point occupies exactly one slot in the destination, with the
+    // overlaid vector and payload.
+    assert_eq!(destination_id_tracker.borrow().total_point_count(), 1);
+    let locked_destination = holder.get(dst_sid).unwrap().get();
+    let read_destination = locked_destination.read();
+    assert_eq!(
+        read_destination
+            .vector(DEFAULT_VECTOR_NAME, 123.into(), &hw_counter)
+            .unwrap(),
+        Some(VectorInternal::Dense(vec![9.0; 4])),
+    );
+    assert_eq!(
+        read_destination
+            .payload(123.into(), &hw_counter)
+            .unwrap()
+            .get_value(&JsonPath::from_str(PAYLOAD_KEY).unwrap())[0],
+        &Value::from(2)
+    );
+}
+
 /// TurboQuant-as-datatype vectors must survive repeated CoW moves between
 /// segments without degrading.
 ///


### PR DESCRIPTION
## What

With the `append_only_mutations` feature flag, every mutation of an existing point clones the whole point to a fresh internal id. Since shard-level updates decompose one point write into several `SegmentEntry` steps, a single upsert burned one slot per step:

- **CoW move** (point living in a non-appendable segment): `upsert_point_raw` + `update_vectors` + `set_full_payload` → **3 slots**, the first holding an essentially empty point (plain upserts clear `raw_vectors` before the move).
- **In-segment update**: `upsert_point` + `set_full_payload`/`clear_payload` → **2 slots**.

Observed on a real segment: every point in an upsert batch occupied three consecutive offsets stamped with the same op_num, e.g. `insert 38 -> 0,1,2`, `insert 3 -> 3,4,5`, … — 3x id-tracker changelog growth, 3x full-point writes (all vectors + payload each time), and a chain of immediately-dead slots per upsert for the optimizer to reclaim.

## How

Two independent fixes, one commit each:

1. **Fuse the CoW move into a single destination write.** New `SegmentEntry::upsert_moved_point` writes raw vectors, the decoded overlay, and the payload in one operation, allocating exactly one slot. The CoW arm of `apply_points_with_conditional_move` now issues this single call.

2. **Mutate same-operation slots in place.** In `handle_point_mutate`, a slot whose version already equals `op_num` was written by an earlier step of the *current* operation. It cannot be durable yet: the segment write lock is held across the whole operation, so no flush — and no read-only follower — can have observed it; versions flush last, so a crash discards it and WAL replay re-applies the whole operation. Such slots are mutated in place instead of cloned, so any multi-step point write allocates exactly one slot, regardless of how many `SegmentEntry` steps it decomposes into.

Committed slots are still never mutated: an update arriving with a new op_num clones as before.

## Tests

- `test_upsert_moved_point_single_slot`: fused write allocates one slot on both insert and append-only replace paths; decoded overlay wins over raw bytes; payload lands.
- `test_cow_move_append_only_single_slot`: shard-level CoW move into an append-only destination allocates exactly one slot with overlaid vector and payload.
- `test_append_only_same_op_multi_step_single_slot`: `upsert_point` + `set_full_payload` at one op_num → one slot for a new point, one fresh slot for an update; a later op still clones.
- Existing CoW semantics tests (`test_cow_operation`, TurboQuant move/overlay/delete-name suite) and the full `segment::tests` / `shard` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)