### PR TITLE
Add optional block-index sidecar to accelerate on-disk binary searches

### DIFF
--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -9,6 +9,7 @@ mod local_file_ops;
 mod mmap;
 mod oneshot;
 mod simple_disk_cache;
+mod sorted_block_index;
 mod traits;
 mod types;
 mod wrappers;
@@ -22,6 +23,7 @@ pub use self::oneshot::OneshotFile;
 pub use self::simple_disk_cache::{
     DiskCache, DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, DiskCacheRemote,
 };
+pub use self::sorted_block_index::SortedBlockIndex;
 pub use self::traits::{
     CachedReadFs, Item, OpenExtra, OwnedPipeline, ReadPipeline, UniversalRead,
     UniversalReadFileOps, UniversalReadFs, UniversalWrite, UniversalWriteFileOps, UserData,

--- a/lib/common/common/src/universal_io/sorted_block_index.rs
+++ b/lib/common/common/src/universal_io/sorted_block_index.rs
@@ -1,0 +1,359 @@
+use std::cmp::Ordering;
+use std::ops::Range;
+use std::path::Path;
+
+use super::traits::UniversalReadFs;
+use super::types::read_whole_via;
+use super::{OkNotFound, Result};
+
+/// Target size of one logical block of the indexed array, in bytes.
+///
+/// Chosen to match the `DiskCache` block size and the auto-chunking read size
+/// ([`ReadRange::iter_autochunks`]), so locating an element costs one cache
+/// block / one remote range read.
+///
+/// [`ReadRange::iter_autochunks`]: super::ReadRange::iter_autochunks
+pub const BLOCK_SIZE_BYTES: usize = 16 * 1024;
+
+const MAGIC: [u8; 8] = *b"QdrntSBI";
+const FORMAT_VERSION: u32 = 1;
+const HEADER_SIZE: usize = 32;
+
+/// In-RAM sparse index over an on-disk sorted array: the first element of
+/// every [`BLOCK_SIZE_BYTES`]-sized block of the array.
+///
+/// Binary search directly over an unpopulated storage costs `O(log n)` random
+/// reads scattered across the whole file — each probe is a page fault (or a
+/// remote range read) on high-latency storage. With this index, a lookup is an
+/// in-RAM search over the block firsts plus a single contiguous read of one
+/// block, which the caller then bisects in RAM.
+///
+/// The index is persisted as an *optional* sidecar file next to the main
+/// array:
+/// - old files without a sidecar keep working — [`Self::open`] returns
+///   `Ok(None)` and callers fall back to plain binary search over the storage;
+/// - old code ignores the sidecar file, so data written by new code stays
+///   readable;
+/// - any validation failure (unknown version, wrong element size, size
+///   mismatch) is treated as "no sidecar", never as a hard error: the main
+///   array remains the source of truth and losing the sidecar only loses the
+///   acceleration.
+///
+/// File layout (header fields little-endian, elements native-endian, exactly
+/// as they are encoded in the main array):
+///
+/// ```text
+/// offset  size  field
+///      0     8  magic b"QdrntSBI"
+///      8     4  format version (u32)
+///     12     4  element size in bytes (u32)
+///     16     4  elements per block (u32)
+///     20     4  reserved, zero
+///     24     8  number of elements in the indexed array (u64)
+///     32     -  first element of each block, `element size` bytes each
+/// ```
+pub struct SortedBlockIndex<T> {
+    /// First element of every `block_entries`-sized block of the main array.
+    firsts: Vec<T>,
+    /// Number of array elements covered by one entry of `firsts`.
+    block_entries: usize,
+    /// Length of the indexed array.
+    total_len: usize,
+}
+
+impl<T: bytemuck::Pod> SortedBlockIndex<T> {
+    /// Number of `T` elements per block when building a new index.
+    ///
+    /// Readers must use the value recorded in the file header instead, so the
+    /// constant can change without breaking existing files.
+    fn default_block_entries() -> usize {
+        (BLOCK_SIZE_BYTES / size_of::<T>()).max(1)
+    }
+
+    /// Write a block index for `sorted` to `path`.
+    ///
+    /// `sorted` must be exactly the array served by the main storage, in the
+    /// same order.
+    pub fn write(path: &Path, sorted: &[T]) -> std::io::Result<()> {
+        let block_entries = Self::default_block_entries();
+        let firsts_count = sorted.len().div_ceil(block_entries);
+
+        let mut bytes = Vec::with_capacity(HEADER_SIZE + firsts_count * size_of::<T>());
+        bytes.extend_from_slice(&MAGIC);
+        bytes.extend_from_slice(&FORMAT_VERSION.to_le_bytes());
+        bytes.extend_from_slice(&(size_of::<T>() as u32).to_le_bytes());
+        bytes.extend_from_slice(&(block_entries as u32).to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&(sorted.len() as u64).to_le_bytes());
+        debug_assert_eq!(bytes.len(), HEADER_SIZE);
+        for first in sorted.iter().step_by(block_entries) {
+            bytes.extend_from_slice(bytemuck::bytes_of(first));
+        }
+
+        fs_err::write(path, bytes)
+    }
+
+    /// Read the whole block index at `path` into RAM.
+    ///
+    /// `expected_len` is the element count of the main array the index must
+    /// cover; a mismatch means a stale sidecar which must not be trusted to
+    /// locate elements.
+    ///
+    /// Returns `Ok(None)` when the file is absent or fails validation; the
+    /// caller is expected to fall back to plain binary search over the main
+    /// storage.
+    pub fn open<Fs: UniversalReadFs>(
+        fs: &Fs,
+        path: &Path,
+        expected_len: usize,
+    ) -> Result<Option<Self>> {
+        let parsed =
+            read_whole_via(fs, path, |bytes| Ok(Self::parse(&bytes, path))).ok_not_found()?;
+        let Some(index) = parsed.flatten() else {
+            return Ok(None);
+        };
+        if index.total_len != expected_len {
+            log::warn!(
+                "Ignoring block index {path}: it covers {} elements while the indexed array has \
+                 {expected_len}, falling back to plain binary search",
+                index.total_len,
+                path = path.display(),
+            );
+            return Ok(None);
+        }
+        Ok(Some(index))
+    }
+
+    fn parse(bytes: &[u8], path: &Path) -> Option<Self> {
+        let warn = |reason: &str| {
+            log::warn!(
+                "Ignoring block index {path}: {reason}, falling back to plain binary search",
+                path = path.display(),
+            );
+        };
+
+        let Some(header) = bytes.get(..HEADER_SIZE) else {
+            warn("file is too short");
+            return None;
+        };
+        if header[0..8] != MAGIC {
+            warn("wrong magic");
+            return None;
+        }
+        let version = u32::from_le_bytes(header[8..12].try_into().unwrap());
+        if version != FORMAT_VERSION {
+            warn("unsupported format version");
+            return None;
+        }
+        let entry_size = u32::from_le_bytes(header[12..16].try_into().unwrap());
+        if entry_size as usize != size_of::<T>() {
+            warn("element size mismatch");
+            return None;
+        }
+        let block_entries = u32::from_le_bytes(header[16..20].try_into().unwrap());
+        if block_entries == 0 {
+            warn("zero elements per block");
+            return None;
+        }
+        let total_len = u64::from_le_bytes(header[24..32].try_into().unwrap());
+        let firsts_count = total_len.div_ceil(u64::from(block_entries));
+        let firsts_bytes = &bytes[HEADER_SIZE..];
+        if firsts_bytes.len() as u64 != firsts_count * u64::from(entry_size) {
+            warn("element count does not match file size");
+            return None;
+        }
+
+        Some(Self {
+            firsts: bytemuck::pod_collect_to_vec(firsts_bytes),
+            block_entries: block_entries as usize,
+            total_len: total_len as usize,
+        })
+    }
+
+    /// Element index range of the single block that may contain the target.
+    ///
+    /// `cmp` compares a stored element against the target (like the closure of
+    /// [`slice::binary_search_by`]). Both an exact match and the insertion
+    /// position of a missing target are guaranteed to lie within the returned
+    /// range, so bisecting only this range gives the same result as bisecting
+    /// the whole array. Requires a strict order: no two array elements may
+    /// compare `Equal` under `cmp`, otherwise matches in earlier blocks are
+    /// missed.
+    pub fn find_block(&self, cmp: impl Fn(&T) -> Ordering) -> Range<usize> {
+        let total_len = self.total_len;
+        // First block whose first element is > target, minus one: the target —
+        // or its insertion position — can only be in that block. Insertion
+        // positions may also fall on the block-end boundary, which is covered
+        // because `end` here is exclusive while `binary_search` may return it
+        // as `Err(end)`.
+        let block = self
+            .firsts
+            .partition_point(|first| cmp(first).is_le())
+            .saturating_sub(1);
+        let start = (block * self.block_entries).min(total_len);
+        let end = (start + self.block_entries).min(total_len);
+        start..end
+    }
+
+    pub fn ram_usage_bytes(&self) -> usize {
+        let Self {
+            firsts,
+            block_entries: _,
+            total_len: _,
+        } = self;
+        size_of::<Self>() + firsts.capacity() * size_of::<T>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::MmapFs;
+    use super::*;
+
+    /// 16-byte Pod element, 1024 per block.
+    #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+    #[repr(C)]
+    struct Pair {
+        val: u64,
+        idx: u64,
+    }
+
+    fn pairs(count: usize) -> Vec<Pair> {
+        // Even values only, so odd targets test insertion positions.
+        (0..count)
+            .map(|i| Pair {
+                val: 2 * i as u64,
+                idx: i as u64,
+            })
+            .collect()
+    }
+
+    fn build_and_open(data: &[Pair]) -> SortedBlockIndex<Pair> {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("block_index.bin");
+        SortedBlockIndex::write(&path, data).unwrap();
+
+        // A stale index (wrong array length) must be rejected.
+        assert!(
+            SortedBlockIndex::<Pair>::open(&MmapFs, &path, data.len() + 1)
+                .unwrap()
+                .is_none()
+        );
+
+        SortedBlockIndex::open(&MmapFs, &path, data.len())
+            .unwrap()
+            .unwrap()
+    }
+
+    /// For every target, bisecting only `find_block`'s range must equal
+    /// bisecting the whole array.
+    fn assert_equivalent(index: &SortedBlockIndex<Pair>, data: &[Pair], target: u64) {
+        let range = index.find_block(|pair| pair.val.cmp(&target));
+        let expected = data.binary_search_by(|pair| pair.val.cmp(&target));
+        let actual = data[range.clone()]
+            .binary_search_by(|pair| pair.val.cmp(&target))
+            .map(|i| i + range.start)
+            .map_err(|i| i + range.start);
+        assert_eq!(actual, expected, "target {target}, range {range:?}");
+    }
+
+    #[test]
+    fn test_roundtrip_multiple_blocks() {
+        // 2.5 blocks of 1024 entries.
+        let data = pairs(2560);
+        let index = build_and_open(&data);
+
+        assert_eq!(index.firsts.len(), 3);
+
+        for target in 0..=(2 * data.len() as u64 + 1) {
+            assert_equivalent(&index, &data, target);
+        }
+    }
+
+    #[test]
+    fn test_single_partial_block() {
+        let data = pairs(7);
+        let index = build_and_open(&data);
+        for target in 0..16 {
+            assert_equivalent(&index, &data, target);
+        }
+    }
+
+    #[test]
+    fn test_empty() {
+        let data = pairs(0);
+        let index = build_and_open(&data);
+        assert_eq!(index.find_block(|pair| pair.val.cmp(&42)), 0..0);
+    }
+
+    #[test]
+    fn test_absent_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing.bin");
+        assert!(
+            SortedBlockIndex::<Pair>::open(&MmapFs, &path, 100)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_invalid_files_are_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("block_index.bin");
+        let data = pairs(100);
+        SortedBlockIndex::write(&path, &data).unwrap();
+        let valid = fs_err::read(&path).unwrap();
+
+        // Too short
+        fs_err::write(&path, &valid[..HEADER_SIZE - 1]).unwrap();
+        assert!(
+            SortedBlockIndex::<Pair>::open(&MmapFs, &path, 100)
+                .unwrap()
+                .is_none()
+        );
+
+        // Wrong magic
+        let mut corrupted = valid.clone();
+        corrupted[0] ^= 0xff;
+        fs_err::write(&path, &corrupted).unwrap();
+        assert!(
+            SortedBlockIndex::<Pair>::open(&MmapFs, &path, 100)
+                .unwrap()
+                .is_none()
+        );
+
+        // Unknown (future) version
+        let mut corrupted = valid.clone();
+        corrupted[8..12].copy_from_slice(&(FORMAT_VERSION + 1).to_le_bytes());
+        fs_err::write(&path, &corrupted).unwrap();
+        assert!(
+            SortedBlockIndex::<Pair>::open(&MmapFs, &path, 100)
+                .unwrap()
+                .is_none()
+        );
+
+        // Element size of a different type
+        assert!(
+            SortedBlockIndex::<u64>::open(&MmapFs, &path, 100)
+                .unwrap()
+                .is_none()
+        );
+
+        // Truncated firsts section
+        fs_err::write(&path, &valid[..valid.len() - 1]).unwrap();
+        assert!(
+            SortedBlockIndex::<Pair>::open(&MmapFs, &path, 100)
+                .unwrap()
+                .is_none()
+        );
+
+        // Intact file still opens
+        fs_err::write(&path, &valid).unwrap();
+        assert!(
+            SortedBlockIndex::<Pair>::open(&MmapFs, &path, 100)
+                .unwrap()
+                .is_some()
+        );
+    }
+}

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
@@ -14,16 +14,16 @@ use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFile, MmapFs, OkNotFound, OpenOptions, Populate, ReadRange, TypedStorage,
-    UniversalRead, UniversalReadFs, read_json_via,
+    CachedReadFs, MmapFile, MmapFs, OkNotFound, OpenOptions, Populate, ReadRange, SortedBlockIndex,
+    TypedStorage, UniversalRead, UniversalReadFs, read_json_via,
 };
 use fs_err as fs;
 use memmap2::MmapMut;
 
 use super::super::mutable_geo_index::InMemoryGeoIndex;
 use super::{
-    COUNTS_PER_HASH, Counts, DELETED_PATH, OnDiskGeoIndex, POINTS_MAP, POINTS_MAP_IDS,
-    PointKeyValue, STATS_PATH, Storage, StoredGeoIndexStat,
+    COUNTS_PER_HASH, COUNTS_PER_HASH_BLOCK_INDEX, Counts, DELETED_PATH, OnDiskGeoIndex, POINTS_MAP,
+    POINTS_MAP_BLOCK_INDEX, POINTS_MAP_IDS, PointKeyValue, STATS_PATH, Storage, StoredGeoIndexStat,
 };
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -90,6 +90,8 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
                 );
                 ids_offset += ids.len();
             }
