### PR TITLE
Add Float16 and Uint8 storage datatypes to the model tester

### DIFF
--- a/lib/collection/src/model_testing/fixture.rs
+++ b/lib/collection/src/model_testing/fixture.rs
@@ -15,9 +15,7 @@ use segment::types::{
     ScalarQuantization, ScalarQuantizationConfig, ScalarType,
 };
 
-use super::{
-    COLLECTION_NAME, INITIAL_ACTIVE, INLINE_STORAGE_VECTOR, PEER_ID, VectorKind, candidate_of,
-};
+use super::{ALL_CANDIDATES, COLLECTION_NAME, INLINE_STORAGE_VECTOR, PEER_ID, VectorKind};
 use crate::collection::{Collection, RequestShardTransfer};
 use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use crate::operations::config_diff::HnswConfigDiff;
@@ -81,15 +79,15 @@ pub(super) async fn fixture(
     // inactive) candidates are reachable through `Op::CreateVectorName` later in the run.
     let mut dense_vectors = BTreeMap::new();
     let mut sparse_vectors = BTreeMap::new();
-    for name in INITIAL_ACTIVE {
-        let candidate = candidate_of(name);
+    for candidate in ALL_CANDIDATES.iter().filter(|c| c.initially_active) {
+        let name = candidate.name;
         match candidate.kind {
             VectorKind::Dense(dim) => {
                 let mut builder = dense_params_builder(dim, on_disk, candidate.datatype);
                 // The inline-storage vector exercises the HNSW `inline_storage` layout, which
                 // stores original + quantized vectors inside the index file and therefore
                 // requires quantization. Pair it with scalar quantization.
-                if *name == INLINE_STORAGE_VECTOR {
+                if name == INLINE_STORAGE_VECTOR {
                     builder = builder
                         .with_quantization_config(QuantizationConfig::Scalar(ScalarQuantization {
                             scalar: ScalarQuantizationConfig {

--- a/lib/collection/src/model_testing/fixture.rs
+++ b/lib/collection/src/model_testing/fixture.rs
@@ -15,12 +15,14 @@ use segment::types::{
     ScalarQuantization, ScalarQuantizationConfig, ScalarType,
 };
 
-use super::{COLLECTION_NAME, INITIAL_ACTIVE, INLINE_STORAGE_VECTOR, PEER_ID, VectorKind, kind_of};
+use super::{
+    COLLECTION_NAME, INITIAL_ACTIVE, INLINE_STORAGE_VECTOR, PEER_ID, VectorKind, candidate_of,
+};
 use crate::collection::{Collection, RequestShardTransfer};
 use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use crate::operations::config_diff::HnswConfigDiff;
 use crate::operations::shared_storage_config::SharedStorageConfig;
-use crate::operations::types::{Datatype, SparseVectorParams, VectorsConfig};
+use crate::operations::types::{SparseVectorParams, VectorsConfig};
 use crate::operations::vector_params_builder::VectorParamsBuilder;
 use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::channel_service::ChannelService;
@@ -60,7 +62,8 @@ pub(super) async fn fixture(
     let mut dense_vectors = BTreeMap::new();
     let mut sparse_vectors = BTreeMap::new();
     for name in INITIAL_ACTIVE {
-        match kind_of(name) {
+        let candidate = candidate_of(name);
+        match candidate.kind {
             VectorKind::Dense(dim) => {
                 let mut builder = VectorParamsBuilder::new(dim, Distance::Dot);
                 // Only override when enabled. Leaving `on_disk` unset (None) preserves the
@@ -69,6 +72,11 @@ pub(super) async fn fixture(
                 // e.g. the config-mismatch optimizer only acts on `Some`).
                 if on_disk {
                     builder = builder.with_on_disk(true);
+                }
+                // Same reasoning for the storage datatype: only set it when the candidate
+                // carries an override, leave it unset when the candidate has `None`.
+                if let Some(datatype) = candidate.datatype {
+                    builder = builder.with_datatype(datatype);
                 }
                 // The inline-storage vector exercises the HNSW `inline_storage` layout, which
                 // stores original + quantized vectors inside the index file and therefore
@@ -109,14 +117,6 @@ pub(super) async fn fixture(
                 let mut params = builder.build();
                 params.multivector_config = Some(MultiVectorConfig::default());
                 dense_vectors.insert(name.to_string(), params);
-            }
-            VectorKind::DenseTurbo(dim) => {
-                let mut builder =
-                    VectorParamsBuilder::new(dim, Distance::Dot).with_datatype(Datatype::Turbo4);
-                if on_disk {
-                    builder = builder.with_on_disk(true);
-                }
-                dense_vectors.insert(name.to_string(), builder.build());
             }
         }
     }

--- a/lib/collection/src/model_testing/fixture.rs
+++ b/lib/collection/src/model_testing/fixture.rs
@@ -114,6 +114,9 @@ pub(super) async fn fixture(
                 if on_disk {
                     builder = builder.with_on_disk(true);
                 }
+                if let Some(datatype) = candidate.datatype {
+                    builder = builder.with_datatype(datatype);
+                }
                 let mut params = builder.build();
                 params.multivector_config = Some(MultiVectorConfig::default());
                 dense_vectors.insert(name.to_string(), params);

--- a/lib/collection/src/model_testing/fixture.rs
+++ b/lib/collection/src/model_testing/fixture.rs
@@ -22,7 +22,7 @@ use crate::collection::{Collection, RequestShardTransfer};
 use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use crate::operations::config_diff::HnswConfigDiff;
 use crate::operations::shared_storage_config::SharedStorageConfig;
-use crate::operations::types::{SparseVectorParams, VectorsConfig};
+use crate::operations::types::{Datatype, SparseVectorParams, VectorsConfig};
 use crate::operations::vector_params_builder::VectorParamsBuilder;
 use crate::optimizers_builder::OptimizersConfig;
 use crate::shards::channel_service::ChannelService;
@@ -30,6 +30,26 @@ use crate::shards::collection_shard_distribution::CollectionShardDistribution;
 use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
 use crate::shards::shard::{PeerId, ShardId};
+
+/// Shared builder plumbing for dense and multi-dense fixture params. Only override when
+/// enabled/present: leaving `on_disk` and `datatype` unset (None) preserves the engine's
+/// default resolution, so no-flag runs stay byte-identical to before these overrides
+/// existed (`None` and `Some(false)` aren't equivalent everywhere: the
+/// config-mismatch optimizer, for one, only acts on `Some`).
+fn dense_params_builder(
+    dim: u64,
+    on_disk: bool,
+    datatype: Option<Datatype>,
+) -> VectorParamsBuilder {
+    let mut builder = VectorParamsBuilder::new(dim, Distance::Dot);
+    if on_disk {
+        builder = builder.with_on_disk(true);
+    }
+    if let Some(datatype) = datatype {
+        builder = builder.with_datatype(datatype);
+    }
+    builder
+}
 
 /// Build a fresh soak collection rooted at `storage_path`. Creates `collection/` and
 /// `snapshots/` subdirs, wiping any pre-existing contents — each soak run starts from a
@@ -65,19 +85,7 @@ pub(super) async fn fixture(
         let candidate = candidate_of(name);
         match candidate.kind {
             VectorKind::Dense(dim) => {
-                let mut builder = VectorParamsBuilder::new(dim, Distance::Dot);
-                // Only override when enabled. Leaving `on_disk` unset (None) preserves the
-                // engine's default resolution, so no-flag runs stay byte-identical to before
-                // this flag existed (`None` and `Some(false)` aren't equivalent everywhere —
-                // e.g. the config-mismatch optimizer only acts on `Some`).
-                if on_disk {
-                    builder = builder.with_on_disk(true);
-                }
-                // Same reasoning for the storage datatype: only set it when the candidate
-                // carries an override, leave it unset when the candidate has `None`.
-                if let Some(datatype) = candidate.datatype {
-                    builder = builder.with_datatype(datatype);
-                }
+                let mut builder = dense_params_builder(dim, on_disk, candidate.datatype);
                 // The inline-storage vector exercises the HNSW `inline_storage` layout, which
                 // stores original + quantized vectors inside the index file and therefore
                 // requires quantization. Pair it with scalar quantization.
@@ -110,14 +118,7 @@ pub(super) async fn fixture(
             VectorKind::MultiDense(dim) => {
                 // The builder has no `with_multivector_config`; set the field on the built
                 // `VectorParams` directly to mark this dense slot as a ColBERT-style multi-vec.
-                let mut builder = VectorParamsBuilder::new(dim, Distance::Dot);
-                if on_disk {
-                    builder = builder.with_on_disk(true);
-                }
-                if let Some(datatype) = candidate.datatype {
-                    builder = builder.with_datatype(datatype);
-                }
-                let mut params = builder.build();
+                let mut params = dense_params_builder(dim, on_disk, candidate.datatype).build();
                 params.multivector_config = Some(MultiVectorConfig::default());
                 dense_vectors.insert(name.to_string(), params);
             }

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -25,19 +25,21 @@ use crate::shards::shard::PeerId;
 const PEER_ID: PeerId = 1;
 const COLLECTION_NAME: &str = "test";
 
-/// Static metadata for every vector name the test might ever activate. Eleven names start
-/// active in the fixture (see `INITIAL_ACTIVE`); "u" is reachable through
+/// Static metadata for every vector name the test might ever activate. All names but "u"
+/// start active in the fixture (`initially_active`); inactive ones are reachable through
 /// `Op::CreateVectorName`.
 pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
     VectorCandidate {
         name: "a",
         kind: VectorKind::Dense(4),
         datatype: None,
+        initially_active: true,
     },
     VectorCandidate {
         name: "b",
         kind: VectorKind::Dense(6),
         datatype: None,
+        initially_active: true,
     },
     // Explicit `Some(Float32)` rather than the unset default: exercises schema configs that
     // spell the default datatype out (config serialization + any `None` vs `Some` comparison
@@ -46,6 +48,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         name: "c",
         kind: VectorKind::Dense(5),
         datatype: Some(Datatype::Float32),
+        initially_active: true,
     },
     // Dense vector configured with HNSW `inline_storage` (original + quantized vectors stored
     // inside the HNSW index file) backed by scalar quantization. From the model's perspective
@@ -54,21 +57,25 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         name: "i",
         kind: VectorKind::Dense(4),
         datatype: None,
+        initially_active: true,
     },
     VectorCandidate {
         name: "s",
         kind: VectorKind::Sparse,
         datatype: None,
+        initially_active: true,
     },
     VectorCandidate {
         name: "u",
         kind: VectorKind::Sparse,
         datatype: None,
+        initially_active: false,
     },
     VectorCandidate {
         name: "m",
         kind: VectorKind::MultiDense(4),
         datatype: None,
+        initially_active: true,
     },
     // TurboQuant 4-bit compressed storage, the primary quantized datatype, applied to
     // appendable segments too. Lossy: the model records the dequantized read-back
@@ -77,6 +84,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         name: "q",
         kind: VectorKind::Dense(8),
         datatype: Some(Datatype::Turbo4),
+        initially_active: true,
     },
     // Half-precision storage. Lossy but deterministic and idempotent: the model records
     // the f32 -> f16 -> f32 round-trip and compares exactly.
@@ -84,6 +92,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         name: "h",
         kind: VectorKind::Dense(6),
         datatype: Some(Datatype::Float16),
+        initially_active: true,
     },
     // Unsigned-byte storage. The engine truncates each component with `x as u8`; the
     // generator draws components from `0.0..256.0` so values don't collapse to 0/1,
@@ -92,6 +101,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         name: "y",
         kind: VectorKind::Dense(4),
         datatype: Some(Datatype::Uint8),
+        initially_active: true,
     },
     // Multi-vector variants of the lossy-but-idempotent datatypes: each stored row goes
     // through the same per-component round-trip as its dense counterpart ("h" / "y").
@@ -99,11 +109,13 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         name: "w",
         kind: VectorKind::MultiDense(5),
         datatype: Some(Datatype::Float16),
+        initially_active: true,
     },
     VectorCandidate {
         name: "z",
         kind: VectorKind::MultiDense(3),
         datatype: Some(Datatype::Uint8),
+        initially_active: true,
     },
 ];
 
@@ -130,9 +142,6 @@ fn assert_candidates_predictable() {
     }
 }
 
-/// Names present in the collection schema at fixture time.
-pub(super) const INITIAL_ACTIVE: &[&str] = &["a", "b", "c", "i", "s", "m", "q", "h", "y", "w", "z"];
-
 /// Dense vector name configured with HNSW `inline_storage` + scalar quantization in the fixture.
 pub(super) const INLINE_STORAGE_VECTOR: &str = "i";
 
@@ -144,6 +153,10 @@ pub(super) struct VectorCandidate {
     /// datatypes) and `VectorKind::MultiDense` (all but Turbo4); enforced by the
     /// startup check (`assert_candidates_predictable`).
     pub(super) datatype: Option<Datatype>,
+    /// Whether the name is present in the collection schema at fixture time. Inactive
+    /// names are only reachable through `Op::CreateVectorName`, which is FORCE_OFF by
+    /// default, so a candidate gets default-soak coverage only when this is true.
+    pub(super) initially_active: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -257,8 +270,11 @@ pub async fn run(
     );
 
     let mut model: Model = Model::new();
-    let mut active_names: BTreeSet<VectorNameBuf> =
-        INITIAL_ACTIVE.iter().map(|s| s.to_string()).collect();
+    let mut active_names: BTreeSet<VectorNameBuf> = ALL_CANDIDATES
+        .iter()
+        .filter(|c| c.initially_active)
+        .map(|c| c.name.to_string())
+        .collect();
     // In-flight background snapshot task, if any (at most one at a time). A `CreateSnapshot` op
     // spawns it; the loop reaps it on completion each iteration and drains it before any
     // close+reopen. `None` when no snapshot is running. See [`drain_snapshot`].

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -19,27 +19,33 @@ use tokio::task::JoinHandle;
 
 use crate::collection::Collection;
 use crate::operations::snapshot_ops::SnapshotDescription;
-use crate::operations::types::CollectionResult;
+use crate::operations::types::{CollectionResult, Datatype};
 use crate::shards::shard::PeerId;
 
 const PEER_ID: PeerId = 1;
 const COLLECTION_NAME: &str = "test";
 
-/// Static metadata for every vector name the test might ever activate. Six names start
-/// active in the fixture ("a", "b", "i", "s", "m", "q", see `INITIAL_ACTIVE`); "c" and
-/// "u" are reachable through `Op::CreateVectorName`.
+/// Static metadata for every vector name the test might ever activate. Eight names start
+/// active in the fixture ("a", "b", "i", "s", "m", "q", "h", "y", see `INITIAL_ACTIVE`);
+/// "c" and "u" are reachable through `Op::CreateVectorName`.
 pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
     VectorCandidate {
         name: "a",
         kind: VectorKind::Dense(4),
+        datatype: None,
     },
     VectorCandidate {
         name: "b",
         kind: VectorKind::Dense(6),
+        datatype: None,
     },
+    // Explicit `Some(Float32)` rather than the unset default: exercises schema configs that
+    // spell the default datatype out (config serialization + any `None` vs `Some` comparison
+    // logic), a path the `datatype: None` candidates never hit. Storage-wise identical to them.
     VectorCandidate {
         name: "c",
         kind: VectorKind::Dense(5),
+        datatype: Some(Datatype::Float32),
     },
     // Dense vector configured with HNSW `inline_storage` (original + quantized vectors stored
     // inside the HNSW index file) backed by scalar quantization. From the model's perspective
@@ -47,27 +53,67 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
     VectorCandidate {
         name: "i",
         kind: VectorKind::Dense(4),
+        datatype: None,
     },
     VectorCandidate {
         name: "s",
         kind: VectorKind::Sparse,
+        datatype: None,
     },
     VectorCandidate {
         name: "u",
         kind: VectorKind::Sparse,
+        datatype: None,
     },
     VectorCandidate {
         name: "m",
         kind: VectorKind::MultiDense(4),
+        datatype: None,
     },
+    // TurboQuant 4-bit compressed storage, the primary quantized datatype, applied to
+    // appendable segments too. Lossy: the model records the dequantized read-back
+    // (see `model_vector`) and compares with a few-ulp tolerance (see `dense_matches`).
     VectorCandidate {
         name: "q",
-        kind: VectorKind::DenseTurbo(8),
+        kind: VectorKind::Dense(8),
+        datatype: Some(Datatype::Turbo4),
+    },
+    // Half-precision storage. Lossy but deterministic and idempotent: the model records
+    // the f32 -> f16 -> f32 round-trip and compares exactly.
+    VectorCandidate {
+        name: "h",
+        kind: VectorKind::Dense(6),
+        datatype: Some(Datatype::Float16),
+    },
+    // Unsigned-byte storage. The engine truncates each component with `x as u8`; the
+    // generator draws components from `0.0..256.0` so values don't collapse to 0/1,
+    // and the model records the truncated read-back and compares exactly.
+    VectorCandidate {
+        name: "y",
+        kind: VectorKind::Dense(4),
+        datatype: Some(Datatype::Uint8),
     },
 ];
 
+// The `datatype` override is only plumbed for plain dense candidates: the fixture's
+// sparse/multi-dense arms ignore it, `model_vector` has no multi-dense round-trip
+// prediction, and multi-dense read-backs are compared exactly rather than through
+// `dense_matches`. Fail the build if a non-Dense candidate ever carries one, instead
+// of soak-panicking with a false divergence at runtime.
+const _: () = {
+    let mut i = 0;
+    while i < ALL_CANDIDATES.len() {
+        let c = &ALL_CANDIDATES[i];
+        assert!(
+            matches!(c.kind, VectorKind::Dense(_)) || c.datatype.is_none(),
+            "datatype overrides are only supported for VectorKind::Dense candidates"
+        );
+        i += 1;
+    }
+};
+
 /// Names present in the collection schema at fixture time.
-pub(super) const INITIAL_ACTIVE: &[&str] = &["a", "b", "i", "s", "m", "q"];
+pub(super) const INITIAL_ACTIVE: &[&str] = &["a", "b", "i", "s", "m", "q", "h", "y"];
 
 /// Dense vector name configured with HNSW `inline_storage` + scalar quantization in the fixture.
 pub(super) const INLINE_STORAGE_VECTOR: &str = "i";
@@ -75,6 +121,10 @@ pub(super) const INLINE_STORAGE_VECTOR: &str = "i";
 pub(super) struct VectorCandidate {
     pub(super) name: &'static str,
     pub(super) kind: VectorKind,
+    /// Storage datatype override; `None` leaves the schema field unset so the engine's
+    /// default (Float32) resolution applies. Only supported for `VectorKind::Dense` today,
+    /// enforced by the compile-time check next to `ALL_CANDIDATES`.
+    pub(super) datatype: Option<Datatype>,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -84,17 +134,17 @@ pub(super) enum VectorKind {
     /// ColBERT-style multi-vector: each point stores a matrix of `dim`-wide rows. Scoring
     /// uses MaxSim across query rows × stored rows.
     MultiDense(u64),
-    /// Dense vector stored with the `Turbo4` (TurboQuant 4-bit) storage datatype, the
-    /// primary quantized storage, applied to appendable segments too.
-    DenseTurbo(u64),
 }
 
-pub(super) fn kind_of(name: &str) -> VectorKind {
+pub(super) fn candidate_of(name: &str) -> &'static VectorCandidate {
     ALL_CANDIDATES
         .iter()
         .find(|c| c.name == name)
-        .map(|c| c.kind)
         .unwrap_or_else(|| panic!("unknown vector name: {name}"))
+}
+
+pub(super) fn datatype_of(name: &str) -> Option<Datatype> {
+    candidate_of(name).datatype
 }
 
 // BTreeMap for deterministic iteration order — several op generators sample from `model.keys()`

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -25,9 +25,9 @@ use crate::shards::shard::PeerId;
 const PEER_ID: PeerId = 1;
 const COLLECTION_NAME: &str = "test";
 
-/// Static metadata for every vector name the test might ever activate. Ten names start
-/// active in the fixture ("a", "b", "i", "s", "m", "q", "h", "y", "w", "z", see
-/// `INITIAL_ACTIVE`); "c" and "u" are reachable through `Op::CreateVectorName`.
+/// Static metadata for every vector name the test might ever activate. Eleven names start
+/// active in the fixture (see `INITIAL_ACTIVE`); "u" is reachable through
+/// `Op::CreateVectorName`.
 pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
     VectorCandidate {
         name: "a",
@@ -133,7 +133,7 @@ const _: () = {
 };
 
 /// Names present in the collection schema at fixture time.
-pub(super) const INITIAL_ACTIVE: &[&str] = &["a", "b", "i", "s", "m", "q", "h", "y", "w", "z"];
+pub(super) const INITIAL_ACTIVE: &[&str] = &["a", "b", "c", "i", "s", "m", "q", "h", "y", "w", "z"];
 
 /// Dense vector name configured with HNSW `inline_storage` + scalar quantization in the fixture.
 pub(super) const INLINE_STORAGE_VECTOR: &str = "i";
@@ -162,10 +162,6 @@ pub(super) fn candidate_of(name: &str) -> &'static VectorCandidate {
         .iter()
         .find(|c| c.name == name)
         .unwrap_or_else(|| panic!("unknown vector name: {name}"))
-}
-
-pub(super) fn datatype_of(name: &str) -> Option<Datatype> {
-    candidate_of(name).datatype
 }
 
 // BTreeMap for deterministic iteration order — several op generators sample from `model.keys()`

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -107,18 +107,16 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
     },
 ];
 
-// Reject kind/datatype combinations the model cannot predict yet, at compile time
-// rather than as a false-divergence soak panic hours into a run:
-// - MultiDense + Turbo4: `model_vector` predicts Turbo4 via the per-vector
-//   `turbo_storage_roundtrip`; the engine's multivector quantization path differs, so
-//   there is no prediction for it. Float16/Uint8 multi-dense are fine: each row takes
-//   the same per-component round-trip as the dense case.
-// - Sparse + any datatype: the fixture's sparse arm ignores the field entirely
-//   (sparse datatype lives in the sparse index config, which is not modeled).
-const _: () = {
-    let mut i = 0;
-    while i < ALL_CANDIDATES.len() {
-        let c = &ALL_CANDIDATES[i];
+/// Reject kind/datatype combinations the model cannot predict yet, at run startup
+/// rather than as a false-divergence soak panic hours into a run:
+/// - MultiDense + Turbo4: `model_vector` predicts Turbo4 via the per-vector
+///   `turbo_storage_roundtrip`; the engine's multivector quantization path differs, so
+///   there is no prediction for it. Float16/Uint8 multi-dense are fine: each row takes
+///   the same per-component round-trip as the dense case.
+/// - Sparse + any datatype: the fixture's sparse arm ignores the field entirely
+///   (sparse datatype lives in the sparse index config, which is not modeled).
+fn assert_candidates_predictable() {
+    for c in ALL_CANDIDATES {
         let supported = match c.kind {
             VectorKind::Dense(_) => true,
             VectorKind::MultiDense(_) => !matches!(c.datatype, Some(Datatype::Turbo4)),
@@ -126,11 +124,11 @@ const _: () = {
         };
         assert!(
             supported,
-            "unsupported kind/datatype combination in ALL_CANDIDATES (see comment above)"
+            "unsupported kind/datatype combination for `{}` (see comment above)",
+            c.name
         );
-        i += 1;
     }
-};
+}
 
 /// Names present in the collection schema at fixture time.
 pub(super) const INITIAL_ACTIVE: &[&str] = &["a", "b", "c", "i", "s", "m", "q", "h", "y", "w", "z"];
@@ -144,7 +142,7 @@ pub(super) struct VectorCandidate {
     /// Storage datatype override; `None` leaves the schema field unset so the engine's
     /// default (Float32) resolution applies. Supported for `VectorKind::Dense` (all
     /// datatypes) and `VectorKind::MultiDense` (all but Turbo4); enforced by the
-    /// compile-time check next to `ALL_CANDIDATES`.
+    /// startup check (`assert_candidates_predictable`).
     pub(super) datatype: Option<Datatype>,
 }
 
@@ -220,6 +218,8 @@ pub async fn run(
     duration: Option<Duration>,
     shutdown: Arc<AtomicBool>,
 ) {
+    assert_candidates_predictable();
+
     let (collection_dir, snapshots_dir, collection) = fixture::fixture(
         shard_count,
         storage_path,

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -25,9 +25,9 @@ use crate::shards::shard::PeerId;
 const PEER_ID: PeerId = 1;
 const COLLECTION_NAME: &str = "test";
 
-/// Static metadata for every vector name the test might ever activate. Eight names start
-/// active in the fixture ("a", "b", "i", "s", "m", "q", "h", "y", see `INITIAL_ACTIVE`);
-/// "c" and "u" are reachable through `Op::CreateVectorName`.
+/// Static metadata for every vector name the test might ever activate. Ten names start
+/// active in the fixture ("a", "b", "i", "s", "m", "q", "h", "y", "w", "z", see
+/// `INITIAL_ACTIVE`); "c" and "u" are reachable through `Op::CreateVectorName`.
 pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
     VectorCandidate {
         name: "a",
@@ -93,27 +93,47 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Dense(4),
         datatype: Some(Datatype::Uint8),
     },
+    // Multi-vector variants of the lossy-but-idempotent datatypes: each stored row goes
+    // through the same per-component round-trip as its dense counterpart ("h" / "y").
+    VectorCandidate {
+        name: "w",
+        kind: VectorKind::MultiDense(5),
+        datatype: Some(Datatype::Float16),
+    },
+    VectorCandidate {
+        name: "z",
+        kind: VectorKind::MultiDense(3),
+        datatype: Some(Datatype::Uint8),
+    },
 ];
 
-// The `datatype` override is only plumbed for plain dense candidates: the fixture's
-// sparse/multi-dense arms ignore it, `model_vector` has no multi-dense round-trip
-// prediction, and multi-dense read-backs are compared exactly rather than through
-// `dense_matches`. Fail the build if a non-Dense candidate ever carries one, instead
-// of soak-panicking with a false divergence at runtime.
+// Reject kind/datatype combinations the model cannot predict yet, at compile time
+// rather than as a false-divergence soak panic hours into a run:
+// - MultiDense + Turbo4: `model_vector` predicts Turbo4 via the per-vector
+//   `turbo_storage_roundtrip`; the engine's multivector quantization path differs, so
+//   there is no prediction for it. Float16/Uint8 multi-dense are fine: each row takes
+//   the same per-component round-trip as the dense case.
+// - Sparse + any datatype: the fixture's sparse arm ignores the field entirely
+//   (sparse datatype lives in the sparse index config, which is not modeled).
 const _: () = {
     let mut i = 0;
     while i < ALL_CANDIDATES.len() {
         let c = &ALL_CANDIDATES[i];
+        let supported = match c.kind {
+            VectorKind::Dense(_) => true,
+            VectorKind::MultiDense(_) => !matches!(c.datatype, Some(Datatype::Turbo4)),
+            VectorKind::Sparse => c.datatype.is_none(),
+        };
         assert!(
-            matches!(c.kind, VectorKind::Dense(_)) || c.datatype.is_none(),
-            "datatype overrides are only supported for VectorKind::Dense candidates"
+            supported,
+            "unsupported kind/datatype combination in ALL_CANDIDATES (see comment above)"
         );
         i += 1;
     }
 };
 
 /// Names present in the collection schema at fixture time.
-pub(super) const INITIAL_ACTIVE: &[&str] = &["a", "b", "i", "s", "m", "q", "h", "y"];
+pub(super) const INITIAL_ACTIVE: &[&str] = &["a", "b", "i", "s", "m", "q", "h", "y", "w", "z"];
 
 /// Dense vector name configured with HNSW `inline_storage` + scalar quantization in the fixture.
 pub(super) const INLINE_STORAGE_VECTOR: &str = "i";
@@ -122,8 +142,9 @@ pub(super) struct VectorCandidate {
     pub(super) name: &'static str,
     pub(super) kind: VectorKind,
     /// Storage datatype override; `None` leaves the schema field unset so the engine's
-    /// default (Float32) resolution applies. Only supported for `VectorKind::Dense` today,
-    /// enforced by the compile-time check next to `ALL_CANDIDATES`.
+    /// default (Float32) resolution applies. Supported for `VectorKind::Dense` (all
+    /// datatypes) and `VectorKind::MultiDense` (all but Turbo4); enforced by the
+    /// compile-time check next to `ALL_CANDIDATES`.
     pub(super) datatype: Option<Datatype>,
 }
 

--- a/lib/collection/src/model_testing/op/generators.rs
+++ b/lib/collection/src/model_testing/op/generators.rs
@@ -234,7 +234,7 @@ pub(super) fn random_scroll_filter(
 fn random_dense_vec(rng: &mut impl Rng, dim: u64, datatype: Option<Datatype>) -> Vec<f32> {
     let upper = match datatype {
         Some(Datatype::Uint8) => 256.0,
-        _ => 1.0,
+        None | Some(Datatype::Float32 | Datatype::Float16 | Datatype::Turbo4) => 1.0,
     };
     (0..dim).map(|_| rng.random_range(0.0..upper)).collect()
 }

--- a/lib/collection/src/model_testing/op/generators.rs
+++ b/lib/collection/src/model_testing/op/generators.rs
@@ -13,9 +13,10 @@ use segment::types::{
 use serde_json::{Map, Value};
 use sparse::common::sparse_vector::SparseVector;
 
-use super::super::{Model, VectorKind, VectorValue, kind_of};
+use super::super::{Model, VectorKind, VectorValue, candidate_of};
 use super::{NamedVectors, Op, Prefetch, ScrollFilter, canonical_sparse};
 use crate::operations::point_ops::UpdateMode;
+use crate::operations::types::Datatype;
 
 // ───── payload value pools ────────────────────────────────────────────────
 //
@@ -226,8 +227,16 @@ pub(super) fn random_scroll_filter(
 
 // ───── vector generators ────────────────────────────────────────────────────
 
-fn random_dense_vec(rng: &mut impl Rng, dim: u64) -> Vec<f32> {
-    (0..dim).map(|_| rng.random_range(0.0..1.0)).collect()
+/// Uniform components in `0.0..1.0`, except Uint8-backed names: their storage truncates
+/// each component with `x as u8`, so a unit-range draw would collapse every vector to
+/// zeros. Draw from the full byte range instead (the model records the truncated
+/// read-back, see `model_vector`).
+fn random_dense_vec(rng: &mut impl Rng, dim: u64, datatype: Option<Datatype>) -> Vec<f32> {
+    let upper = match datatype {
+        Some(Datatype::Uint8) => 256.0,
+        _ => 1.0,
+    };
+    (0..dim).map(|_| rng.random_range(0.0..upper)).collect()
 }
 
 fn random_sparse_vector(rng: &mut impl Rng) -> SparseVector {
@@ -266,20 +275,25 @@ pub(super) fn random_partial_named_vectors(
 
 /// Build a random vector matching the kind metadata associated with `name`.
 fn random_vector_for_name(rng: &mut impl Rng, name: &str) -> VectorValue {
-    match kind_of(name) {
-        VectorKind::Dense(dim) | VectorKind::DenseTurbo(dim) => {
-            VectorValue::Dense(random_dense_vec(rng, dim))
+    let candidate = candidate_of(name);
+    match candidate.kind {
+        VectorKind::Dense(dim) => {
+            VectorValue::Dense(random_dense_vec(rng, dim, candidate.datatype))
         }
         VectorKind::Sparse => VectorValue::Sparse(random_sparse_vector(rng)),
-        VectorKind::MultiDense(dim) => VectorValue::MultiDense(random_multi_dense(rng, dim)),
+        VectorKind::MultiDense(dim) => {
+            VectorValue::MultiDense(random_multi_dense(rng, dim, candidate.datatype))
+        }
     }
 }
 
 /// 2-4 rows of `dim`-wide dense vectors. Row count varies per point — exercises the
 /// engine's variable-length matrix storage.
-fn random_multi_dense(rng: &mut impl Rng, dim: u64) -> Vec<Vec<f32>> {
+fn random_multi_dense(rng: &mut impl Rng, dim: u64, datatype: Option<Datatype>) -> Vec<Vec<f32>> {
     let rows = rng.random_range(2..=4);
-    (0..rows).map(|_| random_dense_vec(rng, dim)).collect()
+    (0..rows)
+        .map(|_| random_dense_vec(rng, dim, datatype))
+        .collect()
 }
 
 /// Random 1-2 distinct names from the active set (callers gate on `active` being non-empty).

--- a/lib/collection/src/model_testing/op/mod.rs
+++ b/lib/collection/src/model_testing/op/mod.rs
@@ -33,9 +33,7 @@ use segment::types::{
 use segment::vector_storage::turbo::turbo_storage_roundtrip;
 use sparse::common::sparse_vector::SparseVector;
 
-use super::{
-    ALL_CANDIDATES, Model, ModelEntry, VectorKind, VectorValue, candidate_of, datatype_of,
-};
+use super::{ALL_CANDIDATES, Model, ModelEntry, VectorKind, VectorValue, candidate_of};
 use crate::operations::point_ops::UpdateMode;
 use crate::operations::types::Datatype;
 
@@ -603,21 +601,18 @@ impl Op {
                 let pick = inactive.choose(rng).unwrap();
                 let datatype = pick.datatype.map(VectorStorageDatatype::from);
                 let config = match pick.kind {
-                    VectorKind::Dense(dim) => VectorNameConfig::dense(DenseVectorConfig {
-                        size: dim as usize,
-                        distance: Distance::Dot,
-                        multivector_config: None,
-                        datatype,
-                    }),
+                    VectorKind::Dense(dim) | VectorKind::MultiDense(dim) => {
+                        VectorNameConfig::dense(DenseVectorConfig {
+                            size: dim as usize,
+                            distance: Distance::Dot,
+                            multivector_config: matches!(pick.kind, VectorKind::MultiDense(_))
+                                .then(MultiVectorConfig::default),
+                            datatype,
+                        })
+                    }
                     VectorKind::Sparse => VectorNameConfig::sparse(SparseVectorConfig {
                         modifier: None,
                         datatype: None,
-                    }),
-                    VectorKind::MultiDense(dim) => VectorNameConfig::dense(DenseVectorConfig {
-                        size: dim as usize,
-                        distance: Distance::Dot,
-                        multivector_config: Some(MultiVectorConfig::default()),
-                        datatype,
                     }),
                 };
                 Op::CreateVectorName {
@@ -900,35 +895,40 @@ pub(super) fn model_vector(name: &str, value: &VectorValue) -> VectorValue {
             // Every fixture vector uses Dot (see `fixture::fixture` and the
             // CreateVectorName generator arm above).
             Some(Datatype::Turbo4) => VectorValue::Dense(turbo_storage_roundtrip(v, Distance::Dot)),
-            Some(Datatype::Float16) => {
-                VectorValue::Dense(primitive_storage_roundtrip::<VectorElementTypeHalf>(v))
-            }
-            Some(Datatype::Uint8) => {
-                VectorValue::Dense(primitive_storage_roundtrip::<VectorElementTypeByte>(v))
-            }
-            Some(Datatype::Float32) | None => value.clone(),
+            datatype => match scalar_storage_roundtrip(datatype) {
+                Some(roundtrip) => VectorValue::Dense(roundtrip(v)),
+                None => value.clone(),
+            },
         },
-        (VectorKind::MultiDense(_), VectorValue::MultiDense(rows)) => match candidate.datatype {
-            Some(Datatype::Float16) => VectorValue::MultiDense(
-                rows.iter()
-                    .map(|row| primitive_storage_roundtrip::<VectorElementTypeHalf>(row))
-                    .collect(),
-            ),
-            Some(Datatype::Uint8) => VectorValue::MultiDense(
-                rows.iter()
-                    .map(|row| primitive_storage_roundtrip::<VectorElementTypeByte>(row))
-                    .collect(),
-            ),
-            // Rejected by the compile-time check next to `ALL_CANDIDATES`.
-            Some(Datatype::Turbo4) => {
-                panic!("model_vector: Turbo4 multi-dense has no read-back prediction")
+        // Turbo4 multi-dense is rejected by the compile-time check next to
+        // `ALL_CANDIDATES`, so `scalar_storage_roundtrip`'s panic arm is unreachable here.
+        (VectorKind::MultiDense(_), VectorValue::MultiDense(rows)) => {
+            match scalar_storage_roundtrip(candidate.datatype) {
+                Some(roundtrip) => {
+                    VectorValue::MultiDense(rows.iter().map(|row| roundtrip(row)).collect())
+                }
+                None => value.clone(),
             }
-            Some(Datatype::Float32) | None => value.clone(),
-        },
+        }
         (VectorKind::Sparse, VectorValue::Sparse(_)) => value.clone(),
         (kind, value) => {
             panic!("model_vector: value/kind mismatch for `{name}` ({kind:?}): {value:?}")
         }
+    }
+}
+
+/// Per-slice storage round-trip for the scalar datatypes: `Some` for the lossy
+/// Float16/Uint8 conversions, `None` where storage is exact (explicit Float32 or
+/// unset). Turbo4 is whole-vector quantization, not a per-component conversion;
+/// callers handle it separately.
+type SliceRoundtrip = fn(&[f32]) -> Vec<f32>;
+
+fn scalar_storage_roundtrip(datatype: Option<Datatype>) -> Option<SliceRoundtrip> {
+    match datatype {
+        Some(Datatype::Float16) => Some(primitive_storage_roundtrip::<VectorElementTypeHalf>),
+        Some(Datatype::Uint8) => Some(primitive_storage_roundtrip::<VectorElementTypeByte>),
+        Some(Datatype::Float32) | None => None,
+        Some(Datatype::Turbo4) => panic!("Turbo4 has no per-component scalar round-trip"),
     }
 }
 
@@ -954,7 +954,7 @@ pub(super) fn dense_matches(name: &str, actual: &[f32], expected: &[f32]) -> boo
     if actual.len() != expected.len() {
         return false;
     }
-    match datatype_of(name) {
+    match candidate_of(name).datatype {
         Some(Datatype::Turbo4) => actual.iter().zip(expected).all(|(&a, &e)| {
             let tol = 16.0 * f32::EPSILON * f32::max(a.abs(), e.abs());
             (a - e).abs() <= tol

--- a/lib/collection/src/model_testing/op/mod.rs
+++ b/lib/collection/src/model_testing/op/mod.rs
@@ -877,19 +877,22 @@ pub(super) fn model_entry_from(vecs: &NamedVectors, payload: &Payload) -> ModelE
     }
 }
 
-/// Predicted engine read-back for `value` stored under `name`. Dense vectors with a lossy
-/// storage datatype must record the storage round-trip instead of the inserted value:
+/// Predicted engine read-back for `value` stored under `name`. Dense and multi-dense
+/// vectors with a lossy storage datatype must record the storage round-trip instead of
+/// the inserted value:
 ///
-/// - Turbo4 stores 4-bit quantized codes and returns the dequantized vector. The
-///   round-trip is deterministic (fixed rotation seeds), shared across segments and
-///   reloads, but not idempotent (re-quantizing a read-back shifts the stored norm), so
-///   canonicalizing at generation time would not converge. The engine still receives the
-///   original vector.
+/// - Turbo4 (dense only) stores 4-bit quantized codes and returns the dequantized
+///   vector. The round-trip is deterministic (fixed rotation seeds), shared across
+///   segments and reloads, but not idempotent (re-quantizing a read-back shifts the
+///   stored norm), so canonicalizing at generation time would not converge. The engine
+///   still receives the original vector.
 /// - Float16 rounds each component through f16; Uint8 truncates with `x as u8`. Both are
 ///   deterministic and idempotent (re-storing a read-back is a no-op), so the model's
 ///   prediction stays exact even across copy-on-write point moves. The prediction goes
 ///   through the engine's own `PrimitiveVectorElement` impls (like Turbo4 reuses
-///   `turbo_storage_roundtrip`) so it tracks the engine by construction.
+///   `turbo_storage_roundtrip`) so it tracks the engine by construction. Multi-dense
+///   storage converts the flattened matrix component-wise (see `from_float_multivector`),
+///   so per-row round-trips predict it exactly.
 pub(super) fn model_vector(name: &str, value: &VectorValue) -> VectorValue {
     let candidate = candidate_of(name);
     match (candidate.kind, value) {
@@ -905,8 +908,24 @@ pub(super) fn model_vector(name: &str, value: &VectorValue) -> VectorValue {
             }
             Some(Datatype::Float32) | None => value.clone(),
         },
-        (VectorKind::Sparse, VectorValue::Sparse(_))
-        | (VectorKind::MultiDense(_), VectorValue::MultiDense(_)) => value.clone(),
+        (VectorKind::MultiDense(_), VectorValue::MultiDense(rows)) => match candidate.datatype {
+            Some(Datatype::Float16) => VectorValue::MultiDense(
+                rows.iter()
+                    .map(|row| primitive_storage_roundtrip::<VectorElementTypeHalf>(row))
+                    .collect(),
+            ),
+            Some(Datatype::Uint8) => VectorValue::MultiDense(
+                rows.iter()
+                    .map(|row| primitive_storage_roundtrip::<VectorElementTypeByte>(row))
+                    .collect(),
+            ),
+            // Rejected by the compile-time check next to `ALL_CANDIDATES`.
+            Some(Datatype::Turbo4) => {
+                panic!("model_vector: Turbo4 multi-dense has no read-back prediction")
+            }
+            Some(Datatype::Float32) | None => value.clone(),
+        },
+        (VectorKind::Sparse, VectorValue::Sparse(_)) => value.clone(),
         (kind, value) => {
             panic!("model_vector: value/kind mismatch for `{name}` ({kind:?}): {value:?}")
         }

--- a/lib/collection/src/model_testing/op/mod.rs
+++ b/lib/collection/src/model_testing/op/mod.rs
@@ -900,8 +900,8 @@ pub(super) fn model_vector(name: &str, value: &VectorValue) -> VectorValue {
                 None => value.clone(),
             },
         },
-        // Turbo4 multi-dense is rejected by the compile-time check next to
-        // `ALL_CANDIDATES`, so `scalar_storage_roundtrip`'s panic arm is unreachable here.
+        // Turbo4 multi-dense is rejected at startup (`assert_candidates_predictable`),
+        // so `scalar_storage_roundtrip`'s panic arm is unreachable here.
         (VectorKind::MultiDense(_), VectorValue::MultiDense(rows)) => {
             match scalar_storage_roundtrip(candidate.datatype) {
                 Some(roundtrip) => {

--- a/lib/collection/src/model_testing/op/mod.rs
+++ b/lib/collection/src/model_testing/op/mod.rs
@@ -1,5 +1,6 @@
 mod generators;
 
+use std::borrow::Cow;
 use std::collections::BTreeSet;
 
 use ahash::AHashSet;
@@ -18,9 +19,11 @@ use rand::seq::{IndexedRandom, IteratorRandom};
 use rand::{Rng, RngExt};
 use segment::data_types::index::{KeywordIndexParams, KeywordIndexType};
 use segment::data_types::order_by::Direction;
+use segment::data_types::primitive::PrimitiveVectorElement;
 use segment::data_types::vector_name_config::{
     DenseVectorConfig, SparseVectorConfig, VectorNameConfig,
 };
+use segment::data_types::vectors::{VectorElementTypeByte, VectorElementTypeHalf};
 use segment::json_path::JsonPath;
 use segment::types::{
     Condition, Distance, FieldCondition, Filter, HasIdCondition, HasVectorCondition, Match,
@@ -30,8 +33,11 @@ use segment::types::{
 use segment::vector_storage::turbo::turbo_storage_roundtrip;
 use sparse::common::sparse_vector::SparseVector;
 
-use super::{ALL_CANDIDATES, Model, ModelEntry, VectorKind, VectorValue, kind_of};
+use super::{
+    ALL_CANDIDATES, Model, ModelEntry, VectorKind, VectorValue, candidate_of, datatype_of,
+};
 use crate::operations::point_ops::UpdateMode;
+use crate::operations::types::Datatype;
 
 /// Operations driven against both the live `Collection` and the model.
 #[derive(Debug, Clone)]
@@ -595,12 +601,13 @@ impl Op {
                     return upsert_fallback(rng, active, id_pool);
                 }
                 let pick = inactive.choose(rng).unwrap();
+                let datatype = pick.datatype.map(VectorStorageDatatype::from);
                 let config = match pick.kind {
                     VectorKind::Dense(dim) => VectorNameConfig::dense(DenseVectorConfig {
                         size: dim as usize,
                         distance: Distance::Dot,
                         multivector_config: None,
-                        datatype: None,
+                        datatype,
                     }),
                     VectorKind::Sparse => VectorNameConfig::sparse(SparseVectorConfig {
                         modifier: None,
@@ -610,13 +617,7 @@ impl Op {
                         size: dim as usize,
                         distance: Distance::Dot,
                         multivector_config: Some(MultiVectorConfig::default()),
-                        datatype: None,
-                    }),
-                    VectorKind::DenseTurbo(dim) => VectorNameConfig::dense(DenseVectorConfig {
-                        size: dim as usize,
-                        distance: Distance::Dot,
-                        multivector_config: None,
-                        datatype: Some(VectorStorageDatatype::Turbo4),
+                        datatype,
                     }),
                 };
                 Op::CreateVectorName {
@@ -876,32 +877,52 @@ pub(super) fn model_entry_from(vecs: &NamedVectors, payload: &Payload) -> ModelE
     }
 }
 
-/// Predicted engine read-back for `value` stored under `name`. Turbo4-backed dense
-/// vectors are lossy: the engine stores 4-bit quantized codes and returns the
-/// dequantized vector, so the model must record that round-trip instead of the inserted
-/// value. The round-trip is deterministic (fixed rotation seeds), shared across
-/// segments and reloads. The engine still receives the original vector: the round-trip
-/// is not idempotent (re-quantizing a read-back shifts the stored norm), so
-/// canonicalizing at generation time would not converge.
+/// Predicted engine read-back for `value` stored under `name`. Dense vectors with a lossy
+/// storage datatype must record the storage round-trip instead of the inserted value:
+///
+/// - Turbo4 stores 4-bit quantized codes and returns the dequantized vector. The
+///   round-trip is deterministic (fixed rotation seeds), shared across segments and
+///   reloads, but not idempotent (re-quantizing a read-back shifts the stored norm), so
+///   canonicalizing at generation time would not converge. The engine still receives the
+///   original vector.
+/// - Float16 rounds each component through f16; Uint8 truncates with `x as u8`. Both are
+///   deterministic and idempotent (re-storing a read-back is a no-op), so the model's
+///   prediction stays exact even across copy-on-write point moves. The prediction goes
+///   through the engine's own `PrimitiveVectorElement` impls (like Turbo4 reuses
+///   `turbo_storage_roundtrip`) so it tracks the engine by construction.
 pub(super) fn model_vector(name: &str, value: &VectorValue) -> VectorValue {
-    match (kind_of(name), value) {
-        (VectorKind::DenseTurbo(_), VectorValue::Dense(v)) => {
+    let candidate = candidate_of(name);
+    match (candidate.kind, value) {
+        (VectorKind::Dense(_), VectorValue::Dense(v)) => match candidate.datatype {
             // Every fixture vector uses Dot (see `fixture::fixture` and the
             // CreateVectorName generator arm above).
-            VectorValue::Dense(turbo_storage_roundtrip(v, Distance::Dot))
-        }
-        (
-            VectorKind::Dense(_) | VectorKind::Sparse | VectorKind::MultiDense(_),
-            VectorValue::Dense(_) | VectorValue::Sparse(_) | VectorValue::MultiDense(_),
-        ) => value.clone(),
-        (VectorKind::DenseTurbo(_), VectorValue::Sparse(_) | VectorValue::MultiDense(_)) => {
-            panic!("model_vector: non-dense value for Turbo4 name `{name}`: {value:?}")
+            Some(Datatype::Turbo4) => VectorValue::Dense(turbo_storage_roundtrip(v, Distance::Dot)),
+            Some(Datatype::Float16) => {
+                VectorValue::Dense(primitive_storage_roundtrip::<VectorElementTypeHalf>(v))
+            }
+            Some(Datatype::Uint8) => {
+                VectorValue::Dense(primitive_storage_roundtrip::<VectorElementTypeByte>(v))
+            }
+            Some(Datatype::Float32) | None => value.clone(),
+        },
+        (VectorKind::Sparse, VectorValue::Sparse(_))
+        | (VectorKind::MultiDense(_), VectorValue::MultiDense(_)) => value.clone(),
+        (kind, value) => {
+            panic!("model_vector: value/kind mismatch for `{name}` ({kind:?}): {value:?}")
         }
     }
 }
 
+/// f32 -> storage element -> f32 through the engine's own conversion impls
+/// (`lib/segment/src/data_types/primitive.rs`).
+fn primitive_storage_roundtrip<T: PrimitiveVectorElement>(v: &[f32]) -> Vec<f32> {
+    let stored = T::slice_from_float_cow(Cow::Borrowed(v));
+    T::slice_to_float_cow(stored).into_owned()
+}
+
 /// Compare a returned dense vector against the model's prediction for `name`.
-/// Exact for full-precision names. Turbo4 read-backs are compared with a tiny
+/// Exact for all names except Turbo4 (including the lossy-but-idempotent Float16
+/// and Uint8 datatypes). Turbo4 read-backs are compared with a tiny
 /// relative tolerance: a copy-on-write point move re-quantizes the dequantized
 /// read-back, and although the codes and the centroid norm are reproduced, the
 /// re-measured stored norm passes through two f64 rotation round-trips and can
@@ -914,12 +935,14 @@ pub(super) fn dense_matches(name: &str, actual: &[f32], expected: &[f32]) -> boo
     if actual.len() != expected.len() {
         return false;
     }
-    match kind_of(name) {
-        VectorKind::DenseTurbo(_) => actual.iter().zip(expected).all(|(&a, &e)| {
+    match datatype_of(name) {
+        Some(Datatype::Turbo4) => actual.iter().zip(expected).all(|(&a, &e)| {
             let tol = 16.0 * f32::EPSILON * f32::max(a.abs(), e.abs());
             (a - e).abs() <= tol
         }),
-        VectorKind::Dense(_) | VectorKind::Sparse | VectorKind::MultiDense(_) => actual == expected,
+        // Float16 / Uint8 read-backs are exact: `model_vector` records the storage
+        // round-trip, and re-storing a read-back reproduces it bit-for-bit.
+        Some(Datatype::Float16 | Datatype::Uint8 | Datatype::Float32) | None => actual == expected,
     }
 }
 


### PR DESCRIPTION
## What

Extends the model tester to exercise all four `Datatype` variants (Float32, Float16, Uint8, Turbo4), for both dense and multi-dense vectors:

- `VectorCandidate` gains a `datatype: Option<Datatype>` field; the `DenseTurbo` kind is folded into `Dense` + `Some(Turbo4)`.
- Four new candidates: `h` (dense, Float16), `y` (dense, Uint8), `w` (multi-dense, Float16), `z` (multi-dense, Uint8).
- `c` carries an explicit `Some(Float32)` to exercise schema configs that spell the default datatype out instead of leaving the field unset.
- Each candidate now declares `initially_active` inline (replacing the separate `INITIAL_ACTIVE` list); all names but `u` start active.

## How verification works

The model predicts each read-back by routing the written vector through the engine's own `PrimitiveVectorElement` conversion impls, the same way Turbo4 already reuses `turbo_storage_roundtrip`. Multi-dense applies the same round-trip per row. Unlike Turbo4's few-ulp tolerance, Float16/Uint8 comparisons are exact: the round-trips are deterministic and idempotent, so re-storing a read-back (e.g. a copy-on-write point move) reproduces it bit-for-bit.

Notes:

- Uint8 vectors are generated in `0.0..256.0` because storage truncates with `x as u8`; unit-range draws would collapse every vector to zeros.
- A startup assert rejects the kind/datatype combos the model cannot predict yet (Turbo4 multi-dense, sparse + datatype), failing before the first op instead of as a false divergence hours into a soak.
- Op streams for a given seed differ from before (extra active names consume rng draws), so old seed reproductions do not carry over.
- The datatype-preserving `CreateVectorName` path only fires under `--enable-force-off`; verified there against a baseline showing identical pre-existing failures.

## Verification

- `cargo clippy -p collection --all-targets --features testing` and `cargo fmt` clean.
- Debug-build soak runs all green: seeds 2/3/7 at 5k ops with swarm cycling + restart probability, seed 42 at 20k and 10k ops with restarts, seed 5 with `--on-disk`, plus default-flag runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
