### PR TITLE
[edge] Add readonly ram sparse index

### DIFF
--- a/lib/segment/src/index/read_only/live_reload.rs
+++ b/lib/segment/src/index/read_only/live_reload.rs
@@ -10,18 +10,34 @@ use crate::index::UniversalReadExt;
 impl<S: UniversalReadExt> LiveReload for VectorIndexReadEnum<S> {
     type Fs = S::Fs;
 
-    /// No-op for every variant: read-only vector indexes are immutable — the HNSW
-    /// graph and the sparse inverted index are built once, and plain has no index
-    /// files at all. Deletions and newly appended points are served from the
-    /// shared id-tracker and vector storage, which reload separately, so the index
-    /// itself has no on-disk state to refresh.
+    /// No-op for the persisted variants: read-only vector indexes are immutable —
+    /// the HNSW graph and the compressed sparse inverted indexes are built once,
+    /// and plain has no index files at all. Deletions and newly appended points
+    /// are served from the shared id-tracker and vector storage, which reload
+    /// separately, so those indexes have no on-disk state to refresh.
+    ///
+    /// The mutable-RAM sparse index is the exception: it is rebuilt from the
+    /// vector storage at open rather than loaded, so newly appended points must
+    /// be folded into its inverted index to stay searchable. Deletions still
+    /// need no index surgery — stale postings are filtered at search time via
+    /// the deleted bitslices.
     fn live_reload(
         &mut self,
         _fs: &S::Fs,
         _deleted_points: &SortedSlice<'_, PointOffsetType>,
-        _new_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        Ok(())
+        match self {
+            Self::SparseMutableRam(index) => index.live_reload(new_points),
+            Self::Plain(_)
+            | Self::Hnsw(_)
+            | Self::SparseCompressedImmutableRamF32(_)
+            | Self::SparseCompressedImmutableRamF16(_)
+            | Self::SparseCompressedImmutableRamU8(_)
+            | Self::SparseCompressedStoredF32(_)
+            | Self::SparseCompressedStoredF16(_)
+            | Self::SparseCompressedStoredU8(_) => Ok(()),
+        }
     }
 }

--- a/lib/segment/src/index/read_only/mod.rs
+++ b/lib/segment/src/index/read_only/mod.rs
@@ -16,6 +16,7 @@ use sparse::index::inverted_index::inverted_index_compressed_immutable_ram::Inve
 use sparse::index::inverted_index::inverted_index_compressed_mmap::{
     self as inverted_index_compressed_mmap, InvertedIndexCompressedMmap,
 };
+use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::{InvertedIndex, InvertedIndexReadOnly};
 
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -43,11 +44,12 @@ use crate::vector_storage::read_only::VectorStorageReadEnum;
 /// Read-only counterpart of [`super::VectorIndexEnum`].
 ///
 /// Wraps each read-capable index type with its read-only newtype. The mutable
-/// RAM sparse index is intentionally absent because it has no persisted
-/// read-only representation.
+/// RAM sparse index has no persisted representation, so its read-only variant
+/// is rebuilt from the vector storage at open time.
 pub enum VectorIndexReadEnum<S: UniversalReadExt + 'static> {
     Plain(Box<ReadOnlyPlainVectorIndex<S>>),
     Hnsw(Box<ReadOnlyHNSWIndex<S>>),
+    SparseMutableRam(Box<ReadOnlySparseVectorIndex<S, InvertedIndexRam>>),
     SparseCompressedImmutableRamF32(
         Box<ReadOnlySparseVectorIndex<S, InvertedIndexCompressedImmutableRam<f32>>>,
     ),
@@ -105,12 +107,14 @@ impl<S: UniversalReadExt + 'static> VectorIndexReadEnum<S> {
 
     /// Schedule background prefetch of every file [`Self::open_sparse`] will
     /// read: the sparse index config, the inverted index, its version file
-    /// and the indices tracker. All readable variants share the
+    /// and the indices tracker. All persisted variants share the
     /// compressed-mmap on-disk format, so the datatype plays no role here;
     /// the (effective) index type only decides whether the index data is
     /// populated by the prefetch (the immutable-RAM open reads it in full) or
     /// parked cold (the mmap open reads it lazily) — and it comes from the
     /// segment config's `sparse_vector_config`, so nothing is read here.
+    /// `MutableRam` is never persisted — `open_sparse` rebuilds it from the
+    /// vector storage — so nothing is scheduled for it.
     ///
     /// An absent index config file means the index isn't persisted: nothing
     /// is scheduled, and `open_sparse` is the one to report it.