+
+            SortedBlockIndex::write(&path.join(POINTS_MAP_BLOCK_INDEX), &points_map)?;
         }
 
         {
@@ -114,6 +116,8 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
                     dst.values = *values as u32;
                 }
             }
+
+            SortedBlockIndex::write(&path.join(COUNTS_PER_HASH_BLOCK_INDEX), &counts_per_hash)?;
         }
 
         {
@@ -195,6 +199,15 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         fs.schedule_prefetch(&path.join(POINTS_MAP), Some(options), None)?;
         fs.schedule_prefetch(&path.join(POINTS_MAP_IDS), Some(options), None)?;
 
+        // Block indexes over the two sorted arrays; optional, absent on old
+        // segments
+        let _ = fs
+            .schedule_prefetch(&path.join(COUNTS_PER_HASH_BLOCK_INDEX), None, None)
+            .ok_not_found()?;
+        let _ = fs
+            .schedule_prefetch(&path.join(POINTS_MAP_BLOCK_INDEX), None, None)
+            .ok_not_found()?;
+
         // Point to values
         OnDiskPointToValues::<GeoPoint, S>::preopen(fs, path, populate)?;
 
@@ -230,8 +243,18 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
 
         let counts_per_hash =
             TypedStorage::new(fs.open(&counts_per_hash_path, open_options, Default::default())?);
+        let counts_per_hash_block_index = SortedBlockIndex::open(
+            fs,
+            &path.join(COUNTS_PER_HASH_BLOCK_INDEX),
+            counts_per_hash.len()? as usize,
+        )?;
         let points_map =
             TypedStorage::new(fs.open(&points_map_path, open_options, Default::default())?);
+        let points_map_block_index = SortedBlockIndex::open(
+            fs,
+            &path.join(POINTS_MAP_BLOCK_INDEX),
+            points_map.len()? as usize,
+        )?;
         let points_map_ids =
             TypedStorage::new(fs.open(&points_map_ids_path, open_options, Default::default())?);
         let point_to_values = OnDiskPointToValues::open(fs, path, populate)?;
@@ -258,7 +281,9 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
             path: path.to_owned(),
             storage: Storage {
                 counts_per_hash,
+                counts_per_hash_block_index,
                 points_map,
+                points_map_block_index,
                 points_map_ids,
                 point_to_values,
                 deleted: DeletedBitVec::new(deleted),
@@ -354,6 +379,26 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         let hw_counter = ConditionedCounter::always(hw_counter);
         let len = self.storage.counts_per_hash.len()? as usize;
 
+        if let Some(block_index) = &self.storage.counts_per_hash_block_index {
+            let block = block_index.find_block(|counts| counts.hash.normalize().cmp(&hash));
+            if block.is_empty() {
+                return Ok(None);
+            }
+
+            hw_counter
+                .payload_index_io_read_counter()
+                .incr_delta(block.len() * size_of::<Counts>());
+
+            let counts = self.storage.counts_per_hash.read::<Random>(ReadRange {
+                byte_offset: (block.start * size_of::<Counts>()) as u64,
+                length: block.len() as u64,
+            })?;
+            return Ok(counts
+                .binary_search_by(|counts| counts.hash.normalize().cmp(&hash))
+                .ok()
+                .map(|idx| counts[idx]));
+        }
+
         hw_counter
             .payload_index_io_read_counter()
             // Simulate binary search complexity as IO read estimation
@@ -396,6 +441,7 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
             self.path.join(POINTS_MAP_IDS),
             self.path.join(STATS_PATH),
         ];
+        files.extend(self.block_index_files());
         files.extend(self.storage.point_to_values.files());
         files
     }
