### PR TITLE
Model tester: cover all quantization types

### DIFF
--- a/lib/collection/src/model_testing/fixture.rs
+++ b/lib/collection/src/model_testing/fixture.rs
@@ -11,11 +11,15 @@ use ahash::AHashMap;
 use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use segment::types::{
-    Distance, MultiVectorConfig, PayloadFieldSchema, PayloadSchemaType, QuantizationConfig,
-    ScalarQuantization, ScalarQuantizationConfig, ScalarType,
+    BinaryQuantization, BinaryQuantizationConfig, CompressionRatio, Distance, MultiVectorConfig,
+    PayloadFieldSchema, PayloadSchemaType, ProductQuantization, ProductQuantizationConfig,
+    QuantizationConfig, ScalarQuantization, ScalarQuantizationConfig, ScalarType,
+    TurboQuantBitSize, TurboQuantQuantizationConfig, TurboQuantization,
 };
 
-use super::{ALL_CANDIDATES, COLLECTION_NAME, INLINE_STORAGE_VECTOR, PEER_ID, VectorKind};
+use super::{
+    ALL_CANDIDATES, COLLECTION_NAME, INLINE_STORAGE_VECTOR, PEER_ID, QuantizationKind, VectorKind,
+};
 use crate::collection::{Collection, RequestShardTransfer};
 use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use crate::operations::config_diff::HnswConfigDiff;
@@ -48,6 +52,51 @@ fn dense_params_builder(
         builder = builder.with_datatype(datatype);
     }
     builder
+}
+
+/// Materialize the schema `QuantizationConfig` for a candidate's declared kind. All fields
+/// are the engine defaults (no quantile / memory-placement / encoding overrides); Scalar
+/// matches the config the inline-storage vector has always used, byte for byte.
+fn quantization_config(kind: QuantizationKind) -> QuantizationConfig {
+    match kind {
+        QuantizationKind::Scalar => QuantizationConfig::Scalar(ScalarQuantization {
+            scalar: ScalarQuantizationConfig {
+                r#type: ScalarType::Int8,
+                quantile: None,
+                always_ram: None,
+                memory: None,
+            },
+        }),
+        QuantizationKind::Product => QuantizationConfig::Product(ProductQuantization {
+            product: ProductQuantizationConfig {
+                compression: CompressionRatio::X4,
+                always_ram: None,
+                memory: None,
+            },
+        }),
+        QuantizationKind::Binary => QuantizationConfig::Binary(BinaryQuantization {
+            binary: BinaryQuantizationConfig {
+                always_ram: None,
+                memory: None,
+                encoding: None,
+                query_encoding: None,
+            },
+        }),
+        QuantizationKind::Turbo => QuantizationConfig::Turbo(TurboQuantization {
+            turbo: TurboQuantQuantizationConfig {
+                always_ram: None,
+                memory: None,
+                bits: None,
+            },
+        }),
+        QuantizationKind::TurboBits1_5 => QuantizationConfig::Turbo(TurboQuantization {
+            turbo: TurboQuantQuantizationConfig {
+                always_ram: None,
+                memory: None,
+                bits: Some(TurboQuantBitSize::Bits1_5),
+            },
+        }),
+    }
 }
 
 /// Build a fresh soak collection rooted at `storage_path`. Creates `collection/` and
