### PR TITLE
Fix flaky disk exhaustion in edge-test CI job

### DIFF
--- a/.github/workflows/edge-test.yml
+++ b/.github/workflows/edge-test.yml
@@ -27,6 +27,21 @@ jobs:
           }}
 
     steps:
+      # Building the examples links several large statically-linked binaries,
+      # which gets close to the runner's disk limit. Only the fast `rm -rf`
+      # based options are enabled to keep this step under a minute.
+      - name: Free disk space
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          tool-cache: false
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
       - name: Checkout Qdrant
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/lib/edge/publish/Cargo.toml
+++ b/lib/edge/publish/Cargo.toml
@@ -1,3 +1,10 @@
 [workspace]
 resolver = "3"
 members = [ "examples", "qdrant-edge" ]
+
+# This is a separate workspace, so it does not inherit profiles from the
+# repository root Cargo.toml. Without this override, every example binary
+# statically links qdrant-edge with full debug info (~700 MB per binary),
+# which runs CI runners out of disk at link time.
+[profile.dev]
+debug = "line-tables-only"


### PR DESCRIPTION
## Problem

The `Test Qdrant Edge (ubuntu-latest)` job flakes with a failure in the `🦀 Build Rust examples` step, e.g. [this run](https://github.com/qdrant/qdrant/actions/runs/29158116364/job/86558525743):

```
mold: failed to write to an output file. Disk full?
clang: error: unable to execute command: Bus error (core dumped)
```

This is genuine disk exhaustion: mold sizes the output file up front and writes through mmap, so ENOSPC surfaces as SIGBUS.

## Root cause

`lib/edge/publish` is a **separate Cargo workspace**, so it does not inherit the root workspace's `[profile.dev] debug = "line-tables-only"` override and builds with full debug info instead. Each of the 8 example binaries statically links the whole amalgamated `qdrant-edge` stack at ~700 MB per binary (plus a ~1.1 GB `libqdrant_edge.rlib`) — roughly 6 GB of link outputs on top of deps, the restored build cache, and toolchains. Cargo links several examples concurrently, so mold reserves multiple such output files at the same moment, which makes the peak spiky and the failure flaky rather than deterministic.

## Fix

- Mirror `[profile.dev] debug = "line-tables-only"` in the publish workspace. This cuts the link outputs by several GB while keeping file:line backtraces. Profiles are ignored when the crate is consumed as a dependency, so this doesn't affect published-crate users, and `amalgamate.py` doesn't touch this file, so the `git diff --exit-code` check stays clean.
- Add a Linux-only `free-disk-space` step (same pinned action already used by `nightly-model-testing.yml`), with only the fast `rm -rf`-based options enabled (android/dotnet/haskell, ~20 GB freed in under a minute) as headroom insurance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)