### PR TITLE
Model tester: support Cosine, Euclid and Manhattan distance metrics

### DIFF
--- a/lib/collection/src/model_testing/fixture.rs
+++ b/lib/collection/src/model_testing/fixture.rs
@@ -36,10 +36,11 @@ use crate::shards::shard::{PeerId, ShardId};
 /// config-mismatch optimizer, for one, only acts on `Some`).
 fn dense_params_builder(
     dim: u64,
+    distance: Distance,
     on_disk: bool,
     datatype: Option<Datatype>,
 ) -> VectorParamsBuilder {
-    let mut builder = VectorParamsBuilder::new(dim, Distance::Dot);
+    let mut builder = VectorParamsBuilder::new(dim, distance);
     if on_disk {
         builder = builder.with_on_disk(true);
     }
@@ -83,7 +84,8 @@ pub(super) async fn fixture(
         let name = candidate.name;
         match candidate.kind {
             VectorKind::Dense(dim) => {
-                let mut builder = dense_params_builder(dim, on_disk, candidate.datatype);
+                let mut builder =
+                    dense_params_builder(dim, candidate.distance, on_disk, candidate.datatype);
                 // The inline-storage vector exercises the HNSW `inline_storage` layout, which
                 // stores original + quantized vectors inside the index file and therefore
                 // requires quantization. Pair it with scalar quantization.
@@ -116,7 +118,9 @@ pub(super) async fn fixture(
             VectorKind::MultiDense(dim) => {
                 // The builder has no `with_multivector_config`; set the field on the built
                 // `VectorParams` directly to mark this dense slot as a ColBERT-style multi-vec.
-                let mut params = dense_params_builder(dim, on_disk, candidate.datatype).build();
+                let mut params =
+                    dense_params_builder(dim, candidate.distance, on_disk, candidate.datatype)
+                        .build();
                 params.multivector_config = Some(MultiVectorConfig::default());
                 dense_vectors.insert(name.to_string(), params);
             }

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
-use segment::types::{Payload, PointIdType, VectorNameBuf};
+use segment::types::{Distance, Payload, PointIdType, VectorNameBuf};
 use sparse::common::sparse_vector::SparseVector;
 use tokio::task::JoinHandle;
 
@@ -33,12 +33,14 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         name: "a",
         kind: VectorKind::Dense(4),
         datatype: None,
+        distance: Distance::Dot,
         initially_active: true,
     },
     VectorCandidate {
         name: "b",
         kind: VectorKind::Dense(6),
         datatype: None,
+        distance: Distance::Dot,
         initially_active: true,
     },
     // Explicit `Some(Float32)` rather than the unset default: exercises schema configs that
@@ -48,6 +50,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         name: "c",
         kind: VectorKind::Dense(5),
         datatype: Some(Datatype::Float32),
+        distance: Distance::Dot,
         initially_active: true,
     },
     // Dense vector configured with HNSW `inline_storage` (original + quantized vectors stored
@@ -57,24 +60,28 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         name: "i",
         kind: VectorKind::Dense(4),
         datatype: None,
+        distance: Distance::Dot,
         initially_active: true,
     },
     VectorCandidate {
         name: "s",
         kind: VectorKind::Sparse,
         datatype: None,
+        distance: Distance::Dot,
         initially_active: true,
     },
     VectorCandidate {
         name: "u",
         kind: VectorKind::Sparse,
         datatype: None,
+        distance: Distance::Dot,
         initially_active: false,
     },
     VectorCandidate {
         name: "m",
         kind: VectorKind::MultiDense(4),
         datatype: None,
+        distance: Distance::Dot,
         initially_active: true,
     },
     // TurboQuant 4-bit compressed storage, the primary quantized datatype, applied to
@@ -84,6 +91,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         name: "q",
         kind: VectorKind::Dense(8),
         datatype: Some(Datatype::Turbo4),
+        distance: Distance::Dot,
         initially_active: true,
     },
     // Half-precision storage. Lossy but deterministic and idempotent: the model records
@@ -92,6 +100,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         name: "h",
         kind: VectorKind::Dense(6),
         datatype: Some(Datatype::Float16),
+        distance: Distance::Dot,
         initially_active: true,
     },
     // Unsigned-byte storage. The engine truncates each component with `x as u8`; the
