### PR TITLE
Compact stored bitmask for on-disk field index deleted masks

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -13029,8 +13029,13 @@
             "default": false,
             "type": "boolean"
           },
+          "compact_bitmask": {
+            "description": "Persist write-once bitmasks in the compact `StoredBitmask` format instead of raw dense bitslices. Only gates writing: both formats are always readable.",
+            "default": false,
+            "type": "boolean"
+          },
           "serverless_compatible": {
-            "description": "Serverless-compatible deployment mode. Automatically enables [`Self::write_segment_manifest`] and [`Self::append_only_mutations`].\n\nNote that this will only be applied when passed into [`init_feature_flags`].",
+            "description": "Serverless-compatible deployment mode. Automatically enables [`Self::write_segment_manifest`], [`Self::append_only_mutations`] and [`Self::compact_bitmask`].\n\nNote that this will only be applied when passed into [`init_feature_flags`].",
             "default": false,
             "type": "boolean"
           }

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -41,8 +41,12 @@ pub struct FeatureFlags {
     /// appends instead. Intended for testing the append-only storage path.
     pub append_only_mutations: bool,
 
-    /// Serverless-compatible deployment mode. Automatically enables [`Self::write_segment_manifest`] and
-    /// [`Self::append_only_mutations`].
+    /// Persist write-once bitmasks in the compact `StoredBitmask` format instead of raw dense
+    /// bitslices. Only gates writing: both formats are always readable.
+    pub compact_bitmask: bool,
+
+    /// Serverless-compatible deployment mode. Automatically enables [`Self::write_segment_manifest`],
+    /// [`Self::append_only_mutations`] and [`Self::compact_bitmask`].
     ///
     /// Note that this will only be applied when passed into [`init_feature_flags`].
     serverless_compatible: bool,
@@ -58,6 +62,7 @@ impl Default for FeatureFlags {
             async_payload_storage: false,
             write_segment_manifest: false,
             append_only_mutations: false,
+            compact_bitmask: false,
             serverless_compatible: false,
         }
     }
@@ -86,6 +91,7 @@ impl FeatureFlags {
             // Deliberately not enabled by `all`: this is a test-only escape hatch that changes
             // mutation semantics, and `all` is enabled in dev and e2e configs.
             append_only_mutations: false,
+            compact_bitmask: true,
             serverless_compatible: false,
         }
     }
@@ -101,6 +107,7 @@ impl FeatureFlags {
             self.serverless_compatible = true;
             self.write_segment_manifest = true;
             self.append_only_mutations = true;
+            self.compact_bitmask = true;
         }
 
         self
@@ -153,6 +160,7 @@ mod tests {
 
         assert!(flags.write_segment_manifest);
         assert!(flags.append_only_mutations);
+        assert!(flags.compact_bitmask);
     }
 
     #[test]
@@ -166,5 +174,6 @@ mod tests {
 
         assert!(flags.write_segment_manifest);
         assert!(flags.append_only_mutations);
+        assert!(flags.compact_bitmask);
     }
 }

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -43,6 +43,7 @@ pub mod sort_utils;
 pub mod sorted_slice;
 pub mod stable_hash;
 pub mod storage_version;
+pub mod stored_bitmask;
 pub mod stored_bitslice;
 pub mod tar_ext;
 pub mod tar_unpack;

--- a/lib/common/common/src/stored_bitmask/format.rs
+++ b/lib/common/common/src/stored_bitmask/format.rs
@@ -1,0 +1,62 @@
+//! On-disk layout: file header, payload encodings, and the decoded contents.
+
+use std::borrow::Cow;
+
+use roaring::RoaringBitmap;
+
+use crate::bitvec::BitSlice;
+
+pub(super) const MAGIC: [u8; 4] = *b"QBMK";
+pub(super) const VERSION: u32 = 1;
+pub(super) const HEADER_SIZE: usize = size_of::<BitmaskHeader>();
+
+/// How the payload following the header encodes the mask.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(super) enum Encoding {
+    /// Raw bits: `u64` words in `Lsb0` order, native (little-endian) byte
+    /// order, matching the layout of [`crate::bitvec::BitVec`].
+    Dense = 0,
+    /// Roaring bitmap of the set positions; everything else in
+    /// `0..logical_len` is unset.
+    RoaringOnes = 1,
+    /// Roaring bitmap of the unset positions; everything else in
+    /// `0..logical_len` is set.
+    RoaringZeros = 2,
+}
+
+impl Encoding {
+    pub(super) fn from_u32(value: u32) -> Option<Self> {
+        match value {
+            0 => Some(Self::Dense),
+            1 => Some(Self::RoaringOnes),
+            2 => Some(Self::RoaringZeros),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(C)]
+pub(super) struct BitmaskHeader {
+    pub(super) magic: [u8; 4],
+    pub(super) version: u32,
+    /// Number of logical flags (bits) in the mask.
+    pub(super) logical_len: u64,
+    /// One of the [`Encoding`] discriminants.
+    pub(super) encoding: u32,
+    pub(super) _reserved: u32,
+    /// Exact byte length of the payload following the header.
+    pub(super) payload_len: u64,
+}
+
+/// Decoded mask contents, in the stored polarity: the bitmap always holds the
+/// minority positions, so iterating it is never worse than the dense scan.
+pub enum BitmaskContent<'a> {
+    /// Raw bits, exactly `logical_len` of them. Borrowed (zero-copy) on
+    /// backends that expose their bytes directly, e.g. mmap.
+    Dense(Cow<'a, BitSlice>),
+    /// Positions of set bits; everything else in `0..logical_len` is unset.
+    Ones(RoaringBitmap),
+    /// Positions of unset bits; everything else in `0..logical_len` is set.
+    Zeros(RoaringBitmap),
+}

--- a/lib/common/common/src/stored_bitmask/format.rs
+++ b/lib/common/common/src/stored_bitmask/format.rs
@@ -49,6 +49,19 @@ pub(super) struct BitmaskHeader {
     pub(super) payload_len: u64,
 }
 
+impl BitmaskHeader {
+    pub(super) fn new(logical_len: u64, encoding: Encoding, payload_len: u64) -> Self {
+        Self {
+            magic: MAGIC,
+            version: VERSION,
+            logical_len,
+            encoding: encoding as u32,
+            _reserved: 0,
+            payload_len,
+        }
+    }
+}
+
 /// Decoded mask contents, in the stored polarity: the bitmap always holds the
 /// minority positions, so iterating it is never worse than the dense scan.
 pub enum BitmaskContent<'a> {

--- a/lib/common/common/src/stored_bitmask/mod.rs
+++ b/lib/common/common/src/stored_bitmask/mod.rs
@@ -1,0 +1,18 @@
+//! Compact persisted bitmask, written and read as a whole.
+//!
+//! The payload is a roaring bitmap of whichever bit value is the minority,
+//! or raw dense bits when that is smaller — the file is never larger than
+//! the dense representation.
+//!
+//! There is no in-place mutation: [`save_bitmask`] replaces the file
+//! atomically, so an open always sees a consistent snapshot.
+
+mod format;
+mod read;
+#[cfg(test)]
+mod tests;
+mod write;
+
+pub use format::BitmaskContent;
+pub use read::StoredBitmask;
+pub use write::save_bitmask;

--- a/lib/common/common/src/stored_bitmask/read.rs
+++ b/lib/common/common/src/stored_bitmask/read.rs
@@ -1,0 +1,150 @@
+use std::borrow::Cow;
+use std::io;
+use std::path::Path;
+
+use roaring::RoaringBitmap;
+
+use super::format::{BitmaskContent, BitmaskHeader, Encoding, HEADER_SIZE, MAGIC, VERSION};
+use crate::bitvec::{BitSlice, BitVec};
+use crate::generic_consts::Sequential;
+use crate::universal_io::{
+    OpenOptions, ReadRange, Result, TypedStorage, UniversalIoError, UniversalRead, UniversalReadFs,
+};
+
+/// Read handle over a bitmask persisted by [`save_bitmask`].
+///
+/// [`Self::open`] reads and validates only the fixed-size header; the payload
+/// is not touched until [`Self::read`].
+///
+/// [`save_bitmask`]: super::save_bitmask
+#[derive(Debug)]
+pub struct StoredBitmask<S> {
+    storage: TypedStorage<S, u8>,
+    logical_len: u64,
+    pub(super) encoding: Encoding,
+    pub(super) payload_len: u64,
+}
+
+/// Copy little-endian payload bytes into an owned [`BitVec`] of `len` bits.
+fn dense_to_bitvec(bytes: &[u8], len: usize) -> BitVec {
+    let mut words = vec![0u64; bytes.len().div_ceil(size_of::<u64>())];
+    bytemuck::cast_slice_mut::<u64, u8>(&mut words)[..bytes.len()].copy_from_slice(bytes);
+    let mut bits = BitVec::from_vec(words);
+    bits.truncate(len);
+    bits
+}
+
+fn invalid_data(path: &Path, message: impl std::fmt::Display) -> UniversalIoError {
+    UniversalIoError::Io(io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("{}: {message}", path.display()),
+    ))
+}
+impl<S: UniversalRead> StoredBitmask<S> {
+    /// Open a persisted bitmask, reading and validating its header.
+    pub fn open<Fs: UniversalReadFs<File = S>>(
+        fs: &Fs,
+        path: impl AsRef<Path>,
+        options: OpenOptions,
+        extra: Fs::OpenExtra,
+    ) -> Result<Self> {
+        let path = path.as_ref();
+        let storage = TypedStorage::open(fs, path, options, extra)?;
+
+        let file_len = storage.len()?;
+        if file_len < HEADER_SIZE as u64 {
+            return Err(invalid_data(
+                path,
+                format_args!("file of {file_len} bytes is too short to be a stored bitmask"),
+            ));
+        }
+
+        let header_bytes = storage.read::<Sequential>(ReadRange {
+            byte_offset: 0,
+            length: HEADER_SIZE as u64,
+        })?;
+        let header: BitmaskHeader = bytemuck::pod_read_unaligned(&header_bytes);
+
+        if header.magic != MAGIC {
+            return Err(invalid_data(path, "not a stored bitmask file (bad magic)"));
+        }
+        if header.version != VERSION {
+            return Err(invalid_data(
+                path,
+                format_args!(
+                    "unsupported stored bitmask version {} (supported: {VERSION})",
+                    header.version,
+                ),
+            ));
+        }
+        let Some(encoding) = Encoding::from_u32(header.encoding) else {
+            return Err(invalid_data(
+                path,
+                format_args!("unknown stored bitmask encoding {}", header.encoding),
+            ));
+        };
+        if HEADER_SIZE as u64 + header.payload_len > file_len {
+            return Err(invalid_data(
+                path,
+                format_args!(
+                    "payload of {} bytes exceeds file of {file_len} bytes",
+                    header.payload_len,
+                ),
+            ));
+        }
+        if encoding == Encoding::Dense
+            && header.payload_len < header.logical_len.div_ceil(u64::from(u8::BITS))
+        {
+            return Err(invalid_data(
+                path,
+                format_args!(
+                    "dense payload of {} bytes is too short for {} bits",
+                    header.payload_len, header.logical_len,
+                ),
+            ));
+        }
+
+        Ok(Self {
+            storage,
+            logical_len: header.logical_len,
+            encoding,
+            payload_len: header.payload_len,
+        })
+    }
+
+    /// Number of logical flags (bits) in the mask.
+    pub fn bit_len(&self) -> u64 {
+        self.logical_len
+    }
+
+    /// Read and decode the payload, in the stored polarity.
+    pub fn read(&self) -> Result<BitmaskContent<'_>> {
+        let payload = self.storage.read::<Sequential>(ReadRange {
+            byte_offset: HEADER_SIZE as u64,
+            length: self.payload_len,
+        })?;
+
+        match self.encoding {
+            Encoding::Dense => {
+                let len = self.logical_len as usize;
+                let bits = match payload {
+                    // Zero-copy when the backend exposes its bytes and they
+                    // cast cleanly to whole u64 words (the payload starts at
+                    // a u64-aligned offset and the writer pads it to words).
+                    Cow::Borrowed(bytes) => match bytemuck::try_cast_slice::<u8, u64>(bytes) {
+                        Ok(words) => Cow::Borrowed(&BitSlice::from_slice(words)[..len]),
+                        Err(_) => Cow::Owned(dense_to_bitvec(bytes, len)),
+                    },
+                    Cow::Owned(bytes) => Cow::Owned(dense_to_bitvec(&bytes, len)),
+                };
+                Ok(BitmaskContent::Dense(bits))
+            }
+            Encoding::RoaringOnes => Ok(BitmaskContent::Ones(RoaringBitmap::deserialize_from(
+                payload.as_ref(),
+            )?)),
+            Encoding::RoaringZeros => Ok(BitmaskContent::Zeros(RoaringBitmap::deserialize_from(
+                payload.as_ref(),
+            )?)),
+        }
+    }
+}

