### PR TITLE
Deduplicate plain and raw upsert/sync drivers via point traits

### DIFF
--- a/lib/shard/src/update/points/sync.rs
+++ b/lib/shard/src/update/points/sync.rs
@@ -6,9 +6,12 @@ use ahash::{AHashMap, AHashSet};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::DeferredBehavior;
 use segment::common::operation_error::OperationResult;
+use segment::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
+use segment::entry::ReadSegmentEntry;
 use segment::types::{PointIdType, SeqNumberType, WithPayload, WithVector};
 
-use super::{delete_points, upsert_points, upsert_points_raw};
+use super::delete_points;
+use super::upsert::{PointToUpsert, upsert_points_impl};
 use crate::operations::point_ops::{PointStructPersisted, PointStructRawPersisted};
 use crate::segment_holder::SegmentHolder;
 
@@ -30,73 +33,10 @@ pub fn sync_points(
     points: &[PointStructPersisted],
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<(usize, usize, usize)> {
-    let id_to_point: AHashMap<PointIdType, _> = points.iter().map(|p| (p.id, p)).collect();
-    let sync_points: AHashSet<_> = points.iter().map(|p| p.id).collect();
-    // 1. Retrieve existing points for a range
-    let stored_point_ids: AHashSet<_> = segments
-        .iter()
-        .flat_map(|(_, segment)| segment.get().read().read_range(from_id, to_id))
-        .collect();
-    // 2. Remove points, which are not present in the sync operation
-    let points_to_remove: Vec<_> = stored_point_ids.difference(&sync_points).copied().collect();
-    let deleted = delete_points(segments, op_num, points_to_remove.as_slice(), hw_counter)?;
-    // 3. Retrieve overlapping points, detect which one of them are changed
-    let existing_point_ids: Vec<_> = stored_point_ids
-        .intersection(&sync_points)
-        .copied()
-        .collect();
-
-    let mut points_to_update: Vec<_> = Vec::new();
-    // we don’t want to cancel this filtered read
-    let is_stopped = AtomicBool::new(false);
-    let _num_updated = segments.read_points(
-        existing_point_ids.as_slice(),
-        &is_stopped,
-        DeferredBehavior::WithDeferred,
-        |ids, segment| {
-            let with_vector = WithVector::Bool(true);
-            let with_payload = WithPayload::from(true);
-            // Since we retrieve points, which we already know exist, we expect all of them to be found
-            let stored_records = segment.retrieve(
-                ids,
-                &with_payload,
-                &with_vector,
-                hw_counter,
-                &is_stopped,
-                DeferredBehavior::WithDeferred,
-            )?;
-            let mut updated = 0;
-
-            for (id, stored_record) in stored_records {
-                let point = id_to_point.get(&id).unwrap();
-                if !point.is_equal_to(&stored_record) {
-                    points_to_update.push(*point);
-                    updated += 1;
-                }
-            }
-
-            Ok(updated)
-        },
-    )?;
-
-    // 4. Select new points
-    let num_updated = points_to_update.len();
-    let mut num_new = 0;
-    sync_points.difference(&stored_point_ids).for_each(|id| {
-        num_new += 1;
-        points_to_update.push(*id_to_point.get(id).unwrap());
-    });
-
-    // 5. Upsert points which differ from the stored ones
-    let num_replaced = upsert_points(segments, op_num, points_to_update, hw_counter)?;
-    debug_assert!(
-        num_replaced <= num_updated,
-        "number of replaced points cannot be greater than points to update ({num_replaced} <= {num_updated})",
-    );
-
-    Ok((deleted, num_new, num_updated))
+    sync_points_impl(segments, op_num, from_id, to_id, points, hw_counter)
 }
 
+/// Same as [`sync_points`], but for points carrying raw vector bytes verbatim.
 pub fn sync_points_raw(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
@@ -105,8 +45,51 @@ pub fn sync_points_raw(
     points: &[PointStructRawPersisted],
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<(usize, usize, usize)> {
-    let id_to_point: AHashMap<PointIdType, _> = points.iter().map(|p| (p.id, p)).collect();
-    let sync_points: AHashSet<_> = points.iter().map(|p| p.id).collect();
+    sync_points_impl(segments, op_num, from_id, to_id, points, hw_counter)
+}
+
+/// A point struct that can be compared against its stored counterpart, to
+/// skip upserting points whose stored data is already identical.
+trait PointToSync: PointToUpsert {
+    /// The form the stored counterpart is retrieved in.
+    type StoredRecord;
+
+    /// Retrieve the stored counterparts of the given ids from a segment,
+    /// in the form [`Self::is_equal_to`] compares against.
+    fn retrieve_stored(
+        segment: &dyn ReadSegmentEntry,
+        ids: &[PointIdType],
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+    ) -> OperationResult<AHashMap<PointIdType, Self::StoredRecord>>;
+
+    /// Does this point carry exactly the stored data, so the upsert can be skipped?
+    fn is_equal_to(&self, stored: &Self::StoredRecord) -> bool;
+}
+
+/// Sync points within a given [from_id; to_id) range.
+///
+/// 1. Retrieve existing points for a range
+/// 2. Remove points, which are not present in the sync operation
+/// 3. Retrieve overlapping points, detect which one of them are changed
+/// 4. Select new points
+/// 5. Upsert points which differ from the stored ones
+///
+/// Returns:
+///     (number of deleted points, number of new points, number of updated points)
+fn sync_points_impl<P>(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    from_id: Option<PointIdType>,
+    to_id: Option<PointIdType>,
+    points: &[P],
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<(usize, usize, usize)>
+where
+    P: PointToSync,
+{
+    let id_to_point: AHashMap<PointIdType, &P> = points.iter().map(|p| (p.id(), p)).collect();
+    let sync_points: AHashSet<_> = points.iter().map(|p| p.id()).collect();
     // 1. Retrieve existing points for a range
     let stored_point_ids: AHashSet<_> = segments
         .iter()
@@ -121,7 +104,7 @@ pub fn sync_points_raw(
         .copied()
         .collect();
 
-    let mut points_to_update: Vec<_> = Vec::new();
+    let mut points_to_update: Vec<&P> = Vec::new();
     // we don’t want to cancel this filtered read
     let is_stopped = AtomicBool::new(false);
     let _num_updated = segments.read_points(
@@ -129,17 +112,8 @@ pub fn sync_points_raw(
         &is_stopped,
         DeferredBehavior::WithDeferred,
         |ids, segment| {
-            let with_vector = WithVector::Bool(true);
-            let with_payload = WithPayload::from(true);
             // Since we retrieve points, which we already know exist, we expect all of them to be found
-            let stored_records = segment.retrieve_raw(
-                ids,
-                &with_payload,
-                &with_vector,
-                hw_counter,
-                &is_stopped,
-                DeferredBehavior::WithDeferred,
-            )?;
+            let stored_records = P::retrieve_stored(&**segment, ids, hw_counter, &is_stopped)?;
             let mut updated = 0;
 
             for (id, stored_record) in stored_records {
@@ -163,11 +137,59 @@ pub fn sync_points_raw(
     });
 
     // 5. Upsert points which differ from the stored ones
-    let num_replaced = upsert_points_raw(segments, op_num, points_to_update, hw_counter)?;
+    let num_replaced = upsert_points_impl(segments, op_num, points_to_update, hw_counter)?;
     debug_assert!(
         num_replaced <= num_updated,
         "number of replaced points cannot be greater than points to update ({num_replaced} <= {num_updated})",
     );
 
     Ok((deleted, num_new, num_updated))
+}
+
+impl PointToSync for PointStructPersisted {
+    type StoredRecord = SegmentRecord;
+
+    fn retrieve_stored(
+        segment: &dyn ReadSegmentEntry,
+        ids: &[PointIdType],
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+    ) -> OperationResult<AHashMap<PointIdType, SegmentRecord>> {
+        segment.retrieve(
+            ids,
+            &WithPayload::from(true),
+            &WithVector::Bool(true),
+            hw_counter,
+            is_stopped,
+            DeferredBehavior::WithDeferred,
+        )
+    }
+
+    fn is_equal_to(&self, stored: &SegmentRecord) -> bool {
+        PointStructPersisted::is_equal_to(self, stored)
+    }
+}
+
+impl PointToSync for PointStructRawPersisted {
+    type StoredRecord = SegmentRecordRaw;
+
+    fn retrieve_stored(
+        segment: &dyn ReadSegmentEntry,
+        ids: &[PointIdType],
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+    ) -> OperationResult<AHashMap<PointIdType, SegmentRecordRaw>> {
+        segment.retrieve_raw(
+            ids,
+            &WithPayload::from(true),
+            &WithVector::Bool(true),
+            hw_counter,
+            is_stopped,
+            DeferredBehavior::WithDeferred,
+        )
+    }
+
+    fn is_equal_to(&self, stored: &SegmentRecordRaw) -> bool {
+        PointStructRawPersisted::is_equal_to(self, stored)
+    }
 }

--- a/lib/shard/src/update/points/upsert.rs
+++ b/lib/shard/src/update/points/upsert.rs
@@ -7,7 +7,8 @@ use parking_lot::RwLockWriteGuard;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::data_types::named_vectors::NamedVectors;
 use segment::entry::entry_point::SegmentEntry;
-use segment::types::{Filter, Payload, PointIdType, SeqNumberType};
+use segment::types::{Filter, Payload, PointIdType, SeqNumberType, VectorNameBuf};
+use smallvec::SmallVec;
 
 use crate::operations::point_ops::{
     ConditionalInsertOperationInternal, PointInsertOperationsInternal, PointStructPersisted,
@@ -33,75 +34,10 @@ pub fn upsert_points<'a, T>(
 where
     T: IntoIterator<Item = &'a PointStructPersisted>,
 {
-    let points_map: AHashMap<PointIdType, _> = points.into_iter().map(|p| (p.id, p)).collect();
-    let ids: Vec<PointIdType> = points_map.keys().copied().collect();
-
-    let mut res = 0;
-
-    for ids_chunk in ids.chunks(UPDATE_OP_CHUNK_SIZE) {
-        // Update points in writable segments
-        let updated_points = segments.apply_points_with_conditional_move(
-            op_num,
-            ids_chunk,
-            |id, write_segment| {
-                let point = points_map[&id];
-                upsert_with_payload(
-                    write_segment,
-                    op_num,
-                    id,
-                    point.get_vectors(),
-                    point.payload.as_ref(),
-                    hw_counter,
-                )
-            },
-            |id, raw_vectors, updated_vectors, old_payload| {
-                let point = points_map[&id];
-                // Upsert replaces the whole point: old named vectors and
-                // payload must not survive the move, matching the in-place
-                // `upsert_with_payload` path (`replace_all_vectors` +
-                // clear/set payload).
-                raw_vectors.clear();
-                *updated_vectors = point.get_vectors();
-                *old_payload = point.payload.clone().unwrap_or_default();
-            },
-            hw_counter,
-        )?;
-
-        res += updated_points.len();
-        // Insert new points, which was not updated or existed
-        let new_point_ids = ids_chunk
-            .iter()
-            .copied()
-            .filter(|x| !updated_points.contains(x));
-
-        {
-            let default_write_segment =
-                segments.smallest_appendable_segment().ok_or_else(|| {
-                    OperationError::service_error(
-                        "No appendable segments exist, expected at least one",
-                    )
-                })?;
-
-            let segment_arc = default_write_segment.get();
-            let mut write_segment = segment_arc.write();
-            for point_id in new_point_ids {
-                let point = points_map[&point_id];
-                res += usize::from(upsert_with_payload(
-                    &mut write_segment,
-                    op_num,
-                    point_id,
-                    point.get_vectors(),
-                    point.payload.as_ref(),
-                    hw_counter,
-                )?);
-            }
-            RwLockWriteGuard::unlock_fair(write_segment);
-        };
-    }
-
-    Ok(res)
+    upsert_points_impl(segments, op_num, points, hw_counter)
 }
 
+/// Same as [`upsert_points`], but for points carrying raw vector bytes verbatim.
 pub fn upsert_points_raw<'a, T>(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
@@ -111,60 +47,7 @@ pub fn upsert_points_raw<'a, T>(
 where
     T: IntoIterator<Item = &'a PointStructRawPersisted>,
 {
-    let points_map: AHashMap<PointIdType, _> = points.into_iter().map(|p| (p.id, p)).collect();
-    let ids: Vec<PointIdType> = points_map.keys().copied().collect();
-
-    let mut res = 0;
-
-    for ids_chunk in ids.chunks(UPDATE_OP_CHUNK_SIZE) {
-        // Replace points which are already present in some writable segment
-        let updated_points = segments.apply_points_with_conditional_move(
-            op_num,
-            ids_chunk,
-            |id, write_segment| {
-                upsert_raw_with_payload(write_segment, op_num, points_map[&id], hw_counter)
-            },
-            |id, raw_vectors, _updated_vectors, payload| {
-                // A raw upsert replaces the whole point: drop the old raw
-                // vectors and payload, carry the incoming bytes verbatim.
-                let point = points_map[&id];
-                raw_vectors.clear();
-                raw_vectors.extend(point.vectors.iter().cloned());
-                *payload = point.payload.clone().unwrap_or_default();
-            },
-            hw_counter,
-        )?;
-
-        res += updated_points.len();
-        // Insert new points, which was not updated or existed
-        let new_point_ids = ids_chunk
-            .iter()
-            .copied()
-            .filter(|x| !updated_points.contains(x));
-
-        {
-            let default_write_segment =
-                segments.smallest_appendable_segment().ok_or_else(|| {
-                    OperationError::service_error(
-                        "No appendable segments exist, expected at least one",
-                    )
-                })?;
-
-            let segment_arc = default_write_segment.get();
-            let mut write_segment = segment_arc.write();
-            for point_id in new_point_ids {
-                res += usize::from(upsert_raw_with_payload(
-                    &mut write_segment,
-                    op_num,
-                    points_map[&point_id],
-                    hw_counter,
-                )?);
-            }
-            RwLockWriteGuard::unlock_fair(write_segment);
-        };
-    }
-
-    Ok(res)
+    upsert_points_impl(segments, op_num, points, hw_counter)
 }
 
 /// Drop from `points_op` every point that the conditional-upsert
@@ -237,51 +120,179 @@ pub fn conditional_upsert(
     Ok(upserted_points)
 }
 
-/// Upsert to a point ID with the specified vectors and payload in the given segment.
-///
-/// If the payload is None, the existing payload will be cleared.
-///
-/// Returns
-/// - Ok(true) if the operation was successful and point replaced existing value
-/// - Ok(false) if the operation was successful and point was inserted
-/// - Err if the operation failed
-fn upsert_with_payload(
-    segment: &mut RwLockWriteGuard<dyn SegmentEntry>,
-    op_num: SeqNumberType,
-    point_id: PointIdType,
-    vectors: NamedVectors,
-    payload: Option<&Payload>,
-    hw_counter: &HardwareCounterCell,
-) -> OperationResult<bool> {
-    let mut res = segment.upsert_point(op_num, point_id, vectors, hw_counter)?;
-    if let Some(full_payload) = payload {
-        res &= segment.set_full_payload(op_num, point_id, full_payload, hw_counter)?;
-    } else {
-        res &= segment.clear_payload(op_num, point_id, hw_counter)?;
-    }
-    debug_assert!(
-        segment.has_point(point_id, DeferredBehavior::WithDeferred),
-        "the point {point_id} should be present immediately after the upsert"
+/// A point struct that can be written into a segment as a whole-point
+/// replacement: nothing of a previously stored point (vectors or payload)
+/// survives an upsert, whichever write path it takes.
+trait PointToUpsert {
+    fn id(&self) -> PointIdType;
+
+    /// Upsert in place into a writable segment: vectors plus full payload.
+    ///
+    /// Returns
+    /// - Ok(true) if the operation was successful and point replaced existing value
+    /// - Ok(false) if the operation was successful and point was inserted
+    /// - Err if the operation failed
+    fn upsert_into(
+        &self,
+        segment: &mut RwLockWriteGuard<dyn SegmentEntry>,
+        op_num: SeqNumberType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<bool>;
+
+    /// This function should transform components of the CoW Record according to
+    /// current update operation.
+    ///
+    /// - `raw_vectors`: vectors in storage-native (byte) form; pre-filled with
+    ///   the existing vectors
+    /// - `updated_vectors`: newly modified vectors in decoded form should go here.
+    ///   Takes priority over `raw_vectors` in case of conflict.
+    /// - `payload`: mutate payload of the point; whatever it holds on return
+    ///   is what gets stored
+    fn write_moved<'op>(
+        &'op self,
+        raw_vectors: &mut SmallVec<[(VectorNameBuf, Vec<u8>); 1]>,
+        updated_vectors: &mut NamedVectors<'op>,
+        payload: &mut Payload,
     );
+}
+
+/// Checks point id in each segment, update point if found.
+/// All not found points are inserted into the smallest appendable segment.
+/// Returns: number of updated points.
+fn upsert_points_impl<'a, P>(
+    segments: &SegmentHolder,
+    op_num: SeqNumberType,
+    points: impl IntoIterator<Item = &'a P>,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<usize>
+where
+    P: PointToUpsert + 'a,
+{
+    let points_map: AHashMap<PointIdType, &P> = points.into_iter().map(|p| (p.id(), p)).collect();
+    let ids: Vec<PointIdType> = points_map.keys().copied().collect();
+
+    let mut res = 0;
+
+    for ids_chunk in ids.chunks(UPDATE_OP_CHUNK_SIZE) {
+        // Update points in writable segments
+        let updated_points = segments.apply_points_with_conditional_move(
+            op_num,
+            ids_chunk,
+            |id, write_segment| points_map[&id].upsert_into(write_segment, op_num, hw_counter),
+            |id, raw_vectors, updated_vectors, old_payload| {
+                points_map[&id].write_moved(raw_vectors, updated_vectors, old_payload)
+            },
+            hw_counter,
+        )?;
+
+        res += updated_points.len();
+        // Insert new points, which was not updated or existed
+        let new_point_ids = ids_chunk
+            .iter()
+            .copied()
+            .filter(|x| !updated_points.contains(x));
+
+        {
+            let default_write_segment =
+                segments.smallest_appendable_segment().ok_or_else(|| {
+                    OperationError::service_error(
+                        "No appendable segments exist, expected at least one",
+                    )
+                })?;
+
+            let segment_arc = default_write_segment.get();
+            let mut write_segment = segment_arc.write();
+            for point_id in new_point_ids {
+                res += usize::from(points_map[&point_id].upsert_into(
+                    &mut write_segment,
+                    op_num,
+                    hw_counter,
+                )?);
+            }
+            RwLockWriteGuard::unlock_fair(write_segment);
+        };
+    }
+
     Ok(res)
 }
 
-fn upsert_raw_with_payload(
+impl PointToUpsert for PointStructPersisted {
+    fn id(&self) -> PointIdType {
+        self.id
+    }
+
+    fn upsert_into(
+        &self,
+        segment: &mut RwLockWriteGuard<dyn SegmentEntry>,
+        op_num: SeqNumberType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<bool> {
+        let mut res = segment.upsert_point(op_num, self.id, self.get_vectors(), hw_counter)?;
+        res &=
+            set_full_or_clear_payload(segment, op_num, self.id, self.payload.as_ref(), hw_counter)?;
+        Ok(res)
+    }
+
+    fn write_moved<'op>(
+        &'op self,
+        raw_vectors: &mut SmallVec<[(VectorNameBuf, Vec<u8>); 1]>,
+        updated_vectors: &mut NamedVectors<'op>,
+        payload: &mut Payload,
+    ) {
+        raw_vectors.clear();
+        *updated_vectors = self.get_vectors();
+        *payload = self.payload.clone().unwrap_or_default();
+    }
+}
+
+impl PointToUpsert for PointStructRawPersisted {
+    fn id(&self) -> PointIdType {
+        self.id
+    }
+
+    fn upsert_into(
+        &self,
+        segment: &mut RwLockWriteGuard<dyn SegmentEntry>,
+        op_num: SeqNumberType,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<bool> {
+        let mut res = segment.upsert_point_raw(op_num, self.id, &self.vectors, hw_counter)?;
+        res &=
+            set_full_or_clear_payload(segment, op_num, self.id, self.payload.as_ref(), hw_counter)?;
+        Ok(res)
+    }
+
+    fn write_moved<'op>(
+        &'op self,
+        raw_vectors: &mut SmallVec<[(VectorNameBuf, Vec<u8>); 1]>,
+        _updated_vectors: &mut NamedVectors<'op>,
+        payload: &mut Payload,
+    ) {
+        // Carry the incoming bytes verbatim.
+        raw_vectors.clear();
+        raw_vectors.extend(self.vectors.iter().cloned());
+        *payload = self.payload.clone().unwrap_or_default();
+    }
+}
+
+/// Set the given full payload on the point, or clear the stored payload if `None`.
+///
+/// Finishes a whole-point upsert; the point itself must have just been written.
+fn set_full_or_clear_payload(
     segment: &mut RwLockWriteGuard<dyn SegmentEntry>,
     op_num: SeqNumberType,
-    point: &PointStructRawPersisted,
+    point_id: PointIdType,
+    payload: Option<&Payload>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<bool> {
-    let mut res = segment.upsert_point_raw(op_num, point.id, &point.vectors, hw_counter)?;
-    if let Some(full_payload) = &point.payload {
-        res &= segment.set_full_payload(op_num, point.id, full_payload, hw_counter)?;
+    let res = if let Some(full_payload) = payload {
+        segment.set_full_payload(op_num, point_id, full_payload, hw_counter)?
     } else {
-        res &= segment.clear_payload(op_num, point.id, hw_counter)?;
-    }
+        segment.clear_payload(op_num, point_id, hw_counter)?
+    };
     debug_assert!(
-        segment.has_point(point.id, DeferredBehavior::WithDeferred),
-        "the point {} should be present immediately after the upsert",
-        point.id,
+        segment.has_point(point_id, DeferredBehavior::WithDeferred),
+        "the point {point_id} should be present immediately after the upsert"
     );
     Ok(res)
 }

--- a/lib/shard/src/update/points/upsert.rs
+++ b/lib/shard/src/update/points/upsert.rs
@@ -123,7 +123,7 @@ pub fn conditional_upsert(
 /// A point struct that can be written into a segment as a whole-point
 /// replacement: nothing of a previously stored point (vectors or payload)
 /// survives an upsert, whichever write path it takes.
-trait PointToUpsert {
+pub(super) trait PointToUpsert {
     fn id(&self) -> PointIdType;
 
     /// Upsert in place into a writable segment: vectors plus full payload.
@@ -159,7 +159,7 @@ trait PointToUpsert {
 /// Checks point id in each segment, update point if found.
 /// All not found points are inserted into the smallest appendable segment.
 /// Returns: number of updated points.
-fn upsert_points_impl<'a, P>(
+pub(super) fn upsert_points_impl<'a, P>(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: impl IntoIterator<Item = &'a P>,


### PR DESCRIPTION
## Summary

Follow-up to #9876. The plain and raw variants of the upsert and sync drivers were ~60–80-line clones differing only in how the point struct interacts with a segment.

**Commit 1 — upserts.** Extracts a **private** `PointToUpsert` trait naming the two variation points:

- `upsert_into` — in-place write into a writable segment (vectors + full payload)
- `write_moved` — transform the CoW-move record buffers (`raw_vectors` / `updated_vectors` / `payload`) into what the destination should store; the whole-point-replacement invariant is stated once on the trait instead of as two parallel closure comments

implemented for `PointStructPersisted` and `PointStructRawPersisted`, with the chunked driver folded into a single generic `upsert_points_impl`. The duplicated `upsert_with_payload` / `upsert_raw_with_payload` tails collapse into one shared `set_full_or_clear_payload` helper carrying the single `has_point` debug assertion.

**Commit 2 — syncs.** Extends the same approach: a `PointToSync: PointToUpsert` subtrait with an associated `StoredRecord` type, `retrieve_stored` (`retrieve` vs `retrieve_raw`), and `is_equal_to` (delegating to the existing inherent methods), folding the 5-step sync algorithm into a single generic `sync_points_impl` whose upsert step calls `upsert_points_impl` directly.

The public functions keep their exact names and signatures as thin wrappers, so no caller changes. Everything is monomorphized and private to `update/points/` (`pub(super)` at widest); no generics leak into public signatures.

No behavior changes.

## Testing

- `cargo test -p shard update::` — 17 passed (includes `test_upsert_cow_move_replaces_whole_point`, `test_upsert_points_raw_moves_point_from_non_appendable`, and `test_sync_points_raw`, which pin in-place vs CoW-move equivalence and the raw sync path)
- clippy clean, nightly fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)