@@ -120,6 +124,14 @@ impl<S: UniversalReadExt + 'static> VectorIndexReadEnum<S> {
         path: &Path,
         populate_override: Option<Populate>,
     ) -> OperationResult<()> {
+        // MutableRam has no persisted representation: `open_sparse` rebuilds
+        // it from the vector storage (prefetched separately), so there are no
+        // index files to schedule.
+        match sparse_vector_config.index.index_type {
+            SparseIndexType::MutableRam => return Ok(()),
+            SparseIndexType::ImmutableRam | SparseIndexType::Mmap => {}
+        }
+
         // Sparse index config; `open_sparse` reads it off the parked handle.
         let config_path = SparseIndexConfig::get_config_path(path);
         if fs
@@ -128,16 +140,6 @@ impl<S: UniversalReadExt + 'static> VectorIndexReadEnum<S> {
             .is_none()
         {
             return Ok(());
-        }
-
-        // MutableRam has no persisted representation; mirror `open_sparse`.
-        match sparse_vector_config.index.index_type {
-            SparseIndexType::MutableRam => {
-                return Err(OperationError::service_error(
-                    "MutableRam sparse index has no read-only representation",
-                ));
-            }
-            SparseIndexType::ImmutableRam | SparseIndexType::Mmap => {}
         }
 
         // The effective placement (structural index type refined by the
@@ -221,10 +223,13 @@ impl<S: UniversalReadExt + 'static> VectorIndexReadEnum<S> {
 
     /// Open the read-only sparse vector index from its persisted [`SparseIndexConfig`],
     /// mirroring `create_sparse_vector_index`'s `(index_type, datatype)` selection.
-    /// `MutableRam` has no read-only representation.
+    /// `MutableRam` is never persisted, so it is rebuilt from the vector storage
+    /// instead of loaded — `sparse_vector_config` (from the segment config) is
+    /// what says so, as the persisted config doesn't exist for it.
     /// `populate_override` mirrors [`preopen_sparse`](Self::preopen_sparse): a cold
     /// override downgrades `ImmutableRam` to the lazy `Mmap` open, like low-memory mode.
     pub fn open_sparse<Fs: UniversalReadFs<File = S>>(
+        sparse_vector_config: &SparseVectorDataConfig,
         args: ReadOnlyVectorIndexOpenArgs<'_, S, Fs>,
         populate_override: Option<Populate>,
     ) -> OperationResult<Self> {
@@ -236,6 +241,20 @@ impl<S: UniversalReadExt + 'static> VectorIndexReadEnum<S> {
             payload_index,
             quantized_vectors: _,
         } = args;
+
+        // MutableRam has no persisted representation: rebuild the RAM index
+        // from the (read-only) vector storage, mirroring
+        // `SparseVectorIndex::plan`'s non-persisted branch.
+        if !sparse_vector_config.index.index_type.is_persisted() {
+            return Ok(Self::SparseMutableRam(Box::new(
+                ReadOnlySparseVectorIndex::build_mutable_ram(
+                    sparse_vector_config.index,
+                    id_tracker,
+                    vector_storage,
+                    payload_index,
+                )?,
+            )));
+        }
 
         let config =
             SparseIndexConfig::load_universal(fs, &SparseIndexConfig::get_config_path(path))?;
@@ -280,7 +299,8 @@ impl<S: UniversalReadExt + 'static> VectorIndexReadEnum<S> {
         let index = match (effective_index_type, config.datatype.unwrap_or_default()) {
             (SparseIndexType::MutableRam, _) => {
                 return Err(OperationError::service_error(
-                    "MutableRam sparse index has no read-only representation",
+                    "MutableRam sparse index is never persisted, \
+                     but its config was found on disk",
                 ));
             }
             (SparseIndexType::ImmutableRam, VectorStorageDatatype::Float32) => {
@@ -318,6 +338,7 @@ impl<S: UniversalReadExt + 'static> VectorIndexReadEnum<S> {
         match self {
             Self::Plain(_) => false,
             Self::Hnsw(index) => index.is_on_disk(),
+            Self::SparseMutableRam(index) => index.inverted_index().is_on_disk(),
             Self::SparseCompressedImmutableRamF32(index) => index.inverted_index().is_on_disk(),
             Self::SparseCompressedImmutableRamF16(index) => index.inverted_index().is_on_disk(),
             Self::SparseCompressedImmutableRamU8(index) => index.inverted_index().is_on_disk(),
@@ -331,6 +352,7 @@ impl<S: UniversalReadExt + 'static> VectorIndexReadEnum<S> {
         match self {
             Self::Plain(_) => {}
             Self::Hnsw(index) => index.populate()?,
+            Self::SparseMutableRam(_) => {}
             Self::SparseCompressedImmutableRamF32(_) => {}
             Self::SparseCompressedImmutableRamF16(_) => {}
             Self::SparseCompressedImmutableRamU8(_) => {}
@@ -345,6 +367,7 @@ impl<S: UniversalReadExt + 'static> VectorIndexReadEnum<S> {
         match self {
             Self::Plain(_) => {}
             Self::Hnsw(index) => index.clear_cache()?,
+            Self::SparseMutableRam(_) => {}
             Self::SparseCompressedImmutableRamF32(_) => {}
             Self::SparseCompressedImmutableRamF16(_) => {}
             Self::SparseCompressedImmutableRamU8(_) => {}
@@ -368,6 +391,9 @@ impl<S: UniversalReadExt + 'static> VectorIndexRead for VectorIndexReadEnum<S> {
         match self {
             Self::Plain(index) => index.search(vectors, filter, top, params, query_context),
             Self::Hnsw(index) => index.search(vectors, filter, top, params, query_context),
+            Self::SparseMutableRam(index) => {
+                index.search(vectors, filter, top, params, query_context)
+            }
             Self::SparseCompressedImmutableRamF32(index) => {
                 index.search(vectors, filter, top, params, query_context)
             }
@@ -393,6 +419,7 @@ impl<S: UniversalReadExt + 'static> VectorIndexRead for VectorIndexReadEnum<S> {
         match self {
             Self::Plain(index) => index.get_telemetry_data(detail),
             Self::Hnsw(index) => index.get_telemetry_data(detail),
+            Self::SparseMutableRam(index) => index.get_telemetry_data(detail),
             Self::SparseCompressedImmutableRamF32(index) => index.get_telemetry_data(detail),
             Self::SparseCompressedImmutableRamF16(index) => index.get_telemetry_data(detail),
             Self::SparseCompressedImmutableRamU8(index) => index.get_telemetry_data(detail),
@@ -406,6 +433,7 @@ impl<S: UniversalReadExt + 'static> VectorIndexRead for VectorIndexReadEnum<S> {
         match self {
             Self::Plain(index) => index.indexed_vector_count(),
             Self::Hnsw(index) => index.indexed_vector_count(),
+            Self::SparseMutableRam(index) => index.indexed_vector_count(),
             Self::SparseCompressedImmutableRamF32(index) => index.indexed_vector_count(),
             Self::SparseCompressedImmutableRamF16(index) => index.indexed_vector_count(),
             Self::SparseCompressedImmutableRamU8(index) => index.indexed_vector_count(),
@@ -419,6 +447,7 @@ impl<S: UniversalReadExt + 'static> VectorIndexRead for VectorIndexReadEnum<S> {
         match self {
             Self::Plain(index) => index.size_of_searchable_vectors_in_bytes(),
             Self::Hnsw(index) => index.size_of_searchable_vectors_in_bytes(),
+            Self::SparseMutableRam(index) => index.size_of_searchable_vectors_in_bytes(),
             Self::SparseCompressedImmutableRamF32(index) => {
                 index.size_of_searchable_vectors_in_bytes()
             }
@@ -444,6 +473,9 @@ impl<S: UniversalReadExt + 'static> VectorIndexRead for VectorIndexReadEnum<S> {
         match self {
             Self::Plain(index) => index.fill_idf_statistics(idf, corpus, is_stopped, hw_counter),
             Self::Hnsw(index) => index.fill_idf_statistics(idf, corpus, is_stopped, hw_counter),
+            Self::SparseMutableRam(index) => {
+                index.fill_idf_statistics(idf, corpus, is_stopped, hw_counter)
+            }
             Self::SparseCompressedImmutableRamF32(index) => {
                 index.fill_idf_statistics(idf, corpus, is_stopped, hw_counter)
             }
@@ -469,6 +501,7 @@ impl<S: UniversalReadExt + 'static> VectorIndexRead for VectorIndexReadEnum<S> {
         match self {
             Self::Plain(index) => index.is_index(),
             Self::Hnsw(index) => index.is_index(),
+            Self::SparseMutableRam(index) => index.is_index(),
             Self::SparseCompressedImmutableRamF32(index) => index.is_index(),
             Self::SparseCompressedImmutableRamF16(index) => index.is_index(),
             Self::SparseCompressedImmutableRamU8(index) => index.is_index(),

--- a/lib/segment/src/index/sparse_index/sparse_index_config.rs
+++ b/lib/segment/src/index/sparse_index/sparse_index_config.rs
@@ -27,26 +27,37 @@ pub enum SparseIndexType {
 
 impl SparseIndexType {
     pub fn is_appendable(self) -> bool {
-        self == Self::MutableRam
+        match self {
+            Self::MutableRam => true,
+            Self::ImmutableRam | Self::Mmap => false,
+        }
     }
 
     pub fn is_immutable(self) -> bool {
-        self != Self::MutableRam
+        match self {
+            Self::ImmutableRam | Self::Mmap => true,
+            Self::MutableRam => false,
+        }
     }
 
     pub fn is_on_disk(self) -> bool {
-        self == Self::Mmap
+        match self {
+            Self::Mmap => true,
+            Self::MutableRam | Self::ImmutableRam => false,
+        }
     }
 
     pub fn is_persisted(self) -> bool {
-        self == Self::Mmap || self == Self::ImmutableRam
+        match self {
+            Self::Mmap | Self::ImmutableRam => true,
+            Self::MutableRam => false,
+        }
     }
 
     pub fn from_on_disk(on_disk: bool) -> Self {
-        if on_disk {
-            Self::Mmap
-        } else {
-            Self::MutableRam
+        match on_disk {
+            true => Self::Mmap,
+            false => Self::MutableRam,
         }
     }
 }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::AtomicBool;
 use atomic_refcell::AtomicRefCell;
 #[cfg(feature = "testing")]
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::Random;
+use common::generic_consts::Sequential;
 use common::storage_version::StorageVersion as _;
 use common::universal_io::{MmapFile, MmapFs, UniversalReadFs};
 use fs_err as fs;
@@ -18,7 +18,7 @@ use sparse::index::inverted_index::{InvertedIndex, InvertedIndexReadWrite};
 
 use self::read_view::{SparseVectorIndexReadView, SparseVectorIndexReadViewEnum};
 use super::indices_tracker::IndicesTracker;
-use crate::common::operation_error::{OperationResult, check_process_stopped};
+use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
 use crate::index::sparse_index::sparse_index_config::SparseIndexConfig;
 use crate::index::sparse_index::sparse_search_telemetry::SparseSearchesTelemetry;
@@ -113,39 +113,49 @@ fn build_ram_index(
 ) -> OperationResult<(InvertedIndexRam, IndicesTracker)> {
     let deleted_bitslice = vector_storage.deleted_vector_bitslice();
 
-    let mut ram_index_builder = InvertedIndexBuilder::new();
-    let mut indices_tracker = IndicesTracker::default();
-    for id in id_tracker
+    // Non-deleted internal ids in ascending order. `iter_internal_excluding`
+    // yields them sorted, so a `Sequential` batch read lets the storage
+    // coalesce the IO into block reads instead of a round-trip per point.
+    let ids = id_tracker
         .point_mappings()
         .iter_internal_excluding(deleted_bitslice)
-    {
-        check_process_stopped(stopped)?;
-        // It is possible that the vector is not present in the storage in case of crash.
-        // Because:
-        // - the `id_tracker` is flushed before the `vector_storage`
-        // - the sparse index is built *before* recovering the WAL when loading a segment
-        match vector_storage.get_vector_opt::<Random>(id) {
-            None => {
-                // the vector was lost in a crash but will be recovered by the WAL
-                let point_id = id_tracker.external_id(id);
-                let point_version = id_tracker.internal_version(id);
-                log::debug!(
-                    "Sparse vector with id {id} is not found, external_id: {point_id:?}, version: {point_version:?}",
-                )
+        .map(|id| ((), id));
+
+    let mut ram_index_builder = InvertedIndexBuilder::new();
+    let mut indices_tracker = IndicesTracker::default();
+
+    // One batched, ascending pass over the stored vectors.
+    //
+    // A vector may be absent from the storage after a crash, because:
+    // - the `id_tracker` is flushed before the `vector_storage`
+    // - the sparse index is built *before* recovering the WAL when loading a segment
+    // `read_vectors` simply skips such ids; the WAL replay recovers them afterwards.
+    let mut result: OperationResult<()> = Ok(());
+    vector_storage.read_vectors::<Sequential, _>(ids, |(), id, vector| {
+        if result.is_err() {
+            return;
+        }
+        if let Err(err) = check_process_stopped(stopped) {
+            result = Err(OperationError::from(err));
+            return;
+        }
+        let vector: &SparseVector = match vector.as_vec_ref().try_into() {
+            Ok(vector) => vector,
+            Err(err) => {
+                result = Err(err);
+                return;
             }
-            Some(vector) => {
-                let vector: &SparseVector = vector.as_vec_ref().try_into()?;
-                // do not index empty vectors
-                if vector.is_empty() {
-                    continue;
-                }
-                indices_tracker.register_indices(vector);
-                let vector = indices_tracker.remap_vector(vector.to_owned());
-                ram_index_builder.add(id, vector);
-            }
+        };
+        // do not index empty vectors
+        if !vector.is_empty() {
+            indices_tracker.register_indices(vector);
+            let vector = indices_tracker.remap_vector(vector.to_owned());
+            ram_index_builder.add(id, vector);
         }
         tick_progress();
-    }
+    });
+    result?;
+
     Ok((ram_index_builder.build(), indices_tracker))
 }
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index.rs
@@ -99,6 +99,56 @@ pub enum SparseOpenPlan {
     },
 }
 
+/// Build the (type-agnostic) RAM inverted index and indices tracker from the
+/// vector storage.
+///
+/// Generic over the read halves of the id tracker and vector storage, so the
+/// mutable [`SparseVectorIndex`] and its read-only counterpart build through
+/// the same code.
+fn build_ram_index(
+    id_tracker: &impl IdTrackerRead,
+    vector_storage: &impl VectorStorageRead,
+    stopped: &AtomicBool,
+    mut tick_progress: impl FnMut(),
+) -> OperationResult<(InvertedIndexRam, IndicesTracker)> {
+    let deleted_bitslice = vector_storage.deleted_vector_bitslice();
+
+    let mut ram_index_builder = InvertedIndexBuilder::new();
+    let mut indices_tracker = IndicesTracker::default();
+    for id in id_tracker
+        .point_mappings()
+        .iter_internal_excluding(deleted_bitslice)
+    {
+        check_process_stopped(stopped)?;
+        // It is possible that the vector is not present in the storage in case of crash.
+        // Because:
+        // - the `id_tracker` is flushed before the `vector_storage`
+        // - the sparse index is built *before* recovering the WAL when loading a segment
+        match vector_storage.get_vector_opt::<Random>(id) {
+            None => {
+                // the vector was lost in a crash but will be recovered by the WAL
+                let point_id = id_tracker.external_id(id);
+                let point_version = id_tracker.internal_version(id);
+                log::debug!(
+                    "Sparse vector with id {id} is not found, external_id: {point_id:?}, version: {point_version:?}",
+                )
+            }
+            Some(vector) => {
+                let vector: &SparseVector = vector.as_vec_ref().try_into()?;
+                // do not index empty vectors
+                if vector.is_empty() {
+                    continue;
+                }
+                indices_tracker.register_indices(vector);
+                let vector = indices_tracker.remap_vector(vector.to_owned());
+                ram_index_builder.add(id, vector);
+            }
+        }
+        tick_progress();
+    }
+    Ok((ram_index_builder.build(), indices_tracker))
+}
+
 impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
     /// Open a sparse vector index at a given path
     pub fn open<F: FnMut()>(args: SparseVectorIndexOpenArgs<'_, MmapFs, F>) -> OperationResult<Self>
@@ -189,8 +239,12 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
         if !config.index_type.is_persisted() {
             // RAM mutable case - build from scratch, keep the provided config, do not persist.
             fs::create_dir_all(path)?;
-            let (ram_index, indices_tracker) =
-                Self::build_ram_index(id_tracker, vector_storage, stopped, tick_progress)?;
+            let (ram_index, indices_tracker) = build_ram_index(
+                &*id_tracker.borrow(),
+                &*vector_storage.borrow(),
+                stopped,
+                tick_progress,
+            )?;
             return Ok(SparseOpenPlan::Build {
                 config,
                 ram_index,
@@ -218,62 +272,18 @@ impl<TInvertedIndex: InvertedIndex> SparseVectorIndex<TInvertedIndex> {
             fs::remove_dir_all(path)?;
         }
         fs::create_dir_all(path)?;
-        let (ram_index, indices_tracker) =
-            Self::build_ram_index(id_tracker, vector_storage, stopped, tick_progress)?;
+        let (ram_index, indices_tracker) = build_ram_index(
+            &*id_tracker.borrow(),
+            &*vector_storage.borrow(),
+            stopped,
+            tick_progress,
+        )?;
         Ok(SparseOpenPlan::Build {
             config,
             ram_index,
             indices_tracker,
             persist: true,
         })
-    }
-
-    /// Build the (type-agnostic) RAM inverted index and indices tracker from the
-    /// vector storage.
-    fn build_ram_index(
-        id_tracker: &AtomicRefCell<IdTrackerEnum>,
-        vector_storage: &AtomicRefCell<VectorStorageEnum>,
-        stopped: &AtomicBool,
-        mut tick_progress: impl FnMut(),
-    ) -> OperationResult<(InvertedIndexRam, IndicesTracker)> {
-        let borrowed_vector_storage = vector_storage.borrow();
-        let borrowed_id_tracker = id_tracker.borrow();
-        let deleted_bitslice = borrowed_vector_storage.deleted_vector_bitslice();
-
-        let mut ram_index_builder = InvertedIndexBuilder::new();
-        let mut indices_tracker = IndicesTracker::default();
-        for id in borrowed_id_tracker
-            .point_mappings()
-            .iter_internal_excluding(deleted_bitslice)
-        {
-            check_process_stopped(stopped)?;
-            // It is possible that the vector is not present in the storage in case of crash.
-            // Because:
-            // - the `id_tracker` is flushed before the `vector_storage`
-            // - the sparse index is built *before* recovering the WAL when loading a segment
-            match borrowed_vector_storage.get_vector_opt::<Random>(id) {
-                None => {
-                    // the vector was lost in a crash but will be recovered by the WAL
-                    let point_id = borrowed_id_tracker.external_id(id);
-                    let point_version = borrowed_id_tracker.internal_version(id);
-                    log::debug!(
-                        "Sparse vector with id {id} is not found, external_id: {point_id:?}, version: {point_version:?}",
-                    )
-                }
-                Some(vector) => {
-                    let vector: &SparseVector = vector.as_vec_ref().try_into()?;
-                    // do not index empty vectors
-                    if vector.is_empty() {
-                        continue;
-                    }
-                    indices_tracker.register_indices(vector);
-                    let vector = indices_tracker.remap_vector(vector.to_owned());
-                    ram_index_builder.add(id, vector);
-                }
-            }
-            tick_progress();
-        }
-        Ok((ram_index_builder.build(), indices_tracker))
     }
 
     pub fn inverted_index(&self) -> &TInvertedIndex {

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
@@ -5,13 +5,18 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use atomic_refcell::AtomicRefCell;
+use common::generic_consts::Sequential;
+use common::sorted_slice::SortedSlice;
 use common::storage_version::StorageVersion as _;
+use common::types::PointOffsetType;
 use common::universal_io::UniversalReadFs;
 use sparse::SearchScratchPool;
+use sparse::common::sparse_vector::SparseVector;
 use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::{InvertedIndex, InvertedIndexReadOnly};
 
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::id_tracker::IdTrackerRead;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
 use crate::index::UniversalReadExt;
 use crate::index::field_index::ReadOnlyFieldIndex;
@@ -22,6 +27,7 @@ use crate::index::sparse_index::sparse_vector_index::read_view::SparseVectorInde
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
 use crate::index::struct_payload_index::read_only::ReadOnlyStructPayloadIndex;
 use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
+use crate::vector_storage::VectorStorageRead;
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
 /// Read-only, generic-over-storage counterpart of [`SparseVectorIndex`].
@@ -171,5 +177,59 @@ impl<S: UniversalReadExt> ReadOnlySparseVectorIndex<S, InvertedIndexRam> {
             indices_tracker,
             search_scratch_pool: SearchScratchPool::new(),
         })
+    }
+
+    /// Fold a live-reload delta into the rebuilt RAM index, mirroring
+    /// [`SparseVectorIndex::update_vector`]'s mutable-RAM path.
+    ///
+    /// Deleted points need no index surgery: their stale postings are filtered
+    /// at search time via the deleted bitslices, which the id-tracker and
+    /// storage reloads refresh.
+    ///
+    /// [`SparseVectorIndex::update_vector`]: super::SparseVectorIndex
+    pub fn live_reload(
+        &mut self,
+        inserted: &SortedSlice<'_, PointOffsetType>,
+    ) -> OperationResult<()> {
+        let id_tracker = self.id_tracker.borrow();
+        let vector_storage = self.vector_storage.borrow();
+        let deferred_internal_id = id_tracker.deferred_internal_id();
+
+        // Split borrows for the read callback: it mutates the tracker and the
+        // index while the storage stays borrowed.
+        let indices_tracker = &mut self.indices_tracker;
+        let inverted_index = &mut self.inverted_index;
+
+        let ids = inserted
+            .iter()
+            .copied()
+            .filter(|&id| deferred_internal_id.is_none_or(|deferred| id < deferred))
+            .map(|id| ((), id));
+
+        // One batched, ascending pass (appended offsets are contiguous): the
+        // storage coalesces the reads, so a cold cache costs block reads
+        // instead of a round-trip per point. A point without a vector for
+        // this sparse name is skipped by the storage.
+        let mut result = Ok(());
+        vector_storage.read_vectors::<Sequential, _>(ids, |(), id, vector| {
+            if result.is_err() {
+                return;
+            }
+            let vector: &SparseVector = match vector.as_vec_ref().try_into() {
+                Ok(vector) => vector,
+                Err(err) => {
+                    result = Err(err);
+                    return;
+                }
+            };
+            // do not index empty vectors
+            if vector.is_empty() {
+                return;
+            }
+            indices_tracker.register_indices(vector);
+            let vector = indices_tracker.remap_vector(vector.to_owned());
+            inverted_index.upsert(id, vector, None);
+        });
+        result
     }
 }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_only/mod.rs
@@ -2,11 +2,13 @@ mod read;
 
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use atomic_refcell::AtomicRefCell;
 use common::storage_version::StorageVersion as _;
 use common::universal_io::UniversalReadFs;
 use sparse::SearchScratchPool;
+use sparse::index::inverted_index::inverted_index_ram::InvertedIndexRam;
 use sparse::index::inverted_index::{InvertedIndex, InvertedIndexReadOnly};
 
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -134,6 +136,40 @@ impl<S: UniversalReadExt, TInvertedIndex: InvertedIndex>
                 search_scratch_pool: &self.search_scratch_pool,
             };
             f(read_view)
+        })
+    }
+}
+
+impl<S: UniversalReadExt> ReadOnlySparseVectorIndex<S, InvertedIndexRam> {
+    /// Build the mutable-RAM variant in place from the read-only id tracker and
+    /// vector storage, mirroring [`SparseVectorIndex::plan`]'s non-persisted
+    /// branch: `MutableRam` has no persisted representation, so its inverted
+    /// index is rebuilt from the vector storage on every open.
+    ///
+    /// [`SparseVectorIndex::plan`]: super::SparseVectorIndex::plan
+    pub fn build_mutable_ram(
+        config: SparseIndexConfig,
+        id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
+        vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
+        payload_index: Arc<AtomicRefCell<ReadOnlyStructPayloadIndex<S>>>,
+    ) -> OperationResult<Self> {
+        // The read-only open path carries no cancellation flag.
+        let stopped = AtomicBool::new(false);
+        let (inverted_index, indices_tracker) = super::build_ram_index(
+            &*id_tracker.borrow(),
+            &*vector_storage.borrow(),
+            &stopped,
+            || (),
+        )?;
+        Ok(Self {
+            config,
+            id_tracker,
+            vector_storage,
+            payload_index,
+            inverted_index,
+            searches_telemetry: SparseSearchesTelemetry::new(),
+            indices_tracker,
+            search_scratch_pool: SearchScratchPool::new(),
         })
     }
 }

--- a/lib/segment/src/segment/read_only/config_reload.rs
+++ b/lib/segment/src/segment/read_only/config_reload.rs
@@ -13,7 +13,8 @@ use crate::index::struct_payload_index::read_only::PayloadIndexReloadDiff;
 use crate::segment::{SEGMENT_STATE_FILE, SegmentVersion};
 use crate::segment_constructor::{get_payload_index_path, get_vector_storage_path};
 use crate::types::{
-    SegmentConfig, SegmentState, SegmentType, VectorDataConfig, VectorName, VectorNameBuf,
+    SegmentConfig, SegmentState, SegmentType, SparseVectorDataConfig, VectorDataConfig, VectorName,
+    VectorNameBuf,
 };
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 use crate::vector_storage::sparse::read_only::ReadOnlySparseVectorStorage;
@@ -146,7 +147,8 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
             &new_config.sparse_vector_data,
         );
         for name in load {
-            let data = self.load_sparse_vector(fs, &name)?;
+            let config = &new_config.sparse_vector_data[&name];
+            let data = self.load_sparse_vector(fs, &name, config)?;
             added.insert(name, data);
         }
         removed.extend(drop);
@@ -190,6 +192,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         &self,
         fs: &S::Fs,
         name: &VectorName,
+        config: &SparseVectorDataConfig,
     ) -> OperationResult<ReadOnlyVectorData<S>> {
         let path = get_vector_storage_path(&self.segment_path, name);
         let storage =
@@ -199,6 +202,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
             fs,
             &self.segment_path,
             name,
+            config,
             self.id_tracker.clone(),
             self.payload_index.clone(),
             storage,

--- a/lib/segment/src/segment/read_only/config_reload.rs
+++ b/lib/segment/src/segment/read_only/config_reload.rs
@@ -195,8 +195,11 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         config: &SparseVectorDataConfig,
     ) -> OperationResult<ReadOnlyVectorData<S>> {
         let path = get_vector_storage_path(&self.segment_path, name);
-        let storage =
-            VectorStorageReadEnum::Sparse(Box::new(ReadOnlySparseVectorStorage::open(fs, &path)?));
+        let storage = VectorStorageReadEnum::Sparse(Box::new(ReadOnlySparseVectorStorage::open(
+            fs,
+            &path,
+            super::lifecycle::sparse_storage_populate(config),
+        )?));
         let storage = Arc::new(AtomicRefCell::new(storage));
         ReadOnlyVectorData::open_sparse(
             fs,

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -72,6 +72,18 @@ fn payload_populate(config: &SegmentConfig) -> Populate {
     }
 }
 
+/// How one sparse vector's storage is brought into memory. Search never reads
+/// it, so it normally stays cold — except when the (non-persisted) mutable-RAM
+/// sparse index is configured: that index is rebuilt from the storage at open,
+/// reading it in full, so the storage is warmed in the background.
+pub(super) fn sparse_storage_populate(sparse_vector_config: &SparseVectorDataConfig) -> Populate {
+    if sparse_vector_config.index.index_type.is_persisted() {
+        Populate::No
+    } else {
+        Populate::PreferBackground
+    }
+}
+
 impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     /// Open the segment over a per-segment [`CachedReadFs`]: known files are
     /// prefetched before the listing snapshot is taken (see
@@ -151,7 +163,11 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         }
         for (vector_name, sparse_vector_config) in &config.sparse_vector_data {
             let path = get_vector_storage_path(segment_path, vector_name);
-            ReadOnlySparseVectorStorage::<S>::preopen(fs, &path)?;
+            ReadOnlySparseVectorStorage::<S>::preopen(
+                fs,
+                &path,
+                sparse_storage_populate(sparse_vector_config),
+            )?;
 
             // Sparse vector index; the sparse open reads lazily, so a profile
             // that never scores this vector just parks the index data cold.
@@ -248,11 +264,14 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
                 })?;
             vector_storages.insert(vector_name.clone(), Arc::new(AtomicRefCell::new(storage)));
         }
-        for vector_name in config.sparse_vector_data.keys() {
+        for (vector_name, sparse_vector_config) in &config.sparse_vector_data {
             let path = get_vector_storage_path(segment_path, vector_name);
-            let storage = VectorStorageReadEnum::Sparse(Box::new(
-                ReadOnlySparseVectorStorage::open(fs, &path)?,
-            ));
+            let storage =
+                VectorStorageReadEnum::Sparse(Box::new(ReadOnlySparseVectorStorage::open(
+                    fs,
+                    &path,
+                    sparse_storage_populate(sparse_vector_config),
+                )?));
             vector_storages.insert(vector_name.clone(), Arc::new(AtomicRefCell::new(storage)));
         }
 

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -24,8 +24,8 @@ use crate::segment_constructor::{
     get_payload_index_path, get_vector_index_path, get_vector_storage_path,
 };
 use crate::types::{
-    PayloadStorageType, SegmentConfig, SegmentState, SegmentType, VectorDataConfig, VectorName,
-    VectorNameBuf,
+    PayloadStorageType, SegmentConfig, SegmentState, SegmentType, SparseVectorDataConfig,
+    VectorDataConfig, VectorName, VectorNameBuf,
 };
 use crate::vector_storage::VectorStorageRead;
 use crate::vector_storage::quantized::quantized_vectors::ReadOnlyQuantizedVectors;
@@ -283,12 +283,13 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
             )?;
             vector_data.insert(vector_name.clone(), data);
         }
-        for vector_name in config.sparse_vector_data.keys() {
+        for (vector_name, sparse_vector_config) in &config.sparse_vector_data {
             let vector_storage = vector_storages.remove(vector_name).unwrap();
             let data = ReadOnlyVectorData::open_sparse(
                 fs,
                 segment_path,
                 vector_name,
+                sparse_vector_config,
                 id_tracker.clone(),
                 payload_index.clone(),
                 vector_storage,
@@ -396,6 +397,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlyVectorData<S> {
         fs: &impl UniversalReadFs<File = S>,
         segment_path: &Path,
         vector_name: &VectorName,
+        sparse_vector_config: &SparseVectorDataConfig,
         id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
         payload_index: Arc<AtomicRefCell<ReadOnlyStructPayloadIndex<S>>>,
         vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
@@ -410,6 +412,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlyVectorData<S> {
         let index_populate =
             load_profile.and_then(|profile| profile.vector_index_placement(vector_name));
         let vector_index = VectorIndexReadEnum::open_sparse(
+            sparse_vector_config,
             ReadOnlyVectorIndexOpenArgs {
                 fs,
                 path: &vector_index_path,

--- a/lib/segment/src/segment/read_only/live_reload.rs
+++ b/lib/segment/src/segment/read_only/live_reload.rs
@@ -88,6 +88,9 @@ impl<S: UniversalReadExt + 'static> ReadOnlyVectorData<S> {
             quantized_vectors,
         } = self;
 
+        // Storage strictly before index: the mutable-RAM sparse index reads
+        // the newly inserted vectors from this very storage to fold them into
+        // its inverted index (see `ReadOnlySparseVectorIndex::live_reload`).
         vector_storage
             .borrow_mut()
             .live_reload(fs, deleted, inserted, hw_counter)?;

--- a/lib/segment/src/segment/read_only/tests.rs
+++ b/lib/segment/src/segment/read_only/tests.rs
@@ -347,7 +347,9 @@ fn read_only_segment_over_s3() {
 
 /// A `MutableRam` sparse index has no persisted representation: the read-only
 /// open rebuilds it from the sparse vector storage. Sparse searches over the
-/// rebuilt index must match the mutable segment point-for-point.
+/// rebuilt index must match the mutable segment point-for-point — both right
+/// after the open and after a live reload folds in appends, an update and
+/// deletions from the writer.
 #[test]
 fn read_only_segment_sparse_mutable_ram_matches_mutable() {
     use sparse::common::sparse_vector::SparseVector;
@@ -357,6 +359,55 @@ fn read_only_segment_sparse_mutable_ram_matches_mutable() {
     use crate::types::{SparseVectorDataConfig, SparseVectorStorageType};
 
     const SPARSE_VECTOR_NAME: &str = "sparse";
+
+    fn sparse_vector(i: usize) -> SparseVector {
+        let indices = vec![(i % 7) as u32, 8 + (i % 15) as u32, 32 + (i % 29) as u32];
+        let values = vec![
+            1.0 + (i % 11) as f32,
+            0.5 + (i % 5) as f32,
+            0.25 + (i % 3) as f32,
+        ];
+        SparseVector::new(indices, values).unwrap()
+    }
+
+    fn assert_sparse_search_matches(
+        reference: &impl ReadSegmentEntry,
+        candidate: &impl ReadSegmentEntry,
+        query: &SparseVector,
+    ) {
+        let query = QueryVector::Nearest(VectorInternal::Sparse(query.clone()));
+        let query_context = QueryContext::default();
+        let sqc = query_context.get_segment_query_context();
+        let reference_hits = reference
+            .search_batch(
+                SPARSE_VECTOR_NAME,
+                &[&query],
+                &WithPayload::default(),
+                &false.into(),
+                None,
+                2 * NUM_POINTS,
+                None,
+                &sqc,
+            )
+            .unwrap();
+        let candidate_hits = candidate
+            .search_batch(
+                SPARSE_VECTOR_NAME,
+                &[&query],
+                &WithPayload::default(),
+                &false.into(),
+                None,
+                2 * NUM_POINTS,
+                None,
+                &sqc,
+            )
+            .unwrap();
+        assert!(!reference_hits[0].is_empty());
+        assert_eq!(
+            reference_hits[0], candidate_hits[0],
+            "sparse search mismatch"
+        );
+    }
 
     let dir = Builder::new().prefix("ro_sparse_mut").tempdir().unwrap();
     let hw = HardwareCounterCell::new();
@@ -379,15 +430,13 @@ fn read_only_segment_sparse_mutable_ram_matches_mutable() {
         true,
     )
     .unwrap();
+    // The read-only follower tails the writer's append-only logs; an in-place
+    // update would be invisible to it, so the writer must run append-only
+    // (an update becomes a delete plus an insert at a fresh offset).
+    mutable.append_only_mutations = true;
 
     for i in 0..NUM_POINTS {
-        let indices = vec![(i % 7) as u32, 8 + (i % 15) as u32, 32 + (i % 29) as u32];
-        let values = vec![
-            1.0 + (i % 11) as f32,
-            0.5 + (i % 5) as f32,
-            0.25 + (i % 3) as f32,
-        ];
-        let vector = SparseVector::new(indices, values).unwrap();
+        let vector = sparse_vector(i);
         let vectors = NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&vector));
         mutable
             .upsert_point((i + 1) as u64, (i as u64 + 1).into(), vectors, &hw)
@@ -395,45 +444,50 @@ fn read_only_segment_sparse_mutable_ram_matches_mutable() {
     }
     mutable.flush(true).unwrap();
 
-    let read_only =
+    let mut read_only =
         ReadOnlySegment::<MmapFile>::open(&MmapFs, &mutable.data_path(), mutable.uuid, None, None)
             .expect("read-only open");
     assert_eq!(read_only.available_point_count(), NUM_POINTS);
 
-    let query = QueryVector::Nearest(VectorInternal::Sparse(
-        SparseVector::new(vec![2, 10, 40], vec![1.0, 0.5, 0.25]).unwrap(),
-    ));
-    let query_context = QueryContext::default();
-    let sqc = query_context.get_segment_query_context();
-    let reference_hits = mutable
-        .search_batch(
-            SPARSE_VECTOR_NAME,
-            &[&query],
-            &WithPayload::default(),
-            &false.into(),
-            None,
-            NUM_POINTS,
-            None,
-            &sqc,
-        )
+    let query = SparseVector::new(vec![2, 10, 40], vec![1.0, 0.5, 0.25]).unwrap();
+    assert_sparse_search_matches(&mutable, &read_only, &query);
+
+    // The writer keeps going: append new points introducing a fresh dimension
+    // (64), re-upsert an existing point (a delete + insert at a new offset) and
+    // delete a couple of points, then flush.
+    let mut op_num = NUM_POINTS as u64 + 1;
+    for i in NUM_POINTS..NUM_POINTS + 20 {
+        let mut vector = sparse_vector(i);
+        vector.indices.push(64);
+        vector.values.push(2.0 + (i % 4) as f32);
+        let vectors = NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&vector));
+        mutable
+            .upsert_point(op_num, (i as u64 + 1).into(), vectors, &hw)
+            .unwrap();
+        op_num += 1;
+    }
+    let updated = sparse_vector(NUM_POINTS + 20);
+    let vectors = NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&updated));
+    mutable
+        .upsert_point(op_num, 3.into(), vectors, &hw)
         .unwrap();
-    let candidate_hits = read_only
-        .search_batch(
-            SPARSE_VECTOR_NAME,
-            &[&query],
-            &WithPayload::default(),
-            &false.into(),
-            None,
-            NUM_POINTS,
-            None,
-            &sqc,
-        )
-        .unwrap();
-    assert!(!reference_hits[0].is_empty());
-    assert_eq!(
-        reference_hits[0], candidate_hits[0],
-        "sparse search mismatch"
-    );
+    op_num += 1;
+    for point_id in [5, 17] {
+        mutable.delete_point(op_num, point_id.into(), &hw).unwrap();
+        op_num += 1;
+    }
+    mutable.flush(true).unwrap();
+
+    // A live reload folds the delta into the rebuilt sparse index.
+    read_only
+        .live_reload(&MmapFs, &hw)
+        .expect("read-only live reload");
+    assert_eq!(read_only.available_point_count(), NUM_POINTS + 20 - 2);
+
+    assert_sparse_search_matches(&mutable, &read_only, &query);
+    // A query on the fresh dimension only reaches points added after the open.
+    let fresh_dim_query = SparseVector::new(vec![64], vec![1.0]).unwrap();
+    assert_sparse_search_matches(&mutable, &read_only, &fresh_dim_query);
 }
 
 /// Drive `config_reload_diff` + `apply_config_reload`: toggle the on-disk

--- a/lib/segment/src/segment/read_only/tests.rs
+++ b/lib/segment/src/segment/read_only/tests.rs
@@ -345,6 +345,97 @@ fn read_only_segment_over_s3() {
     assert_query_equivalence(&mutable, &read_only);
 }
 
+/// A `MutableRam` sparse index has no persisted representation: the read-only
+/// open rebuilds it from the sparse vector storage. Sparse searches over the
+/// rebuilt index must match the mutable segment point-for-point.
+#[test]
+fn read_only_segment_sparse_mutable_ram_matches_mutable() {
+    use sparse::common::sparse_vector::SparseVector;
+
+    use crate::data_types::vectors::VectorRef;
+    use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
+    use crate::types::{SparseVectorDataConfig, SparseVectorStorageType};
+
+    const SPARSE_VECTOR_NAME: &str = "sparse";
+
+    let dir = Builder::new().prefix("ro_sparse_mut").tempdir().unwrap();
+    let hw = HardwareCounterCell::new();
+
+    let (mut mutable, _) = build_segment(
+        dir.path(),
+        &SegmentConfig {
+            vector_data: Default::default(),
+            sparse_vector_data: HashMap::from([(
+                SPARSE_VECTOR_NAME.to_owned(),
+                SparseVectorDataConfig {
+                    index: SparseIndexConfig::new(None, SparseIndexType::MutableRam, None, None),
+                    storage_type: SparseVectorStorageType::default(),
+                    modifier: None,
+                },
+            )]),
+            payload_storage_type: Default::default(),
+        },
+        None,
+        true,
+    )
+    .unwrap();
+
+    for i in 0..NUM_POINTS {
+        let indices = vec![(i % 7) as u32, 8 + (i % 15) as u32, 32 + (i % 29) as u32];
+        let values = vec![
+            1.0 + (i % 11) as f32,
+            0.5 + (i % 5) as f32,
+            0.25 + (i % 3) as f32,
+        ];
+        let vector = SparseVector::new(indices, values).unwrap();
+        let vectors = NamedVectors::from_ref(SPARSE_VECTOR_NAME, VectorRef::Sparse(&vector));
+        mutable
+            .upsert_point((i + 1) as u64, (i as u64 + 1).into(), vectors, &hw)
+            .unwrap();
+    }
+    mutable.flush(true).unwrap();
+
+    let read_only =
+        ReadOnlySegment::<MmapFile>::open(&MmapFs, &mutable.data_path(), mutable.uuid, None, None)
+            .expect("read-only open");
+    assert_eq!(read_only.available_point_count(), NUM_POINTS);
+
+    let query = QueryVector::Nearest(VectorInternal::Sparse(
+        SparseVector::new(vec![2, 10, 40], vec![1.0, 0.5, 0.25]).unwrap(),
+    ));
+    let query_context = QueryContext::default();
+    let sqc = query_context.get_segment_query_context();
+    let reference_hits = mutable
+        .search_batch(
+            SPARSE_VECTOR_NAME,
+            &[&query],
+            &WithPayload::default(),
+            &false.into(),
+            None,
+            NUM_POINTS,
+            None,
+            &sqc,
+        )
+        .unwrap();
+    let candidate_hits = read_only
+        .search_batch(
+            SPARSE_VECTOR_NAME,
+            &[&query],
+            &WithPayload::default(),
+            &false.into(),
+            None,
+            NUM_POINTS,
+            None,
+            &sqc,
+        )
+        .unwrap();
+    assert!(!reference_hits[0].is_empty());
+    assert_eq!(
+        reference_hits[0], candidate_hits[0],
+        "sparse search mismatch"
+    );
+}
+
 /// Drive `config_reload_diff` + `apply_config_reload`: toggle the on-disk
 /// payload config (the `num` field index) while its index files stay in place,
 /// and assert the read-only segment loads/drops the field index accordingly and

--- a/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/lifecycle.rs
@@ -12,20 +12,25 @@ use crate::vector_storage::sparse::stored_sparse_vectors::StoredSparseVector;
 impl<S: UniversalRead> ReadOnlySparseVectorStorage<S> {
     /// Schedule background prefetch of the files [`Self::open`] will read.
     ///
+    /// `populate` decides whether the vector data is warmed: search doesn't
+    /// read the sparse storage (`Populate::No` suffices), but a mutable-RAM
+    /// sparse index is rebuilt from it at open, reading it in full — the
+    /// caller warms it then.
+    ///
     /// Absent files are skipped rather than reported: the subsequent open is
     /// the one to produce the error.
-    pub fn preopen(fs: &impl CachedReadFs<File = S>, path: &Path) -> OperationResult<()> {
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        path: &Path,
+        populate: Populate,
+    ) -> OperationResult<()> {
         // Gridstore reader
-        GridstoreReader::<StoredSparseVector, S>::preopen(
-            fs,
-            path.join(STORAGE_DIRNAME),
-            Populate::No,
-        )
-        .map_err(|err| {
-            OperationError::service_error(format!(
-                "Failed to preopen read-only sparse vector storage: {err}"
-            ))
-        })?;
+        GridstoreReader::<StoredSparseVector, S>::preopen(fs, path.join(STORAGE_DIRNAME), populate)
+            .map_err(|err| {
+                OperationError::service_error(format!(
+                    "Failed to preopen read-only sparse vector storage: {err}"
+                ))
+            })?;
 
         // Deleted flags
         InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_DIRNAME))?;
@@ -35,12 +40,15 @@ impl<S: UniversalRead> ReadOnlySparseVectorStorage<S> {
 
     /// Open the read-only counterpart of the mmap sparse storage at `path`,
     /// threading every file open through `fs`; reads the existing layout but
-    /// creates and writes nothing. `next_point_offset` is reconstructed like the
+    /// creates and writes nothing. `populate` mirrors [`Self::preopen`].
+    /// `next_point_offset` is reconstructed like the
     /// writable storage on reopen: the highest deleted id or the Gridstore
     /// pointer count, whichever is larger.
-    pub fn open(fs: &impl UniversalReadFs<File = S>, path: &Path) -> OperationResult<Self> {
-        // Sparse vector storage is not used during search
-        let populate = Populate::No;
+    pub fn open(
+        fs: &impl UniversalReadFs<File = S>,
+        path: &Path,
+        populate: Populate,
+    ) -> OperationResult<Self> {
         let storage = GridstoreReader::<StoredSparseVector, S>::open(
             fs,
             path.join(STORAGE_DIRNAME),

--- a/lib/segment/src/vector_storage/sparse/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/mod.rs
@@ -22,7 +22,7 @@ mod tests {
     use common::generic_consts::Random;
     use common::sorted_slice::SortedSlice;
     use common::types::PointOffsetType;
-    use common::universal_io::{CachedFs, CachedReadFs, MmapFile, MmapFs};
+    use common::universal_io::{CachedFs, CachedReadFs, MmapFile, MmapFs, Populate};
     use sparse::common::sparse_vector::SparseVector;
     use tempfile::Builder;
 
@@ -71,7 +71,9 @@ mod tests {
             storage.flusher()().unwrap();
         }
 
-        let storage = ReadOnlySparseVectorStorage::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+        let storage =
+            ReadOnlySparseVectorStorage::<MmapFile>::open(&MmapFs, dir.path(), Populate::No)
+                .unwrap();
 
         assert_eq!(storage.total_vector_count(), POINT_COUNT as usize);
         assert_eq!(storage.distance(), SPARSE_VECTOR_DISTANCE);
@@ -141,7 +143,8 @@ mod tests {
         // Same order as the segment open path: snapshot, then preopen, then open.
         let mut cached_fs = CachedFs::new(MmapFs, dir.path()).unwrap();
         cached_fs.cache_file_info().unwrap();
-        ReadOnlySparseVectorStorage::<MmapFile>::preopen(&cached_fs, dir.path()).unwrap();
+        ReadOnlySparseVectorStorage::<MmapFile>::preopen(&cached_fs, dir.path(), Populate::No)
+            .unwrap();
 
         // Everything `open` reads must now come from the prefetch pool.
         for dir_name in [STORAGE_DIRNAME, DELETED_DIRNAME] {
@@ -149,7 +152,8 @@ mod tests {
         }
 
         let storage =
-            ReadOnlySparseVectorStorage::<MmapFile>::open(&cached_fs, dir.path()).unwrap();
+            ReadOnlySparseVectorStorage::<MmapFile>::open(&cached_fs, dir.path(), Populate::No)
+                .unwrap();
 
         assert_eq!(storage.total_vector_count(), POINT_COUNT as usize);
         match storage.get_vector::<Random>(7) {
@@ -187,7 +191,8 @@ mod tests {
         writer.flusher()().unwrap();
 
         let mut reader =
-            ReadOnlySparseVectorStorage::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+            ReadOnlySparseVectorStorage::<MmapFile>::open(&MmapFs, dir.path(), Populate::No)
+                .unwrap();
         assert_eq!(reader.total_vector_count(), first.len());
 
         for (offset, vector) in second.iter().enumerate() {


### PR DESCRIPTION
## Why

Appendable segments do not have a persisted sparse index, they rely on rebuilding it from gridstore storage. 

Currently, the entire appendable segment fails to load in edge shard because of this reason.

## What

This PR
- Adds the `VectorIndexReadEnum::SparseMutableRam` variant, which loads from Gridstore. 
- Ensures live-reload works nicely with a single batch read.
- Picks `Populate::PreferBackground` for sparse vector storage, when the index is to be loaded from storage.


Assisted by AI ™️ 