@@ -101,6 +110,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         name: "y",
         kind: VectorKind::Dense(4),
         datatype: Some(Datatype::Uint8),
+        distance: Distance::Dot,
         initially_active: true,
     },
     // Multi-vector variants of the lossy-but-idempotent datatypes: each stored row goes
@@ -109,17 +119,78 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         name: "w",
         kind: VectorKind::MultiDense(5),
         datatype: Some(Datatype::Float16),
+        distance: Distance::Dot,
         initially_active: true,
     },
     VectorCandidate {
         name: "z",
         kind: VectorKind::MultiDense(3),
         datatype: Some(Datatype::Uint8),
+        distance: Distance::Dot,
+        initially_active: true,
+    },
+    // Cosine candidates. The engine normalizes Cosine vectors once, at first ingestion
+    // (`Metric::preprocess`, dispatched per storage datatype); every later move
+    // (optimizer rebuilds, copy-on-write point moves, `upsert_moved_point`) transfers the
+    // stored form as raw bytes without re-preprocessing, so the model records
+    // normalize-then-datatype-round-trip and compares exactly (Turbo4: usual tolerance).
+    VectorCandidate {
+        name: "e",
+        kind: VectorKind::Dense(5),
+        datatype: None,
+        distance: Distance::Cosine,
+        initially_active: true,
+    },
+    // Per-row normalization: each stored row of the matrix is preprocessed like a dense
+    // Cosine vector.
+    VectorCandidate {
+        name: "n",
+        kind: VectorKind::MultiDense(4),
+        datatype: None,
+        distance: Distance::Cosine,
+        initially_active: true,
+    },
+    // Ordering coverage: normalization happens in f32 first, then the f16 storage
+    // round-trip. The f16-rounded unit vector is stored as-is (raw-byte moves), so the
+    // prediction stays exact even though its norm is no longer 1.0 within f16 precision.
+    VectorCandidate {
+        name: "x",
+        kind: VectorKind::Dense(6),
+        datatype: Some(Datatype::Float16),
+        distance: Distance::Cosine,
+        initially_active: true,
+    },
+    // TurboQuant's dedicated Cosine mode: the l2 length is not stored (forced to 1.0,
+    // recovered via the centroid-norm recompute at dequantize), plus zero-vector guards.
+    // Same padding-free dim as "q" so the CoW re-quantization fixed point holds.
+    VectorCandidate {
+        name: "o",
+        kind: VectorKind::Dense(8),
+        datatype: Some(Datatype::Turbo4),
+        distance: Distance::Cosine,
+        initially_active: true,
+    },
+    // Euclid / Manhattan candidates. Both metrics' ingestion preprocess is an identity
+    // (like Dot), so the model's read-back prediction needs no distance-specific logic;
+    // their coverage value is on the engine side: `Order::SmallBetter` comparator paths
+    // in search/HNSW that Dot and Cosine never exercise.
+    VectorCandidate {
+        name: "j",
+        kind: VectorKind::Dense(6),
+        datatype: None,
+        distance: Distance::Euclid,
+        initially_active: true,
+    },
+    VectorCandidate {
+        name: "k",
+        kind: VectorKind::Dense(4),
+        datatype: None,
+        distance: Distance::Manhattan,
         initially_active: true,
     },
 ];
 
-/// Reject kind/datatype combinations the model cannot predict yet, at run startup
+/// Reject kind/datatype/distance combinations the model cannot predict yet, at run startup
 /// rather than as a false-divergence soak panic hours into a run:
 /// - MultiDense + Turbo4: `model_vector` predicts Turbo4 via the per-vector
 ///   `turbo_storage_roundtrip`; the engine's multivector quantization path differs, so
@@ -127,16 +198,25 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
 ///   the same per-component round-trip as the dense case.
 /// - Sparse + any datatype: the fixture's sparse arm ignores the field entirely
 ///   (sparse datatype lives in the sparse index config, which is not modeled).
