### PR TITLE
[TQDT] Reduce allocations

### DIFF
--- a/lib/segment/src/data_types/segment_record.rs
+++ b/lib/segment/src/data_types/segment_record.rs
@@ -1,7 +1,11 @@
+use smallvec::SmallVec;
+
 use crate::data_types::vectors::VectorInternal;
 use crate::types::{Payload, PointIdType, VectorNameBuf};
 
-pub type NamedVectorsOwned = Vec<(VectorNameBuf, VectorInternal)>;
+/// A point almost always has a single (default) named vector, so keep it inline
+/// to avoid a heap allocation on the common retrieve path.
+pub type NamedVectorsOwned = SmallVec<[(VectorNameBuf, VectorInternal); 1]>;
 
 /// A retrieved point: id, optional vectors, optional payload.
 ///
@@ -9,7 +13,7 @@ pub type NamedVectorsOwned = Vec<(VectorNameBuf, VectorInternal)>;
 /// storage-native bytes for [`SegmentRecordRaw`].
 pub struct SegmentRecordGeneric<V> {
     pub id: PointIdType,
-    pub vectors: Option<Vec<(VectorNameBuf, V)>>,
+    pub vectors: Option<SmallVec<[(VectorNameBuf, V); 1]>>,
     pub payload: Option<Payload>,
 }
 

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -5,6 +5,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::iterator_ext::IteratorExt;
 use common::types::{DeferredBehavior, PointOffsetType, ScoredPointOffset};
+use smallvec::SmallVec;
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::{check_query_vectors, check_stopped};
@@ -117,7 +118,7 @@ where
             .map(|&id| {
                 let record = SegmentRecordGeneric {
                     id,
-                    vectors: needs_vectors.then(Vec::new),
+                    vectors: needs_vectors.then(SmallVec::new),
                     payload: None,
                 };
                 (id, record)

--- a/lib/shard/src/operations/point_ops.rs
+++ b/lib/shard/src/operations/point_ops.rs
@@ -447,7 +447,7 @@ impl PointStructPersisted {
             return false;
         }
 
-        let self_vectors = self.get_vectors().into_owned_map();
+        let self_vectors = self.get_vectors();
 
         if let Some(segment_vectors) = vectors {
             if self_vectors.len() != segment_vectors.len() {

--- a/lib/shard/src/operations/point_ops.rs
+++ b/lib/shard/src/operations/point_ops.rs
@@ -13,7 +13,7 @@ use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::segment_record::SegmentRecord;
 use segment::data_types::vectors::{
     BatchVectorStructInternal, DEFAULT_VECTOR_NAME, DenseVector, MultiDenseVector,
-    MultiDenseVectorInternal, VectorInternal, VectorStructInternal,
+    MultiDenseVectorInternal, VectorInternal, VectorRef, VectorStructInternal,
 };
 use segment::types::{Filter, Payload, PointIdType, VectorNameBuf};
 use serde::{Deserialize, Serialize};
@@ -454,7 +454,7 @@ impl PointStructPersisted {
                 return false;
             }
             for (name, vec) in segment_vectors {
-                if self_vectors.get(name) != Some(vec) {
+                if self_vectors.get(name) != Some(VectorRef::from(vec)) {
                     return false;
                 }
             }

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -996,7 +996,7 @@ impl SegmentHolder {
         F: FnMut(PointIdType, &mut RwLockWriteGuard<dyn SegmentEntry>) -> OperationResult<bool>,
         G: FnMut(
             PointIdType,
-            &mut Vec<(VectorNameBuf, Vec<u8>)>,
+            &mut SmallVec<[(VectorNameBuf, Vec<u8>); 1]>,
             &mut NamedVectors<'op>,
             &mut Payload,
         ),


### PR DESCRIPTION
Depends on #9761 

This PR reduces some allocations by utilizing `SmallVec` in places where we have missed it before.


I deliberately did _not_ adjust the return type of [this function](https://github.com/qdrant/qdrant/blob/da7eedeaf3dd4e31748898832c983f8d26e99329/lib/segment/src/entry/entry_point.rs#L118), because:
  - `TinyMap` degrades lookup to `O(n)`, which for large amount of points would mean (significant) performance regression (much more than the one allocation would cost us).
  - A new `retrieve_raw_one` trait function would mean significant amount of duplicated code.
  - Enum dispatched approach with `Single((key, value))` and `Multi(HashMap<.., ..>)` variants would introduce significant complexity, again not worth.