### PR TITLE
[TQDT] TQ roundtrip: raw vectors in grpc, WAL and apply internal operation

### DIFF
--- a/lib/api/src/grpc/proto/points_internal_service.proto
+++ b/lib/api/src/grpc/proto/points_internal_service.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "points.proto";
 import "qdrant_common.proto";
+import "json_with_int.proto";
 
 package qdrant;
 option csharp_namespace = "Qdrant.Client.Grpc";
@@ -45,6 +46,12 @@ service PointsInternal {
   rpc Facet(FacetCountsInternal) returns (FacetResponseInternal) {}
 }
 
+message PointStructRaw {
+  PointId id = 1;
+  map<string, bytes> vectors = 2;
+  map<string, Value> payload = 3;
+}
+
 message SyncPoints {
   // name of the collection
   string collection_name = 1;
@@ -58,6 +65,8 @@ message SyncPoints {
   optional WriteOrdering ordering = 6;
   // Timeout for the request in seconds
   optional uint64 timeout = 7;
+  // Points with storage-native (raw bytes) vectors
+  repeated PointStructRaw raw_points = 8;
 }
 
 message SyncPointsInternal {
@@ -76,6 +85,8 @@ message UpsertPointsInternal {
   // When present, overrides the `wait` parameter of the wrapped public message.
   // When absent, falls back to `wait` (backward compatible with older nodes).
   optional WaitUntil wait_override = 4;
+  // Points with storage-native (raw bytes) vectors
+  repeated PointStructRaw raw_points = 5;
 }
 
 message DeletePointsInternal {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -10557,6 +10557,19 @@ pub mod points_server {
     }
 }
 #[derive(serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PointStructRaw {
+    #[prost(message, optional, tag = "1")]
+    pub id: ::core::option::Option<PointId>,
+    #[prost(map = "string, bytes", tag = "2")]
+    pub vectors: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::vec::Vec<u8>,
+    >,
+    #[prost(map = "string, message", tag = "3")]
+    pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
+}
+#[derive(serde::Serialize)]
 #[derive(validator::Validate)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SyncPoints {
@@ -10583,6 +10596,9 @@ pub struct SyncPoints {
     /// Timeout for the request in seconds
     #[prost(uint64, optional, tag = "7")]
     pub timeout: ::core::option::Option<u64>,
+    /// Points with storage-native (raw bytes) vectors
+    #[prost(message, repeated, tag = "8")]
+    pub raw_points: ::prost::alloc::vec::Vec<PointStructRaw>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]
@@ -10615,6 +10631,9 @@ pub struct UpsertPointsInternal {
     /// When absent, falls back to `wait` (backward compatible with older nodes).
     #[prost(enumeration = "WaitUntil", optional, tag = "4")]
     pub wait_override: ::core::option::Option<i32>,
+    /// Points with storage-native (raw bytes) vectors
+    #[prost(message, repeated, tag = "5")]
+    pub raw_points: ::prost::alloc::vec::Vec<PointStructRaw>,
 }
 #[derive(serde::Serialize)]
 #[derive(validator::Validate)]

--- a/lib/collection/src/operations/generalizer/update_persisted.rs
+++ b/lib/collection/src/operations/generalizer/update_persisted.rs
@@ -4,8 +4,8 @@ use serde_json::Value;
 use shard::operations::payload_ops::{PayloadOps, SetPayloadOp};
 use shard::operations::point_ops::{
     BatchPersisted, BatchVectorStructPersisted, ConditionalInsertOperationInternal,
-    PointInsertOperationsInternal, PointOperations, PointStructPersisted, PointSyncOperation,
-    VectorPersisted, VectorStructPersisted,
+    PointInsertOperationsInternal, PointOperations, PointStructPersisted, PointStructRawPersisted,
+    PointSyncOperation, PointSyncRawOperation, VectorPersisted, VectorStructPersisted,
 };
 use shard::operations::vector_ops::{PointVectorsPersisted, UpdateVectorsOp, VectorOperations};
 use shard::operations::{CollectionUpdateOperations, FieldIndexOperations, VectorNameOperations};
@@ -71,6 +71,48 @@ impl Generalizer for PointOperations {
             PointOperations::SyncPoints(sync_operation) => {
                 PointOperations::SyncPoints(sync_operation.remove_details())
             }
+            PointOperations::UpsertPointsRaw(points) => PointOperations::UpsertPointsRaw(
+                points.iter().map(|point| point.remove_details()).collect(),
+            ),
+            PointOperations::SyncPointsRaw(sync_operation) => {
+                PointOperations::SyncPointsRaw(sync_operation.remove_details())
+            }
+        }
+    }
+}
+
+impl Generalizer for PointSyncRawOperation {
+    fn remove_details(&self) -> Self {
+        let Self {
+            from_id,
+            to_id,
+            points,
+        } = self;
+
+        Self {
+            from_id: *from_id,
+            to_id: *to_id,
+            points: points.iter().map(|point| point.remove_details()).collect(),
+        }
+    }
+}
+
+impl Generalizer for PointStructRawPersisted {
+    fn remove_details(&self) -> Self {
+        let Self {
+            id: _, // ignore actual id for generalization
+            vectors,
+            payload,
+        } = self;
+
+        Self {
+            id: PointIdType::NumId(0),
+            // Keep only the vector names and byte lengths
+            vectors: vectors
+                .iter()
+                .map(|(name, bytes)| (name.clone(), (bytes.len() as u64).to_le_bytes().to_vec()))
+                .collect(),
+            payload: payload.as_ref().map(|p| p.remove_details()),
         }
     }
 }

--- a/lib/collection/src/operations/operation_effect.rs
+++ b/lib/collection/src/operations/operation_effect.rs
@@ -71,6 +71,18 @@ impl EstimateOperationEffectArea for point_ops::PointOperations {
                     sync_op.points.iter().map(|x| x.id).collect(),
                 ))
             }
+            point_ops::PointOperations::UpsertPointsRaw(points) => {
+                OperationEffectArea::Points(Cow::Owned(points.iter().map(|x| x.id).collect()))
+            }
+            point_ops::PointOperations::SyncPointsRaw(sync_op) => {
+                debug_assert!(
+                    false,
+                    "SyncPointsRaw operation should not be used during transfer"
+                );
+                OperationEffectArea::Points(Cow::Owned(
+                    sync_op.points.iter().map(|x| x.id).collect(),
+                ))
+            }
         }
     }
 }

--- a/lib/collection/src/operations/point_ops.rs
+++ b/lib/collection/src/operations/point_ops.rs
@@ -79,6 +79,12 @@ impl SplitByShard for PointOperations {
                 #[cfg(not(debug_assertions))]
                 OperationToShard::by_shard(vec![])
             }
+            PointOperations::UpsertPointsRaw(_) | PointOperations::SyncPointsRaw(_) => {
+                #[cfg(debug_assertions)]
+                panic!("Raw point operations are intended to be applied to specific shard only");
+                #[cfg(not(debug_assertions))]
+                OperationToShard::by_shard(vec![])
+            }
         }
     }
 }

--- a/lib/collection/src/shards/conversions.rs
+++ b/lib/collection/src/shards/conversions.rs
@@ -18,8 +18,8 @@ use tonic::Status;
 use crate::operations::conversions::write_ordering_to_proto;
 use crate::operations::payload_ops::{DeletePayloadOp, SetPayloadOp};
 use crate::operations::point_ops::{
-    ConditionalInsertOperationInternal, PointInsertOperationsInternal, PointSyncOperation,
-    WriteOrdering,
+    ConditionalInsertOperationInternal, PointInsertOperationsInternal, PointStructRawPersisted,
+    PointSyncOperation, PointSyncRawOperation, WriteOrdering,
 };
 use crate::operations::types::CollectionResult;
 use crate::operations::vector_ops::UpdateVectorsOp;
