### PR TITLE
Avoid exact on-disk map cardinality with soft deletions

### DIFF
--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/read_ops.rs
@@ -15,6 +15,8 @@ use super::super::{IdIter, MapIndexKey};
 use super::OnDiskMapIndex;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::on_disk_point_to_values::ValuesIter;
+use crate::index::field_index::stat_tools::number_of_selected_points;
+use crate::index::field_index::CardinalityEstimation;
 use crate::index::payload_config::StorageType;
 
 impl<'a, N: MapIndexKey + Key + ?Sized + 'a, S: UniversalRead> MapIndexRead<'a, N>
@@ -147,6 +149,119 @@ impl<'a, N: MapIndexKey + Key + ?Sized + 'a, S: UniversalRead> MapIndexRead<'a, 
                 log::error!("Error while getting iterator for value {value:?}: {err:?}");
                 Box::new(iter::empty())
             }
+        }
+    }
+
+    fn match_cardinality(
+        &self,
+        value: &N,
+        hw_counter: &HardwareCounterCell,
+    ) -> CardinalityEstimation {
+        let Some(stored_count) = self.get_count_for_value(value, hw_counter) else {
+            return CardinalityEstimation::exact(0);
+        };
+
+        if self.storage.deleted.deleted_count() == 0 {
+            return CardinalityEstimation::exact(stored_count);
+        }
+
+        let live_points = self.get_indexed_points();
+        let total_points = live_points + self.storage.deleted.deleted_count();
+        let max = stored_count.min(live_points);
+        let exp = if total_points == 0 {
+            0
+        } else {
+            stored_count
+                .saturating_mul(live_points)
+                .div_ceil(total_points)
+                .min(max)
+        };
+
+        CardinalityEstimation {
+            primary_clauses: vec![],
+            min: 0,
+            exp,
+            max,
+        }
+    }
+
+    fn except_cardinality<'b>(
+        &self,
+        excluded: impl Iterator<Item = &'b N>,
+        hw_counter: &HardwareCounterCell,
+    ) -> CardinalityEstimation
+    where
+        N: 'b,
+    {
+        let excluded_value_counts: Vec<_> = excluded
+            .map(|val| self.get_count_for_value(val, hw_counter).unwrap_or(0))
+            .collect();
+        let total_excluded_value_count: usize = excluded_value_counts.iter().sum();
+
+        if self.storage.deleted.deleted_count() == 0 {
+            debug_assert!(total_excluded_value_count <= self.get_values_count());
+
+            let non_excluded_values_count = self
+                .get_values_count()
+                .saturating_sub(total_excluded_value_count);
+            let max_values_per_point = self
+                .get_unique_values_count()
+                .saturating_sub(excluded_value_counts.len());
+
+            if max_values_per_point == 0 {
+                debug_assert_eq!(non_excluded_values_count, 0);
+                return CardinalityEstimation::exact(0);
+            }
+
+            let min_not_excluded_by_values =
+                non_excluded_values_count.div_ceil(max_values_per_point);
+
+            let min = min_not_excluded_by_values.max(
+                self.get_indexed_points()
+                    .saturating_sub(total_excluded_value_count),
+            );
+
+            let max_excluded_value_count = excluded_value_counts.iter().max().copied().unwrap_or(0);
+
+            let max = self
+                .get_indexed_points()
+                .saturating_sub(max_excluded_value_count)
+                .min(non_excluded_values_count);
+
+            let exp =
+                number_of_selected_points(self.get_indexed_points(), non_excluded_values_count)
+                    .max(min)
+                    .min(max);
+
+            return CardinalityEstimation {
+                primary_clauses: vec![],
+                min,
+                exp,
+                max,
+            };
+        }
+
+        let live_points = self.get_indexed_points();
+        let stored_non_excluded_values = self
+            .get_values_count()
+            .saturating_sub(total_excluded_value_count);
+
+        if live_points == 0 || stored_non_excluded_values == 0 {
+            return CardinalityEstimation::exact(0);
+        }
+
+        let total_points = live_points + self.storage.deleted.deleted_count();
+        let estimated_live_non_excluded_values = stored_non_excluded_values
+            .saturating_mul(live_points)
+            .div_ceil(total_points);
+        let exp = number_of_selected_points(live_points, estimated_live_non_excluded_values)
+            .min(live_points);
+
+        CardinalityEstimation {
+            primary_clauses: vec![],
+            min: 0,
+            exp,
+            max: live_points,
         }
     }
 

--- a/lib/segment/src/index/field_index/map_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/map_index/read_ops.rs
@@ -12,8 +12,8 @@ use itertools::Itertools;
 use super::key::MapIndexKey;
 use super::{IdIter, MapIndex};
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::index::field_index::CardinalityEstimation;
 use crate::index::field_index::stat_tools::number_of_selected_points;
