### PR TITLE
Fix flaky test_join_all_completes_sibling_restart_after_workers_stop

### DIFF
--- a/lib/collection/src/shards/local_shard/optimizer_config_update_tests.rs
+++ b/lib/collection/src/shards/local_shard/optimizer_config_update_tests.rs
@@ -255,8 +255,12 @@ mod tests {
             let _ = release_tx.send(());
         });
 
+        // Generous timeout: the two-shard stop/rebuild cycle can exceed 5s on loaded
+        // CI runners (notably Windows). The regression check is not weakened by this:
+        // if join_all drops the sibling restart again, the paused shard is never
+        // released and the timeout still fails the test.
         let result = tokio::time::timeout(
-            Duration::from_secs(5),
+            Duration::from_secs(30),
             future::join_all(vec![
                 paused_shard.on_optimizer_config_update(),
                 failing_shard.on_optimizer_config_update(),


### PR DESCRIPTION
Fixes #9739 

The test wraps a two-shard worker stop/rebuild cycle in a 5s timeout, which is too tight on loaded CI runners: the flaky report is from windows-latest, where nextest retried the test, and it passed on the same runner seconds later.

Bumped the timeout to 30s with a comment. The regression check from #9671 is not weakened: if `join_all` drops the sibling, restart again, the paused shard is never released, and the timeout still fails the test. Verified locally with 30 consecutive runs (0 failures, ~0.5s each).

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