@@ -58,6 +58,42 @@ pub fn internal_sync_points(
                 .into_iter()
                 .map(api::grpc::qdrant::PointStruct::try_from)
                 .collect::<Result<Vec<_>, Status>>()?,
+            raw_points: Vec::new(),
+            from_id: from_id.map(PointIdType::into),
+            to_id: to_id.map(PointIdType::into),
+            ordering: ordering.map(write_ordering_to_proto),
+            timeout: wait_timeout,
+        }),
+    })
+}
+
+#[allow(clippy::unnecessary_wraps)]
+pub fn internal_sync_points_raw(
+    shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
+    collection_name: String,
+    points_sync_operation: PointSyncRawOperation,
+    wait: WaitUntil,
+    wait_timeout: Option<u64>,
+    ordering: Option<WriteOrdering>,
+) -> CollectionResult<SyncPointsInternal> {
+    let PointSyncRawOperation {
+        points,
+        from_id,
+        to_id,
+    } = points_sync_operation;
+    Ok(SyncPointsInternal {
+        shard_id,
+        clock_tag: clock_tag.map(ClockTag::into),
+        wait_override: wait_override_to_proto(wait),
+        sync_points: Some(SyncPoints {
+            collection_name,
+            wait: Some(wait.needs_callback()),
+            points: Vec::new(),
+            raw_points: points
+                .into_iter()
+                .map(api::grpc::qdrant::PointStructRaw::from)
+                .collect(),
             from_id: from_id.map(PointIdType::into),
             to_id: to_id.map(PointIdType::into),
             ordering: ordering.map(write_ordering_to_proto),
@@ -79,6 +115,7 @@ pub fn internal_upsert_points(
         shard_id,
         clock_tag: clock_tag.map(ClockTag::into),
         wait_override: wait_override_to_proto(wait),
+        raw_points: Vec::new(),
         upsert_points: Some(UpsertPoints {
             collection_name,
             wait: Some(wait.needs_callback()),
@@ -89,6 +126,37 @@ pub fn internal_upsert_points(
                     .map(api::grpc::qdrant::PointStruct::try_from)
                     .collect::<Result<Vec<_>, Status>>()?,
             },
+            ordering: ordering.map(write_ordering_to_proto),
+            shard_key_selector: None,
+            update_filter: None,
+            timeout: wait_timeout,
+            update_mode: None, // Default mode (Upsert)
+        }),
+    })
+}
+
+#[allow(clippy::unnecessary_wraps)]
+pub fn internal_upsert_points_raw(
+    shard_id: Option<ShardId>,
+    clock_tag: Option<ClockTag>,
+    collection_name: String,
+    points: Vec<PointStructRawPersisted>,
+    wait: WaitUntil,
+    wait_timeout: Option<u64>,
+    ordering: Option<WriteOrdering>,
+) -> CollectionResult<UpsertPointsInternal> {
+    Ok(UpsertPointsInternal {
+        shard_id,
+        clock_tag: clock_tag.map(ClockTag::into),
+        wait_override: wait_override_to_proto(wait),
+        raw_points: points
+            .into_iter()
+            .map(api::grpc::qdrant::PointStructRaw::from)
+            .collect(),
+        upsert_points: Some(UpsertPoints {
+            collection_name,
+            wait: Some(wait.needs_callback()),
+            points: Vec::new(),
             ordering: ordering.map(write_ordering_to_proto),
             shard_key_selector: None,
             update_filter: None,
@@ -125,6 +193,7 @@ pub fn internal_conditional_upsert_points(
         shard_id,
         clock_tag: clock_tag.map(ClockTag::into),
         wait_override: wait_override_to_proto(wait),
+        raw_points: Vec::new(),
         upsert_points: Some(UpsertPoints {
             collection_name,
             wait: Some(wait.needs_callback()),

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -69,8 +69,8 @@ use crate::shards::conversions::{
     internal_clear_payload, internal_clear_payload_by_filter, internal_create_index,
     internal_create_vector_name, internal_delete_index, internal_delete_payload,
     internal_delete_points, internal_delete_points_by_filter, internal_delete_vector_name,
-    internal_set_payload, internal_sync_points, internal_upsert_points, try_scored_point_from_grpc,
-    wait_override_to_proto,
+    internal_set_payload, internal_sync_points, internal_sync_points_raw, internal_upsert_points,
+    internal_upsert_points_raw, try_scored_point_from_grpc, wait_override_to_proto,
 };
 use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::shard::{PeerId, ShardId};
@@ -310,6 +310,30 @@ impl RemoteShard {
                             None, // TODO!?
                             collection_name.clone(),
                             operation,
+                            wait,
+                            timeout,
+                            ordering,
+                        )?;
+                        Update::Sync(request)
+                    }
+                    PointOperations::UpsertPointsRaw(points) => {
+                        let request = internal_upsert_points_raw(
+                            shard_id,
+                            operation.clock_tag,
+                            collection_name.clone(),
+                            points,
+                            wait,
+                            timeout,
+                            ordering,
+                        )?;
+                        Update::Upsert(request)
+                    }
+                    PointOperations::SyncPointsRaw(sync_operation) => {
+                        let request = internal_sync_points_raw(
+                            shard_id,
+                            None,
+                            collection_name.clone(),
+                            sync_operation,
                             wait,
                             timeout,
                             ordering,
@@ -633,6 +657,38 @@ impl RemoteShard {
                     let request = &internal_sync_points(
                         shard_id,
                         None, // TODO!?
+                        collection_name,
+                        operation,
+                        wait,
+                        timeout,
+                        ordering,
+                    )?;
+                    self.with_points_client(|mut client| async move {
+                        client.sync(tonic::Request::new(request.clone())).await
+                    })
+                    .await?
+                    .into_inner()
+                }
+                PointOperations::UpsertPointsRaw(points) => {
+                    let request = &internal_upsert_points_raw(
+                        shard_id,
+                        operation.clock_tag,
+                        collection_name,
+                        points,
+                        wait,
+                        timeout,
+                        ordering,
+                    )?;
+                    self.with_points_client(|mut client| async move {
+                        client.upsert(tonic::Request::new(request.clone())).await
+                    })
+                    .await?
+                    .into_inner()
+                }
+                PointOperations::SyncPointsRaw(operation) => {
+                    let request = &internal_sync_points_raw(
+                        shard_id,
+                        None,
                         collection_name,
                         operation,
                         wait,

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -675,6 +675,16 @@ impl OperationsByMode {
                         PointOperations::SyncPoints(op),
                     )]
                 }
+                PointOperations::UpsertPointsRaw(points) => {
+                    vec![CollectionUpdateOperations::PointOperation(
+                        PointOperations::UpsertPointsRaw(points),
+                    )]
+                }
+                PointOperations::SyncPointsRaw(op) => {
+                    vec![CollectionUpdateOperations::PointOperation(
+                        PointOperations::SyncPointsRaw(op),
+                    )]
+                }
             },
             CollectionUpdateOperations::VectorOperation(_)
             | CollectionUpdateOperations::PayloadOperation(_)

--- a/lib/shard/src/operations/mod.rs
+++ b/lib/shard/src/operations/mod.rs
@@ -388,7 +388,7 @@ mod tests {
             // Use a non-empty raw point so the byte-blob path is actually exercised
             let raw_point = PointStructRawPersisted {
                 id: 1.into(),
-                vectors: vec![("dense".to_string(), vec![0, 1, 2, 3, 255])],
+                vectors: vec![("dense".to_string(), vec![0, 1, 2, 3, 255])].into(),
                 payload: None,
             };
 

--- a/lib/shard/src/operations/mod.rs
+++ b/lib/shard/src/operations/mod.rs
@@ -73,6 +73,12 @@ impl CollectionUpdateOperations {
                 PointOperations::SyncPoints(op) => {
                     Some(op.points.iter().map(|point| point.id).collect())
                 }
+                PointOperations::UpsertPointsRaw(points) => {
+                    Some(points.iter().map(|point| point.id).collect())
+                }
+                PointOperations::SyncPointsRaw(op) => {
+                    Some(op.points.iter().map(|point| point.id).collect())
+                }
             },
             Self::VectorOperation(_) => None,
             Self::PayloadOperation(_) => None,
@@ -379,11 +385,28 @@ mod tests {
                 points: Vec::new(),
             });
 
+            // Use a non-empty raw point so the byte-blob path is actually exercised
+            let raw_point = PointStructRawPersisted {
+                id: 1.into(),
+                vectors: vec![("dense".to_string(), vec![0, 1, 2, 3, 255])],
+                payload: None,
+            };
+
+            let upsert_raw = Self::UpsertPointsRaw(vec![raw_point.clone()]);
+
+            let sync_raw = Self::SyncPointsRaw(PointSyncRawOperation {
+                from_id: Some(1.into()),
+                to_id: None,
+                points: vec![raw_point],
+            });
+
             prop_oneof![
                 Just(upsert),
                 Just(delete),
                 Just(delete_by_filter),
                 Just(sync),
+                Just(upsert_raw),
+                Just(sync_raw),
             ]
             .boxed()
         }

--- a/lib/shard/src/operations/operation_name.rs
+++ b/lib/shard/src/operations/operation_name.rs
@@ -16,6 +16,8 @@ impl CollectionUpdateOperations {
                 PointOperations::DeletePoints { .. } => "delete_points",
                 PointOperations::DeletePointsByFilter(_) => "delete_points_by_filter",
                 PointOperations::SyncPoints(_) => "sync_points",
+                PointOperations::UpsertPointsRaw(_) => "upsert_points_raw",
+                PointOperations::SyncPointsRaw(_) => "sync_points_raw",
             },
             CollectionUpdateOperations::VectorOperation(op) => match op {
                 VectorOperations::UpdateVectors(_) => "update_vectors",

--- a/lib/shard/src/operations/point_ops.rs
+++ b/lib/shard/src/operations/point_ops.rs
@@ -17,6 +17,7 @@ use segment::data_types::vectors::{
 };
 use segment::types::{Filter, Payload, PointIdType, VectorNameBuf};
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 use sparse::common::types::{DimId, DimWeight};
 use strum::{EnumDiscriminants, EnumIter};
 use validator::{Validate, ValidationErrors};
@@ -322,6 +323,8 @@ pub struct PointSyncRawOperation {
     pub points: Vec<PointStructRawPersisted>,
 }
 
+pub type RawVectorsPersisted = SmallVec<[(VectorNameBuf, Vec<u8>); 1]>;
+
 /// A point with vectors as storage-native bytes, as it is persisted in WAL.
 #[derive(Clone, PartialEq, Deserialize, Serialize, Hash)]
 #[serde(rename_all = "snake_case")]
@@ -330,7 +333,7 @@ pub struct PointStructRawPersisted {
     pub id: PointIdType,
     /// All named vectors of the point, storage-native bytes per vector name
     #[serde(with = "raw_vectors_serde")]
-    pub vectors: Vec<(VectorNameBuf, Vec<u8>)>,
+    pub vectors: RawVectorsPersisted,
     /// Payload values (optional)
     pub payload: Option<Payload>,
 }
@@ -347,6 +350,8 @@ mod raw_vectors_serde {
     use segment::types::VectorNameBuf;
     use serde::de::{self, Deserializer, SeqAccess, Visitor};
     use serde::ser::{SerializeSeq, Serializer};
+
+    use super::RawVectorsPersisted;
 
     /// Upper bound for the capacity we pre-allocate from an untrusted `size_hint`
     /// when deserializing a single vector's raw bytes.
@@ -419,7 +424,7 @@ mod raw_vectors_serde {
 
     pub fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
-    ) -> Result<Vec<(VectorNameBuf, Vec<u8>)>, D::Error> {
+    ) -> Result<RawVectorsPersisted, D::Error> {
         let raw: Vec<(VectorNameBuf, ByteVec)> = serde::Deserialize::deserialize(deserializer)?;
         Ok(raw
             .into_iter()
@@ -1107,7 +1112,7 @@ mod tests {
         let blob: Vec<u8> = (0..4096u32).map(|i| i as u8).collect();
         let point = PointStructRawPersisted {
             id: 1.into(),
-            vectors: vec![("dense".to_string(), blob.clone())],
+            vectors: vec![("dense".to_string(), blob.clone())].into(),
             payload: None,
         };
 

--- a/lib/shard/src/operations/point_ops.rs
+++ b/lib/shard/src/operations/point_ops.rs
@@ -10,7 +10,7 @@ use schemars::JsonSchema;
 use segment::common::operation_error::OperationError;
 use segment::common::utils::unordered_hash_unique;
 use segment::data_types::named_vectors::NamedVectors;
-use segment::data_types::segment_record::SegmentRecord;
+use segment::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
 use segment::data_types::vectors::{
     BatchVectorStructInternal, DEFAULT_VECTOR_NAME, DenseVector, MultiDenseVector,
     MultiDenseVectorInternal, VectorInternal, VectorRef, VectorStructInternal,
@@ -116,6 +116,10 @@ pub enum PointOperations {
     DeletePointsByFilter(Filter),
     /// Points Sync
     SyncPoints(PointSyncOperation),
+    /// Insert or update points with storage-native (raw bytes) vectors
+    UpsertPointsRaw(Vec<PointStructRawPersisted>),
+    /// Points sync with storage-native (raw bytes) vectors
+    SyncPointsRaw(PointSyncRawOperation),
 }
 
 impl PointOperations {
@@ -126,6 +130,8 @@ impl PointOperations {
             Self::DeletePoints { ids } => Some(ids.clone()),
             Self::DeletePointsByFilter(_) => None,
             Self::SyncPoints(op) => Some(op.points.iter().map(|point| point.id).collect()),
+            Self::UpsertPointsRaw(points) => Some(points.iter().map(|point| point.id).collect()),
+            Self::SyncPointsRaw(op) => Some(op.points.iter().map(|point| point.id).collect()),
         }
     }
 
@@ -141,6 +147,8 @@ impl PointOperations {
             Self::DeletePoints { ids } => ids.retain(filter),
             Self::DeletePointsByFilter(_) => (),
             Self::SyncPoints(op) => op.points.retain(|point| filter(&point.id)),
+            Self::UpsertPointsRaw(points) => points.retain(|point| filter(&point.id)),
+            Self::SyncPointsRaw(op) => op.points.retain(|point| filter(&point.id)),
         }
     }
 
@@ -153,6 +161,16 @@ impl PointOperations {
             Self::SyncPoints(op) => {
                 for point in &mut op.points {
                     point.vector.retain_vector_names(valid);
+                }
+            }
+            Self::UpsertPointsRaw(points) => {
+                for point in points {
+                    point.vectors.retain(|(name, _)| valid.contains(name));
+                }
+            }
+            Self::SyncPointsRaw(op) => {
+                for point in &mut op.points {
+                    point.vectors.retain(|(name, _)| valid.contains(name));
                 }
             }
             Self::DeletePoints { .. } | Self::DeletePointsByFilter(_) => (),
@@ -293,6 +311,234 @@ pub struct PointSyncOperation {
     /// Maximal id og
     pub to_id: Option<PointIdType>,
     pub points: Vec<PointStructPersisted>,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Hash)]
+pub struct PointSyncRawOperation {
+    /// Minimal id of the sync range
+    pub from_id: Option<PointIdType>,
+    /// Maximal id of the sync range
+    pub to_id: Option<PointIdType>,
+    pub points: Vec<PointStructRawPersisted>,
+}
+
+/// A point with vectors as storage-native bytes, as it is persisted in WAL.
+#[derive(Clone, PartialEq, Deserialize, Serialize, Hash)]
+#[serde(rename_all = "snake_case")]
+pub struct PointStructRawPersisted {
+    /// Point id
+    pub id: PointIdType,
+    /// All named vectors of the point, storage-native bytes per vector name
+    #[serde(with = "raw_vectors_serde")]
+    pub vectors: Vec<(VectorNameBuf, Vec<u8>)>,
+    /// Payload values (optional)
+    pub payload: Option<Payload>,
+}
+
+/// Serde helper for [`PointStructRawPersisted::vectors`].
+///
+/// By default serde serializes `Vec<u8>` as a sequence of integers, which in
+/// CBOR (used for the WAL) costs ~2x for high-entropy data such as raw vector
+/// bytes. This module forces each blob through `serialize_bytes` so it is
+/// encoded as a compact byte string (~1x overhead) instead.
+mod raw_vectors_serde {
+    use std::fmt;
+
+    use segment::types::VectorNameBuf;
+    use serde::de::{self, Deserializer, SeqAccess, Visitor};
+    use serde::ser::{SerializeSeq, Serializer};
+
+    /// Upper bound for the capacity we pre-allocate from an untrusted `size_hint`
+    /// when deserializing a single vector's raw bytes.
+    ///
+    /// Realistic sizes are far below this: a maximum-size dense vector is
+    /// 65536 dims x 4 bytes (f32) = 256 KiB. The 128 MiB headroom comfortably
+    /// covers large multivectors and sparse vectors while staying orders of
+    /// magnitude away from OOM territory.
+    const MAX_RAW_VECTOR_PREALLOC: usize = 128 * 1024 * 1024;
+
+    /// Reference wrapper that serializes a byte slice as a byte string.
+    struct BytesRef<'a>(&'a [u8]);
+
+    impl serde::Serialize for BytesRef<'_> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.serialize_bytes(self.0)
+        }
+    }
+
+    pub fn serialize<S: Serializer>(
+        vectors: &[(VectorNameBuf, Vec<u8>)],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(vectors.len()))?;
+        for (name, bytes) in vectors {
+            seq.serialize_element(&(name, BytesRef(bytes)))?;
+        }
+        seq.end()
+    }
+
+    /// Owned wrapper that deserializes a byte string into a `Vec<u8>`.
+    struct ByteVec(Vec<u8>);
+
+    impl<'de> serde::Deserialize<'de> for ByteVec {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            struct ByteVecVisitor;
+
+            impl<'de> Visitor<'de> for ByteVecVisitor {
+                type Value = Vec<u8>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("a byte string")
+                }
+
+                fn visit_bytes<E: de::Error>(self, value: &[u8]) -> Result<Self::Value, E> {
+                    Ok(value.to_vec())
+                }
+
+                fn visit_byte_buf<E: de::Error>(self, value: Vec<u8>) -> Result<Self::Value, E> {
+                    Ok(value)
+                }
+
+                /// Formats that lack a native byte-string type (e.g. JSON) fall
+                /// back to a sequence of integers; accept those too.
+                fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                    let capacity = seq.size_hint().unwrap_or(0).min(MAX_RAW_VECTOR_PREALLOC);
+                    let mut bytes = Vec::with_capacity(capacity);
+                    while let Some(byte) = seq.next_element()? {
+                        bytes.push(byte);
+                    }
+                    Ok(bytes)
+                }
+            }
+
+            deserializer
+                .deserialize_byte_buf(ByteVecVisitor)
+                .map(ByteVec)
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Vec<(VectorNameBuf, Vec<u8>)>, D::Error> {
+        let raw: Vec<(VectorNameBuf, ByteVec)> = serde::Deserialize::deserialize(deserializer)?;
+        Ok(raw
+            .into_iter()
+            .map(|(name, bytes)| (name, bytes.0))
+            .collect())
+    }
+}
+
+impl From<SegmentRecordRaw> for PointStructRawPersisted {
+    fn from(record: SegmentRecordRaw) -> Self {
+        let SegmentRecordRaw {
+            id,
+            vectors,
+            payload,
+        } = record;
+
+        Self {
+            id,
+            vectors: vectors.unwrap_or_default(),
+            payload,
+        }
+    }
+}
+
+impl PointStructRawPersisted {
+    pub fn is_equal_to(&self, segment_record: &SegmentRecordRaw) -> bool {
+        let SegmentRecordRaw {
+            id,
+            vectors,
+            payload,
+        } = segment_record;
+
+        if &self.id != id {
+            return false;
+        }
+
+        let segment_vectors = vectors.as_deref().unwrap_or(&[]);
+        if self.vectors.len() != segment_vectors.len() {
+            return false;
+        }
+        for (name, bytes) in segment_vectors {
+            let own_bytes = self
+                .vectors
+                .iter()
+                .find(|(own_name, _)| own_name == name)
+                .map(|(_, bytes)| bytes);
+            if own_bytes != Some(bytes) {
+                return false;
+            }
+        }
+
+        // Check if payloads are equal, empty and non-existent payloads are considered equal
+        let self_payload = self.payload.as_ref().filter(|p| !p.is_empty());
+        let segment_payload = payload.as_ref().filter(|p| !p.is_empty());
+        self_payload == segment_payload
+    }
+}
+
+#[cfg(feature = "api")]
+impl From<PointStructRawPersisted> for api::grpc::qdrant::PointStructRaw {
+    fn from(value: PointStructRawPersisted) -> Self {
+        let PointStructRawPersisted {
+            id,
+            vectors,
+            payload,
+        } = value;
+
+        Self {
+            id: Some(id.into()),
+            vectors: vectors.into_iter().collect(),
+            payload: payload
+                .map(api::conversions::json::payload_to_proto)
+                .unwrap_or_default(),
+        }
+    }
+}
+
+#[cfg(feature = "api")]
+impl TryFrom<api::grpc::qdrant::PointStructRaw> for PointStructRawPersisted {
+    type Error = tonic::Status;
+
+    fn try_from(value: api::grpc::qdrant::PointStructRaw) -> Result<Self, Self::Error> {
+        let api::grpc::qdrant::PointStructRaw {
+            id,
+            vectors,
+            payload,
+        } = value;
+
+        let id = id
+            .ok_or_else(|| tonic::Status::invalid_argument("Empty id is not allowed"))?
+            .try_into()?;
+
+        let payload = if payload.is_empty() {
+            None
+        } else {
+            Some(api::conversions::json::proto_to_payloads(payload)?)
+        };
+
+        Ok(Self {
+            id,
+            vectors: vectors.into_iter().collect(),
+            payload,
+        })
+    }
+}
+
+impl Debug for PointStructRawPersisted {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let vectors = self
+            .vectors
+            .iter()
+            .map(|(name, bytes)| format!("{name}: {} bytes", bytes.len()))
+            .join(", ");
+        write!(
+            f,
+            "PointStructRawPersisted {{ id: {}, vectors: [{vectors}], payload: {:?} }}",
+            self.id, self.payload,
+        )
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, Hash)]
@@ -854,6 +1100,31 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn raw_persisted_vectors_use_compact_byte_string() {
+        // High-entropy payload: byte value == (index % 256), most bytes >= 24.
+        let blob: Vec<u8> = (0..4096u32).map(|i| i as u8).collect();
+        let point = PointStructRawPersisted {
+            id: 1.into(),
+            vectors: vec![("dense".to_string(), blob.clone())],
+            payload: None,
+        };
+
+        let encoded = serde_cbor::to_vec(&point).unwrap();
+        // A byte string is ~1x; an integer array would be ~1.9x for this data.
+        // Guard well below the naive-array size (>7800 bytes for 4096 bytes).
+        assert!(
+            encoded.len() < blob.len() + 128,
+            "expected compact byte-string encoding, got {} bytes for a {}-byte blob",
+            encoded.len(),
+            blob.len(),
+        );
+
+        // Round-trips losslessly.
+        let decoded: PointStructRawPersisted = serde_cbor::from_slice(&encoded).unwrap();
+        assert!(decoded == point, "round-trip mismatch");
+    }
 
     fn dense(v: f32) -> VectorPersisted {
         VectorPersisted::Dense(vec![v])

--- a/lib/shard/src/resolve.rs
+++ b/lib/shard/src/resolve.rs
@@ -38,11 +38,13 @@ pub fn is_filter_resolving(operation: &CollectionUpdateOperations) -> bool {
             PointOperations::UpsertPointsConditional(_) => true,
             PointOperations::DeletePointsByFilter(_) => true,
             PointOperations::UpsertPoints(_)
+            | PointOperations::UpsertPointsRaw(_)
             | PointOperations::DeletePoints { .. }
             // `SyncPoints` reads current state too, but every point it touches
             // is alive and version-guarded, so its replay is protected by the
             // per-point version checks.
-            | PointOperations::SyncPoints(_) => false,
+            | PointOperations::SyncPoints(_)
+            | PointOperations::SyncPointsRaw(_) => false,
         },
         CollectionUpdateOperations::VectorOperation(op) => match op {
             VectorOperations::UpdateVectors(update) => update.update_filter.is_some(),
@@ -95,8 +97,10 @@ pub fn resolve_operation(
                     resolve_conditional_upsert(segments, op, hw_counter)?
                 }
                 op @ (PointOperations::UpsertPoints(_)
+                | PointOperations::UpsertPointsRaw(_)
                 | PointOperations::DeletePoints { .. }
-                | PointOperations::SyncPoints(_)) => op,
+                | PointOperations::SyncPoints(_)
+                | PointOperations::SyncPointsRaw(_)) => op,
             })
         }
         CollectionUpdateOperations::VectorOperation(op) => {

--- a/lib/shard/src/update.rs
+++ b/lib/shard/src/update.rs
@@ -19,7 +19,7 @@ use segment::types::{
 use crate::operations::payload_ops::PayloadOps;
 use crate::operations::point_ops::{
     ConditionalInsertOperationInternal, PointInsertOperationsInternal, PointOperations,
-    PointStructPersisted, UpdateMode,
+    PointStructPersisted, PointStructRawPersisted, UpdateMode,
 };
 use crate::operations::vector_ops::{PointVectorsPersisted, UpdateVectorsOp, VectorOperations};
 use crate::operations::{
@@ -53,6 +53,25 @@ pub fn process_point_operation(
         }
         PointOperations::SyncPoints(operation) => {
             let (deleted, new, updated) = sync_points(
+                segments,
+                op_num,
+                operation.from_id,
+                operation.to_id,
+                &operation.points,
+                hw_counter,
+            )?;
+            Ok(deleted + new + updated)
+        }
+        PointOperations::UpsertPointsRaw(points) => {
+            if points.is_empty() {
+                // An empty upsert touches no segment; bump so WAL can acknowledge it.
+                segments.bump_max_segment_version_overwrite(op_num);
+            }
+            let res = upsert_points_raw(segments, op_num, points.iter(), hw_counter)?;
+            Ok(res)
+        }
+        PointOperations::SyncPointsRaw(operation) => {
+            let (deleted, new, updated) = sync_points_raw(
                 segments,
                 op_num,
                 operation.from_id,
@@ -616,6 +635,166 @@ pub fn sync_points(
     Ok((deleted, num_new, num_updated))
 }
 
+pub fn upsert_points_raw<'a, T>(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    points: T,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize>
+where
+    T: IntoIterator<Item = &'a PointStructRawPersisted>,
+{
+    let points_map: AHashMap<PointIdType, _> = points.into_iter().map(|p| (p.id, p)).collect();
+    let ids: Vec<PointIdType> = points_map.keys().copied().collect();
+
+    let mut res = 0;
+
+    for ids_chunk in ids.chunks(UPDATE_OP_CHUNK_SIZE) {
+        // Replace points which are already present in some writable segment
+        let updated_points = segments.apply_points_with_conditional_move(
+            op_num,
+            ids_chunk,
+            |id, write_segment| {
+                upsert_raw_with_payload(write_segment, op_num, points_map[&id], hw_counter)
+            },
+            |id, raw_vectors, _updated_vectors, payload| {
+                // A raw upsert replaces the whole point: drop the old raw
+                // vectors and payload, carry the incoming bytes verbatim.
+                let point = points_map[&id];
+                raw_vectors.clear();
+                raw_vectors.extend_from_slice(&point.vectors);
+                *payload = point.payload.clone().unwrap_or_default();
+            },
+            hw_counter,
+        )?;
+
+        res += updated_points.len();
+        // Insert new points, which was not updated or existed
+        let new_point_ids = ids_chunk
+            .iter()
+            .copied()
+            .filter(|x| !updated_points.contains(x));
+
+        {
+            let default_write_segment =
+                segments.smallest_appendable_segment().ok_or_else(|| {
+                    OperationError::service_error(
+                        "No appendable segments exist, expected at least one",
+                    )
+                })?;
+
+            let segment_arc = default_write_segment.get();
+            let mut write_segment = segment_arc.write();
+            for point_id in new_point_ids {
+                res += usize::from(upsert_raw_with_payload(
+                    &mut write_segment,
+                    op_num,
+                    points_map[&point_id],
+                    hw_counter,
+                )?);
+            }
+            RwLockWriteGuard::unlock_fair(write_segment);
+        };
+    }
+
+    Ok(res)
+}
+
+fn upsert_raw_with_payload(
+    segment: &mut RwLockWriteGuard<dyn SegmentEntry>,
+    op_num: SeqNumberType,
+    point: &PointStructRawPersisted,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<bool> {
+    let mut res = segment.upsert_point_raw(op_num, point.id, &point.vectors, hw_counter)?;
+    if let Some(full_payload) = &point.payload {
+        res &= segment.set_full_payload(op_num, point.id, full_payload, hw_counter)?;
+    } else {
+        res &= segment.clear_payload(op_num, point.id, hw_counter)?;
+    }
+    debug_assert!(
+        segment.has_point(point.id, DeferredBehavior::WithDeferred),
+        "the point {} should be present immediately after the upsert",
+        point.id,
+    );
+    Ok(res)
+}
+
+pub fn sync_points_raw(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    from_id: Option<PointIdType>,
+    to_id: Option<PointIdType>,
+    points: &[PointStructRawPersisted],
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<(usize, usize, usize)> {
+    let id_to_point: AHashMap<PointIdType, _> = points.iter().map(|p| (p.id, p)).collect();
+    let sync_points: AHashSet<_> = points.iter().map(|p| p.id).collect();
+    // 1. Retrieve existing points for a range
+    let stored_point_ids: AHashSet<_> = segments
+        .iter()
+        .flat_map(|(_, segment)| segment.get().read().read_range(from_id, to_id))
+        .collect();
+    // 2. Remove points, which are not present in the sync operation
+    let points_to_remove: Vec<_> = stored_point_ids.difference(&sync_points).copied().collect();
+    let deleted = delete_points(segments, op_num, points_to_remove.as_slice(), hw_counter)?;
+    // 3. Retrieve overlapping points, detect which one of them are changed
+    let existing_point_ids: Vec<_> = stored_point_ids
+        .intersection(&sync_points)
+        .copied()
+        .collect();
+
+    let mut points_to_update: Vec<_> = Vec::new();
+    // we don’t want to cancel this filtered read
+    let is_stopped = AtomicBool::new(false);
+    let _num_updated = segments.read_points(
+        existing_point_ids.as_slice(),
+        &is_stopped,
+        DeferredBehavior::WithDeferred,
+        |ids, segment| {
+            let with_vector = WithVector::Bool(true);
+            let with_payload = WithPayload::from(true);
+            // Since we retrieve points, which we already know exist, we expect all of them to be found
+            let stored_records = segment.retrieve_raw(
+                ids,
+                &with_payload,
+                &with_vector,
+                hw_counter,
+                &is_stopped,
+                DeferredBehavior::WithDeferred,
+            )?;
+            let mut updated = 0;
+
+            for (id, stored_record) in stored_records {
+                let point = id_to_point.get(&id).unwrap();
+                if !point.is_equal_to(&stored_record) {
+                    points_to_update.push(*point);
+                    updated += 1;
+                }
+            }
+
+            Ok(updated)
+        },
+    )?;
+
+    // 4. Select new points
+    let num_updated = points_to_update.len();
+    let mut num_new = 0;
+    sync_points.difference(&stored_point_ids).for_each(|id| {
+        num_new += 1;
+        points_to_update.push(*id_to_point.get(id).unwrap());
+    });
+
+    // 5. Upsert points which differ from the stored ones
+    let num_replaced = upsert_points_raw(segments, op_num, points_to_update, hw_counter)?;
+    debug_assert!(
+        num_replaced <= num_updated,
+        "number of replaced points cannot be greater than points to update ({num_replaced} <= {num_updated})",
+    );
+
+    Ok((deleted, num_new, num_updated))
+}
+
 /// Batch size when modifying vector
 const VECTOR_OP_BATCH_SIZE: usize = 32;
 
@@ -1158,11 +1337,12 @@ mod test {
     use crate::fixtures::{
         build_segment_1, build_segment_2, empty_segment, empty_segment_with_deferred,
     };
+    use crate::operations::point_ops::PointStructRawPersisted;
     use crate::segment_holder::{FlushMode, SegmentHolder};
     use crate::update::{
         clear_payload_by_filter, create_field_index, delete_payload_by_filter,
         delete_points_by_filter, delete_vectors_by_filter, overwrite_payload_by_filter,
-        set_payload_by_filter,
+        set_payload_by_filter, sync_points_raw, upsert_points_raw,
     };
 
     #[test]
@@ -1214,6 +1394,152 @@ mod test {
         // delete operation in WAL.
         assert_eq!(old_version + 1, new_version);
         assert_eq!(new_version, DELETE_OP_NUM);
+    }
+
+    fn retrieve_raw_record(
+        holder: &SegmentHolder,
+        segment_id: crate::segment_holder::SegmentId,
+        point_id: u64,
+    ) -> Option<segment::data_types::segment_record::SegmentRecordRaw> {
+        let hw_counter = HardwareCounterCell::new();
+        let is_stopped = std::sync::atomic::AtomicBool::new(false);
+        let segment = holder.get(segment_id).unwrap().get();
+        let segment = segment.read();
+        segment
+            .retrieve_raw(
+                &[point_id.into()],
+                &segment::types::WithPayload::from(true),
+                &segment::types::WithVector::Bool(true),
+                &hw_counter,
+                &is_stopped,
+                common::types::DeferredBehavior::WithDeferred,
+            )
+            .unwrap()
+            .remove(&point_id.into())
+    }
+
+    #[test]
+    fn test_upsert_points_raw_moves_point_from_non_appendable() {
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        let mut non_appendable = build_segment_1(dir.path()); // points 1-5
+        non_appendable.appendable_flag = false;
+        let appendable = empty_segment(dir.path());
+
+        let mut holder = SegmentHolder::default();
+        let sid_non_app = holder.add_new(non_appendable);
+        let sid_app = holder.add_new(appendable);
+
+        let new_vector: Vec<f32> = vec![9.0, 8.0, 7.0, 6.0];
+        let new_bytes: Vec<u8> = new_vector.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let payload: segment::types::Payload = payload_json! {"city": "Berlin"};
+
+        let points = [
+            PointStructRawPersisted {
+                id: 1.into(),
+                vectors: vec![(DEFAULT_VECTOR_NAME.to_owned(), new_bytes.clone())],
+                payload: Some(payload.clone()),
+            },
+            PointStructRawPersisted {
+                id: 100.into(),
+                vectors: vec![(DEFAULT_VECTOR_NAME.to_owned(), new_bytes.clone())],
+                payload: None,
+            },
+        ];
+
+        let updated = upsert_points_raw(&holder, 100, points.iter(), &hw_counter).unwrap();
+        assert_eq!(updated, 1);
+
+        {
+            let non_app = holder.get(sid_non_app).unwrap().get();
+            let non_app = non_app.read();
+            assert!(!non_app.has_point(1.into(), common::types::DeferredBehavior::WithDeferred));
+        }
+
+        for point_id in [1, 100] {
+            let record = retrieve_raw_record(&holder, sid_app, point_id)
+                .unwrap_or_else(|| panic!("point {point_id} must be in the appendable segment"));
+            let vectors = record.vectors.expect("vectors were requested");
+            assert_eq!(
+                vectors,
+                vec![(DEFAULT_VECTOR_NAME.to_owned(), new_bytes.clone())],
+                "raw bytes of point {point_id} must round-trip exactly",
+            );
+        }
+
+        let record = retrieve_raw_record(&holder, sid_app, 1).unwrap();
+        assert_eq!(record.payload, Some(payload));
+        let record = retrieve_raw_record(&holder, sid_app, 100).unwrap();
+        assert_eq!(record.payload.filter(|p| !p.is_empty()), None);
+    }
+
+    #[test]
+    fn test_sync_points_raw() {
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        let segment = build_segment_1(dir.path()); // points 1-5
+        let mut holder = SegmentHolder::default();
+        let sid = holder.add_new(segment);
+
+        let point_2 = PointStructRawPersisted::from(retrieve_raw_record(&holder, sid, 2).unwrap());
+        let point_2_version_before = holder
+            .get(sid)
+            .unwrap()
+            .get()
+            .read()
+            .point_version(2.into());
+
+        let mut point_3 =
+            PointStructRawPersisted::from(retrieve_raw_record(&holder, sid, 3).unwrap());
+        let changed_bytes: Vec<u8> = [9.0f32, 8.0, 7.0, 6.0]
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect();
+        point_3.vectors = vec![(DEFAULT_VECTOR_NAME.to_owned(), changed_bytes.clone())];
+
+        let point_100 = PointStructRawPersisted {
+            id: 100.into(),
+            vectors: vec![(DEFAULT_VECTOR_NAME.to_owned(), changed_bytes.clone())],
+            payload: None,
+        };
+
+        let (deleted, new, updated) = sync_points_raw(
+            &holder,
+            100,
+            None,
+            None,
+            &[point_2, point_3, point_100],
+            &hw_counter,
+        )
+        .unwrap();
+
+        assert_eq!(deleted, 3, "points 1, 4 and 5 are not in the sync set");
+        assert_eq!(new, 1, "point 100 is new");
+        assert_eq!(updated, 1, "only point 3 has different bytes");
+
+        {
+            let segment = holder.get(sid).unwrap().get();
+            let segment = segment.read();
+            for point_id in [1, 4, 5] {
+                assert!(
+                    !segment.has_point(
+                        point_id.into(),
+                        common::types::DeferredBehavior::WithDeferred
+                    ),
+                    "point {point_id} must be deleted",
+                );
+            }
+            assert_eq!(segment.point_version(2.into()), point_2_version_before);
+            assert_eq!(segment.point_version(3.into()), Some(100));
+        }
+
+        let record = retrieve_raw_record(&holder, sid, 3).unwrap();
+        assert_eq!(
+            record.vectors.unwrap(),
+            vec![(DEFAULT_VECTOR_NAME.to_owned(), changed_bytes)],
+        );
     }
 
     /// Helper: creates a non-appendable segment with a single point at the given version and city payload.

--- a/lib/shard/src/update.rs
+++ b/lib/shard/src/update.rs
@@ -662,7 +662,7 @@ where
                 // vectors and payload, carry the incoming bytes verbatim.
                 let point = points_map[&id];
                 raw_vectors.clear();
-                raw_vectors.extend_from_slice(&point.vectors);
+                raw_vectors.extend(point.vectors.iter().cloned());
                 *payload = point.payload.clone().unwrap_or_default();
             },
             hw_counter,
@@ -1438,12 +1438,12 @@ mod test {
         let points = [
             PointStructRawPersisted {
                 id: 1.into(),
-                vectors: vec![(DEFAULT_VECTOR_NAME.to_owned(), new_bytes.clone())],
+                vectors: vec![(DEFAULT_VECTOR_NAME.to_owned(), new_bytes.clone())].into(),
                 payload: Some(payload.clone()),
             },
             PointStructRawPersisted {
                 id: 100.into(),
-                vectors: vec![(DEFAULT_VECTOR_NAME.to_owned(), new_bytes.clone())],
+                vectors: vec![(DEFAULT_VECTOR_NAME.to_owned(), new_bytes.clone())].into(),
                 payload: None,
             },
         ];
@@ -1462,7 +1462,7 @@ mod test {
                 .unwrap_or_else(|| panic!("point {point_id} must be in the appendable segment"));
             let vectors = record.vectors.expect("vectors were requested");
             assert_eq!(
-                vectors,
+                vectors.to_vec(),
                 vec![(DEFAULT_VECTOR_NAME.to_owned(), new_bytes.clone())],
                 "raw bytes of point {point_id} must round-trip exactly",
             );
@@ -1497,11 +1497,11 @@ mod test {
             .iter()
             .flat_map(|v| v.to_le_bytes())
             .collect();
-        point_3.vectors = vec![(DEFAULT_VECTOR_NAME.to_owned(), changed_bytes.clone())];
+        point_3.vectors = vec![(DEFAULT_VECTOR_NAME.to_owned(), changed_bytes.clone())].into();
 
         let point_100 = PointStructRawPersisted {
             id: 100.into(),
-            vectors: vec![(DEFAULT_VECTOR_NAME.to_owned(), changed_bytes.clone())],
+            vectors: vec![(DEFAULT_VECTOR_NAME.to_owned(), changed_bytes.clone())].into(),
             payload: None,
         };
 
@@ -1537,7 +1537,7 @@ mod test {
 
         let record = retrieve_raw_record(&holder, sid, 3).unwrap();
         assert_eq!(
-            record.vectors.unwrap(),
+            record.vectors.unwrap().to_vec(),
             vec![(DEFAULT_VECTOR_NAME.to_owned(), changed_bytes)],
         );
     }

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -371,8 +371,8 @@ mod tests_ops {
     use collection::operations::point_ops::{
         BatchPersisted, BatchVectorStructPersisted, ConditionalInsertOperationInternal,
         PointInsertOperationsInternal, PointInsertOperationsInternalDiscriminants,
-        PointOperationsDiscriminants, PointStructPersisted, PointSyncOperation,
-        VectorStructPersisted,
+        PointOperationsDiscriminants, PointStructPersisted, PointStructRawPersisted,
+        PointSyncOperation, PointSyncRawOperation, VectorStructPersisted,
     };
     use collection::operations::query_enum::QueryEnum;
     use collection::operations::types::{ContextExamplePair, RecommendExample, UsingVector};
@@ -790,6 +790,28 @@ mod tests_ops {
                         points: Vec::new(),
                     },
                 ));
+                assert_requires_whole_write_access(&op);
+            }
+
+            PointOperationsDiscriminants::UpsertPointsRaw => {
+                let op = CollectionUpdateOperations::PointOperation(
+                    PointOperations::UpsertPointsRaw(vec![PointStructRawPersisted {
+                        id: ExtendedPointId::NumId(12345),
+                        vectors: vec![("dense".to_string(), vec![0, 1, 2, 3])],
+                        payload: None,
+                    }]),
+                );
+                assert_requires_whole_write_access(&op);
+            }
+
+            PointOperationsDiscriminants::SyncPointsRaw => {
+                let op = CollectionUpdateOperations::PointOperation(
+                    PointOperations::SyncPointsRaw(PointSyncRawOperation {
+                        from_id: None,
+                        to_id: None,
+                        points: Vec::new(),
+                    }),
+                );
                 assert_requires_whole_write_access(&op);
             }
         });

--- a/lib/storage/src/rbac/ops_checks.rs
+++ b/lib/storage/src/rbac/ops_checks.rs
@@ -797,7 +797,7 @@ mod tests_ops {
                 let op = CollectionUpdateOperations::PointOperation(
                     PointOperations::UpsertPointsRaw(vec![PointStructRawPersisted {
                         id: ExtendedPointId::NumId(12345),
-                        vectors: vec![("dense".to_string(), vec![0, 1, 2, 3])],
+                        vectors: vec![("dense".to_string(), vec![0, 1, 2, 3])].into(),
                         payload: None,
                     }]),
                 );

--- a/src/common/update.rs
+++ b/src/common/update.rs
@@ -1249,16 +1249,23 @@ pub async fn update(
         wait_override.unwrap_or_else(|| collection::shards::shard_trait::WaitUntil::from(wait));
 
     let shard_selector = match operation {
-        CollectionUpdateOperations::PointOperation(point_ops::PointOperations::SyncPoints(_)) => {
+        CollectionUpdateOperations::PointOperation(
+            point_ops::PointOperations::SyncPoints(_)
+            | point_ops::PointOperations::SyncPointsRaw(_)
+            | point_ops::PointOperations::UpsertPointsRaw(_),
+        ) => {
             debug_assert_eq!(
                 shard_key, None,
-                "Sync points operations can't specify shard key"
+                "Sync points and raw point operations can't specify shard key"
             );
 
             match shard_id {
                 Some(shard_id) => ShardSelectorInternal::ShardId(shard_id),
                 None => {
-                    debug_assert!(false, "Sync operation is supposed to select shard directly");
+                    debug_assert!(
+                        false,
+                        "Sync and raw operations are supposed to select shard directly"
+                    );
                     ShardSelectorInternal::Empty
                 }
             }

--- a/src/tonic/api/points_internal_api.rs
+++ b/src/tonic/api/points_internal_api.rs
@@ -99,9 +99,35 @@ impl PointsInternalService {
             shard_id,
             clock_tag,
             wait_override,
+            raw_points,
         } = upsert_points_internal;
 
         let upsert_points = extract_internal_request(upsert_points)?;
+
+        if !raw_points.is_empty() {
+            if !upsert_points.points.is_empty() {
+                return Err(Status::invalid_argument(
+                    "An upsert request must carry either `points` or `raw_points`, never both",
+                ));
+            }
+
+            let hw_metrics = self.get_request_collection_hw_usage_counter_for_internal(
+                upsert_points.collection_name.clone(),
+            );
+
+            return upsert_raw(
+                self.toc.clone(),
+                upsert_points.collection_name,
+                raw_points,
+                upsert_points.wait,
+                upsert_points.ordering,
+                upsert_points.timeout,
+                InternalUpdateParams::from_grpc(shard_id, clock_tag, wait_override),
+                auth,
+                hw_metrics,
+            )
+            .await;
+        }
 
         let hw_metrics = self.get_request_collection_hw_usage_counter_for_internal(
             upsert_points.collection_name.clone(),

--- a/src/tonic/api/update_common.rs
+++ b/src/tonic/api/update_common.rs
@@ -18,7 +18,9 @@ use api::rest::{PointStruct, PointVectors, ShardKeySelector, UpdateVectors, Vect
 use collection::operations::CollectionUpdateOperations;
 use collection::operations::conversions::try_points_selector_from_grpc;
 use collection::operations::payload_ops::DeletePayload;
-use collection::operations::point_ops::{self, PointOperations, PointSyncOperation};
+use collection::operations::point_ops::{
+    self, PointOperations, PointStructRawPersisted, PointSyncOperation, PointSyncRawOperation,
+};
 use collection::operations::vector_ops::DeleteVectors;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
@@ -851,6 +853,7 @@ pub async fn sync(
         collection_name,
         wait,
         points,
+        raw_points,
         from_id,
         to_id,
         ordering,
@@ -859,21 +862,48 @@ pub async fn sync(
 
     let timing = Instant::now();
 
-    let point_structs: Result<_, _> = points.into_iter().map(PointStruct::try_from).collect();
+    let from_id = from_id.map(|x| x.try_into()).transpose()?;
+    let to_id = to_id.map(|x| x.try_into()).transpose()?;
 
-    // No actual inference should happen here, as we are just syncing existing points
-    // So, this function is used for consistency only
-    let (points, usage) =
-        convert_point_struct(point_structs?, InferenceType::Update, inference_params).await?;
+    let (operation, usage) = if !raw_points.is_empty() {
+        if !points.is_empty() {
+            return Err(Status::invalid_argument(
+                "A sync request must carry either `points` or `raw_points`, never both",
+            ));
+        }
 
-    let operation = PointSyncOperation {
-        points,
-        from_id: from_id.map(|x| x.try_into()).transpose()?,
-        to_id: to_id.map(|x| x.try_into()).transpose()?,
+        let points: Result<Vec<PointStructRawPersisted>, _> =
+            raw_points.into_iter().map(TryFrom::try_from).collect();
+
+        let operation = PointSyncRawOperation {
+            points: points?,
+            from_id,
+            to_id,
+        };
+
+        let operation =
+            CollectionUpdateOperations::PointOperation(PointOperations::SyncPointsRaw(operation));
+
+        (operation, None)
+    } else {
+        let point_structs: Result<_, _> = points.into_iter().map(PointStruct::try_from).collect();
+
+        // No actual inference should happen here, as we are just syncing existing points
+        // So, this function is used for consistency only
+        let (points, usage) =
+            convert_point_struct(point_structs?, InferenceType::Update, inference_params).await?;
+
+        let operation = PointSyncOperation {
+            points,
+            from_id,
+            to_id,
+        };
+
+        let operation =
+            CollectionUpdateOperations::PointOperation(PointOperations::SyncPoints(operation));
+
+        (operation, usage)
     };
-
-    let operation =
-        CollectionUpdateOperations::PointOperation(PointOperations::SyncPoints(operation));
 
     let result = update(
         &toc,
@@ -889,6 +919,44 @@ pub async fn sync(
 
     let response = points_operation_response_internal(timing, result, None);
     Ok(Response::new((response, usage.unwrap_or_default().into())))
+}
+
+/// Upsert points carrying storage-native (raw bytes) vectors.
+#[allow(clippy::too_many_arguments)]
+pub async fn upsert_raw(
+    toc: Arc<TableOfContent>,
+    collection_name: String,
+    raw_points: Vec<grpc::qdrant::PointStructRaw>,
+    wait: Option<bool>,
+    ordering: Option<grpc::qdrant::WriteOrdering>,
+    timeout: Option<u64>,
+    internal_params: InternalUpdateParams,
+    auth: Auth,
+    request_hw_counter: RequestHwCounter,
+) -> Result<Response<PointsOperationResponseInternal>, Status> {
+    let timing = Instant::now();
+
+    let points: Result<Vec<PointStructRawPersisted>, _> =
+        raw_points.into_iter().map(TryFrom::try_from).collect();
+
+    let operation =
+        CollectionUpdateOperations::PointOperation(PointOperations::UpsertPointsRaw(points?));
+
+    let result = update(
+        &toc,
+        &collection_name,
+        operation,
+        internal_params,
+        UpdateParams::from_grpc(wait, ordering, timeout)?,
+        None,
+        auth,
+        request_hw_counter.get_counter(),
+    )
+    .await?;
+
+    let response =
+        points_operation_response_internal(timing, result, request_hw_counter.to_grpc_api());
+    Ok(Response::new(response))
 }
 
 pub fn points_operation_response_internal_with_inference_usage(


### PR DESCRIPTION
This PR implements TQ roundtrip problem on grpc receive side.

In includes gprc changes:
```
message SyncPoints {
  // Old points (may be removed after next release)
  repeated PointStruct points = 3;

  // NEW! Raw version
  repeated PointStructRaw raw_points = 8;
}

message UpsertPointsInternal {
  // Old points (may be removed after next release)
  UpsertPoints upsert_points = 1;

  // NEW! Raw version
  repeated PointStructRaw raw_points = 5;
}

message PointStructRaw {
  PointId id = 1;
  map<string, bytes> vectors = 2;
  map<string, Value> payload = 3;
}
```


Also is includes WAL record changes:
```
pub enum PointOperations {
    UpsertPoints(PointInsertOperationsInternal),
    UpsertPointsConditional(ConditionalInsertOperationInternal),
    DeletePoints { ids: Vec<PointIdType> },
    DeletePointsByFilter(Filter),
    SyncPoints(PointSyncOperation),

    /// NEW! Raw versions
    UpsertPointsRaw(Vec<PointStructRawPersisted>),
    SyncPointsRaw(PointSyncRawOperation),
}
```

Everything else looks like a copy-paste machinery