@@ -408,7 +454,20 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
             self.path.join(POINTS_MAP_IDS),
             self.path.join(STATS_PATH),
         ];
+        files.extend(self.block_index_files());
         files.extend(self.storage.point_to_values.immutable_files());
+        files
+    }
+
+    /// Paths of the optional block-index sidecar files which are present.
+    fn block_index_files(&self) -> Vec<PathBuf> {
+        let mut files = Vec::new();
+        if self.storage.counts_per_hash_block_index.is_some() {
+            files.push(self.path.join(COUNTS_PER_HASH_BLOCK_INDEX));
+        }
+        if self.storage.points_map_block_index.is_some() {
+            files.push(self.path.join(POINTS_MAP_BLOCK_INDEX));
+        }
         files
     }
 
@@ -463,13 +522,27 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         // │ entries < smallest_hash       │ m = matching      │ past end    │
         // └───────────────────────────────┴───────────────────┴─────────────┘
 
-        // Step 1: binary search to find the index of the `start` entry.
-        let start_idx = binary_search_by(0..len, |idx| {
-            let range = ReadRange::one(idx * size_of::<PointKeyValue>() as u64);
-            let value = self.storage.points_map.read::<Random>(range)?;
-            OperationResult::Ok(value[0].hash.normalize().cmp(&smallest_hash))
-        })?
-        .unwrap_or_else(|index| index);
+        // Step 1: binary search to find the index of the `start` entry. With a
+        // block index available, this costs a single contiguous read of one
+        // block instead of `O(log n)` random reads.
+        let start_idx = if let Some(block_index) = &self.storage.points_map_block_index {
+            let block = block_index.find_block(|entry| entry.hash.normalize().cmp(&smallest_hash));
+            let entries = self.storage.points_map.read::<Random>(ReadRange {
+                byte_offset: (block.start * size_of::<PointKeyValue>()) as u64,
+                length: block.len() as u64,
+            })?;
+            let idx = entries
+                .binary_search_by(|entry| entry.hash.normalize().cmp(&smallest_hash))
+                .unwrap_or_else(|idx| idx);
+            (block.start + idx) as u64
+        } else {
+            binary_search_by(0..len, |idx| {
+                let range = ReadRange::one(idx * size_of::<PointKeyValue>() as u64);
+                let value = self.storage.points_map.read::<Random>(range)?;
+                OperationResult::Ok(value[0].hash.normalize().cmp(&smallest_hash))
+            })?
+            .unwrap_or_else(|index| index)
+        };
 
         // Step 2: read entries in chunks starting from `start`. Chunks may
         // arrive out of order from the underlying IO, so we reorder them with
