### PR TITLE
Skip loggable operation copy when slow-request collector is off

### DIFF
--- a/lib/collection/src/profiling/interface.rs
+++ b/lib/collection/src/profiling/interface.rs
@@ -8,6 +8,13 @@ use crate::profiling::slow_requests_log::LogEntry;
 static REQUESTS_COLLECTOR: OnceCell<crate::profiling::slow_requests_collector::RequestsCollector> =
     OnceCell::const_new();
 
+/// Whether the requests profile collector has been initialized.
+///
+/// Allows callers to skip building loggable copies of requests when profiling is disabled.
+pub fn is_requests_profile_collector_initialized() -> bool {
+    REQUESTS_COLLECTOR.get().is_some()
+}
+
 /// This function should be used to log request profiles into the shared log structure.
 /// This structure is later can be read via API.
 pub fn log_request_to_collector<F, L>(

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -13,7 +13,9 @@ use tokio_util::task::AbortOnDropHandle;
 use crate::collection_manager::collection_updater::CollectionUpdater;
 use crate::operations::generalizer::Generalizer;
 use crate::operations::types::{CollectionError, CollectionResult, UpdateStatus};
-use crate::profiling::interface::log_request_to_collector;
+use crate::profiling::interface::{
+    is_requests_profile_collector_initialized, log_request_to_collector,
+};
 use crate::shards::CollectionId;
 use crate::shards::update_tracker::UpdateTracker;
 use crate::update_handler::{OperationData, OptimizerSignal, UpdateSignal};
@@ -326,7 +328,8 @@ impl UpdateWorkers {
 
         // This represents the operation without vectors and payloads for logging purposes
         // Do not use for anything else
-        let loggable_operation = operation.remove_details();
+        let loggable_operation =
+            is_requests_profile_collector_initialized().then(|| operation.remove_details());
 
         let cpu_utilization = hw_measurements.cpu_utilization();
 
@@ -349,9 +352,11 @@ impl UpdateWorkers {
             None
         };
 
-        log_request_to_collector(&collection_name, duration, cpu_usage_ratio, move || {
-            loggable_operation
-        });
+        if let Some(loggable_operation) = loggable_operation {
+            log_request_to_collector(&collection_name, duration, cpu_usage_ratio, move || {
+                loggable_operation
+            });
+        }
 
         result
     }


### PR DESCRIPTION
## What

`update_worker_internal` unconditionally calls `operation.remove_details()` to build a vectors-stripped copy of every update operation for the slow-request collector. 

For named-vector points this deep copy rebuilds a `HashMap<String, VectorPersisted>` per point: a `String` clone per vector name, a replacement `Vec` allocation, and a SipHash-based insert into a freshly allocated map.

`log_request_to_collector` only consumes that copy when the request is slow AND the global `REQUESTS_COLLECTOR` is initialized, so in binaries that never initialize the collector (e.g. `model_testing`) the copy is built and thrown away on every single update. It showed up as a top CPU consumer in update-worker profiles there.

## Change

- Add `is_requests_profile_collector_initialized()` to the profiling interface.
- In the update worker, build the loggable copy only when the collector is initialized, and skip the `log_request_to_collector` call otherwise.

Behavior with the collector running is unchanged.

## Note

When the collector IS initialized, the copy is still built eagerly for fast requests too, because the operation is moved into `CollectionUpdater::update` before the duration is known. Deferring it below `MIN_SLOW_REQUEST_DURATION` would need the updater to borrow or return the operation; left as a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)