### PR TITLE
Clamp WAL replay target to the truncated prefix on shard load

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -749,11 +749,16 @@ impl LocalShard {
         );
 
         let to = cmp::min(to, last_wal_index);
-        debug_assert!(
-            from <= to,
-            "WAL first_index ({from}) is ahead of replay target ({to}) (last_wal_index:{last_wal_index} op_num_upper_bound:{op_num_upper_bound:?})"
-        );
-        let wal_entries_to_replay = to.saturating_sub(from);
+
+        // The WAL is only truncated past operations whose segment flush was confirmed, so
+        // `first_index` is itself a durable lower bound on the applied sequence and nothing
+        // before it ever needs replay. The persisted applied_seq can legitimately lag behind
+        // it: it is saved every `APPLIED_SEQ_SAVE_INTERVAL` update-worker calls from a counter
+        // that restarts at zero on every process start, and the synchronous replay below never
+        // feeds it. Without this clamp, a replay target computed from such a stale applied_seq
+        // would sit before `first_index`, targeting already-truncated entries.
+        let to = cmp::max(to, from);
+        let wal_entries_to_replay = to - from;
 
         assert!(
             last_wal_index - to <= update_queue_size as u64,

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -10,6 +10,7 @@ use shard::operations::CollectionUpdateOperations;
 use shard::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted,
 };
+use shard::segment_holder::FlushMode;
 use shard::wal::{SerdeWal, WalRawRecord};
 use tempfile::Builder;
 use tokio::runtime::Handle;
@@ -720,6 +721,152 @@ async fn test_wal_replay_tolerates_corrupt_tail_entry() {
     assert_eq!(
         points_count, total_ops as usize,
         "All {total_ops} points should be present after WAL replay with a corrupt tail entry",
+    );
+
+    shard.stop_gracefully().await;
+}
+
+/// A WAL truncated past the persisted applied_seq upper bound must not fail shard load.
+///
+/// The flush worker acks the WAL up to the segments' confirmed flush version, while the
+/// applied_seq file is persisted only every `APPLIED_SEQ_SAVE_INTERVAL` update-worker calls
+/// (from a counter that restarts at zero each process start, and synchronous WAL replay is
+/// not counted at all). After a restart the persisted applied_seq can therefore lag the WAL
+/// `first_index` by more than one save interval, putting the replay target computed from it
+/// before `first_index`. Load must clamp the target instead of trying to replay truncated
+/// entries: everything before `first_index` is already durably flushed.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_wal_replay_truncated_past_applied_seq() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+
+    let config = create_collection_config();
+
+    let collection_name = "test".to_string();
+
+    let update_runtime = Handle::current();
+    let current_runtime: AdaptiveSearchHandle = AdaptiveSearchHandle::current_for_tests();
+
+    let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+    let payload_index_schema =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
+    let shared_storage_config = Arc::new(SharedStorageConfig {
+        update_queue_size: 10_000,
+        ..Default::default()
+    });
+
+    let total_ops = 500u64;
+
+    let shard = LocalShard::build(
+        0,
+        collection_name.clone(),
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        shared_storage_config.clone(),
+        payload_index_schema.clone(),
+        update_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+        config.optimizer_config.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Stop flush worker so the WAL truncation below is under the test's control.
+    shard.stop_flush_worker().await;
+
+    let hw_acc = HwMeasurementAcc::new();
+
+    // Insert all operations
+    for i in 0..total_ops {
+        let point = PointStructPersisted {
+            id: i.into(),
+            vector: VectorStructInternal::from(vec![1.0, 2.0, 3.0, 4.0]).into(),
+            payload: None,
+        };
+        let op = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+            PointInsertOperationsInternal::PointsList(vec![point]),
+        ));
+        shard
+            .update(op.into(), WaitUntil::Visible, None, hw_acc.clone())
+            .await
+            .unwrap();
+    }
+
+    // Flush segments so acking the whole WAL below matches what the flush worker is
+    // allowed to do: truncation must only pass durably applied operations.
+    shard
+        .segments()
+        .read()
+        .flush_all(FlushMode::Sync, true)
+        .unwrap();
+
+    shard.stop_gracefully().await;
+
+    // Persist an applied_seq lagging the WAL head by well over one save interval, as left
+    // behind by a run that restarted (uncounted synchronous replay) and then applied fewer
+    // ops than the save interval before stopping.
+    let applied_seq_handler = AppliedSeqHandler::load_or_init(collection_dir.path(), total_ops);
+    let low_applied_seq = total_ops - 2 * APPLIED_SEQ_SAVE_INTERVAL;
+    applied_seq_handler
+        .force_set_and_persist(low_applied_seq)
+        .unwrap();
+
+    // Ack the WAL up to its head, as the flush worker does after the segment flush above.
+    // WAL indices: fake operation at 0, then one entry per upsert (1..=total_ops).
+    {
+        let wal_path = LocalShard::wal_path(collection_dir.path());
+        let mut raw_wal: SerdeWal<String> =
+            SerdeWal::new(&wal_path, (&config.wal_config).into()).unwrap();
+        raw_wal.ack(total_ops).unwrap();
+        assert!(
+            raw_wal.first_index() > low_applied_seq + APPLIED_SEQ_SAVE_INTERVAL + 1,
+            "test setup must put the WAL first_index past the applied_seq upper bound"
+        );
+    }
+
+    // Shard load must clamp the replay target to the truncated prefix and succeed.
+    let shard = LocalShard::load(
+        0,
+        collection_name,
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        config.optimizer_config.clone(),
+        shared_storage_config,
+        payload_index_schema,
+        false,
+        update_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+    )
+    .await
+    .expect("shard load must tolerate a WAL truncated past the applied_seq upper bound");
+
+    // Wait for the update worker to drain the queued tail.
+    let timeout = std::time::Duration::from_secs(2);
+    let start = std::time::Instant::now();
+    let poll_interval = std::time::Duration::from_millis(10);
+
+    while shard.local_update_queue_info().await.length > 0 {
+        assert!(
+            start.elapsed() <= timeout,
+            "Timeout waiting for update queue to empty"
+        );
+        tokio::time::sleep(poll_interval).await;
+    }
+
+    // Channel length reaching zero only means the last operation was received,
+    // not that it finished applying; wait for the worker to go idle.
+    shard.plunge_async().await.unwrap().await.unwrap();
+
+    // All points are present: everything before the truncated prefix was durably flushed.
+    let info = shard.info().await.unwrap();
+    let points_count = info.points_count.unwrap_or(0);
+    assert_eq!(
+        points_count, total_ops as usize,
+        "All {total_ops} points should be present after loading with a truncated WAL",
     );
 
     shard.stop_gracefully().await;


