### PR TITLE
Single inverse rotation in TurboQuant symmetric L1 scoring

### DIFF
--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -428,15 +428,15 @@ impl TurboQuantizer {
             }
             DistanceType::L1 => {
                 // Fallback case for L1, where we need to fully dequantize both vectors.
-                let mut deq_v1: Vec<f64> = self.dequantize(v1);
-                self.apply_inverse_rotation(deq_v1.as_mut_slice());
-                let mut deq_v2: Vec<f64> = self.dequantize(v2);
-                self.apply_inverse_rotation(deq_v2.as_mut_slice());
-                deq_v1
-                    .iter()
-                    .zip(deq_v2.iter())
-                    .map(|(&x, &y)| (x - y).abs() as f32)
-                    .sum()
+                // The rotation is linear, so `|R⁻¹d1 - R⁻¹d2| = |R⁻¹(d1 - d2)|`:
+                // subtracting in rotated space needs one inverse rotation, not two.
+                let deq_v1: Vec<f64> = self.dequantize(v1);
+                let mut diff: Vec<f64> = self.dequantize(v2);
+                for (d, &x) in diff.iter_mut().zip(&deq_v1) {
+                    *d = x - *d;
+                }
+                self.apply_inverse_rotation(diff.as_mut_slice());
+                diff.iter().map(|&x| x.abs() as f32).sum()
             }
         }
     }


### PR DESCRIPTION
## What

Speed up `TurboQuantizer::score_symmetric` for `DistanceType::L1` by applying the inverse Hadamard rotation once instead of twice per score call.

Manhattan distance is not invariant under rotation, so the L1 scoring path has to leave the rotated (quantized) space: it dequantizes both vectors and applies the inverse rotation to each before summing absolute differences. The rotation is linear (WHT stages and permutation gathers), so the inverse rotation distributes over subtraction:

```
|R⁻¹d₁ - R⁻¹d₂|₁ = |R⁻¹(d₁ - d₂)|₁
```

The symmetric arm now subtracts the two dequantized vectors in rotated space and inverse-rotates the difference, halving the rotation work (4 WHT passes + 3 gathers per vector). The asymmetric path (`score_precomputed`) is unchanged: the query is kept unrotated there, so it already performs a single rotation per score.

## Why

`perf` profiling of `test_quantization_over_typed_storage_hnsw::case_16_nearest_turbo_turbo_manhattan` showed 96.6% of cycles in the HNSW build threads, almost entirely under the L1 dequantize + inverse-rotation fallback. The graph-linking heuristic scores stored-vector pairs through `score_symmetric`, paying two full rotations per pair.

The test runs in 57.4s with this change vs 69.9s before (debug build, ~18% faster). The relative win on the symmetric scoring path itself is larger in optimized builds, where the fixed per-call overhead around the rotation kernels is smaller.

## Correctness

Scores are the same quantity but not bit-identical to before: subtracting before rotating changes the floating-point evaluation order. L1 scoring is approximate by nature and all its tests are tolerance-based:

- `test_tq_l1_internal` / `test_tq_l1` (Normal and Plus modes) exercise the changed arm directly and pass.
- Full `quantization` crate suite: 208 passed.
- All 18 cases of `test_quantization_over_typed_storage_hnsw` pass, including the three turbo-storage re-quantization cases.

The identity also holds for TQ+ (error correction): the EC revert happens inside `dequantize`, before the subtraction, so linearity of the rotation is all that's needed. Padding tails beyond `rotation.dim()` are untouched by the rotation in both the old and new code and contribute identically to the sum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)