### PR TITLE
[DiskCache] Dedup overlapping remote requests

### DIFF
--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -185,15 +185,17 @@ where
     R: UniversalRead + 'file,
     U: UserData,
 {
-    fn get_or_init_remote_pipeline(
-        &mut self,
-    ) -> universal_io::Result<&mut RemotePipeline<'file, R>> {
-        if self.remote_pipeline.get().is_none() {
+    /// Takes the field instead of `&mut self` so callers can keep disjoint
+    /// borrows of other fields (see the `vacant_entry` in `schedule`).
+    fn get_or_init_remote_pipeline<'a>(
+        remote_pipeline: &'a mut OnceCell<RemotePipeline<'file, R>>,
+    ) -> universal_io::Result<&'a mut RemotePipeline<'file, R>> {
+        if remote_pipeline.get().is_none() {
             let remote = R::ReadPipeline::new()?;
-            // We just observed the cell as empty and hold `&mut self`, so set cannot fail.
-            let _ = self.remote_pipeline.set(remote);
+            // We just observed the cell as empty and hold `&mut`, so set cannot fail.
+            let _ = remote_pipeline.set(remote);
         }
-        Ok(self.remote_pipeline.get_mut().expect("just initialized"))
+        Ok(remote_pipeline.get_mut().expect("just initialized"))
     }
 
     /// Number of remote fetches currently in flight.
@@ -259,20 +261,19 @@ where
                     return Ok(());
                 }
 
-                // Peek the slot `in_flight` would assign next, without
-                // consuming it: a failed remote schedule must leave no trace,
-                // and only the `insert` below actually commits a slot. Since
-                // nothing else touches `in_flight` in between, `insert` is
-                // guaranteed to land on this same key.
-                let id = self.in_flight.vacant_entry().key() as u64;
-                let remote_pipeline = self.get_or_init_remote_pipeline()?;
+                // Reserve the slot without occupying it: only the
+                // `entry.insert` below commits it, so a failed remote schedule
+                // leaves no trace, and inserting through the entry guarantees
+                // the fetch lands on the key the remote read was tagged with.
+                let remote_pipeline = Self::get_or_init_remote_pipeline(&mut self.remote_pipeline)?;
+                let entry = self.in_flight.vacant_entry();
                 remote_pipeline.schedule::<P>(
-                    id,
+                    entry.key() as u64,
                     state.remote,
                     blocks_byte_range,
                     REMOTE_READ_ALIGNMENT,
                 )?;
