### PR TITLE
tests: stop uploaders cleanly before consistency check in WAL delta tests

### DIFF
--- a/tests/consensus_tests/test_shard_wal_delta_transfer.py
+++ b/tests/consensus_tests/test_shard_wal_delta_transfer.py
@@ -230,9 +230,8 @@ def test_shard_wal_delta_transfer_manual_recovery(tmp_path: pathlib.Path):
         cluster_info = get_collection_cluster_info(uri, COLLECTION_NAME)
         assert len(cluster_info['local_shards']) == 1
 
-    upload_process_1.kill()
-    upload_process_2.kill()
-    sleep(1)
+    stop_update_process(upload_process_1)
+    stop_update_process(upload_process_2)
 
     # Ensure data consistency
     data = []
@@ -349,12 +348,10 @@ def test_shard_wal_delta_transfer_manual_recovery_chain(tmp_path: pathlib.Path):
     wait_for_collection_shard_transfers_count(peer_api_uris[3], COLLECTION_NAME, 1)
     wait_for_collection_shard_transfers_count(peer_api_uris[3], COLLECTION_NAME, 0)
 
-    upload_process_1.kill()
-    upload_process_2.kill()
-    upload_process_3.kill()
-    upload_process_4.kill()
-
-    sleep(1)
+    stop_update_process(upload_process_1)
+    stop_update_process(upload_process_2)
+    stop_update_process(upload_process_3)
+    stop_update_process(upload_process_4)
 
     # All nodes must have one shard
     for uri in peer_api_uris:
@@ -484,9 +481,8 @@ def test_shard_wal_delta_transfer_abort_and_retry(tmp_path: pathlib.Path):
         cluster_info = get_collection_cluster_info(uri, COLLECTION_NAME)
         assert len(cluster_info['local_shards']) == 1
 
-    upload_process_1.kill()
-    upload_process_2.kill()
-    sleep(1)
+    stop_update_process(upload_process_1)
+    stop_update_process(upload_process_2)
 
     # Ensure data consistency
     data = []


### PR DESCRIPTION
## Problem

`test_shard_wal_delta_transfer_abort_and_retry` is flaky on CI, failing the final `check_data_consistency` with one peer missing the last batch of points from a background uploader (e.g. `200051–200053`).

Investigation of the failure logs shows this is a test race, not a replication/transfer bug — the abort and retry of the WAL delta transfer both behaved correctly:

- The uploader's last `PUT` (batch `200051–200053`, `wait=true`) was sent at ~17.66s and took **1.89s** on slow CI, completing at **19.551s**.
- The test did `upload_process.kill()` + `sleep(1)` and started scrolling. Killing the client does not cancel the request server-side, and the 1s sleep was shorter than the in-flight PUT.
- Peer 0 was scrolled at **19.089s**, and received the forwarded batch at **19.179s** (90ms later, `200 OK`). Peer 1, which had already applied the batch locally, was scrolled at **19.267s** — so the scrolls diverged by exactly those 3 points. No data was lost; consistency was reached moments after the scroll.

## Fix

#8713 already introduced `stop_update_process()` (signal the uploader to exit between requests, then join) for the pre-peer-kill case, but the end-of-test teardowns still used raw `.kill()` + `sleep(1)`.

Use `stop_update_process()` in the three teardowns that precede consistency scrolls. Since uploads use `wait=true`, once the uploader's last PUT returns, all active replicas have applied it — the scrolls can no longer race with in-flight replication.

Peer-process `.kill()` calls are intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)