### PR DESCRIPTION
Fixes #9844

### Problem

The `harness_no_optimizer_snapshots` gate flakes with:

```
WAL first_index (5716) is ahead of replay target (5655) (last_wal_index:5717 op_num_upper_bound:Some(5655))
```

`load_from_wal` computes its replay target from the persisted `applied_seq` upper bound (persisted value + save interval + 1) and debug_asserts it is not behind the WAL `first_index`. 

That invariant does not survive restarts, for two compounding reasons:

1. The synchronous replay in `load_from_wal` applies operations via `CollectionUpdater::update` directly and never calls `applied_seq_handler.update`, so the replay window (up to 65 ops) is invisible to the save counter.
2. `AppliedSeqHandler` saves every 64 update-worker *calls* from a counter that restarts at zero on every process start (and the first call early-returns), so after a reopen the first save is up to 65 calls away while the in-memory op number is already up to 65 ahead of the persisted value.

Combined, the persisted `applied_seq` can lag the newest applied operation by ~130.

 Meanwhile the flush worker legitimately acks the WAL up to the segments' confirmed flush version, which reaches the newest applied operation. The next load then computes a replay target *before* `first_index`.

Replaying the CI seed reproduces the pre-panic state deterministically and byte-exactly (`applied_seq.json` = 5590, target 5655, last index 5717): a restart at op 4566 reset the counter (last save landed at call #1025 = op 5590), a second restart at WAL 5653 replayed everything synchronously (uncounted), and only 64 ops ran before the final reload, so no save ever fired. Whether the assert trips then depends only on whether the flush worker acked inside that window: on slow macOS CI it did; locally the 38s run never acks and stays green. Hence the flake, and its bias toward the snapshots variant (concurrent snapshot IO stretches wall-clock past the 5s flush interval).

### Consequences before the fix

* Debug builds: the `debug_assert` from #8454 panics (the model-testing flake).
* Release builds: no data loss (truncation only ever passes durably flushed operations), but the synchronous replay is skipped entirely and the deferred tail is enqueued from the stale target, so the update workers log a spurious `Operation not found in WAL` error for every already-truncated index.

### Fix

Clamp the replay target at `first_index`: the WAL is only truncated past operations whose segment flush was confirmed, so `first_index` is itself a durable lower bound on the applied sequence and nothing before it ever needs replay. This restores `from <= to` by construction (the debug_assert is removed) and the deferred tail starts at `first_index`, eliminating the release-mode error spam.

### Testing

* New regression test `test_wal_replay_truncated_past_applied_seq`: flush + ack the whole WAL while the persisted `applied_seq` lags by two save intervals, then reload. Panics with the exact CI assert without the fix, passes with it, and verifies all points survive.
* CI seed 11077234403348194052 replayed through the fixed binary with `--flush-interval-sec 1` (so truncation is actually active locally, `ack_index` reached 5376 with partial replays): green.
* `cargo test -p collection --lib wal_recovery` (9 tests), clippy (`--lib` and `--all-targets`), fmt: all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)