--- a/lib/common/common/src/stored_bitmask/read.rs
+++ b/lib/common/common/src/stored_bitmask/read.rs
@@ -83,7 +83,10 @@ impl<S: UniversalRead> StoredBitmask<S> {
                 format_args!("unknown stored bitmask encoding {}", header.encoding),
             ));
         };
-        if HEADER_SIZE as u64 + header.payload_len > file_len {
+        // `file_len >= HEADER_SIZE` was checked above, so the subtraction
+        // cannot underflow; phrasing it this way avoids overflowing on a
+        // corrupted `payload_len` near `u64::MAX`.
+        if header.payload_len > file_len - HEADER_SIZE as u64 {
             return Err(invalid_data(
                 path,
                 format_args!(
@@ -139,12 +142,27 @@ impl<S: UniversalRead> StoredBitmask<S> {
                 };
                 Ok(BitmaskContent::Dense(bits))
             }
-            Encoding::RoaringOnes => Ok(BitmaskContent::Ones(RoaringBitmap::deserialize_from(
-                payload.as_ref(),
-            )?)),
-            Encoding::RoaringZeros => Ok(BitmaskContent::Zeros(RoaringBitmap::deserialize_from(
-                payload.as_ref(),
-            )?)),
+            Encoding::RoaringOnes => Ok(BitmaskContent::Ones(self.decode_roaring(&payload)?)),
+            Encoding::RoaringZeros => Ok(BitmaskContent::Zeros(self.decode_roaring(&payload)?)),
         }
+    }
+
+    /// Deserialize a roaring payload, rejecting positions outside
+    /// `0..logical_len` so [`BitmaskContent`]'s range contract holds even for
+    /// corrupted files.
+    fn decode_roaring(&self, payload: &[u8]) -> Result<RoaringBitmap> {
+        let bitmap = RoaringBitmap::deserialize_from(payload)?;
+        if let Some(max) = bitmap.max()
+            && u64::from(max) >= self.logical_len
+        {
+            return Err(UniversalIoError::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "stored bitmask position {max} out of {} bits",
+                    self.logical_len,
+                ),
+            )));
+        }
+        Ok(bitmap)
     }
 }

--- a/lib/common/common/src/stored_bitmask/tests.rs
+++ b/lib/common/common/src/stored_bitmask/tests.rs
@@ -159,6 +159,33 @@ fn overwrite_replaces_previous_snapshot() {
 }
 
 #[test]
+fn rejects_positions_beyond_logical_len() {
+    // Hand-craft a file whose roaring payload contains a position past
+    // `logical_len` — the writer refuses to produce this, so build it from
+    // format parts directly.
+    use super::format::BitmaskHeader;
+
+    let bitmap = RoaringBitmap::from_sorted_iter([100u32]).unwrap();
+    let mut payload = Vec::new();
+    bitmap.serialize_into(&mut payload).unwrap();
+
+    let mut bytes = bytemuck::bytes_of(&BitmaskHeader::new(
+        8,
+        Encoding::RoaringOnes,
+        payload.len() as u64,
+    ))
+    .to_vec();
+    bytes.extend_from_slice(&payload);
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("mask.bin");
+    fs_err::write(&path, bytes).unwrap();
+
+    let mask = open(&path); // header itself is valid
+    assert!(mask.read().is_err());
+}
+
+#[test]
 fn rejects_foreign_files() {
     let dir = TempDir::new().unwrap();
 

--- a/lib/common/common/src/stored_bitmask/tests.rs
+++ b/lib/common/common/src/stored_bitmask/tests.rs
@@ -1,0 +1,178 @@
+use std::path::Path;
+
+use roaring::RoaringBitmap;
+use tempfile::TempDir;
+
+use super::format::{BitmaskContent, Encoding};
+use super::{StoredBitmask, save_bitmask};
+use crate::bitvec::BitVec;
+use crate::universal_io::{MmapFile, MmapFs, OpenOptions};
+
+fn open(path: &Path) -> StoredBitmask<MmapFile> {
+    StoredBitmask::open(&MmapFs, path, OpenOptions::new_for_test(), ()).unwrap()
+}
+
+/// Decode the whole mask into a dense [`BitVec`] of [`StoredBitmask::bit_len`]
+/// bits.
+fn read_to_bitvec(mask: &StoredBitmask<MmapFile>) -> BitVec {
+    let len = mask.bit_len() as usize;
+    match mask.read().unwrap() {
+        BitmaskContent::Dense(bits) => bits.into_owned(),
+        BitmaskContent::Ones(ones) => {
+            let mut bits = BitVec::repeat(false, len);
+            for idx in ones {
+                bits.set(idx as usize, true);
+            }
+            bits
+        }
+        BitmaskContent::Zeros(zeros) => {
+            let mut bits = BitVec::repeat(true, len);
+            for idx in zeros {
+                bits.set(idx as usize, false);
+            }
+            bits
+        }
+    }
+}
+
+fn roundtrip(logical_len: u64, ones: &RoaringBitmap) -> (StoredBitmask<MmapFile>, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("mask.bin");
+    save_bitmask(&MmapFs, &path, logical_len, ones.clone()).unwrap();
+    (open(&path), dir)
+}
+
+fn assert_bits(mask: &StoredBitmask<MmapFile>, logical_len: u64, ones: &RoaringBitmap) {
+    assert_eq!(mask.bit_len(), logical_len);
+    let bits = read_to_bitvec(mask);
+    assert_eq!(bits.len() as u64, logical_len);
+    for idx in 0..logical_len {
+        assert_eq!(
+            bits[idx as usize],
+            ones.contains(idx as u32),
+            "mismatch at bit {idx}",
+        );
+    }
+}
+
+#[test]
+fn sparse_ones_stored_as_roaring_ones() {
+    let ones = RoaringBitmap::from_sorted_iter([1u32, 7, 63, 64, 100_000]).unwrap();
+    let (mask, _dir) = roundtrip(1_000_000, &ones);
+    assert_eq!(mask.encoding, Encoding::RoaringOnes);
+    assert!(matches!(mask.read().unwrap(), BitmaskContent::Ones(_)));
+    assert_bits(&mask, 1_000_000, &ones);
+    // Orders of magnitude below the 125_000-byte dense representation.
+    assert!(mask.payload_len < 1_000);
+}
+
+#[test]
+fn mostly_ones_stored_as_roaring_zeros() {
+    let len = 1_000_000u64;
+    let mut ones = RoaringBitmap::new();
+    ones.insert_range(0..len as u32);
+    for zero in [3u32, 500, 65_536, 999_999] {
+        ones.remove(zero);
+    }
+    let (mask, _dir) = roundtrip(len, &ones);
+    assert_eq!(mask.encoding, Encoding::RoaringZeros);
+    match mask.read().unwrap() {
+        BitmaskContent::Zeros(zeros) => {
+            assert_eq!(
+                zeros.iter().collect::<Vec<_>>(),
+                vec![3, 500, 65_536, 999_999]
+            );
+        }
+        BitmaskContent::Dense(_) | BitmaskContent::Ones(_) => {
+            panic!("expected zeros encoding")
+        }
+    }
+    assert_bits(&mask, len, &ones);
+    assert!(mask.payload_len < 1_000);
+}
+
+#[test]
+fn incompressible_mask_falls_back_to_dense() {
+    // Alternating bits: the worst case for both roaring polarities.
+    let len = 100_000u64;
+    let ones = RoaringBitmap::from_sorted_iter((0..len as u32).filter(|i| i % 2 == 0)).unwrap();
+    let (mask, _dir) = roundtrip(len, &ones);
+    assert_eq!(mask.encoding, Encoding::Dense);
+    assert!(mask.payload_len <= len.div_ceil(8).next_multiple_of(8));
+    assert_bits(&mask, len, &ones);
+}
+
+#[test]
+fn incompressible_mostly_ones_falls_back_to_dense() {
+    // Majority ones with scattered zeros: zeros polarity is chosen, but the
+    // zeros are still too scattered for roaring — the dense fallback must
+    // reconstruct the majority bits, including the unaligned trailing byte.
+    let len = 100_003u64;
+    let ones = RoaringBitmap::from_sorted_iter((0..len as u32).filter(|i| i % 5 != 0)).unwrap();
+    let (mask, _dir) = roundtrip(len, &ones);
+    assert_eq!(mask.encoding, Encoding::Dense);
+    assert_bits(&mask, len, &ones);
+}
+
+#[test]
+fn empty_mask() {
+    let ones = RoaringBitmap::new();
+    let (mask, _dir) = roundtrip(0, &ones);
+    assert_bits(&mask, 0, &ones);
+
+    let (mask, _dir) = roundtrip(12_345, &ones);
+    assert_bits(&mask, 12_345, &ones);
+}
+
+#[test]
+fn full_mask() {
+    let len = 12_345u64;
+    let mut ones = RoaringBitmap::new();
+    ones.insert_range(0..len as u32);
+    let (mask, _dir) = roundtrip(len, &ones);
+    assert_eq!(mask.encoding, Encoding::RoaringZeros);
+    assert_bits(&mask, len, &ones);
+}
+
+#[test]
+fn unaligned_length() {
+    // Length not a multiple of 64: dense truncation must be exact.
+    let len = 131u64;
+    let ones = RoaringBitmap::from_sorted_iter((0..len as u32).filter(|i| i % 2 == 1)).unwrap();
+    let (mask, _dir) = roundtrip(len, &ones);
+    assert_eq!(mask.encoding, Encoding::Dense);
+    assert_bits(&mask, len, &ones);
+}
+
+#[test]
+fn overwrite_replaces_previous_snapshot() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("mask.bin");
+
+    let first = RoaringBitmap::from_sorted_iter(0..50_000u32).unwrap();
+    save_bitmask(&MmapFs, &path, 100_000, first).unwrap();
+
+    let second = RoaringBitmap::from_sorted_iter([42u32]).unwrap();
+    save_bitmask(&MmapFs, &path, 100_000, second.clone()).unwrap();
+
+    assert_bits(&open(&path), 100_000, &second);
+}
+
+#[test]
+fn rejects_foreign_files() {
+    let dir = TempDir::new().unwrap();
+
+    // Too short.
+    let path = dir.path().join("short.bin");
+    fs_err::write(&path, b"QBMK").unwrap();
+    assert!(
+        StoredBitmask::<MmapFile>::open(&MmapFs, &path, OpenOptions::new_for_test(), ()).is_err()
+    );
+
+    // Right size, wrong magic (e.g. a legacy dense bitslice file).
+    let path = dir.path().join("legacy.bin");
+    fs_err::write(&path, vec![0u8; 64]).unwrap();
+    assert!(
+        StoredBitmask::<MmapFile>::open(&MmapFs, &path, OpenOptions::new_for_test(), ()).is_err()
+    );
+}

