### PR TITLE
feat: segment manifest optimizing state with lease

### DIFF
--- a/lib/edge/src/lib.rs
+++ b/lib/edge/src/lib.rs
@@ -196,16 +196,16 @@ impl EdgeShard {
             return Ok(());
         };
 
-        let current = {
+        let rebuilt = {
             let holder = self.segments.read();
-            SegmentsManifest::from_segment_holder(&holder).preserving(&manifest.read())
+            SegmentsManifest::from_segment_holder(&holder)
         };
-        if *manifest.read() == current {
-            return Ok(());
-        }
-
+        // Merge under the write lock (see `SegmentsManifest::sync`).
         manifest
-            .write(|manifest| *manifest = current)
+            .write_optional(|previous| {
+                let current = rebuilt.preserving(previous);
+                (*previous != current).then_some(current)
+            })
             .map_err(|err| OperationError::service_error(err.to_string()))?;
         Ok(())
     }

--- a/lib/edge/src/lib.rs
+++ b/lib/edge/src/lib.rs
@@ -50,7 +50,7 @@ use shard::files::{PAYLOAD_INDEX_CONFIG_FILE, SEGMENTS_PATH, segment_manifest_pa
 use shard::operations::CollectionUpdateOperations;
 use shard::segment_holder::locked::LockedSegmentHolder;
 use shard::segment_holder::{FlushMode, SegmentHolder};
-use shard::segment_manifest::SegmentsManifest;
+pub use shard::segment_manifest::{SegmentManifestState, SegmentsManifest};
 use shard::wal::SerdeWal;
 use uuid::Uuid;
 
@@ -189,13 +189,17 @@ impl EdgeShard {
     }
 
     /// Rebuild and persist the segment manifest from the current live segment set, when enabled.
-    /// Cheap and idempotent: only writes when the set differs from what's persisted.
+    /// Cheap and idempotent: only writes when the set differs from what's persisted. Preserves an
+    /// out-of-process optimizer's marks for still-live segments.
     pub(crate) fn update_segment_manifest(&self) -> OperationResult<()> {
         let Some(manifest) = &self.segment_manifest else {
             return Ok(());
         };
 
-        let current = SegmentsManifest::from_segment_holder(&self.segments.read());
+        let current = {
+            let holder = self.segments.read();
+            SegmentsManifest::from_segment_holder(&holder).preserving(&manifest.read())
+        };
         if *manifest.read() == current {
             return Ok(());
         }
@@ -273,8 +277,18 @@ fn init_segment_manifest(
         return Ok(None);
     }
 
-    let manifest = SegmentsManifest::from_segment_holder(segments);
-    let manifest = SaveOnDisk::new(segment_manifest_path(path), manifest)
+    // `SaveOnDisk::new` persists immediately — read the existing manifest first so an
+    // optimizer's marks survive a (re)load. An unreadable manifest is replaced, as before.
+    let manifest_path = segment_manifest_path(path);
+    let rebuilt = SegmentsManifest::from_segment_holder(segments);
+    let manifest = match fs::read(&manifest_path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<SegmentsManifest>(&bytes).ok())
+    {
+        Some(previous) => rebuilt.preserving(&previous),
+        None => rebuilt,
+    };
+    let manifest = SaveOnDisk::new(manifest_path, manifest)
         .map_err(|err| OperationError::service_error(err.to_string()))?;
     Ok(Some(manifest))
 }

--- a/lib/edge/src/read_only/enumerate.rs
+++ b/lib/edge/src/read_only/enumerate.rs
@@ -65,11 +65,13 @@ impl<F: UniversalReadFs + Send + Sync> SegmentEnumerator for ManifestSegmentEnum
         Ok(manifest
             .iter()
             // Optimizing segments stay live (deletes keep landing in them) until the swap.
-            .filter(|(_, state)| {
-                matches!(
-                    state,
-                    SegmentManifestState::Active | SegmentManifestState::Optimizing { .. },
-                )
+            .filter(|(_, state)| match state {
+                SegmentManifestState::Active
+                | SegmentManifestState::Optimizing {
+                    holder: _,
+                    lease_until: _,
+                } => true,
+                SegmentManifestState::UnderConstruction | SegmentManifestState::Retiring => false,
             })
             .map(|(uuid, _)| (*uuid, self.segments_path.join(uuid.to_string())))
             .collect())

--- a/lib/edge/src/read_only/enumerate.rs
+++ b/lib/edge/src/read_only/enumerate.rs
@@ -111,7 +111,7 @@ mod tests {
         let building = "6ba7b812-9dad-11d1-80b4-00c04fd430c8";
 
         let dir = tempfile::tempdir().unwrap();
-        std::fs::write(
+        fs_err::write(
             segment_manifest_path(dir.path()),
             format!(
                 r#"{{"{active}":"active",

--- a/lib/edge/src/read_only/enumerate.rs
+++ b/lib/edge/src/read_only/enumerate.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use common::universal_io::{UniversalReadFs, read_json_via};
 use segment::common::operation_error::OperationResult;
 use shard::files::{SEGMENTS_PATH, segment_manifest_path};
-use shard::segment_manifest::{SegmentManifestState, SegmentsManifest};
+use shard::segment_manifest::SegmentsManifest;
 use uuid::Uuid;
 
 use crate::scan_segment_dirs;
@@ -64,15 +64,7 @@ impl<F: UniversalReadFs + Send + Sync> SegmentEnumerator for ManifestSegmentEnum
         let manifest: SegmentsManifest = read_json_via(&self.fs, &self.manifest_path)?;
         Ok(manifest
             .iter()
-            // Optimizing segments stay live (deletes keep landing in them) until the swap.
-            .filter(|(_, state)| match state {
-                SegmentManifestState::Active
-                | SegmentManifestState::Optimizing {
-                    holder: _,
-                    lease_until: _,
-                } => true,
-                SegmentManifestState::UnderConstruction | SegmentManifestState::Retiring => false,
-            })
+            .filter(|(_, state)| state.is_usable())
             .map(|(uuid, _)| (*uuid, self.segments_path.join(uuid.to_string())))
             .collect())
     }
@@ -96,44 +88,5 @@ impl LocalSegmentEnumerator {
 impl SegmentEnumerator for LocalSegmentEnumerator {
     fn list_segments(&self) -> OperationResult<HashMap<Uuid, PathBuf>> {
         scan_segment_dirs(&self.segments_path)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use common::universal_io::MmapFs;
-
-    use super::*;
-
-    #[test]
-    fn manifest_enumerator_serves_active_and_optimizing_only() {
-        let active = "1b4e28ba-2fa1-11d2-883f-0016d3cca427";
-        let optimizing = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
-        let retiring = "6ba7b811-9dad-11d1-80b4-00c04fd430c8";
-        let building = "6ba7b812-9dad-11d1-80b4-00c04fd430c8";
-
-        let dir = tempfile::tempdir().unwrap();
-        fs_err::write(
-            segment_manifest_path(dir.path()),
-            format!(
-                r#"{{"{active}":"active",
-                    "{optimizing}":{{"optimizing":{{"holder":"indexer-1","lease_until":42}}}},
-                    "{retiring}":"retiring",
-                    "{building}":"under_construction"}}"#,
-            ),
-        )
-        .unwrap();
-
-        let listed = ManifestSegmentEnumerator::new(MmapFs, dir.path())
-            .list_segments()
-            .unwrap();
-
-        let mut uuids: Vec<String> = listed.keys().map(Uuid::to_string).collect();
-        uuids.sort();
-        assert_eq!(uuids, [active, optimizing]);
-        assert_eq!(
-            listed[&Uuid::parse_str(optimizing).unwrap()],
-            dir.path().join(SEGMENTS_PATH).join(optimizing),
-        );
     }
 }

--- a/lib/edge/src/read_only/enumerate.rs
+++ b/lib/edge/src/read_only/enumerate.rs
@@ -28,10 +28,10 @@ pub trait SegmentEnumerator: Send + Sync {
 }
 
 /// [`SegmentEnumerator`] that reads the leader's segment manifest (`segments_manifest.json`, sitting
-/// next to the `segments/` directory) and returns its `active` segments — the proper, scan-free
-/// discovery path. Errors if no manifest is present: the manifest is the source of truth, so a
-/// follower using this enumerator requires the leader to write one (the `write_segment_manifest`
-/// feature flag).
+/// next to the `segments/` directory) and returns its readable segments — `active`, plus
+/// `optimizing` ones which stay live until their rebuild's swap. Errors if no manifest is present:
+/// the manifest is the source of truth, so a follower using this enumerator requires the leader to
+/// write one (the `write_segment_manifest` feature flag).
 ///
 /// Generic over the read backend `F` (a [`UniversalReadFs`]), so it reads the manifest over any
 /// storage — local memory-mapped files ([`MmapFs`](common::universal_io::MmapFs)) or a blob/S3
@@ -64,7 +64,13 @@ impl<F: UniversalReadFs + Send + Sync> SegmentEnumerator for ManifestSegmentEnum
         let manifest: SegmentsManifest = read_json_via(&self.fs, &self.manifest_path)?;
         Ok(manifest
             .iter()
-            .filter(|(_, state)| matches!(state, SegmentManifestState::Active))
+            // Optimizing segments stay live (deletes keep landing in them) until the swap.
+            .filter(|(_, state)| {
+                matches!(
+                    state,
+                    SegmentManifestState::Active | SegmentManifestState::Optimizing { .. },
+                )
+            })
             .map(|(uuid, _)| (*uuid, self.segments_path.join(uuid.to_string())))
             .collect())
     }
@@ -88,5 +94,44 @@ impl LocalSegmentEnumerator {
 impl SegmentEnumerator for LocalSegmentEnumerator {
     fn list_segments(&self) -> OperationResult<HashMap<Uuid, PathBuf>> {
         scan_segment_dirs(&self.segments_path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::universal_io::MmapFs;
+
+    use super::*;
+
+    #[test]
+    fn manifest_enumerator_serves_active_and_optimizing_only() {
+        let active = "1b4e28ba-2fa1-11d2-883f-0016d3cca427";
+        let optimizing = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+        let retiring = "6ba7b811-9dad-11d1-80b4-00c04fd430c8";
+        let building = "6ba7b812-9dad-11d1-80b4-00c04fd430c8";
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            segment_manifest_path(dir.path()),
+            format!(
+                r#"{{"{active}":"active",
+                    "{optimizing}":{{"optimizing":{{"holder":"indexer-1","lease_until":42}}}},
+                    "{retiring}":"retiring",
+                    "{building}":"under_construction"}}"#,
+            ),
+        )
+        .unwrap();
+
+        let listed = ManifestSegmentEnumerator::new(MmapFs, dir.path())
+            .list_segments()
+            .unwrap();
+
+        let mut uuids: Vec<String> = listed.keys().map(Uuid::to_string).collect();
+        uuids.sort();
+        assert_eq!(uuids, [active, optimizing]);
+        assert_eq!(
+            listed[&Uuid::parse_str(optimizing).unwrap()],
+            dir.path().join(SEGMENTS_PATH).join(optimizing),
+        );
     }
 }

--- a/lib/shard/src/segment_manifest.rs
+++ b/lib/shard/src/segment_manifest.rs
@@ -104,10 +104,14 @@ impl SegmentsManifest {
     #[must_use]
     pub fn preserving(mut self, previous: &SegmentsManifest) -> Self {
         for (uuid, state) in previous.iter() {
-            let in_progress = matches!(
-                state,
-                SegmentManifestState::Optimizing { .. } | SegmentManifestState::Retiring,
-            );
+            let in_progress = match state {
+                SegmentManifestState::Optimizing {
+                    holder: _,
+                    lease_until: _,
+                }
+                | SegmentManifestState::Retiring => true,
+                SegmentManifestState::Active | SegmentManifestState::UnderConstruction => false,
+            };
             if in_progress && self.segments.contains_key(uuid) {
                 self.segments.insert(*uuid, state.clone());
             }

--- a/lib/shard/src/segment_manifest.rs
+++ b/lib/shard/src/segment_manifest.rs
@@ -137,18 +137,21 @@ impl SegmentsManifest {
             return Ok(());
         };
 
-        let mut current = Self::from_segment_holder(holder).preserving(&manifest.read());
+        let mut rebuilt = Self::from_segment_holder(holder);
         if let Some(uuid) = extra_segment {
-            current.set(uuid, SegmentManifestState::Active);
+            rebuilt.set(uuid, SegmentManifestState::Active);
         }
 
-        if *manifest.read() == current {
-            return Ok(());
-        }
-
-        manifest.write(|m| *m = current).map_err(|err| {
-            OperationError::service_error(format!("failed to persist segment manifest: {err}"))
-        })?;
+        // Merge under the write lock, so a concurrent rebuild cannot slip between a
+        // read and a write and erase preserved marks.
+        manifest
+            .write_optional(|previous| {
+                let current = rebuilt.preserving(previous);
+                (*previous != current).then_some(current)
+            })
+            .map_err(|err| {
+                OperationError::service_error(format!("failed to persist segment manifest: {err}"))
+            })?;
         Ok(())
     }
 

--- a/lib/shard/src/segment_manifest.rs
+++ b/lib/shard/src/segment_manifest.rs
@@ -20,17 +20,26 @@ use crate::segment_holder::SegmentHolder;
 
 /// State of a segment in the manifest.
 ///
-/// Only [`Active`](SegmentManifestState::Active) is written today. The other variants are defined so
-/// the on-disk format can grow to describe in-progress segment transitions without breaking
-/// compatibility for readers.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+/// The shard itself only writes [`Active`](SegmentManifestState::Active); the in-progress states
+/// come from out-of-process rewriters (the serverless indexer). A data-carrying state serializes
+/// as a tagged object, which readers predating it cannot parse — write it only once every reader
+/// understands it.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SegmentManifestState {
     /// Live segment, part of the shard's data and safe to read.
     Active,
     /// Reserved for future use: a segment being built that is not yet ready to read.
     UnderConstruction,
-    /// Reserved for future use: a superseded segment that is still readable but pending removal.
+    /// Being rebuilt by an out-of-process optimizer; still live and readable. The claim is a
+    /// lease: past `lease_until` another optimizer may take the segment over.
+    Optimizing {
+        /// Identity of the optimizer run holding the claim (e.g. pod name).
+        holder: String,
+        /// Unix seconds after which the claim is stale.
+        lease_until: u64,
+    },
+    /// A superseded segment that is still readable but pending removal.
     Retiring,
 }
 
@@ -79,8 +88,31 @@ impl SegmentsManifest {
         Self { segments }
     }
 
-    fn add_extra(&mut self, uuid: Uuid, state: SegmentManifestState) {
-        self.segments.insert(uuid, state);
+    /// Set `uuid`'s state, returning the previous one.
+    pub fn set(&mut self, uuid: Uuid, state: SegmentManifestState) -> Option<SegmentManifestState> {
+        self.segments.insert(uuid, state)
+    }
+
+    /// Remove `uuid`'s entry, returning its state.
+    pub fn remove(&mut self, uuid: &Uuid) -> Option<SegmentManifestState> {
+        self.segments.remove(uuid)
+    }
+
+    /// Keep `previous`'s in-progress marks (`Optimizing`/`Retiring`) for segments this manifest
+    /// also lists: a holder rebuild marks everything `Active`, which would erase another
+    /// process's claim. Staleness is governed by the lease, not by rebuilds.
+    #[must_use]
+    pub fn preserving(mut self, previous: &SegmentsManifest) -> Self {
+        for (uuid, state) in previous.iter() {
+            let in_progress = matches!(
+                state,
+                SegmentManifestState::Optimizing { .. } | SegmentManifestState::Retiring,
+            );
+            if in_progress && self.segments.contains_key(uuid) {
+                self.segments.insert(*uuid, state.clone());
+            }
+        }
+        self
     }
 
     /// Rebuild the manifest from `holder` and persist it if it changed.
@@ -101,9 +133,9 @@ impl SegmentsManifest {
             return Ok(());
         };
 
-        let mut current = Self::from_segment_holder(holder);
+        let mut current = Self::from_segment_holder(holder).preserving(&manifest.read());
         if let Some(uuid) = extra_segment {
-            current.add_extra(uuid, SegmentManifestState::Active);
+            current.set(uuid, SegmentManifestState::Active);
         }
 
         if *manifest.read() == current {
@@ -117,7 +149,7 @@ impl SegmentsManifest {
     }
 
     pub fn get(&self, uuid: &Uuid) -> Option<SegmentManifestState> {
-        self.segments.get(uuid).copied()
+        self.segments.get(uuid).cloned()
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&Uuid, &SegmentManifestState)> {
@@ -130,6 +162,14 @@ impl SegmentsManifest {
 
     pub fn is_empty(&self) -> bool {
         self.segments.is_empty()
+    }
+}
+
+impl FromIterator<(Uuid, SegmentManifestState)> for SegmentsManifest {
+    fn from_iter<I: IntoIterator<Item = (Uuid, SegmentManifestState)>>(iter: I) -> Self {
+        Self {
+            segments: iter.into_iter().collect(),
+        }
     }
 }
 
@@ -169,5 +209,73 @@ mod tests {
             Some(SegmentManifestState::UnderConstruction),
         );
         assert_eq!(parsed.get(&retiring), Some(SegmentManifestState::Retiring));
+    }
+
+    #[test]
+    fn optimizing_roundtrips_as_tagged_object() {
+        let uuid = Uuid::parse_str("1b4e28ba-2fa1-11d2-883f-0016d3cca427").unwrap();
+        let manifest: SegmentsManifest = [(
+            uuid,
+            SegmentManifestState::Optimizing {
+                holder: "indexer-1".to_string(),
+                lease_until: 1_752_000_000,
+            },
+        )]
+        .into_iter()
+        .collect();
+
+        let json = serde_json::to_string(&manifest).unwrap();
+        assert_eq!(
+            json,
+            r#"{"1b4e28ba-2fa1-11d2-883f-0016d3cca427":{"optimizing":{"holder":"indexer-1","lease_until":1752000000}}}"#,
+        );
+
+        let parsed: SegmentsManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, manifest);
+    }
+
+    /// Byte-compat guard: today's writers produce bare strings for the unit states; adding
+    /// the data-carrying variant must not change how those serialize.
+    #[test]
+    fn unit_states_keep_their_bare_string_form() {
+        let uuid = Uuid::parse_str("6ba7b811-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let manifest: SegmentsManifest = [(uuid, SegmentManifestState::Retiring)]
+            .into_iter()
+            .collect();
+        assert_eq!(
+            serde_json::to_string(&manifest).unwrap(),
+            r#"{"6ba7b811-9dad-11d1-80b4-00c04fd430c8":"retiring"}"#,
+        );
+    }
+
+    #[test]
+    fn preserving_keeps_in_progress_marks_for_listed_segments_only() {
+        let kept = Uuid::parse_str("1b4e28ba-2fa1-11d2-883f-0016d3cca427").unwrap();
+        let gone = Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8").unwrap();
+        let fresh = Uuid::parse_str("6ba7b811-9dad-11d1-80b4-00c04fd430c8").unwrap();
+
+        let optimizing = SegmentManifestState::Optimizing {
+            holder: "indexer-1".to_string(),
+            lease_until: 42,
+        };
+        let previous: SegmentsManifest = [
+            (kept, optimizing.clone()),
+            (gone, SegmentManifestState::Retiring),
+        ]
+        .into_iter()
+        .collect();
+
+        // A holder rebuild lists every live segment as Active; `gone` left the holder.
+        let rebuilt: SegmentsManifest = [
+            (kept, SegmentManifestState::Active),
+            (fresh, SegmentManifestState::Active),
+        ]
+        .into_iter()
+        .collect();
+
+        let merged = rebuilt.preserving(&previous);
+        assert_eq!(merged.get(&kept), Some(optimizing));
+        assert_eq!(merged.get(&fresh), Some(SegmentManifestState::Active));
+        assert_eq!(merged.get(&gone), None, "marks drop with the segment");
     }
 }

--- a/lib/shard/src/segment_manifest.rs
+++ b/lib/shard/src/segment_manifest.rs
@@ -43,6 +43,37 @@ pub enum SegmentManifestState {
     Retiring,
 }
 
+impl SegmentManifestState {
+    /// Whether a reader may serve the segment: live ([`Active`](Self::Active)), or
+    /// [`Optimizing`](Self::Optimizing) — being rebuilt out-of-process, but live (and still
+    /// receiving deletes) until the swap.
+    pub fn is_usable(&self) -> bool {
+        match self {
+            SegmentManifestState::Active
+            | SegmentManifestState::Optimizing {
+                holder: _,
+                lease_until: _,
+            } => true,
+            SegmentManifestState::UnderConstruction | SegmentManifestState::Retiring => false,
+        }
+    }
+
+    /// Whether the state is a mark owned by an out-of-process optimizer — a rebuild claim
+    /// ([`Optimizing`](Self::Optimizing)) or a pending removal ([`Retiring`](Self::Retiring)) —
+    /// rather than something derivable from the segment holder. A holder rebuild must not erase
+    /// such marks (see [`SegmentsManifest::preserving`]).
+    pub fn is_optimizer_mark(&self) -> bool {
+        match self {
+            SegmentManifestState::Optimizing {
+                holder: _,
+                lease_until: _,
+            }
+            | SegmentManifestState::Retiring => true,
+            SegmentManifestState::Active | SegmentManifestState::UnderConstruction => false,
+        }
+    }
+}
+
 /// Contents of `segments_manifest.json`: a flat map of segment UUID to its state, e.g.
 /// `{ "1b4e28ba-...": "active", "6ba7b810-...": "active" }`.
 ///
@@ -98,21 +129,15 @@ impl SegmentsManifest {
         self.segments.remove(uuid)
     }
 
-    /// Keep `previous`'s in-progress marks (`Optimizing`/`Retiring`) for segments this manifest
-    /// also lists: a holder rebuild marks everything `Active`, which would erase another
-    /// process's claim. Staleness is governed by the lease, not by rebuilds.
+    /// Merge rule for persisting a rebuild: a rebuild from the segment holder marks every live
+    /// segment `Active`, which would erase an out-of-process optimizer's marks. Re-apply
+    /// `previous`'s optimizer marks (`Optimizing`/`Retiring`) to segments this manifest still
+    /// lists; marks for segments gone from the holder drop with them. Staleness is governed by
+    /// the lease, not by rebuilds.
     #[must_use]
     pub fn preserving(mut self, previous: &SegmentsManifest) -> Self {
         for (uuid, state) in previous.iter() {
-            let in_progress = match state {
-                SegmentManifestState::Optimizing {
-                    holder: _,
-                    lease_until: _,
-                }
-                | SegmentManifestState::Retiring => true,
-                SegmentManifestState::Active | SegmentManifestState::UnderConstruction => false,
-            };
-            if in_progress && self.segments.contains_key(uuid) {
+            if state.is_optimizer_mark() && self.segments.contains_key(uuid) {
                 self.segments.insert(*uuid, state.clone());
             }
         }


### PR DESCRIPTION
## What

Adds an `optimizing` segment state to the segment manifest so an out-of-process optimizer (the serverless indexer) can claim segments for rebuild while the shard keeps serving them, plus the plumbing that keeps such claims alive across leader manifest rebuilds.

- `shard`: `SegmentManifestState::Optimizing { holder, lease_until }` — a lease-bearing claim, so a crashed optimizer cannot wedge a segment (past `lease_until` another optimizer may take over). Public `set`/`remove`/`FromIterator` on `SegmentsManifest`, so external writers use the shared type instead of hand-rolled JSON, and `preserving()` so holder rebuilds don't erase another process's marks (`sync` uses it).
- `edge`: both manifest rebuild paths (`update_segment_manifest`, `init_segment_manifest`) preserve optimizer marks; the read-only follower serves `optimizing` segments (they stay live until the rebuild's swap); `SegmentsManifest`/`SegmentManifestState` re-exported for out-of-process consumers.

## Compatibility

- Unit states keep their bare-string serde form — manifests containing only `active`/`retiring` are byte-identical to today's.
- The new state serializes as a tagged object (`{"optimizing":{"holder":…,"lease_until":…}}`), which readers predating it cannot parse — write it only once every reader understands it (readers-first rollout).

## Tests

- serde: exact-JSON roundtrip of `optimizing`; byte-compat guard for the unit states
- `preserving`: marks kept for still-listed segments, dropped with removed ones
- follower: `ManifestSegmentEnumerator` lists `active` + `optimizing`, skips `retiring`/`under_construction`