### PR TITLE
[TQDT] Fix/upsert raw malformed blob badinput

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1124,6 +1124,9 @@ impl From<OperationError> for CollectionError {
             OperationError::WrongVectorDimension { .. } => Self::BadInput {
                 description: err.to_string(),
             },
+            OperationError::WrongVectorBytesSize { .. } => Self::BadInput {
+                description: err.to_string(),
+            },
             OperationError::VectorNameNotExists { .. } => Self::BadInput {
                 description: err.to_string(),
             },

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -1330,20 +1330,6 @@ async fn test_old_wal_filter_op_replays_with_apply_semantics() {
     shard.stop_gracefully().await;
 }
 
-/// Reproducer for <https://github.com/qdrant/qdrant/pull/9813#discussion_r3587293412>.
-///
-/// The raw upsert path (the internal node-to-node API carrying storage-native
-/// vector bytes) does not validate blob length before the WAL write; a malformed
-/// blob is only rejected deep in the storage layer. That rejection used to be a
-/// `ServiceError`, which aborts WAL replay and crash-loops recovery — a single
-/// malformed raw op persisted to the WAL would brick the shard on restart.
-///
-/// After the fix the storage raises `WrongVectorBytesSize`, a user error mapped
-/// to `BadInput`, which WAL replay logs-and-skips just like a plain
-/// `WrongVectorDimension` on the normal upsert path. This test drives the whole
-/// path: a valid raw op and a malformed raw op both reach the WAL, the shard is
-/// reloaded (replaying both), and we assert recovery succeeds with the valid
-/// point preserved and the malformed one skipped.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_malformed_raw_upsert_is_skipped_on_wal_replay() {
     let _ = env_logger::builder().is_test(true).try_init();

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -4,11 +4,11 @@ use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use common::types::DeferredBehavior;
-use segment::data_types::vectors::VectorStructInternal;
+use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, VectorStructInternal};
 use segment::types::{PayloadFieldSchema, PayloadSchemaType, WithPayload, WithVector};
 use shard::operations::CollectionUpdateOperations;
 use shard::operations::point_ops::{
-    PointInsertOperationsInternal, PointOperations, PointStructPersisted,
+    PointInsertOperationsInternal, PointOperations, PointStructPersisted, PointStructRawPersisted,
 };
 use shard::segment_holder::FlushMode;
 use shard::wal::{SerdeWal, WalRawRecord};
@@ -18,7 +18,7 @@ use tokio::sync::RwLock;
 
 use crate::common::adaptive_handle::AdaptiveSearchHandle;
 use crate::operations::shared_storage_config::SharedStorageConfig;
-use crate::operations::types::PointRequestInternal;
+use crate::operations::types::{CollectionError, PointRequestInternal};
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::{ShardOperation, WaitUntil};
 use crate::tests::fixtures::*;
