### PR TITLE
Return sorted Vec from SegmentEntry::vector_names

### DIFF
--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -197,7 +197,8 @@ pub trait ReadSegmentEntry {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<CardinalityEstimation>;
 
-    fn vector_names(&self) -> HashSet<VectorNameBuf>;
+    /// Names of all vectors in this segment, sorted.
+    fn vector_names(&self) -> Vec<VectorNameBuf>;
 
     /// Whether this segment is completely empty in terms of points
     ///

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -308,8 +308,10 @@ impl ReadSegmentEntry for Segment {
             .with_view(|v| v.indexed_fields())
     }
 
-    fn vector_names(&self) -> HashSet<VectorNameBuf> {
-        self.vector_data.keys().cloned().collect()
+    fn vector_names(&self) -> Vec<VectorNameBuf> {
+        let mut names: Vec<_> = self.vector_data.keys().cloned().collect();
+        names.sort_unstable();
+        names
     }
 
     fn get_telemetry_data(&self, detail: TelemetryDetail) -> OperationResult<SegmentTelemetry> {

--- a/lib/segment/src/segment/read_only/read_entry.rs
+++ b/lib/segment/src/segment/read_only/read_entry.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
@@ -257,8 +257,10 @@ impl<S: UniversalReadExt + 'static> ReadSegmentEntry for ReadOnlySegment<S> {
         self.with_view(|view| view.estimate_point_count(filter, hw_counter))
     }
 
-    fn vector_names(&self) -> HashSet<VectorNameBuf> {
-        self.vector_data.keys().cloned().collect()
+    fn vector_names(&self) -> Vec<VectorNameBuf> {
+        let mut names: Vec<_> = self.vector_data.keys().cloned().collect();
+        names.sort_unstable();
+        names
     }
 
     fn is_empty(&self) -> bool {

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -1,5 +1,5 @@
 use std::cmp;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -738,7 +738,7 @@ impl ReadSegmentEntry for ProxySegment {
         indexed_fields
     }
 
-    fn vector_names(&self) -> HashSet<VectorNameBuf> {
+    fn vector_names(&self) -> Vec<VectorNameBuf> {
         self.wrapped_segment.get().read().vector_names()
     }
 


### PR DESCRIPTION
`SegmentEntry::vector_names()` returned a `HashSet<VectorNameBuf>` cloned from `vector_data.keys()`.

The set bought nothing: 
- the names are unique by construction (map keys)
- all three callers only iterate the result

In exchange it paid hashing plus the set allocation on each call, and leaked `HashMap` iteration order.

Now returns a sorted `Vec<VectorNameBuf>`: no hashing, one exact-size allocation, **deterministic** order.

All callers are order-insensitive (max/accumulate loops), so no behavior changes.

Owned values are still required: the proxy locks the wrapped segment inside the method.

`CollectionParams::vector_names()` keeps its `HashSet`, its consumers do`contains` lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)