-                self.in_flight.insert(InFlightFetch {
+                entry.insert(InFlightFetch {
                     file,
                     blocks_range,
                     reads: vec![(user_data, range)],

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -1,6 +1,8 @@
 use std::cell::OnceCell;
-use std::fmt;
+use std::collections::VecDeque;
 use std::ops::Range;
+
+use slab::Slab;
 
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Random, Sequential};
@@ -18,33 +20,30 @@ pub(super) const REMOTE_READ_ALIGNMENT: usize = universal_io::io_uring::KERNEL_P
 /// Default alignment on non-Linux platforms
 pub(super) const REMOTE_READ_ALIGNMENT: usize = 1;
 
-struct RemoteMeta<File, U> {
-    file: File,
-    scheduled_read: ScheduledRead,
-    user_data: U,
-}
-
-impl<File, U: fmt::Debug> fmt::Debug for RemoteMeta<File, U> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self {
-            scheduled_read,
-            user_data,
-            file: _,
-        } = self;
-        f.debug_struct("RemoteMeta")
-            .field("scheduled_read", scheduled_read)
-            .field("user_data", user_data)
-            .finish_non_exhaustive()
-    }
-}
-
-#[derive(Debug)]
-struct ScheduledRead {
+/// A remote fetch in flight: which file and blocks it covers, and every
+/// scheduled read waiting on it — the read that triggered the fetch, plus any
+/// later reads whose blocks it fully covers. See [`DiskCachePipeline::schedule`].
+///
+/// Lives in `DiskCachePipeline::in_flight`, keyed by its slab slot, which
+/// also serves as the fetch's user data on the remote pipeline.
+struct InFlightFetch<'file, R, U>
+where
+    R: UniversalRead + 'static,
+{
+    /// Identifies which file this fetch belongs to. Matched by reference
+    /// identity (see `schedule`'s piggyback check): sound because `DiskCache`
+    /// isn't `Clone`, and `'file` pins the borrow for the pipeline's lifetime,
+    /// so two live `&'file DiskCache<R>` referring to the same logical file
+    /// are guaranteed to be the same reference.
+    file: &'file DiskCache<R>,
+    /// Blocks the fetch covers; committed to the local mirror on completion.
     blocks_range: Range<u32>,
-    read_range: Range<u64>,
+    /// `(user_data, byte range)` of every read resolved by this fetch; each is
+    /// re-read from the local mirror once the fetch commits. Never empty.
+    reads: Vec<(U, Range<u64>)>,
 }
 
-/// Outcome of [`plan_schedule`]: either the requested range is already available
+/// Outcome of [`pick_source`]: either the requested range is already available
 /// locally (or is empty) and needs no remote work, or a remote read must be
 /// scheduled for `blocks_byte_range` covering `blocks_range`.
 enum Source {
@@ -107,8 +106,8 @@ where
 ///
 /// # Safety
 /// `byte_range` must correspond to blocks already known to be local (typically
-/// because [`plan_schedule`] returned [`SchedulePlan::Local`] for it, or
-/// [`complete_remote_read`] just fetched them).
+/// because [`pick_source`] returned [`Source::Local`] for it, or
+/// [`commit_and_read`] just fetched them).
 unsafe fn read_local<R>(
     file: &DiskCache<R>,
     range: Range<u64>,
@@ -128,22 +127,26 @@ where
     }
 }
 
-/// Commit remote-fetched `bytes` into local mmap and re-read the user's slice.
+/// Commit remote-fetched `bytes` into local mmap and resolve every read waiting
+/// on `fetch`, pushing the resulting slices to `results`.
 ///
 /// # Safety
-/// `blocks_range` and `read_range` must correspond to the `bytes` section of the mmap.
-unsafe fn commit_and_read<'a, R>(
-    file: &'a DiskCache<R>,
+/// `bytes` must be the remote content of `fetch.blocks_range` (clamped to EOF),
+/// and every range in `fetch.reads` must be covered by those blocks.
+unsafe fn commit_and_read<'file, R, U>(
+    fetch: InFlightFetch<'file, R, U>,
     bytes: &[u8],
-    scheduled_read: ScheduledRead,
-) -> universal_io::Result<&'a [u8]>
+    results: &mut VecDeque<(U, &'file [u8])>,
+) -> universal_io::Result<()>
 where
     R: DiskCacheRemote,
+    U: UserData,
 {
-    let ScheduledRead {
+    let InFlightFetch {
+        file,
         blocks_range,
-        read_range,
-    } = scheduled_read;
+        reads,
+    } = fetch;
 
     // The mirror is already materialized: scheduling this remote read went
     // through `file.state()` (see `schedule`), which forces initialization.
@@ -151,22 +154,30 @@ where
 
     unsafe {
         local.write_mmap_bytes(bytes, blocks_range);
-        local.read_mmap_bytes::<Random>(read_range)
+        for (user_data, read_range) in reads {
+            let slice = local.read_mmap_bytes::<Random>(read_range)?;
+            results.push_back((user_data, slice));
+        }
     }
+
+    Ok(())
 }
 
-type RemotePipeline<'file, R, U> =
-    <R as UniversalRead>::ReadPipeline<'file, RemoteMeta<&'file DiskCache<R>, U>>;
+type RemotePipeline<'file, R> = <R as UniversalRead>::ReadPipeline<'file, u64>;
 
 pub struct DiskCachePipeline<'file, R, U>
 where
     R: UniversalRead + 'static,
     U: UserData,
 {
-    /// Pipeline for queuing remote reads.
-    remote_pipeline: OnceCell<RemotePipeline<'file, R, U>>,
-    /// A result of (user_data, bytes)
-    result: Option<(U, &'file [u8])>,
+    /// Pipeline for queuing remote reads. Each read's user data is its
+    /// `in_flight` slot key.
+    remote_pipeline: OnceCell<RemotePipeline<'file, R>>,
+    /// One entry per remote read scheduled and not yet completed, keyed by
+    /// the id passed to the remote pipeline as user data.
+    in_flight: Slab<InFlightFetch<'file, R, U>>,
+    /// Resolved reads, ready to be returned by `wait`.
+    results: VecDeque<(U, &'file [u8])>,
 }
 
 impl<'file, R, U> DiskCachePipeline<'file, R, U>
@@ -176,13 +187,19 @@ where
 {
     fn get_or_init_remote_pipeline(
         &mut self,
-    ) -> universal_io::Result<&mut RemotePipeline<'file, R, U>> {
+    ) -> universal_io::Result<&mut RemotePipeline<'file, R>> {
         if self.remote_pipeline.get().is_none() {
             let remote = R::ReadPipeline::new()?;
             // We just observed the cell as empty and hold `&mut self`, so set cannot fail.
             let _ = self.remote_pipeline.set(remote);
         }
         Ok(self.remote_pipeline.get_mut().expect("just initialized"))
+    }
+
+    /// Number of remote fetches currently in flight.
+    #[cfg(test)]
+    pub(super) fn in_flight_fetches(&self) -> usize {
+        self.in_flight.len()
     }
 }
 
@@ -196,12 +213,13 @@ where
     fn new() -> universal_io::Result<Self> {
         Ok(Self {
             remote_pipeline: OnceCell::new(),
-            result: None,
+            in_flight: Slab::new(),
+            results: VecDeque::new(),
         })
     }
 
     fn can_schedule(&mut self) -> bool {
-        self.result.is_none()
+        self.results.is_empty()
             && self
                 .remote_pipeline
                 .get_mut()
@@ -223,27 +241,42 @@ where
             } => {
                 // SAFETY: Source::Local confirms the range is local (or empty).
                 let bytes = unsafe { read_local::<R>(file, range, is_sequential)? };
-                self.result = Some((user_data, bytes));
+                self.results.push_back((user_data, bytes));
             }
             Source::Remote {
                 blocks_range,
                 blocks_byte_range,
             } => {
-                let remote_meta = RemoteMeta {
-                    file,
-                    scheduled_read: ScheduledRead {
-                        blocks_range,
-                        read_range: range,
-                    },
-                    user_data,
-                };
+                // An in-flight fetch for the same file covering all needed
+                // blocks resolves this read too: piggyback on it instead of
+                // fetching the same blocks twice.
+                if let Some((_, fetch)) = self.in_flight.iter_mut().find(|(_, inflight)| {
+                    std::ptr::eq(inflight.file, file)
+                        && inflight.blocks_range.start <= blocks_range.start
+                        && blocks_range.end <= inflight.blocks_range.end
+                }) {
+                    fetch.reads.push((user_data, range));
+                    return Ok(());
+                }
+
+                // Peek the slot `in_flight` would assign next, without
+                // consuming it: a failed remote schedule must leave no trace,
+                // and only the `insert` below actually commits a slot. Since
+                // nothing else touches `in_flight` in between, `insert` is
+                // guaranteed to land on this same key.
+                let id = self.in_flight.vacant_entry().key() as u64;
                 let remote_pipeline = self.get_or_init_remote_pipeline()?;
                 remote_pipeline.schedule::<P>(
-                    remote_meta,
+                    id,
                     state.remote,
                     blocks_byte_range,
                     REMOTE_READ_ALIGNMENT,
                 )?;
+                self.in_flight.insert(InFlightFetch {
+                    file,
+                    blocks_range,
+                    reads: vec![(user_data, range)],
+                });
             }
         }
         Ok(())