--- a/lib/common/common/src/stored_bitmask/write.rs
+++ b/lib/common/common/src/stored_bitmask/write.rs
@@ -1,0 +1,105 @@
+use std::io;
+use std::path::Path;
+
+use roaring::RoaringBitmap;
+
+use super::format::{BitmaskHeader, Encoding, HEADER_SIZE, MAGIC, VERSION};
+use crate::universal_io::{Result, UniversalIoError, UniversalWriteFileOps};
+
+/// Atomically persist a bitmask of `logical_len` bits whose set positions are
+/// `ones`.
+///
+/// Picks the cheapest encoding: a roaring bitmap of the minority bit value,
+/// or raw dense bits when the roaring payload would not be smaller.
+pub fn save_bitmask(
+    fs: &impl UniversalWriteFileOps,
+    path: &Path,
+    logical_len: u64,
+    ones: RoaringBitmap,
+) -> Result<()> {
+    if logical_len > u64::from(u32::MAX) + 1 {
+        return Err(UniversalIoError::Io(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("bitmask of {logical_len} bits exceeds the u32 position space"),
+        )));
+    }
+    // Hard check, not a debug_assert: the zeros-polarity branch below relies on
+    // `logical_len > 0` whenever `ones` is non-empty.
+    if let Some(max) = ones.max()
+        && u64::from(max) >= logical_len
+    {
+        return Err(UniversalIoError::Io(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("set position {max} beyond bitmask of {logical_len} bits"),
+        )));
+    }
+
+    // Store whichever polarity is the minority.
+    let (encoding, mut bitmap) = if ones.len().saturating_mul(2) <= logical_len {
+        (Encoding::RoaringOnes, ones)
+    } else {
+        let mut zeros = RoaringBitmap::new();
+        zeros.insert_range(0..=(logical_len - 1) as u32);
+        zeros -= ones;
+        (Encoding::RoaringZeros, zeros)
+    };
+    bitmap.optimize();
+
+    let dense_payload_len = logical_len.div_ceil(u64::from(u8::BITS));
+    let roaring_payload_len = bitmap.serialized_size() as u64;
+
+    let mut bytes;
+    if roaring_payload_len < dense_payload_len {
+        let header = BitmaskHeader {
+            magic: MAGIC,
+            version: VERSION,
+            logical_len,
+            encoding: encoding as u32,
+            _reserved: 0,
+            payload_len: roaring_payload_len,
+        };
+        bytes = Vec::with_capacity(HEADER_SIZE + roaring_payload_len as usize);
+        bytes.extend_from_slice(bytemuck::bytes_of(&header));
+        bitmap.serialize_into(&mut bytes)?;
+    } else {
+        // Even the minority polarity does not compress below raw bits: store
+        // them densely, so the compact format is never larger than the mask.
+        // Reconstruct the raw bits straight into the output buffer from the
+        // minority bitmap and its polarity.
+        let payload_len = (logical_len as usize).div_ceil(u64::BITS as usize) * size_of::<u64>();
+        let header = BitmaskHeader {
+            magic: MAGIC,
+            version: VERSION,
+            logical_len,
+            encoding: Encoding::Dense as u32,
+            _reserved: 0,
+            payload_len: payload_len as u64,
+        };
+        bytes = vec![0u8; HEADER_SIZE + payload_len];
+        bytes[..HEADER_SIZE].copy_from_slice(bytemuck::bytes_of(&header));
+        let payload = &mut bytes[HEADER_SIZE..];
+
+        let minority_is_ones = encoding == Encoding::RoaringOnes;
+        if !minority_is_ones {
+            // Majority is ones: prefill the first `logical_len` bits with
+            // ones, leaving any trailing capacity bits clear.
+            let full_bytes = (logical_len / u64::from(u8::BITS)) as usize;
+            payload[..full_bytes].fill(u8::MAX);
+            let trailing_bits = (logical_len % u64::from(u8::BITS)) as u8;
+            if trailing_bits > 0 {
+                payload[full_bytes] = (1u8 << trailing_bits) - 1;
+            }
+        }
+        for idx in bitmap {
+            let byte = &mut payload[(idx / u8::BITS) as usize];
+            let bit = 1u8 << (idx % u8::BITS);
+            if minority_is_ones {
+                *byte |= bit;
+            } else {
+                *byte &= !bit;
+            }
+        }
+    }
+
+    fs.atomic_save(path, &bytes)
+}

--- a/lib/common/common/src/stored_bitmask/write.rs
+++ b/lib/common/common/src/stored_bitmask/write.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use roaring::RoaringBitmap;
 
-use super::format::{BitmaskHeader, Encoding, HEADER_SIZE, MAGIC, VERSION};
+use super::format::{BitmaskHeader, Encoding, HEADER_SIZE};
 use crate::universal_io::{Result, UniversalIoError, UniversalWriteFileOps};
 
 /// Atomically persist a bitmask of `logical_len` bits whose set positions are