@@ -571,14 +644,22 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         } = self;
         let Storage {
             counts_per_hash,
+            counts_per_hash_block_index,
             points_map,
+            points_map_block_index,
             points_map_ids,
             point_to_values,
             deleted: _,
         } = storage;
         clear_disk_cache(&path.join(DELETED_PATH))?;
         counts_per_hash.clear_ram_cache()?;
+        if counts_per_hash_block_index.is_some() {
+            clear_disk_cache(&path.join(COUNTS_PER_HASH_BLOCK_INDEX))?;
+        }
         points_map.clear_ram_cache()?;
+        if points_map_block_index.is_some() {
+            clear_disk_cache(&path.join(POINTS_MAP_BLOCK_INDEX))?;
+        }
         points_map_ids.clear_ram_cache()?;
         point_to_values.clear_cache()?;
         Ok(())

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/mod.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use common::bitvec::DeletedBitVec;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, TypedStorage, UniversalRead};
+use common::universal_io::{MmapFile, SortedBlockIndex, TypedStorage, UniversalRead};
 use serde::{Deserialize, Serialize};
 
 use crate::index::field_index::geo_hash::GeoHashRaw;
@@ -15,7 +15,9 @@ mod read_ops;
 
 pub(super) const DELETED_PATH: &str = "deleted.bin";
 pub(super) const COUNTS_PER_HASH: &str = "counts_per_hash.bin";
+pub(super) const COUNTS_PER_HASH_BLOCK_INDEX: &str = "counts_per_hash_block_index.bin";
 pub(super) const POINTS_MAP: &str = "points_map.bin";
+pub(super) const POINTS_MAP_BLOCK_INDEX: &str = "points_map_block_index.bin";
 pub(super) const POINTS_MAP_IDS: &str = "points_map_ids.bin";
 pub(super) const STATS_PATH: &str = "mmap_field_index_stats.json";
 