@@ -86,23 +135,21 @@ pub(super) async fn fixture(
             VectorKind::Dense(dim) => {
                 let mut builder =
                     dense_params_builder(dim, candidate.distance, on_disk, candidate.datatype);
+                if let Some(kind) = candidate.quantization {
+                    builder = builder.with_quantization_config(quantization_config(kind));
+                }
                 // The inline-storage vector exercises the HNSW `inline_storage` layout, which
                 // stores original + quantized vectors inside the index file and therefore
-                // requires quantization. Pair it with scalar quantization.
+                // requires quantization.
                 if name == INLINE_STORAGE_VECTOR {
-                    builder = builder
-                        .with_quantization_config(QuantizationConfig::Scalar(ScalarQuantization {
-                            scalar: ScalarQuantizationConfig {
-                                r#type: ScalarType::Int8,
-                                quantile: None,
-                                always_ram: None,
-                                memory: None,
-                            },
-                        }))
-                        .with_hnsw_config(HnswConfigDiff {
-                            inline_storage: Some(true),
-                            ..Default::default()
-                        });
+                    assert!(
+                        candidate.quantization.is_some(),
+                        "HNSW inline_storage requires a quantized candidate",
+                    );
+                    builder = builder.with_hnsw_config(HnswConfigDiff {
+                        inline_storage: Some(true),
+                        ..Default::default()
+                    });
                 }
                 dense_vectors.insert(name.to_string(), builder.build());
             }

--- a/lib/collection/src/model_testing/fixture.rs
+++ b/lib/collection/src/model_testing/fixture.rs
@@ -17,9 +17,7 @@ use segment::types::{
     TurboQuantBitSize, TurboQuantQuantizationConfig, TurboQuantization,
 };
 
-use super::{
-    ALL_CANDIDATES, COLLECTION_NAME, INLINE_STORAGE_VECTOR, PEER_ID, QuantizationKind, VectorKind,
-};
+use super::{ALL_CANDIDATES, COLLECTION_NAME, PEER_ID, QuantizationKind, VectorKind};
 use crate::collection::{Collection, RequestShardTransfer};
 use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use crate::operations::config_diff::HnswConfigDiff;
@@ -138,14 +136,7 @@ pub(super) async fn fixture(
                 if let Some(kind) = candidate.quantization {
                     builder = builder.with_quantization_config(quantization_config(kind));
                 }
-                // The inline-storage vector exercises the HNSW `inline_storage` layout, which
-                // stores original + quantized vectors inside the index file and therefore
-                // requires quantization.
-                if name == INLINE_STORAGE_VECTOR {
-                    assert!(
-                        candidate.quantization.is_some(),
-                        "HNSW inline_storage requires a quantized candidate",
-                    );
+                if candidate.inline_storage {
                     builder = builder.with_hnsw_config(HnswConfigDiff {
                         inline_storage: Some(true),
                         ..Default::default()

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -35,6 +35,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: None,
         distance: Distance::Dot,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     VectorCandidate {
@@ -43,6 +44,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: None,
         distance: Distance::Dot,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     // Explicit `Some(Float32)` rather than the unset default: exercises schema configs that
@@ -54,6 +56,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: Some(Datatype::Float32),
         distance: Distance::Dot,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     // Dense vector configured with HNSW `inline_storage` (original + quantized vectors stored
@@ -65,6 +68,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: None,
         distance: Distance::Dot,
         quantization: Some(QuantizationKind::Scalar),
+        inline_storage: true,
         initially_active: true,
     },
     VectorCandidate {
@@ -73,6 +77,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: None,
         distance: Distance::Dot,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     VectorCandidate {
@@ -81,6 +86,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: None,
         distance: Distance::Dot,
         quantization: None,
+        inline_storage: false,
         initially_active: false,
     },
     VectorCandidate {
@@ -89,6 +95,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: None,
         distance: Distance::Dot,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     // TurboQuant 4-bit compressed storage, the primary quantized datatype, applied to
@@ -100,6 +107,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: Some(Datatype::Turbo4),
         distance: Distance::Dot,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     // Half-precision storage. Lossy but deterministic and idempotent: the model records
@@ -110,6 +118,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: Some(Datatype::Float16),
         distance: Distance::Dot,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     // Unsigned-byte storage. The engine truncates each component with `x as u8`; the
@@ -121,6 +130,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: Some(Datatype::Uint8),
         distance: Distance::Dot,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     // Multi-vector variants of the lossy-but-idempotent datatypes: each stored row goes
@@ -131,6 +141,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: Some(Datatype::Float16),
         distance: Distance::Dot,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     VectorCandidate {
@@ -139,6 +150,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: Some(Datatype::Uint8),
         distance: Distance::Dot,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     // Cosine candidates. The engine normalizes Cosine vectors once, at first ingestion
@@ -152,6 +164,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: None,
         distance: Distance::Cosine,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     // Per-row normalization: each stored row of the matrix is preprocessed like a dense
@@ -162,6 +175,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: None,
         distance: Distance::Cosine,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     // Ordering coverage: normalization happens in f32 first, then the f16 storage
@@ -173,6 +187,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: Some(Datatype::Float16),
         distance: Distance::Cosine,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     // TurboQuant's dedicated Cosine mode: the l2 length is not stored (forced to 1.0,
@@ -184,6 +199,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: Some(Datatype::Turbo4),
         distance: Distance::Cosine,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     // Euclid / Manhattan candidates. Both metrics' ingestion preprocess is an identity
@@ -196,6 +212,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: None,
         distance: Distance::Euclid,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     VectorCandidate {
@@ -204,6 +221,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: None,
         distance: Distance::Manhattan,
         quantization: None,
+        inline_storage: false,
         initially_active: true,
     },
     // Search-side quantization coverage: one candidate per remaining `QuantizationConfig`
@@ -218,6 +236,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: None,
         distance: Distance::Dot,
         quantization: Some(QuantizationKind::Product),
+        inline_storage: false,
         initially_active: true,
     },
     // Dim 6 is deliberately not byte-aligned: the packed 1-bit codes have trailing padding.
@@ -227,6 +246,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: None,
         distance: Distance::Dot,
         quantization: Some(QuantizationKind::Binary),
+        inline_storage: false,
         initially_active: true,
     },
     // TurboQuant as search-side quantization over regular Float32 storage, distinct from
@@ -237,6 +257,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: None,
         distance: Distance::Dot,
         quantization: Some(QuantizationKind::Turbo),
+        inline_storage: false,
         initially_active: true,
     },
     // Quantization x datatype combos. Live appendable inserts quantize the pristine f32
@@ -244,12 +265,16 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
     // read-back, so the codes for the same point differ across those paths. Predictions
     // still only depend on the datatype side (quantization never changes the stored
     // vectors).
+    // Also inline-stored: covers a non-f32 base layout (Float16) and Binary link codes
+    // with trailing padding (dim 6 is not byte-aligned) in the links file; "v" keeps the
+    // regular non-inline Binary path.
     VectorCandidate {
         name: "l",
         kind: VectorKind::Dense(6),
         datatype: Some(Datatype::Float16),
         distance: Distance::Dot,
         quantization: Some(QuantizationKind::Binary),
+        inline_storage: true,
         initially_active: true,
     },
     // Turbo4 storage re-quantized with TurboQuant, one candidate per branch of
@@ -257,12 +282,16 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
     // secondary TQ keeps the source codes in their rotated space and reuses the storage's
     // `Unpadded` rotation for queries. Same padding-free dim 8 as "q" so the CoW
     // re-quantization fixed point holds on the storage side.
+    // Also inline-stored: the Turbo4 base vectors go through the dedicated
+    // `get_dense_tq_vector_layout` path (the inlined base vectors are themselves TQ
+    // codes); "r" and "g" keep the non-inline TQ path for both rotation branches.
     VectorCandidate {
         name: "d",
         kind: VectorKind::Dense(8),
         datatype: Some(Datatype::Turbo4),
         distance: Distance::Dot,
         quantization: Some(QuantizationKind::Turbo),
+        inline_storage: true,
         initially_active: true,
     },
     // `Bits1_5` requires a `Padded` rotation, so the same predicate takes the rotate-back
@@ -273,6 +302,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         datatype: Some(Datatype::Turbo4),
         distance: Distance::Dot,
         quantization: Some(QuantizationKind::TurboBits1_5),
+        inline_storage: false,
         initially_active: true,
     },
 ];
@@ -296,6 +326,9 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
 /// - Quantization on inactive candidates: `Op::CreateVectorName`'s `DenseVectorConfig`
 ///   carries no quantization, so the name would activate without it and the intended
 ///   coverage would silently vanish.
+/// - `inline_storage` without quantization: the HNSW inline layout stores original +
+///   quantized vectors inside the index file, so it requires a quantized candidate
+///   (dense-only follows from the quantization constraint).
 fn assert_candidates_predictable() {
     for c in ALL_CANDIDATES {
         let turbo4 = matches!(c.datatype, Some(Datatype::Turbo4));
@@ -318,11 +351,15 @@ fn assert_candidates_predictable() {
                 c.name
             );
         }
+        if c.inline_storage {
+            assert!(
+                c.quantization.is_some(),
+                "HNSW inline_storage requires quantization for `{}` (see comment above)",
+                c.name
+            );
+        }
     }
 }
-
-/// Dense vector name configured with HNSW `inline_storage` + scalar quantization in the fixture.
-pub(super) const INLINE_STORAGE_VECTOR: &str = "i";
 
 pub(super) struct VectorCandidate {
     pub(super) name: &'static str,
@@ -344,6 +381,11 @@ pub(super) struct VectorCandidate {
     /// membership-only nearest checks see the approximate quantized scoring. Dense-only, and
     /// only on `initially_active` candidates; enforced by `assert_candidates_predictable`.
     pub(super) quantization: Option<QuantizationKind>,
+    /// Store original + quantized vectors inside the HNSW index file (`inline_storage` in
+    /// the vector's `HnswConfigDiff`). From the model's perspective the vector behaves like
+    /// any other dense one; only the on-disk index layout differs. Requires `quantization`
+    /// (the layout stores quantized codes); enforced by `assert_candidates_predictable`.
+    pub(super) inline_storage: bool,
     /// Whether the name is present in the collection schema at fixture time. Inactive
     /// names are only reachable through `Op::CreateVectorName`, which is FORCE_OFF by
     /// default, so a candidate gets default-soak coverage only when this is true.

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -34,6 +34,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Dense(4),
         datatype: None,
         distance: Distance::Dot,
+        quantization: None,
         initially_active: true,
     },
     VectorCandidate {
@@ -41,6 +42,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Dense(6),
         datatype: None,
         distance: Distance::Dot,
+        quantization: None,
         initially_active: true,
     },
     // Explicit `Some(Float32)` rather than the unset default: exercises schema configs that
@@ -51,6 +53,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Dense(5),
         datatype: Some(Datatype::Float32),
         distance: Distance::Dot,
+        quantization: None,
         initially_active: true,
     },
     // Dense vector configured with HNSW `inline_storage` (original + quantized vectors stored
@@ -61,6 +64,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Dense(4),
         datatype: None,
         distance: Distance::Dot,
+        quantization: Some(QuantizationKind::Scalar),
         initially_active: true,
     },
     VectorCandidate {
@@ -68,6 +72,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Sparse,
         datatype: None,
         distance: Distance::Dot,
+        quantization: None,
         initially_active: true,
     },
     VectorCandidate {
@@ -75,6 +80,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Sparse,
         datatype: None,
         distance: Distance::Dot,
+        quantization: None,
         initially_active: false,
     },
     VectorCandidate {
@@ -82,6 +88,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::MultiDense(4),
         datatype: None,
         distance: Distance::Dot,
+        quantization: None,
         initially_active: true,
     },
     // TurboQuant 4-bit compressed storage, the primary quantized datatype, applied to
@@ -92,6 +99,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Dense(8),
         datatype: Some(Datatype::Turbo4),
         distance: Distance::Dot,
+        quantization: None,
         initially_active: true,
     },
     // Half-precision storage. Lossy but deterministic and idempotent: the model records
@@ -101,6 +109,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Dense(6),
         datatype: Some(Datatype::Float16),
         distance: Distance::Dot,
+        quantization: None,
         initially_active: true,
     },
     // Unsigned-byte storage. The engine truncates each component with `x as u8`; the