@@ -17,89 +17,104 @@ pub fn save_bitmask(
     logical_len: u64,
     ones: RoaringBitmap,
 ) -> Result<()> {
+    validate(logical_len, &ones)?;
+
+    let (polarity, mut minority) = minority_polarity(logical_len, ones);
+    minority.optimize();
+
+    let dense_payload_len = logical_len.div_ceil(u64::from(u8::BITS));
+    let bytes = if (minority.serialized_size() as u64) < dense_payload_len {
+        roaring_file_bytes(logical_len, polarity, &minority)?
+    } else {
+        // Even the minority polarity does not compress below raw bits: store
+        // them densely, so the compact format is never larger than the mask.
+        dense_file_bytes(logical_len, polarity, &minority)
+    };
+
+    fs.atomic_save(path, &bytes)
+}
+
+fn validate(logical_len: u64, ones: &RoaringBitmap) -> Result<()> {
+    let invalid = |message: String| {
+        UniversalIoError::Io(io::Error::new(io::ErrorKind::InvalidInput, message))
+    };
+
     if logical_len > u64::from(u32::MAX) + 1 {
-        return Err(UniversalIoError::Io(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("bitmask of {logical_len} bits exceeds the u32 position space"),
+        return Err(invalid(format!(
+            "bitmask of {logical_len} bits exceeds the u32 position space"
         )));
     }
-    // Hard check, not a debug_assert: the zeros-polarity branch below relies on
+    // Hard check, not a debug_assert: `minority_polarity` relies on
     // `logical_len > 0` whenever `ones` is non-empty.
     if let Some(max) = ones.max()
         && u64::from(max) >= logical_len
     {
-        return Err(UniversalIoError::Io(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("set position {max} beyond bitmask of {logical_len} bits"),
+        return Err(invalid(format!(
+            "set position {max} beyond bitmask of {logical_len} bits"
         )));
     }
+    Ok(())
+}
 
-    // Store whichever polarity is the minority.
-    let (encoding, mut bitmap) = if ones.len().saturating_mul(2) <= logical_len {
+/// Reduce to whichever bit value is the minority: the set positions as-is, or
+/// their complement within `0..logical_len`.
+fn minority_polarity(logical_len: u64, ones: RoaringBitmap) -> (Encoding, RoaringBitmap) {
+    if ones.len().saturating_mul(2) <= logical_len {
         (Encoding::RoaringOnes, ones)
     } else {
         let mut zeros = RoaringBitmap::new();
         zeros.insert_range(0..=(logical_len - 1) as u32);
         zeros -= ones;
         (Encoding::RoaringZeros, zeros)
-    };
-    bitmap.optimize();
+    }
+}
 
-    let dense_payload_len = logical_len.div_ceil(u64::from(u8::BITS));
-    let roaring_payload_len = bitmap.serialized_size() as u64;
+/// Header followed by the serialized roaring bitmap of the minority positions.
+fn roaring_file_bytes(
+    logical_len: u64,
+    polarity: Encoding,
+    minority: &RoaringBitmap,
+) -> Result<Vec<u8>> {
+    let payload_len = minority.serialized_size();
+    let header = BitmaskHeader::new(logical_len, polarity, payload_len as u64);
 
-    let mut bytes;
-    if roaring_payload_len < dense_payload_len {
-        let header = BitmaskHeader {
-            magic: MAGIC,
-            version: VERSION,
-            logical_len,
-            encoding: encoding as u32,
-            _reserved: 0,
-            payload_len: roaring_payload_len,
-        };
-        bytes = Vec::with_capacity(HEADER_SIZE + roaring_payload_len as usize);
-        bytes.extend_from_slice(bytemuck::bytes_of(&header));
-        bitmap.serialize_into(&mut bytes)?;
-    } else {
-        // Even the minority polarity does not compress below raw bits: store
-        // them densely, so the compact format is never larger than the mask.
-        // Reconstruct the raw bits straight into the output buffer from the
-        // minority bitmap and its polarity.
-        let payload_len = (logical_len as usize).div_ceil(u64::BITS as usize) * size_of::<u64>();
-        let header = BitmaskHeader {
-            magic: MAGIC,
-            version: VERSION,
-            logical_len,
-            encoding: Encoding::Dense as u32,
-            _reserved: 0,
-            payload_len: payload_len as u64,
-        };
-        bytes = vec![0u8; HEADER_SIZE + payload_len];
-        bytes[..HEADER_SIZE].copy_from_slice(bytemuck::bytes_of(&header));
-        let payload = &mut bytes[HEADER_SIZE..];
+    let mut bytes = Vec::with_capacity(HEADER_SIZE + payload_len);
+    bytes.extend_from_slice(bytemuck::bytes_of(&header));
+    minority.serialize_into(&mut bytes)?;
+    Ok(bytes)
+}
 
-        let minority_is_ones = encoding == Encoding::RoaringOnes;
-        if !minority_is_ones {
-            // Majority is ones: prefill the first `logical_len` bits with
-            // ones, leaving any trailing capacity bits clear.
-            let full_bytes = (logical_len / u64::from(u8::BITS)) as usize;
-            payload[..full_bytes].fill(u8::MAX);
-            let trailing_bits = (logical_len % u64::from(u8::BITS)) as u8;
-            if trailing_bits > 0 {
-                payload[full_bytes] = (1u8 << trailing_bits) - 1;
-            }
-        }
-        for idx in bitmap {
-            let byte = &mut payload[(idx / u8::BITS) as usize];
-            let bit = 1u8 << (idx % u8::BITS);
-            if minority_is_ones {
-                *byte |= bit;
-            } else {
-                *byte &= !bit;
-            }
+/// Header followed by raw dense bits, reconstructed from the minority
+/// positions: start from all-majority bits and flip the minority in.
+fn dense_file_bytes(logical_len: u64, polarity: Encoding, minority: &RoaringBitmap) -> Vec<u8> {
+    let payload_len = (logical_len as usize).div_ceil(u64::BITS as usize) * size_of::<u64>();
+    let header = BitmaskHeader::new(logical_len, Encoding::Dense, payload_len as u64);
+
+    let mut bytes = vec![0u8; HEADER_SIZE + payload_len];
+    bytes[..HEADER_SIZE].copy_from_slice(bytemuck::bytes_of(&header));
+    let payload = &mut bytes[HEADER_SIZE..];
+
+    let minority_is_ones = polarity == Encoding::RoaringOnes;
+    if !minority_is_ones {
+        // Majority is ones: prefill the first `logical_len` bits with ones,
+        // leaving any trailing capacity bits clear.
+        let full_bytes = (logical_len / u64::from(u8::BITS)) as usize;
+        payload[..full_bytes].fill(u8::MAX);
+        let trailing_bits = (logical_len % u64::from(u8::BITS)) as u8;
+        if trailing_bits > 0 {
+            payload[full_bytes] = (1u8 << trailing_bits) - 1;
         }
     }
 
-    fs.atomic_save(path, &bytes)
+    for idx in minority {
+        let byte = &mut payload[(idx / u8::BITS) as usize];
+        let bit = 1u8 << (idx % u8::BITS);
+        if minority_is_ones {
+            *byte |= bit;
+        } else {
+            *byte &= !bit;
+        }
+    }
+
+    bytes
 }

--- a/lib/segment/src/index/field_index/deleted_mask.rs
+++ b/lib/segment/src/index/field_index/deleted_mask.rs
@@ -1,0 +1,317 @@
+//! Persistence of the on-disk field indexes' build-time "no values" mask.
+//!
+//! Written once at build, never mutated afterwards. The format is gated by
+//! [`FeatureFlags::compact_bitmask`]: compact [`StoredBitmask`] when on, the
+//! legacy raw bitslice otherwise. Reading accepts both formats regardless of
+//! the flag — the compact file is tried first, then the index-specific
+//! legacy file.
+//!
+//! [`FeatureFlags::compact_bitmask`]: common::flags::FeatureFlags::compact_bitmask
+
+use std::ops::BitOrAssign;
+use std::path::{Path, PathBuf};
+
+use common::bitvec::BitVec;
+use common::flags::feature_flags;
+use common::mmap::{AdviceSetting, create_and_ensure_length};
+use common::stored_bitmask::{BitmaskContent, StoredBitmask, save_bitmask};
+use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
+use common::types::PointOffsetType;
+use common::universal_io::{
+    CachedReadFs, MmapFs, OkNotFound, OpenOptions, Populate, UniversalRead, UniversalReadFs,
+};
+use roaring::RoaringBitmap;
+
+use crate::common::operation_error::{OperationError, OperationResult};
+
+/// File name of the compact mask; legacy dense-bitslice file names are
+/// index-specific.
+pub(super) const DELETED_MASK_FILE: &str = "deleted_mask.bin";
+
+pub(super) fn deleted_mask_path(dir: &Path) -> PathBuf {
+    dir.join(DELETED_MASK_FILE)
+}
+
+/// Path of the file backing the mask, compact or legacy per the `compact`
+/// value recorded at open time by [`bitor_deleted_mask`].
+pub(super) fn deleted_mask_file(dir: &Path, compact: bool, legacy_file: &str) -> PathBuf {
+    if compact {
+        deleted_mask_path(dir)
+    } else {
+        dir.join(legacy_file)
+    }
+}
+
+/// Persist the mask: compact format when the `compact_bitmask` feature flag
+/// is on, legacy dense bitslice otherwise.
+///
+/// `empty_points` are the ascending offsets of points with no values;
+/// `num_points` is the index's total point count. The file is always
+/// created, even when `empty_points` is empty.
+pub(super) fn save_deleted_mask(
+    dir: &Path,
+    legacy_file: &str,
+    num_points: usize,
+    empty_points: impl IntoIterator<Item = PointOffsetType>,
+) -> OperationResult<()> {
+    save_deleted_mask_format(
+        dir,
+        legacy_file,
+        num_points,
+        empty_points,
+        feature_flags().compact_bitmask,
+    )
+}
+
+fn save_deleted_mask_format(
+    dir: &Path,
+    legacy_file: &str,
+    num_points: usize,
+    empty_points: impl IntoIterator<Item = PointOffsetType>,
+    compact: bool,
+) -> OperationResult<()> {
+    if compact {
+        let ones = RoaringBitmap::from_sorted_iter(empty_points).map_err(|err| {
+            OperationError::service_error(format!("deleted mask offsets are not ascending: {err}"))
+        })?;
+        save_bitmask(&MmapFs, &deleted_mask_path(dir), num_points as u64, ones)?;
+        return Ok(());
+    }
+
+    // Legacy layout: raw bitslice, zero-padded up to whole u64 words.
+    let legacy_path = dir.join(legacy_file);
+    let _ = create_and_ensure_length(
+        &legacy_path,
+        num_points
+            .div_ceil(u8::BITS as usize)
+            .next_multiple_of(size_of::<u64>()),
+    )?;
+    let mut deleted = MmapBitSlice::open(
+        &MmapFs,
+        &legacy_path,
+        OpenOptions {
+            writeable: true,
+            need_sequential: false,
+            populate: Populate::Auto,
+            advice: AdviceSetting::Global,
+        },
+        (),
+    )?;
+    deleted.set_ascending_bits_batch(empty_points.into_iter().map(|idx| (u64::from(idx), true)))?;
+    deleted.flusher()()?;
+    Ok(())
+}
+
+/// OR the persisted mask into `deleted`, which the caller has already resized
+/// to the index's point count. Returns whether the compact file was used.
+pub(super) fn bitor_deleted_mask<S, Fs>(
+    fs: &Fs,
+    dir: &Path,
+    legacy_file: &str,
+    options: OpenOptions,
+    deleted: &mut BitVec,
+) -> OperationResult<bool>
+where
+    S: UniversalRead,
+    Fs: UniversalReadFs<File = S>,
+{
+    let compact = StoredBitmask::<S>::open(fs, deleted_mask_path(dir), options, Default::default())
+        .ok_not_found()?;
+
+    let Some(mask) = compact else {
+        let legacy =
+            StoredBitSlice::<S>::open(fs, dir.join(legacy_file), options, Default::default())?;
+        // The legacy file is padded up to whole u64 words; the padding bits are
+        // always clear, so OR-ing the full slice is harmless.
+        deleted.bitor_assign(legacy.read_all()?.as_ref());
+        return Ok(false);
+    };
+
+    match mask.read()? {
+        BitmaskContent::Dense(bits) => deleted.bitor_assign(bits.as_ref()),
+        BitmaskContent::Ones(ones) => {
+            for idx in ones {
+                let idx = idx as usize;
+                if idx < deleted.len() {
+                    deleted.set(idx, true);
+                }
+            }
+        }
+        BitmaskContent::Zeros(zeros) => {
+            // Everything in `0..bit_len` except `zeros` is set: fill the gaps
+            // between consecutive zero positions instead of setting the
+            // (majority) ones one by one.
+            let end = (mask.bit_len() as usize).min(deleted.len());
+            let mut cursor = 0usize;
+            for zero in zeros {
+                let zero = zero as usize;
+                if zero >= end {
+                    break;
+                }
+                deleted[cursor..zero].fill(true);
+                cursor = zero + 1;
+            }
+            deleted[cursor..end].fill(true);
+        }
+    }
+    Ok(true)
+}
+
+/// Schedule background prefetch of whichever mask file exists.
+pub(super) fn preopen_deleted_mask<S>(
+    fs: &impl CachedReadFs<File = S>,
+    dir: &Path,
+    legacy_file: &str,
+    options: OpenOptions,
+) -> OperationResult<()>
+where
+    S: UniversalRead,
+{
+    if fs
+        .schedule_prefetch(&deleted_mask_path(dir), Some(options), None)
+        .ok_not_found()?
+        .is_some()
+    {
+        return Ok(());
+    }
+    fs.schedule_prefetch(&dir.join(legacy_file), Some(options), None)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use common::mmap::{AdviceSetting, create_and_ensure_length};
+    use common::universal_io::{MmapFile, MmapFs, Populate};
+    use tempfile::TempDir;
+
+    use super::*;
+
+    const LEGACY_FILE: &str = "deleted.bin";
+
+    fn options() -> OpenOptions {
+        OpenOptions::new_for_test()
+    }
+
+    fn read_mask(dir: &Path, num_points: usize) -> (BitVec, bool) {
+        let mut deleted = BitVec::repeat(false, num_points);
+        let compact =
+            bitor_deleted_mask::<MmapFile, _>(&MmapFs, dir, LEGACY_FILE, options(), &mut deleted)
+                .unwrap();
+        (deleted, compact)
+    }
+
+    #[test]
+    fn compact_roundtrip_sparse() {
+        let dir = TempDir::new().unwrap();
+        let empty_points = [3u32, 17, 64, 9_999];
+        save_deleted_mask_format(dir.path(), LEGACY_FILE, 10_000, empty_points, true).unwrap();
+
+        let (deleted, compact) = read_mask(dir.path(), 10_000);
+        assert!(compact);
+        for idx in 0..10_000u32 {
+            assert_eq!(deleted[idx as usize], empty_points.contains(&idx));
+        }
+    }
+
+    #[test]
+    fn compact_roundtrip_mostly_empty_uses_gap_fill() {
+        // A field present on only a few points: the mask is mostly ones and is
+        // stored as roaring-of-zeros, exercising the gap-fill merge path.
+        let dir = TempDir::new().unwrap();
+        let num_points = 100_000usize;
+        let with_values = [0u32, 1, 50_000, 99_999];
+        save_deleted_mask_format(
+            dir.path(),
+            LEGACY_FILE,
+            num_points,
+            (0..num_points as u32).filter(|idx| !with_values.contains(idx)),
+            true,
+        )
+        .unwrap();
+
+        let (deleted, compact) = read_mask(dir.path(), num_points);
+        assert!(compact);
+        for idx in 0..num_points as u32 {
+            assert_eq!(
+                deleted[idx as usize],
+                !with_values.contains(&idx),
+                "mismatch at {idx}",
+            );
+        }
+    }
+
+    #[test]
+    fn flag_off_writes_legacy_format() {
+        let dir = TempDir::new().unwrap();
+        let empty_points = [3u32, 17, 64, 9_999];
+        save_deleted_mask_format(dir.path(), LEGACY_FILE, 10_000, empty_points, false).unwrap();
+
+        assert!(dir.path().join(LEGACY_FILE).exists());
+        assert!(!deleted_mask_path(dir.path()).exists());
+
+        let (deleted, compact) = read_mask(dir.path(), 10_000);
+        assert!(!compact);
+        for idx in 0..10_000u32 {
+            assert_eq!(deleted[idx as usize], empty_points.contains(&idx));
+        }
+    }
+
+    #[test]
+    fn merge_preserves_existing_deletions() {
+        let dir = TempDir::new().unwrap();
+        save_deleted_mask_format(dir.path(), LEGACY_FILE, 100, [7u32], true).unwrap();
+
+        let mut deleted = BitVec::repeat(false, 100);
+        deleted.set(42, true); // pre-existing id-tracker deletion
+        bitor_deleted_mask::<MmapFile, _>(
+            &MmapFs,
+            dir.path(),
+            LEGACY_FILE,
+            options(),
+            &mut deleted,
+        )
+        .unwrap();
+        assert!(deleted[7]);
+        assert!(deleted[42]);
+        assert_eq!(deleted.count_ones(), 2);
+    }
+
+    #[test]
+    fn falls_back_to_legacy_dense_file() {
+        let dir = TempDir::new().unwrap();
+        let legacy_path = dir.path().join(LEGACY_FILE);
+
+        // Legacy layout: raw bitslice padded to whole u64 words.
+        let num_points = 100usize;
+        create_and_ensure_length(
+            &legacy_path,
+            num_points
+                .div_ceil(u8::BITS as usize)
+                .next_multiple_of(size_of::<u64>()),
+        )
+        .unwrap();
+        let mut legacy: StoredBitSlice<MmapFile> = StoredBitSlice::open(
+            &MmapFs,
+            &legacy_path,
+            OpenOptions {
+                writeable: true,
+                need_sequential: false,
+                populate: Populate::Auto,
+                advice: AdviceSetting::Global,
+            },
+            (),
+        )
+        .unwrap();
+        legacy
+            .set_ascending_bits_batch([(5u64, true), (99, true)])
+            .unwrap();
+        legacy.flusher()().unwrap();
+        drop(legacy);
+
+        let (deleted, compact) = read_mask(dir.path(), num_points);
+        assert!(!compact);
+        assert!(deleted[5]);
+        assert!(deleted[99]);
+        assert_eq!(deleted.count_ones(), 2);
+    }
+}

--- a/lib/segment/src/index/field_index/deleted_mask.rs
+++ b/lib/segment/src/index/field_index/deleted_mask.rs
@@ -63,6 +63,15 @@ pub(super) fn save_deleted_mask(
     )
 }
 
+/// Remove a mask file left behind by a build with the opposite format choice,
+/// so readers can't pick up stale bits from it. Missing file is fine.
+fn remove_stale_mask(path: &Path) -> OperationResult<()> {
+    match fs_err::remove_file(path) {
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        result => Ok(result?),
+    }
+}
+
 fn save_deleted_mask_format(
     dir: &Path,
     legacy_file: &str,
@@ -75,7 +84,7 @@ fn save_deleted_mask_format(
             OperationError::service_error(format!("deleted mask offsets are not ascending: {err}"))
         })?;
         save_bitmask(&MmapFs, &deleted_mask_path(dir), num_points as u64, ones)?;
-        return Ok(());
+        return remove_stale_mask(&dir.join(legacy_file));
     }
 
     // Legacy layout: raw bitslice, zero-padded up to whole u64 words.
@@ -99,7 +108,7 @@ fn save_deleted_mask_format(
     )?;
     deleted.set_ascending_bits_batch(empty_points.into_iter().map(|idx| (u64::from(idx), true)))?;
     deleted.flusher()()?;
-    Ok(())
+    remove_stale_mask(&deleted_mask_path(dir))
 }
 
 /// OR the persisted mask into `deleted`, which the caller has already resized
@@ -254,6 +263,29 @@ mod tests {
         for idx in 0..10_000u32 {
             assert_eq!(deleted[idx as usize], empty_points.contains(&idx));
         }
+    }
+
+    #[test]
+    fn format_switch_removes_stale_mask() {
+        let dir = TempDir::new().unwrap();
+
+        // Compact first, then a legacy rebuild with different bits: the stale
+        // compact file must not shadow the fresh legacy mask.
+        save_deleted_mask_format(dir.path(), LEGACY_FILE, 100, [1u32], true).unwrap();
+        save_deleted_mask_format(dir.path(), LEGACY_FILE, 100, [2u32], false).unwrap();
+        assert!(!deleted_mask_path(dir.path()).exists());
+        let (deleted, compact) = read_mask(dir.path(), 100);
+        assert!(!compact);
+        assert!(!deleted[1]);
+        assert!(deleted[2]);
+
+        // And back: a compact rebuild removes the legacy file.
+        save_deleted_mask_format(dir.path(), LEGACY_FILE, 100, [3u32], true).unwrap();
+        assert!(!dir.path().join(LEGACY_FILE).exists());
+        let (deleted, compact) = read_mask(dir.path(), 100);
+        assert!(compact);
+        assert!(!deleted[2]);
+        assert!(deleted[3]);
     }
 
     #[test]

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
@@ -1,17 +1,15 @@
 use std::collections::HashMap;
-use std::ops::BitOrAssign;
 use std::path::{Path, PathBuf};
 
-use common::bitvec::{BitSlice, BitVec, DeletedBitVec};
+use common::bitvec::{BitSlice, DeletedBitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::fs::clear_disk_cache;
 use common::generic_consts::Random;
-use common::mmap::{Advice, AdviceSetting, MmapSlice, create_and_ensure_length};
+use common::mmap::{Advice, AdviceSetting, MmapSlice};
 use common::persisted_hashmap::{READ_ENTRY_OVERHEAD, UniversalHashMap, serialize_hashmap};
-use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFile, MmapFs, OkNotFound, OpenOptions, Populate, ReadRange, TypedStorage,
+    CachedReadFs, MmapFile, OkNotFound, OpenOptions, Populate, ReadRange, TypedStorage,
     UniversalRead, UniversalReadFs, UserData,
 };
 use on_disk_postings::OnDiskPostings;
@@ -28,6 +26,9 @@ use super::postings_iterator::{
 use super::{InvertedIndex, ParsedQuery, TokenId, TokenSet};
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::field_index::deleted_mask::{
+    bitor_deleted_mask, deleted_mask_file, preopen_deleted_mask, save_deleted_mask,
+};
 use crate::index::field_index::full_text_index::inverted_index::Document;
 use crate::index::field_index::full_text_index::inverted_index::postings_iterator::{
     check_compressed_postings_phrase, intersect_compressed_postings_phrase_iterator,
@@ -47,9 +48,10 @@ const DELETED_POINTS_FILE: &str = "deleted_points.dat";
 /// Mmap-backed immutable full-text inverted index.
 ///
 /// On-disk state (`postings.dat`, `vocab.dat`, `point_to_tokens_count.dat`,
-/// `deleted_points.dat`) is written once during [`Self::create`] and not
-/// mutated afterwards: `deleted_points.dat` records only the points whose
-/// document was empty at build time.
+/// `deleted_mask.bin`) is written once during [`Self::create`] and not
+/// mutated afterwards: `deleted_mask.bin` (legacy `deleted_points.dat` on
+/// older segments) records only the points whose document was empty at build
+/// time.
 ///
 /// Runtime deletions live in the in-memory `Storage::deleted_points` bitvec.
 /// They are **not persisted** — [`Self::flusher`] is a no-op and [`Self::remove`]
@@ -59,6 +61,9 @@ const DELETED_POINTS_FILE: &str = "deleted_points.dat";
 pub struct OnDiskInvertedIndex<S: UniversalRead = MmapFile> {
     pub(in crate::index::field_index::full_text_index) path: PathBuf,
     pub(in crate::index::field_index::full_text_index) storage: Storage<S>,
+    /// Whether the "no values" mask was read from the compact
+    /// `deleted_mask.bin` or the legacy `deleted_points.dat`.
+    compact_deleted_mask: bool,
 }
 
 pub(in crate::index::field_index::full_text_index) struct Storage<S: UniversalRead = MmapFile> {
@@ -96,7 +101,6 @@ impl OnDiskInvertedIndex<MmapFile> {
         let postings_path = path.join(POSTINGS_FILE);
         let vocab_path = path.join(VOCAB_FILE);
         let point_to_tokens_count_path = path.join(POINT_TO_TOKENS_COUNT_FILE);
-        let deleted_points_path = path.join(DELETED_POINTS_FILE);
 
         match postings {
             ImmutablePostings::Ids(postings) => create_postings_file(postings_path, postings)?,
@@ -110,36 +114,18 @@ impl OnDiskInvertedIndex<MmapFile> {
             vocab.iter().map(|(k, v)| (k.as_str(), std::iter::once(*v))),
         )?;
 
-        // Save point_to_tokens_count, separated into a bitslice for None values and a slice for actual values
-        //
-        // None values are represented as deleted in the bitslice
-        let deleted_bitslice: BitVec = point_to_tokens_count
-            .iter()
-            .map(|count| *count == 0)
-            .collect();
-        {
-            let deleted_flags_count = deleted_bitslice.len();
-            let _ = create_and_ensure_length(
-                &deleted_points_path,
-                deleted_flags_count
-                    .div_ceil(u8::BITS as usize)
-                    .next_multiple_of(size_of::<u64>()),
-            )?;
-
-            let mut deleted_storage = MmapBitSlice::open(
-                &MmapFs,
-                &deleted_points_path,
-                OpenOptions {
-                    writeable: true,
-                    need_sequential: false,
-                    populate: Populate::Auto,
-                    advice: AdviceSetting::Global,
-                },
-                (),
-            )?;
-            deleted_storage.write_bitslice(&deleted_bitslice)?;
-            deleted_storage.flusher()()?;
-        }
+        // Save point_to_tokens_count, separated into a "no tokens" mask and a
+        // slice for actual values.
+        save_deleted_mask(
+            &path,
+            DELETED_POINTS_FILE,
+            point_to_tokens_count.len(),
+            point_to_tokens_count
+                .iter()
+                .enumerate()
+                .filter(|(_, count)| **count == 0)
+                .map(|(idx, _)| idx as PointOffsetType),
+        )?;
 
         // The actual values go in the slice
         let point_to_tokens_count_iter = point_to_tokens_count.iter().copied();
@@ -200,14 +186,12 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
             None,
         )?;
 
-        // Deleted points
-        fs.schedule_prefetch(
-            &path.join(DELETED_POINTS_FILE),
-            Some(Self::open_options(
-                Populate::PreferBackground,
-                AdviceSetting::Global,
-            )),
-            None,
+        // "No tokens" mask
+        preopen_deleted_mask(
+            fs,
+            path,
+            DELETED_POINTS_FILE,
+            Self::open_options(Populate::PreferBackground, AdviceSetting::Global),
         )?;
 
         Ok(true)
@@ -223,7 +207,6 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
         let postings_path = path.join(POSTINGS_FILE);
         let vocab_path = path.join(VOCAB_FILE);
         let point_to_tokens_count_path = path.join(POINT_TO_TOKENS_COUNT_FILE);
-        let deleted_points_path = path.join(DELETED_POINTS_FILE);
 
         let postings_open_options =
             Self::open_options(populate, AdviceSetting::Advice(Advice::Normal));
@@ -260,14 +243,6 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
             Default::default(),
         )?);
 
-        let deleted_payload_mmap = StoredBitSlice::<S>::open(
-            fs,
-            &deleted_points_path,
-            Self::open_options(populate, AdviceSetting::Global),
-            Default::default(),
-        )?;
-        let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
-
         // `deleted` length must match `point_to_tokens_count.len()` because it
         // only tracks the index's contents. The id-tracker's deleted mask can
         // be shorter or longer; if shorter, the missing entries default to
@@ -277,7 +252,13 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
         let total_count = point_to_tokens_count.len()? as usize;
         let mut deleted = deleted_points.to_owned();
         deleted.resize(total_count, false);
-        deleted.bitor_assign(deleted_payloads_bitslice.as_ref());
+        let compact_deleted_mask = bitor_deleted_mask(
+            fs,
+            &path,
+            DELETED_POINTS_FILE,
+            Self::open_options(populate, AdviceSetting::Global),
+            &mut deleted,
+        )?;
 
         let deleted = DeletedBitVec::new(deleted);
 
@@ -289,6 +270,7 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
                 point_to_tokens_count,
                 deleted_points: deleted,
             },
+            compact_deleted_mask,
         }))
     }
 
@@ -500,7 +482,7 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
             self.path.join(POSTINGS_FILE),
             self.path.join(VOCAB_FILE),
             self.path.join(POINT_TO_TOKENS_COUNT_FILE),
-            self.path.join(DELETED_POINTS_FILE),
+            deleted_mask_file(&self.path, self.compact_deleted_mask, DELETED_POINTS_FILE),
         ]
     }
 