@@ -264,25 +297,43 @@ where
     }
 
     fn wait(&mut self) -> universal_io::Result<Option<(U, ACow<'file>)>> {
-        if let Some((user_data, slice)) = self.result.take() {
+        if let Some((user_data, slice)) = self.results.pop_front() {
             return Ok(Some((user_data, ACow::Borrowed(slice))));
         }
 
         let Some(remote_pipeline) = self.remote_pipeline.get_mut() else {
             return Ok(None);
         };
-        let Some((remote_meta, bytes)) = remote_pipeline.wait()? else {
+        let completion = match remote_pipeline.wait() {
+            Ok(completion) => completion,
+            Err(err) => {
+                // Note: `wait()` interface is blind to which request belongs
+                // to which response, so, we can't remove the requests waiting for
+                // this particular failed response.
+                //
+                // Let's just drop all in-flight requests.
+                self.in_flight.clear();
+                self.remote_pipeline.take();
+                return Err(err);
+            }
+        };
+        let Some((fetch_id, bytes)) = completion else {
             return Ok(None);
         };
 
-        let RemoteMeta {
-            file,
-            scheduled_read,
-            user_data,
-        } = remote_meta;
+        let fetch = self
+            .in_flight
+            .try_remove(fetch_id as usize)
+            .expect("completed fetch has an in-flight entry");
 
-        // SAFETY: `blocks_range` and `read_range` match what was scheduled.
-        let items = unsafe { commit_and_read::<R>(file, &bytes, scheduled_read)? };
-        Ok(Some((user_data, ACow::Borrowed(items))))
+        // SAFETY: `bytes` is the content of `fetch.blocks_range` as scheduled,
+        // and piggybacked reads were accepted only when covered by those blocks.
+        unsafe { commit_and_read(fetch, &bytes, &mut self.results)? };
+
+        let (user_data, slice) = self
+            .results
+            .pop_front()
+            .expect("a completed fetch resolves at least one read");
+        Ok(Some((user_data, ACow::Borrowed(slice))))
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -1,10 +1,8 @@
 use std::assert_matches;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::ops::Range;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use fs_err as fs;
 
@@ -12,13 +10,11 @@ use super::pipeline::DiskCachePipeline;
 use super::{
     BLOCK_SIZE, DiskCache, DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, DiskCacheRemote,
 };
-use crate::ext::aligned_vec::ACow;
-use crate::generic_consts::{AccessPattern, Random, Sequential};
+use crate::generic_consts::{Random, Sequential};
 use crate::mmap::AdviceSetting;
 use crate::universal_io::{
-    ListedFile, MmapFile, MmapFs, OpenOptions, Populate, ReadPipeline, ReadRange, Result,
-    UniversalIoError, UniversalKind, UniversalRead, UniversalReadFileOps, UniversalReadFs,
-    UserData,
+    OpenOptions, Populate, ReadPipeline, ReadRange, UniversalIoError, UniversalRead,
+    UniversalReadFileOps, UniversalReadFs,
 };
 
 fn make_test_data(n_bytes: usize) -> Vec<u8> {
@@ -133,148 +129,6 @@ impl Scenario {
         file.write_all(&new_data[old_len..]).unwrap();
         self.data = new_data.clone();
         new_data
-    }
-}
-
-/// A remote backend delegating to [`MmapFile`], whose completed reads fail at
-/// `wait` while the shared `fail` flag is set. Mirrors the io_uring per-op
-/// error path: the op's user data is consumed and the error identifies no
-/// specific fetch.
-#[derive(Debug, Clone)]
-struct FailingRemote {
-    inner: MmapFile,
-    fail: Arc<AtomicBool>,
-}
-
-#[derive(Debug, Clone)]
-struct FailingRemoteFs {
-    fail: Arc<AtomicBool>,
-}
-
-impl UniversalReadFileOps for FailingRemoteFs {
-    type ContextConfig = Arc<AtomicBool>;
-
-    fn from_context(fail: Arc<AtomicBool>) -> Result<Self> {
-        Ok(Self { fail })
-    }
-
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
-        MmapFs.list_files(prefix_path)
-    }
-
-    fn exists(&self, path: &Path) -> Result<bool> {
-        MmapFs.exists(path)
-    }
-}
-
-impl UniversalReadFs for FailingRemoteFs {
-    type File = FailingRemote;
-    type OpenExtra = ();
-
-    fn open(
-        &self,
-        path: impl AsRef<Path>,
-        options: OpenOptions,
-        _extra: (),
-    ) -> Result<FailingRemote> {
-        Ok(FailingRemote {
-            inner: MmapFs.open(path, options, ())?,
-            fail: self.fail.clone(),
-        })
-    }
-}
-
-impl UniversalRead for FailingRemote {
-    type Fs = FailingRemoteFs;
-
-    type ReadPipeline<'a, U>
-        = FailingPipeline<'a, U>
-    where
-        Self: 'a,
-        U: UserData;
-
-    fn reopen(&mut self) -> Result<()> {
-        self.inner.reopen()
-    }
-
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> Result<ACow<'_>> {
-        self.inner.read_bytes::<P>(range, align)
-    }
-
-    fn len<T>(&self) -> Result<u64> {
-        self.inner.len::<T>()
-    }
-
-    fn populate(&self) -> Result<()> {
-        self.inner.populate()
-    }
-
-    fn populate_auto() -> bool {
-        MmapFile::populate_auto()
-    }
-
-    fn clear_ram_cache(&self) -> Result<()> {
-        self.inner.clear_ram_cache()
-    }
-
-    fn kind() -> UniversalKind {
-        UniversalKind::Mmap
-    }
-}
-
-struct FailingPipeline<'file, U: UserData> {
-    inner: <MmapFile as UniversalRead>::ReadPipeline<'file, U>,
-    fail: Option<Arc<AtomicBool>>,
-}
-
-impl<'file, U: UserData> ReadPipeline<'file, U> for FailingPipeline<'file, U> {
-    type File = FailingRemote;
-
-    fn new() -> Result<Self> {
-        Ok(Self {
-            inner: ReadPipeline::new()?,
-            fail: None,
-        })
-    }
-
-    fn can_schedule(&mut self) -> bool {
-        self.inner.can_schedule()
-    }
-
-    fn schedule<P: AccessPattern>(
-        &mut self,
-        user_data: U,
-        file: &'file FailingRemote,
-        range: Range<u64>,
-        align: usize,
-    ) -> Result<()> {
-        self.fail = Some(file.fail.clone());
-        self.inner
-            .schedule::<P>(user_data, &file.inner, range, align)
-    }
-
-    fn schedule_whole(
-        &mut self,
-        user_data: U,
-        file: &'file FailingRemote,
-        from: u64,
-    ) -> Result<()> {
-        self.fail = Some(file.fail.clone());
-        self.inner.schedule_whole(user_data, &file.inner, from)
-    }
-
-    fn wait(&mut self) -> Result<Option<(U, ACow<'file>)>> {
-        let next = self.inner.wait()?;
-        let injected = self
-            .fail
-            .as_ref()
-            .is_some_and(|fail| fail.load(Ordering::Relaxed));
-        if next.is_some() && injected {
-            return Err(UniversalIoError::Io(std::io::Error::other(
-                "injected fetch failure",
-            )));
-        }
-        Ok(next)
     }
 }
 