@@ -111,6 +120,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Dense(4),
         datatype: Some(Datatype::Uint8),
         distance: Distance::Dot,
+        quantization: None,
         initially_active: true,
     },
     // Multi-vector variants of the lossy-but-idempotent datatypes: each stored row goes
@@ -120,6 +130,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::MultiDense(5),
         datatype: Some(Datatype::Float16),
         distance: Distance::Dot,
+        quantization: None,
         initially_active: true,
     },
     VectorCandidate {
@@ -127,6 +138,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::MultiDense(3),
         datatype: Some(Datatype::Uint8),
         distance: Distance::Dot,
+        quantization: None,
         initially_active: true,
     },
     // Cosine candidates. The engine normalizes Cosine vectors once, at first ingestion
@@ -139,6 +151,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Dense(5),
         datatype: None,
         distance: Distance::Cosine,
+        quantization: None,
         initially_active: true,
     },
     // Per-row normalization: each stored row of the matrix is preprocessed like a dense
@@ -148,6 +161,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::MultiDense(4),
         datatype: None,
         distance: Distance::Cosine,
+        quantization: None,
         initially_active: true,
     },
     // Ordering coverage: normalization happens in f32 first, then the f16 storage
@@ -158,6 +172,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Dense(6),
         datatype: Some(Datatype::Float16),
         distance: Distance::Cosine,