@@ -72,9 +74,16 @@ pub(in super::super) struct Storage<S: UniversalRead = MmapFile> {
     /// Stores GeoHash, points count and values count.
     /// Sorted by geohash, so we binary search the region.
     pub(in super::super) counts_per_hash: TypedStorage<S, Counts>,
+    /// Optional in-RAM block index over `counts_per_hash`: locating an entry
+    /// costs one block read instead of `O(log n)` random reads. Absent on
+    /// segments built before the sidecar file was introduced.
+    pub(in super::super) counts_per_hash_block_index: Option<SortedBlockIndex<Counts>>,
     /// Stores GeoHash and associated range of offsets in the points_map_ids.
     /// Sorted by geohash, so we binary search the region.
     pub(in super::super) points_map: TypedStorage<S, PointKeyValue>,
+    /// Optional in-RAM block index over `points_map`; see
+    /// `counts_per_hash_block_index`.
+    pub(in super::super) points_map_block_index: Option<SortedBlockIndex<PointKeyValue>>,
     /// A storage of associations between geo-hashes and point ids. (See the diagram above)
     pub(in super::super) points_map_ids: TypedStorage<S, PointOffsetType>,
     /// One-to-many mapping of the PointOffsetType to the GeoPoint.
@@ -89,14 +98,22 @@ impl<S: UniversalRead> Storage<S> {
     pub(crate) fn ram_usage_bytes(&self) -> usize {
         let Self {
             counts_per_hash,
+            counts_per_hash_block_index,
             points_map,
+            points_map_block_index,
             points_map_ids,
             point_to_values,
             deleted,
         } = self;
 
         counts_per_hash.ram_usage_bytes()
+            + counts_per_hash_block_index
+                .as_ref()
+                .map_or(0, |index| index.ram_usage_bytes())
             + points_map.ram_usage_bytes()
+            + points_map_block_index
+                .as_ref()
+                .map_or(0, |index| index.ram_usage_bytes())
             + points_map_ids.ram_usage_bytes()
             + point_to_values.ram_usage_bytes()
             + deleted.ram_usage_bytes()

--- a/lib/segment/src/index/field_index/geo_index/tests.rs
+++ b/lib/segment/src/index/field_index/geo_index/tests.rs
@@ -1182,3 +1182,88 @@ fn test_geo_index_reload_short_deleted_bitslice(#[case] index_type: IndexType) {
     let hits = filtered_points(&new_index, &field_condition);
     assert_eq!(hits, vec![2, 4]);
 }
+
+/// The optional block-index sidecars over `counts_per_hash` and `points_map`
+/// must be pure accelerators: cardinality estimates and filter results must
+/// be identical with the sidecars present and after deleting them (which
+/// falls back to plain binary search over the storage).
+#[test]
+fn test_block_index_fallback_equivalence() {
+    fn collect_results(
+        index: &GeoIndex,
+        conditions: &[FieldCondition],
+    ) -> Vec<(usize, usize, usize, Vec<PointOffsetType>)> {
+        let hw_counter = HardwareCounterCell::new();
+        conditions
+            .iter()
+            .map(|condition| {
+                let estimation = index
+                    .estimate_cardinality(condition, &hw_counter)
+                    .unwrap()
+                    .unwrap();
+                let points = filtered_points(index, condition);
+                (estimation.min, estimation.exp, estimation.max, points)
+            })
+            .collect()
+    }
+
+    let (index, temp_dir, _db) = build_random_index(2000, 5, IndexType::OnDisk);
+    drop(index);
+
+    let counts_sidecar = temp_dir
+        .path()
+        .join(super::on_disk_geo_index::COUNTS_PER_HASH_BLOCK_INDEX);
+    let points_map_sidecar = temp_dir
+        .path()
+        .join(super::on_disk_geo_index::POINTS_MAP_BLOCK_INDEX);
+    assert!(counts_sidecar.exists());
+    assert!(points_map_sidecar.exists());
+
+    // Radius queries around random centers (the payload fixture spreads
+    // points across the whole globe) plus the named cities, with radii from
+    // tight to continent-scale.
+    let mut rnd = StdRng::seed_from_u64(7);
+    let mut conditions = Vec::new();
+    for i in 0..50 {
+        let center = GeoPoint::new_unchecked(
+            rand::RngExt::random_range(&mut rnd, LON_RANGE),
+            rand::RngExt::random_range(&mut rnd, LAT_RANGE),
+        );
+        let radius_meters = 1_000.0 * 10_f64.powi(i % 4);
+        conditions.push(condition_for_geo_radius(
+            "test",
+            GeoRadius {
+                center,
+                radius: OrderedFloat(radius_meters),
+            },
+        ));
+    }
+    for city in [NYC, BERLIN, POTSDAM, TOKYO, LOS_ANGELES] {
+        conditions.push(condition_for_geo_radius(
+            "test",
+            GeoRadius {
+                center: city,
+                radius: OrderedFloat(500_000.0),
+            },
+        ));
+    }
+
+    let deleted = empty_deleted();
+
+    let with_block_index = reload_index(IndexType::OnDisk, &temp_dir, &deleted);
+    let with_results = collect_results(&with_block_index, &conditions);
+    drop(with_block_index);
+
+    fs_err::remove_file(&counts_sidecar).unwrap();
+    fs_err::remove_file(&points_map_sidecar).unwrap();
+    let without_block_index = reload_index(IndexType::OnDisk, &temp_dir, &deleted);
+    let without_results = collect_results(&without_block_index, &conditions);
+
+    assert_eq!(with_results, without_results);
+    // Sanity: the query mix actually matches points.
+    assert!(
+        with_results
+            .iter()
+            .any(|(_, _, _, points)| !points.is_empty())
+    );
+}

--- a/lib/segment/src/index/field_index/geo_index/tests.rs
+++ b/lib/segment/src/index/field_index/geo_index/tests.rs
@@ -1267,3 +1267,71 @@ fn test_block_index_fallback_equivalence() {
             .any(|(_, _, _, points)| !points.is_empty())
     );
 }
+
+/// The block-index sidecars must be covered by `preopen`: after
+/// `schedule_prefetch`, `open` must be served from the prefetch pool without
+/// touching the filesystem again. Conversely, absent sidecars (old segment)
+/// must not fail `preopen` and must open in fallback mode.
+#[test]
+fn test_block_index_preopen() {
+    use common::universal_io::{
+        CachedFs, CachedReadFs as _, Populate, ReadOnly, UniversalRead, UniversalReadFileOps as _,
+    };
+
+    type Storage = ReadOnly<MmapFile>;
+    type RoFs = <Storage as UniversalRead>::Fs;
+
+    let (index, temp_dir, _db) = build_random_index(2000, 5, IndexType::OnDisk);
+    drop(index);
+    let counts_sidecar = temp_dir
+        .path()
+        .join(super::on_disk_geo_index::COUNTS_PER_HASH_BLOCK_INDEX);
+    let points_map_sidecar = temp_dir
+        .path()
+        .join(super::on_disk_geo_index::POINTS_MAP_BLOCK_INDEX);
+    let deleted = empty_deleted();
+
+    // Same order as the segment open path: snapshot, then preopen, then open.
+    let fs = RoFs::from_context(Default::default()).unwrap();
+    let mut cached_fs = CachedFs::new(fs.clone(), temp_dir.path()).unwrap();
+    cached_fs.cache_file_info().unwrap();
+    assert!(
+        OnDiskGeoIndex::<Storage>::preopen(&cached_fs, temp_dir.path(), Populate::PreferBackground)
+            .unwrap()
+    );
+
+    // The sidecar reads of `open` must now come from the prefetch pool.
+    fs_err::remove_file(&counts_sidecar).unwrap();
+    fs_err::remove_file(&points_map_sidecar).unwrap();
+
+    let index = OnDiskGeoIndex::<Storage>::open(
+        &cached_fs,
+        temp_dir.path(),
+        Populate::PreferBackground,
+        &deleted,
+    )
+    .unwrap()
+    .unwrap();
+    assert!(index.storage.counts_per_hash_block_index.is_some());
+    assert!(index.storage.points_map_block_index.is_some());
+    drop(index);
+
+    // Absent sidecars (segment built before they were introduced): `preopen`
+    // must not fail on the missing files and `open` must fall back.
+    let mut cached_fs = CachedFs::new(fs, temp_dir.path()).unwrap();
+    cached_fs.cache_file_info().unwrap();
+    assert!(
+        OnDiskGeoIndex::<Storage>::preopen(&cached_fs, temp_dir.path(), Populate::PreferBackground)
+            .unwrap()
+    );
+    let index = OnDiskGeoIndex::<Storage>::open(
+        &cached_fs,
+        temp_dir.path(),
+        Populate::PreferBackground,
+        &deleted,
+    )
+    .unwrap()
+    .unwrap();
+    assert!(index.storage.counts_per_hash_block_index.is_none());
+    assert!(index.storage.points_map_block_index.is_none());
+}

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
@@ -8,8 +8,8 @@ use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFs, OkNotFound, OpenOptions, Populate, TypedStorage, UniversalRead,
-    UniversalReadFs, read_json_via,
+    CachedReadFs, MmapFs, OkNotFound, OpenOptions, Populate, SortedBlockIndex, TypedStorage,
+    UniversalRead, UniversalReadFs, read_json_via,
 };
 use fs_err as fs;
 use memmap2::MmapMut;
@@ -17,7 +17,9 @@ use serde::{Deserialize, Serialize};
 
 use super::super::Encodable;
 use super::super::mutable_numeric_index::InMemoryNumericIndex;
-use super::{CONFIG_PATH, DELETED_PATH, OnDiskNumericIndex, PAIRS_PATH, Storage};
+use super::{
+    CONFIG_PATH, DELETED_PATH, OnDiskNumericIndex, PAIRS_BLOCK_INDEX_PATH, PAIRS_PATH, Storage,
+};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::histogram::Histogram;
@@ -76,6 +78,8 @@ where
             for (src, dst) in in_memory_index.map.iter().zip(pairs.iter_mut()) {
                 *dst = *src;
             }
+
+            SortedBlockIndex::write(&path.join(PAIRS_BLOCK_INDEX_PATH), &pairs)?;
         }
 
         {
@@ -150,6 +154,11 @@ where
         let pairs_path = path.join(PAIRS_PATH);
         fs.schedule_prefetch(&pairs_path, Some(Self::open_options(populate)), None)?;
 
+        // Block index over the value pairs; optional, absent on old segments
+        let _ = fs
+            .schedule_prefetch(&path.join(PAIRS_BLOCK_INDEX_PATH), None, None)
+            .ok_not_found()?;
+
         // Point to values
         OnDiskPointToValues::<T, S>::preopen(fs, path, populate)?;
 
@@ -190,6 +199,12 @@ where
             Default::default(),
         )?);
 
