### PR TITLE
Wire segment provisioning through the update path

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use segment::types::SeqNumberType;
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::segment_holder::provisioning::SegmentProvisioning;
 use shard::update::*;
 
 use crate::operations::CollectionUpdateOperations;
@@ -40,6 +41,7 @@ impl CollectionUpdater {
 
     pub fn update(
         segments: &LockedSegmentHolder,
+        provisioning: Option<&SegmentProvisioning>,
         op_num: SeqNumberType,
         operation: CollectionUpdateOperations,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
@@ -58,18 +60,33 @@ impl CollectionUpdater {
             // Needs to be acquired before locking segments.
             let _another_update_lock = segments.acquire_updates_lock();
 
-            let segments_guard = segments.read();
-
+            // Operations that may CoW-move or insert points receive the segment holder lock
+            // itself (plus provisioning): when all appendable segments hit `max_segment_size`,
+            // they provision a fresh one — which needs the holder write lock — and re-apply.
+            // Operations that cannot grow appendable segments just take a read guard here.
             match operation {
                 CollectionUpdateOperations::PointOperation(point_operation) => {
-                    process_point_operation(&segments_guard, op_num, point_operation, hw_counter)
+                    process_point_operation(
+                        segments,
+                        provisioning,
+                        op_num,
+                        point_operation,
+                        hw_counter,
+                    )
                 }
                 CollectionUpdateOperations::VectorOperation(vector_operation) => {
-                    process_vector_operation(&segments_guard, op_num, vector_operation, hw_counter)
+                    process_vector_operation(
+                        segments,
+                        provisioning,
+                        op_num,
+                        vector_operation,
+                        hw_counter,
+                    )
                 }
                 CollectionUpdateOperations::PayloadOperation(payload_operation) => {
                     process_payload_operation(
-                        &segments_guard,
+                        segments,
+                        provisioning,
                         op_num,
                         payload_operation,
                         hw_counter,
@@ -77,19 +94,19 @@ impl CollectionUpdater {
                 }
                 CollectionUpdateOperations::FieldIndexOperation(index_operation) => {
                     process_field_index_operation(
-                        &segments_guard,
+                        &segments.read(),
                         op_num,
                         &index_operation,
                         hw_counter,
                     )
                 }
                 CollectionUpdateOperations::VectorNameOperation(vector_name_operation) => {
-                    process_vector_name_operation(&segments_guard, op_num, &vector_name_operation)
+                    process_vector_name_operation(&segments.read(), op_num, &vector_name_operation)
                 }
                 #[cfg(feature = "staging")]
                 CollectionUpdateOperations::StagingOperation(staging_operation) => {
                     shard::update::process_staging_operation(
-                        &segments_guard,
+                        &segments.read(),
                         op_num,
                         staging_operation,
                     )
@@ -246,7 +263,8 @@ mod tests {
         }
 
         process_point_operation(
-            &segments.read(),
+            &segments,
+            None,
             101,
             PointOperations::DeletePoints {
                 ids: vec![500.into()],
@@ -287,7 +305,8 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         process_payload_operation(
-            &segments.read(),
+            &segments,
+            None,
             100,
             PayloadOps::SetPayload(SetPayloadOp {
                 payload,
@@ -327,7 +346,8 @@ mod tests {
 
         // Test payload delete
         process_payload_operation(
-            &segments.read(),
+            &segments,
+            None,
             101,
             PayloadOps::DeletePayload(DeletePayloadOp {
                 points: Some(vec![3.into()]),
@@ -375,7 +395,8 @@ mod tests {
         assert!(res[0].payload.as_ref().unwrap().contains_key("color"));
 
         process_payload_operation(
-            &segments.read(),
+            &segments,
+            None,
             102,
             PayloadOps::ClearPayload {
                 points: vec![2.into()],
@@ -444,7 +465,8 @@ mod tests {
         let points = vec![11.into(), 12.into(), 13.into()];
 
         process_payload_operation(
-            &segments.read(),
+            &segments,
+            None,
             102,
             PayloadOps::SetPayload(SetPayloadOp {
                 payload,
@@ -508,7 +530,8 @@ mod tests {
         let payload: Payload = serde_json::from_str(r#"{ "color":"blue"}"#).unwrap();
 
         process_payload_operation(
-            &segments.read(),
+            &segments,
+            None,
             103,
             PayloadOps::SetPayload(SetPayloadOp {
                 payload,

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -628,7 +628,8 @@ mod tests {
         let hw_counter = HardwareCounterCell::new();
 
         process_point_operation(
-            &locked_holder.read(),
+            &locked_holder,
+            None,
             opnum.next().unwrap(),
             insert_point_ops,
             &hw_counter,
@@ -693,7 +694,8 @@ mod tests {
             PointOperations::UpsertPoints(PointInsertOperationsInternal::from(batch));
 
         process_point_operation(
-            &locked_holder.read(),
+            &locked_holder,
+            None,
             opnum.next().unwrap(),
             insert_point_ops,
             &hw_counter,

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -60,6 +60,7 @@ use shard::operations::optimization::{OptimizationSegmentInfo, PendingOptimizati
 use shard::operations::point_ops::{PointInsertOperationsInternal, PointOperations};
 use shard::segment_holder::FlushMode;
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::segment_holder::provisioning::SegmentProvisioning;
 use shard::wal::SerdeWal;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::Sender;
@@ -812,6 +813,15 @@ impl LocalShard {
         // operations, so a name that is created and used within the replay window stays valid.
         let mut valid_vector_names = self.collection_config.read().await.params.vector_names();
 
+        // Replayed operations must be able to provision fresh appendable segments, just like the
+        // regular update path.
+        let provisioning = self.optimizers.load().first().map(|optimizer| {
+            SegmentProvisioning::from_optimizer(
+                optimizer.as_ref(),
+                self.payload_index_schema.clone(),
+            )
+        });
+
         for entry in wal.read_range(from..to) {
             let (op_num, mut update) = entry.map_err(|e| {
                 CollectionError::service_error(format!(
@@ -839,6 +849,7 @@ impl LocalShard {
             // Propagate `CollectionError::ServiceError`, but skip other error types.
             match &CollectionUpdater::update(
                 &self.segments,
+                provisioning.as_ref(),
                 op_num,
                 update.operation,
                 self.update_operation_lock.clone(),

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -7,9 +8,11 @@ use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use parking_lot::Mutex;
+use segment::common::BYTES_IN_KB;
 use segment::types::SeqNumberType;
 use shard::operations::CollectionUpdateOperations;
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::segment_holder::provisioning::SegmentProvisioning;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::{self, Receiver};
 use tokio::sync::{Mutex as TokioMutex, oneshot, watch};
@@ -189,6 +192,26 @@ impl UpdateHandler {
     }
 
     pub fn run_workers(&mut self, update_receiver: Receiver<UpdateSignal>) {
+        // Mirror the resolved optimizer size threshold into the segment holder (both on shard
+        // creation and on optimizer config updates, which restart the workers), and hand the
+        // update worker everything it needs to provision fresh appendable segments when all
+        // existing ones reach that threshold.
+        let provisioning = self.optimizers.first().map(|optimizer| {
+            let max_segment_size_bytes = NonZeroUsize::new(
+                optimizer
+                    .threshold_config()
+                    .max_segment_size_kb
+                    .saturating_mul(BYTES_IN_KB),
+            );
+            self.segments
+                .write()
+                .set_max_segment_size_bytes(max_segment_size_bytes);
+            Arc::new(SegmentProvisioning::from_optimizer(
+                optimizer.as_ref(),
+                self.payload_index_schema.clone(),
+            ))
+        });
+
         let (tx, rx) = mpsc::channel(self.shared_storage_config.update_queue_size);
 
         // Optimization notifier is triggered when a new optimization is finished
@@ -232,6 +255,7 @@ impl UpdateHandler {
             tx,
             wal,
             segments,
+            provisioning,
             scroll_read_lock,
             update_tracker,
             self.prevent_unoptimized,

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -70,6 +70,13 @@ impl UpdateWorkers {
         let max_handles = max_handles.unwrap_or(usize::MAX);
         let num_indexing_threads = some_optimizer.num_indexing_threads();
 
+        // For failed-operation recovery: re-applied operations must be able to provision fresh
+        // appendable segments, just like the regular update path.
+        let recovery_provisioning = SegmentProvisioning::from_optimizer(
+            some_optimizer.as_ref(),
+            payload_index_schema.clone(),
+        );
+
         // Asynchronous task to trigger optimizers once CPU budget is available again
         let mut resource_available_trigger: Option<JoinHandle<()>> = None;
 
@@ -140,6 +147,7 @@ impl UpdateWorkers {
             if Self::try_recover(
                 segments.clone(),
                 wal.clone(),
+                Some(&recovery_provisioning),
                 update_operation_lock.clone(),
                 update_tracker.clone(),
             )
@@ -492,6 +500,7 @@ impl UpdateWorkers {
     async fn try_recover(
         segments: LockedSegmentHolder,
         wal: LockedWal,
+        provisioning: Option<&SegmentProvisioning>,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
     ) -> CollectionResult<usize> {
@@ -509,6 +518,7 @@ impl UpdateWorkers {
                     })?;
                     CollectionUpdater::update(
                         &segments,
+                        provisioning,
                         op_num,
                         operation.operation,
                         update_operation_lock.clone(),

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -6,6 +6,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::types::SeqNumberType;
 use shard::operations::CollectionUpdateOperations;
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::segment_holder::provisioning::SegmentProvisioning;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::{oneshot, watch};
 use tokio_util::task::AbortOnDropHandle;
@@ -47,6 +48,7 @@ impl UpdateWorkers {
         optimize_sender: Sender<OptimizerSignal>,
         wal: LockedWal,
         segments: LockedSegmentHolder,
+        provisioning: Option<Arc<SegmentProvisioning>>,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
         prevent_unoptimized: bool,
@@ -120,6 +122,7 @@ impl UpdateWorkers {
 
                     let wait = sender.is_some();
                     let segments_clone = segments.clone();
+                    let provisioning_clone = provisioning.clone();
                     let operation_result = tokio::task::spawn_blocking(move || {
                         Self::update_worker_internal(
                             collection_name_clone,
@@ -128,6 +131,7 @@ impl UpdateWorkers {
                             wait,
                             wal_clone,
                             segments_clone,
+                            provisioning_clone,
                             update_operation_lock_clone,
                             update_tracker_clone,
                             hw_measurements,
@@ -309,6 +313,7 @@ impl UpdateWorkers {
         wait: bool,
         wal: LockedWal,
         segments: LockedSegmentHolder,
+        provisioning: Option<Arc<SegmentProvisioning>>,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
         hw_measurements: HwMeasurementAcc,
@@ -333,6 +338,7 @@ impl UpdateWorkers {
         let result = cpu_utilization.measure(|| {
             CollectionUpdater::update(
                 &segments,
+                provisioning.as_deref(),
                 op_num,
                 operation,
                 update_operation_lock.clone(),

--- a/lib/edge/src/update.rs
+++ b/lib/edge/src/update.rs
@@ -20,15 +20,20 @@ impl EdgeShard {
         let hw_counter = HardwareCounterCell::disposable();
         let _update_guard = self.segments.acquire_updates_lock();
 
-        let segments_guard = self.segments.read();
-
+        // No segment provisioning: the edge shard configures no appendable size cap, so updates
+        // never report `OutOfAppendableCapacity` and run in a single attempt.
         let result = match operation {
-            CollectionUpdateOperations::PointOperation(point_operation) => {
-                process_point_operation(&segments_guard, operation_id, point_operation, &hw_counter)
-            }
+            CollectionUpdateOperations::PointOperation(point_operation) => process_point_operation(
+                &self.segments,
+                None,
+                operation_id,
+                point_operation,
+                &hw_counter,
+            ),
             CollectionUpdateOperations::VectorOperation(vector_operation) => {
                 process_vector_operation(
-                    &segments_guard,
+                    &self.segments,
+                    None,
                     operation_id,
                     vector_operation,
                     &hw_counter,
@@ -36,7 +41,8 @@ impl EdgeShard {
             }
             CollectionUpdateOperations::PayloadOperation(payload_operation) => {
                 process_payload_operation(
-                    &segments_guard,
+                    &self.segments,
+                    None,
                     operation_id,
                     payload_operation,
                     &hw_counter,
@@ -44,7 +50,7 @@ impl EdgeShard {
             }
             CollectionUpdateOperations::FieldIndexOperation(index_operation) => {
                 process_field_index_operation(
-                    &segments_guard,
+                    &self.segments.read(),
                     operation_id,
                     &index_operation,
                     &hw_counter,
@@ -52,7 +58,7 @@ impl EdgeShard {
             }
             CollectionUpdateOperations::VectorNameOperation(ref vector_name_operation) => {
                 let result = process_vector_name_operation(
-                    &segments_guard,
+                    &self.segments.read(),
                     operation_id,
                     vector_name_operation,
                 );
@@ -65,7 +71,7 @@ impl EdgeShard {
             #[cfg(feature = "staging")]
             CollectionUpdateOperations::StagingOperation(staging_operation) => {
                 shard::update::process_staging_operation(
-                    &segments_guard,
+                    &self.segments.read(),
                     operation_id,
                     staging_operation,
                 )

--- a/lib/shard/src/resolve.rs
+++ b/lib/shard/src/resolve.rs
@@ -249,6 +249,7 @@ mod tests {
     use crate::operations::point_ops::{
         PointInsertOperationsInternal, PointStructPersisted, UpdateMode, VectorStructPersisted,
     };
+    use crate::segment_holder::locked::LockedSegmentHolder;
     use crate::update::{delete_points_by_filter, points_by_filter, process_point_operation};
 
     fn color_filter(color: &str) -> Filter {
@@ -313,10 +314,11 @@ mod tests {
         let CollectionUpdateOperations::PointOperation(op) = resolved else {
             unreachable!()
         };
-        process_point_operation(&holder, 100, op, &hw_counter).unwrap();
+        let locked_holder = LockedSegmentHolder::new(holder);
+        process_point_operation(&locked_holder, None, 100, op, &hw_counter).unwrap();
         delete_points_by_filter(&twin_holder, 100, &filter, &hw_counter).unwrap();
 
-        let remaining = points_by_filter(&holder, &filter, &hw_counter).unwrap();
+        let remaining = points_by_filter(&locked_holder.read(), &filter, &hw_counter).unwrap();
         let twin_remaining = points_by_filter(&twin_holder, &filter, &hw_counter).unwrap();
         assert!(remaining.is_empty(), "resolved delete left {remaining:?}");
         assert!(twin_remaining.is_empty());

--- a/lib/shard/src/update.rs
+++ b/lib/shard/src/update.rs
@@ -16,7 +16,7 @@ use segment::types::{
     SeqNumberType, VectorNameBuf, WithPayload, WithVector,
 };
 
-use crate::operations::payload_ops::PayloadOps;
+use crate::operations::payload_ops::{DeletePayloadOp, PayloadOps, SetPayloadOp};
 use crate::operations::point_ops::{
     ConditionalInsertOperationInternal, PointInsertOperationsInternal, PointOperations,
     PointStructPersisted, PointStructRawPersisted, UpdateMode,
@@ -25,10 +25,13 @@ use crate::operations::vector_ops::{PointVectorsPersisted, UpdateVectorsOp, Vect
 use crate::operations::{
     CreateVectorName, DeleteVectorName, FieldIndexOperations, VectorNameOperations,
 };
+use crate::segment_holder::locked::LockedSegmentHolder;
+use crate::segment_holder::provisioning::SegmentProvisioning;
 use crate::segment_holder::{SegmentHolder, SegmentId};
 
 pub fn process_point_operation(
-    segments: &SegmentHolder,
+    segments: &LockedSegmentHolder,
+    provisioning: Option<&SegmentProvisioning>,
     op_num: SeqNumberType,
     point_operation: PointOperations,
     hw_counter: &HardwareCounterCell,
@@ -36,50 +39,58 @@ pub fn process_point_operation(
     match point_operation {
         PointOperations::UpsertPoints(operation) => {
             let points = operation.into_point_vec();
-            if points.is_empty() {
-                // An empty upsert (e.g. an emptied-out resolved conditional upsert)
-                // touches no segment; bump so WAL can acknowledge it.
-                segments.bump_max_segment_version_overwrite(op_num);
-            }
-            let res = upsert_points(segments, op_num, points.iter(), hw_counter)?;
-            Ok(res)
+            segments.update_with_segment_provisioning(provisioning, |segments| {
+                if points.is_empty() {
+                    // An empty upsert (e.g. an emptied-out resolved conditional upsert)
+                    // touches no segment; bump so WAL can acknowledge it.
+                    segments.bump_max_segment_version_overwrite(op_num);
+                }
+                upsert_points(segments, op_num, points.iter(), hw_counter)
+            })
         }
         PointOperations::UpsertPointsConditional(operation) => {
-            conditional_upsert(segments, op_num, operation, hw_counter)
+            conditional_upsert(segments, provisioning, op_num, operation, hw_counter)
         }
-        PointOperations::DeletePoints { ids } => delete_points(segments, op_num, &ids, hw_counter),
+        PointOperations::DeletePoints { ids } => {
+            delete_points(&segments.read(), op_num, &ids, hw_counter)
+        }
         PointOperations::DeletePointsByFilter(filter) => {
-            delete_points_by_filter(segments, op_num, &filter, hw_counter)
+            delete_points_by_filter(&segments.read(), op_num, &filter, hw_counter)
         }
         PointOperations::SyncPoints(operation) => {
-            let (deleted, new, updated) = sync_points(
-                segments,
-                op_num,
-                operation.from_id,
-                operation.to_id,
-                &operation.points,
-                hw_counter,
-            )?;
-            Ok(deleted + new + updated)
+            segments.update_with_segment_provisioning(provisioning, |segments| {
+                let (deleted, new, updated) = sync_points(
+                    segments,
+                    op_num,
+                    operation.from_id,
+                    operation.to_id,
+                    &operation.points,
+                    hw_counter,
+                )?;
+                Ok(deleted + new + updated)
+            })
         }
         PointOperations::UpsertPointsRaw(points) => {
-            if points.is_empty() {
-                // An empty upsert touches no segment; bump so WAL can acknowledge it.
-                segments.bump_max_segment_version_overwrite(op_num);
-            }
-            let res = upsert_points_raw(segments, op_num, points.iter(), hw_counter)?;
-            Ok(res)
+            segments.update_with_segment_provisioning(provisioning, |segments| {
+                if points.is_empty() {
+                    // An empty upsert touches no segment; bump so WAL can acknowledge it.
+                    segments.bump_max_segment_version_overwrite(op_num);
+                }
+                upsert_points_raw(segments, op_num, points.iter(), hw_counter)
+            })
         }
         PointOperations::SyncPointsRaw(operation) => {
-            let (deleted, new, updated) = sync_points_raw(
-                segments,
-                op_num,
-                operation.from_id,
-                operation.to_id,
-                &operation.points,
-                hw_counter,
-            )?;
-            Ok(deleted + new + updated)
+            segments.update_with_segment_provisioning(provisioning, |segments| {
+                let (deleted, new, updated) = sync_points_raw(
+                    segments,
+                    op_num,
+                    operation.from_id,
+                    operation.to_id,
+                    &operation.points,
+                    hw_counter,
+                )?;
+                Ok(deleted + new + updated)
+            })
         }
     }
 }
@@ -103,37 +114,50 @@ pub fn process_staging_operation(
 }
 
 pub fn process_vector_operation(
-    segments: &SegmentHolder,
+    segments: &LockedSegmentHolder,
+    provisioning: Option<&SegmentProvisioning>,
     op_num: SeqNumberType,
     vector_operation: VectorOperations,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     match vector_operation {
         VectorOperations::UpdateVectors(update_vectors) => {
-            update_vectors_conditional(segments, op_num, update_vectors, hw_counter)
+            update_vectors_conditional(segments, provisioning, op_num, update_vectors, hw_counter)
         }
-        VectorOperations::DeleteVectors(ids, vector_names) => {
-            delete_vectors(segments, op_num, &ids.points, &vector_names, hw_counter)
-        }
-        VectorOperations::DeleteVectorsByFilter(filter, vector_names) => {
-            delete_vectors_by_filter(segments, op_num, &filter, &vector_names, hw_counter)
-        }
+        VectorOperations::DeleteVectors(ids, vector_names) => segments
+            .update_with_segment_provisioning(provisioning, |segments| {
+                delete_vectors(segments, op_num, &ids.points, &vector_names, hw_counter)
+            }),
+        VectorOperations::DeleteVectorsByFilter(filter, vector_names) => segments
+            .update_with_segment_provisioning(provisioning, |segments| {
+                delete_vectors_by_filter(segments, op_num, &filter, &vector_names, hw_counter)
+            }),
     }
 }
 
 pub fn process_payload_operation(
-    segments: &SegmentHolder,
+    segments: &LockedSegmentHolder,
+    provisioning: Option<&SegmentProvisioning>,
     op_num: SeqNumberType,
     payload_operation: PayloadOps,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     match payload_operation {
-        PayloadOps::SetPayload(sp) => {
-            let payload: Payload = sp.payload;
-            if let Some(points) = sp.points {
-                set_payload(segments, op_num, &payload, &points, &sp.key, hw_counter)
-            } else if let Some(filter) = sp.filter {
-                set_payload_by_filter(segments, op_num, &payload, &filter, &sp.key, hw_counter)
+        PayloadOps::SetPayload(set_payload_op) => {
+            let SetPayloadOp {
+                payload,
+                points,
+                filter,
+                key,
+            } = set_payload_op;
+            if let Some(points) = points {
+                segments.update_with_segment_provisioning(provisioning, |segments| {
+                    set_payload(segments, op_num, &payload, &points, &key, hw_counter)
+                })
+            } else if let Some(filter) = filter {
+                segments.update_with_segment_provisioning(provisioning, |segments| {
+                    set_payload_by_filter(segments, op_num, &payload, &filter, &key, hw_counter)
+                })
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(
@@ -141,11 +165,20 @@ pub fn process_payload_operation(
                 ))
             }
         }
-        PayloadOps::DeletePayload(dp) => {
-            if let Some(points) = dp.points {
-                delete_payload(segments, op_num, &points, &dp.keys, hw_counter)
-            } else if let Some(filter) = dp.filter {
-                delete_payload_by_filter(segments, op_num, &filter, &dp.keys, hw_counter)
+        PayloadOps::DeletePayload(delete_payload_op) => {
+            let DeletePayloadOp {
+                points,
+                keys,
+                filter,
+            } = delete_payload_op;
+            if let Some(points) = points {
+                segments.update_with_segment_provisioning(provisioning, |segments| {
+                    delete_payload(segments, op_num, &points, &keys, hw_counter)
+                })
+            } else if let Some(filter) = filter {
+                segments.update_with_segment_provisioning(provisioning, |segments| {
+                    delete_payload_by_filter(segments, op_num, &filter, &keys, hw_counter)
+                })
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(
@@ -153,18 +186,29 @@ pub fn process_payload_operation(
                 ))
             }
         }
-        PayloadOps::ClearPayload { ref points, .. } => {
-            clear_payload(segments, op_num, points, hw_counter)
-        }
-        PayloadOps::ClearPayloadByFilter(ref filter) => {
-            clear_payload_by_filter(segments, op_num, filter, hw_counter)
-        }
-        PayloadOps::OverwritePayload(sp) => {
-            let payload: Payload = sp.payload;
-            if let Some(points) = sp.points {
-                overwrite_payload(segments, op_num, &payload, &points, hw_counter)
-            } else if let Some(filter) = sp.filter {
-                overwrite_payload_by_filter(segments, op_num, &payload, &filter, hw_counter)
+        PayloadOps::ClearPayload { points } => segments
+            .update_with_segment_provisioning(provisioning, |segments| {
+                clear_payload(segments, op_num, &points, hw_counter)
+            }),
+        PayloadOps::ClearPayloadByFilter(filter) => segments
+            .update_with_segment_provisioning(provisioning, |segments| {
+                clear_payload_by_filter(segments, op_num, &filter, hw_counter)
+            }),
+        PayloadOps::OverwritePayload(set_payload_op) => {
+            let SetPayloadOp {
+                payload,
+                points,
+                filter,
+                key: _,
+            } = set_payload_op;
+            if let Some(points) = points {
+                segments.update_with_segment_provisioning(provisioning, |segments| {
+                    overwrite_payload(segments, op_num, &payload, &points, hw_counter)
+                })
+            } else if let Some(filter) = filter {
+                segments.update_with_segment_provisioning(provisioning, |segments| {
+                    overwrite_payload_by_filter(segments, op_num, &payload, &filter, hw_counter)
+                })
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(
@@ -342,7 +386,8 @@ pub(crate) fn retain_conditional_upsert_points(
 }
 
 pub fn conditional_upsert(
-    segments: &SegmentHolder,
+    segments: &LockedSegmentHolder,
+    provisioning: Option<&SegmentProvisioning>,
     op_num: SeqNumberType,
     operation: ConditionalInsertOperationInternal,
     hw_counter: &HardwareCounterCell,
@@ -353,18 +398,31 @@ pub fn conditional_upsert(
         update_mode,
     } = operation;
 
-    retain_conditional_upsert_points(segments, &mut points_op, condition, update_mode, hw_counter)?;
-
-    let points = points_op.into_point_vec();
-    let upserted_points = upsert_points(segments, op_num, points.iter(), hw_counter)?;
-
-    if upserted_points == 0 {
-        // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.
-        // If we don't do this, startup might take up a lot of time in some scenarios because of recovering these no-op operations.
-        segments.bump_max_segment_version_overwrite(op_num);
+    // The condition is resolved once, against pre-operation state; a provisioning re-run of the
+    // upsert below must not re-evaluate it against partially applied points.
+    {
+        let segments_guard = segments.read();
+        retain_conditional_upsert_points(
+            &segments_guard,
+            &mut points_op,
+            condition,
+            update_mode,
+            hw_counter,
+        )?;
     }
 
-    Ok(upserted_points)
+    let points = points_op.into_point_vec();
+    segments.update_with_segment_provisioning(provisioning, |segments| {
+        let upserted_points = upsert_points(segments, op_num, points.iter(), hw_counter)?;
+
+        if upserted_points == 0 {
+            // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.
+            // If we don't do this, startup might take up a lot of time in some scenarios because of recovering these no-op operations.
+            segments.bump_max_segment_version_overwrite(op_num);
+        }
+
+        Ok(upserted_points)
+    })
 }
 
 /// Upsert to a point ID with the specified vectors and payload in the given segment.
@@ -811,7 +869,8 @@ pub fn sync_points_raw(
 const VECTOR_OP_BATCH_SIZE: usize = 32;
 
 pub fn update_vectors_conditional(
-    segments: &SegmentHolder,
+    segments: &LockedSegmentHolder,
+    provisioning: Option<&SegmentProvisioning>,
     op_num: SeqNumberType,
     points: UpdateVectorsOp,
     hw_counter: &HardwareCounterCell,
@@ -821,26 +880,22 @@ pub fn update_vectors_conditional(
         update_filter,
     } = points;
 
-    let Some(filter_condition) = update_filter else {
-        return update_vectors(segments, op_num, points, hw_counter);
-    };
+    // The filter is resolved once, against pre-operation state; a provisioning re-run of the
+    // update below must not re-evaluate it against partially applied points.
+    if let Some(filter_condition) = update_filter {
+        let segments_guard = segments.read();
+        let point_ids: Vec<_> = points.iter().map(|point| point.id).collect();
 
-    let point_ids: Vec<_> = points.iter().map(|point| point.id).collect();
+        let points_to_exclude = select_excluded_by_filter_ids(
+            &segments_guard,
+            point_ids,
+            filter_condition,
+            hw_counter,
+        )?;
 
-    let points_to_exclude =
-        select_excluded_by_filter_ids(segments, point_ids, filter_condition, hw_counter)?;
+        points.retain(|p| !points_to_exclude.contains(&p.id));
+    }
 
-    points.retain(|p| !points_to_exclude.contains(&p.id));
-    update_vectors(segments, op_num, points, hw_counter)
-}
-
-/// Update the specified named vectors of a point, keeping unspecified vectors intact.
-fn update_vectors(
-    segments: &SegmentHolder,
-    op_num: SeqNumberType,
-    points: Vec<PointVectorsPersisted>,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<usize> {
     // Build a map of vectors to update per point, merge updates on same point ID
     let mut points_map: AHashMap<PointIdType, NamedVectors> = AHashMap::new();
     for point in points {
@@ -851,6 +906,18 @@ fn update_vectors(
         entry.merge(named_vector);
     }
 
+    segments.update_with_segment_provisioning(provisioning, |segments| {
+        update_vectors(segments, op_num, &points_map, hw_counter)
+    })
+}
+
+/// Update the specified named vectors of a point, keeping unspecified vectors intact.
+fn update_vectors(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    points_map: &AHashMap<PointIdType, NamedVectors>,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize> {
     let ids: Vec<PointIdType> = points_map.keys().copied().collect();
 
     let mut total_updated_points = 0;


### PR DESCRIPTION
Part **4/5** of the appendable segment overflow fix (#9158). Stacked on the provisioning PR. This is the mechanical fan-out part — the substantive hunks to review are `update_handler.rs::run_workers`, `collection_updater.rs`, and the retry closures in `shard/src/update.rs`; the rest is signature repetition.

- `UpdateHandler::run_workers` mirrors the resolved optimizer `max_segment_size` threshold into the segment holder — covering both shard creation and optimizer config updates, which restart the workers — and builds the `SegmentProvisioning` handed to the update worker. This is what activates the cap from part 2.
- The moving entry points (`process_point/vector/payload_operation`) now take `&LockedSegmentHolder` + `Option<&SegmentProvisioning>` and run through `update_with_segment_provisioning`: one attempt = one read guard (happy path keeps the previous locking granularity); a capacity error provisions and re-applies. The retry loop lives at this level because everything below it borrows the operation data, so re-running never clones the operation.
- Filter/condition resolution for conditional upserts and conditional vector updates happens once, against pre-operation state, outside the retry loop.
- Provisioning is also wired into WAL replay (`load_from_wal`) and failed-operation recovery (`try_recover`).
- The edge shard passes no provisioning and configures no cap — behavior unchanged. Deletes/field-index ops (which cannot grow appendable segments) keep a plain read guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)