@@ -509,7 +491,7 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
             self.path.join(POSTINGS_FILE),
             self.path.join(VOCAB_FILE),
             self.path.join(POINT_TO_TOKENS_COUNT_FILE),
-            self.path.join(DELETED_POINTS_FILE),
+            deleted_mask_file(&self.path, self.compact_deleted_mask, DELETED_POINTS_FILE),
         ]
     }
 
@@ -535,7 +517,11 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
 
     /// Drop disk cache.
     pub fn clear_cache(&self) -> OperationResult<()> {
-        let Self { path, storage } = self;
+        let Self {
+            path,
+            storage,
+            compact_deleted_mask,
+        } = self;
         let Storage {
             postings,
             vocab,
@@ -545,7 +531,11 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
         postings.clear_cache()?;
         vocab.clear_ram_cache()?;
         point_to_tokens_count.clear_ram_cache()?;
-        clear_disk_cache(&path.join(DELETED_POINTS_FILE))?;
+        clear_disk_cache(&deleted_mask_file(
+            path,
+            *compact_deleted_mask,
+            DELETED_POINTS_FILE,
+        ))?;
         Ok(())
     }
 }

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::ops::BitOrAssign;
 use std::path::{Path, PathBuf};
 
 use ahash::AHashSet;
@@ -11,10 +10,9 @@ use common::fs::{atomic_save_json, clear_disk_cache};
 use common::generic_consts::{Random, Sequential};
 use common::iterator_ext::ordering_iterator::OrderingIterator;
 use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