+        let pairs_block_index = SortedBlockIndex::open(
+            fs,
+            &path.join(PAIRS_BLOCK_INDEX_PATH),
+            pairs.len()? as usize,
+        )?;
+
         let point_to_values = OnDiskPointToValues::open(fs, path, populate)?;
         let mut deleted = deleted_points.to_owned();
 
@@ -214,6 +229,7 @@ where
             storage: Storage {
                 deleted: DeletedBitVec::new(deleted),
                 pairs,
+                pairs_block_index,
                 point_to_values,
             },
             histogram,
@@ -245,6 +261,9 @@ where
             self.path.join(DELETED_PATH),
             self.path.join(CONFIG_PATH),
         ];
+        if self.storage.pairs_block_index.is_some() {
+            files.push(self.path.join(PAIRS_BLOCK_INDEX_PATH));
+        }
         files.extend(self.storage.point_to_values.files());
         files.extend(Histogram::<T>::files(&self.path));
         files
@@ -256,6 +275,9 @@ where
             self.path.join(DELETED_PATH),
             self.path.join(CONFIG_PATH),
         ];
+        if self.storage.pairs_block_index.is_some() {
+            files.push(self.path.join(PAIRS_BLOCK_INDEX_PATH));
+        }
         files.extend(self.storage.point_to_values.immutable_files());
         files.extend(Histogram::<T>::immutable_files(&self.path));
         files
@@ -294,9 +316,13 @@ where
         let Storage {
             deleted: _,
             pairs,
+            pairs_block_index,
             point_to_values,
         } = storage;
         pairs.clear_ram_cache()?;
+        if pairs_block_index.is_some() {
+            clear_disk_cache(&path.join(PAIRS_BLOCK_INDEX_PATH))?;
+        }
         clear_disk_cache(&path.join(DELETED_PATH))?;
         point_to_values.clear_cache()?;
         Ok(())

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/mod.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use common::bitvec::DeletedBitVec;
-use common::universal_io::{MmapFile, TypedStorage, UniversalRead};
+use common::universal_io::{MmapFile, SortedBlockIndex, TypedStorage, UniversalRead};
 
 use super::Encodable;
 use crate::index::field_index::histogram::Histogram;
@@ -13,6 +13,7 @@ mod live_reload;
 mod read_ops;
 
 pub(super) const PAIRS_PATH: &str = "data.bin";
+pub(super) const PAIRS_BLOCK_INDEX_PATH: &str = "data_block_index.bin";
 pub(super) const DELETED_PATH: &str = "deleted.bin";
 pub(super) const CONFIG_PATH: &str = "mmap_field_index_config.json";
 
@@ -45,6 +46,10 @@ pub(in super::super) struct Storage<
     pub(super) deleted: DeletedBitVec,
     // sorted pairs (id + value), sorted by value (by id if values are equal)
     pub(super) pairs: TypedStorage<S, Point<T>>,
+    /// Optional in-RAM block index over `pairs`: locating a pair costs one
+    /// block read instead of `O(log n)` random reads. Absent on segments
+    /// built before the sidecar file was introduced.
+    pub(super) pairs_block_index: Option<SortedBlockIndex<Point<T>>>,
     pub(in super::super) point_to_values: OnDiskPointToValues<T, S>,
 }
 
@@ -53,9 +58,15 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
         let Self {
             deleted,
             pairs,
+            pairs_block_index,
             point_to_values,
         } = self;
 
-        deleted.ram_usage_bytes() + pairs.ram_usage_bytes() + point_to_values.ram_usage_bytes()
+        deleted.ram_usage_bytes()
+            + pairs.ram_usage_bytes()
+            + pairs_block_index
+                .as_ref()
+                .map_or(0, |index| index.ram_usage_bytes())
+            + point_to_values.ram_usage_bytes()
     }
 }

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/read_ops.rs
@@ -144,12 +144,35 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
     ///
     /// Returns `Ok(index)` if the element is found, `Err(index)` if not
     /// (where `index` is where the element would be inserted).
+    ///
+    /// With a block index available, this costs a single contiguous read of
+    /// one block; without one it falls back to `O(log n)` random reads spread
+    /// across the whole storage.
     fn binary_search_pairs(
         &self,
         bound: &Point<T>,
         lo: usize,
         hi: usize,
     ) -> OperationResult<Result<usize, usize>> {
+        if let Some(block_index) = &self.storage.pairs_block_index {
+            let block = block_index.find_block(|elem| elem.cmp(bound));
+            let block_lo = lo.max(block.start);
+            let block_hi = hi.min(block.end);
+            if block_lo >= block_hi {
+                // The block does not intersect `[lo, hi)`, so the answer
+                // saturates to the boundary the block lies beyond.
+                return Ok(Err(if block.end <= lo { lo } else { hi }));
+            }
+            let elems = self.storage.pairs.read::<Random>(ReadRange {
+                byte_offset: (block_lo * size_of::<Point<T>>()) as u64,
+                length: (block_hi - block_lo) as u64,
+            })?;
+            return Ok(elems
+                .binary_search(bound)
+                .map(|idx| idx + block_lo)
+                .map_err(|idx| idx + block_lo));
+        }
+
         let mut left = lo;
         let mut right = hi;
         while left < right {

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -1067,3 +1067,74 @@ fn test_block_index_fallback_equivalence() {
             .any(|(_, _, _, points)| !points.is_empty())
     );
 }
+
+/// The block-index sidecar must be covered by `preopen`: after
+/// `schedule_prefetch`, `open` must be served from the prefetch pool without
+/// touching the filesystem again. Conversely, an absent sidecar (old segment)
+/// must not fail `preopen` and must open in fallback mode.
+#[test]
+fn test_block_index_preopen() {
+    use common::universal_io::{CachedFs, CachedReadFs as _, MmapFile, Populate, ReadOnly};
+
+    use crate::index::field_index::numeric_index::on_disk_numeric_index::OnDiskNumericIndex;
+
+    type Storage = ReadOnly<MmapFile>;
+    type RoFs = <Storage as common::universal_io::UniversalRead>::Fs;
+
+    let (temp_dir, index) = random_index(3000, 2, IndexType::Mmap);
+    drop(index);
+    let block_index_path = temp_dir
+        .path()
+        .join(on_disk_numeric_index::PAIRS_BLOCK_INDEX_PATH);
+    let deleted = empty_deleted();
+
+    // Same order as the segment open path: snapshot, then preopen, then open.
+    use common::universal_io::UniversalReadFileOps as _;
+    let fs = RoFs::from_context(Default::default()).unwrap();
+    let mut cached_fs = CachedFs::new(fs.clone(), temp_dir.path()).unwrap();
+    cached_fs.cache_file_info().unwrap();
+    assert!(
+        OnDiskNumericIndex::<FloatPayloadType, Storage>::preopen(
+            &cached_fs,
+            temp_dir.path(),
+            Populate::PreferBackground,
+        )
+        .unwrap()
+    );
+
+    // The sidecar read of `open` must now come from the prefetch pool.
+    fs_err::remove_file(&block_index_path).unwrap();
+
+    let index = OnDiskNumericIndex::<FloatPayloadType, Storage>::open(
+        &cached_fs,
+        temp_dir.path(),
+        Populate::PreferBackground,
+        &deleted,
+    )
+    .unwrap()
+    .unwrap();
+    assert!(index.storage.pairs_block_index.is_some());
+    drop(index);
+
+    // An absent sidecar (segment built before it was introduced): `preopen`
+    // must not fail on the missing file and `open` must fall back.
+    let mut cached_fs = CachedFs::new(fs, temp_dir.path()).unwrap();
+    cached_fs.cache_file_info().unwrap();
+    assert!(
+        OnDiskNumericIndex::<FloatPayloadType, Storage>::preopen(
+            &cached_fs,
+            temp_dir.path(),
+            Populate::PreferBackground,
+        )
+        .unwrap()
+    );
+    let index = OnDiskNumericIndex::<FloatPayloadType, Storage>::open(
+        &cached_fs,
+        temp_dir.path(),
+        Populate::PreferBackground,
+        &deleted,
+    )
+    .unwrap()
+    .unwrap();
+    assert!(index.storage.pairs_block_index.is_none());
+}

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -979,3 +979,91 @@ fn test_integer_index_fractional_range_bounds() {
         "lte: 1.5 must include integer 1 and exclude 2",
     );
 }