+/// - Sparse + non-Dot distance: sparse schemas have no distance parameter (the fixture's
+///   sparse arm ignores the field), so anything but `Dot` would silently not apply.
+/// - Turbo4 + Euclid/Manhattan: TQ's L1/L2 modes store vector lengths differently from
+///   Dot/Cosine (dedicated `l2_length` field / scaling-factor-as-length), and the
+///   copy-on-write re-quantization fixed point that `dense_matches`' ulp tolerance
+///   relies on has only been soak-validated for Dot and Cosine.
 fn assert_candidates_predictable() {
     for c in ALL_CANDIDATES {
+        let turbo4 = matches!(c.datatype, Some(Datatype::Turbo4));
         let supported = match c.kind {
-            VectorKind::Dense(_) => true,
-            VectorKind::MultiDense(_) => !matches!(c.datatype, Some(Datatype::Turbo4)),
-            VectorKind::Sparse => c.datatype.is_none(),
+            VectorKind::Dense(_) => {
+                !turbo4 || matches!(c.distance, Distance::Dot | Distance::Cosine)
+            }
+            VectorKind::MultiDense(_) => !turbo4,
+            VectorKind::Sparse => c.datatype.is_none() && c.distance == Distance::Dot,
         };
         assert!(
             supported,
-            "unsupported kind/datatype combination for `{}` (see comment above)",
+            "unsupported kind/datatype/distance combination for `{}` (see comment above)",
             c.name
         );
     }
@@ -153,6 +233,13 @@ pub(super) struct VectorCandidate {
     /// datatypes) and `VectorKind::MultiDense` (all but Turbo4); enforced by the
     /// startup check (`assert_candidates_predictable`).
     pub(super) datatype: Option<Datatype>,
+    /// Distance metric for dense / multi-dense storage. Cosine vectors are normalized by
+    /// the engine at first ingestion; `model_vector` mirrors that (per-datatype dispatch:
+    /// the byte metric's Cosine preprocess is an identity, so Uint8 is stored
+    /// un-normalized). Sparse candidates must use `Dot` — sparse schemas carry no
+    /// distance and score as dot product by construction — enforced by
+    /// `assert_candidates_predictable`.
+    pub(super) distance: Distance,
     /// Whether the name is present in the collection schema at fixture time. Inactive
     /// names are only reachable through `Op::CreateVectorName`, which is FORCE_OFF by
     /// default, so a candidate gets default-soak coverage only when this is true.

--- a/lib/collection/src/model_testing/op/mod.rs
+++ b/lib/collection/src/model_testing/op/mod.rs
@@ -23,17 +23,21 @@ use segment::data_types::primitive::PrimitiveVectorElement;
 use segment::data_types::vector_name_config::{
     DenseVectorConfig, SparseVectorConfig, VectorNameConfig,
 };
-use segment::data_types::vectors::{VectorElementTypeByte, VectorElementTypeHalf};
+use segment::data_types::vectors::{
+    VectorElementType, VectorElementTypeByte, VectorElementTypeHalf,
+};
 use segment::json_path::JsonPath;
 use segment::types::{
-    Condition, Distance, FieldCondition, Filter, HasIdCondition, HasVectorCondition, Match,
+    Condition, FieldCondition, Filter, HasIdCondition, HasVectorCondition, Match,
     MultiVectorConfig, Payload, PayloadFieldSchema, PayloadSchemaParams, PayloadSchemaType,
     PointIdType, VectorNameBuf, VectorStorageDatatype, WithPayloadInterface, WithVector,
 };
 use segment::vector_storage::turbo::turbo_storage_roundtrip;
 use sparse::common::sparse_vector::SparseVector;
 
-use super::{ALL_CANDIDATES, Model, ModelEntry, VectorKind, VectorValue, candidate_of};
+use super::{
+    ALL_CANDIDATES, Model, ModelEntry, VectorCandidate, VectorKind, VectorValue, candidate_of,
+};
 use crate::operations::point_ops::UpdateMode;
 use crate::operations::types::Datatype;
 
@@ -604,7 +608,7 @@ impl Op {
                     VectorKind::Dense(dim) | VectorKind::MultiDense(dim) => {
                         VectorNameConfig::dense(DenseVectorConfig {
                             size: dim as usize,
-                            distance: Distance::Dot,
+                            distance: pick.distance,
                             multivector_config: matches!(pick.kind, VectorKind::MultiDense(_))
                                 .then(MultiVectorConfig::default),
                             datatype,
@@ -873,8 +877,10 @@ pub(super) fn model_entry_from(vecs: &NamedVectors, payload: &Payload) -> ModelE
 }
 
 /// Predicted engine read-back for `value` stored under `name`. Dense and multi-dense
-/// vectors with a lossy storage datatype must record the storage round-trip instead of
-/// the inserted value:
+/// vectors first go through the distance metric's ingestion preprocessing (Cosine
+/// normalizes, Dot is an identity — see `metric_preprocess`); vectors with a lossy
+/// storage datatype must then record the storage round-trip instead of the
+/// preprocessed value:
 ///
 /// - Turbo4 (dense only) stores 4-bit quantized codes and returns the dequantized
 ///   vector. The round-trip is deterministic (fixed rotation seeds), shared across
@@ -891,29 +897,62 @@ pub(super) fn model_entry_from(vecs: &NamedVectors, payload: &Payload) -> ModelE
 pub(super) fn model_vector(name: &str, value: &VectorValue) -> VectorValue {
     let candidate = candidate_of(name);
     match (candidate.kind, value) {
-        (VectorKind::Dense(_), VectorValue::Dense(v)) => match candidate.datatype {
-            // Every fixture vector uses Dot (see `fixture::fixture` and the
-            // CreateVectorName generator arm above).
-            Some(Datatype::Turbo4) => VectorValue::Dense(turbo_storage_roundtrip(v, Distance::Dot)),
-            datatype => match scalar_storage_roundtrip(datatype) {
-                Some(roundtrip) => VectorValue::Dense(roundtrip(v)),
-                None => value.clone(),
-            },
-        },
+        (VectorKind::Dense(_), VectorValue::Dense(v)) => {
+            let stored = metric_preprocess(candidate, v);
+            match candidate.datatype {
+                Some(Datatype::Turbo4) => {
+                    VectorValue::Dense(turbo_storage_roundtrip(&stored, candidate.distance))
+                }
+                datatype => match scalar_storage_roundtrip(datatype) {
+                    Some(roundtrip) => VectorValue::Dense(roundtrip(&stored)),
+                    None => VectorValue::Dense(stored),
+                },
+            }
+        }
         // Turbo4 multi-dense is rejected at startup (`assert_candidates_predictable`),
         // so `scalar_storage_roundtrip`'s panic arm is unreachable here.
         (VectorKind::MultiDense(_), VectorValue::MultiDense(rows)) => {
-            match scalar_storage_roundtrip(candidate.datatype) {
-                Some(roundtrip) => {
-                    VectorValue::MultiDense(rows.iter().map(|row| roundtrip(row)).collect())
-                }
-                None => value.clone(),
-            }
+            let roundtrip = scalar_storage_roundtrip(candidate.datatype);
+            VectorValue::MultiDense(
+                rows.iter()
+                    .map(|row| {
+                        let stored = metric_preprocess(candidate, row);
+                        match roundtrip {
+                            Some(roundtrip) => roundtrip(&stored),
+                            None => stored,
+                        }
+                    })
+                    .collect(),
+            )
         }
         (VectorKind::Sparse, VectorValue::Sparse(_)) => value.clone(),
         (kind, value) => {
             panic!("model_vector: value/kind mismatch for `{name}` ({kind:?}): {value:?}")
         }
+    }
+}
+
+/// The engine's ingestion-time metric preprocessing for one dense vector (or one
+/// multi-dense row): Cosine normalizes, everything else is an identity. Mirrors
+/// `NamedVectors::preprocess_dense_vector`'s per-datatype dispatch — the byte metric's
+/// Cosine preprocess is an identity, so Uint8 vectors are stored un-normalized — and
+/// goes through the engine's own `Distance::preprocess_vector` (same SIMD dispatch
+/// included) so the prediction tracks the engine by construction. Stored vectors are
+/// preprocessed exactly once: optimizer rebuilds and copy-on-write moves transfer the
+/// stored form as raw bytes (see `SegmentEntry::upsert_moved_point`), so read-backs are
+/// never re-normalized and the prediction stays exact across moves.
+fn metric_preprocess(candidate: &VectorCandidate, v: &[f32]) -> Vec<f32> {
+    let v = v.to_vec();
+    match candidate.datatype {
+        None | Some(Datatype::Float32 | Datatype::Turbo4) => {
+            candidate.distance.preprocess_vector::<VectorElementType>(v)
+        }
+        Some(Datatype::Float16) => candidate
+            .distance
+            .preprocess_vector::<VectorElementTypeHalf>(v),
+        Some(Datatype::Uint8) => candidate
+            .distance
+            .preprocess_vector::<VectorElementTypeByte>(v),
     }
 }
 


### PR DESCRIPTION
Extends the model tester beyond the hardcoded `Distance::Dot`: every vector candidate now carries a distance metric, threaded into the fixture schema, the `CreateVectorName` generator, and the model's read-back prediction.

### Modeling

Cosine is the only metric whose ingestion changes the stored value (normalization at first upsert). The model predicts it exactly by mirroring the engine:

* `metric_preprocess` follows `NamedVectors::preprocess_dense_vector`'s per-datatype dispatch and calls the engine's own `Distance::preprocess_vector`, so predictions track the engine by construction, SIMD dispatch included. The byte metric's Cosine preprocess is an identity, so Uint8 vectors are stored un-normalized, and the model dispatch reproduces that.
* Stored vectors are preprocessed exactly once: optimizer rebuilds and copy-on-write moves transfer the stored form as raw bytes (`upsert_moved_point` / `upsert_point_raw`), so read-backs are never re-normalized. This is what keeps Cosine + Float16 exact (an f16-rounded unit vector would re-normalize if preprocess ever re-ran).
* Turbo4 + Cosine reuses `turbo_storage_roundtrip` with the candidate's distance; TQ's Cosine mode shares the Dot dequantize arm (`l2` forced to 1.0, centroid-norm recompute), so the existing CoW re-quantization fixed point and the few-ulp `dense_matches` tolerance carry over.

Euclid and Manhattan preprocess are identities, so they need no model logic; their coverage value is on the engine side (`Order::SmallBetter` comparator paths that Dot/Cosine never exercise). The harness's search oracle is membership-based, so score ordering is not asserted.

### New candidates

| name | kind | datatype | distance |
|---|---|---|---|
| `e` | Dense(5) | f32 | Cosine |
| `n` | MultiDense(4) | f32 | Cosine (per-row normalization) |
| `x` | Dense(6) | Float16 | Cosine (normalize first, then f16 round-trip) |
| `o` | Dense(8) | Turbo4 | Cosine (padding-free dim, like `q`) |
| `j` | Dense(6) | f32 | Euclid |
| `k` | Dense(4) | f32 | Manhattan |

### Guard rails

`assert_candidates_predictable` now also rejects, at startup:

* sparse + non-Dot distance (sparse schemas carry no distance parameter; the field would silently not apply)
* Turbo4 + Euclid/Manhattan (TQ's L1/L2 modes store vector lengths differently from Dot/Cosine; their copy-on-write re-quantization fixed point is not soak-validated yet)

### Validation

* `cargo check` / clippy / fmt green with `--features testing`
* Soaks green on seeds 1/2/4/5/6/7/8 (30k ops, optimizer enabled), including two restart runs (`--restart-probability 0.002`) exercising WAL replay re-normalization determinism and reload verification
* The pre-existing `--enable-force-off` failures reproduce identically on the base branch (known FORCE_OFF engine bugs), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)