### PR TITLE
Fix live-reload staleness of in-place-mutated files on caching backends

### DIFF
--- a/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
@@ -26,8 +26,12 @@ mod reopen;
 /// blocks on demand from the remote) or eagerly if populate is set. See
 /// [`init`] for the precise lifecycle.
 ///
-/// WARN: There should be only a single instance of DiskCache per path.
-/// Initializing multiple instances will try to re-read from remote.
+/// Every instance mirrors into its own uniquely-named local file (see
+/// [`unique_local_path`](super::fs)), so multiple instances per remote path
+/// are safe — e.g. a live-reload can open a fresh handle while the old one is
+/// still alive. Each instance fetches from the remote independently though,
+/// so per-path handles should not be multiplied without reason. The mirror
+/// file is removed on drop.
 #[derive(Debug)]
 pub struct DiskCache<R>
 where
@@ -133,5 +137,17 @@ where
 
         self.remote_fs
             .open(&self.remote_path, remote_options, self.remote_extra.clone())
+    }
+}
+
+impl<R> Drop for DiskCache<R>
+where
+    R: UniversalRead + 'static,
+{
+    fn drop(&mut self) {
+        // Best-effort mirror cleanup: mirror names are unique per open, so a
+        // file left behind would never be reused. Absent (`Err`) when the
+        // state never materialized a local mirror.
+        let _ = fs_err::remove_file(&self.local_path);
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::config::DiskCacheConfig;
 use super::file::{DiskCache, State};
@@ -157,6 +158,22 @@ where
     }
 }
 
+/// Make the mirror path unique per open, so concurrently-alive [`DiskCache`]
+/// instances for the same remote path never share (and truncate) each other's
+/// local mirror. This lets callers refresh a file by opening a fresh handle
+/// while the old one is still alive.
+///
+/// The name carries no state across opens: a mirror is truncated when its
+/// [`LocalState`] materializes and removed when its `DiskCache` is dropped.
+fn unique_local_path(mut path: PathBuf) -> PathBuf {
+    static NEXT_MIRROR_ID: AtomicU64 = AtomicU64::new(0);
+    let id = NEXT_MIRROR_ID.fetch_add(1, Ordering::Relaxed);
+    // Process id disambiguates processes sharing a local cache dir.
+    path.as_mut_os_string()
+        .push(format!(".{:x}-{id:x}", std::process::id()));
+    path
+}
+
 impl<R> UniversalReadFs for DiskCacheFs<R>
 where
     R: DiskCacheRemote,
@@ -179,7 +196,7 @@ where
         }
 
         let remote_extra = extra.remote_extra.with_prevent_caching(true);
-        let local_path = self.config.local_path_for(path.as_ref())?;
+        let local_path = unique_local_path(self.config.local_path_for(path.as_ref())?);
 
         let populate = if crate::low_memory::low_memory_mode().skip_populate() {
             Populate::No

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -48,7 +48,8 @@ impl Scenario {
         }
     }
 