+use crate::index::field_index::CardinalityEstimation;
 use crate::index::payload_config::{IndexMutability, StorageType};
 use crate::payload_storage::condition_checker::INDEXSET_ITER_THRESHOLD;
 use crate::telemetry::PayloadIndexTelemetry;
@@ -361,6 +361,33 @@ where
             MapIndex::Mutable(index) => index.get_iterator(value, hw_counter),
             MapIndex::Immutable(index) => index.get_iterator(value, hw_counter),
             MapIndex::OnDisk(index) => index.get_iterator(value, hw_counter),
+        }
+    }
+
+    fn match_cardinality(
+        &self,
+        value: &N,
+        hw_counter: &HardwareCounterCell,
+    ) -> CardinalityEstimation {
+        match self {
+            MapIndex::Mutable(index) => index.match_cardinality(value, hw_counter),
+            MapIndex::Immutable(index) => index.match_cardinality(value, hw_counter),
+            MapIndex::OnDisk(index) => index.match_cardinality(value, hw_counter),
+        }
+    }
+
+    fn except_cardinality<'b>(
+        &self,
+        excluded: impl Iterator<Item = &'b N>,
+        hw_counter: &HardwareCounterCell,
+    ) -> CardinalityEstimation
+    where
+        N: 'b,
+    {
+        match self {
+            MapIndex::Mutable(index) => index.except_cardinality(excluded, hw_counter),
+            MapIndex::Immutable(index) => index.except_cardinality(excluded, hw_counter),
+            MapIndex::OnDisk(index) => index.except_cardinality(excluded, hw_counter),
         }
     }
 

--- a/lib/segment/src/index/field_index/map_index/tests.rs
+++ b/lib/segment/src/index/field_index/map_index/tests.rs
@@ -12,9 +12,9 @@ use rstest::rstest;
 use serde_json::Value;
 use tempfile::Builder;
 
-use super::MapIndex;
 use super::key::MapIndexKey;
 use super::read_ops::MapIndexRead;
+use super::MapIndex;
 use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadFieldIndex, PayloadFieldIndexRead,
     ValueIndexer,
@@ -389,17 +389,68 @@ fn test_map_index_reload(#[case] index_type: IndexType) {
         );
     }
 
+    let expected_count = match index_type {
+        IndexType::Mmap => Some(3),
+        IndexType::MutableGridstore | IndexType::RamMmap => Some(2),
+    };
+    let expected_cardinality = match index_type {
+        IndexType::Mmap => CardinalityEstimation {
+            primary_clauses: vec![],
+            min: 0,
+            exp: 2,
+            max: 3,
+        },
+        IndexType::MutableGridstore | IndexType::RamMmap => CardinalityEstimation::exact(2),
+    };
+
     let mut hits: Vec<PointOffsetType> = new_index.get_iterator(&1, &hw_counter).collect();
     hits.sort();
     assert_eq!(hits, vec![0, 3]);
+    assert_eq!(
+        new_index.get_count_for_value(&1, &hw_counter),
+        expected_count
+    );
+    assert_eq!(
+        new_index.match_cardinality(&1, &hw_counter),
+        expected_cardinality
+    );
 
     let mut hits: Vec<PointOffsetType> = new_index.get_iterator(&2, &hw_counter).collect();
     hits.sort();
     assert_eq!(hits, vec![0, 4]);
+    assert_eq!(
+        new_index.get_count_for_value(&2, &hw_counter),
+        expected_count
+    );
+    assert_eq!(
+        new_index.match_cardinality(&2, &hw_counter),
+        expected_cardinality
+    );
 
     let mut hits: Vec<PointOffsetType> = new_index.get_iterator(&3, &hw_counter).collect();
     hits.sort();
     assert_eq!(hits, vec![3, 4]);
+    assert_eq!(
+        new_index.get_count_for_value(&3, &hw_counter),
+        expected_count
+    );
+    assert_eq!(
+        new_index.match_cardinality(&3, &hw_counter),
+        expected_cardinality
+    );
+
+    if index_type == IndexType::Mmap {
+        let excluded = [1];
+        assert_eq!(
+            new_index.except_cardinality(excluded.iter(), &hw_counter),
+            CardinalityEstimation {
+                primary_clauses: vec![],
+                min: 0,
+                exp: 2,
+                max: 3,
+            },
+        );
+    }
 }
 
 /// Regression test: when reloading an mmap map index with a `deleted_points`


### PR DESCRIPTION
## Summary

Addresses #9802.

This changes the on-disk map index cardinality path so it no longer reports an exact count when soft-deleted points may still be present in persisted postings.

To avoid the performance cost of reading and filtering the full posting list during cardinality estimation, the on-disk path keeps the existing cheap persisted-count lookup and returns a bounded estimate when deletions are present.

When there are no deleted points, the estimate remains exact. Mutable and RAM-loaded immutable map indexes still return exact live counts.

## Testing

```bash
cargo test -p segment index::field_index::map_index::tests::test_map_index_reload -- --nocapture