@@ -1325,6 +1325,155 @@ async fn test_old_wal_filter_op_replays_with_apply_semantics() {
         present,
         vec![1.into(), 4.into(), 5.into()],
         "old-style filter record was not replayed with the by-filter apply semantics",
+    );
+
+    shard.stop_gracefully().await;
+}
+
+/// Reproducer for <https://github.com/qdrant/qdrant/pull/9813#discussion_r3587293412>.
+///
+/// The raw upsert path (the internal node-to-node API carrying storage-native
+/// vector bytes) does not validate blob length before the WAL write; a malformed
+/// blob is only rejected deep in the storage layer. That rejection used to be a
+/// `ServiceError`, which aborts WAL replay and crash-loops recovery — a single
+/// malformed raw op persisted to the WAL would brick the shard on restart.
+///
+/// After the fix the storage raises `WrongVectorBytesSize`, a user error mapped
+/// to `BadInput`, which WAL replay logs-and-skips just like a plain
+/// `WrongVectorDimension` on the normal upsert path. This test drives the whole
+/// path: a valid raw op and a malformed raw op both reach the WAL, the shard is
+/// reloaded (replaying both), and we assert recovery succeeds with the valid
+/// point preserved and the malformed one skipped.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_malformed_raw_upsert_is_skipped_on_wal_replay() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+
+    // Single dense vector, dim 4, Distance::Dot (no cosine preprocessing, so the
+    // storage-native form is just the packed f32 bytes).
+    let config = create_collection_config();
+    let collection_name = "test".to_string();
+
+    let update_runtime = Handle::current();
+    let current_runtime: AdaptiveSearchHandle = AdaptiveSearchHandle::current_for_tests();
+
+    let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+    let payload_index_schema =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
+    let shard = LocalShard::build(
+        0,
+        collection_name.clone(),
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        Arc::new(Default::default()),
+        payload_index_schema.clone(),
+        update_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+        config.optimizer_config.clone(),
+    )
+    .await
+    .unwrap();
+
+    let hw_acc = HwMeasurementAcc::new();
+
+    // A dim-4 dense f32 vector is exactly 16 storage-native bytes; 12 bytes
+    // (3 floats) is a dimension mismatch the storage must reject.
+    let good_bytes: Vec<u8> = [1.0f32, 2.0, 3.0, 4.0]
+        .iter()
+        .flat_map(|f| f.to_ne_bytes())
+        .collect();
+    let bad_bytes: Vec<u8> = [1.0f32, 2.0, 3.0]
+        .iter()
+        .flat_map(|f| f.to_ne_bytes())
+        .collect();
+
+    let raw_upsert = |id: u64, bytes: Vec<u8>| {
+        CollectionUpdateOperations::PointOperation(PointOperations::UpsertPointsRaw(vec![
+            PointStructRawPersisted {
+                id: id.into(),
+                vectors: std::iter::once((DEFAULT_VECTOR_NAME.to_owned(), bytes)).collect(),
+                payload: None,
+            },
+        ]))
+    };
+
+    // Op 1: a valid raw point — applied and persisted to the WAL.
+    shard
+        .update(
+            raw_upsert(1, good_bytes).into(),
+            WaitUntil::Visible,
+            None,
+            hw_acc.clone(),
+        )
+        .await
+        .expect("valid raw upsert should succeed");
+
+    // Op 2: a malformed raw point. `submit_update` writes to the WAL *before*
+    // applying, so this op survives its own failed apply and is replayed on
+    // reload. The apply must fail as a user error (`BadInput`), not a
+    // `ServiceError` — that is exactly what makes replay skip it.
+    let err = shard
+        .update(
+            raw_upsert(2, bad_bytes).into(),
+            WaitUntil::Visible,
+            None,
+            hw_acc.clone(),
+        )
+        .await
+        .expect_err("malformed raw upsert must be rejected");
+    assert!(
+        matches!(err, CollectionError::BadInput { .. }),
+        "malformed raw blob must be a BadInput user error (skipped on replay), got {err:?}",
+    );
+
+    shard.stop_gracefully().await;
+
+    // Reload replays the WAL, including the malformed op. Before the fix this
+    // `LocalShard::load` would fail (or, in production, panic) because
+    // `load_from_wal` propagates the storage `ServiceError` and aborts recovery.
+    let shard = LocalShard::load(
+        0,
+        collection_name,
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        config.optimizer_config.clone(),
+        Arc::new(Default::default()),
+        payload_index_schema,
+        true,
+        update_runtime,
+        current_runtime.clone(),
+        ResourceBudget::default(),
+    )
+    .await
+    .expect("shard must recover: the malformed raw op is skipped, not crash-looped");
+
+    // The valid point survives; the malformed one was never stored.
+    let request = Arc::new(PointRequestInternal {
+        ids: vec![1.into(), 2.into()],
+        with_payload: None,
+        with_vector: WithVector::Bool(false),
+    });
+    let retrieved = shard
+        .retrieve(
+            request,
+            &WithPayload::from(false),
+            &WithVector::Bool(false),
+            &current_runtime,
+            None,
+            hw_acc,
+            DeferredBehavior::VisibleOnly,
+        )
+        .await
+        .unwrap();
+
+    let present: Vec<_> = retrieved.iter().map(|record| record.id).collect();
+    assert_eq!(
+        present,
+        vec![1.into()],
+        "only the valid point should survive; the malformed raw op must be skipped on replay",
     );
 
     shard.stop_gracefully().await;

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -25,6 +25,12 @@ pub enum OperationError {
         expected_dim: usize,
         received_dim: usize,
     },
+    /// A storage-native (raw byte) vector blob whose length is incompatible with
+    /// the target storage. Classified as user error (maps to `BadInput`), not
+    /// `ServiceError`, so a malformed blob that reached the WAL is skipped on
+    /// replay instead of crash-looping recovery.
+    #[error("{description}")]
+    WrongVectorBytesSize { description: String },
     #[error("Not existing vector name error: {received_name}")]
     VectorNameNotExists { received_name: VectorNameBuf },
     #[error("No point with id {missed_point_id}")]
@@ -133,12 +139,19 @@ impl OperationError {
         }
     }
 
