### PR TITLE
test: fix flaky test_recover_from_snapshot version comparison

### DIFF
--- a/tests/consensus_tests/test_snapshot_recovery.py
+++ b/tests/consensus_tests/test_snapshot_recovery.py
@@ -150,6 +150,9 @@ def recover_from_snapshot(tmp_path: pathlib.Path, n_replicas):
     new_dense_search_result = search(new_url, dense_query_vector, query_city)
     assert len(new_dense_search_result) == len(dense_search_result)
     for i in range(len(new_dense_search_result)):
+        # version is a per-replica WAL op_num; the snapshot was taken on a
+        # different replica than this reference search, so versions may differ
+        new_dense_search_result[i]["version"] = dense_search_result[i]["version"]
         assert new_dense_search_result[i] == dense_search_result[i]
 
     # check that the sparse vectors are still the same
@@ -158,6 +161,8 @@ def recover_from_snapshot(tmp_path: pathlib.Path, n_replicas):
     for i in range(len(new_sparse_search_result)):
         # skip score check because it is not deterministic
         new_sparse_search_result[i]["score"] = sparse_search_result[i]["score"]
+        # version is a per-replica WAL op_num (see dense check above)
+        new_sparse_search_result[i]["version"] = sparse_search_result[i]["version"]
         assert new_sparse_search_result[i] == sparse_search_result[i]
 
     new_collection_info = get_collection_info(new_url, COLLECTION_NAME)


### PR DESCRIPTION
`test_recover_from_snapshot` compares the full search-result dicts — including each point's `version`.

A point's `version` is the local WAL op_num (`wal.lock_and_write` → `operation_id` in `local_shard/shard_ops.rs`), assigned per-replica. `upsert_random_points` uses `ordering="weak"`, so replicas don't agree on op_nums. The snapshot is taken on a different replica (peer -1) than the reference search (peer 0), so the same point can legitimately have a different `version` (e.g. 2 vs 3) → flaky failure.

Normalize `version` before comparing (dense + sparse), mirroring the existing non-deterministic `score` handling. The meaningful checks (id, payload, dense score) are unchanged.
