### PR TITLE
[UIO | vector storage] exhaustive match on async-like backends

### DIFF
--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -38,6 +38,19 @@ impl UniversalKind {
             | UniversalKind::UioGrpc => false,
         }
     }
+
+    pub fn can_be_async(self) -> bool {
+        match self {
+            UniversalKind::Mmap => false,
+            UniversalKind::IoUring
+            | UniversalKind::DiskCache
+            | UniversalKind::SimpleDiskCache
+            | UniversalKind::S3
+            | UniversalKind::Gcs
+            | UniversalKind::Azure
+            | UniversalKind::UioGrpc => true,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]

--- a/lib/segment/src/vector_storage/chunked_vectors/read.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read.rs
@@ -211,8 +211,7 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
     where
         F: FnMut(usize, &[T]),
     {
-        #[cfg(target_os = "linux")]
-        if TypedStorage::<S, T>::kind() == common::universal_io::UniversalKind::IoUring {
+        if TypedStorage::<S, T>::kind().can_be_async() {
             let point_offsets = keys
                 .iter()
                 .copied()

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -142,8 +142,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectorData<T, S>
         keys: &[PointOffsetType],
         mut f: F,
     ) -> OperationResult<()> {
-        #[cfg(target_os = "linux")]
-        if TypedStorage::<ReadOnly<S>, T>::kind() == common::universal_io::UniversalKind::IoUring {
+        if TypedStorage::<ReadOnly<S>, T>::kind().can_be_async() {
             return self.for_each_in_batch_async(keys, f);
         }
 


### PR DESCRIPTION
We choose how to read a batch of vectors depending on the storage kind, but we were only considering io-uring. 

This PR covers every other backend that can be doing async reads