### PR TITLE
Improve error message for non-string `key` in filter conditions

### DIFF
--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -4869,7 +4869,6 @@ mod tests {
         assert!(err.contains("Example"), "err was: {err}");
     }
 
-
     #[test]
     fn test_condition_non_string_key_returns_clear_error() {
         for json in [

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -3899,8 +3899,15 @@ impl<'de> serde::Deserialize<'de> for Condition {
         // Special case: FieldCondition first to surface datetime parse errors.
         // Untagged enum would swallow these errors with generic message.
         if let serde_value::Value::Map(obj) = &value
-            && obj.contains_key(&serde_value::Value::String("key".into()))
+            && let Some(key) = obj.get(&serde_value::Value::String("key".into()))
         {
+            // Reject non-string `key` upfront, the deserialization error for it
+            // would not mention which field is invalid.
+            if !matches!(key, serde_value::Value::String(_)) {
+                return Err(serde::de::Error::custom(
+                    "Filter condition 'key' must be a string",
+                ));
+            }
             return value
                 .deserialize_into()
                 .map(Condition::Field)
@@ -4860,6 +4867,25 @@ mod tests {
         assert!(err.contains("RFC3339"), "err was: {err}");
         assert!(err.contains("2014-01-01T00:00:00BAD"), "err was: {err}");
         assert!(err.contains("Example"), "err was: {err}");
+    }
+
+
+    #[test]
+    fn test_condition_non_string_key_returns_clear_error() {
+        for json in [
+            r#"{"key": null, "match": {"value": "A"}}"#,
+            r#"{"key": 42, "match": {"value": "A"}}"#,
+            r#"{"key": ["a"], "match": {"value": "A"}}"#,
+        ] {
+            let err = serde_json::from_str::<Condition>(json)
+                .unwrap_err()
+                .to_string();
+
+            assert!(
+                err.contains("Filter condition 'key' must be a string"),
+                "err was: {err}"
+            );
+        }
     }
 
     /// Regression test: DateTimePayloadType binary serialization roundtrip.


### PR DESCRIPTION

Fixes #9524 (case 6 - the only case maintainers agreed with, per @generall's comment).

A filter condition with a non-string `key` was correctly rejected with 400, but the error
message was a raw serde error that didn't name the field:

Format error in JSON body: Invalid type unit value. Expected a string at line 1 column 106

Now it returns:

Format error in JSON body: Filter condition 'key' must be a string at line 1 column 103

The check lives in `Condition::deserialize`, where a map containing `key` is routed to
`FieldCondition`. If the `key` value isn't a string (null, number, array), we return a clear
error before deserialization. No behavior change for valid filters, and the existing RFC3339
datetime error path is untouched. Added a regression test covering null, numeric, and array keys.

Verified against a locally built server: null and numeric keys on `/points/search`,
`/points/query`, and `/points/scroll` return 400 with the new message; valid filters still
return 200.

Disclosure per the contributing guide: this change was written with an AI tool (Claude Code)
and reviewed/tested by me. Initial prompt: "improve the error message for case 6 of #9524:
null key in filter condition returns a raw serde error that doesn't mention the parameter name."

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?