+    pub fn wrong_vector_bytes_size(description: impl Into<String>) -> Self {
+        Self::WrongVectorBytesSize {
+            description: description.into(),
+        }
+    }
+
     /// Whether this error signals that all appendable segments are at `max_segment_size` capacity,
     /// so the operation can be re-applied after provisioning a fresh appendable segment.
     pub fn is_out_of_appendable_capacity(&self) -> bool {
         match self {
             Self::OutOfAppendableCapacity { .. } => true,
             Self::WrongVectorDimension { .. }
+            | Self::WrongVectorBytesSize { .. }
             | Self::VectorNameNotExists { .. }
             | Self::PointIdError { .. }
             | Self::TypeError { .. }
@@ -178,6 +191,7 @@ impl IsNotFound for OperationError {
         match self {
             Self::FileNotFound { .. } => true,
             Self::WrongVectorDimension { .. }
+            | Self::WrongVectorBytesSize { .. }
             | Self::VectorNameNotExists { .. }
             | Self::PointIdError { .. }
             | Self::TypeError { .. }

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -1393,7 +1393,16 @@ fn test_upsert_raw_malformed_blob_rejected() {
         &[(DEFAULT_VECTOR_NAME.to_owned(), vec![0_u8, 1, 2])],
         &hw_counter,
     );
-    assert!(result.is_err(), "malformed blob must be rejected");
+    // Must be a user error (`WrongVectorBytesSize`), not a `ServiceError`: a
+    // malformed blob that reached the WAL is skipped on replay instead of
+    // crash-looping recovery.
+    assert!(
+        matches!(
+            result,
+            Err(crate::common::operation_error::OperationError::WrongVectorBytesSize { .. })
+        ),
+        "malformed blob must be rejected as WrongVectorBytesSize, got {result:?}",
+    );
 }
 
 /// TurboQuant dense raw round-trip: the encoded TQ blob must be ingested

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -100,7 +100,7 @@ impl TurboVectorStorage {
     ) -> OperationResult<()> {
         let expected_size = self.quantizer.quantized_size();
         if bytes.len() != expected_size {
-            return Err(OperationError::service_error(format!(
+            return Err(OperationError::wrong_vector_bytes_size(format!(
                 "Malformed dense TQ blob of {} bytes, expected {expected_size}",
                 bytes.len(),
             )));

--- a/lib/segment/src/vector_storage/turbo/multi.rs
+++ b/lib/segment/src/vector_storage/turbo/multi.rs
@@ -329,7 +329,7 @@ impl TurboMultiVectorStorage {
     ) -> OperationResult<()> {
         let record_size = self.quantizer.quantized_size();
         if bytes.is_empty() || !bytes.len().is_multiple_of(record_size) {
-            return Err(OperationError::service_error(format!(
+            return Err(OperationError::wrong_vector_bytes_size(format!(
                 "Malformed multi TQ blob of {} bytes, expected a positive multiple of {record_size}",
                 bytes.len(),
             )));

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -892,7 +892,9 @@ fn insert_dense_bytes<T: PrimitiveVectorElement, S: DenseVectorStorageRead<T> + 
 ) -> OperationResult<()> {
     let expected_size = storage.vector_dim() * size_of::<T>();
     if bytes.len() != expected_size {
-        return Err(OperationError::service_error(format!(
+        // `WrongVectorBytesSize` (not `service_error`) so a malformed blob that
+        // reached the WAL is skipped on replay instead of crash-looping recovery.
+        return Err(OperationError::wrong_vector_bytes_size(format!(
             "Malformed dense vector blob of {} bytes, expected {expected_size}",
             bytes.len(),
         )));
@@ -920,7 +922,7 @@ fn insert_multi_bytes<T: PrimitiveVectorElement, S: MultiVectorStorageRead<T> + 
 ) -> OperationResult<()> {
     let inner_size = storage.vector_dim() * size_of::<T>();
     if bytes.is_empty() || !bytes.len().is_multiple_of(inner_size) {
-        return Err(OperationError::service_error(format!(
+        return Err(OperationError::wrong_vector_bytes_size(format!(
             "Malformed multi vector blob of {} bytes, expected a positive multiple of {inner_size}",
             bytes.len(),
         )));


### PR DESCRIPTION
This PR adds a new Error type - malformed raw vector. It's analogue of the bad input error.
It's required for the WAL replay case, where we dont return service error and produce the WAL-replay loop if the raw vector is malformed. It's silently skipped.

It's just a protection from WAL-replay loop, not a complete solution. We also need to validete vector BEFORE pushing it into WAL to notify another node that the wrong vector was sent.