+
+/// The optional block-index sidecar over the sorted pairs must be a pure
+/// accelerator: cardinality estimates and filter results must be identical
+/// with the sidecar present and after deleting it (which falls back to plain
+/// binary search over the storage).
+#[test]
+fn test_block_index_fallback_equivalence() {
+    fn collect_results(
+        index: &NumericIndex<FloatPayloadType, FloatPayloadType>,
+        queries: &[Range<OrderedFloat<FloatPayloadType>>],
+    ) -> Vec<(usize, usize, usize, Vec<PointOffsetType>)> {
+        let hw_counter = HardwareCounterCell::new();
+        queries
+            .iter()
+            .map(|query| {
+                let estimation =
+                    query::range_cardinality(index.inner(), &RangeInterface::Float(*query))
+                        .unwrap();
+                let points = index
+                    .inner()
+                    .filter(
+                        &FieldCondition::new_range(JsonPath::new("unused"), *query),
+                        &hw_counter,
+                    )
+                    .unwrap()
+                    .unwrap()
+                    .collect_vec();
+                (estimation.min, estimation.exp, estimation.max, points)
+            })
+            .collect()
+    }
+
+    // 3000 points x 2 values = 6000 pairs, several 16KiB blocks.
+    let (temp_dir, index) = random_index(3000, 2, IndexType::Mmap);
+    drop(index);
+
+    let block_index_path = temp_dir
+        .path()
+        .join(on_disk_numeric_index::PAIRS_BLOCK_INDEX_PATH);
+    assert!(block_index_path.exists());
+
+    // Random ranges (values live in 0..100), exact-value probes, and bounds
+    // outside the value domain.
+    let mut rng = StdRng::seed_from_u64(7);
+    let mut queries = Vec::new();
+    for _ in 0..100 {
+        let a: FloatPayloadType = rng.random_range(-10.0..110.0);
+        let b: FloatPayloadType = rng.random_range(-10.0..110.0);
+        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+        let (lo, hi) = (OrderedFloat(lo), OrderedFloat(hi));
+        queries.push(Range {
+            lt: None,
+            gt: None,
+            gte: Some(lo),
+            lte: Some(hi),
+        });
+        queries.push(Range {
+            lt: Some(hi),
+            gt: Some(lo),
+            gte: None,
+            lte: None,
+        });
+        queries.push(Range {
+            lt: None,
+            gt: None,
+            gte: Some(lo),
+            lte: Some(lo),
+        });
+    }
+
+    let deleted = empty_deleted();
+
+    let with_block_index = open_index_from_disk(temp_dir.path(), IndexType::Mmap, &deleted);
+    let with_results = collect_results(&with_block_index, &queries);
+    drop(with_block_index);
+
+    fs_err::remove_file(&block_index_path).unwrap();
+    let without_block_index = open_index_from_disk(temp_dir.path(), IndexType::Mmap, &deleted);
+    let without_results = collect_results(&without_block_index, &queries);
+
+    assert_eq!(with_results, without_results);
+    // Sanity: the query mix actually matches points.
+    assert!(
+        with_results
+            .iter()
+            .any(|(_, _, _, points)| !points.is_empty())
+    );
+}

--- a/lib/segment/src/segment/tests/test_immutable_payload_index_files.rs
+++ b/lib/segment/src/segment/tests/test_immutable_payload_index_files.rs
@@ -472,3 +472,119 @@ fn payload_index_files_are_immutable_after_build() {
         "after delete + flush on reloaded segment",
     );
 }
