### PR TITLE
Provision fresh appendable segments when all reach max_segment_size

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use segment::types::SeqNumberType;
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::segment_holder::provisioning::SegmentProvisioning;
 use shard::update::*;
 
 use crate::operations::CollectionUpdateOperations;
@@ -40,6 +41,7 @@ impl CollectionUpdater {
 
     pub fn update(
         segments: &LockedSegmentHolder,
+        provisioning: Option<&SegmentProvisioning>,
         op_num: SeqNumberType,
         operation: CollectionUpdateOperations,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
@@ -58,18 +60,33 @@ impl CollectionUpdater {
             // Needs to be acquired before locking segments.
             let _another_update_lock = segments.acquire_updates_lock();
 
-            let segments_guard = segments.read();
-
+            // Operations that may CoW-move or insert points receive the segment holder lock
+            // itself (plus provisioning): when all appendable segments hit `max_segment_size`,
+            // they provision a fresh one — which needs the holder write lock — and re-apply.
+            // Operations that cannot grow appendable segments just take a read guard here.
             match operation {
                 CollectionUpdateOperations::PointOperation(point_operation) => {
-                    process_point_operation(&segments_guard, op_num, point_operation, hw_counter)
+                    process_point_operation(
+                        segments,
+                        provisioning,
+                        op_num,
+                        point_operation,
+                        hw_counter,
+                    )
                 }
                 CollectionUpdateOperations::VectorOperation(vector_operation) => {
-                    process_vector_operation(&segments_guard, op_num, vector_operation, hw_counter)
+                    process_vector_operation(
+                        segments,
+                        provisioning,
+                        op_num,
+                        vector_operation,
+                        hw_counter,
+                    )
                 }
                 CollectionUpdateOperations::PayloadOperation(payload_operation) => {
                     process_payload_operation(
-                        &segments_guard,
+                        segments,
+                        provisioning,
                         op_num,
                         payload_operation,
                         hw_counter,
@@ -77,19 +94,19 @@ impl CollectionUpdater {
                 }
                 CollectionUpdateOperations::FieldIndexOperation(index_operation) => {
                     process_field_index_operation(
-                        &segments_guard,
+                        &segments.read(),
                         op_num,
                         &index_operation,
                         hw_counter,
                     )
                 }
                 CollectionUpdateOperations::VectorNameOperation(vector_name_operation) => {
-                    process_vector_name_operation(&segments_guard, op_num, &vector_name_operation)
+                    process_vector_name_operation(&segments.read(), op_num, &vector_name_operation)
                 }
                 #[cfg(feature = "staging")]
                 CollectionUpdateOperations::StagingOperation(staging_operation) => {
                     shard::update::process_staging_operation(
-                        &segments_guard,
+                        &segments.read(),
                         op_num,
                         staging_operation,
                     )
@@ -246,7 +263,8 @@ mod tests {
         }
 
         process_point_operation(
-            &segments.read(),
+            &segments,
+            None,
             101,
             PointOperations::DeletePoints {
                 ids: vec![500.into()],
@@ -287,7 +305,8 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         process_payload_operation(
-            &segments.read(),
+            &segments,
+            None,
             100,
             PayloadOps::SetPayload(SetPayloadOp {
                 payload,
@@ -327,7 +346,8 @@ mod tests {
 
         // Test payload delete
         process_payload_operation(
-            &segments.read(),
+            &segments,
+            None,
             101,
             PayloadOps::DeletePayload(DeletePayloadOp {
                 points: Some(vec![3.into()]),
@@ -375,7 +395,8 @@ mod tests {
         assert!(res[0].payload.as_ref().unwrap().contains_key("color"));
 
         process_payload_operation(
-            &segments.read(),
+            &segments,
+            None,
             102,
             PayloadOps::ClearPayload {
                 points: vec![2.into()],
@@ -444,7 +465,8 @@ mod tests {
         let points = vec![11.into(), 12.into(), 13.into()];
 
         process_payload_operation(
-            &segments.read(),
+            &segments,
+            None,
             102,
             PayloadOps::SetPayload(SetPayloadOp {
                 payload,
@@ -508,7 +530,8 @@ mod tests {
         let payload: Payload = serde_json::from_str(r#"{ "color":"blue"}"#).unwrap();
 
         process_payload_operation(
-            &segments.read(),
+            &segments,
+            None,
             103,
             PayloadOps::SetPayload(SetPayloadOp {
                 payload,

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -39,8 +39,11 @@ mod tests {
     use shard::operations::optimization::OptimizerThresholds;
     use shard::optimizers::segment_optimizer::SegmentOptimizer;
     use shard::segment_holder::locked::LockedSegmentHolder;
+    use shard::segment_holder::provisioning::SegmentProvisioning;
     use shard::segment_holder::{FlushMode, SegmentId};
-    use shard::update::{process_field_index_operation, process_point_operation};
+    use shard::update::{
+        process_field_index_operation, process_payload_operation, process_point_operation,
+    };
     use tempfile::Builder;
 
     use super::*;
@@ -628,7 +631,8 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         process_point_operation(
-            &locked_holder.read(),
+            &locked_holder,
+            None,
             opnum.next().unwrap(),
             insert_point_ops,
             &hw_counter,
@@ -693,7 +697,8 @@ mod tests {
             PointOperations::UpsertPoints(PointInsertOperationsInternal::from(batch));
 
         process_point_operation(
-            &locked_holder.read(),
+            &locked_holder,
+            None,
             opnum.next().unwrap(),
             insert_point_ops,
             &hw_counter,
@@ -1121,5 +1126,181 @@ mod tests {
             any_hnsw,
             "an HNSW index should have been created to promote the deferred points",
         );
+    }
+
+    /// Regression test for segment overgrow on `set_payload` by filter (originally reproduced
+    /// in PR #9158).
+    ///
+    /// When all points of a collection live in immutable (indexed) segments and `set_payload`
+    /// is executed via a filter that matches all points, `apply_points_with_conditional_move`
+    /// CoW-moves every matched point into an appendable segment. Without a size check on the
+    /// destination, all moved points used to pile up into a single appendable segment,
+    /// growing it far beyond `max_segment_size`.
+    ///
+    /// With a size cap configured on the segment holder and segment provisioning enabled, the
+    /// update must spill into freshly provisioned appendable segments instead, keeping every
+    /// segment at or below the cap.
+    #[test]
+    fn test_set_payload_by_filter_does_not_overgrow_segment() {
+        init();
+
+        let dim = 256;
+        // Each random_segment with 200 points and 256-dim f32 vectors has roughly
+        // ~200 KB of vector data on its own.
+        let points_per_segment = 200u64;
+        // Use a small max segment size so the combined indexed size exceeds it,
+        // but each individual indexed segment fits below it.
+        let max_segment_size_kb = 300;
+        let max_segment_size_bytes = max_segment_size_kb * segment::common::BYTES_IN_KB;
+
+        let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
+        let segments_temp_dir = Builder::new()
+            .prefix("segments_temp_dir")
+            .tempdir()
+            .unwrap();
+        let mut opnum = 101..1_000_000;
+
+        // --- 1. Build two sizeable random segments (initially appendable). ---
+        let segment_a = random_segment(
+            segments_dir.path(),
+            opnum.next().unwrap(),
+            points_per_segment,
+            dim,
+        );
+        let segment_b = random_segment(
+            segments_dir.path(),
+            opnum.next().unwrap(),
+            points_per_segment,
+            dim,
+        );
+
+        let segment_config = segment_a.segment_config.clone();
+
+        let mut holder = SegmentHolder::default();
+        let segment_a_id = holder.add_new(segment_a);
+        let segment_b_id = holder.add_new(segment_b);
+        holder.set_max_segment_size_bytes(NonZeroUsize::new(max_segment_size_bytes));
+
+        let locked_holder = LockedSegmentHolder::new(holder);
+
+        // --- 2. Run indexing optimizer to convert both segments to indexed
+        // (non-appendable) segments. ---
+        let index_optimizer = new_indexing_optimizer(
+            2,
+            OptimizerThresholds {
+                max_segment_size_kb,
+                memmap_threshold_kb: 1_000_000,
+                indexing_threshold_kb: 10, // Always optimize / index
+                deferred_internal_id: None,
+            },
+            segments_dir.path().to_owned(),
+            segments_temp_dir.path().to_owned(),
+            CollectionParams {
+                vectors: VectorsConfig::Single(
+                    VectorParamsBuilder::new(
+                        segment_config.vector_data[DEFAULT_VECTOR_NAME].size as u64,
+                        segment_config.vector_data[DEFAULT_VECTOR_NAME].distance,
+                    )
+                    .build(),
+                ),
+                ..CollectionParams::empty()
+            },
+            Default::default(),
+            HnswGlobalConfig::default(),
+            Default::default(),
+        );
+
+        // Index both raw segments. Each gets converted into an indexed
+        // non-appendable segment and a fresh empty appendable segment is
+        // created by the optimizer.
+        index_optimizer.optimize_for_test(locked_holder.clone(), vec![segment_a_id]);
+        index_optimizer.optimize_for_test(locked_holder.clone(), vec![segment_b_id]);
+
+        // Sanity check: the combined indexed size exceeds the configured max segment size, and
+        // at least 2 indexed (non-appendable) segments exist.
+        let (indexed_total, indexed_count) = {
+            let holder_guard = locked_holder.read();
+            let sizes: Vec<_> = holder_guard
+                .iter()
+                .filter_map(|(_segment_id, segment)| {
+                    let segment = segment.get().read();
+                    if segment.is_appendable() {
+                        None
+                    } else {
+                        Some(segment.max_available_vectors_size_in_bytes().unwrap())
+                    }
+                })
+                .collect();
+            (sizes.iter().sum::<usize>(), sizes.len())
+        };
+        assert!(
+            indexed_total > max_segment_size_bytes,
+            "Expected combined indexed size ({indexed_total}) to exceed max_segment_size ({max_segment_size_bytes})",
+        );
+        assert!(
+            indexed_count >= 2,
+            "Expected at least 2 indexed segments after optimization, got {indexed_count}",
+        );
+
+        // --- 3. Run set_payload by a filter that matches ALL points. ---
+        let payload_index_schema = std::sync::Arc::new(
+            common::save_on_disk::SaveOnDisk::load_or_init_default(
+                segments_dir.path().join("payload.schema"),
+            )
+            .unwrap(),
+        );
+        let provisioning =
+            SegmentProvisioning::from_optimizer(&index_optimizer, payload_index_schema);
+
+        let payload_op = crate::operations::payload_ops::PayloadOps::SetPayload(
+            crate::operations::payload_ops::SetPayloadOp {
+                payload: payload_json! {"new_field": "value"},
+                points: None,
+                filter: Some(segment::types::Filter::default()),
+                key: None,
+            },
+        );
+
+        let hw_counter = HardwareCounterCell::new();
+        process_payload_operation(
+            &locked_holder,
+            Some(&provisioning),
+            opnum.next().unwrap(),
+            payload_op,
+            &hw_counter,
+        )
+        .unwrap();
+
+        // --- 4. Verify no segment exceeds max_segment_size. ---
+        let holder_guard = locked_holder.read();
+        let largest_segment_bytes = holder_guard
+            .iter()
+            .map(|(segment_id, segment)| {
+                let segment = segment.get().read();
+                let size = segment.max_available_vectors_size_in_bytes().unwrap();
+                let info = segment.info().unwrap();
+                log::info!(
+                    "segment {segment_id:?}: appendable={} num_points={} num_vectors={} size_bytes={size}",
+                    segment.is_appendable(),
+                    info.num_points,
+                    info.num_vectors,
+                );
+                size
+            })
+            .max()
+            .unwrap_or_default();
+
+        assert!(
+            largest_segment_bytes <= max_segment_size_bytes,
+            "A segment overgrew the configured max_segment_size: largest={largest_segment_bytes} bytes, max={max_segment_size_bytes} bytes",
+        );
+
+        // The spilled points must have landed in a freshly provisioned appendable segment,
+        // and every moved point must still be accounted for.
+        let total_points: usize = holder_guard
+            .iter()
+            .map(|(_segment_id, segment)| segment.get().read().available_point_count())
+            .sum();
+        assert_eq!(total_points, 2 * points_per_segment as usize);
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1171,6 +1171,12 @@ impl From<OperationError> for CollectionError {
             OperationError::MissingMapIndexForFacet { .. } => Self::bad_input(err.to_string()),
             OperationError::VariableTypeError { .. } => Self::bad_input(err.to_string()),
             OperationError::NonFiniteNumber { .. } => Self::bad_input(err.to_string()),
+            // Normally handled by segment provisioning before reaching this conversion; if it
+            // leaks, stay transient so failed-operation recovery re-applies the operation.
+            OperationError::OutOfAppendableCapacity { .. } => Self::ServiceError {
+                error: err.to_string(),
+                backtrace: None,
+            },
         }
     }
 }

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -60,6 +60,7 @@ use shard::operations::optimization::{OptimizationSegmentInfo, PendingOptimizati
 use shard::operations::point_ops::{PointInsertOperationsInternal, PointOperations};
 use shard::segment_holder::FlushMode;
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::segment_holder::provisioning::SegmentProvisioning;
 use shard::wal::SerdeWal;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::Sender;
@@ -812,6 +813,15 @@ impl LocalShard {
         // operations, so a name that is created and used within the replay window stays valid.
         let mut valid_vector_names = self.collection_config.read().await.params.vector_names();
 
+        // Replayed operations must be able to provision fresh appendable segments, just like the
+        // regular update path.
+        let provisioning = self.optimizers.load().first().map(|optimizer| {
+            SegmentProvisioning::from_optimizer(
+                optimizer.as_ref(),
+                self.payload_index_schema.clone(),
+            )
+        });
+
         for entry in wal.read_range(from..to) {
             let (op_num, mut update) = entry.map_err(|e| {
                 CollectionError::service_error(format!(
@@ -839,6 +849,7 @@ impl LocalShard {
             // Propagate `CollectionError::ServiceError`, but skip other error types.
             match &CollectionUpdater::update(
                 &self.segments,
+                provisioning.as_ref(),
                 op_num,
                 update.operation,
                 self.update_operation_lock.clone(),

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -7,9 +8,11 @@ use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use parking_lot::Mutex;
+use segment::common::BYTES_IN_KB;
 use segment::types::SeqNumberType;
 use shard::operations::CollectionUpdateOperations;
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::segment_holder::provisioning::SegmentProvisioning;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::{self, Receiver};
 use tokio::sync::{Mutex as TokioMutex, oneshot, watch};
@@ -189,6 +192,26 @@ impl UpdateHandler {
     }
 
     pub fn run_workers(&mut self, update_receiver: Receiver<UpdateSignal>) {
+        // Mirror the resolved optimizer size threshold into the segment holder (both on shard
+        // creation and on optimizer config updates, which restart the workers), and hand the
+        // update worker everything it needs to provision fresh appendable segments when all
+        // existing ones reach that threshold.
+        let provisioning = self.optimizers.first().map(|optimizer| {
+            let max_segment_size_bytes = NonZeroUsize::new(
+                optimizer
+                    .threshold_config()
+                    .max_segment_size_kb
+                    .saturating_mul(BYTES_IN_KB),
+            );
+            self.segments
+                .write()
+                .set_max_segment_size_bytes(max_segment_size_bytes);
+            Arc::new(SegmentProvisioning::from_optimizer(
+                optimizer.as_ref(),
+                self.payload_index_schema.clone(),
+            ))
+        });
+
         let (tx, rx) = mpsc::channel(self.shared_storage_config.update_queue_size);
 
         // Optimization notifier is triggered when a new optimization is finished
@@ -232,6 +255,7 @@ impl UpdateHandler {
             tx,
             wal,
             segments,
+            provisioning,
             scroll_read_lock,
             update_tracker,
             self.prevent_unoptimized,

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::panic::AssertUnwindSafe;
 use std::path::Path;
 use std::sync::Arc;
@@ -15,6 +16,7 @@ use shard::operations::optimization::OptimizerThresholds;
 use shard::optimizers::config::SegmentOptimizerConfig;
 use shard::payload_index_schema::PayloadIndexSchema;
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::segment_holder::provisioning::SegmentProvisioning;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::{Mutex as TokioMutex, watch};
 use tokio::task;
@@ -67,6 +69,13 @@ impl UpdateWorkers {
 
         let max_handles = max_handles.unwrap_or(usize::MAX);
         let num_indexing_threads = some_optimizer.num_indexing_threads();
+
+        // For failed-operation recovery: re-applied operations must be able to provision fresh
+        // appendable segments, just like the regular update path.
+        let recovery_provisioning = SegmentProvisioning::from_optimizer(
+            some_optimizer.as_ref(),
+            payload_index_schema.clone(),
+        );
 
         // Asynchronous task to trigger optimizers once CPU budget is available again
         let mut resource_available_trigger: Option<JoinHandle<()>> = None;
@@ -138,6 +147,7 @@ impl UpdateWorkers {
             if Self::try_recover(
                 segments.clone(),
                 wal.clone(),
+                Some(&recovery_provisioning),
                 update_operation_lock.clone(),
                 update_tracker.clone(),
             )
@@ -449,43 +459,18 @@ impl UpdateWorkers {
         thresholds_config: &OptimizerThresholds,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
     ) -> OperationResult<()> {
-        let no_segment_with_capacity = {
-            let segments_read = segments.read();
-            segments_read
-                .appendable_segments_ids()
-                .into_iter()
-                .filter_map(|segment_id| segments_read.get(segment_id))
-                .all(|segment| {
-                    let max_vector_size_bytes = segment
-                        .get()
-                        .read()
-                        .max_available_vectors_size_in_bytes()
-                        .unwrap_or_default();
-                    let max_segment_size_bytes = thresholds_config
-                        .max_segment_size_kb
-                        .saturating_mul(segment::common::BYTES_IN_KB);
-
-                    max_vector_size_bytes >= max_segment_size_bytes
-                })
+        let provisioning = SegmentProvisioning {
+            segments_path: segments_path.to_owned(),
+            segment_config: segment_config.plain_segment_config(),
+            payload_index_schema,
+            deferred_internal_id: thresholds_config.deferred_internal_id,
         };
-
-        if no_segment_with_capacity {
-            log::debug!("Creating new appendable segment, all existing segments are over capacity");
-
-            let segments_guard = segments.upgradable_read();
-            // Building the segment yields a `NewSegmentToken` obliging us to register it.
-            let (new_segment, token) = segments_guard.build_tmp_segment(
-                segments_path,
-                Some(segment_config.plain_segment_config()),
-                payload_index_schema,
-                thresholds_config.deferred_internal_id,
-                true,
-            )?;
-            segments_guard.sync_segment_manifest(Some(token))?;
-            let mut write_guard = parking_lot::RwLockUpgradableReadGuard::upgrade(segments_guard);
-            write_guard.add_new_locked(new_segment);
-        }
-
+        let max_segment_size_bytes = NonZeroUsize::new(
+            thresholds_config
+                .max_segment_size_kb
+                .saturating_mul(segment::common::BYTES_IN_KB),
+        );
+        segments.ensure_appendable_segment_with_capacity(&provisioning, max_segment_size_bytes)?;
         Ok(())
     }
 
@@ -515,6 +500,7 @@ impl UpdateWorkers {
     async fn try_recover(
         segments: LockedSegmentHolder,
         wal: LockedWal,
+        provisioning: Option<&SegmentProvisioning>,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
     ) -> CollectionResult<usize> {
@@ -532,6 +518,7 @@ impl UpdateWorkers {
                     })?;
                     CollectionUpdater::update(
                         &segments,
+                        provisioning,
                         op_num,
                         operation.operation,
                         update_operation_lock.clone(),

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -6,6 +6,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::types::SeqNumberType;
 use shard::operations::CollectionUpdateOperations;
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::segment_holder::provisioning::SegmentProvisioning;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::{oneshot, watch};
 use tokio_util::task::AbortOnDropHandle;
@@ -47,6 +48,7 @@ impl UpdateWorkers {
         optimize_sender: Sender<OptimizerSignal>,
         wal: LockedWal,
         segments: LockedSegmentHolder,
+        provisioning: Option<Arc<SegmentProvisioning>>,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
         prevent_unoptimized: bool,
@@ -120,6 +122,7 @@ impl UpdateWorkers {
 
                     let wait = sender.is_some();
                     let segments_clone = segments.clone();
+                    let provisioning_clone = provisioning.clone();
                     let operation_result = tokio::task::spawn_blocking(move || {
                         Self::update_worker_internal(
                             collection_name_clone,
@@ -128,6 +131,7 @@ impl UpdateWorkers {
                             wait,
                             wal_clone,
                             segments_clone,
+                            provisioning_clone,
                             update_operation_lock_clone,
                             update_tracker_clone,
                             hw_measurements,
@@ -309,6 +313,7 @@ impl UpdateWorkers {
         wait: bool,
         wal: LockedWal,
         segments: LockedSegmentHolder,
+        provisioning: Option<Arc<SegmentProvisioning>>,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
         hw_measurements: HwMeasurementAcc,
@@ -333,6 +338,7 @@ impl UpdateWorkers {
         let result = cpu_utilization.measure(|| {
             CollectionUpdater::update(
                 &segments,
+                provisioning.as_deref(),
                 op_num,
                 operation,
                 update_operation_lock.clone(),

--- a/lib/edge/src/update.rs
+++ b/lib/edge/src/update.rs
@@ -20,15 +20,20 @@ impl EdgeShard {
         let hw_counter = HardwareCounterCell::disposable();
         let _update_guard = self.segments.acquire_updates_lock();
 
-        let segments_guard = self.segments.read();
-
+        // No segment provisioning: the edge shard configures no appendable size cap, so updates
+        // never report `OutOfAppendableCapacity` and run in a single attempt.
         let result = match operation {
-            CollectionUpdateOperations::PointOperation(point_operation) => {
-                process_point_operation(&segments_guard, operation_id, point_operation, &hw_counter)
-            }
+            CollectionUpdateOperations::PointOperation(point_operation) => process_point_operation(
+                &self.segments,
+                None,
+                operation_id,
+                point_operation,
+                &hw_counter,
+            ),
             CollectionUpdateOperations::VectorOperation(vector_operation) => {
                 process_vector_operation(
-                    &segments_guard,
+                    &self.segments,
+                    None,
                     operation_id,
                     vector_operation,
                     &hw_counter,
@@ -36,7 +41,8 @@ impl EdgeShard {
             }
             CollectionUpdateOperations::PayloadOperation(payload_operation) => {
                 process_payload_operation(
-                    &segments_guard,
+                    &self.segments,
+                    None,
                     operation_id,
                     payload_operation,
                     &hw_counter,
@@ -44,7 +50,7 @@ impl EdgeShard {
             }
             CollectionUpdateOperations::FieldIndexOperation(index_operation) => {
                 process_field_index_operation(
-                    &segments_guard,
+                    &self.segments.read(),
                     operation_id,
                     &index_operation,
                     &hw_counter,
@@ -52,7 +58,7 @@ impl EdgeShard {
             }
             CollectionUpdateOperations::VectorNameOperation(ref vector_name_operation) => {
                 let result = process_vector_name_operation(
-                    &segments_guard,
+                    &self.segments.read(),
                     operation_id,
                     vector_name_operation,
                 );
@@ -65,7 +71,7 @@ impl EdgeShard {
             #[cfg(feature = "staging")]
             CollectionUpdateOperations::StagingOperation(staging_operation) => {
                 shard::update::process_staging_operation(
-                    &segments_guard,
+                    &self.segments.read(),
                     operation_id,
                     staging_operation,
                 )

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -82,6 +82,13 @@ pub enum OperationError {
     },
     #[error("The expression {expression} produced a non-finite number")]
     NonFiniteNumber { expression: String },
+    /// All appendable segments reached `max_segment_size`, so there is no valid destination for
+    /// new or moved points. Recoverable by provisioning a fresh appendable segment and re-applying
+    /// the operation; already-applied points are skipped by their point version.
+    #[error(
+        "All appendable segments reached the maximum segment size of {max_segment_size_bytes} bytes"
+    )]
+    OutOfAppendableCapacity { max_segment_size_bytes: usize },
 }
 
 impl OperationError {
@@ -126,6 +133,32 @@ impl OperationError {
         }
     }
 
+    /// Whether this error signals that all appendable segments are at `max_segment_size` capacity,
+    /// so the operation can be re-applied after provisioning a fresh appendable segment.
+    pub fn is_out_of_appendable_capacity(&self) -> bool {
+        match self {
+            Self::OutOfAppendableCapacity { .. } => true,
+            Self::WrongVectorDimension { .. }
+            | Self::VectorNameNotExists { .. }
+            | Self::PointIdError { .. }
+            | Self::TypeError { .. }
+            | Self::TypeInferenceError { .. }
+            | Self::ServiceError { .. }
+            | Self::InconsistentStorage { .. }
+            | Self::FileNotFound { .. }
+            | Self::OutOfMemory { .. }
+            | Self::Cancelled { .. }
+            | Self::Timeout { .. }
+            | Self::ValidationError { .. }
+            | Self::WrongSparse
+            | Self::WrongMulti
+            | Self::MissingRangeIndexForOrderBy { .. }
+            | Self::MissingMapIndexForFacet { .. }
+            | Self::VariableTypeError { .. }
+            | Self::NonFiniteNumber { .. } => false,
+        }
+    }
+
     pub fn timeout(timeout: Duration, operation: impl Into<String>) -> Self {
         Self::Timeout {
             description: format!(
@@ -160,7 +193,8 @@ impl IsNotFound for OperationError {
             | Self::MissingRangeIndexForOrderBy { .. }
             | Self::MissingMapIndexForFacet { .. }
             | Self::VariableTypeError { .. }
-            | Self::NonFiniteNumber { .. } => false,
+            | Self::NonFiniteNumber { .. }
+            | Self::OutOfAppendableCapacity { .. } => false,
         }
     }
 }

--- a/lib/shard/src/resolve.rs
+++ b/lib/shard/src/resolve.rs
@@ -249,6 +249,7 @@ mod tests {
     use crate::operations::point_ops::{
         PointInsertOperationsInternal, PointStructPersisted, UpdateMode, VectorStructPersisted,
     };
+    use crate::segment_holder::locked::LockedSegmentHolder;
     use crate::update::{delete_points_by_filter, points_by_filter, process_point_operation};
 
     fn color_filter(color: &str) -> Filter {
@@ -313,10 +314,11 @@ mod tests {
         let CollectionUpdateOperations::PointOperation(op) = resolved else {
             unreachable!()
         };
-        process_point_operation(&holder, 100, op, &hw_counter).unwrap();
+        let locked_holder = LockedSegmentHolder::new(holder);
+        process_point_operation(&locked_holder, None, 100, op, &hw_counter).unwrap();
         delete_points_by_filter(&twin_holder, 100, &filter, &hw_counter).unwrap();
 
-        let remaining = points_by_filter(&holder, &filter, &hw_counter).unwrap();
+        let remaining = points_by_filter(&locked_holder.read(), &filter, &hw_counter).unwrap();
         let twin_remaining = points_by_filter(&twin_holder, &filter, &hw_counter).unwrap();
         assert!(remaining.is_empty(), "resolved delete left {remaining:?}");
         assert!(twin_remaining.is_empty());

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -1,6 +1,7 @@
 mod flush;
 pub mod locked;
 pub use flush::FlushMode;
+pub mod provisioning;
 pub mod read_points;
 mod snapshot;
 #[cfg(test)]
@@ -8,6 +9,7 @@ mod tests;
 
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::sync::Arc;
@@ -135,6 +137,16 @@ pub struct SegmentHolder {
     /// funnels through [`add_existing_locked`](Self::add_existing_locked) and
     /// [`remove`](Self::remove), which reconcile it.
     segment_manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>,
+
+    /// Soft cap on appendable segment size for the update path, mirroring the resolved optimizer
+    /// `max_segment_size_kb` threshold (set by the shard on load and on optimizer config updates).
+    ///
+    /// When set, the update path avoids inserting or CoW-moving points into appendable segments
+    /// whose vector size already reached the cap, and reports
+    /// [`OperationError::OutOfAppendableCapacity`] when no appendable segment is below it. `None`
+    /// disables capacity checks (the pre-existing behavior: any appendable segment is a valid
+    /// destination, regardless of size).
+    max_segment_size_bytes: Option<NonZeroUsize>,
 }
 
 impl Drop for SegmentHolder {
@@ -620,9 +632,92 @@ impl SegmentHolder {
             .collect()
     }
 
+    /// Set the soft cap on appendable segment size used by the update path.
+    ///
+    /// Mirrors the resolved optimizer `max_segment_size_kb` threshold; `None` disables capacity
+    /// checks. See [`SegmentHolder::max_segment_size_bytes`].
+    pub fn set_max_segment_size_bytes(&mut self, max_segment_size_bytes: Option<NonZeroUsize>) {
+        self.max_segment_size_bytes = max_segment_size_bytes;
+    }
+
+    pub fn max_segment_size_bytes(&self) -> Option<NonZeroUsize> {
+        self.max_segment_size_bytes
+    }
+
+    /// Whether at least one appendable segment is below the given size cap.
+    ///
+    /// `false` when there are no appendable segments at all. With no cap, any appendable segment
+    /// counts as having capacity. Segments that cannot be read-locked right now count as having
+    /// capacity: the cap is a soft limit and liveness wins over precision.
+    pub fn has_appendable_segment_with_capacity(
+        &self,
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> bool {
+        let appendable_segments = self.appendable_segments_ids();
+        !appendable_segments.is_empty()
+            && appendable_segments
+                .iter()
+                .any(|segment_id| self.segment_has_capacity(*segment_id, max_segment_size_bytes))
+    }
+
+    /// Whether the given segment's measured size is below the given cap.
+    ///
+    /// Unmeasurable segments (gone, read-lock contention, size errors) count as having capacity,
+    /// so that the soft cap never blocks progress on measurement issues alone.
+    fn segment_has_capacity(
+        &self,
+        segment_id: SegmentId,
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> bool {
+        let Some(max_segment_size_bytes) = max_segment_size_bytes else {
+            return true;
+        };
+        let Some(locked_segment) = self.get(segment_id) else {
+            return true;
+        };
+        let Some(segment) = locked_segment.get().try_read() else {
+            return true;
+        };
+        match segment.max_available_vectors_size_in_bytes() {
+            Ok(size) => size < max_segment_size_bytes.get(),
+            Err(err) => {
+                log::error!("Failed to get segment size, ignoring: {err}");
+                true
+            }
+        }
+    }
+
+    /// Filter CoW-move destination candidates down to appendable segments below the configured
+    /// size cap.
+    ///
+    /// Errors with [`OperationError::OutOfAppendableCapacity`] when candidates exist but all of
+    /// them reached the cap; re-applying the operation after provisioning a fresh appendable
+    /// segment resumes where it left off (already-moved points are skipped by point version).
+    fn candidates_with_capacity(
+        &self,
+        candidates: &[SegmentId],
+    ) -> OperationResult<Vec<SegmentId>> {
+        let eligible: Vec<_> = candidates
+            .iter()
+            .copied()
+            .filter(|segment_id| {
+                self.segment_has_capacity(*segment_id, self.max_segment_size_bytes)
+            })
+            .collect();
+        if eligible.is_empty()
+            && !candidates.is_empty()
+            && let Some(max_segment_size_bytes) = self.max_segment_size_bytes
+        {
+            return Err(OperationError::OutOfAppendableCapacity {
+                max_segment_size_bytes: max_segment_size_bytes.get(),
+            });
+        }
+        Ok(eligible)
+    }
+
     /// Get a random appendable segment
     ///
-    /// If you want the smallest segment, use `random_appendable_segment_with_capacity` instead.
+    /// If you want the smallest segment, use `smallest_appendable_segment` instead.
     pub fn random_appendable_segment(&self) -> Option<LockedSegment> {
         let segment_ids: Vec<_> = self.appendable_segments_ids();
         segment_ids
@@ -637,10 +732,17 @@ impl SegmentHolder {
     ///
     /// This attempts a non-blocking read-lock on all segments to find the smallest one. Segments
     /// that cannot be read-locked at this time are skipped. If no segment can be read-locked at
-    /// all, a random one is returned.
+    /// all, a random one is returned without a size check.
+    ///
+    /// # Errors
+    ///
+    /// - [`OperationError::OutOfAppendableCapacity`] when a size cap is configured and even the
+    ///   smallest segment reached it; re-applying the operation after provisioning a fresh
+    ///   appendable segment resumes where it left off.
+    /// - Service error when there are no appendable segments at all.
     ///
     /// If capacity is not important use `random_appendable_segment` instead because it is cheaper.
-    pub fn smallest_appendable_segment(&self) -> Option<LockedSegment> {
+    pub fn smallest_appendable_segment(&self) -> OperationResult<LockedSegment> {
         let segment_ids: Vec<_> = self.appendable_segments_ids();
 
         // Try a non-blocking read lock on all segments and return the smallest one
@@ -661,14 +763,24 @@ impl SegmentHolder {
                 }
             })
             .min_by_key(|(_, segment_size)| *segment_size);
-        if let Some((smallest_segment, _)) = smallest_segment {
-            return Some(LockedSegment::clone(smallest_segment));
+        if let Some((smallest_segment, size)) = smallest_segment {
+            if let Some(max_segment_size_bytes) = self.max_segment_size_bytes
+                && size >= max_segment_size_bytes.get()
+            {
+                return Err(OperationError::OutOfAppendableCapacity {
+                    max_segment_size_bytes: max_segment_size_bytes.get(),
+                });
+            }
+            return Ok(LockedSegment::clone(smallest_segment));
         }
 
         // Fall back to picking a random segment
         segment_ids
             .choose(&mut rand::rng())
             .and_then(|idx| self.appendable_segments.get(idx).cloned())
+            .ok_or_else(|| {
+                OperationError::service_error("No appendable segments exist, expected at least one")
+            })
     }
 
     /// Selects point ids, which is stored in this segment
@@ -1020,8 +1132,19 @@ impl SegmentHolder {
             let is_applied = if can_apply_operation {
                 point_operation(point_id, write_segment)?
             } else {
+                // Re-check destination capacity per moved point: a large operation can fill the
+                // destination mid-way, and the next point must then go elsewhere (or the
+                // operation must fail with `OutOfAppendableCapacity` so the caller provisions a
+                // fresh appendable segment and re-applies).
+                let eligible_segments;
+                let destination_candidates = if self.max_segment_size_bytes.is_some() {
+                    eligible_segments = self.candidates_with_capacity(&appendable_segments)?;
+                    &eligible_segments
+                } else {
+                    &appendable_segments
+                };
                 self.aloha_random_write(
-                    &appendable_segments,
+                    destination_candidates,
                     |appendable_idx, appendable_write_segment| {
                         // If we are moving point from one segment to another,
                         // we must guarantee, that data in new segment will be persisted before

--- a/lib/shard/src/segment_holder/provisioning.rs
+++ b/lib/shard/src/segment_holder/provisioning.rs
@@ -1,0 +1,143 @@
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use common::save_on_disk::SaveOnDisk;
+use common::types::PointOffsetType;
+use parking_lot::RwLockUpgradableReadGuard;
+use segment::common::operation_error::{OperationError, OperationResult};
+use segment::types::SegmentConfig;
+
+use crate::locked_segment::LockedSegment;
+use crate::optimizers::segment_optimizer::Optimizer;
+use crate::payload_index_schema::PayloadIndexSchema;
+use crate::segment_holder::SegmentHolder;
+use crate::segment_holder::locked::LockedSegmentHolder;
+
+/// Backstop against an update that keeps provisioning segments without terminating. Generous on
+/// purpose: a single operation legitimately provisions one segment per `max_segment_size` worth
+/// of moved data, and the emptiness check in
+/// [`LockedSegmentHolder::update_with_segment_provisioning`] already catches non-progress.
+const MAX_PROVISIONING_ATTEMPTS_PER_OPERATION: usize = 1024;
+
+/// Everything needed to create a fresh appendable segment on demand while applying an update.
+///
+/// Sourced from the shard's optimizer configuration (see
+/// [`SegmentProvisioning::from_optimizer`]), the same way the optimization worker provisions
+/// appendable capacity between operations.
+#[derive(Clone)]
+pub struct SegmentProvisioning {
+    pub segments_path: PathBuf,
+    pub segment_config: SegmentConfig,
+    pub payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
+    pub deferred_internal_id: Option<PointOffsetType>,
+}
+
+impl SegmentProvisioning {
+    pub fn from_optimizer(
+        optimizer: &Optimizer,
+        payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
+    ) -> Self {
+        Self {
+            segments_path: optimizer.segments_path().to_owned(),
+            segment_config: optimizer.segment_optimizer_config().plain_segment_config(),
+            payload_index_schema,
+            deferred_internal_id: optimizer.threshold_config().deferred_internal_id,
+        }
+    }
+}
+
+impl LockedSegmentHolder {
+    /// Ensure there is at least one appendable segment with capacity, creating a fresh empty one
+    /// when there is none (no appendable segments at all, or all of them measure at or over
+    /// `max_segment_size_bytes`).
+    ///
+    /// Returns the created segment, or `None` when capacity already exists.
+    pub fn ensure_appendable_segment_with_capacity(
+        &self,
+        provisioning: &SegmentProvisioning,
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> OperationResult<Option<LockedSegment>> {
+        let segments_guard = self.upgradable_read();
+        if segments_guard.has_appendable_segment_with_capacity(max_segment_size_bytes) {
+            return Ok(None);
+        }
+
+        log::debug!("Creating new appendable segment, all existing segments are over capacity");
+
+        // Building the segment yields a `NewSegmentToken` obliging us to register it.
+        let (new_segment, token) = segments_guard.build_tmp_segment(
+            &provisioning.segments_path,
+            Some(provisioning.segment_config.clone()),
+            provisioning.payload_index_schema.clone(),
+            provisioning.deferred_internal_id,
+            true,
+        )?;
+        segments_guard.sync_segment_manifest(Some(token))?;
+        let mut write_guard = RwLockUpgradableReadGuard::upgrade(segments_guard);
+        write_guard.add_new_locked(new_segment.clone());
+        Ok(Some(new_segment))
+    }
+
+    /// Run `update` under a read guard of this holder, provisioning a fresh appendable segment
+    /// and re-running it whenever it reports
+    /// [`OutOfAppendableCapacity`](segment::common::operation_error::OperationError::OutOfAppendableCapacity).
+    ///
+    /// Re-running the update is how a single operation moving more data than one segment's
+    /// capacity is applied across several fresh segments: updates are idempotent per point
+    /// version, so every attempt skips the points already applied by previous attempts and
+    /// resumes where the last one stopped — exactly like re-applying an operation from WAL.
+    ///
+    /// With `provisioning: None` the update runs once and a capacity error propagates to the
+    /// caller (holders without a configured size cap never report one).
+    pub fn update_with_segment_provisioning<T>(
+        &self,
+        provisioning: Option<&SegmentProvisioning>,
+        mut update: impl FnMut(&SegmentHolder) -> OperationResult<T>,
+    ) -> OperationResult<T> {
+        let mut last_provisioned: Option<LockedSegment> = None;
+
+        for _attempt in 0..MAX_PROVISIONING_ATTEMPTS_PER_OPERATION {
+            let (result, max_segment_size_bytes) = {
+                let segments_guard = self.read();
+                let result = update(&segments_guard);
+                (result, segments_guard.max_segment_size_bytes())
+            };
+
+            let err = match result {
+                Err(err) if err.is_out_of_appendable_capacity() => err,
+                other => return other,
+            };
+            let Some(provisioning) = provisioning else {
+                return Err(err);
+            };
+
+            // Progress invariant: on a repeated capacity error, the segment provisioned by the
+            // previous attempt must have absorbed data by now (it measured under the cap, so the
+            // update preferred it as a destination). A still-empty segment means re-running
+            // cannot make progress — e.g. a segment whose size cannot be measured — so fail
+            // instead of provisioning segments forever.
+            if let Some(segment) = &last_provisioned {
+                let absorbed = segment
+                    .get()
+                    .read()
+                    .max_available_vectors_size_in_bytes()
+                    .unwrap_or(0)
+                    > 0;
+                if !absorbed {
+                    return Err(err);
+                }
+            }
+
+            // Re-check under the holder lock: capacity may have been provisioned concurrently
+            // (e.g. by the optimization worker), in which case just re-run the update.
+            last_provisioned =
+                self.ensure_appendable_segment_with_capacity(provisioning, max_segment_size_bytes)?;
+        }
+
+        Err(OperationError::service_error(format!(
+            "Update did not complete after provisioning appendable segments \
+             {MAX_PROVISIONING_ATTEMPTS_PER_OPERATION} times",
+        )))
+    }
+}

--- a/lib/shard/src/update.rs
+++ b/lib/shard/src/update.rs
@@ -16,7 +16,7 @@ use segment::types::{
     SeqNumberType, VectorNameBuf, WithPayload, WithVector,
 };
 
-use crate::operations::payload_ops::PayloadOps;
+use crate::operations::payload_ops::{DeletePayloadOp, PayloadOps, SetPayloadOp};
 use crate::operations::point_ops::{
     ConditionalInsertOperationInternal, PointInsertOperationsInternal, PointOperations,
     PointStructPersisted, PointStructRawPersisted, UpdateMode,
@@ -25,10 +25,13 @@ use crate::operations::vector_ops::{PointVectorsPersisted, UpdateVectorsOp, Vect
 use crate::operations::{
     CreateVectorName, DeleteVectorName, FieldIndexOperations, VectorNameOperations,
 };
+use crate::segment_holder::locked::LockedSegmentHolder;
+use crate::segment_holder::provisioning::SegmentProvisioning;
 use crate::segment_holder::{SegmentHolder, SegmentId};
 
 pub fn process_point_operation(
-    segments: &SegmentHolder,
+    segments: &LockedSegmentHolder,
+    provisioning: Option<&SegmentProvisioning>,
     op_num: SeqNumberType,
     point_operation: PointOperations,
     hw_counter: &HardwareCounterCell,
@@ -36,50 +39,58 @@ pub fn process_point_operation(
     match point_operation {
         PointOperations::UpsertPoints(operation) => {
             let points = operation.into_point_vec();
-            if points.is_empty() {
-                // An empty upsert (e.g. an emptied-out resolved conditional upsert)
-                // touches no segment; bump so WAL can acknowledge it.
-                segments.bump_max_segment_version_overwrite(op_num);
-            }
-            let res = upsert_points(segments, op_num, points.iter(), hw_counter)?;
-            Ok(res)
+            segments.update_with_segment_provisioning(provisioning, |segments| {
+                if points.is_empty() {
+                    // An empty upsert (e.g. an emptied-out resolved conditional upsert)
+                    // touches no segment; bump so WAL can acknowledge it.
+                    segments.bump_max_segment_version_overwrite(op_num);
+                }
+                upsert_points(segments, op_num, points.iter(), hw_counter)
+            })
         }
         PointOperations::UpsertPointsConditional(operation) => {
-            conditional_upsert(segments, op_num, operation, hw_counter)
+            conditional_upsert(segments, provisioning, op_num, operation, hw_counter)
         }
-        PointOperations::DeletePoints { ids } => delete_points(segments, op_num, &ids, hw_counter),
+        PointOperations::DeletePoints { ids } => {
+            delete_points(&segments.read(), op_num, &ids, hw_counter)
+        }
         PointOperations::DeletePointsByFilter(filter) => {
-            delete_points_by_filter(segments, op_num, &filter, hw_counter)
+            delete_points_by_filter(&segments.read(), op_num, &filter, hw_counter)
         }
         PointOperations::SyncPoints(operation) => {
-            let (deleted, new, updated) = sync_points(
-                segments,
-                op_num,
-                operation.from_id,
-                operation.to_id,
-                &operation.points,
-                hw_counter,
-            )?;
-            Ok(deleted + new + updated)
+            segments.update_with_segment_provisioning(provisioning, |segments| {
+                let (deleted, new, updated) = sync_points(
+                    segments,
+                    op_num,
+                    operation.from_id,
+                    operation.to_id,
+                    &operation.points,
+                    hw_counter,
+                )?;
+                Ok(deleted + new + updated)
+            })
         }
         PointOperations::UpsertPointsRaw(points) => {
-            if points.is_empty() {
-                // An empty upsert touches no segment; bump so WAL can acknowledge it.
-                segments.bump_max_segment_version_overwrite(op_num);
-            }
-            let res = upsert_points_raw(segments, op_num, points.iter(), hw_counter)?;
-            Ok(res)
+            segments.update_with_segment_provisioning(provisioning, |segments| {
+                if points.is_empty() {
+                    // An empty upsert touches no segment; bump so WAL can acknowledge it.
+                    segments.bump_max_segment_version_overwrite(op_num);
+                }
+                upsert_points_raw(segments, op_num, points.iter(), hw_counter)
+            })
         }
         PointOperations::SyncPointsRaw(operation) => {
-            let (deleted, new, updated) = sync_points_raw(
-                segments,
-                op_num,
-                operation.from_id,
-                operation.to_id,
-                &operation.points,
-                hw_counter,
-            )?;
-            Ok(deleted + new + updated)
+            segments.update_with_segment_provisioning(provisioning, |segments| {
+                let (deleted, new, updated) = sync_points_raw(
+                    segments,
+                    op_num,
+                    operation.from_id,
+                    operation.to_id,
+                    &operation.points,
+                    hw_counter,
+                )?;
+                Ok(deleted + new + updated)
+            })
         }
     }
 }
@@ -103,37 +114,50 @@ pub fn process_staging_operation(
 }
 
 pub fn process_vector_operation(
-    segments: &SegmentHolder,
+    segments: &LockedSegmentHolder,
+    provisioning: Option<&SegmentProvisioning>,
     op_num: SeqNumberType,
     vector_operation: VectorOperations,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     match vector_operation {
         VectorOperations::UpdateVectors(update_vectors) => {
-            update_vectors_conditional(segments, op_num, update_vectors, hw_counter)
+            update_vectors_conditional(segments, provisioning, op_num, update_vectors, hw_counter)
         }
-        VectorOperations::DeleteVectors(ids, vector_names) => {
-            delete_vectors(segments, op_num, &ids.points, &vector_names, hw_counter)
-        }
-        VectorOperations::DeleteVectorsByFilter(filter, vector_names) => {
-            delete_vectors_by_filter(segments, op_num, &filter, &vector_names, hw_counter)
-        }
+        VectorOperations::DeleteVectors(ids, vector_names) => segments
+            .update_with_segment_provisioning(provisioning, |segments| {
+                delete_vectors(segments, op_num, &ids.points, &vector_names, hw_counter)
+            }),
+        VectorOperations::DeleteVectorsByFilter(filter, vector_names) => segments
+            .update_with_segment_provisioning(provisioning, |segments| {
+                delete_vectors_by_filter(segments, op_num, &filter, &vector_names, hw_counter)
+            }),
     }
 }
 
 pub fn process_payload_operation(
-    segments: &SegmentHolder,
+    segments: &LockedSegmentHolder,
+    provisioning: Option<&SegmentProvisioning>,
     op_num: SeqNumberType,
     payload_operation: PayloadOps,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     match payload_operation {
-        PayloadOps::SetPayload(sp) => {
-            let payload: Payload = sp.payload;
-            if let Some(points) = sp.points {
-                set_payload(segments, op_num, &payload, &points, &sp.key, hw_counter)
-            } else if let Some(filter) = sp.filter {
-                set_payload_by_filter(segments, op_num, &payload, &filter, &sp.key, hw_counter)
+        PayloadOps::SetPayload(set_payload_op) => {
+            let SetPayloadOp {
+                payload,
+                points,
+                filter,
+                key,
+            } = set_payload_op;
+            if let Some(points) = points {
+                segments.update_with_segment_provisioning(provisioning, |segments| {
+                    set_payload(segments, op_num, &payload, &points, &key, hw_counter)
+                })
+            } else if let Some(filter) = filter {
+                segments.update_with_segment_provisioning(provisioning, |segments| {
+                    set_payload_by_filter(segments, op_num, &payload, &filter, &key, hw_counter)
+                })
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(
@@ -141,11 +165,20 @@ pub fn process_payload_operation(
                 ))
             }
         }
-        PayloadOps::DeletePayload(dp) => {
-            if let Some(points) = dp.points {
-                delete_payload(segments, op_num, &points, &dp.keys, hw_counter)
-            } else if let Some(filter) = dp.filter {
-                delete_payload_by_filter(segments, op_num, &filter, &dp.keys, hw_counter)
+        PayloadOps::DeletePayload(delete_payload_op) => {
+            let DeletePayloadOp {
+                points,
+                keys,
+                filter,
+            } = delete_payload_op;
+            if let Some(points) = points {
+                segments.update_with_segment_provisioning(provisioning, |segments| {
+                    delete_payload(segments, op_num, &points, &keys, hw_counter)
+                })
+            } else if let Some(filter) = filter {
+                segments.update_with_segment_provisioning(provisioning, |segments| {
+                    delete_payload_by_filter(segments, op_num, &filter, &keys, hw_counter)
+                })
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(
@@ -153,18 +186,29 @@ pub fn process_payload_operation(
                 ))
             }
         }
-        PayloadOps::ClearPayload { ref points, .. } => {
-            clear_payload(segments, op_num, points, hw_counter)
-        }
-        PayloadOps::ClearPayloadByFilter(ref filter) => {
-            clear_payload_by_filter(segments, op_num, filter, hw_counter)
-        }
-        PayloadOps::OverwritePayload(sp) => {
-            let payload: Payload = sp.payload;
-            if let Some(points) = sp.points {
-                overwrite_payload(segments, op_num, &payload, &points, hw_counter)
-            } else if let Some(filter) = sp.filter {
-                overwrite_payload_by_filter(segments, op_num, &payload, &filter, hw_counter)
+        PayloadOps::ClearPayload { points } => segments
+            .update_with_segment_provisioning(provisioning, |segments| {
+                clear_payload(segments, op_num, &points, hw_counter)
+            }),
+        PayloadOps::ClearPayloadByFilter(filter) => segments
+            .update_with_segment_provisioning(provisioning, |segments| {
+                clear_payload_by_filter(segments, op_num, &filter, hw_counter)
+            }),
+        PayloadOps::OverwritePayload(set_payload_op) => {
+            let SetPayloadOp {
+                payload,
+                points,
+                filter,
+                key: _,
+            } = set_payload_op;
+            if let Some(points) = points {
+                segments.update_with_segment_provisioning(provisioning, |segments| {
+                    overwrite_payload(segments, op_num, &payload, &points, hw_counter)
+                })
+            } else if let Some(filter) = filter {
+                segments.update_with_segment_provisioning(provisioning, |segments| {
+                    overwrite_payload_by_filter(segments, op_num, &payload, &filter, hw_counter)
+                })
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(
@@ -199,6 +243,26 @@ pub fn process_field_index_operation(
 /// This is needed to avoid locking segments for too long, so that
 /// parallel read operations are not starved.
 const UPDATE_OP_CHUNK_SIZE: usize = 32;
+
+/// Guard for the insert loops: with a size cap configured on the holder, refuse to insert into a
+/// destination segment that already reached it. The resulting
+/// [`OperationError::OutOfAppendableCapacity`] lets the caller provision a fresh appendable
+/// segment and re-apply; points inserted so far are then skipped by their point version.
+fn check_insert_capacity(
+    segments: &SegmentHolder,
+    write_segment: &RwLockWriteGuard<dyn SegmentEntry>,
+) -> OperationResult<()> {
+    let Some(max_segment_size_bytes) = segments.max_segment_size_bytes() else {
+        return Ok(());
+    };
+    let size = write_segment.max_available_vectors_size_in_bytes()?;
+    if size >= max_segment_size_bytes.get() {
+        return Err(OperationError::OutOfAppendableCapacity {
+            max_segment_size_bytes: max_segment_size_bytes.get(),
+        });
+    }
+    Ok(())
+}
 
 /// Checks point id in each segment, update point if found.
 /// All not found points are inserted into random segment.
@@ -254,16 +318,12 @@ where
             .filter(|x| !updated_points.contains(x));
 
         {
-            let default_write_segment =
-                segments.smallest_appendable_segment().ok_or_else(|| {
-                    OperationError::service_error(
-                        "No appendable segments exist, expected at least one",
-                    )
-                })?;
+            let default_write_segment = segments.smallest_appendable_segment()?;
 
             let segment_arc = default_write_segment.get();
             let mut write_segment = segment_arc.write();
             for point_id in new_point_ids {
+                check_insert_capacity(segments, &write_segment)?;
                 let point = points_map[&point_id];
                 res += usize::from(upsert_with_payload(
                     &mut write_segment,
@@ -326,7 +386,8 @@ pub(crate) fn retain_conditional_upsert_points(
 }
 
 pub fn conditional_upsert(
-    segments: &SegmentHolder,
+    segments: &LockedSegmentHolder,
+    provisioning: Option<&SegmentProvisioning>,
     op_num: SeqNumberType,
     operation: ConditionalInsertOperationInternal,
     hw_counter: &HardwareCounterCell,
@@ -337,18 +398,31 @@ pub fn conditional_upsert(
         update_mode,
     } = operation;
 
-    retain_conditional_upsert_points(segments, &mut points_op, condition, update_mode, hw_counter)?;
-
-    let points = points_op.into_point_vec();
-    let upserted_points = upsert_points(segments, op_num, points.iter(), hw_counter)?;
-
-    if upserted_points == 0 {
-        // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.
-        // If we don't do this, startup might take up a lot of time in some scenarios because of recovering these no-op operations.
-        segments.bump_max_segment_version_overwrite(op_num);
+    // The condition is resolved once, against pre-operation state; a provisioning re-run of the
+    // upsert below must not re-evaluate it against partially applied points.
+    {
+        let segments_guard = segments.read();
+        retain_conditional_upsert_points(
+            &segments_guard,
+            &mut points_op,
+            condition,
+            update_mode,
+            hw_counter,
+        )?;
     }
 
-    Ok(upserted_points)
+    let points = points_op.into_point_vec();
+    segments.update_with_segment_provisioning(provisioning, |segments| {
+        let upserted_points = upsert_points(segments, op_num, points.iter(), hw_counter)?;
+
+        if upserted_points == 0 {
+            // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.
+            // If we don't do this, startup might take up a lot of time in some scenarios because of recovering these no-op operations.
+            segments.bump_max_segment_version_overwrite(op_num);
+        }
+
+        Ok(upserted_points)
+    })
 }
 
 /// Upsert to a point ID with the specified vectors and payload in the given segment.
@@ -676,16 +750,12 @@ where
             .filter(|x| !updated_points.contains(x));
 
         {
-            let default_write_segment =
-                segments.smallest_appendable_segment().ok_or_else(|| {
-                    OperationError::service_error(
-                        "No appendable segments exist, expected at least one",
-                    )
-                })?;
+            let default_write_segment = segments.smallest_appendable_segment()?;
 
             let segment_arc = default_write_segment.get();
             let mut write_segment = segment_arc.write();
             for point_id in new_point_ids {
+                check_insert_capacity(segments, &write_segment)?;
                 res += usize::from(upsert_raw_with_payload(
                     &mut write_segment,
                     op_num,
@@ -799,7 +869,8 @@ pub fn sync_points_raw(
 const VECTOR_OP_BATCH_SIZE: usize = 32;
 
 pub fn update_vectors_conditional(
-    segments: &SegmentHolder,
+    segments: &LockedSegmentHolder,
+    provisioning: Option<&SegmentProvisioning>,
     op_num: SeqNumberType,
     points: UpdateVectorsOp,
     hw_counter: &HardwareCounterCell,
@@ -809,26 +880,22 @@ pub fn update_vectors_conditional(
         update_filter,
     } = points;
 
-    let Some(filter_condition) = update_filter else {
-        return update_vectors(segments, op_num, points, hw_counter);
-    };
+    // The filter is resolved once, against pre-operation state; a provisioning re-run of the
+    // update below must not re-evaluate it against partially applied points.
+    if let Some(filter_condition) = update_filter {
+        let segments_guard = segments.read();
+        let point_ids: Vec<_> = points.iter().map(|point| point.id).collect();
 
-    let point_ids: Vec<_> = points.iter().map(|point| point.id).collect();
+        let points_to_exclude = select_excluded_by_filter_ids(
+            &segments_guard,
+            point_ids,
+            filter_condition,
+            hw_counter,
+        )?;
 
-    let points_to_exclude =
-        select_excluded_by_filter_ids(segments, point_ids, filter_condition, hw_counter)?;
+        points.retain(|p| !points_to_exclude.contains(&p.id));
+    }
 
-    points.retain(|p| !points_to_exclude.contains(&p.id));
-    update_vectors(segments, op_num, points, hw_counter)
-}
-
-/// Update the specified named vectors of a point, keeping unspecified vectors intact.
-fn update_vectors(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    points: Vec<PointVectorsPersisted>,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
     // Build a map of vectors to update per point, merge updates on same point ID
     let mut points_map: AHashMap<PointIdType, NamedVectors> = AHashMap::new();
     for point in points {
@@ -839,6 +906,18 @@ fn update_vectors(
         entry.merge(named_vector);
     }
 
+    segments.update_with_segment_provisioning(provisioning, |segments| {
+        update_vectors(segments, op_num, &points_map, hw_counter)
+    })
+}
+
+/// Update the specified named vectors of a point, keeping unspecified vectors intact.
+fn update_vectors(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    points_map: &AHashMap<PointIdType, NamedVectors>,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
     let ids: Vec<PointIdType> = points_map.keys().copied().collect();
 
     let mut total_updated_points = 0;
@@ -1321,9 +1400,11 @@ fn check_unprocessed_points(
 
 #[cfg(test)]
 mod test {
+    use std::num::NonZeroUsize;
     use std::sync::Arc;
 
     use common::counter::hardware_counter::HardwareCounterCell;
+    use common::save_on_disk::SaveOnDisk;
     use parking_lot::RwLock;
     use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, only_default_vector};
     use segment::entry::ReadSegmentEntry as _;
@@ -1334,15 +1415,22 @@ mod test {
     };
     use tempfile::Builder;
 
+    use super::{
+        PayloadOps, PointInsertOperationsInternal, PointOperations, PointStructPersisted,
+        SetPayloadOp,
+    };
     use crate::fixtures::{
         build_segment_1, build_segment_2, empty_segment, empty_segment_with_deferred,
     };
     use crate::operations::point_ops::PointStructRawPersisted;
+    use crate::segment_holder::locked::LockedSegmentHolder;
+    use crate::segment_holder::provisioning::SegmentProvisioning;
     use crate::segment_holder::{FlushMode, SegmentHolder};
     use crate::update::{
         clear_payload_by_filter, create_field_index, delete_payload_by_filter,
         delete_points_by_filter, delete_vectors_by_filter, overwrite_payload_by_filter,
-        set_payload_by_filter, sync_points_raw, upsert_points_raw,
+        process_payload_operation, process_point_operation, set_payload_by_filter, sync_points_raw,
+        upsert_points_raw,
     };
 
     #[test]
@@ -2224,6 +2312,158 @@ mod test {
         assert!(
             hits.is_empty(),
             "filtered reads must agree with payload storage: the row was cleared",
+        );
+    }
+
+    /// Fixtures use dim-4 f32 vectors: 16 bytes per point.
+    const TEST_POINT_SIZE_BYTES: usize = 16;
+
+    /// Build a holder with a non-appendable segment holding points 1-5 and one empty appendable
+    /// segment, capped at two points worth of vector data, plus the matching provisioning.
+    fn capped_holder_with_immutable_points(
+        path: &std::path::Path,
+    ) -> (LockedSegmentHolder, SegmentProvisioning) {
+        let mut non_appendable = build_segment_1(path); // points 1-5
+        non_appendable.appendable_flag = false;
+        let appendable = empty_segment(path);
+        let segment_config = appendable.segment_config.clone();
+
+        let mut holder = SegmentHolder::default();
+        holder.add_new(non_appendable);
+        holder.add_new(appendable);
+        holder.set_max_segment_size_bytes(NonZeroUsize::new(2 * TEST_POINT_SIZE_BYTES));
+
+        let provisioning = SegmentProvisioning {
+            segments_path: path.to_owned(),
+            segment_config,
+            payload_index_schema: Arc::new(
+                SaveOnDisk::load_or_init_default(path.join("payload.schema")).unwrap(),
+            ),
+            deferred_internal_id: None,
+        };
+
+        (LockedSegmentHolder::new(holder), provisioning)
+    }
+
+    fn appendable_segment_sizes(segments: &LockedSegmentHolder) -> Vec<usize> {
+        let segments = segments.read();
+        segments
+            .iter()
+            .filter_map(|(_segment_id, segment)| {
+                let segment = segment.get().read();
+                segment
+                    .is_appendable()
+                    .then(|| segment.max_available_vectors_size_in_bytes().unwrap())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_cow_move_provisions_segments_at_capacity() {
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        let (segments, provisioning) = capped_holder_with_immutable_points(dir.path());
+
+        // Set payload on all 5 points: every one CoW-moves out of the non-appendable segment.
+        // Only 2 fit into the existing appendable segment, so the update must provision fresh
+        // segments for the remaining 3 instead of overgrowing the destination.
+        let operation = PayloadOps::SetPayload(SetPayloadOp {
+            payload: payload_json! {"town": "Amsterdam"},
+            points: Some((1..=5).map(Into::into).collect()),
+            filter: None,
+            key: None,
+        });
+        let updated =
+            process_payload_operation(&segments, Some(&provisioning), 100, operation, &hw_counter)
+                .unwrap();
+        assert_eq!(updated, 5);
+
+        let sizes = appendable_segment_sizes(&segments);
+        assert!(
+            sizes.iter().all(|size| *size <= 2 * TEST_POINT_SIZE_BYTES),
+            "no appendable segment may exceed the cap: {sizes:?}",
+        );
+        assert_eq!(
+            sizes.iter().sum::<usize>(),
+            5 * TEST_POINT_SIZE_BYTES,
+            "all moved points must be accounted for: {sizes:?}",
+        );
+        assert!(
+            sizes.len() >= 3,
+            "the update must have provisioned fresh appendable segments: {sizes:?}",
+        );
+    }
+
+    #[test]
+    fn test_upsert_provisions_segments_at_capacity() {
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        let appendable = empty_segment(dir.path());
+        let segment_config = appendable.segment_config.clone();
+
+        let mut holder = SegmentHolder::default();
+        holder.add_new(appendable);
+        holder.set_max_segment_size_bytes(NonZeroUsize::new(2 * TEST_POINT_SIZE_BYTES));
+
+        let provisioning = SegmentProvisioning {
+            segments_path: dir.path().to_owned(),
+            segment_config,
+            payload_index_schema: Arc::new(
+                SaveOnDisk::load_or_init_default(dir.path().join("payload.schema")).unwrap(),
+            ),
+            deferred_internal_id: None,
+        };
+        let segments = LockedSegmentHolder::new(holder);
+
+        // Insert 5 new points; only 2 fit under the cap in the initial appendable segment.
+        let points: Vec<_> = (1..=5)
+            .map(|id: u64| PointStructPersisted {
+                id: id.into(),
+                vector: crate::operations::point_ops::VectorStructPersisted::Single(vec![
+                    1.0, 0.0, 1.0, 0.0,
+                ]),
+                payload: None,
+            })
+            .collect();
+        let operation =
+            PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsList(points));
+        process_point_operation(&segments, Some(&provisioning), 100, operation, &hw_counter)
+            .unwrap();
+
+        let sizes = appendable_segment_sizes(&segments);
+        assert!(
+            sizes.iter().all(|size| *size <= 2 * TEST_POINT_SIZE_BYTES),
+            "no appendable segment may exceed the cap: {sizes:?}",
+        );
+        assert_eq!(
+            sizes.iter().sum::<usize>(),
+            5 * TEST_POINT_SIZE_BYTES,
+            "all inserted points must be accounted for: {sizes:?}",
+        );
+    }
+
+    #[test]
+    fn test_capacity_error_without_provisioning() {
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        let (segments, _provisioning) = capped_holder_with_immutable_points(dir.path());
+
+        // Without provisioning, the same update must fail once the destination is full, and the
+        // error must be recognizable so callers with provisioning can recover from it.
+        let operation = PayloadOps::SetPayload(SetPayloadOp {
+            payload: payload_json! {"town": "Amsterdam"},
+            points: Some((1..=5).map(Into::into).collect()),
+            filter: None,
+            key: None,
+        });
+        let err = process_payload_operation(&segments, None, 100, operation, &hw_counter)
+            .expect_err("the appendable segment cannot hold all 5 moved points");
+        assert!(
+            err.is_out_of_appendable_capacity(),
+            "expected OutOfAppendableCapacity, got: {err}",
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes appendable segment overflow (repro in #9158): the update path picked CoW-move destinations and insert targets without any size check, so one large operation (e.g. `set_payload` by a broad filter over indexed segments) piled every moved point into a single appendable segment, growing it far past `max_segment_size`. This is Phase 1 of the unstuck-WAL-recovery plan.

## How it works

**Soft size cap on the holder.** `UpdateHandler::run_workers` mirrors the resolved optimizer `max_segment_size_kb` threshold into `SegmentHolder::max_segment_size_bytes` — on shard creation and on optimizer config updates (which restart the workers). Holders without a cap (edge, tests) behave exactly as before.

**Capacity-aware destination selection** (`lib/shard/src/segment_holder/mod.rs`):
- `apply_points_with_conditional_move` re-checks destination capacity **per moved point** — a large operation fills the destination mid-way and the next point must go elsewhere. Aloha randomization is kept among under-cap candidates; unmeasurable segments (lock contention) stay eligible, so the soft cap never blocks progress on measurement issues.
- `smallest_appendable_segment` (upsert insert path) errors when even the smallest segment reached the cap, and the insert loops re-check the destination per inserted point.
- When no appendable segment has capacity, the operation fails with the new recoverable `OperationError::OutOfAppendableCapacity`.

**Provision-and-re-apply** (`lib/shard/src/segment_holder/provisioning.rs`): `LockedSegmentHolder::update_with_segment_provisioning` runs the update under a read guard; on a capacity error it provisions a fresh appendable segment (the same `build_tmp_segment` + manifest + `add_new_locked` machinery the optimization worker already used between operations, now shared) and re-runs the update. Re-running is safe and cheap because updates are idempotent per point version — each attempt skips already-applied points and resumes where the last one stopped, exactly like WAL replay. Guarded by a progress invariant (a repeated capacity error with the previously provisioned segment still empty aborts) plus a generous attempt backstop.

**Wiring.** The moving `process_point/vector/payload_operation` entry points now take `&LockedSegmentHolder` plus `Option<&SegmentProvisioning>` and manage the holder guard per attempt (one attempt = one guard, so the happy path keeps today's locking granularity). Filter/condition resolution for conditional upserts and conditional vector updates happens once, against pre-operation state, outside the retry loop. Provisioning is wired from the update worker, WAL replay (`load_from_wal`), and failed-operation recovery (`try_recover`); it is sourced from the first optimizer, same as the worker's periodic capacity ensure. The edge shard passes `None` and sets no cap — unchanged behavior.

Since a capacity error escaping the retry (provisioning failure) maps to a transient `ServiceError`, the existing failed-operation recovery re-applies it later.

## Testing

- The reproduction test from #9158 is included, adapted to configure the cap and provisioning; it now passes: `set_payload` by an all-matching filter over two indexed segments spills into provisioned segments and no segment exceeds `max_segment_size`.
- New lib/shard unit tests: CoW-move spilling across provisioned segments at a 2-point cap, upsert insert spilling, and the `OutOfAppendableCapacity` error surfacing without provisioning.
- `cargo test -p shard --lib` (108), `cargo test -p collection --lib` (245), `cargo test -p edge` all pass; clippy clean on touched crates.

## Notes

- The cap is deliberately soft: per-point checks bound overshoot to at most one point past the cap; under segment lock contention the check is skipped rather than blocking or failing.
- Not in scope: the edge shard could later opt in by setting a cap + provisioning; strict-mode limits on resolved filter-op sizes remain a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)