### PR TITLE
fix(wal): flush the copied mmap in Segment::copy_to_path

### DIFF
--- a/lib/wal/src/segment.rs
+++ b/lib/wal/src/segment.rs
@@ -672,6 +672,7 @@ impl Segment {
                 .as_mut_slice()
                 .copy_from_slice(self.mmap.as_slice());
         }
+        other.mmap.flush()?;
         Ok(())
     }
 }
@@ -817,6 +818,34 @@ mod test {
         check_append(&mut create_segment(1025).0);
         check_append(&mut create_segment(4096).0);
         check_append(&mut create_segment(8 * 1024 * 1024).0);
+    }
+
+    #[test]
+    fn test_copy_to_path_roundtrip() {
+        init_logger();
+        let (mut segment, _dir) = create_segment(4096);
+
+        let entries: Vec<&[u8]> = vec![
+            b"alpha".as_slice(),
+            b"beta".as_slice(),
+            b"gamma".as_slice(),
+            b"delta".as_slice(),
+        ];
+        for entry in &entries {
+            segment.append(entry).unwrap();
+        }
+        segment.flush().unwrap();
+
+        let dst_dir = Builder::new().prefix("segment-copy").tempdir().unwrap();
+        let dst_path = dst_dir.path().join("copied-segment");
+        segment.copy_to_path(&dst_path).unwrap();
+
+        // The copy must be a complete, re-openable segment with byte-identical entries.
+        let copied = Segment::open(&dst_path).unwrap();
+        assert_eq!(copied.len(), entries.len());
+        for (idx, entry) in entries.iter().enumerate() {
+            assert_eq!(&*copied.entry(idx).unwrap(), *entry);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #9867

`copy_to_path` copied the segment into a new mmap file but returned `Ok(())` without flushing, so the copy was not guaranteed on disk. Added `other.mmap.flush()?` after the copy, matching what `create()` and `flush()` already do in the same file.

Also added a round-trip test for `copy_to_path`, which had none. It covers the copy path and byte-identical read-back; the flush is a crash-durability guarantee, so it mirrors the sibling write paths rather than being directly asserted.

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### AI disclosure (per CONTRIBUTING.md)

The one-line flush fix was written by me. The round-trip test and the bug analysis/review were AI-assisted.