-    fn expected_local_path(&self) -> PathBuf {
+    /// Base mirror path for the remote; every open appends a unique suffix.
+    fn local_path_base(&self) -> PathBuf {
         self.config.local_path_for(&self.remote_path).unwrap()
     }
 
@@ -202,9 +203,16 @@ mod tests_mod {
     #[test]
     fn local_file_is_created_on_first_read() {
         let scn = Scenario::new(BLOCK_SIZE * 2);
-        let expected_local = scn.expected_local_path();
 
         let file = scn.open::<R>(PREFILL);
+        let expected_local = file.local_path.clone();
+        assert!(
+            expected_local
+                .to_str()
+                .unwrap()
+                .starts_with(scn.local_path_base().to_str().unwrap()),
+            "unique mirror name must derive from the configured mapping",
+        );
 
         // Before the first read, the local file doesn't exist yet.
         assert!(
@@ -265,12 +273,61 @@ mod tests_mod {
         );
     }
 
+    /// Two live instances for the same remote path must not share a mirror:
+    /// each open gets a unique local name, so the second open cannot truncate
+    /// the first instance's mirror out from under it. This is what makes
+    /// refresh-by-fresh-open (live-reload) safe while the old handle is alive.
+    #[test]
+    fn concurrent_instances_have_independent_mirrors() {
+        let scn = Scenario::new(BLOCK_SIZE * 2);
+
+        let first = scn.open::<R>(PREFILL);
+        let read_all = |cache: &DiskCache<R>| {
+            cache
+                .read::<Sequential, u8>(ReadRange {
+                    byte_offset: 0,
+                    length: scn.data.len() as u64,
+                })
+                .unwrap()
+                .to_vec()
+        };
+        assert_eq!(read_all(&first), scn.data);
+
+        let second = scn.open::<R>(PREFILL);
+        assert_ne!(first.local_path, second.local_path);
+        assert_eq!(read_all(&second), scn.data);
+
+        // The first instance's mirror survived the second open.
+        assert_eq!(read_all(&first), scn.data);
+    }
+
+    /// Dropping an instance removes its mirror file: names are unique per
+    /// open, so a leftover would never be reused.
+    #[test]
+    fn drop_removes_local_mirror() {
+        let scn = Scenario::new(BLOCK_SIZE);
+        let cache = scn.open::<R>(PREFILL);
+
+        let _ = cache
+            .read::<Sequential, u8>(ReadRange {
+                byte_offset: 0,
+                length: 1,
+            })
+            .unwrap();
+
+        let local_path = cache.local_path.clone();
+        assert!(local_path.exists());
+
+        drop(cache);
+        assert!(!local_path.exists());
+    }
+
     /// Reopen with no prior reads leaves the local mirror untouched.
     #[test]
     fn reopen_without_prior_reads_keeps_local_uninitialized() {
         let scn = Scenario::new(BLOCK_SIZE * 2);
         let mut cache = scn.open::<R>(PREFILL);
-        let expected_local = scn.expected_local_path();
+        let expected_local = cache.local_path.clone();
         assert!(!expected_local.exists());
 
         cache.reopen().unwrap();
@@ -416,7 +473,7 @@ mod tests_mod {
         let file = scn.open_partial::<R>(0..(BLOCK_SIZE as u64 + 50));
 
         // The mirror is materialized lazily; nothing exists before the first read.
-        let expected_local = scn.expected_local_path();
+        let expected_local = file.local_path.clone();
         assert!(!expected_local.exists());
         assert!(!file.is_ready());
 

--- a/lib/gridstore/src/gridstore/mod.rs
+++ b/lib/gridstore/src/gridstore/mod.rs
@@ -60,7 +60,7 @@ where
     S: UniversalWrite + 'static,
 {
     /// Create a [`GridstoreView`] by locking pages and tracker, then call `f` with the view.
-    fn with_view<R>(&self, f: impl FnOnce(GridstoreView<'_, V, S>) -> R) -> R {
+    fn with_view<R>(&self, f: impl FnOnce(GridstoreView<'_, V, S, Tracker<S>>) -> R) -> R {
         let pages = self.pages.read();
         let tracker = self.tracker.read();
         f(GridstoreView::new(&self.config, &tracker, &pages))
@@ -451,7 +451,7 @@ where
             // - https://github.com/qdrant/qdrant/pull/7983
             // - https://github.com/qdrant/qdrant/pull/8248
             self.with_view(|view| -> Result<_, E> {
-                max_offset = view.max_point_offset();
+                max_offset = view.max_point_offset()?;
 
                 if current_offset >= max_offset {
                     return Ok(());

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -15,7 +15,7 @@ use crate::blob::Blob;
 use crate::config::StorageConfig;
 use crate::error::GridstoreError;
 use crate::pages::Pages;
-use crate::tracker::{PageId, PointOffset, Tracker};
+use crate::tracker::{PageId, PointOffset, ReadOnlyTracker, Tracker};
 
 pub(super) const CONFIG_FILENAME: &str = "config.json";
 
@@ -26,7 +26,7 @@ pub(super) const CONFIG_FILENAME: &str = "config.json";
 #[derive(Debug)]
 pub struct GridstoreReader<V, S: UniversalRead> {
     pub(super) config: StorageConfig,
-    pub(super) tracker: Tracker<S>,
+    pub(super) tracker: ReadOnlyTracker<S>,
     pub(super) pages: Pages<S>,
     pub(super) base_path: PathBuf,
     pub(super) _value_type: std::marker::PhantomData<V>,
@@ -36,7 +36,7 @@ pub struct GridstoreReader<V, S: UniversalRead> {
 
 impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
     /// Create a [`GridstoreView`] borrowing this reader's data.
-    pub fn view(&self) -> GridstoreView<'_, V, S> {
+    pub fn view(&self) -> GridstoreView<'_, V, S, ReadOnlyTracker<S>> {
         GridstoreView::new(&self.config, &self.tracker, &self.pages)
     }
 
@@ -56,7 +56,12 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
         paths
     }
 
-    pub fn max_point_offset(&self) -> PointOffset {
+    /// Exclusive upper bound of point offsets that may have a value.
+    ///
+    /// An upper bound derived from the tracker file's slot capacity, not an
+    /// exact count — see
+    /// [`TrackerRead::max_point_offset`](crate::tracker::TrackerRead::max_point_offset).
+    pub fn max_point_offset(&self) -> Result<PointOffset> {
         self.view().max_point_offset()
     }
 
@@ -89,10 +94,14 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
         base_path: PathBuf,
         populate: Populate,
     ) -> Result<Self> {
+        let config_path = base_path.join(CONFIG_FILENAME);
+        let config: StorageConfig =
+            read_json_via::<Fs, StorageConfig>(fs, &config_path).map_err(GridstoreError::from)?;
+
         // A reader only reads, so open pages and tracker non-writable. This
         // lets the backend be write-enforced (e.g. `ReadOnly<MmapFile>`); the
         // writable `Gridstore` opens these same files writable instead.
-        let (config, tracker) = read_config_and_tracker(fs, &base_path, populate, false)?;
+        let tracker = ReadOnlyTracker::open(fs, &base_path, populate)?;
 
         let pages = Pages::<S>::open(fs, &base_path, false, populate)?;
 
@@ -134,7 +143,7 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
         F: FnMut(PointOffset, V) -> Result<bool, E>,
         E: From<GridstoreError>,
     {
-        let max_id = cmp::min(max_id, self.max_point_offset());
+        let max_id = cmp::min(max_id, self.max_point_offset()?);
 
         let point_offsets = (0..max_id).map(|point_offset| ((), point_offset));
 
@@ -192,13 +201,12 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
     /// - Only appending new data is supported, for modifications of existing data there are no consistency guarantees.
     /// - Partial writes are possible, it is up to the caller to read only fully written data.
     ///
+    /// Both the tracker and the pages are refreshed unconditionally: the
+    /// tracker file is mutated in place and carries no reliable
+    /// cheaply-readable change signal, so there is no "nothing changed"
+    /// fast path. Both refreshes are cheap for non-populated readers.
     pub fn live_reload(&mut self, fs: &S::Fs) -> Result<()> {
-        let has_new_data = self.tracker.live_reload()?;
-
-        if !has_new_data {
-            return Ok(());
-        }
-
+        self.tracker.live_reload(fs)?;
         self.pages.live_reload(fs, self.populate)?;
 
         Ok(())

--- a/lib/gridstore/src/gridstore/reader.rs
+++ b/lib/gridstore/src/gridstore/reader.rs
@@ -58,8 +58,8 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
 
     /// Exclusive upper bound of point offsets that may have a value.
     ///
-    /// An upper bound derived from the tracker file's slot capacity, not an
-    /// exact count — see
+    /// The writer-maintained count read from the stored tracker header, as of
+    /// the last [`Self::live_reload`] — see
     /// [`TrackerRead::max_point_offset`](crate::tracker::TrackerRead::max_point_offset).
     pub fn max_point_offset(&self) -> Result<PointOffset> {
         self.view().max_point_offset()

--- a/lib/gridstore/src/gridstore/tests.rs
+++ b/lib/gridstore/src/gridstore/tests.rs
@@ -1133,7 +1133,7 @@ fn test_live_reload() {
     // Step 2: Open a reader
     let mut reader =
         GridstoreReader::<Payload, MmapFile>::open(&MmapFs, path.clone(), Populate::No).unwrap();
-    assert_eq!(reader.max_point_offset(), 2);
+    assert_eq!(reader.max_point_offset().unwrap(), 2);
 
     // Step 3: Verify reader sees initial data
     let v0 = reader.get_value::<Random>(0, &hw_counter).unwrap();
@@ -1141,9 +1141,8 @@ fn test_live_reload() {
     let v1 = reader.get_value::<Random>(1, &hw_counter).unwrap();
     assert_eq!(v1.as_ref(), Some(&payload_1));
 
-    // Step 4: live_reload when nothing changed should be a no-op
+    // Step 4: live_reload when nothing changed must keep serving the same data
     reader.live_reload(&MmapFs).unwrap();
-    assert_eq!(reader.max_point_offset(), 2);
     let v0 = reader.get_value::<Random>(0, &hw_counter).unwrap();
     assert_eq!(v0.as_ref(), Some(&payload_0));
 
@@ -1154,12 +1153,9 @@ fn test_live_reload() {
     storage.put_value(3, &payload_3, hw_counter_ref).unwrap();
     storage.flusher()().unwrap();
 
-    // Reader's max_point_offset is stale before live_reload
-    assert_eq!(reader.max_point_offset(), 2);
-
-    // Step 6: live_reload should update max_point_offset and make new data accessible
+    // Step 6: live_reload should make new data accessible
     reader.live_reload(&MmapFs).unwrap();
-    assert_eq!(reader.max_point_offset(), 4);
+    assert_eq!(reader.max_point_offset().unwrap(), 4);
     let v2 = reader.get_value::<Random>(2, &hw_counter).unwrap();
     assert_eq!(v2.as_ref(), Some(&payload_2));
     let v3 = reader.get_value::<Random>(3, &hw_counter).unwrap();
@@ -1170,6 +1166,85 @@ fn test_live_reload() {
     assert_eq!(v0.as_ref(), Some(&payload_0));
     let v1 = reader.get_value::<Random>(1, &hw_counter).unwrap();
     assert_eq!(v1.as_ref(), Some(&payload_1));
+}
+
+/// Case-3 regression of the live-reload staleness audit: the reader goes
+/// through a caching backend ([`DiskCacheFs`]) whose `reopen` assumes
+/// append-only files. The tracker file is preallocated and mutated in place
+/// (header rewrites, slot updates), so a held handle would serve the stale
+/// pre-write state forever: the reader would keep reporting values as
+/// missing after a live-reload. [`ReadOnlyTracker::live_reload`] opens a
+/// fresh handle instead.
+///
+/// [`DiskCacheFs`]: common::universal_io::DiskCacheFs
+/// [`ReadOnlyTracker::live_reload`]: crate::tracker::ReadOnlyTracker::live_reload
+#[test]
+fn test_live_reload_disk_cache() {
+    use std::sync::Arc;
+
+    use common::universal_io::{
+        DiskCache, DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, MmapFile, UniversalReadFileOps,
+    };
+
+    let dir = Builder::new().prefix("test-storage").tempdir().unwrap();
+    let remote_root = dir.path().join("remote");
+    let local_root = dir.path().join("local");
+    let path = remote_root.join("storage");
+    fs::create_dir_all(&path).unwrap();
+    fs::create_dir_all(&local_root).unwrap();
+
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+
+    let make_payload = |key: &str, value: &str| -> Payload {
+        let mut payload = Payload::default();
+        payload.0.insert(
+            key.to_string(),
+            serde_json::Value::String(value.to_string()),
+        );
+        payload
+    };
+
+    // The writer works on the "remote" directly; the reader mirrors it into
+    // `local_root` through the disk cache.
+    let mut storage = Gridstore::<_>::new(MmapFs, path.clone(), Default::default()).unwrap();
+
+    let payload_0 = make_payload("key", "value_0");
+    storage.put_value(0, &payload_0, hw_counter_ref).unwrap();
+    storage.flusher()().unwrap();
+
+    let cache_fs = DiskCacheFs::<MmapFile>::from_context(DiskCacheFsContext {
+        config: Arc::new(DiskCacheConfig::new(remote_root, local_root).unwrap()),
+        remote: Default::default(),
+    })
+    .unwrap();
+    let mut reader = GridstoreReader::<Payload, DiskCache<MmapFile>>::open(
+        &cache_fs,
+        path.clone(),
+        Populate::No,
+    )
+    .unwrap();
+
+    // Read through the cache so the tracker's header/slot blocks are mirrored
+    // locally — the staleness this test guards against only occurs once the
+    // pre-write state is cached.
+    assert_eq!(reader.max_point_offset().unwrap(), 1);
+    let v0 = reader.get_value::<Random>(0, &hw_counter).unwrap();
+    assert_eq!(v0.as_ref(), Some(&payload_0));
+
+    // Write another value; the tracker header (and slot block 0) are
+    // rewritten in place, the pages grow.
+    let payload_1 = make_payload("key", "value_1");
+    storage.put_value(1, &payload_1, hw_counter_ref).unwrap();
+    storage.flusher()().unwrap();
+
+    reader.live_reload(&cache_fs).unwrap();
+
+    assert_eq!(reader.max_point_offset().unwrap(), 2);
+    let v1 = reader.get_value::<Random>(1, &hw_counter).unwrap();
+    assert_eq!(v1.as_ref(), Some(&payload_1));
+    let v0 = reader.get_value::<Random>(0, &hw_counter).unwrap();
+    assert_eq!(v0.as_ref(), Some(&payload_0));
 }
 
 /// Test that `live_reload` works across page boundaries.
@@ -1210,7 +1285,7 @@ fn test_live_reload_across_pages() {
     // Open reader
     let mut reader =
         GridstoreReader::<Payload, MmapFile>::open(&MmapFs, path.clone(), Populate::No).unwrap();
-    assert_eq!(reader.max_point_offset(), first_batch);
+    assert_eq!(reader.max_point_offset().unwrap(), first_batch);
 
     // Verify reader can read all initial data
     for i in 0..first_batch {
@@ -1231,12 +1306,17 @@ fn test_live_reload_across_pages() {
         "expected more pages after second batch: {new_pages} vs {initial_pages}"
     );
 
-    // Reader should not see new data yet
-    assert_eq!(reader.max_point_offset(), first_batch);
+    // NOTE: no read of the second batch before the reload — over a
+    // read-through backend (mmap) the tracker already sees the new slots,
+    // whose pointers reference pages the reader has not attached yet.
+    // Reading them would panic on the page index rather than return None.
 
     // Live reload should pick up new pages and data
     reader.live_reload(&MmapFs).unwrap();
-    assert_eq!(reader.max_point_offset(), first_batch + second_batch);
+    assert_eq!(
+        reader.max_point_offset().unwrap(),
+        first_batch + second_batch
+    );
 
     // Verify all data is readable
     for i in 0..(first_batch + second_batch) {

--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -49,8 +49,8 @@ impl<'a, V, S: UniversalRead, T: TrackerRead<S>> GridstoreView<'a, V, S, T> {
 
     /// Exclusive upper bound of point offsets that may have a value.
     ///
-    /// Exact for the writable tracker; an upper bound (slot capacity) for the
-    /// read-only one — see [`TrackerRead::max_point_offset`].
+    /// Exact for the writable tracker; the stored header count as of the last
+    /// reload for the read-only one — see [`TrackerRead::max_point_offset`].
     pub fn max_point_offset(&self) -> Result<PointOffset> {
         self.tracker.max_point_offset()
     }

--- a/lib/gridstore/src/gridstore/view.rs
+++ b/lib/gridstore/src/gridstore/view.rs
@@ -11,7 +11,7 @@ use crate::blob::Blob;
 use crate::config::{Compression, StorageConfig};
 use crate::error::GridstoreError;
 use crate::pages::Pages;
-use crate::tracker::{PointOffset, PointerItem, Tracker, ValuePointer};
+use crate::tracker::{PointOffset, PointerItem, TrackerRead, ValuePointer};
 
 #[inline]
 pub(super) fn compress_lz4(value: &[u8]) -> Vec<u8> {
@@ -26,23 +26,19 @@ pub(super) fn decompress_lz4(value: &[u8]) -> Vec<u8> {
 /// A non-owning view into gridstore data.
 ///
 /// Holds borrowed references to pages and tracker, and contains all reading logic.
-/// Generic over the storage backend `S` for both pages and tracker (same as [`Pages<S>`] and
-/// [`Tracker<S>`]).
-///
-/// Constructed from either [`super::Gridstore`] or [`super::GridstoreReader`].
-pub struct GridstoreView<'a, V, S: UniversalRead> {
+/// Generic over the storage backend `S` (same as [`Pages<S>`]) and over the
+/// tracker type `T` — the writable [`Tracker`](crate::tracker::Tracker) for
+/// [`super::Gridstore`], the [`ReadOnlyTracker`](crate::tracker::ReadOnlyTracker)
+/// for [`super::GridstoreReader`].
+pub struct GridstoreView<'a, V, S: UniversalRead, T: TrackerRead<S>> {
     pub(super) config: &'a StorageConfig,
-    pub(super) tracker: &'a Tracker<S>,
+    pub(super) tracker: &'a T,
     pub(super) pages: &'a Pages<S>,
     pub(super) _value_type: std::marker::PhantomData<V>,
 }
 
-impl<'a, V, S: UniversalRead> GridstoreView<'a, V, S> {
-    pub(crate) fn new(
-        config: &'a StorageConfig,
-        tracker: &'a Tracker<S>,
-        pages: &'a Pages<S>,
-    ) -> Self {
+impl<'a, V, S: UniversalRead, T: TrackerRead<S>> GridstoreView<'a, V, S, T> {
+    pub(crate) fn new(config: &'a StorageConfig, tracker: &'a T, pages: &'a Pages<S>) -> Self {
         Self {
             config,
             tracker,
@@ -51,8 +47,12 @@ impl<'a, V, S: UniversalRead> GridstoreView<'a, V, S> {
         }
     }
 
-    pub fn max_point_offset(&self) -> PointOffset {
-        self.tracker.pointer_count()
+    /// Exclusive upper bound of point offsets that may have a value.
+    ///
+    /// Exact for the writable tracker; an upper bound (slot capacity) for the
+    /// read-only one — see [`TrackerRead::max_point_offset`].
+    pub fn max_point_offset(&self) -> Result<PointOffset> {
+        self.tracker.max_point_offset()
     }
 
     fn get_pointer(&self, point_offset: PointOffset) -> Result<Option<ValuePointer>> {
@@ -73,7 +73,7 @@ impl<'a, V, S: UniversalRead> GridstoreView<'a, V, S> {
     }
 }
 
-impl<'a, V: Blob, S: UniversalRead> GridstoreView<'a, V, S> {
+impl<'a, V: Blob, S: UniversalRead, T: TrackerRead<S>> GridstoreView<'a, V, S, T> {
     pub(super) fn compress(&self, value: Vec<u8>) -> Vec<u8> {
         match self.config.compression {
             Compression::None => value,

--- a/lib/gridstore/src/tracker/iter.rs
+++ b/lib/gridstore/src/tracker/iter.rs
@@ -26,7 +26,7 @@ where
     I: Iterator<Item = (U, PointOffset)>,
     S: UniversalRead,
 {
-    pub fn new(
+    pub(crate) fn new(
         point_offsets: I,
         storage: &'a S,
         pending_updates: &'a AHashMap<PointOffset, PointerUpdates>,

--- a/lib/gridstore/src/tracker/mod.rs
+++ b/lib/gridstore/src/tracker/mod.rs
@@ -1,4 +1,5 @@
 pub mod iter;
+pub mod read_only;
 
 #[cfg(test)]
 mod tests;
@@ -15,6 +16,7 @@ use common::universal_io::{
 use smallvec::SmallVec;
 
 pub use self::iter::{Iter, PointerItem};
+pub use self::read_only::ReadOnlyTracker;
 use crate::Result;
 use crate::error::GridstoreError;
 
@@ -106,6 +108,50 @@ impl ValuePointer {
             length,
         }
     }
+}
+
+/// Read-side interface over the pointer tracker.
+///
+/// Implemented by the writable [`Tracker`] — whose reads see pending
+/// in-memory updates — and by [`ReadOnlyTracker`], which serves plain
+/// on-disk state. [`crate::GridstoreView`] is generic over this trait, so
+/// the same read logic works for both.
+pub trait TrackerRead<S: UniversalRead> {
+    /// Exclusive upper bound of point offsets that may have a pointer, as
+    /// maintained by the writer (in memory for [`Tracker`], in the stored
+    /// header for [`ReadOnlyTracker`]).
+    fn max_point_offset(&self) -> Result<PointOffset>;
+
+    /// Get the page pointer at the given point offset.
+    fn get(&self, point_offset: PointOffset) -> Result<Option<ValuePointer>>;
+
+    /// Iterate page pointers for the given point offsets.
+    ///
+    /// Issues batched reads against the underlying storage, so async backends
+    /// can fetch entries in parallel.
+    fn iter<U, I>(&self, point_offsets: I) -> Result<Iter<'_, U, I, S>>
+    where
+        U: UserData,
+        I: Iterator<Item = (U, PointOffset)>;
+}
+
+/// Read the slot for `point_offset` directly from `storage`.
+///
+/// Offsets beyond the file read as `None`; so do allocated-but-never-written
+/// slots — the file is zero-initialized and all-zeroes is the `None` slot.
+fn read_slot<S: UniversalRead>(
+    storage: &S,
+    point_offset: PointOffset,
+) -> Result<Option<ValuePointer>> {
+    let start_offset =
+        size_of::<TrackerHeader>() + point_offset as usize * size_of::<OptionalPointer>();
+    let end_offset = start_offset + size_of::<OptionalPointer>();
+    let storage_len = storage.len::<u8>()?;
+    if end_offset as u64 > storage_len {
+        return Ok(None);
+    }
+    let opt = storage.read::<Random, OptionalPointer>(ReadRange::one(start_offset as u64))?[0];
+    Ok(opt.to_option())
 }
 
 /// Pointer updates for a given point offset
@@ -337,52 +383,9 @@ impl<S: UniversalRead> Tracker<S> {
         Ok(storage)
     }
 
-    /// This method reloads the tracker storage from "disk", so that
-    /// it should make newly written data visible to the tracker.
-    ///
-    /// Important assumptions:
-    ///
-    /// - Should only be called on read-only instances of the tracker.
-    /// - Only appending new pointers is supported, not modifications of existing pointers.
-    /// - Partial writes are possible, but ignored. Header is a source of truth.
-    ///
-    /// Returns `true` if there are new changes, `false` if the tracker is already up to date.
-    pub fn live_reload(&mut self) -> Result<bool> {
-        let new_header = Self::read_header(&self.storage)?;
-
-        if new_header.next_pointer_offset < self.next_pointer_offset {
-            Err(GridstoreError::service_error(format!(
-                "live reload cannot decrease pointer count, possible data loss: old count {:#?}, new count {:#?}",
-                self.next_pointer_offset, new_header.next_pointer_offset
-            )))
-        } else if new_header.next_pointer_offset == self.next_pointer_offset {
-            // No new pointers, no need to reload
-            Ok(false)
-        } else {
-            // reopen storage to make new data visible
-            // For some storages it should be a no-op.
-            self.storage.reopen()?;
-
-            // Update in-memory state to reflect new pointers
-            self.header = new_header;
-            self.next_pointer_offset = new_header.next_pointer_offset;
-            Ok(true)
-        }
-    }
-
     /// Get the raw value at the given point offset
     fn get_raw(&self, point_offset: PointOffset) -> Result<Option<ValuePointer>> {
-        let start_offset =
-            size_of::<TrackerHeader>() + point_offset as usize * size_of::<OptionalPointer>();
-        let end_offset = start_offset + size_of::<OptionalPointer>();
-        let storage_len = self.storage.len::<u8>()?;
-        if end_offset as u64 > storage_len {
-            return Ok(None);
-        }
-        let opt = self
-            .storage
-            .read::<Random, OptionalPointer>(ReadRange::one(start_offset as u64))?[0];
-        Ok(opt.to_option())
+        read_slot(&self.storage, point_offset)
     }
 
     /// Get the page pointer at the given point offset
@@ -418,6 +421,26 @@ impl<S: UniversalRead> Tracker<S> {
 
     pub fn populate(&self) -> Result<()> {
         self.storage.populate().map_err(Into::into)
+    }
+}
+
+impl<S: UniversalRead> TrackerRead<S> for Tracker<S> {
+    /// Exact for the writable tracker: maintained in memory alongside the
+    /// header (see [`Tracker::pointer_count`]).
+    fn max_point_offset(&self) -> Result<PointOffset> {
+        Ok(self.pointer_count())
+    }
+
+    fn get(&self, point_offset: PointOffset) -> Result<Option<ValuePointer>> {
+        Tracker::get(self, point_offset)
+    }
+
+    fn iter<U, I>(&self, point_offsets: I) -> Result<Iter<'_, U, I, S>>
+    where
+        U: UserData,
+        I: Iterator<Item = (U, PointOffset)>,
+    {
+        Tracker::iter(self, point_offsets)
     }
 }
 

--- a/lib/gridstore/src/tracker/read_only.rs
+++ b/lib/gridstore/src/tracker/read_only.rs
@@ -1,0 +1,92 @@
+//! [`ReadOnlyTracker`]: header-less, read-only counterpart of
+//! [`Tracker`](super::Tracker) for follower reloads.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use ahash::AHashMap;
+use common::universal_io::{Populate, UniversalRead, UniversalReadFs, UserData};
+
+use super::iter::Iter;
+use super::{PointOffset, PointerUpdates, Tracker, TrackerRead, ValuePointer, read_slot};
+use crate::Result;
+
+/// Read-only counterpart of [`Tracker`].
+///
+/// Holds nothing but the storage handle. Reads don't need header *state* —
+/// slot addressing is positional, and unwritten slots read as `None` (the
+/// file is zero-initialized) — nor a pending-updates buffer, so neither is
+/// kept. The stored header is only ever read as plain data, to answer
+/// [`TrackerRead::max_point_offset`]; it never gates a reload.
+///
+/// The tracker file is preallocated and mutated in place (header rewrites,
+/// slot updates), which a held handle's `reopen()` — an append-only-growth
+/// contract — never picks up on caching backends. [`Self::live_reload`]
+/// therefore refreshes by opening a *fresh* handle (a fresh open always
+/// mirrors the current remote bytes) and swapping it in.
+#[derive(Debug)]
+pub struct ReadOnlyTracker<S> {
+    /// Path to the tracker file.
+    path: PathBuf,
+    /// Storage handle; replaced wholesale on [`Self::live_reload`].
+    storage: S,
+    /// How to populate the storage on (re)open.
+    populate: Populate,
+}
+
+/// The pending updates of a read-only tracker: always empty, readers have no
+/// write buffer. Shared so [`Iter`] can borrow it for its lifetime.
+fn no_pending_updates() -> &'static AHashMap<PointOffset, PointerUpdates> {
+    static EMPTY: OnceLock<AHashMap<PointOffset, PointerUpdates>> = OnceLock::new();
+    EMPTY.get_or_init(AHashMap::new)
+}
+
+impl<S: UniversalRead> ReadOnlyTracker<S> {
+    /// Open an existing tracker file in the given dir, read-only.
+    /// If the file does not exist, return an error.
+    pub fn open<Fs: UniversalReadFs<File = S>>(
+        fs: &Fs,
+        base_path: &Path,
+        populate: Populate,
+    ) -> Result<Self> {
+        let path = Tracker::<S>::tracker_file_name(base_path);
+        let storage = Tracker::open_storage(fs, &path, populate, false)?;
+        Ok(Self {
+            path,
+            storage,
+            populate,
+        })
+    }
+
+    /// Refresh to the current on-disk state by opening a fresh storage handle
+    /// and swapping it in. See the type docs for why `reopen()` is not enough.
+    pub fn live_reload<Fs: UniversalReadFs<File = S>>(&mut self, fs: &Fs) -> Result<()> {
+        self.storage = Tracker::open_storage(fs, &self.path, self.populate, false)?;
+        Ok(())
+    }
+
+    pub fn files(&self) -> Vec<PathBuf> {
+        vec![self.path.clone()]
+    }
+}
+
+impl<S: UniversalRead> TrackerRead<S> for ReadOnlyTracker<S> {
+    /// The writer-maintained count from the stored header, read as plain data
+    /// through the current handle — i.e. as of the last
+    /// [`Self::live_reload`]. Not kept as in-memory state.
+    fn max_point_offset(&self) -> Result<PointOffset> {
+        Ok(Tracker::read_header(&self.storage)?.next_pointer_offset)
+    }
+
+    fn get(&self, point_offset: PointOffset) -> Result<Option<ValuePointer>> {
+        read_slot(&self.storage, point_offset)
+    }
+
+    fn iter<U, I>(&self, point_offsets: I) -> Result<Iter<'_, U, I, S>>
+    where
+        U: UserData,
+        I: Iterator<Item = (U, PointOffset)>,
+    {
+        Iter::new(point_offsets, &self.storage, no_pending_updates())
+    }
+}

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -1,9 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
-use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap::AdviceSetting;
-use common::sorted_slice::SortedSlice;
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
@@ -13,26 +11,24 @@ use roaring::RoaringBitmap;
 
 use super::dynamic_stored_flags::{DynamicFlagsStatus, FLAGS_FILE, status_file};
 use super::roaring_flags::RoaringFlagsRead;
-use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 
 /// Read-only counterpart of [`RoaringFlags`][1].
 ///
 /// Materializes the persisted flags into an in-memory roaring bitmap on first
-/// use — *not* on open, unlike the writable variant — and keeps the backing
-/// [`StoredBitSlice`] handle so [`LiveReload::live_reload`] can reopen it to
-/// read the points the writer appended, rather than re-scanning the whole file.
-/// There is no write path: no buffer, no [`BufferedDynamicFlags`][2], no
-/// [`DynamicStoredFlags`][3]. The retained `S` is the one [`Self::open`] was
-/// called with, mirroring the other read-only field indexes, which likewise
-/// hold their backing storage across reloads.
+/// use — *not* on open, unlike the writable variant. The backing
+/// [`StoredBitSlice`] handle is kept for that lazy scan and is replaced
+/// wholesale by [`Self::live_reload`]. There is no write path: no buffer, no
+/// [`BufferedDynamicFlags`][2], no [`DynamicStoredFlags`][3]. The retained `S`
+/// is the one [`Self::open`] was called with, mirroring the other read-only
+/// field indexes, which likewise hold their backing storage across reloads.
 ///
 /// [1]: super::roaring_flags::RoaringFlags
 /// [2]: super::buffered_dynamic_flags::BufferedDynamicFlags
 /// [3]: super::dynamic_stored_flags::DynamicStoredFlags
 pub struct ReadOnlyRoaringFlags<S: UniversalRead> {
     /// In-memory bitmap of true flags, materialized from the backing file on
-    /// first access and patched in place on [`LiveReload::live_reload`].
+    /// first access and resynced by [`Self::live_reload`].
     ///
     /// Lazy so that opening the flags reads only the (tiny) status file: a
     /// segment open would otherwise scan every flags file end to end, which
@@ -42,8 +38,8 @@ pub struct ReadOnlyRoaringFlags<S: UniversalRead> {
     /// through `&self` from many threads. On a race both threads may build a
     /// bitmap; the first to finish wins and the loser's copy is dropped.
     bitmap: OnceLock<RoaringBitmap>,
-    /// Backing bitslice. A reload reopens this handle so points the writer
-    /// appended become readable, then reads only those new positions.
+    /// Backing bitslice, used by the lazy [`Self::bitmap`] scan. Replaced with
+    /// a freshly opened handle on every [`Self::live_reload`].
     storage: StoredBitSlice<S>,
     /// Total length of the flags, including trailing falses. Read from the status file.
     len: usize,
@@ -110,7 +106,7 @@ impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
     }
 
     /// Open persisted flags read-only, retaining the bitslice handle for
-    /// [`Self::bitmap`] and [`LiveReload`].
+    /// [`Self::bitmap`].
     ///
     /// Returns [`Ok(None)`] when the flag directory doesn't exist (the status
     /// file is absent), matching the read path's never-create contract.
@@ -162,60 +158,40 @@ impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
 
         Ok(self.bitmap.get_or_init(|| bitmap))
     }
-}
 
-impl<S: UniversalRead> LiveReload for ReadOnlyRoaringFlags<S> {
-    type Fs = S::Fs;
+    /// Refresh to the current on-disk state.
+    ///
+    /// Deliberately *not* an impl of [`LiveReload`][1]: this storage holds
+    /// arbitrary flags with no notion of points, so a point-delta interface
+    /// (deleted/new points) does not belong here — `open` never applied
+    /// deleted points either. The on-disk flags are the sole source of truth.
+    ///
+    /// The flags file is preallocated (power-of-two capacity) and mutated in
+    /// place within its length, which the held handle's `reopen()` — an
+    /// append-only-growth contract — never picks up on caching backends. So
+    /// instead a *fresh* handle is opened (a fresh open always mirrors the
+    /// current remote bytes), the materialized bitmap, if any, is resynced
+    /// from it, and it replaces the old handle.
+    ///
+    /// While the bitmap is still unmaterialized there is nothing to resync:
+    /// the eventual first scan reads the fresh storage installed here.
+    ///
+    /// [1]: crate::common::live_reload::LiveReload
+    pub fn live_reload(&mut self, fs: &impl UniversalReadFs<File = S>) -> OperationResult<()> {
+        let storage = StoredBitSlice::<S>::open(
+            fs,
+            self.directory.join(FLAGS_FILE),
+            open_options(Populate::No),
+            Default::default(),
+        )?;
 
-    /// Refresh the in-memory bitmap to the current on-disk state by fetching
-    /// only the delta, instead of re-scanning every set position like
-    /// [`Self::open`].
-    ///
-    /// `deleted_points` are dropped from the bitmap — a removed point belongs in
-    /// no flag set, so this needs no I/O. `new_points` are freshly appended
-    /// offsets (the producer is append-only — see the body): each has its flag
-    /// read from the reopened bitslice and is inserted when set. A new offset was
-    /// never in the bitmap, so an unset flag needs no action.
-    ///
-    /// `hw_counter` is unused: the per-position reads go through the reopened
-    /// [`StoredBitSlice`], which takes no hardware counter — mirroring
-    /// [`Self::bitmap`], which also doesn't account its scan.
-    ///
-    /// While the bitmap is still unmaterialized there is nothing to patch: the
-    /// eventual scan reads the current on-disk flags, which the writer has
-    /// already brought up to date (it clears a retired point's flag). The
-    /// bitslice is still reopened, so that scan sees the grown file.
-    fn live_reload(
-        &mut self,
-        fs: &S::Fs,
-        deleted_points: &SortedSlice<'_, PointOffsetType>,
-        new_points: &SortedSlice<'_, PointOffsetType>,
-        _hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
         if let Some(bitmap) = self.bitmap.get_mut() {
-            for &point in deleted_points {
-                bitmap.remove(point);
-            }
+            *bitmap =
+                RoaringBitmap::from_sorted_iter(storage.iter_ones()?.map(|i| i as PointOffsetType))
+                    .expect("iter_ones iterates in sorted order");
         }
 
-        // Nothing appended → no on-disk delta to fetch, skip all I/O.
-        if new_points.is_empty() {
-            return Ok(());
-        }
-
-        // Live reload is append-only, so we only need to process the new range of
-        // the bitslice.
-        self.storage.reopen()?;
-        if let (Some(bitmap), Some(new_range)) = (self.bitmap.get_mut(), new_points.range_u64()) {
-            let start = new_range.start as usize;
-            let bitslice = self.storage.read_bit_range(new_range)?;
-            for point in bitslice
-                .iter_ones()
-                .map(|idx| (idx + start) as PointOffsetType)
-            {
-                bitmap.insert(point);
-            }
-        }
+        self.storage = storage;
 
         // The logical length grows as points are appended; refresh it so
         // length-driven readers (the null index's `iter_falses`) stay correct.
@@ -245,5 +221,110 @@ impl<S: UniversalRead> RoaringFlagsRead for ReadOnlyRoaringFlags<S> {
             status_file(&self.directory),
             self.directory.join(FLAGS_FILE),
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common::universal_io::{
+        DiskCache, DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, MmapFile, MmapFs,
+        UniversalReadFileOps,
+    };
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
+
+    /// The flags file is preallocated (power-of-two capacity) and mutated in
+    /// place within its length, so a reader over a caching backend cannot rely
+    /// on `reopen()`: bits the writer changes inside already-cached blocks
+    /// would stay stale forever. `live_reload` opens a fresh handle instead —
+    /// this drives it over `DiskCacheFs`, where the stale-cache failure
+    /// actually reproduces (mmap readers are read-through and can't catch it).
+    #[test]
+    fn live_reload_over_disk_cache_sees_in_place_bit_writes() {
+        let tmp = Builder::new().prefix("roaring_reload").tempdir().unwrap();
+        let remote_root = tmp.path().join("remote");
+        let local_root = tmp.path().join("local");
+        let dir = remote_root.join("flags");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::create_dir_all(&local_root).unwrap();
+
+        // The writer works on the "remote" directly; the reader mirrors it
+        // into `local_root` through the disk cache.
+        let mut writer = DynamicStoredFlags::<MmapFile>::open(&MmapFs, &dir, Populate::No).unwrap();
+        writer.set_len(&MmapFs, 100).unwrap();
+        writer.set(5, true).unwrap();
+        writer.flusher()().unwrap();
+
+        let cache_fs = DiskCacheFs::<MmapFile>::from_context(DiskCacheFsContext {
+            config: Arc::new(DiskCacheConfig::new(remote_root, local_root).unwrap()),
+            remote: Default::default(),
+        })
+        .unwrap();
+        let mut flags = ReadOnlyRoaringFlags::<DiskCache<MmapFile>>::open(&cache_fs, &dir)
+            .unwrap()
+            .unwrap();
+
+        // Materialize the bitmap: scans (and locally caches) the whole
+        // preallocated flags file — the pre-write state this test must escape.
+        assert!(flags.get_bitmap().unwrap().contains(5));
+        assert_eq!(flags.len(), 100);
+
+        // In-place bit writes within the already-cached capacity, plus growth.
+        writer.set(6, true).unwrap();
+        writer.set(50, true).unwrap();
+        writer.set(5, false).unwrap();
+        writer.set_len(&MmapFs, 120).unwrap();
+        writer.flusher()().unwrap();
+
+        flags.live_reload(&cache_fs).unwrap();
+
+        let bitmap = flags.get_bitmap().unwrap();
+        assert!(bitmap.contains(6));
+        assert!(bitmap.contains(50));
+        assert!(
+            !bitmap.contains(5),
+            "cleared flag must not survive a reload"
+        );
+        assert_eq!(flags.len(), 120);
+    }
+
+    /// A bitmap that was never materialized needs no resync: the reload just
+    /// swaps in the fresh handle, and the eventual first scan reads it.
+    #[test]
+    fn live_reload_before_materialization_scans_fresh_state() {
+        let tmp = Builder::new().prefix("roaring_reload").tempdir().unwrap();
+        let remote_root = tmp.path().join("remote");
+        let local_root = tmp.path().join("local");
+        let dir = remote_root.join("flags");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::create_dir_all(&local_root).unwrap();
+
+        let mut writer = DynamicStoredFlags::<MmapFile>::open(&MmapFs, &dir, Populate::No).unwrap();
+        writer.set_len(&MmapFs, 100).unwrap();
+        writer.set(5, true).unwrap();
+        writer.flusher()().unwrap();
+
+        let cache_fs = DiskCacheFs::<MmapFile>::from_context(DiskCacheFsContext {
+            config: Arc::new(DiskCacheConfig::new(remote_root, local_root).unwrap()),
+            remote: Default::default(),
+        })
+        .unwrap();
+        let mut flags = ReadOnlyRoaringFlags::<DiskCache<MmapFile>>::open(&cache_fs, &dir)
+            .unwrap()
+            .unwrap();
+
+        // No `get_bitmap` here: the bitmap stays unmaterialized.
+        writer.set(6, true).unwrap();
+        writer.flusher()().unwrap();
+
+        flags.live_reload(&cache_fs).unwrap();
+
+        let bitmap = flags.get_bitmap().unwrap();
+        assert!(bitmap.contains(5));
+        assert!(bitmap.contains(6));
     }
 }

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -249,8 +249,8 @@ mod tests {
         let remote_root = tmp.path().join("remote");
         let local_root = tmp.path().join("local");
         let dir = remote_root.join("flags");
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::create_dir_all(&local_root).unwrap();
+        fs_err::create_dir_all(&dir).unwrap();
+        fs_err::create_dir_all(&local_root).unwrap();
 
         // The writer works on the "remote" directly; the reader mirrors it
         // into `local_root` through the disk cache.
@@ -300,8 +300,8 @@ mod tests {
         let remote_root = tmp.path().join("remote");
         let local_root = tmp.path().join("local");
         let dir = remote_root.join("flags");
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::create_dir_all(&local_root).unwrap();
+        fs_err::create_dir_all(&dir).unwrap();
+        fs_err::create_dir_all(&local_root).unwrap();
 
         let mut writer = DynamicStoredFlags::<MmapFile>::open(&MmapFs, &dir, Populate::No).unwrap();
         writer.set_len(&MmapFs, 100).unwrap();

--- a/lib/segment/src/id_tracker/disk_id_tracker/read_only.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/read_only.rs
@@ -44,7 +44,8 @@ pub struct ReadOnlyDiskIdTracker<S: UniversalRead> {
 
     versions: TypedStorage<S, SeqNumberType>,
     versions_len: u64,
-    /// Kept for per-point `get_bit` and for `live_reload` reopen.
+    /// Kept for per-point `get_bit`; replaced with a freshly opened handle on
+    /// every [`Self::live_reload`].
     deleted_file: StoredBitSlice<S>,
 
     /// Full deleted set. NOT loaded on open or by point lookups. Materialized on
@@ -143,13 +144,29 @@ impl<S: UniversalRead> ReadOnlyDiskIdTracker<S> {
     /// Re-read the on-disk deleted bitslice and report points deleted since the
     /// last reload. Mappings are immutable, so nothing is ever inserted.
     ///
+    /// The deleted file is a fixed-size bitmap whose bits the writer flips in
+    /// place, which the held handle's `reopen()` — an append-only-growth
+    /// contract — never picks up on caching backends. So a *fresh* handle is
+    /// opened instead (a fresh open always mirrors the current remote bytes)
+    /// and swapped in; the per-point `get_bit` lookups read fresh state from
+    /// then on too.
+    ///
     /// The full deleted set (`deleted_full`) doubles as the diff baseline: if it
     /// was materialized (by a prior search/scroll/count/reload) we diff against
     /// it; otherwise this is the first baseline and every currently-deleted
     /// offset is reported (an idempotent replay downstream).
-    pub fn live_reload(&mut self) -> OperationResult<LiveReloadResult> {
-        self.deleted_file.reopen()?;
-        let new: BitVec = self.deleted_file.read_all()?.into_owned();
+    pub fn live_reload(
+        &mut self,
+        fs: &impl UniversalReadFs<File = S>,
+    ) -> OperationResult<LiveReloadResult> {
+        let fresh = StoredBitSlice::<S>::open(
+            fs,
+            deleted_path(&self.path),
+            Self::open_options(),
+            Default::default(),
+        )?;
+        let new: BitVec = fresh.read_all()?.into_owned();
+        self.deleted_file = fresh;
 
         let baseline = self.deleted_full.take();
         let deleted: Vec<PointOffsetType> = match baseline {

--- a/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
@@ -292,9 +292,9 @@ fn deletion_and_live_reload_disk_cache() {
     let local_root = dir.path().join("local");
     let immutable_path = remote_root.join("immutable_tracker");
     let disk_path = remote_root.join("disk_tracker");
-    std::fs::create_dir_all(&immutable_path).unwrap();
-    std::fs::create_dir_all(&disk_path).unwrap();
-    std::fs::create_dir_all(&local_root).unwrap();
+    fs_err::create_dir_all(&immutable_path).unwrap();
+    fs_err::create_dir_all(&disk_path).unwrap();
+    fs_err::create_dir_all(&local_root).unwrap();
 
     // The writers work on the "remote" directly; the readers mirror it into
     // `local_root` through the disk cache.

--- a/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
@@ -268,6 +268,77 @@ fn deletion_and_live_reload() {
     }
 }
 
+/// Case-1 regression of the live-reload staleness audit: the immutable
+/// tracker's `deleted` file is a fixed-size bitmap whose bits the writer
+/// flips in place — its length never changes — so a reader over a caching
+/// backend must not rely on `reopen()` (append-only-growth contract): the
+/// pre-deletion state, cached when `open` scanned the file, would be served
+/// forever and `live_reload` would never report the deletions.
+/// `live_reload` opens a fresh handle instead; this drives it over
+/// `DiskCacheFs`, where the stale-cache failure actually reproduces (mmap
+/// readers are read-through and can't catch it).
+#[test]
+fn immutable_deletion_and_live_reload_disk_cache() {
+    use std::sync::Arc;
+
+    use common::universal_io::{
+        DiskCache, DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, UniversalReadFileOps,
+    };
+
+    use crate::id_tracker::immutable_id_tracker::read_only::ReadOnlyImmutableIdTracker;
+
+    let dir = Builder::new().prefix("imm").tempdir().unwrap();
+    let remote_root = dir.path().join("remote");
+    let local_root = dir.path().join("local");
+    let segment_path = remote_root.join("segment");
+    std::fs::create_dir_all(&segment_path).unwrap();
+    std::fs::create_dir_all(&local_root).unwrap();
+
+    // The writer works on the "remote" directly; the reader mirrors it into
+    // `local_root` through the disk cache.
+    let (versions, mappings) = make_data(6);
+    let mut immutable =
+        ImmutableIdTracker::<MmapFile>::new(&MmapFs, &segment_path, &versions, mappings).unwrap();
+
+    let cache_fs = DiskCacheFs::<MmapFile>::from_context(DiskCacheFsContext {
+        config: Arc::new(DiskCacheConfig::new(remote_root, local_root).unwrap()),
+        remote: Default::default(),
+    })
+    .unwrap();
+    // `open` reads the whole pre-deletion deleted bitmap — the state this
+    // test must escape is now in the reader's local cache.
+    let mut read_only =
+        ReadOnlyImmutableIdTracker::<DiskCache<MmapFile>>::open(&cache_fs, &segment_path).unwrap();
+
+    let to_delete: Vec<(PointIdType, u32)> = immutable
+        .point_mappings()
+        .iter_from(None)
+        .take(50)
+        .collect();
+    for (external_id, _) in &to_delete {
+        immutable.drop(*external_id).unwrap();
+    }
+    immutable.mapping_flusher()().unwrap();
+    immutable.versions_flusher()().unwrap();
+
+    let result = read_only.live_reload(&cache_fs).unwrap();
+
+    let mut expected: Vec<u32> = to_delete.iter().map(|(_, offset)| *offset).collect();
+    expected.sort_unstable();
+    assert_eq!(result.deleted, expected, "live_reload delta mismatch");
+    assert!(result.inserted.is_empty());
+
+    // After reload, the reader hides the deleted points on every path.
+    for (external_id, offset) in &to_delete {
+        assert_eq!(
+            read_only.internal_id_with_behavior(*external_id, DeferredBehavior::VisibleOnly),
+            None,
+        );
+        assert!(read_only.is_deleted_point(*offset));
+        assert_eq!(read_only.external_id(*offset), None);
+    }
+}
+
 /// The on-disk layout must keep headers and every section start aligned to
 /// `SECTION_ALIGN`, so the files stay mmap+transmute-friendly (`u128` requires
 /// 16-byte alignment). Also pins the store/parse padding agreement: parsed

--- a/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
@@ -249,7 +249,7 @@ fn deletion_and_live_reload() {
     disk.mapping_flusher()().unwrap();
     disk.versions_flusher()().unwrap();
 
-    let result = read_only.live_reload().unwrap();
+    let result = read_only.live_reload(&MmapFs).unwrap();
     let mut reported = result.deleted.clone();
     reported.sort_unstable();
     let mut expected: Vec<u32> = to_delete.iter().map(|(_, offset)| *offset).collect();
@@ -268,17 +268,17 @@ fn deletion_and_live_reload() {
     }
 }
 
-/// Case-1 regression of the live-reload staleness audit: the immutable
-/// tracker's `deleted` file is a fixed-size bitmap whose bits the writer
-/// flips in place — its length never changes — so a reader over a caching
-/// backend must not rely on `reopen()` (append-only-growth contract): the
-/// pre-deletion state, cached when `open` scanned the file, would be served
-/// forever and `live_reload` would never report the deletions.
-/// `live_reload` opens a fresh handle instead; this drives it over
-/// `DiskCacheFs`, where the stale-cache failure actually reproduces (mmap
-/// readers are read-through and can't catch it).
+/// Cases 1+2 regression of the live-reload staleness audit: both trackers'
+/// `deleted` file is a fixed-size bitmap whose bits the writer flips in
+/// place — its length never changes — so a reader over a caching backend
+/// must not rely on `reopen()` (append-only-growth contract): the
+/// pre-deletion state, cached when first scanned, would be served forever
+/// and `live_reload` would never report the deletions. `live_reload` opens a
+/// fresh handle instead; this drives it over `DiskCacheFs`, where the
+/// stale-cache failure actually reproduces (mmap readers are read-through
+/// and can't catch it).
 #[test]
-fn immutable_deletion_and_live_reload_disk_cache() {
+fn deletion_and_live_reload_disk_cache() {
     use std::sync::Arc;
 
     use common::universal_io::{
@@ -287,28 +287,41 @@ fn immutable_deletion_and_live_reload_disk_cache() {
 
     use crate::id_tracker::immutable_id_tracker::read_only::ReadOnlyImmutableIdTracker;
 
-    let dir = Builder::new().prefix("imm").tempdir().unwrap();
+    let dir = Builder::new().prefix("disk").tempdir().unwrap();
     let remote_root = dir.path().join("remote");
     let local_root = dir.path().join("local");
-    let segment_path = remote_root.join("segment");
-    std::fs::create_dir_all(&segment_path).unwrap();
+    let immutable_path = remote_root.join("immutable_tracker");
+    let disk_path = remote_root.join("disk_tracker");
+    std::fs::create_dir_all(&immutable_path).unwrap();
+    std::fs::create_dir_all(&disk_path).unwrap();
     std::fs::create_dir_all(&local_root).unwrap();
 
-    // The writer works on the "remote" directly; the reader mirrors it into
+    // The writers work on the "remote" directly; the readers mirror it into
     // `local_root` through the disk cache.
     let (versions, mappings) = make_data(6);
     let mut immutable =
-        ImmutableIdTracker::<MmapFile>::new(&MmapFs, &segment_path, &versions, mappings).unwrap();
+        ImmutableIdTracker::<MmapFile>::new(&MmapFs, &immutable_path, &versions, mappings.clone())
+            .unwrap();
+    let mut disk =
+        DiskIdTracker::<MmapFile>::new(&MmapFs, &disk_path, &versions, mappings).unwrap();
 
     let cache_fs = DiskCacheFs::<MmapFile>::from_context(DiskCacheFsContext {
         config: Arc::new(DiskCacheConfig::new(remote_root, local_root).unwrap()),
         remote: Default::default(),
     })
     .unwrap();
-    // `open` reads the whole pre-deletion deleted bitmap — the state this
-    // test must escape is now in the reader's local cache.
-    let mut read_only =
-        ReadOnlyImmutableIdTracker::<DiskCache<MmapFile>>::open(&cache_fs, &segment_path).unwrap();
+    // The immutable tracker's `open` reads the whole pre-deletion deleted
+    // bitmap; the disk tracker caches it on the baseline materialization
+    // below — either way, the state this test must escape ends up in the
+    // readers' local caches.
+    let mut read_only_immutable =
+        ReadOnlyImmutableIdTracker::<DiskCache<MmapFile>>::open(&cache_fs, &immutable_path)
+            .unwrap();
+    let mut read_only_disk =
+        ReadOnlyDiskIdTracker::<DiskCache<MmapFile>>::open(&cache_fs, &disk_path).unwrap();
+    // Establish the diff baseline (a search-style access) so the reload
+    // reports only the incremental deletions, not every build-time deletion.
+    let _ = read_only_disk.deleted_point_bitslice();
 
     let to_delete: Vec<(PointIdType, u32)> = immutable
         .point_mappings()
@@ -317,25 +330,40 @@ fn immutable_deletion_and_live_reload_disk_cache() {
         .collect();
     for (external_id, _) in &to_delete {
         immutable.drop(*external_id).unwrap();
+        disk.drop(*external_id).unwrap();
     }
     immutable.mapping_flusher()().unwrap();
     immutable.versions_flusher()().unwrap();
-
-    let result = read_only.live_reload(&cache_fs).unwrap();
+    disk.mapping_flusher()().unwrap();
+    disk.versions_flusher()().unwrap();
 
     let mut expected: Vec<u32> = to_delete.iter().map(|(_, offset)| *offset).collect();
     expected.sort_unstable();
-    assert_eq!(result.deleted, expected, "live_reload delta mismatch");
-    assert!(result.inserted.is_empty());
 
-    // After reload, the reader hides the deleted points on every path.
+    for result in [
+        read_only_immutable.live_reload(&cache_fs).unwrap(),
+        read_only_disk.live_reload(&cache_fs).unwrap(),
+    ] {
+        assert_eq!(result.deleted, expected, "live_reload delta mismatch");
+        assert!(result.inserted.is_empty());
+    }
+
+    // After reload, both readers hide the deleted points on every path.
     for (external_id, offset) in &to_delete {
         assert_eq!(
-            read_only.internal_id_with_behavior(*external_id, DeferredBehavior::VisibleOnly),
+            read_only_immutable
+                .internal_id_with_behavior(*external_id, DeferredBehavior::VisibleOnly),
             None,
         );
-        assert!(read_only.is_deleted_point(*offset));
-        assert_eq!(read_only.external_id(*offset), None);
+        assert!(read_only_immutable.is_deleted_point(*offset));
+        assert_eq!(read_only_immutable.external_id(*offset), None);
+
+        assert_eq!(
+            read_only_disk.internal_id_with_behavior(*external_id, DeferredBehavior::VisibleOnly),
+            None,
+        );
+        assert!(read_only_disk.is_deleted_point(*offset));
+        assert_eq!(read_only_disk.external_id(*offset), None);
     }
 }
 

--- a/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
@@ -69,10 +69,14 @@ impl<S: UniversalRead> ReadOnlyIdTrackerEnum<S> {
     }
 
     /// Reload externally-applied changes, dispatching to the active variant.
-    pub fn live_reload(&mut self) -> OperationResult<LiveReloadResult> {
+    ///
+    /// `fs` refreshes storages that mutate in place (the immutable tracker's
+    /// deleted bitmap) by opening fresh handles; the appendable tracker keeps
+    /// its own raw fs handle instead (see [`Self::detect_and_load`]).
+    pub fn live_reload(&mut self, fs: &S::Fs) -> OperationResult<LiveReloadResult> {
         match self {
             Self::Appendable(id_tracker) => id_tracker.live_reload(),
-            Self::Immutable(id_tracker) => id_tracker.live_reload(),
+            Self::Immutable(id_tracker) => id_tracker.live_reload(fs),
             Self::DiskResident(id_tracker) => id_tracker.live_reload(),
         }
     }

--- a/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
@@ -70,14 +70,15 @@ impl<S: UniversalRead> ReadOnlyIdTrackerEnum<S> {
 
     /// Reload externally-applied changes, dispatching to the active variant.
     ///
-    /// `fs` refreshes storages that mutate in place (the immutable tracker's
-    /// deleted bitmap) by opening fresh handles; the appendable tracker keeps
-    /// its own raw fs handle instead (see [`Self::detect_and_load`]).
+    /// `fs` refreshes storages that mutate in place (the immutable and disk
+    /// trackers' deleted bitmaps) by opening fresh handles; the appendable
+    /// tracker keeps its own raw fs handle instead (see
+    /// [`Self::detect_and_load`]).
     pub fn live_reload(&mut self, fs: &S::Fs) -> OperationResult<LiveReloadResult> {
         match self {
             Self::Appendable(id_tracker) => id_tracker.live_reload(),
             Self::Immutable(id_tracker) => id_tracker.live_reload(fs),
-            Self::DiskResident(id_tracker) => id_tracker.live_reload(),
+            Self::DiskResident(id_tracker) => id_tracker.live_reload(fs),
         }
     }
 }

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/lifecycle.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/lifecycle.rs
@@ -19,7 +19,7 @@ use crate::id_tracker::immutable_id_tracker::versions_storage::version_mapping_p
 use crate::types::SeqNumberType;
 
 impl<S: UniversalRead> ReadOnlyImmutableIdTracker<S> {
-    fn open_options() -> OpenOptions {
+    pub(super) fn open_options() -> OpenOptions {
         OpenOptions {
             writeable: false,
             need_sequential: false,

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/live_reload.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/live_reload.rs
@@ -1,26 +1,45 @@
+use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyImmutableIdTracker;
 use crate::common::operation_error::OperationResult;
+use crate::id_tracker::immutable_id_tracker::deleted_storage::deleted_path;
 use crate::id_tracker::mutable_id_tracker::read_only::LiveReloadResult;
 
 impl<S: UniversalRead> ReadOnlyImmutableIdTracker<S> {
     /// Re-read the on-disk `deleted` bitslice and apply points deleted since the last reload.
     ///
+    /// The bitslice is a fixed-size bitmap whose bits the writer flips in
+    /// place, which the held handle's `reopen()` — an append-only-growth
+    /// contract — never picks up on caching backends. So a *fresh* handle is
+    /// opened instead (a fresh open always mirrors the current remote bytes),
+    /// diffed against the tracker's current state, and swapped in.
+    ///
     /// An immutable tracker only ever loses points (no inserts), so `inserted` is always empty.
     /// Result offsets are sorted ascending.
-    pub fn live_reload(&mut self) -> OperationResult<LiveReloadResult> {
-        self.deleted.reopen()?;
+    pub fn live_reload(
+        &mut self,
+        fs: &impl UniversalReadFs<File = S>,
+    ) -> OperationResult<LiveReloadResult> {
+        let fresh = StoredBitSlice::<S>::open(
+            fs,
+            deleted_path(&self.path),
+            Self::open_options(),
+            Default::default(),
+        )?;
 
+        // `mappings` already reflects every previously reported deletion, so
+        // it is the diff baseline: a set bit not yet dropped there is new.
         let newly_deleted: Vec<PointOffsetType> = {
-            let deleted = self.deleted.read_all()?;
+            let deleted = fresh.read_all()?;
             deleted
                 .iter_ones()
                 .map(|internal_id| internal_id as PointOffsetType)
                 .filter(|&internal_id| !self.mappings.is_deleted_point(internal_id))
                 .collect()
         };
+        self.deleted = fresh;
 
         let mut deleted = Vec::with_capacity(newly_deleted.len());
         for internal_id in newly_deleted {

--- a/lib/segment/src/id_tracker/mutable_id_tracker/read_only/live_reload.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/read_only/live_reload.rs
@@ -79,6 +79,11 @@ impl<S: UniversalRead> ReadOnlyAppendableIdTracker<S> {
         // Consume new mapping changes. Inserts are buffered until committed (their version exists);
         // deletes act on the committed mapping immediately, or cancel a still-pending insert.
         let changes = self.read_new_mapping_changes()?;
+
+        for change in &changes {
+            log::trace!(target: "live-reload", "Read mapping in {:?} change: {:?}", self.segment_path, change);
+        }
+
         let mut deleted = Vec::new();
         for change in &changes {
             match *change {

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
@@ -13,24 +13,18 @@ impl<S: UniversalReadExt> LiveReload for ReadOnlyBoolIndex<S> {
     fn live_reload(
         &mut self,
         fs: &S::Fs,
-        deleted_points: &SortedSlice<'_, PointOffsetType>,
-        new_points: &SortedSlice<'_, PointOffsetType>,
-        hw_counter: &HardwareCounterCell,
+        _deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _new_points: &SortedSlice<'_, PointOffsetType>,
+        _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        // Reload each flag set's bitmap from the changed points only.
-        self.storage
-            .trues_flags
-            .live_reload(fs, deleted_points, new_points, hw_counter)?;
-        self.storage
-            .falses_flags
-            .live_reload(fs, deleted_points, new_points, hw_counter)?;
+        // Resync each flag set from its on-disk state; the point deltas are
+        // irrelevant, the flag files are the source of truth.
+        self.storage.trues_flags.live_reload(fs)?;
+        self.storage.falses_flags.live_reload(fs)?;
 
-        // Re-derive the counts from the just-reloaded bitmaps, but only if they
+        // Re-derive the counts from the just-resynced bitmaps, but only if they
         // were computed before: an untouched index must not pay for the bitmap
         // scan that deriving them would force.
-        //
-        // possible opt: update this using deleted_points and new_points separately,
-        //               so we only process the delta
         self.refresh_counts()?;
 
         Ok(())

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/lifecycle.rs
@@ -62,7 +62,7 @@ impl<S: UniversalRead> ReadOnlyAppendableFullTextIndex<S> {
 
         storage
             .iter::<_, OperationError>(
-                storage.max_point_offset(),
+                storage.max_point_offset()?,
                 |idx, value: Vec<u8>| {
                     let str_tokens = FullTextIndex::deserialize_document(&value)?;
                     builder.add(idx, str_tokens);

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/lifecycle.rs
@@ -54,7 +54,7 @@ impl<S: UniversalRead> ReadOnlyAppendableGeoIndex<S> {
         let hw_counter = HardwareCounterCell::disposable();
         storage
             .iter::<_, OperationError>(
-                storage.max_point_offset(),
+                storage.max_point_offset()?,
                 |idx, values: Vec<RawGeoPoint>| {
                     let geo_points = values.into_iter().map(GeoPoint::from).collect::<Vec<_>>();
                     in_memory_index.add_many_geo_points(idx, geo_points, &hw_counter)?;

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/lifecycle.rs
@@ -63,7 +63,7 @@ where
         let mut in_memory_index = InMemoryMapIndex::<N>::empty(false);
         let hw_counter = HardwareCounterCell::disposable();
         storage.iter::<_, GridstoreError>(
-            storage.max_point_offset(),
+            storage.max_point_offset()?,
             |idx, values: Vec<_>| {
                 in_memory_index.add_many_to_map(idx, values);
                 Ok(true)

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/live_reload.rs
@@ -13,17 +13,14 @@ impl<S: UniversalRead> LiveReload for ReadOnlyNullIndex<S> {
     fn live_reload(
         &mut self,
         fs: &S::Fs,
-        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        _deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
-        hw_counter: &HardwareCounterCell,
+        _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        // Reload each flag set's bitmap from the changed points only.
-        self.storage
-            .has_values_flags
-            .live_reload(fs, deleted_points, new_points, hw_counter)?;
-        self.storage
-            .is_null_flags
-            .live_reload(fs, deleted_points, new_points, hw_counter)?;
+        // Resync each flag set from its on-disk state; the point deltas are
+        // irrelevant, the flag files are the source of truth.
+        self.storage.has_values_flags.live_reload(fs)?;
+        self.storage.is_null_flags.live_reload(fs)?;
 
         // total_point_count only grows, to cover appended offsets.
         self.total_point_count = new_points

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/lifecycle.rs
@@ -57,7 +57,7 @@ where
         let hw_counter = HardwareCounterCell::disposable();
         storage
             .iter::<_, OperationError>(
-                storage.max_point_offset(),
+                storage.max_point_offset()?,
                 |idx, values: Vec<T>| {
                     in_memory_index.add_many_to_list(idx, values);
                     Ok(true)

--- a/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
+++ b/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
@@ -65,7 +65,7 @@ impl<S: UniversalRead> PayloadStorageRead for ReadOnlyPayloadStorage<S> {
     where
         F: FnMut(PointOffsetType, &Payload) -> OperationResult<bool>,
     {
-        let max_id = self.storage.max_point_offset();
+        let max_id = self.storage.max_point_offset()?;
         self.storage.iter(
             max_id,
             |point_id, payload| callback(point_id, &payload),

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -359,6 +359,21 @@ impl Segment {
         self.is_appendable() && self.append_only_mutations
     }
 
+    /// Whether point deletions on this segment must be tombstone-only: drop
+    /// from the id tracker, leaving payload rows and field indexes untouched.
+    ///
+    /// Unlike [`Self::is_append_only`], this deliberately does *not* require
+    /// the segment to be appendable. In append-only deployments,
+    /// non-appendable segments are read by live-reload followers too, and
+    /// clearing the payload of a deleted point mutates committed state of an
+    /// offset that stays visible until the id-tracker drop is flushed — a
+    /// follower refreshing in that window observes the point alive with an
+    /// empty payload. Tombstone-only deletion needs nothing from the segment
+    /// but the id tracker, so appendability is irrelevant.
+    pub fn is_append_only_delete(&self) -> bool {
+        self.append_only_mutations
+    }
+
     /// Iterator over all points in segment in ascending order.
     pub fn iter_points(&self) -> Box<dyn Iterator<Item = PointIdType> + '_> {
         let mappings =
@@ -585,7 +600,7 @@ impl NonAppendableSegmentEntry for Segment {
             .id_tracker
             .borrow()
             .internal_id_with_behavior(point_id, DeferredBehavior::WithDeferred);
-        let append_only = self.is_append_only();
+        let append_only = self.is_append_only_delete();
         match internal_id {
             // Point does already not exist anymore
             None => Ok(false),

--- a/lib/segment/src/segment/mod.rs
+++ b/lib/segment/src/segment/mod.rs
@@ -87,9 +87,11 @@ pub struct Segment {
     /// vector and payload storages are never written in place. Intended for
     /// S3-backed storages that prefer pure appends.
     ///
-    /// Runtime-only — not persisted in the segment state file. Only takes
-    /// effect when [`Segment::is_appendable`] is also true, see
-    /// [`Segment::is_append_only`].
+    /// Runtime-only — not persisted in the segment state file. Clone-based
+    /// mutations only take effect when [`Segment::is_appendable`] is also
+    /// true (see [`Segment::is_append_only`]); point *deletions* are
+    /// tombstone-only regardless of appendability (see
+    /// [`Segment::is_append_only_delete`]).
     pub append_only_mutations: bool,
     /// Shows what kind of indexes and storages are used in this segment
     pub segment_type: SegmentType,

--- a/lib/segment/src/segment/read_only/live_reload.rs
+++ b/lib/segment/src/segment/read_only/live_reload.rs
@@ -36,7 +36,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         // Drain the tracker delta and fold it into whatever a previous reload left
         // unapplied. This must happen before any component reload can fail, so the
         // accumulated delta survives an error and is replayed on the next call.
-        let fresh = id_tracker.borrow_mut().live_reload()?;
+        let fresh = id_tracker.borrow_mut().live_reload(fs)?;
         let mut pending = pending_reload.borrow_mut();
         pending.merge(fresh);
 

--- a/lib/segment/src/segment/read_only/live_reload.rs
+++ b/lib/segment/src/segment/read_only/live_reload.rs
@@ -40,6 +40,8 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         let mut pending = pending_reload.borrow_mut();
         pending.merge(fresh);
 
+        log::trace!(target: "live-reload", "Pending live-reload in {} changes: {:?}", self.uuid, pending);
+
         // Replay the full accumulated delta to every component. Bail on the first
         // error without clearing `pending`, so the next reload retries the union.
         {

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -1037,6 +1037,54 @@ fn test_append_only_clone_stamps_payload_version() {
     assert_eq!(plain.version_tracker.get_payload(), Some(101));
 }
 
+/// In append-only mode a point deletion must be tombstone-only even on a
+/// non-appendable segment: clearing the payload row mutates committed state
+/// of an offset that stays visible to live-reload followers until the
+/// id-tracker drop is flushed — a follower refreshing in that window
+/// observes the point alive with an empty payload. Observed 2026-07-13 on
+/// the CoW-update path, which deletes the old copy from a non-appendable
+/// segment.
+#[test]
+fn test_append_only_delete_is_tombstone_only_on_non_appendable() {
+    use crate::id_tracker::IdTrackerRead as _;
+    use crate::index::PayloadIndexRead as _;
+
+    init_logger();
+    let dir = Builder::new().prefix("segment").tempdir().unwrap();
+    let dim = 4;
+
+    let mut segment = build_simple_segment(dir.path(), dim, Distance::Dot).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let vec = vec![1.0_f32, 0.0, 1.0, 0.0];
+    segment
+        .upsert_point(100, 7.into(), only_default_vector(&vec), &hw_counter)
+        .unwrap();
+    let payload: Payload = serde_json::from_str(r#"{"color": "red"}"#).unwrap();
+    segment
+        .set_full_payload(101, 7.into(), &payload, &hw_counter)
+        .unwrap();
+
+    let internal_id = segment.get_internal_id(7.into()).unwrap();
+
+    // Emulate a non-appendable segment in an append-only deployment.
+    segment.appendable_flag = false;
+    segment.append_only_mutations = true;
+
+    assert!(segment.delete_point(102, 7.into(), &hw_counter).unwrap());
+
+    // The point is masked via the id tracker...
+    assert!(segment.id_tracker.borrow().is_deleted_point(internal_id));
+    // ...but its payload row is untouched: committed state of the old offset
+    // must not be mutated in place while readers may still resolve to it.
+    let stored = segment
+        .payload_index
+        .borrow()
+        .with_view(|view| view.get_payload(internal_id, &hw_counter))
+        .unwrap();
+    assert_eq!(stored, payload);
+}
+
 /// `upsert_moved_point` writes the whole point — raw bytes, decoded overlay,
 /// payload — in one operation, allocating exactly one internal slot where the
 /// separate `upsert_point_raw` + `update_vectors` + `set_full_payload` steps

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -1160,61 +1160,6 @@ fn test_append_only_same_op_multi_step_single_slot() {
     assert_eq!(segment.payload(7.into(), &hw_counter).unwrap(), payload3);
 }
 
-/// On an append-only segment, the follow-up steps of a multi-step point
-/// write (e.g. the `set_full_payload` after an `upsert_point`, sharing its
-/// `op_num`) must mutate the slot written by the same operation in place
-/// instead of cloning it: one operation allocates exactly one slot.
-#[test]
-fn test_append_only_same_op_multi_step_single_slot() {
-    use crate::id_tracker::IdTrackerRead as _;
-
-    init_logger();
-    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-    let dim = 4;
-
-    let mut segment = build_simple_segment(dir.path(), dim, Distance::Dot).unwrap();
-    segment.append_only_mutations = true;
-    let hw_counter = HardwareCounterCell::new();
-
-    // New point: insert + payload at the same op_num — one slot.
-    let vec = vec![1.0_f32, 0.0, 1.0, 0.0];
-    let payload: Payload = serde_json::from_str(r#"{"color": "red"}"#).unwrap();
-    segment
-        .upsert_point(100, 7.into(), only_default_vector(&vec), &hw_counter)
-        .unwrap();
-    segment
-        .set_full_payload(100, 7.into(), &payload, &hw_counter)
-        .unwrap();
-    assert_eq!(segment.id_tracker.borrow().total_point_count(), 1);
-
-    // Update of a committed point: the first step clones to a fresh slot,
-    // the second step mutates that same-op slot in place — one new slot.
-    let vec2 = vec![0.1_f32, 0.2, 0.3, 0.4];
-    let payload2: Payload = serde_json::from_str(r#"{"color": "blue"}"#).unwrap();
-    segment
-        .upsert_point(101, 7.into(), only_default_vector(&vec2), &hw_counter)
-        .unwrap();
-    segment
-        .set_full_payload(101, 7.into(), &payload2, &hw_counter)
-        .unwrap();
-    assert_eq!(segment.id_tracker.borrow().total_point_count(), 2);
-    assert_eq!(
-        segment
-            .vector(DEFAULT_VECTOR_NAME, 7.into(), &hw_counter)
-            .unwrap(),
-        Some(VectorInternal::Dense(vec2)),
-    );
-    assert_eq!(segment.payload(7.into(), &hw_counter).unwrap(), payload2);
-
-    // A later operation still clones: committed slots are never mutated.
-    let payload3: Payload = serde_json::from_str(r#"{"color": "green"}"#).unwrap();
-    segment
-        .set_full_payload(102, 7.into(), &payload3, &hw_counter)
-        .unwrap();
-    assert_eq!(segment.id_tracker.borrow().total_point_count(), 3);
-    assert_eq!(segment.payload(7.into(), &hw_counter).unwrap(), payload3);
-}
-
 /// Multi-dense raw round-trip: the flattened inner-vector blob must survive
 /// `retrieve_raw` → `upsert_point_raw` byte-identically and decode to the
 /// original multivector.

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -1160,6 +1160,61 @@ fn test_append_only_same_op_multi_step_single_slot() {
     assert_eq!(segment.payload(7.into(), &hw_counter).unwrap(), payload3);
 }
 
+/// On an append-only segment, the follow-up steps of a multi-step point
+/// write (e.g. the `set_full_payload` after an `upsert_point`, sharing its
+/// `op_num`) must mutate the slot written by the same operation in place
+/// instead of cloning it: one operation allocates exactly one slot.
+#[test]
+fn test_append_only_same_op_multi_step_single_slot() {
+    use crate::id_tracker::IdTrackerRead as _;
+
+    init_logger();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let dim = 4;
+
+    let mut segment = build_simple_segment(dir.path(), dim, Distance::Dot).unwrap();
+    segment.append_only_mutations = true;
+    let hw_counter = HardwareCounterCell::new();
+
+    // New point: insert + payload at the same op_num — one slot.
+    let vec = vec![1.0_f32, 0.0, 1.0, 0.0];
+    let payload: Payload = serde_json::from_str(r#"{"color": "red"}"#).unwrap();
+    segment
+        .upsert_point(100, 7.into(), only_default_vector(&vec), &hw_counter)
+        .unwrap();
+    segment
+        .set_full_payload(100, 7.into(), &payload, &hw_counter)
+        .unwrap();
+    assert_eq!(segment.id_tracker.borrow().total_point_count(), 1);
+
+    // Update of a committed point: the first step clones to a fresh slot,
+    // the second step mutates that same-op slot in place — one new slot.
+    let vec2 = vec![0.1_f32, 0.2, 0.3, 0.4];
+    let payload2: Payload = serde_json::from_str(r#"{"color": "blue"}"#).unwrap();
+    segment
+        .upsert_point(101, 7.into(), only_default_vector(&vec2), &hw_counter)
+        .unwrap();
+    segment
+        .set_full_payload(101, 7.into(), &payload2, &hw_counter)
+        .unwrap();
+    assert_eq!(segment.id_tracker.borrow().total_point_count(), 2);
+    assert_eq!(
+        segment
+            .vector(DEFAULT_VECTOR_NAME, 7.into(), &hw_counter)
+            .unwrap(),
+        Some(VectorInternal::Dense(vec2)),
+    );
+    assert_eq!(segment.payload(7.into(), &hw_counter).unwrap(), payload2);
+
+    // A later operation still clones: committed slots are never mutated.
+    let payload3: Payload = serde_json::from_str(r#"{"color": "green"}"#).unwrap();
+    segment
+        .set_full_payload(102, 7.into(), &payload3, &hw_counter)
+        .unwrap();
+    assert_eq!(segment.id_tracker.borrow().total_point_count(), 3);
+    assert_eq!(segment.payload(7.into(), &hw_counter).unwrap(), payload3);
+}
+
 /// Multi-dense raw round-trip: the flattened inner-vector blob must survive
 /// `retrieve_raw` → `upsert_point_raw` byte-identically and decode to the
 /// original multivector.

--- a/lib/segment/src/vector_storage/chunked_vectors/live_reload.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/live_reload.rs
@@ -36,7 +36,6 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> LiveReload for ChunkedVectorsRea
         }
 
         let reload_from = self.chunks.len().saturating_sub(1);
-        self.chunks.truncate(reload_from);
         let new_chunks = read_chunks_from(
             fs,
             &self.directory,
@@ -45,6 +44,7 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> LiveReload for ChunkedVectorsRea
             self.populate,
             false,
         )?;
+        self.chunks.truncate(reload_from);
         self.chunks.extend(new_chunks);
         self.len = new_len;
         Ok(())

--- a/lib/segment/src/vector_storage/chunked_vectors/live_reload.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/live_reload.rs
@@ -11,10 +11,18 @@ use crate::common::operation_error::OperationResult;
 impl<T: bytemuck::Pod + Send, S: UniversalRead> LiveReload for ChunkedVectorsRead<T, S> {
     type Fs = S::Fs;
 
-    /// Open only chunk files appended since the last load; a no-op when the
-    /// length is unchanged. Chunk files are pre-allocated to full size, so the
-    /// chunks already held keep reflecting appended vectors through their mmap.
-    /// Deletions/new points are tracked by callers, so they are unused here.
+    /// Refresh the chunks that can have gained vectors since the last load; a
+    /// no-op when the length is unchanged (the status file is read fresh, so
+    /// it is a reliable change signal).
+    ///
+    /// Chunk files are preallocated to full size, so appended vectors are
+    /// in-place writes *within* the existing file length — which a held
+    /// handle's cached blocks never reflect on caching backends (a block
+    /// fetched earlier extends past the old tail into then-unwritten space).
+    /// So, mirroring `Pages::live_reload`, the last held chunk — the only one
+    /// that can have gained vectors — is dropped and re-opened fresh,
+    /// alongside adopting newly created chunk files. Deletions/new points are
+    /// tracked by callers, so they are unused here.
     fn live_reload(
         &mut self,
         fs: &S::Fs,
@@ -27,10 +35,12 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> LiveReload for ChunkedVectorsRea
             return Ok(());
         }
 
+        let reload_from = self.chunks.len().saturating_sub(1);
+        self.chunks.truncate(reload_from);
         let new_chunks = read_chunks_from(
             fs,
             &self.directory,
-            self.chunks.len(),
+            reload_from,
             self.advice,
             self.populate,
             false,

--- a/lib/segment/src/vector_storage/chunked_vectors/read.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read.rs
@@ -446,8 +446,91 @@ mod tests {
         assert_eq!(got.as_ref(), second[0].as_slice());
     }
 
-    /// `live_reload` opens only chunk files created since the last load, keeping
-    /// the chunks it already holds (which still see vectors appended into them).
+    /// Case-5 regression of the live-reload staleness audit: chunk files are
+    /// preallocated to full size, so appended vectors are in-place writes
+    /// within the existing file length. A reader over a caching backend that
+    /// fetched a block straddling the old tail (any read near the tail pulls
+    /// a 16KiB block extending into then-unwritten space) would keep serving
+    /// those stale bytes for vectors appended later into that block —
+    /// `live_reload` must re-open the last held chunk, not keep the handle.
+    /// This drives it over `DiskCacheFs`, where the failure actually
+    /// reproduces (mmap readers are read-through and can't catch it).
+    #[test]
+    fn live_reload_over_disk_cache_sees_in_place_appends() {
+        use std::sync::Arc;
+
+        use common::universal_io::{
+            DiskCache, DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, UniversalReadFileOps,
+        };
+
+        const DIM: usize = 32;
+        let tmp = Builder::new().prefix("chunked_reload").tempdir().unwrap();
+        let remote_root = tmp.path().join("remote");
+        let local_root = tmp.path().join("local");
+        let dir = remote_root.join("vectors");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::create_dir_all(&local_root).unwrap();
+
+        let hw = HardwareCounterCell::disposable();
+
+        // The writer works on the "remote" directly; the reader mirrors it
+        // into `local_root` through the disk cache.
+        let mut writer = ChunkedVectors::<f32, MmapFile>::open(
+            MmapFs,
+            &dir,
+            DIM,
+            AdviceSetting::Global,
+            Populate::No,
+        )
+        .unwrap();
+        for s in 0..100 {
+            writer.push(make_vec(s, DIM).as_slice(), &hw).unwrap();
+        }
+        writer.flusher()().unwrap();
+
+        let cache_fs = DiskCacheFs::<MmapFile>::from_context(DiskCacheFsContext {
+            config: Arc::new(DiskCacheConfig::new(remote_root, local_root).unwrap()),
+            remote: Default::default(),
+        })
+        .unwrap();
+        let mut reader = ChunkedVectorsRead::<f32, DiskCache<MmapFile>>::open(
+            &cache_fs,
+            &dir,
+            DIM,
+            AdviceSetting::Global,
+            Populate::No,
+        )
+        .unwrap();
+        assert_eq!(reader.len(), 100);
+
+        // Read the tail vector: the fetched block extends past it into
+        // then-unwritten space — the stale bytes this test must escape are
+        // now in the reader's local cache.
+        let got = reader.get::<Random>(99).unwrap();
+        assert_eq!(got.as_ref(), make_vec(99, DIM).as_slice());
+
+        // Append into that same block region, then reload.
+        for s in 100..150 {
+            writer.push(make_vec(s, DIM).as_slice(), &hw).unwrap();
+        }
+        writer.flusher()().unwrap();
+
+        let empty = SortedSlice::new(&[]).unwrap();
+        reader.live_reload(&cache_fs, &empty, &empty, &hw).unwrap();
+
+        assert_eq!(reader.len(), 150);
+        for offset in [0, 99, 100, 149] {
+            assert_eq!(
+                reader.get::<Random>(offset).unwrap().as_ref(),
+                make_vec(offset as usize, DIM).as_slice(),
+                "vector {offset} mismatch after reload",
+            );
+        }
+    }
+
+    /// `live_reload` re-opens the last held chunk (the only one that can have
+    /// gained vectors) and adopts chunk files created since the last load;
+    /// fully-loaded earlier chunks are kept as-is.
     #[test]
     fn live_reload_adopts_only_new_chunks() {
         const DIM: usize = 32; // 4096 vectors per test chunk

--- a/lib/segment/src/vector_storage/chunked_vectors/read.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read.rs
@@ -583,4 +583,75 @@ mod tests {
             );
         }
     }
+
+    /// A `live_reload` that fails mid-way (transient I/O error re-opening the
+    /// last chunk) must leave the reader serving its pre-refresh state: the
+    /// old chunk handle stays live, so no previously-readable vector vanishes.
+    #[cfg(unix)]
+    #[test]
+    fn failed_live_reload_keeps_serving_pre_refresh_state() {
+        use std::os::unix::fs::PermissionsExt;
+
+        const DIM: usize = 32;
+        let dir = Builder::new()
+            .prefix("chunked_reload_err")
+            .tempdir()
+            .unwrap();
+        let hw = HardwareCounterCell::disposable();
+
+        let mut writer = ChunkedVectors::<f32, MmapFile>::open(
+            MmapFs,
+            dir.path(),
+            DIM,
+            AdviceSetting::Global,
+            Populate::No,
+        )
+        .unwrap();
+        for s in 0..100 {
+            writer.push(make_vec(s, DIM).as_slice(), &hw).unwrap();
+        }
+        writer.flusher()().unwrap();
+
+        let mut reader = ChunkedVectorsRead::<f32, MmapFile>::open(
+            &MmapFs,
+            dir.path(),
+            DIM,
+            AdviceSetting::Global,
+            Populate::No,
+        )
+        .unwrap();
+        assert_eq!(reader.len(), 100);
+        assert_eq!(
+            reader.get::<Random>(99).unwrap().as_ref(),
+            make_vec(99, DIM).as_slice(),
+        );
+
+        // Grow within the same chunk so the reload takes the slow path.
+        for s in 100..150 {
+            writer.push(make_vec(s, DIM).as_slice(), &hw).unwrap();
+        }
+        writer.flusher()().unwrap();
+
+        // Inject a transient error: chunk 0 still exists but cannot be opened.
+        let chunk_file = chunk_name(dir.path(), 0);
+        fs_err::set_permissions(&chunk_file, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let empty = SortedSlice::new(&[]).unwrap();
+        let reloaded = reader.live_reload(&MmapFs, &empty, &empty, &hw);
+
+        // Restore before asserting, so a failure leaves the tempdir removable.
+        fs_err::set_permissions(&chunk_file, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(
+            reloaded.is_err(),
+            "reload must fail while chunk is unreadable"
+        );
+
+        // The failed reload must not have torn the pre-refresh state.
+        assert_eq!(reader.len(), 100);
+        assert_eq!(
+            reader.get::<Random>(99).as_deref(),
+            Some(make_vec(99, DIM).as_slice()),
+            "vector 99 must survive a failed reload",
+        );
+    }
 }

--- a/lib/segment/src/vector_storage/chunked_vectors/read.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read.rs
@@ -468,8 +468,8 @@ mod tests {
         let remote_root = tmp.path().join("remote");
         let local_root = tmp.path().join("local");
         let dir = remote_root.join("vectors");
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::create_dir_all(&local_root).unwrap();
+        fs_err::create_dir_all(&dir).unwrap();
+        fs_err::create_dir_all(&local_root).unwrap();
 
         let hw = HardwareCounterCell::disposable();
 
@@ -522,7 +522,7 @@ mod tests {
         for offset in [0, 99, 100, 149] {
             assert_eq!(
                 reader.get::<Random>(offset).unwrap().as_ref(),
-                make_vec(offset as usize, DIM).as_slice(),
+                make_vec(offset, DIM).as_slice(),
                 "vector {offset} mismatch after reload",
             );
         }

--- a/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
@@ -57,7 +57,7 @@ impl<S: UniversalRead> ReadOnlySparseVectorStorage<S> {
         let next_point_offset = deleted
             .as_bitslice()
             .last_one()
-            .max(Some(storage.max_point_offset() as usize))
+            .max(Some(storage.max_point_offset()? as usize))
             .unwrap_or_default();
 
         Ok(Self {

--- a/lib/segment/src/vector_storage/sparse/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/live_reload.rs
@@ -27,7 +27,7 @@ impl<S: UniversalRead> LiveReload for ReadOnlySparseVectorStorage<S> {
             .deleted
             .as_bitslice()
             .last_one()
-            .max(Some(self.storage.max_point_offset() as usize))
+            .max(Some(self.storage.max_point_offset()? as usize))
             .unwrap_or_default();
 
         Ok(())


### PR DESCRIPTION
## What

Shard followers over the caching backend (`simple_disk_cache::DiskCache`) never observed writer changes to files that are mutated **in place**. `DiskCache::reopen()` has a deliberately simple append-only contract — cached blocks are never invalidated, only growth is adopted — so any reload path that held a `UniversalRead` handle and called `reopen()` on a preallocated / in-place-rewritten file kept serving stale bytes forever.

Observed on a 10k-point repro: updating a point inserted it into the appendable segment, but the deletion never surfaced from the immutable segment, and the payload read back empty.

The fix direction (kept consistent across all cases): **don't** complicate `DiskCache` with mutation-model knobs — reload sites drop their handle and open a fresh one instead (a fresh open always mirrors the current remote bytes).

## Groundwork: unique DiskCache mirrors

To make refresh-by-fresh-open safe while the old handle is still alive, every `DiskCache` open now mirrors into a uniquely-named local file (`.{pid:x}-{counter:x}` suffix), removed on `Drop`. Mirrors were already truncated on every open (block validity is in-memory only), so the stable name carried no state. This replaces the "single instance per path" constraint.

Known trade-off: mirrors of a crashed process are not reused and accumulate until the local cache dir is cleaned externally.

## Fixes (one commit each)

1. **`ReadOnlyRoaringFlags`** (null / has-values / bool flag sets): dropped its `LiveReload` impl — this storage has no notion of points, so the point-delta interface didn't belong there (and `open` never applied deleted points either). An inherent `live_reload(fs)` opens a fresh `StoredBitSlice`, resyncs the materialized bitmap, and swaps the handle. The flags file is padded to power-of-two capacity, so new bits are in-place writes the old `reopen()` + read-new-range could never see — including *cleared* flags, which the delta approach missed even on mmap.

2. **Immutable id tracker** `id_tracker.deleted`: fixed-size bitmap, bits flipped in place → `reopen()` was a complete no-op. `live_reload` now takes `fs`, opens a fresh bitslice, diffs against `mappings` (which already reflect every previously reported deletion), and swaps the handle. `ReadOnlyIdTrackerEnum` and the segment-level reload pass `fs` through.

3. **Disk id tracker** `id_tracker.deleted`: same shape; the swap also refreshes the per-point `get_bit` lookups. (The disk tracker's *versions* file staleness is a known, separate follow-up.)

4. **Gridstore tracker** (payload storage, sparse vectors, appendable-variant field indexes): replaced the reader's `Tracker` with a header-stateless **`ReadOnlyTracker`** — reads are positional and need no header state; `live_reload(fs)` fresh-opens and swaps the storage handle. A new **`TrackerRead`** trait (implemented by both trackers) makes `GridstoreView` shared between writer and reader. The old `Tracker::live_reload` — which read the header through the stale handle *before* `reopen()` and gated the pages reload on it (the empty-payload symptom) — is deleted. `max_point_offset` reads the stored header count as plain data through the current handle; deriving it from file capacity was rejected because sparse `total_vector_count` builds on it and the 1MB-preallocated file would inflate every follower segment's count to ≥65k. The method is now fallible; consumers propagate the error.

5. **Chunked vectors** (dense / multi-dense / quantized-chunked): chunk files are preallocated, so appends are in-place writes — a cached block straddling the old tail served stale bytes for vectors appended later into it. `live_reload` now mirrors `Pages::live_reload`: on a `len` change it drops and re-opens the *last* held chunk alongside adopting new chunk files.

6. **Tombstone-only deletes on non-appendable segments** (writer side): with the reader fixes in place, a follower refreshing mid-flush could observe a live point with an `{}` payload for one refresh — the CoW update deletes the point's old copy from a non-appendable segment via `delete_point_internal`, which clears the payload row in place *before* the id-tracker drop is visible. The tombstone-only delete path existed but its gate (`is_append_only()`) required appendability; the new `is_append_only_delete()` gates deletes on `append_only_mutations` alone. Normal deployments keep eager clearing + space reuse. Same failure class as the previously disabled vector-deletion propagation; writer flush ordering cannot close the window because followers sample the id tracker and the payload storage at different instants.

## Tests

Every fix has a two-fs regression test (writer on a "remote" dir via `MmapFs`, reader through `DiskCacheFs` with a separate mirror dir), each verified to fail under the old behavior:

- `read_only_roaring_flags::tests::live_reload_over_disk_cache_sees_in_place_bit_writes` (+ unmaterialized-bitmap variant)
- `disk_id_tracker::tests::deletion_and_live_reload_disk_cache` (covers both id trackers)
- `gridstore::tests::test_live_reload_disk_cache`
- `chunked_vectors::read::tests::live_reload_over_disk_cache_sees_in_place_appends`
- `simple_disk_cache::tests::{concurrent_instances_have_independent_mirrors, drop_removes_local_mirror}`
- `segment::tests::test_append_only_delete_is_tombstone_only_on_non_appendable`

## Known follow-ups (out of scope)

- Reload currently refetches the whole tracker mirror and re-attaches the whole last page/chunk — no incremental path yet.
- Disk id tracker `versions` file is read lazily through cached blocks and never refreshed; immutable tracker versions are loaded once with no reload path at all.
- `Pages::read_from_pages` panics (index out of bounds) if a slot references a page the reader hasn't attached yet — reachable over read-through backends between writer flush and reader reload; deserves a graceful error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