+
+/// End-to-end snapshot round-trip for the optional block-index sidecar files
+/// written by the on-disk numeric and geo indexes: `files()` must include
+/// them in the snapshot tar, restore must bring them back byte-for-byte, and
+/// the restored segment must answer indexed queries identically.
+#[rstest::rstest]
+#[case::regular(crate::types::SnapshotFormat::Regular)]
+#[case::streamable(crate::types::SnapshotFormat::Streamable)]
+fn snapshot_roundtrip_recovers_block_index_sidecars(#[case] format: crate::types::SnapshotFormat) {
+    use common::tar_ext;
+    use common::tar_unpack::tar_unpack_file;
+    use fs_err::File;
+
+    use crate::entry::snapshot_entry::SnapshotEntry as _;
+
+    fn block_index_sidecars(payload_index_dir: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+        snapshot_dir(payload_index_dir)
+            .into_iter()
+            .filter(|(path, _)| {
+                path.file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .ends_with("_block_index.bin")
+            })
+            .collect()
+    }
+
+    let segments_dir = Builder::new().prefix("segments").tempdir().unwrap();
+    let temp_dir = Builder::new().prefix("builder_tmp").tempdir().unwrap();
+
+    let segment =
+        build_immutable_segment_with_indexed_payload(segments_dir.path(), temp_dir.path());
+    let payload_index_dir = segment.data_path().join("payload_index");
+
+    // The on-disk numeric indexes (int, float, datetime) write one sidecar
+    // each, the geo index writes two.
+    let built_sidecars = block_index_sidecars(&payload_index_dir);
+    assert_eq!(
+        built_sidecars.len(),
+        5,
+        "expected block-index sidecars after build, got {:?}",
+        built_sidecars.keys().collect::<Vec<_>>(),
+    );
+
+    let queries = indexed_queries();
+    let live = vec![true; NUM_POINTS];
+    assert_query_counts(&segment, &live, &queries, "before snapshot");
+
+    segment.flush(true).unwrap();
+
+    // Snapshot into a parent tar, unpack, restore in place, reload — the same
+    // sequence as collection snapshot recovery.
+    let snapshot_temp = Builder::new().prefix("snapshot_temp").tempdir().unwrap();
+    let parent_snapshot_tar = Builder::new()
+        .prefix("parent_snapshot")
+        .suffix(".tar")
+        .tempfile()
+        .unwrap();
+    let tar =
+        tar_ext::BuilderExt::new_seekable_owned(File::create(parent_snapshot_tar.path()).unwrap());
+    segment
+        .take_snapshot(snapshot_temp.path(), &tar, format, None)
+        .unwrap();
+    tar.blocking_finish().unwrap();
+
+    let unpacked = Builder::new().prefix("parent_snapshot").tempdir().unwrap();
+    tar_unpack_file(parent_snapshot_tar.path(), unpacked.path()).unwrap();
+    let mut entries = fs_err::read_dir(unpacked.path()).unwrap();
+    let entry = entries.next().unwrap().unwrap();
+    assert!(entries.next().is_none());
+
+    Segment::restore_snapshot_in_place(&entry.path()).unwrap();
+
+    // For the Regular format, restore replaces the `.tar` entry with the
+    // unpacked segment directory — re-read it.
+    let mut entries = fs_err::read_dir(unpacked.path()).unwrap();
+    let entry = entries.next().unwrap().unwrap();
+    assert!(entries.next().is_none());
+    assert!(entry.path().is_dir());
+
+    let restored = load_segment(
+        &entry.path(),
+        uuid::Uuid::nil(),
+        None,
+        &AtomicBool::new(false),
+    )
+    .unwrap();
+
+    // The sidecars survived the round trip byte-for-byte...
+    let restored_sidecars = block_index_sidecars(&entry.path().join("payload_index"));
+    assert_eq!(
+        restored_sidecars
+            .keys()
+            .map(|path| path.file_name().unwrap().to_owned())
+            .collect::<Vec<_>>(),
+        built_sidecars
+            .keys()
+            .map(|path| path.file_name().unwrap().to_owned())
+            .collect::<Vec<_>>(),
+        "block-index sidecars lost in the snapshot round trip",
+    );
+    for ((restored_path, restored_bytes), (built_path, built_bytes)) in
+        restored_sidecars.iter().zip(built_sidecars.iter())
+    {
+        assert_eq!(
+            restored_bytes,
+            built_bytes,
+            "sidecar content changed in the snapshot round trip: {} vs {}",
+            restored_path.display(),
+            built_path.display(),
+        );
+    }
+
+    // ...and the restored segment answers every indexed query correctly.
+    assert_query_counts(&restored, &live, &queries, "after restore");
+}


### PR DESCRIPTION
## Problem

We binary-search sorted arrays directly on unpopulated mmap in a few hot query paths. Each probe is a random read scattered across the whole file — `O(log n)` page faults (or remote range reads) per lookup on high-latency storage.

Audit of all binary-search-over-storage sites found exactly three with the scatter pattern, all per-query:

- **on-disk numeric index** — `binary_search_pairs` over `data.bin` (`Point<T>` sorted by value): two searches per range query, driving both cardinality estimation and range iteration
- **on-disk geo index** — `counts_of_hash` over `counts_per_hash.bin`: one search per candidate geohash during cardinality estimation
- **on-disk geo index** — `all_points` start-boundary search over `points_map.bin`

(The disk ID tracker and the prefix index already use the sparse-block-index pattern; sparse/full-text posting lists bisect only within one contiguously-read posting.)

## Solution

New reusable component `SortedBlockIndex<T>` in `common::universal_io`: an **optional sidecar file** storing the first element of every 16 KiB block of a sorted on-disk array (same block size as `DiskCache` blocks / `iter_autochunks`, following the disk ID tracker's sparse-index precedent).

- **Open**: read whole into RAM via `read_whole_via` (one logical read; single GET on object-store backends), `Ok(None)` when absent.
- **Lookup**: in-RAM `partition_point` over block firsts → `find_block` returns the one element range that must contain the target (or its insertion position) → caller does a single contiguous read of ≤16 KiB and bisects in RAM.
- **RAM cost**: 1/1024 of the main array for 16-byte elements (~1 MiB per 1 GiB), reported via `ram_usage_bytes`.

### Compatibility

- **Old files, new code**: sidecar absent → `open` returns `None` → unchanged fallback binary search over the storage.
- **New files, old code**: old code ignores the unknown file. Snapshots taken by old code drop it; restored segments just fall back.
- **Corruption / future versions / stale sidecar** (element size, array length, or version mismatch): `log::warn!` + treat as absent, never a hard error — the main array stays the source of truth, losing the sidecar only loses the acceleration.

### Cached-data case

When the array is already in page cache, the new path is an in-RAM partition_point plus one zero-copy borrowed read of one block — no regression vs. the old probes (which also all hit cache), and existing populate/`Memory::Pinned` behavior is untouched.

### Wiring

Sidecars are written at build time (`data_block_index.bin`, `counts_per_hash_block_index.bin`, `points_map_block_index.bin`) and registered in `files()` / `immutable_files()` (only when present), `clear_cache()`, and `preopen` prefetch scheduling. Read-only and immutable (pinned) index variants delegate to the same open/files/wipe paths, so no separate wiring was needed.

## Testing

- Unit tests for the component: multi-block/partial/empty roundtrips checking `find_block`-restricted bisection ≡ whole-array bisection for exhaustive targets (hits, misses, out-of-domain), plus rejection of truncated/corrupted/future-version/stale files.
- Equivalence tests for both indexes: build on-disk index, run a mixed query workload with the sidecar present, delete the sidecar file(s), reopen, and assert identical cardinality estimates and filter results via the fallback path.
- Full `numeric_index`/`geo_index`/`common` suites pass; clippy and fmt clean.

## Possible follow-ups

- Same pattern for other sorted structures if new scatter sites appear (the component is generic over any `bytemuck::Pod` element with a caller-supplied comparator).
- Backfill sidecars for existing segments on load/optimization (currently only newly built indexes get them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)