-use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFile, MmapFs, OkNotFound, OpenOptions, Populate, ReadRange, SortedBlockIndex,
+    CachedReadFs, MmapFile, OkNotFound, OpenOptions, Populate, ReadRange, SortedBlockIndex,
     TypedStorage, UniversalRead, UniversalReadFs, read_json_via,
 };
 use fs_err as fs;
@@ -27,6 +25,9 @@ use super::{
 };
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::field_index::deleted_mask::{
+    bitor_deleted_mask, deleted_mask_file, preopen_deleted_mask, save_deleted_mask,
+};
 use crate::index::field_index::geo_hash::{GeoHash, GeoHashRaw};
 use crate::index::field_index::on_disk_point_to_values::OnDiskPointToValues;
 use crate::types::GeoPoint;
@@ -41,7 +42,6 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
     ) -> OperationResult<Self> {
         fs::create_dir_all(path)?;
 
-        let deleted_path = path.join(DELETED_PATH);
         let stats_path = path.join(STATS_PATH);
         let counts_per_hash_path = path.join(COUNTS_PER_HASH);
         let points_map_path = path.join(POINTS_MAP);
@@ -120,36 +120,17 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
             SortedBlockIndex::write(&path.join(COUNTS_PER_HASH_BLOCK_INDEX), &counts_per_hash)?;
         }
 
-        {
-            let _ = create_and_ensure_length(
-                &deleted_path,
-                dynamic_index
-                    .point_to_values
-                    .len()
-                    .div_ceil(u8::BITS as usize)
-                    .next_multiple_of(size_of::<u64>()),
-            )?;
-            let mut deleted = MmapBitSlice::open(
-                &MmapFs,
-                &deleted_path,
-                OpenOptions {
-                    writeable: true,
-                    need_sequential: false,
-                    populate: Populate::Auto,
-                    advice: AdviceSetting::Global,
-                },
-                (),
-            )?;
-            deleted.set_ascending_bits_batch(
-                dynamic_index
-                    .point_to_values
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, values)| values.is_empty())
-                    .map(|(idx, _)| (idx as u64, true)),
-            )?;
-            deleted.flusher()()?;
-        }
+        save_deleted_mask(
+            path,
+            DELETED_PATH,
+            dynamic_index.point_to_values.len(),
+            dynamic_index
+                .point_to_values
+                .iter()
+                .enumerate()
+                .filter(|(_, values)| values.is_empty())
+                .map(|(idx, _)| idx as PointOffsetType),
+        )?;
 
         atomic_save_json(
             &stats_path,
@@ -211,11 +192,12 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         // Point to values
         OnDiskPointToValues::<GeoPoint, S>::preopen(fs, path, populate)?;
 
-        // Deleted bitslice
-        fs.schedule_prefetch(
-            &path.join(DELETED_PATH),
-            Some(Self::open_options(Populate::PreferBackground)),
-            None,
+        // "No values" mask
+        preopen_deleted_mask(
+            fs,
+            path,
+            DELETED_PATH,
+            Self::open_options(Populate::PreferBackground),
         )?;
 
         Ok(true)
@@ -227,7 +209,6 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         populate: Populate,
         deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
-        let deleted_path = path.join(DELETED_PATH);
         let stats_path = path.join(STATS_PATH);
         let counts_per_hash_path = path.join(COUNTS_PER_HASH);
         let points_map_path = path.join(POINTS_MAP);
@@ -261,21 +242,19 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
 
         let mut deleted = deleted_points.to_owned();
 
-        let deleted_payload_mmap = StoredBitSlice::<S>::open(
-            fs,
-            &deleted_path,
-            Self::open_options(populate),
-            Default::default(),
-        )?;
-        let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
-
         // `deleted` length must match `point_to_values.len()` because it only
         // tracks the index's contents. The id-tracker's deleted mask can be
         // shorter or longer; if shorter, the missing entries default to live
         // (the id-tracker is the source of truth for deletions, and a shorter
         // mask just means it doesn't yet know about those higher offsets).
         deleted.resize(point_to_values.len(), false);
-        deleted.bitor_assign(deleted_payloads_bitslice.as_ref());
+        let compact_deleted_mask = bitor_deleted_mask(
+            fs,
+            path,
+            DELETED_PATH,
+            Self::open_options(populate),
+            &mut deleted,
+        )?;
 
         Ok(Some(Self {
             path: path.to_owned(),
@@ -290,6 +269,7 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
             },
             points_values_count: stats.points_values_count,
             max_values_per_point: stats.max_values_per_point,
+            compact_deleted_mask,
         }))
     }
 
