### PR TITLE
Stamp payload storage version on append-only clone paths

### DIFF
--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -923,7 +923,12 @@ impl SegmentEntry for Segment {
                 missed_point_id: point_id,
             });
         };
-        let applied = self.handle_point_mutate(
+        // Payload-storage version stamping: the in-place arm mutates payload
+        // storage right here, so it bumps inside the closure. The clone arm
+        // is stamped by `clone_and_mutate_point` itself — bumping again after
+        // it with the same version would collapse the tracked version to
+        // `None`. Same pattern for the other payload operations below.
+        self.handle_point_mutate(
             op_num,
             point_id,
             internal_id,
@@ -934,17 +939,14 @@ impl SegmentEntry for Segment {
                     full_payload,
                     hw_counter,
                 )?;
+                segment.version_tracker.set_payload(Some(op_num));
                 Ok(true)
             },
             |_vectors, snapshot_payload| {
                 *snapshot_payload = full_payload.clone();
                 Ok(true)
             },
-        )?;
-        if applied {
-            self.version_tracker.set_payload(Some(op_num));
-        }
-        Ok(applied)
+        )
     }
 
     fn set_payload(
@@ -964,7 +966,7 @@ impl SegmentEntry for Segment {
                 missed_point_id: point_id,
             });
         };
-        let applied = self.handle_point_mutate(
+        self.handle_point_mutate(
             op_num,
             point_id,
             internal_id,
@@ -976,6 +978,7 @@ impl SegmentEntry for Segment {
                     key,
                     hw_counter,
                 )?;
+                segment.version_tracker.set_payload(Some(op_num));
                 Ok(true)
             },
             |_vectors, snapshot_payload| {
@@ -985,11 +988,7 @@ impl SegmentEntry for Segment {
                 }
                 Ok(true)
             },
-        )?;
-        if applied {
-            self.version_tracker.set_payload(Some(op_num));
-        }
-        Ok(applied)
+        )
     }
 
     fn delete_payload(
@@ -1008,7 +1007,7 @@ impl SegmentEntry for Segment {
                 missed_point_id: point_id,
             });
         };
-        let applied = self.handle_point_mutate(
+        self.handle_point_mutate(
             op_num,
             point_id,
             internal_id,
@@ -1018,17 +1017,14 @@ impl SegmentEntry for Segment {
                     .payload_index
                     .borrow_mut()
                     .delete_payload(internal_id, key, hw_counter)?;
+                segment.version_tracker.set_payload(Some(op_num));
                 Ok(true)
             },
             |_vectors, snapshot_payload| {
                 snapshot_payload.remove(key);
                 Ok(true)
             },
-        )?;
-        if applied {
-            self.version_tracker.set_payload(Some(op_num));
-        }
-        Ok(applied)
+        )
     }
 
     fn clear_payload(
@@ -1046,7 +1042,7 @@ impl SegmentEntry for Segment {
                 missed_point_id: point_id,
             });
         };
-        let applied = self.handle_point_mutate(
+        self.handle_point_mutate(
             op_num,
             point_id,
             internal_id,
@@ -1056,17 +1052,14 @@ impl SegmentEntry for Segment {
                     .payload_index
                     .borrow_mut()
                     .clear_payload(internal_id, hw_counter)?;
+                segment.version_tracker.set_payload(Some(op_num));
                 Ok(true)
             },
             |_vectors, snapshot_payload| {
                 *snapshot_payload = Payload::default();
                 Ok(true)
             },
-        )?;
-        if applied {
-            self.version_tracker.set_payload(Some(op_num));
-        }
-        Ok(applied)
+        )
     }
 }
 

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -213,6 +213,10 @@ impl Segment {
         self.payload_index
             .borrow_mut()
             .overwrite_payload(new_id, &payload, hw_counter)?;
+        // The payload content is unchanged, but writing it at `new_id` still
+        // mutates payload storage: stamp it so partial snapshots re-upload
+        // the changed files.
+        self.version_tracker.set_payload(Some(op_num));
         self.id_tracker.borrow_mut().set_link(point_id, new_id)?;
         Ok(new_id)
     }
