### PR TITLE
[edge] Actually use batched vector reads

### DIFF
--- a/lib/segment/src/vector_storage/dense/read_only/immutable/read_ops.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/read_ops.rs
@@ -33,7 +33,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorStorageRead<T>
         self.vectors.for_each_in_batch(&keys, |idx, dense| {
             let user_data = user_data[idx];
             let key = keys[idx];
-            callback(user_data, key, bytemuck::cast_slice(&dense).to_vec());
+            callback(user_data, key, bytemuck::cast_slice(dense).to_vec());
         })
     }
 

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/read_ops.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/read_ops.rs
@@ -23,6 +23,27 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorStorageRead<T>
             .get_vector_opt::<P>(key)
             .expect("vector not found")
     }
+
+    fn read_dense_bytes<P: AccessPattern, U: Copy + common::universal_io::UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> crate::common::operation_error::OperationResult<()> {
+        let (user_data, keys): (Vec<_>, Vec<_>) = keys.into_iter().unzip();
+        self.vectors.for_each_in_batch(&keys, |idx, dense| {
+            let user_data = user_data[idx];
+            let key = keys[idx];
+            callback(user_data, key, bytemuck::cast_slice(&dense).to_vec());
+        })
+    }
+
+    fn for_each_in_dense_batch<F: FnMut(usize, &[T])>(
+        &self,
+        keys: &[PointOffsetType],
+        f: F,
+    ) -> crate::common::operation_error::OperationResult<()> {
+        self.vectors.for_each_in_batch(keys, f)
+    }
 }
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead

--- a/lib/segment/src/vector_storage/dense/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/read_ops.rs
@@ -6,6 +6,7 @@ use common::types::PointOffsetType;
 use common::universal_io::{UniversalRead, UserData};
 
 use super::ReadOnlyChunkedDenseVectorStorage;
+use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::types::{Distance, VectorStorageDatatype};
@@ -22,6 +23,27 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorStorageRead<T>
         self.vectors
             .get::<P>(key as VectorOffsetType)
             .expect("vector not found")
+    }
+
+    fn read_dense_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> crate::common::operation_error::OperationResult<()> {
+        let (user_datas, keys): (Vec<_>, Vec<_>) = keys.into_iter().unzip();
+        self.vectors.for_each_in_batch(&keys, |idx, dense| {
+            let user_data = user_datas[idx];
+            let key = keys[idx];
+            callback(user_data, key, bytemuck::cast_slice(&dense).to_vec());
+        })
+    }
+
+    fn for_each_in_dense_batch<F: FnMut(usize, &[T])>(
+        &self,
+        keys: &[PointOffsetType],
+        callback: F,
+    ) -> OperationResult<()> {
+        self.vectors.for_each_in_batch(keys, callback)
     }
 }
 

--- a/lib/segment/src/vector_storage/dense/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/read_ops.rs
@@ -34,7 +34,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorStorageRead<T>
         self.vectors.for_each_in_batch(&keys, |idx, dense| {
             let user_data = user_datas[idx];
             let key = keys[idx];
-            callback(user_data, key, bytemuck::cast_slice(&dense).to_vec());
+            callback(user_data, key, bytemuck::cast_slice(dense).to_vec());
         })
     }
 


### PR DESCRIPTION
We have batched implementations for reading vectors from storage, nice. We weren't using them 😅 .

This PR overrides the sequential implementations for batched operations, so that we actually use these for `ReadOnly` immutable and chunked storages.