### PR TITLE
Bump client timeout in flaky snapshots-consensus e2e test

### DIFF
--- a/tests/e2e_tests/test_bugs.py
+++ b/tests/e2e_tests/test_bugs.py
@@ -9,7 +9,11 @@ class TestSnapshotsInterferenceWithConsensus:
     ], indirect=True)
     def test_snapshot_does_not_block_other_operations(self, qdrant_compose):
         """Test that creating snapshots does not block other operations - https://github.com/qdrant/qdrant/issues/7489."""
-        client = ClientUtils(host=qdrant_compose[0].host, port=qdrant_compose[0].http_port, timeout=10)
+        # Generous client-side timeout: setup operations can exceed 10s on loaded CI
+        # runners (e.g. a leader election triggered mid-create_collection). The actual
+        # regression check below relies on the server-side `timeout=5` passed to
+        # delete_collection, so it is not weakened by this.
+        client = ClientUtils(host=qdrant_compose[0].host, port=qdrant_compose[0].http_port, timeout=30)
         client.wait_for_server()
         assert client.wait_for_cluster_ready(expected_peers=3), "Cluster did not become ready within timeout"
 


### PR DESCRIPTION
## Problem

`TestSnapshotsInterferenceWithConsensus::test_snapshot_does_not_block_other_operations` flakes with a client-side `ReadTimeout` on the initial `create_collection` — i.e. in test **setup**, before any snapshots are taken. Example: [this run](https://github.com/qdrant/qdrant/actions/runs/29184532897/job/86628130182). Previous attempts to deflake it: #9012, #9102.

## Root cause

Cluster logs from the failing run (`e2e-test-logs` artifact) show:

1. `07:42:49.2` — `CreateCollection` commits at term 1; the client's 10s read-timeout clock starts.
2. `07:42:49.9–07:42:54.9` — the leader spends ~5s creating its local shard on a loaded runner (the e2e job runs 4 xdist workers, each with its own compose cluster). Followers receive no heartbeats for the whole window.
3. `07:42:55–07:42:56.6` — followers hit their election timeout; two elections later `qdrant_2` is leader at term 3.
4. `07:42:59.5` — the last shard becomes `Active`, ~10.3s after the request — just past the 10s client timeout.

Applying a slow `CreateCollection` stalls the consensus loop long enough to trigger a spurious leader election, and the election delays the operation past the timeout — a sibling of the very issue (#7489) this test guards against.

## Fix

Bump the `ClientUtils` client-side timeout from 10s to 30s so setup survives runner-load hiccups. The actual regression assertion is **not weakened**: `delete_collection("small", timeout=5)` passes a server-side operation-commit timeout, which is independent of the client read timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)