@@ -709,22 +563,6 @@ mod tests_mod {
         assert_eq!(&*bytes, &scn.data[..]);
         assert_eq!(file.len::<u8>().unwrap(), 100);
     }
-}
-
-/// White-box tests for [`DiskCachePipeline`]'s fetch deduplication: reads whose
-/// blocks are fully covered by an in-flight fetch on the same file piggyback on
-/// it instead of scheduling a duplicate remote fetch.
-#[duplicate::duplicate_item(
-    tests_mod               R               cfg_predicate;
-    [pipeline_tests_mmap]   [MmapFile]      [cfg(all())];
-    [pipeline_tests_uring]  [IoUringFile]   [cfg(target_os = "linux")];
-)]
-#[cfg_predicate]
-#[cfg(test)]
-mod tests_mod {
-    use super::*;
-    #[cfg_predicate]
-    use crate::universal_io::R;
 
     #[test]
     fn same_block_reads_share_one_fetch() {
@@ -910,94 +748,5 @@ mod tests_mod {
         })
         .unwrap();
         assert!(seen.iter().all(|&s| s));
-    }
-}
-
-/// How [`DiskCachePipeline`] resolves remote fetch errors: the failure can't be
-/// attributed to a specific fetch, so every pending read fails with it and the
-/// pipeline resets to a clean, reusable state.
-#[cfg(test)]
-mod pipeline_error_tests {
-    use super::*;
-
-    fn open_failing(scn: &Scenario) -> (DiskCache<FailingRemote>, Arc<AtomicBool>) {
-        let fail = Arc::new(AtomicBool::new(false));
-        let fs = DiskCacheFs::<FailingRemote>::from_context(DiskCacheFsContext {
-            config: scn.config.clone(),
-            remote: fail.clone(),
-        })
-        .unwrap();
-        let file = fs
-            .open(
-                &scn.remote_path,
-                OpenOptions {
-                    writeable: false,
-                    populate: Populate::No,
-                    need_sequential: false,
-                    advice: AdviceSetting::Global,
-                },
-                Default::default(),
-            )
-            .unwrap();
-        (file, fail)
-    }
-
-    /// A failed fetch fails all its reads — the originator and the
-    /// piggybacked ones. None are left stranded, and the pipeline stays
-    /// usable: a retry schedules a fresh fetch instead of piggybacking on
-    /// the dead one.
-    #[test]
-    fn failed_fetch_fails_piggybacked_reads() {
-        let scn = Scenario::new(BLOCK_SIZE * 2);
-        let (file, fail) = open_failing(&scn);
-
-        let mut pipeline = DiskCachePipeline::<FailingRemote, u32>::new().unwrap();
-        pipeline.schedule::<Random>(0, &file, 10..30, 1).unwrap();
-        pipeline.schedule::<Random>(1, &file, 100..200, 1).unwrap();
-        assert_eq!(pipeline.in_flight_fetches(), 1);
-
-        // The fetch fails: the error surfaces once, failing both reads.
-        fail.store(true, Ordering::Relaxed);
-        assert!(pipeline.wait().is_err());
-
-        // Neither read is left stranded: the pipeline reports empty.
-        assert!(pipeline.wait().unwrap().is_none());
-
-        fail.store(false, Ordering::Relaxed);
-        pipeline.schedule::<Random>(2, &file, 100..200, 1).unwrap();
-        // A fresh fetch, not a piggyback on the dead entry or a local hit.
-        assert_eq!(pipeline.in_flight_fetches(), 1);
-        let results = drain_pipeline(&mut pipeline);
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[&2], &scn.data[100..200]);
-    }
-
-    /// Reads resolved before the failure are still returned; only pending
-    /// ones fail with the error.
-    #[test]
-    fn resolved_reads_survive_fetch_failure() {
-        let scn = Scenario::new(BLOCK_SIZE * 2);
-        let (file, fail) = open_failing(&scn);
-
-        let mut pipeline = DiskCachePipeline::<FailingRemote, u32>::new().unwrap();
-        // Commit block 0 to the mirror.
-        pipeline.schedule::<Random>(0, &file, 10..30, 1).unwrap();
-        drain_pipeline(&mut pipeline);
-
-        // A local hit queued ahead of a remote fetch that will fail.
-        pipeline.schedule::<Random>(1, &file, 40..60, 1).unwrap();
-        pipeline
-            .schedule::<Random>(2, &file, BLOCK_SIZE as u64..BLOCK_SIZE as u64 + 50, 1)
-            .unwrap();
-        fail.store(true, Ordering::Relaxed);
-
-        // The already-resolved read is still returned...
-        let (user_data, bytes) = pipeline.wait().unwrap().unwrap();
-        assert_eq!(user_data, 1);
-        assert_eq!(&*bytes, &scn.data[40..60]);
-
-        // ...then the failed fetch surfaces its error, and nothing is stranded.
-        assert!(pipeline.wait().is_err());
-        assert!(pipeline.wait().unwrap().is_none());
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -1,17 +1,24 @@
 use std::assert_matches;
 use std::borrow::Cow;
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use fs_err as fs;
 
+use super::pipeline::DiskCachePipeline;
 use super::{
     BLOCK_SIZE, DiskCache, DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, DiskCacheRemote,
 };
-use crate::generic_consts::Sequential;
+use crate::ext::aligned_vec::ACow;
+use crate::generic_consts::{AccessPattern, Random, Sequential};
 use crate::mmap::AdviceSetting;
 use crate::universal_io::{
-    OpenOptions, Populate, ReadRange, UniversalRead, UniversalReadFileOps, UniversalReadFs,
+    ListedFile, MmapFile, MmapFs, OpenOptions, Populate, ReadPipeline, ReadRange, Result,
+    UniversalIoError, UniversalKind, UniversalRead, UniversalReadFileOps, UniversalReadFs,
+    UserData,
 };
 
 fn make_test_data(n_bytes: usize) -> Vec<u8> {
@@ -107,6 +114,11 @@ impl Scenario {
         .unwrap()
     }
 
+    /// Slice of the remote data corresponding to `range`.
+    fn slice(&self, range: &std::ops::Range<u64>) -> &[u8] {
+        &self.data[range.start as usize..range.end as usize]
+    }
+
     /// Append `additional_bytes` bytes to the remote file in-place.
     /// Returns the full new remote contents.
     fn grow_remote(&mut self, additional_bytes: usize) -> Vec<u8> {
@@ -122,6 +134,160 @@ impl Scenario {
         self.data = new_data.clone();
         new_data
     }
+}
+
+/// A remote backend delegating to [`MmapFile`], whose completed reads fail at
+/// `wait` while the shared `fail` flag is set. Mirrors the io_uring per-op
+/// error path: the op's user data is consumed and the error identifies no
+/// specific fetch.
+#[derive(Debug, Clone)]
+struct FailingRemote {
+    inner: MmapFile,
+    fail: Arc<AtomicBool>,
+}
+
+#[derive(Debug, Clone)]
+struct FailingRemoteFs {
+    fail: Arc<AtomicBool>,
+}
+
+impl UniversalReadFileOps for FailingRemoteFs {
+    type ContextConfig = Arc<AtomicBool>;
+
+    fn from_context(fail: Arc<AtomicBool>) -> Result<Self> {
+        Ok(Self { fail })
+    }
+
+    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
+        MmapFs.list_files(prefix_path)
+    }
+
+    fn exists(&self, path: &Path) -> Result<bool> {
+        MmapFs.exists(path)
+    }
+}
+
+impl UniversalReadFs for FailingRemoteFs {
+    type File = FailingRemote;
+    type OpenExtra = ();
+
+    fn open(
+        &self,
+        path: impl AsRef<Path>,
+        options: OpenOptions,
+        _extra: (),
+    ) -> Result<FailingRemote> {
+        Ok(FailingRemote {
+            inner: MmapFs.open(path, options, ())?,
+            fail: self.fail.clone(),
+        })
+    }
+}
+
+impl UniversalRead for FailingRemote {
+    type Fs = FailingRemoteFs;
+
+    type ReadPipeline<'a, U>
+        = FailingPipeline<'a, U>
+    where
+        Self: 'a,
+        U: UserData;
+
+    fn reopen(&mut self) -> Result<()> {
+        self.inner.reopen()
+    }
+
+    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> Result<ACow<'_>> {
+        self.inner.read_bytes::<P>(range, align)
+    }
+
+    fn len<T>(&self) -> Result<u64> {
+        self.inner.len::<T>()
+    }
+
+    fn populate(&self) -> Result<()> {
+        self.inner.populate()
+    }
+
+    fn populate_auto() -> bool {
+        MmapFile::populate_auto()
+    }
+
+    fn clear_ram_cache(&self) -> Result<()> {
+        self.inner.clear_ram_cache()
+    }
+
+    fn kind() -> UniversalKind {
+        UniversalKind::Mmap
+    }
+}
+
+struct FailingPipeline<'file, U: UserData> {
+    inner: <MmapFile as UniversalRead>::ReadPipeline<'file, U>,
+    fail: Option<Arc<AtomicBool>>,
+}
+
+impl<'file, U: UserData> ReadPipeline<'file, U> for FailingPipeline<'file, U> {
+    type File = FailingRemote;
+
+    fn new() -> Result<Self> {
+        Ok(Self {
+            inner: ReadPipeline::new()?,
+            fail: None,
+        })
+    }
+
+    fn can_schedule(&mut self) -> bool {
+        self.inner.can_schedule()
+    }
+
+    fn schedule<P: AccessPattern>(
+        &mut self,
+        user_data: U,
+        file: &'file FailingRemote,
+        range: Range<u64>,
+        align: usize,
+    ) -> Result<()> {
+        self.fail = Some(file.fail.clone());
+        self.inner
+            .schedule::<P>(user_data, &file.inner, range, align)
+    }
+
+    fn schedule_whole(
+        &mut self,
+        user_data: U,
+        file: &'file FailingRemote,
+        from: u64,
+    ) -> Result<()> {
+        self.fail = Some(file.fail.clone());
+        self.inner.schedule_whole(user_data, &file.inner, from)
+    }
+
+    fn wait(&mut self) -> Result<Option<(U, ACow<'file>)>> {
+        let next = self.inner.wait()?;
+        let injected = self
+            .fail
+            .as_ref()
+            .is_some_and(|fail| fail.load(Ordering::Relaxed));
+        if next.is_some() && injected {
+            return Err(UniversalIoError::Io(std::io::Error::other(
+                "injected fetch failure",
+            )));
+        }
+        Ok(next)
+    }
+}
+
+/// Drain `pipeline` until `wait` returns `None`, collecting results by user data.
+fn drain_pipeline<R: DiskCacheRemote>(
+    pipeline: &mut DiskCachePipeline<'_, R, u32>,
+) -> HashMap<u32, Vec<u8>> {
+    let mut results = HashMap::new();
+    while let Some((user_data, bytes)) = pipeline.wait().unwrap() {
+        let previous = results.insert(user_data, bytes.to_vec());
+        assert!(previous.is_none(), "duplicate result for {user_data}");
+    }
+    results
 }
 
 #[duplicate::duplicate_item(
