### PR TITLE
Use AHashMap for JsonPath-keyed field index lookups

### DIFF
--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
 
+use ahash::AHashMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -11,7 +12,7 @@ use crate::data_types::vectors::VectorInternal;
 use crate::index::field_index::FieldIndex;
 use crate::types::{PayloadKeyType, VectorNameBuf};
 
-pub type IndexesMap = HashMap<PayloadKeyType, Vec<FieldIndex>>;
+pub type IndexesMap = AHashMap<PayloadKeyType, Vec<FieldIndex>>;
 
 /// A container for JSON values, optimized for the common case of a single value.
 pub type MultiValue<T> = SmallVec<[T; 1]>;

--- a/lib/segment/src/index/struct_payload_index/read_only/config_reload.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/config_reload.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
@@ -55,7 +54,7 @@ impl<S: UniversalReadExt> ReadOnlyStructPayloadIndex<S> {
         fs: &impl UniversalReadFs<File = S>,
         new_config: PayloadConfig,
     ) -> OperationResult<PayloadIndexReloadDiff<S>> {
-        let mut added: ReadOnlyIndexesMap<S> = HashMap::new();
+        let mut added: ReadOnlyIndexesMap<S> = Default::default();
         {
             let id_tracker = self.id_tracker.borrow();
             let total_point_count = id_tracker.total_point_count();

--- a/lib/segment/src/index/struct_payload_index/read_only/lifecycle.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/lifecycle.rs
@@ -72,7 +72,7 @@ impl<S: UniversalReadExt> ReadOnlyStructPayloadIndex<S> {
             let total_point_count = id_tracker.total_point_count();
             let deleted_points = id_tracker.deleted_point_bitslice();
 
-            let mut field_indexes: ReadOnlyIndexesMap<S> = HashMap::new();
+            let mut field_indexes: ReadOnlyIndexesMap<S> = Default::default();
             for (field, indexed) in config.indices.iter() {
                 let populate_override =
                     load_profile.and_then(|profile| profile.payload_index_placement(field));

--- a/lib/segment/src/index/struct_payload_index/read_only/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
@@ -24,7 +25,7 @@ mod lifecycle;
 
 pub use config_reload::PayloadIndexReloadDiff;
 
-type ReadOnlyIndexesMap<S> = HashMap<PayloadKeyType, Vec<ReadOnlyFieldIndex<S>>>;
+type ReadOnlyIndexesMap<S> = AHashMap<PayloadKeyType, Vec<ReadOnlyFieldIndex<S>>>;
 
 pub struct ReadOnlyStructPayloadIndex<S: UniversalReadExt> {
     /// Payload storage

--- a/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use ahash::AHashSet;
+use ahash::{AHashMap, AHashSet};
 use atomic_refcell::AtomicRefCell;
 use common::condition_checker::{ConditionChecker, ConstantConditionChecker};
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -171,7 +171,7 @@ where
 
 /// For [`Condition::Field`], [`Condition::IsEmpty`] and [`Condition::IsNull`].
 fn field_condition_checker<'a>(
-    field_indexes: &'a HashMap<JsonPath, Vec<impl FieldIndexRead>>,
+    field_indexes: &'a AHashMap<JsonPath, Vec<impl FieldIndexRead>>,
     key: &JsonPath,
     hw_counter: &HardwareCounterCell,
     field_condition: &FieldCondition,

--- a/lib/segment/src/index/struct_payload_index/read_view/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/mod.rs
@@ -12,6 +12,7 @@ mod tests;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use atomic_refcell::AtomicRefCell;
 
 use crate::id_tracker::IdTrackerRead;
@@ -54,7 +55,7 @@ where
     pub(crate) payload: &'a Arc<AtomicRefCell<P>>,
     pub(crate) id_tracker: &'a I,
     pub(crate) vector_storages: &'a HashMap<VectorNameBuf, Arc<AtomicRefCell<V>>>,
-    pub(crate) field_indexes: &'a HashMap<PayloadKeyType, Vec<F>>,
+    pub(crate) field_indexes: &'a AHashMap<PayloadKeyType, Vec<F>>,
     pub(crate) config: &'a PayloadConfig,
     pub(crate) visited_pool: &'a VisitedPool,
 }

--- a/lib/segment/src/index/struct_payload_index/read_view/value_retriever/helpers.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/value_retriever/helpers.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use serde_json::Value;
@@ -14,7 +13,7 @@ use crate::payload_storage::PayloadStorageRead;
 use crate::types::PayloadContainer;
 
 pub(super) fn variable_retriever<'a, 'q, P, F>(
-    indices: &'a HashMap<JsonPath, Vec<F>>,
+    indices: &'a AHashMap<JsonPath, Vec<F>>,
     json_path: &JsonPath,
     payload_provider: PayloadProvider<P>,
     hw_counter: &'q HardwareCounterCell,
@@ -84,9 +83,9 @@ fn payload_variable_retriever<'a, P: PayloadStorageRead + 'a>(
 #[cfg(test)]
 #[cfg(feature = "testing")]
 mod tests {
-    use std::collections::HashMap;
     use std::sync::Arc;
 
+    use ahash::AHashMap;
     use atomic_refcell::AtomicRefCell;
     use common::bitvec::BitVec;
     use common::counter::hardware_counter::HardwareCounterCell;
@@ -159,7 +158,7 @@ mod tests {
         let payload_provider = fixture_payload_provider();
 
         // No indices — pick FieldIndex as the concrete F for type inference.
-        let no_indices: HashMap<_, Vec<FieldIndex>> = Default::default();
+        let no_indices: AHashMap<_, Vec<FieldIndex>> = Default::default();
 
         let hw_counter = Default::default();
 
@@ -256,7 +255,7 @@ mod tests {
         let datetime_index = builder.finalize().unwrap();
         let datetime_index = FieldIndex::DatetimeIndex(datetime_index);
 
-        let mut indices = HashMap::new();
+        let mut indices = AHashMap::new();
         indices.insert("value".try_into().unwrap(), vec![numeric_index]);
         indices.insert("location".try_into().unwrap(), vec![geo_index]);
         indices.insert("creation".try_into().unwrap(), vec![datetime_index]);

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
@@ -107,13 +108,13 @@ where
 
 pub fn select_nested_indexes<'a, R, FI>(
     nested_path: &PayloadKeyType,
-    field_indexes: &'a HashMap<PayloadKeyType, R>,
-) -> HashMap<PayloadKeyType, &'a Vec<FI>>
+    field_indexes: &'a AHashMap<PayloadKeyType, R>,
+) -> AHashMap<PayloadKeyType, &'a Vec<FI>>
 where
     FI: FieldIndexRead,
     R: AsRef<Vec<FI>>,
 {
-    let nested_indexes: HashMap<_, _> = field_indexes
+    let nested_indexes: AHashMap<_, _> = field_indexes
         .iter()
         .filter_map(|(key, indexes)| {
             key.strip_prefix(nested_path)
@@ -129,7 +130,7 @@ pub fn check_payload<'a, R, FI>(
     vector_storages: &HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageEnum>>>,
     query: &Filter,
     point_id: PointOffsetType,
-    field_indexes: &HashMap<PayloadKeyType, R>,
+    field_indexes: &AHashMap<PayloadKeyType, R>,
     hw_counter: &HardwareCounterCell,
 ) -> bool
 where
@@ -200,7 +201,7 @@ pub fn check_is_null_condition(is_null: &IsNullCondition, payload: &impl Payload
 pub fn check_field_condition<R, FI>(
     field_condition: &FieldCondition,
     payload: &impl PayloadContainer,
-    field_indexes: &HashMap<PayloadKeyType, R>,
+    field_indexes: &AHashMap<PayloadKeyType, R>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<bool>
 where
@@ -719,7 +720,7 @@ mod tests {
         // The key must include the `[]` wildcard so that
         // `select_nested_indexes` can strip the `items[]` prefix and pass the
         // index under key `title` into the nested `check_payload`.
-        let field_indexes: HashMap<PayloadKeyType, Vec<FieldIndex>> = HashMap::from([(
+        let field_indexes: IndexesMap = AHashMap::from([(
             JsonPath::new("items[].title"),
             vec![FieldIndex::FullTextIndex(ft_index)],
         )]);


### PR DESCRIPTION
Profiling filtered search showed `<std::hash::random::RandomState as BuildHasher>::hash_one::<JsonPath>` significant field index lookups, called from `StructPayloadIndexReadView::estimate_field_condition`.

 The map holds only a handful of indexed fields, but it is queried once per field condition per filter evaluation per query (`estimate_field_condition`, plus a second lookup per primary clause in `query_field`), and SipHash over the path's `first_key` string and `rest` items is essentially the entire lookup cost.

### Change

Switch the `JsonPath`-keyed field index lookup maps from std `HashMap` (SipHash) to `AHashMap`, which is already used throughout the crate:

* `IndexesMap` (`common/utils.rs`) and `ReadOnlyIndexesMap` (`read_only/mod.rs`), the owning maps
* the `StructPayloadIndexReadView::field_indexes` borrow
* the receiving signatures: `select_nested_indexes` / `check_payload` / `check_field_condition` (`query_checker.rs`), `field_condition_checker` (`condition_converter.rs`), `variable_retriever` (`value_retriever/helpers.rs`)

Deliberately left on std `HashMap`: the serialized / API-level schema maps (`PayloadConfig::fields`, `SegmentInfo::index_schema`, `indexed_fields()` returns) which are cold and whose types leak into conversions, and the `VectorNameBuf`-keyed `vector_storages` maps (same SipHash cost, separate concern).

No behavior change: iteration order of these maps was already randomized per instance with `RandomState`, so nothing that was deterministic becomes less so.

### Benchmark

`conditional_search` bench, criterion, 100 samples, against a saved baseline of the parent commit on the same machine:

| bench | before | after | change |
|---|---|---|---|
| `struct-conditional-search-query-points` | 583.7 µs | 443.5 µs | **-23.1%** (CI -28.7%…-16.8%, p ≈ 0) |
| `struct-conditional-search-context-check` | 73.2 µs | 64.8 µs | **-12.6%** (CI -16.4%…-8.5%, p ≈ 0) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)