@@ -435,7 +415,7 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
 
     pub fn files(&self) -> Vec<PathBuf> {
         let mut files = vec![
-            self.path.join(DELETED_PATH),
+            deleted_mask_file(&self.path, self.compact_deleted_mask, DELETED_PATH),
             self.path.join(COUNTS_PER_HASH),
             self.path.join(POINTS_MAP),
             self.path.join(POINTS_MAP_IDS),
@@ -448,7 +428,7 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
 
     pub fn immutable_files(&self) -> Vec<PathBuf> {
         let mut files = vec![
-            self.path.join(DELETED_PATH),
+            deleted_mask_file(&self.path, self.compact_deleted_mask, DELETED_PATH),
             self.path.join(COUNTS_PER_HASH),
             self.path.join(POINTS_MAP),
             self.path.join(POINTS_MAP_IDS),
@@ -641,6 +621,7 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
             storage,
             points_values_count: _,
             max_values_per_point: _,
+            compact_deleted_mask,
         } = self;
         let Storage {
             counts_per_hash,
@@ -651,7 +632,11 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
             point_to_values,
             deleted: _,
         } = storage;
-        clear_disk_cache(&path.join(DELETED_PATH))?;
+        clear_disk_cache(&deleted_mask_file(
+            path,
+            *compact_deleted_mask,
+            DELETED_PATH,
+        ))?;
         counts_per_hash.clear_ram_cache()?;
         if counts_per_hash_block_index.is_some() {
             clear_disk_cache(&path.join(COUNTS_PER_HASH_BLOCK_INDEX))?;

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/mod.rs
@@ -54,9 +54,10 @@ pub(in super::super) struct PointKeyValue {
 /// Mmap-backed immutable geo index.
 ///
 /// On-disk state (`counts_per_hash.bin`, `points_map.bin`, `points_map_ids.bin`,
-/// `deleted.bin`, `point_to_values.*`, etc.) is written once during
-/// [`Self::build`] and not mutated afterwards: `deleted.bin` records only the
-/// points whose payload was empty at build time.
+/// `deleted_mask.bin`, `point_to_values.*`, etc.) is written once during
+/// [`Self::build`] and not mutated afterwards: `deleted_mask.bin` (legacy
+/// `deleted.bin` on older segments) records only the points whose payload was
+/// empty at build time.
 ///
 /// Runtime deletions live in the in-memory `Storage::deleted` bitvec. They are
 /// **not persisted** — [`Self::flusher`] is a no-op and [`Self::remove_point`]
@@ -68,6 +69,9 @@ pub struct OnDiskGeoIndex<S: UniversalRead = MmapFile> {
     pub(in super::super) storage: Storage<S>,
     pub(super) points_values_count: usize,
     pub(super) max_values_per_point: usize,
+    /// Whether the "no values" mask was read from the compact
+    /// `deleted_mask.bin` or the legacy `deleted.bin`.
+    pub(super) compact_deleted_mask: bool,
 }
 
 pub(in super::super) struct Storage<S: UniversalRead = MmapFile> {
@@ -89,8 +93,8 @@ pub(in super::super) struct Storage<S: UniversalRead = MmapFile> {
     /// One-to-many mapping of the PointOffsetType to the GeoPoint.
     pub(in super::super) point_to_values: OnDiskPointToValues<GeoPoint, S>,
     /// In-memory deletion bitmap. Reconstructed at load time as the union of
-    /// the build-time empty-payload bits read from `deleted.bin` and the
-    /// segment-level deleted bitslice supplied by the id-tracker. Not persisted.
+    /// the build-time empty-payload mask read from disk and the segment-level
+    /// deleted bitslice supplied by the id-tracker. Not persisted.
     pub(in super::super) deleted: DeletedBitVec,
 }
 

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
@@ -1,13 +1,11 @@
 use std::borrow::Borrow;
-use std::ops::BitOrAssign;
 use std::path::{Path, PathBuf};
 
 use ahash::HashMap;
 use common::bitvec::{BitSlice, DeletedBitVec};
 use common::fs::{atomic_save_json, clear_disk_cache};
-use common::mmap::{AdviceSetting, create_and_ensure_length};
+use common::mmap::AdviceSetting;
 use common::persisted_hashmap::{Key, UniversalHashMap, serialize_hashmap};
-use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
     CachedReadFs, MmapFile, OkNotFound, OpenOptions, Populate, UniversalRead, UniversalReadFs,
@@ -22,6 +20,9 @@ use super::{
 };
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::field_index::deleted_mask::{
+    bitor_deleted_mask, deleted_mask_file, preopen_deleted_mask, save_deleted_mask,
+};
 use crate::index::field_index::on_disk_point_to_values::OnDiskPointToValues;
 
 impl<N, S> OnDiskMapIndex<N, S>
@@ -68,12 +69,12 @@ where
         // Prefix index
         PrefixIndex::preopen(fs, path, populate)?;
 
-        // Deleted bitslice
-        let deleted_path = path.join(DELETED_PATH);
-        fs.schedule_prefetch(
-            &deleted_path,
-            Some(Self::open_options(Populate::PreferBackground)),
-            None,
+        // "No values" mask
+        preopen_deleted_mask(
+            fs,
+            path,
+            DELETED_PATH,
+            Self::open_options(Populate::PreferBackground),
         )?;
 
         Ok(true)
@@ -87,7 +88,6 @@ where
         deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
         let hashmap_path = path.join(HASHMAP_PATH);
-        let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
 
         let Some(config) =
@@ -108,22 +108,19 @@ where
 
         let mut deleted = deleted_points.to_owned();
 
-        let deleted_payload_mmap = StoredBitSlice::<S>::open(
-            fs,
-            &deleted_path,
-            Self::open_options(Populate::No),
-            Default::default(),
-        )?;
-
-        let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
-
         // `deleted` length must match `point_to_values.len()` because it only
         // tracks the index's contents. The id-tracker's deleted mask can be
         // shorter or longer; if shorter, the missing entries default to live
         // (the id-tracker is the source of truth for deletions, and a shorter
         // mask just means it doesn't yet know about those higher offsets).
         deleted.resize(point_to_values.len(), false);
-        deleted.bitor_assign(deleted_payloads_bitslice.as_ref());
+        let compact_deleted_mask = bitor_deleted_mask(
+            fs,
+            path,
+            DELETED_PATH,
+            Self::open_options(Populate::No),
+            &mut deleted,
+        )?;
 
         Ok(Some(Self {
             path: path.to_path_buf(),
@@ -134,6 +131,7 @@ where
                 prefix_index,
             },
             total_key_value_pairs: config.total_key_value_pairs,
+            compact_deleted_mask,
         }))
     }
 
@@ -148,7 +146,7 @@ where
     pub fn files(&self) -> Vec<PathBuf> {
         let mut files = vec![
             self.path.join(HASHMAP_PATH),
-            self.path.join(DELETED_PATH),
+            deleted_mask_file(&self.path, self.compact_deleted_mask, DELETED_PATH),
             self.path.join(CONFIG_PATH),
         ];
         if self.storage.prefix_index.is_some() {
@@ -161,7 +159,7 @@ where
     pub fn immutable_files(&self) -> Vec<PathBuf> {
         let mut files = vec![
             self.path.join(HASHMAP_PATH),
-            self.path.join(DELETED_PATH),
+            deleted_mask_file(&self.path, self.compact_deleted_mask, DELETED_PATH),
             self.path.join(CONFIG_PATH),
         ];
         if self.storage.prefix_index.is_some() {
@@ -188,6 +186,7 @@ where
             path,
             storage,
             total_key_value_pairs: _,
+            compact_deleted_mask,
         } = self;
         let Storage {
             value_to_points,
@@ -196,7 +195,11 @@ where
             prefix_index,
         } = storage;
         value_to_points.clear_ram_cache()?;
-        clear_disk_cache(&path.join(DELETED_PATH))?;
+        clear_disk_cache(&deleted_mask_file(
+            path,
+            *compact_deleted_mask,
+            DELETED_PATH,
+        ))?;
         point_to_values.clear_cache()?;
         if let Some(prefix_index) = prefix_index {
             prefix_index.clear_cache()?;
@@ -233,7 +236,6 @@ where
         fs::create_dir_all(path)?;
 
         let hashmap_path = path.join(HASHMAP_PATH);
-        let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
 
         atomic_save_json(
@@ -274,35 +276,16 @@ where
             }),
         )?;
 
-        {
-            let deleted_flags_count = point_to_values.len();
-            let _ = create_and_ensure_length(
-                &deleted_path,
-                deleted_flags_count
-                    .div_ceil(u8::BITS as usize)
-                    .next_multiple_of(size_of::<u64>()),
-            )?;
-
-            let mut deleted = StoredBitSlice::<S>::open(
-                fs,
-                &deleted_path,
-                OpenOptions {
-                    writeable: true,
-                    need_sequential: false,
-                    populate: Populate::Auto,
-                    advice: AdviceSetting::Global,
-                },
-                Default::default(),
-            )?;
-            deleted.set_ascending_bits_batch(
-                point_to_values
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, values)| values.is_empty())
-                    .map(|(idx, _)| (idx as u64, true)),
-            )?;
-            deleted.flusher()()?;
-        }
+        save_deleted_mask(
+            path,
+            DELETED_PATH,
+            point_to_values.len(),
+            point_to_values
+                .iter()
+                .enumerate()
+                .filter(|(_, values)| values.is_empty())
+                .map(|(idx, _)| idx as PointOffsetType),
+        )?;
 
         Self::open(fs, path, populate, deleted_points)?.ok_or_else(|| {
             OperationError::service_error("Failed to open UniversalMapIndex after building it")

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/mod.rs
@@ -20,10 +20,11 @@ pub(super) const CONFIG_PATH: &str = "mmap_field_index_config.json";
 
 /// Immutable map index served directly from a [`UniversalRead`] storage backend.
 ///
-/// On-disk state (`values_to_points.bin`, `deleted.bin`, `point_to_values.*`,
-/// `mmap_field_index_config.json`) is written once during [`Self::build`] and
-/// not mutated afterwards: `deleted.bin` records only the points whose payload
-/// was empty at build time.
+/// On-disk state (`values_to_points.bin`, `deleted_mask.bin`,
+/// `point_to_values.*`, `mmap_field_index_config.json`) is written once during
+/// [`Self::build`] and not mutated afterwards: `deleted_mask.bin` (legacy
+/// `deleted.bin` on older segments) records only the points whose payload was
+/// empty at build time.
 ///
 /// Runtime deletions live in the in-memory `Storage::deleted` bitvec. They are
 /// **not persisted** — [`Self::flusher`] is a no-op and [`Self::remove_point`]
@@ -34,14 +35,17 @@ pub struct OnDiskMapIndex<N: MapIndexKey + Key + ?Sized, S: UniversalRead = Mmap
     pub(super) path: PathBuf,
     pub(super) storage: Storage<N, S>,
     pub(super) total_key_value_pairs: usize,
+    /// Whether the "no values" mask was read from the compact
+    /// `deleted_mask.bin` or the legacy `deleted.bin`.
+    pub(super) compact_deleted_mask: bool,
 }
 
 pub(super) struct Storage<N: MapIndexKey + Key + ?Sized, S: UniversalRead = MmapFile> {
     pub(super) value_to_points: UniversalHashMap<N, PointOffsetType, S>,
     pub(super) point_to_values: OnDiskPointToValues<N, S>,
     /// In-memory deletion bitmap. Reconstructed at load time as the union of
-    /// the build-time empty-payload bits read from `deleted.bin` and the
-    /// segment-level deleted bitslice supplied by the id-tracker. Not persisted.
+    /// the build-time empty-payload mask read from disk and the segment-level
+    /// deleted bitslice supplied by the id-tracker. Not persisted.
     pub(super) deleted: DeletedBitVec,
     /// Sorted key dictionary for prefix queries. Present only when the index
     /// was built with the `prefix` option (signalled by the presence of its

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -6,6 +6,7 @@ use common::types::PointOffsetType;
 use crate::types::{Condition, FieldCondition, PointIdType, VectorNameBuf};
 
 pub mod bool_index;
+mod deleted_mask;
 pub(super) mod facet_index;
 mod field_index_base;
 pub mod full_text_index;

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/lifecycle.rs
@@ -1,15 +1,13 @@
 use std::borrow::Borrow;
-use std::ops::BitOrAssign;
 use std::path::{Path, PathBuf};
 
 use common::bitvec::{BitSlice, DeletedBitVec};
 use common::fs::{atomic_save_json, clear_disk_cache};
 use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
-use common::stored_bitslice::{MmapBitSlice, StoredBitSlice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFs, OkNotFound, OpenOptions, Populate, SortedBlockIndex, TypedStorage,
-    UniversalRead, UniversalReadFs, read_json_via,
+    CachedReadFs, OkNotFound, OpenOptions, Populate, SortedBlockIndex, TypedStorage, UniversalRead,
+    UniversalReadFs, read_json_via,
 };
 use fs_err as fs;
 use memmap2::MmapMut;
@@ -22,6 +20,9 @@ use super::{
 };
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::field_index::deleted_mask::{
+    bitor_deleted_mask, deleted_mask_file, preopen_deleted_mask, save_deleted_mask,
+};
 use crate::index::field_index::histogram::Histogram;
 use crate::index::field_index::numeric_point::{Numericable, Point};
 use crate::index::field_index::on_disk_point_to_values::{OnDiskPointToValues, StoredValue};
@@ -47,7 +48,6 @@ where
         fs::create_dir_all(path)?;
 
         let pairs_path = path.join(PAIRS_PATH);
-        let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
 
         atomic_save_json(
@@ -82,36 +82,17 @@ where
             SortedBlockIndex::write(&path.join(PAIRS_BLOCK_INDEX_PATH), &pairs)?;
         }
 
-        {
-            let deleted_flags_count = in_memory_index.point_to_values.len();
-            let _ = create_and_ensure_length(
-                &deleted_path,
-                deleted_flags_count
-                    .div_ceil(u8::BITS as usize)
-                    .next_multiple_of(size_of::<u64>()),
-            )?;
-
-            let mut deleted = MmapBitSlice::open(
-                &MmapFs,
-                &deleted_path,
-                OpenOptions {
-                    writeable: true,
-                    need_sequential: false,
-                    populate: Populate::Auto,
-                    advice: AdviceSetting::Global,
-                },
-                (),
-            )?;
-            deleted.set_ascending_bits_batch(
-                in_memory_index
-                    .point_to_values
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, values)| values.is_empty())
-                    .map(|(idx, _)| (idx as u64, true)),
-            )?;
-            deleted.flusher()()?;
-        }
+        save_deleted_mask(
+            path,
+            DELETED_PATH,
+            in_memory_index.point_to_values.len(),
+            in_memory_index
+                .point_to_values
+                .iter()
+                .enumerate()
+                .filter(|(_, values)| values.is_empty())
+                .map(|(idx, _)| idx as PointOffsetType),
+        )?;
 
         Self::open(fs, path, populate, deleted_points)?.ok_or_else(|| {
             OperationError::service_error("Failed to open UniversalNumericIndex after building it")
@@ -162,12 +143,12 @@ where
         // Point to values
         OnDiskPointToValues::<T, S>::preopen(fs, path, populate)?;
 
-        // Deleted bitslice
-        let deleted_path = path.join(DELETED_PATH);
-        fs.schedule_prefetch(
-            &deleted_path,
-            Some(Self::open_options(Populate::PreferBackground)),
-            None,
+        // "No values" mask
+        preopen_deleted_mask(
+            fs,
+            path,
+            DELETED_PATH,
+            Self::open_options(Populate::PreferBackground),
         )?;
 
         Ok(true)
@@ -181,7 +162,6 @@ where
         deleted_points: &BitSlice,
     ) -> OperationResult<Option<Self>> {
         let pairs_path = path.join(PAIRS_PATH);
-        let deleted_path = path.join(DELETED_PATH);
         let config_path = path.join(CONFIG_PATH);
 
         let Some(config) =
@@ -208,21 +188,19 @@ where
         let point_to_values = OnDiskPointToValues::open(fs, path, populate)?;
         let mut deleted = deleted_points.to_owned();
 
-        let deleted_payload_mmap = StoredBitSlice::<S>::open(
-            fs,
-            &deleted_path,
-            Self::open_options(Populate::Auto),
-            Default::default(),
-        )?;
-        let deleted_payloads_bitslice = deleted_payload_mmap.read_all()?;
-
         // `deleted` length must match `point_to_values.len()` because it only
         // tracks the index's contents. The id-tracker's deleted mask can be
         // shorter or longer; if shorter, the missing entries default to live
         // (the id-tracker is the source of truth for deletions, and a shorter
         // mask just means it doesn't yet know about those higher offsets).
         deleted.resize(point_to_values.len(), false);
-        deleted.bitor_assign(deleted_payloads_bitslice.as_ref());
+        let compact_deleted_mask = bitor_deleted_mask(
+            fs,
+            path,
+            DELETED_PATH,
+            Self::open_options(Populate::Auto),
+            &mut deleted,
+        )?;
 
         Ok(Some(Self {
             path: path.to_path_buf(),
@@ -234,6 +212,7 @@ where
             },
             histogram,
             max_values_per_point: config.max_values_per_point,
+            compact_deleted_mask,
         }))
     }
 }
@@ -258,7 +237,7 @@ where
     pub fn files(&self) -> Vec<PathBuf> {
         let mut files = vec![
             self.path.join(PAIRS_PATH),
-            self.path.join(DELETED_PATH),
+            deleted_mask_file(&self.path, self.compact_deleted_mask, DELETED_PATH),
             self.path.join(CONFIG_PATH),
         ];
         if self.storage.pairs_block_index.is_some() {
@@ -272,7 +251,7 @@ where
     pub fn immutable_files(&self) -> Vec<PathBuf> {
         let mut files = vec![
             self.path.join(PAIRS_PATH),
-            self.path.join(DELETED_PATH),
+            deleted_mask_file(&self.path, self.compact_deleted_mask, DELETED_PATH),
             self.path.join(CONFIG_PATH),
         ];
         if self.storage.pairs_block_index.is_some() {
@@ -312,6 +291,7 @@ where
             storage,
             histogram: _,
             max_values_per_point: _,
+            compact_deleted_mask,
         } = self;
         let Storage {
             deleted: _,
@@ -323,7 +303,11 @@ where
         if pairs_block_index.is_some() {
             clear_disk_cache(&path.join(PAIRS_BLOCK_INDEX_PATH))?;
         }
-        clear_disk_cache(&path.join(DELETED_PATH))?;
+        clear_disk_cache(&deleted_mask_file(
+            path,
+            *compact_deleted_mask,
+            DELETED_PATH,
+        ))?;
         point_to_values.clear_cache()?;
         Ok(())
     }
@@ -334,6 +318,7 @@ where
             storage,
             histogram,
             max_values_per_point: _,
+            compact_deleted_mask: _,
         } = self;
 
         histogram.ram_usage_bytes() + storage.ram_usage_bytes()

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/mod.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/mod.rs
@@ -20,9 +20,10 @@ pub(super) const CONFIG_PATH: &str = "mmap_field_index_config.json";
 /// Immutable numeric index served directly from a [`UniversalRead`] storage
 /// backend.
 ///
-/// On-disk state (`data.bin`, `deleted.bin`, `point_to_values.*`, etc.) is
-/// written once during [`Self::build`] and not mutated afterwards: `deleted.bin`
-/// records only the points whose payload was empty at build time.
+/// On-disk state (`data.bin`, `deleted_mask.bin`, `point_to_values.*`, etc.)
+/// is written once during [`Self::build`] and not mutated afterwards:
+/// `deleted_mask.bin` (legacy `deleted.bin` on older segments) records only
+/// the points whose payload was empty at build time.
 ///
 /// Runtime deletions live in the in-memory `Storage::deleted` bitvec. They are
 /// **not persisted** — [`Self::flusher`] is a no-op and [`Self::remove_point`]
@@ -37,6 +38,9 @@ pub struct OnDiskNumericIndex<
     pub(super) storage: Storage<T, S>,
     pub(super) histogram: Histogram<T>,
     pub(super) max_values_per_point: usize,
+    /// Whether the "no values" mask was read from the compact
+    /// `deleted_mask.bin` or the legacy `deleted.bin`.
+    pub(super) compact_deleted_mask: bool,
 }
 
 pub(in super::super) struct Storage<

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -837,9 +837,13 @@ fn test_numeric_index_open_compact_deleted_mask(#[case] index_type: IndexType) {
     // Convert the legacy dense mask into the compact format: same bits
     // (offset 0 = no point at internal id 0, offset 4 = the empty-payload
     // point), 10 logical flags.
+    // The legacy file only exists when the build ran with `compact_bitmask`
+    // off (the default in tests); tolerate either so a future flag-default
+    // change doesn't break the test.
     let legacy_path = temp_dir.path().join("deleted.bin");
-    assert!(legacy_path.exists());
-    fs_err::remove_file(&legacy_path).unwrap();
+    if legacy_path.exists() {
+        fs_err::remove_file(&legacy_path).unwrap();
+    }
     let ones = RoaringBitmap::from_sorted_iter([0u32, 4]).unwrap();
     save_bitmask(&MmapFs, &deleted_mask_path(temp_dir.path()), 10, ones).unwrap();
     assert!(temp_dir.path().join(DELETED_MASK_FILE).exists());

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -790,6 +790,78 @@ fn test_numeric_index_reload_short_deleted_bitslice(#[case] index_type: IndexTyp
     assert_eq!(index.inner().get_points_count(), 7);
 }
 
+/// An index whose "no values" mask is stored in the compact `StoredBitmask`
+/// format (written when the `compact_bitmask` feature flag is on) must open
+/// and filter identically to one with the legacy dense bitslice.
+///
+/// Tests run with default feature flags, so the build above writes the legacy
+/// file; convert it to the compact format by hand and reopen.
+#[rstest]
+#[case(IndexType::Mmap)]
+#[case(IndexType::RamMmap)]
+fn test_numeric_index_open_compact_deleted_mask(#[case] index_type: IndexType) {
+    use common::stored_bitmask::save_bitmask;
+    use common::universal_io::MmapFs;
+    use roaring::RoaringBitmap;
+
+    use crate::index::field_index::deleted_mask::{DELETED_MASK_FILE, deleted_mask_path};
+
+    let (temp_dir, mut index_builder) = get_index_builder(index_type);
+
+    // Same setup as `test_numeric_index_reload_short_deleted_bitslice`:
+    // point 4 has an empty payload, so the build marks it in the mask.
+    let values: Vec<Vec<f64>> = vec![
+        vec![1.0],
+        vec![1.0],
+        vec![1.0],
+        vec![], // empty payload at id 4
+        vec![1.0],
+        vec![2.0],
+        vec![2.5],
+        vec![2.6],
+        vec![3.0],
+    ];
+
+    let hw_counter = HardwareCounterCell::new();
+    values.into_iter().enumerate().for_each(|(idx, values)| {
+        let values = values.iter().map(|v| Value::from(*v)).collect_vec();
+        let values = values.iter().collect_vec();
+        let new_idx = idx as PointOffsetType + 1;
+        index_builder
+            .add_point(new_idx, &values, &hw_counter)
+            .unwrap();
+    });
+    let index = index_builder.finalize().unwrap();
+    drop(index);
+
+    // Convert the legacy dense mask into the compact format: same bits
+    // (offset 0 = no point at internal id 0, offset 4 = the empty-payload
+    // point), 10 logical flags.
+    let legacy_path = temp_dir.path().join("deleted.bin");
+    assert!(legacy_path.exists());
+    fs_err::remove_file(&legacy_path).unwrap();
+    let ones = RoaringBitmap::from_sorted_iter([0u32, 4]).unwrap();
+    save_bitmask(&MmapFs, &deleted_mask_path(temp_dir.path()), 10, ones).unwrap();
+    assert!(temp_dir.path().join(DELETED_MASK_FILE).exists());
+
+    let mut short_deleted = BitVec::repeat(false, 3);
+    short_deleted.set(1, true);
+    let index = open_index_from_disk(temp_dir.path(), index_type, &short_deleted);
+
+    // Same expectations as the legacy-format test.
+    test_cond(
+        index.inner(),
+        Range {
+            gt: None,
+            gte: Some(1.0),
+            lt: None,
+            lte: None,
+        },
+        vec![2, 3, 5, 6, 7, 8, 9],
+    );
+    assert_eq!(index.inner().get_points_count(), 7);
+}
+
 fn test_cond<T: NumericIndexValue + PartialOrd + Clone + 'static>(
     index: &NumericIndexInner<T>,
     rng: Range<FloatPayloadType>,


### PR DESCRIPTION
## What

Adds `StoredBitmask` (`lib/common/common/src/stored_bitmask/`): a compact persisted bitmask, written and read as a whole. The payload is a roaring bitmap of whichever bit value is the minority, falling back to raw dense bits when roaring would not be smaller — so the file is never larger than the dense representation, and both mostly-0 and mostly-1 masks stay tiny. Files are replaced atomically via `UniversalWriteFileOps::atomic_save`; there is no in-place mutation, so an open always sees a consistent snapshot.

First consumer: the write-once "no values" masks of the on-disk numeric, geo, map and full-text indexes (via a shared `field_index::deleted_mask` helper). These were previously raw dense bitslices sized `point_count / 8` bytes regardless of content; for a typical sparse mask the compact file is a few dozen bytes.

## Format gating and compatibility

- Writing the new format is gated by a new `compact_bitmask` feature flag: **default off**, enabled by `all` and by `serverless_compatible`. With the flag off, builds write byte-identical legacy dense files.
- Reading is format-agnostic regardless of the flag: the compact `deleted_mask.bin` is tried first, then the index-specific legacy file (`deleted.bin` / `deleted_points.dat`). Old segments stay readable; the fallback never errors on them.
- Both formats always create the mask file, even with zero set bits — absence never encodes emptiness, matching the legacy reader contract.
- Each index records which format it opened so `files()` / `immutable_files()` / `clear_cache()` report the right file.

## Notes

- Encoding is chosen per write: minority polarity as roaring (with `optimize()` for run containers), dense as the capped worst case (e.g. alternating bits).
- Dense reads are zero-copy on mmap (`BitmaskContent::Dense(Cow<BitSlice>)`); mostly-1s masks merge via gap-fill between zero positions rather than per-bit sets.
- Once a segment is built with the flag on, binaries predating this PR cannot open it — the usual forward-only implication of enabling the flag.

## Tests

- Format unit tests: both polarities, dense fallback (both polarities), empty/full masks, unaligned lengths, atomic overwrite, foreign-file rejection.
- Helper tests: compact + legacy read paths, gap-fill merge, OR-merge preserving id-tracker deletions, flag-off writes legacy.
- End-to-end: numeric index opened over a compact mask filters identically to the legacy format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)