@@ -313,6 +317,15 @@ impl Segment {
         self.payload_index
             .borrow_mut()
             .overwrite_payload(new_id, &payload, hw_counter)?;
+
+        // Writing the payload row at new_id mutated payload storage — even
+        // for a vectors-only mutation whose entry point never touches the
+        // payload version. Stamp it here so partial snapshots re-upload the
+        // changed files. The payload entry points deliberately do not bump
+        // again on this path (a same-version double bump would collapse the
+        // tracked version to `None`, degrading the stamp to the segment
+        // version): they bump inside their in-place closures instead.
+        self.version_tracker.set_payload(Some(op_num));
 
         // 6. Repoint the id tracker. `set_link` auto-tombstones old_id in
         //    the deleted bitslice when external_id was previously mapped to

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -970,6 +970,73 @@ fn test_upsert_raw_append_only_replace() {
     assert_eq!(dst.payload(7.into(), &hw_counter).unwrap(), payload);
 }
 
+/// Clone-based mutations rewrite the point's payload row at a fresh internal
+/// id, mutating payload storage even when the triggering operation is
+/// vectors-only — the snapshot version stamp must move, or partial snapshots
+/// skip the changed payload files. Payload operations must stamp exactly
+/// once: a same-version double bump collapses the tracked version to `None`.
+#[test]
+fn test_append_only_clone_stamps_payload_version() {
+    init_logger();
+    let src_dir = Builder::new().prefix("segment_src").tempdir().unwrap();
+    let dst_dir = Builder::new().prefix("segment_dst").tempdir().unwrap();
+    let dim = 4;
+
+    let mut src = build_simple_segment(src_dir.path(), dim, Distance::Dot).unwrap();
+    let mut segment = build_simple_segment(dst_dir.path(), dim, Distance::Dot).unwrap();
+    segment.append_only_mutations = true;
+    let hw_counter = HardwareCounterCell::new();
+
+    let vec = vec![1.0_f32, 0.0, 1.0, 0.0];
+    segment
+        .upsert_point(100, 7.into(), only_default_vector(&vec), &hw_counter)
+        .unwrap();
+    // A fresh insert writes no payload row.
+    assert_eq!(segment.version_tracker.get_payload(), None);
+
+    // A payload operation stamps exactly once (clone arm only, no
+    // caller-side double bump that would collapse the version to `None`).
+    let payload: Payload = serde_json::from_str(r#"{"color": "red"}"#).unwrap();
+    segment
+        .set_full_payload(101, 7.into(), &payload, &hw_counter)
+        .unwrap();
+    assert_eq!(segment.version_tracker.get_payload(), Some(101));
+
+    // A vectors-only update clones the point, rewriting its payload row at
+    // the fresh id: the stamp must follow.
+    let vec2 = vec![0.1_f32, 0.2, 0.3, 0.4];
+    segment
+        .upsert_point(102, 7.into(), only_default_vector(&vec2), &hw_counter)
+        .unwrap();
+    assert_eq!(segment.version_tracker.get_payload(), Some(102));
+
+    // Same for the raw clone path.
+    src.upsert_point(100, 7.into(), only_default_vector(&vec), &hw_counter)
+        .unwrap();
+    let bytes = retrieve_raw_vector(&src, 7.into(), DEFAULT_VECTOR_NAME);
+    segment
+        .upsert_point_raw(
+            103,
+            7.into(),
+            &[(DEFAULT_VECTOR_NAME.to_owned(), bytes)],
+            &hw_counter,
+        )
+        .unwrap();
+    assert_eq!(segment.version_tracker.get_payload(), Some(103));
+    assert_eq!(segment.payload(7.into(), &hw_counter).unwrap(), payload);
+
+    // In-place payload operations (append-only off) still stamp.
+    let plain_dir = Builder::new().prefix("segment_plain").tempdir().unwrap();
+    let mut plain = build_simple_segment(plain_dir.path(), dim, Distance::Dot).unwrap();
+    plain
+        .upsert_point(100, 7.into(), only_default_vector(&vec), &hw_counter)
+        .unwrap();
+    plain
+        .set_full_payload(101, 7.into(), &payload, &hw_counter)
+        .unwrap();
+    assert_eq!(plain.version_tracker.get_payload(), Some(101));
+}
+
 /// Multi-dense raw round-trip: the flattened inner-vector blob must survive
 /// `retrieve_raw` → `upsert_point_raw` byte-identically and decode to the
 /// original multivector.


### PR DESCRIPTION
## What

Follow-up to the review discussion on #9804 (https://github.com/qdrant/qdrant/pull/9804#discussion_r3565072562) — this half of the problem predates that PR.

With `append_only_mutations`, `clone_and_mutate_point` and `clone_and_replace_point_raw` rewrite the point's payload row at a fresh internal id. That mutates payload storage, but neither helper bumped `version_tracker`'s payload version. Payload operations (`set_full_payload` & co.) bump it at the caller, so their clones were covered — vectors-only operations (`upsert_point`, `upsert_point_raw`, `update_vectors`, `delete_vector`) never stamp payload. The segment manifest then reports a stale payload version, a partial snapshot can skip payload storage files that actually changed, and the restored id tracker points at offsets whose payload rows don't exist.

## How

Stamp where the mutation happens: both clone helpers call `version_tracker.set_payload(Some(op_num))` after `overwrite_payload`. To keep stamping exactly-once, the four payload entry points move their caller-side bump into the in-place closure — bumping again after the clone arm with the same version would collapse the tracked version to `None` (`bump()` distrusts equal versions), degrading the stamp to the segment version and defeating the partial-snapshot optimization for payload ops on append-only segments.

Coverage is unchanged for the in-place path: the closure runs exactly when the mutation is applied, same as the old `if applied` gate.

## Tests

`test_append_only_clone_stamps_payload_version`: fresh insert leaves the stamp untouched; a payload op stamps exactly once (no `None` collapse); vectors-only decoded and raw clone paths both move the stamp; in-place (non-append-only) payload ops still stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)