+        quantization: None,
         initially_active: true,
     },
     // TurboQuant's dedicated Cosine mode: the l2 length is not stored (forced to 1.0,
@@ -168,6 +183,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Dense(8),
         datatype: Some(Datatype::Turbo4),
         distance: Distance::Cosine,
+        quantization: None,
         initially_active: true,
     },
     // Euclid / Manhattan candidates. Both metrics' ingestion preprocess is an identity
@@ -179,6 +195,7 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Dense(6),
         datatype: None,
         distance: Distance::Euclid,
+        quantization: None,
         initially_active: true,
     },
     VectorCandidate {
@@ -186,6 +203,76 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
         kind: VectorKind::Dense(4),
         datatype: None,
         distance: Distance::Manhattan,
+        quantization: None,
+        initially_active: true,
+    },
+    // Search-side quantization coverage: one candidate per remaining `QuantizationConfig`
+    // variant ("i" covers Scalar). Original vectors are always kept alongside the quantized
+    // codes, so read-back predictions are unaffected; the lossy quantized scoring only feeds
+    // the membership-only Search/Query/Recommend checks. Scalar/Product quantize at HNSW
+    // build time; Binary/Turbo also quantize appendable segments (`appendable_quantization`
+    // feature flag, on by default).
+    VectorCandidate {
+        name: "p",
+        kind: VectorKind::Dense(8),
+        datatype: None,
+        distance: Distance::Dot,
+        quantization: Some(QuantizationKind::Product),
+        initially_active: true,
+    },
+    // Dim 6 is deliberately not byte-aligned: the packed 1-bit codes have trailing padding.
+    VectorCandidate {
+        name: "v",
+        kind: VectorKind::Dense(6),
+        datatype: None,
+        distance: Distance::Dot,
+        quantization: Some(QuantizationKind::Binary),
+        initially_active: true,
+    },
+    // TurboQuant as search-side quantization over regular Float32 storage, distinct from
+    // the `Datatype::Turbo4` candidates ("q"/"o") where TQ *is* the storage.
+    VectorCandidate {
+        name: "r",
+        kind: VectorKind::Dense(8),
+        datatype: None,
+        distance: Distance::Dot,
+        quantization: Some(QuantizationKind::Turbo),
+        initially_active: true,
+    },
+    // Quantization x datatype combos. Live appendable inserts quantize the pristine f32
+    // input; optimizer rebuilds and CoW moves re-quantize from the lossy storage
+    // read-back, so the codes for the same point differ across those paths. Predictions
+    // still only depend on the datatype side (quantization never changes the stored
+    // vectors).
+    VectorCandidate {
+        name: "l",
+        kind: VectorKind::Dense(6),
+        datatype: Some(Datatype::Float16),
+        distance: Distance::Dot,
+        quantization: Some(QuantizationKind::Binary),
+        initially_active: true,
+    },
+    // Turbo4 storage re-quantized with TurboQuant, one candidate per branch of
+    // `should_keep_source_rotated` (segment's `quantized_vectors.rs`). Default bits: the
+    // secondary TQ keeps the source codes in their rotated space and reuses the storage's
+    // `Unpadded` rotation for queries. Same padding-free dim 8 as "q" so the CoW
+    // re-quantization fixed point holds on the storage side.
+    VectorCandidate {
+        name: "d",
+        kind: VectorKind::Dense(8),
+        datatype: Some(Datatype::Turbo4),
+        distance: Distance::Dot,
+        quantization: Some(QuantizationKind::Turbo),
+        initially_active: true,
+    },
+    // `Bits1_5` requires a `Padded` rotation, so the same predicate takes the rotate-back
+    // branch: source codes are dequantized to the original space and re-rotated.
+    VectorCandidate {
+        name: "g",
+        kind: VectorKind::Dense(8),
+        datatype: Some(Datatype::Turbo4),
+        distance: Distance::Dot,
+        quantization: Some(QuantizationKind::TurboBits1_5),
         initially_active: true,
     },
 ];