@@ -542,5 +708,296 @@ mod tests_mod {
             .unwrap();
         assert_eq!(&*bytes, &scn.data[..]);
         assert_eq!(file.len::<u8>().unwrap(), 100);
+    }
+}
+
+/// White-box tests for [`DiskCachePipeline`]'s fetch deduplication: reads whose
+/// blocks are fully covered by an in-flight fetch on the same file piggyback on
+/// it instead of scheduling a duplicate remote fetch.
+#[duplicate::duplicate_item(
+    tests_mod               R               cfg_predicate;
+    [pipeline_tests_mmap]   [MmapFile]      [cfg(all())];
+    [pipeline_tests_uring]  [IoUringFile]   [cfg(target_os = "linux")];
+)]
+#[cfg_predicate]
+#[cfg(test)]
+mod tests_mod {
+    use super::*;
+    #[cfg_predicate]
+    use crate::universal_io::R;
+
+    #[test]
+    fn same_block_reads_share_one_fetch() {
+        let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
+        let file = scn.open::<R>(false);
+
+        let mut pipeline = DiskCachePipeline::<R, u32>::new().unwrap();
+        pipeline.schedule::<Random>(0, &file, 10..30, 1).unwrap();
+        // Same block as above: piggybacks even if the remote queue is full.
+        pipeline.schedule::<Random>(1, &file, 100..200, 1).unwrap();
+        assert_eq!(pipeline.in_flight_fetches(), 1);
+
+        let results = drain_pipeline(&mut pipeline);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[&0], &scn.data[10..30]);
+        assert_eq!(results[&1], &scn.data[100..200]);
+    }
+
+    #[test]
+    fn spanning_fetch_covers_contained_reads() {
+        let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
+        let file = scn.open::<R>(false);
+
+        let mut pipeline = DiskCachePipeline::<R, u32>::new().unwrap();
+        // Spans blocks 0..2.
+        let spanning = (BLOCK_SIZE - 50) as u64..(BLOCK_SIZE + 50) as u64;
+        // Contained in block 1.
+        let contained = (BLOCK_SIZE + 100) as u64..(BLOCK_SIZE + 200) as u64;
+        pipeline
+            .schedule::<Random>(0, &file, spanning.clone(), 1)
+            .unwrap();
+        pipeline
+            .schedule::<Random>(1, &file, contained.clone(), 1)
+            .unwrap();
+        assert_eq!(pipeline.in_flight_fetches(), 1);
+
+        let results = drain_pipeline(&mut pipeline);
+        assert_eq!(results[&0], scn.slice(&spanning));
+        assert_eq!(results[&1], scn.slice(&contained));
+    }
+
+    /// Piggybacked reads may themselves span multiple blocks, as long as the
+    /// in-flight fetch fully covers them — including reads reaching into the
+    /// EOF-clamped partial tail block.
+    #[test]
+    fn multi_block_reads_share_one_fetch() {
+        // Three full blocks plus a 100-byte partial tail block.
+        let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
+        let file = scn.open::<R>(false);
+        let eof = scn.data.len() as u64;
+
+        let mut pipeline = DiskCachePipeline::<R, u32>::new().unwrap();
+        // Spans all four blocks; the fetch's byte range is clamped to EOF.
+        let spanning = 100u64..eof - 10;
+        // Crosses the block 1/2 boundary.
+        let middle = (BLOCK_SIZE + 200) as u64..(BLOCK_SIZE * 2 + 200) as u64;
+        // Reaches the partial tail block, ending exactly at EOF.
+        let tail = (BLOCK_SIZE * 3 - 50) as u64..eof;
+        pipeline
+            .schedule::<Random>(0, &file, spanning.clone(), 1)
+            .unwrap();
+        pipeline
+            .schedule::<Random>(1, &file, middle.clone(), 1)
+            .unwrap();
+        pipeline
+            .schedule::<Random>(2, &file, tail.clone(), 1)
+            .unwrap();
+        assert_eq!(pipeline.in_flight_fetches(), 1);
+
+        let results = drain_pipeline(&mut pipeline);
+        assert_eq!(results[&0], scn.slice(&spanning));
+        assert_eq!(results[&1], scn.slice(&middle));
+        assert_eq!(results[&2], scn.slice(&tail));
+    }
+
+    /// A read only partially covered by an in-flight fetch must not piggyback
+    /// on it: it goes to the remote queue like any other fetch — never
+    /// resolving against blocks the in-flight fetch doesn't cover.
+    #[test]
+    fn partially_covered_read_does_not_piggyback() {
+        let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
+        let file = scn.open::<R>(false);
+
+        let mut pipeline = DiskCachePipeline::<R, u32>::new().unwrap();
+        // Fetch covers blocks 0..2.
+        let first = (BLOCK_SIZE - 50) as u64..(BLOCK_SIZE + 50) as u64;
+        // Needs blocks 1..3: block 2 is not covered by the fetch above.
+        let second = (BLOCK_SIZE + 100) as u64..(BLOCK_SIZE * 2 + 100) as u64;
+        pipeline
+            .schedule::<Random>(0, &file, first.clone(), 1)
+            .unwrap();
+
+        let mut results = HashMap::new();
+        match pipeline.schedule::<Random>(1, &file, second.clone(), 1) {
+            // Queued backends: a separate fetch was scheduled.
+            Ok(()) => assert_eq!(pipeline.in_flight_fetches(), 2),
+            // Single-slot backends (mmap remote): the read went for the remote
+            // queue and found it full — either way, it did not piggyback.
+            Err(UniversalIoError::QueueIsFull) => {
+                assert_eq!(pipeline.in_flight_fetches(), 1);
+                // Free the queue and retry; the retried read must still fetch,
+                // as block 2 is not local even after the first fetch commits.
+                results.extend(drain_pipeline(&mut pipeline));
+                pipeline
+                    .schedule::<Random>(1, &file, second.clone(), 1)
+                    .unwrap();
+                assert_eq!(pipeline.in_flight_fetches(), 1);
+            }
+            Err(err) => panic!("unexpected error: {err}"),
+        }
+
+        results.extend(drain_pipeline(&mut pipeline));
+        assert_eq!(results[&0], scn.slice(&first));
+        assert_eq!(results[&1], scn.slice(&second));
+    }
+
+    /// Reads on different files never share a fetch, even for identical ranges.
+    #[test]
+    fn different_files_do_not_share_fetches() {
+        let scn = Scenario::new(BLOCK_SIZE * 2);
+        let file_a = scn.open::<R>(false);
+        let file_b = scn.open::<R>(false);
+
+        let mut pipeline = DiskCachePipeline::<R, u32>::new().unwrap();
+        pipeline.schedule::<Random>(0, &file_a, 10..30, 1).unwrap();
+        match pipeline.schedule::<Random>(1, &file_b, 10..30, 1) {
+            Ok(()) => assert_eq!(pipeline.in_flight_fetches(), 2),
+            // Single-slot backends: the identical range on another file went
+            // to the remote queue instead of piggybacking on `file_a`'s fetch.
+            Err(UniversalIoError::QueueIsFull) => {
+                assert_eq!(pipeline.in_flight_fetches(), 1);
+            }
+            Err(err) => panic!("unexpected error: {err}"),
+        }
+
+        let results = drain_pipeline(&mut pipeline);
+        assert_eq!(results[&0], &scn.data[10..30]);
+    }
+
+    /// Once a fetch commits its blocks to the mirror, later reads of those
+    /// blocks are served locally without scheduling another fetch.
+    #[test]
+    fn committed_blocks_serve_later_reads_locally() {
+        let scn = Scenario::new(BLOCK_SIZE * 2);
+        let file = scn.open::<R>(false);
+
+        let mut pipeline = DiskCachePipeline::<R, u32>::new().unwrap();
+        pipeline.schedule::<Random>(0, &file, 10..30, 1).unwrap();
+        let results = drain_pipeline(&mut pipeline);
+        assert_eq!(results[&0], &scn.data[10..30]);
+
+        pipeline.schedule::<Random>(1, &file, 40..60, 1).unwrap();
+        // Served locally: no remote fetch in flight.
+        assert_eq!(pipeline.in_flight_fetches(), 0);
+        let results = drain_pipeline(&mut pipeline);
+        assert_eq!(results[&1], &scn.data[40..60]);
+    }
+
+    /// End-to-end `read_batch` with many reads clustered in shared blocks:
+    /// every read resolves with its own user data and correct bytes.
+    #[test]
+    fn read_batch_with_shared_blocks_resolves_every_read() {
+        let scn = Scenario::new(BLOCK_SIZE * 3 + 100);
+        let file = scn.open::<R>(false);
+
+        let ranges: Vec<(usize, ReadRange)> = (0..64)
+            .map(|i| {
+                let range = ReadRange {
+                    byte_offset: (i * 700) as u64,
+                    length: 100,
+                };
+                (i, range)
+            })
+            .collect();
+
+        let mut seen = vec![false; ranges.len()];
+        file.read_batch::<Random, u8, usize>(ranges.clone(), |i, bytes| {
+            let start = ranges[i].1.byte_offset as usize;
+            assert_eq!(bytes, &scn.data[start..start + 100]);
+            assert!(!seen[i]);
+            seen[i] = true;
+            Ok(())
+        })
+        .unwrap();
+        assert!(seen.iter().all(|&s| s));
+    }
+}
+
+/// How [`DiskCachePipeline`] resolves remote fetch errors: the failure can't be
+/// attributed to a specific fetch, so every pending read fails with it and the
+/// pipeline resets to a clean, reusable state.
+#[cfg(test)]
+mod pipeline_error_tests {
+    use super::*;
+
+    fn open_failing(scn: &Scenario) -> (DiskCache<FailingRemote>, Arc<AtomicBool>) {
+        let fail = Arc::new(AtomicBool::new(false));
+        let fs = DiskCacheFs::<FailingRemote>::from_context(DiskCacheFsContext {
+            config: scn.config.clone(),
+            remote: fail.clone(),
+        })
+        .unwrap();
+        let file = fs
+            .open(
+                &scn.remote_path,
+                OpenOptions {
+                    writeable: false,
+                    populate: Populate::No,
+                    need_sequential: false,
+                    advice: AdviceSetting::Global,
+                },
+                Default::default(),
+            )
+            .unwrap();
+        (file, fail)
+    }
+
+    /// A failed fetch fails all its reads — the originator and the
+    /// piggybacked ones. None are left stranded, and the pipeline stays
+    /// usable: a retry schedules a fresh fetch instead of piggybacking on
+    /// the dead one.
+    #[test]
+    fn failed_fetch_fails_piggybacked_reads() {
+        let scn = Scenario::new(BLOCK_SIZE * 2);
+        let (file, fail) = open_failing(&scn);
+
+        let mut pipeline = DiskCachePipeline::<FailingRemote, u32>::new().unwrap();
+        pipeline.schedule::<Random>(0, &file, 10..30, 1).unwrap();
+        pipeline.schedule::<Random>(1, &file, 100..200, 1).unwrap();
+        assert_eq!(pipeline.in_flight_fetches(), 1);
+
+        // The fetch fails: the error surfaces once, failing both reads.
+        fail.store(true, Ordering::Relaxed);
+        assert!(pipeline.wait().is_err());
+
+        // Neither read is left stranded: the pipeline reports empty.
+        assert!(pipeline.wait().unwrap().is_none());
+
+        fail.store(false, Ordering::Relaxed);
+        pipeline.schedule::<Random>(2, &file, 100..200, 1).unwrap();
+        // A fresh fetch, not a piggyback on the dead entry or a local hit.
+        assert_eq!(pipeline.in_flight_fetches(), 1);
+        let results = drain_pipeline(&mut pipeline);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[&2], &scn.data[100..200]);
+    }
+
+    /// Reads resolved before the failure are still returned; only pending
+    /// ones fail with the error.
+    #[test]
+    fn resolved_reads_survive_fetch_failure() {
+        let scn = Scenario::new(BLOCK_SIZE * 2);
+        let (file, fail) = open_failing(&scn);
+
+        let mut pipeline = DiskCachePipeline::<FailingRemote, u32>::new().unwrap();
+        // Commit block 0 to the mirror.
+        pipeline.schedule::<Random>(0, &file, 10..30, 1).unwrap();
+        drain_pipeline(&mut pipeline);
+
+        // A local hit queued ahead of a remote fetch that will fail.
+        pipeline.schedule::<Random>(1, &file, 40..60, 1).unwrap();
+        pipeline
+            .schedule::<Random>(2, &file, BLOCK_SIZE as u64..BLOCK_SIZE as u64 + 50, 1)
+            .unwrap();
+        fail.store(true, Ordering::Relaxed);
+
+        // The already-resolved read is still returned...
+        let (user_data, bytes) = pipeline.wait().unwrap().unwrap();
+        assert_eq!(user_data, 1);
+        assert_eq!(&*bytes, &scn.data[40..60]);
+
+        // ...then the failed fetch surfaces its error, and nothing is stranded.
+        assert!(pipeline.wait().is_err());
+        assert!(pipeline.wait().unwrap().is_none());
     }
 }


### PR DESCRIPTION
## Why

It is possible, that when a particular block is not present, a batch of read requests will try to read many parts of it at once. When this happens, current disk cache will fire off every request to the remote, even if a single block would cover all of them.

## What

This PR deduplicates these remote requests, by making the pipeline ready to piggyback some requests on top of in-flight requests.

Instead of relying on only the user data on the remote, we keep track of in-flight requests. If we find an in-flight request that would cover the same blocks as the new request, we append the read to it, for when it gets resolved.

---

Assisted by AI ™️