@@ -204,6 +291,11 @@ pub(super) const ALL_CANDIDATES: &[VectorCandidate] = &[
 ///   Dot/Cosine (dedicated `l2_length` field / scaling-factor-as-length), and the
 ///   copy-on-write re-quantization fixed point that `dense_matches`' ulp tolerance
 ///   relies on has only been soak-validated for Dot and Cosine.
+/// - Quantization on non-dense kinds: the fixture only wires `quantization` into its
+///   dense arm, so it would be silently dropped.
+/// - Quantization on inactive candidates: `Op::CreateVectorName`'s `DenseVectorConfig`
+///   carries no quantization, so the name would activate without it and the intended
+///   coverage would silently vanish.
 fn assert_candidates_predictable() {
     for c in ALL_CANDIDATES {
         let turbo4 = matches!(c.datatype, Some(Datatype::Turbo4));
@@ -219,6 +311,13 @@ fn assert_candidates_predictable() {
             "unsupported kind/datatype/distance combination for `{}` (see comment above)",
             c.name
         );
+        if c.quantization.is_some() {
+            assert!(
+                matches!(c.kind, VectorKind::Dense(_)) && c.initially_active,
+                "quantization is dense-only and requires initially_active for `{}` (see comment above)",
+                c.name
+            );
+        }
     }
 }
 
@@ -240,10 +339,35 @@ pub(super) struct VectorCandidate {
     /// distance and score as dot product by construction — enforced by
     /// `assert_candidates_predictable`.
     pub(super) distance: Distance,
+    /// Search-side quantization attached to the schema (`quantization_config` on the vector
+    /// params). Originals are always kept, so read-back predictions are unaffected; only the
+    /// membership-only nearest checks see the approximate quantized scoring. Dense-only, and
+    /// only on `initially_active` candidates; enforced by `assert_candidates_predictable`.
+    pub(super) quantization: Option<QuantizationKind>,
     /// Whether the name is present in the collection schema at fixture time. Inactive
     /// names are only reachable through `Op::CreateVectorName`, which is FORCE_OFF by
     /// default, so a candidate gets default-soak coverage only when this is true.
     pub(super) initially_active: bool,
+}
+
+/// Which `QuantizationConfig` variant the fixture attaches to a dense candidate; the
+/// concrete config (all engine-default fields) is materialized in
+/// `fixture::quantization_config`.
+#[derive(Copy, Clone, Debug)]
+pub(super) enum QuantizationKind {
+    /// Int8 scalar quantization.
+    Scalar,
+    /// Product quantization, x4 compression (1-dim chunks, 256 centroids each).
+    Product,
+    /// Binary quantization, default one-bit encoding.
+    Binary,
+    /// TurboQuant quantization of the search index (as opposed to `Datatype::Turbo4`,
+    /// which makes TQ the storage itself).
+    Turbo,
+    /// TurboQuant with `Bits1_5` encoding, which requires a `Padded` rotation: over a
+    /// Turbo4 storage source this forces the rotate-back branch of
+    /// `should_keep_source_rotated`, where default-bits `Turbo` takes the keep-rotated one.
+    TurboBits1_5,
 }
 
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
## What

Extends the model tester's candidate pool to cover every `QuantizationConfig` variant, including quantization x datatype combinations.

`VectorCandidate` gains a `quantization: Option<QuantizationKind>` field; the fixture materializes the concrete configs in a new `quantization_config` helper (all engine-default fields). 

HNSW `inline_storage` also becomes a `VectorCandidate` knob (`inline_storage: bool`, requires `quantization`), replacing the fixture's name-based special case. The inline-storage vector `"i"` keeps its scalar Int8 config, now declared on the candidate instead of hard-coded in the fixture.

### New candidates

| name | kind | datatype | quantization | notes |
|---|---|---|---|---|
| `p` | Dense(8) | f32 | Product x4 | PQ codebook path |
| `v` | Dense(6) | f32 | Binary | non-byte-aligned dim, trailing-bit padding |
| `r` | Dense(8) | f32 | Turbo | search-side TQ, distinct from `Datatype::Turbo4` storage |
| `l` | Dense(6) | Float16 | Binary | quantization over lossy storage; inline-stored |
| `d` | Dense(8) | Turbo4 | Turbo (default bits) | keep-source-rotated branch of `should_keep_source_rotated`; inline-stored |
| `g` | Dense(8) | Turbo4 | Turbo `Bits1_5` | Padded rotation, rotate-back branch |

### Inline storage coverage

`"l"` and `"d"` enable `inline_storage` in addition to `"i"`, extending the (base layout, link encoding) pairs baked into the HNSW `CompressedWithVectors` links file beyond `"i"`'s Float32 + Scalar: `"l"` adds a Float16 base with padded Binary link codes (dim 6 is not byte-aligned), `"d"` adds a Turbo4 base (the inlined base vectors are themselves TQ codes, via the dedicated `get_dense_tq_vector_layout` path) with TQ links. `"v"`, `"r"`, `"g"` and `"p"` deliberately stay non-inline so every quantization variant also keeps its regular path; `"p"` in particular is the only PQ candidate, so PQ link encoding is left uncovered rather than trading away the non-inline PQ path.

The engine silently ignores `inline_storage` for unsupported combos (`StorageGraphLinksVectors::try_new`), so the soak verification below checks the `links_comp_vec.bin` files actually materialized on disk for exactly `i`/`l`/`d`.

### Why this is model-safe

Schema quantization keeps the original vectors, so the model's read-back predictions (retrieve/scroll equality) are untouched. The approximate quantized scoring only feeds the membership-only Search/Query/Recommend checks, which assert size bounds and candidate membership, never score order.

 Since `appendable_quantization` defaults on, Binary/Turbo candidates also exercise quantized appendable segments (confirmed on disk: they quantize in ~2x more segments than Scalar/Product).

`assert_candidates_predictable` enforces the wiring constraints at startup: quantization is dense-only (the fixture only wires the dense arm) and requires `initially_active` (`CreateVectorName`'s `DenseVectorConfig` carries no quantization, so an inactive quantized candidate would silently activate without it).

### Known limitations (from review)

- TQ (`TQMode::Plus` quantile pre-pass) and PQ (kmeans sampling) key their sample `Permutor` from `thread_rng`, so quantized codes are not seed-reproducible once a segment exceeds the sample budget (2048/8192 vectors for TQ, 10k for PQ). The default `--id-pool 500` stays far below all budgets, so default soaks remain reproducible; a deterministic Permutor key in the engine would remove the caveat entirely (possible follow-up).
- With `--enable-force-off`, a `DeleteVectorName` + `CreateVectorName` pair recreates a quantized candidate without its quantization (the op config carries none), silently losing that coverage for the rest of the run.

### Verification

- `cargo clippy -p collection --features testing` clean
- Soak seeds 1/2/3/7/42 (5k ops each, restarts enabled, optimizer on) all green, post-#9866 merge so UUID ids were active too
- `quantized.data` confirmed on disk for every quantized candidate
- `links_comp_vec.bin` (inline links format) confirmed on disk for exactly `i`/`l`/`d`, no other vector name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
