### PR TITLE
Benches: use SmallRng instead of ChaCha12-based generators

### DIFF
--- a/lib/collection/benches/batch_query_bench.rs
+++ b/lib/collection/benches/batch_query_bench.rs
@@ -19,7 +19,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use criterion::{Criterion, criterion_group, criterion_main};
 use ordered_float::OrderedFloat;
-use rand::rng;
+use rand::rngs::SmallRng;
 use segment::common::reciprocal_rank_fusion::DEFAULT_RRF_K;
 use segment::data_types::vectors::{VectorStructInternal, only_default_vector};
 use segment::fixtures::payload_fixtures::random_vector;
@@ -113,7 +113,7 @@ fn setup() -> (TempDir, LocalShard, Runtime) {
 }
 
 fn create_rnd_batch() -> CollectionUpdateOperations {
-    let mut rng = rng();
+    let mut rng = rand::make_rng::<SmallRng>();
     let num_points = 2000;
     let dim = 100;
     let mut points = Vec::with_capacity(num_points);
@@ -168,7 +168,7 @@ fn batch_search_bench(c: &mut Criterion) {
         group.bench_function(format!("query-batch-{fid}"), |b| {
             b.iter(|| {
                 search_runtime.block_on(async {
-                    let mut rng = rng();
+                    let mut rng = rand::make_rng::<SmallRng>();
                     let mut searches = Vec::with_capacity(batch_size);
                     for _i in 0..batch_size {
                         let query = random_vector(&mut rng, 100);
@@ -199,7 +199,7 @@ fn batch_search_bench(c: &mut Criterion) {
         group.bench_function(format!("search-batch-{fid}"), |b| {
             b.iter(|| {
                 search_runtime.block_on(async {
-                    let mut rng = rng();
+                    let mut rng = rand::make_rng::<SmallRng>();
                     let mut searches = Vec::with_capacity(batch_size);
                     for _i in 0..batch_size {
                         let query = random_vector(&mut rng, 100);
@@ -248,7 +248,7 @@ fn batch_rrf_query_bench(c: &mut Criterion) {
         group.bench_function(format!("hybrid-query-batch-{fid}"), |b| {
             b.iter(|| {
                 search_runtime.block_on(async {
-                    let mut rng = rng();
+                    let mut rng = rand::make_rng::<SmallRng>();
                     let mut searches = Vec::with_capacity(batch_size);
                     for _i in 0..batch_size {
                         let query1 = random_vector(&mut rng, 100);
@@ -318,7 +318,7 @@ fn batch_rescore_bench(c: &mut Criterion) {
         group.bench_function(format!("rescore-query-batch-{fid}"), |b| {
             b.iter(|| {
                 search_runtime.block_on(async {
-                    let mut rng = rng();
+                    let mut rng = rand::make_rng::<SmallRng>();
                     let mut searches = Vec::with_capacity(batch_size);
                     for _i in 0..batch_size {
                         let query1 = random_vector(&mut rng, 100);

--- a/lib/collection/benches/batch_search_bench.rs
+++ b/lib/collection/benches/batch_search_bench.rs
@@ -16,7 +16,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use criterion::{Criterion, criterion_group, criterion_main};
 use ordered_float::OrderedFloat;
-use rand::rng;
+use rand::rngs::SmallRng;
 use segment::data_types::vectors::{VectorStructInternal, only_default_vector};
 use segment::fixtures::payload_fixtures::random_vector;
 use segment::types::{Condition, Distance, FieldCondition, Filter, Payload, Range};
@@ -30,7 +30,7 @@ use tokio::sync::RwLock;
 mod prof;
 
 fn create_rnd_batch() -> CollectionUpdateOperations {
-    let mut rng = rng();
+    let mut rng = rand::make_rng::<SmallRng>();
     let num_points = 2000;
     let dim = 100;
     let mut points = Vec::with_capacity(num_points);
@@ -153,7 +153,7 @@ fn batch_search_bench(c: &mut Criterion) {
         group.bench_function(format!("search-{fid}"), |b| {
             b.iter(|| {
                 runtime.block_on(async {
-                    let mut rng = rng();
+                    let mut rng = rand::make_rng::<SmallRng>();
                     for _i in 0..batch_size {
                         let query = random_vector(&mut rng, 100);
                         let search_query = SearchRequestInternal {
@@ -187,7 +187,7 @@ fn batch_search_bench(c: &mut Criterion) {
         group.bench_function(format!("search-batch-{fid}"), |b| {
             b.iter(|| {
                 runtime.block_on(async {
-                    let mut rng = rng();
+                    let mut rng = rand::make_rng::<SmallRng>();
                     let mut searches = Vec::with_capacity(batch_size);
                     for _i in 0..batch_size {
                         let query = random_vector(&mut rng, 100);

--- a/lib/collection/benches/hash_ring_bench.rs
+++ b/lib/collection/benches/hash_ring_bench.rs
@@ -4,6 +4,7 @@ mod prof;
 use collection::hash_ring::HashRing;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::RngExt;
+use rand::rngs::SmallRng;
 
 fn hash_ring_bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("hash-ring-bench");
@@ -17,7 +18,7 @@ fn hash_ring_bench(c: &mut Criterion) {
         ring_fair.add(i);
     }
 
-    let mut rnd = rand::rng();
+    let mut rnd = rand::make_rng::<SmallRng>();
 
     group.bench_function("hash-ring-fair", |b| {
         b.iter(|| {

--- a/lib/common/common/benches/atomic_stop.rs
+++ b/lib/common/common/benches/atomic_stop.rs
@@ -5,10 +5,11 @@ use common::iterator_ext::IteratorExt;
 use common::iterator_ext::stoppable_iter::StoppableIter;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::RngExt;
+use rand::rngs::SmallRng;
 
 fn bench_atomic_stop(c: &mut Criterion) {
     // Generate random number from 1 to 1_000_000
-    let mut rng = rand::rng();
+    let mut rng = rand::make_rng::<SmallRng>();
 
     c.bench_function("Sum regular iterator", |b| {
         b.iter(|| {

--- a/lib/common/common/benches/bitpacking.rs
+++ b/lib/common/common/benches/bitpacking.rs
@@ -5,18 +5,18 @@ use common::bitpacking_links::{iterate_packed_links, pack_links};
 use common::bitpacking_ordered;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use itertools::Itertools as _;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng as _};
 use zerocopy::IntoBytes;
 
 pub fn bench_bitpacking(c: &mut Criterion) {
     let mut group = c.benchmark_group("bitpacking");
 
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     let data8 = (0..64_000_000).map(|_| rng.random()).collect::<Vec<u8>>();
     let data32 = (0..4_000_000).map(|_| rng.random()).collect::<Vec<u32>>();
 
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     group.bench_function("read", |b| {
         b.iter_batched(
             || {
@@ -36,7 +36,7 @@ pub fn bench_bitpacking(c: &mut Criterion) {
         )
     });
 
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     let mut out = Vec::new();
     group.bench_function("write", |b| {
         b.iter_batched(
@@ -63,7 +63,7 @@ pub fn bench_bitpacking(c: &mut Criterion) {
 pub fn bench_bitpacking_links(c: &mut Criterion) {
     let mut group = c.benchmark_group("bitpacking_links");
 
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     let mut links = Vec::new();
     let mut pos = vec![(0, 0, 0)];
     while links.len() <= 64_000_000 {
@@ -86,7 +86,7 @@ pub fn bench_bitpacking_links(c: &mut Criterion) {
         pos.push((links.len(), bits_per_unsorted, sorted_count));
     }
 
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     group.bench_function("read", |b| {
         b.iter_batched(
             || {
@@ -106,7 +106,8 @@ pub fn bench_bitpacking_links(c: &mut Criterion) {
 pub fn bench_bitpacking_ordered(c: &mut Criterion) {
     let mut group = c.benchmark_group("bitpacking_ordered");
 
-    let values = bitpacking_ordered::gen_test_sequence(&mut StdRng::seed_from_u64(42), 32, 1 << 22);
+    let values =
+        bitpacking_ordered::gen_test_sequence(&mut SmallRng::seed_from_u64(42), 32, 1 << 22);
 
     group.sample_size(10);
     group.bench_function("compress", |b| {
@@ -125,7 +126,7 @@ pub fn bench_bitpacking_ordered(c: &mut Criterion) {
         decompressor.parameters(),
     );
 
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     group.bench_function("get_raw", |b| {
         b.iter_batched(
             || rng.random_range(0..values.len()),
@@ -136,7 +137,7 @@ pub fn bench_bitpacking_ordered(c: &mut Criterion) {
         )
     });
 
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     group.bench_function("get", |b| {
         b.iter_batched(
             || rng.random_range(0..values.len()),
@@ -147,7 +148,7 @@ pub fn bench_bitpacking_ordered(c: &mut Criterion) {
         )
     });
 
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     group.bench_function("get2", |b| {
         b.iter_batched(
             || rng.random_range(0..values.len() - 1),

--- a/lib/common/common/benches/bitpacking_tango.rs
+++ b/lib/common/common/benches/bitpacking_tango.rs
@@ -6,7 +6,7 @@ use common::bitpacking::{BitReader, BitWriter};
 use common::bitpacking_links::iterate_packed_links;
 use common::bitpacking_ordered;
 use itertools::Itertools as _;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng as _};
 use tango_bench::metrics::WallClock;
 use tango_bench::{
@@ -18,17 +18,17 @@ type Bencher = tango_bench::Bencher<WallClock>;
 
 pub fn benchmarks_bitpacking() -> impl IntoBenchmarks {
     let data8 = StateBencher::new(move || {
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = SmallRng::seed_from_u64(42);
         (0..64_000_000).map(|_| rng.random()).collect::<Vec<u8>>()
     });
     let data32 = StateBencher::new(move || {
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = SmallRng::seed_from_u64(42);
         (0..4_000_000).map(|_| rng.random()).collect::<Vec<u32>>()
     });
 
     [
         data8.benchmark_fn("bitpacking/read", move |b: Bencher, data8| {
-            let mut rng = StdRng::seed_from_u64(42);
+            let mut rng = SmallRng::seed_from_u64(42);
             b.iter(move || {
                 let bits = rng.random_range(1..=32);
                 let bytes = rng.random_range(0..=16);
@@ -43,7 +43,7 @@ pub fn benchmarks_bitpacking() -> impl IntoBenchmarks {
             })
         }),
         data32.benchmark_fn("bitpacking/write", move |b: Bencher, data32| {
-            let mut rng = StdRng::seed_from_u64(42);
+            let mut rng = SmallRng::seed_from_u64(42);
             let mut out = Vec::new();
             b.iter(move || {
                 let bits = rng.random_range(1..=32);
@@ -76,7 +76,7 @@ fn benchmarks_bitpacking_links() -> impl IntoBenchmarks {
 
     let b = StateBencher::new(move || {
         Rc::new({
-            let mut rng = StdRng::seed_from_u64(42);
+            let mut rng = SmallRng::seed_from_u64(42);
             let mut links = Vec::new();
             let mut pos = vec![Item {
                 offset: 0,
@@ -115,7 +115,7 @@ fn benchmarks_bitpacking_links() -> impl IntoBenchmarks {
 
     [
         b.benchmark_fn("bitpacking_links/read", move |b: Bencher, state| {
-            let mut rng = rand::rng();
+            let mut rng = rand::make_rng::<SmallRng>();
             b.iter(move || {
                 let idx = rng.random_range(1..state.items.len());
                 iterate_packed_links(
@@ -151,7 +151,7 @@ fn benchmarks_ordered() -> impl IntoBenchmarks {
 
     let b = StateBencher::new(move || {
         let values =
-            bitpacking_ordered::gen_test_sequence(&mut StdRng::seed_from_u64(42), 32, 1 << 22);
+            bitpacking_ordered::gen_test_sequence(&mut SmallRng::seed_from_u64(42), 32, 1 << 22);
 
         let (compressed, parameters) = bitpacking_ordered::compress(&values);
 
@@ -171,7 +171,7 @@ fn benchmarks_ordered() -> impl IntoBenchmarks {
     [
         b.benchmark_fn("ordered/get", {
             move |b: Bencher, state| {
-                let mut rng = rand::rng();
+                let mut rng = rand::make_rng::<SmallRng>();
                 let len = state.borrow_owner().values.len() - 1;
                 b.iter(move || {
                     let i = rng.random_range(0..len);
@@ -181,7 +181,7 @@ fn benchmarks_ordered() -> impl IntoBenchmarks {
         }),
         b.benchmark_fn("ordered/get2", {
             move |b: Bencher, state| {
-                let mut rng = rand::rng();
+                let mut rng = rand::make_rng::<SmallRng>();
                 let len = state.borrow_owner().values.len() - 1;
                 b.iter(move || {
                     let i = rng.random_range(0..len);

--- a/lib/common/common/benches/mmap_hashmap.rs
+++ b/lib/common/common/benches/mmap_hashmap.rs
@@ -6,7 +6,7 @@ use common::persisted_hashmap::{MmapHashMap, UniversalHashMap, serialize_hashmap
 use common::universal_io::{OpenOptions, UniversalIoError, UniversalReadFileOps};
 use criterion::{Criterion, criterion_group, criterion_main};
 use fs_err as fs;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
 #[cfg(target_os = "linux")]
@@ -156,7 +156,7 @@ fn make_serialized_hashmap(count: usize) -> PathBuf {
         eprintln!("Building serialized hashmap at {path:?}...");
         fs::create_dir_all(path.parent().unwrap()).unwrap();
 
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = SmallRng::seed_from_u64(42);
         let map = gen_map(&mut rng, count);
 
         serialize_hashmap::<str, u32>(
@@ -171,7 +171,7 @@ fn make_serialized_hashmap(count: usize) -> PathBuf {
     path
 }
 
-fn gen_map(rng: &mut StdRng, count: usize) -> BTreeMap<String, Vec<u32>> {
+fn gen_map(rng: &mut SmallRng, count: usize) -> BTreeMap<String, Vec<u32>> {
     let mut map = BTreeMap::new();
     while map.len() < count {
         let key: String = (0..rng.random_range(5..=32))

--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -11,7 +11,7 @@ use common::universal_io::{
 };
 use criterion::{Criterion, criterion_group, criterion_main};
 use fs_err as fs;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::{Rng as _, RngExt, SeedableRng as _};
 
 const FILE_SIZE_BYTES: u64 = 512 * 1024 * 1024;
@@ -84,7 +84,7 @@ fn read_benches<T: bytemuck::Pod + Send, Fs: UniversalReadFs>(
     };
     let storage = fs.open(path, options, Default::default()).unwrap();
     let len = FILE_SIZE_BYTES / size_of::<T>() as u64;
-    let mut rng = rand::rng();
+    let mut rng = rand::make_rng::<SmallRng>();
     assert_eq!(storage.len::<T>().unwrap(), len);
 
     let low_mem = std::env::var_os(LIMIT_MEMORY_ENV_INTERNAL).is_some();
@@ -205,7 +205,7 @@ fn make_random_file() -> PathBuf {
     fs_err::create_dir_all(path.parent().unwrap()).unwrap();
 
     let mut file = fs::File::create(&path).unwrap();
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     let mut buffer = vec![0; 1024 * 1024];
     let mut bytes_left = FILE_SIZE_BYTES as usize;
 

--- a/lib/gridstore/benches/bitmask_bench.rs
+++ b/lib/gridstore/benches/bitmask_bench.rs
@@ -5,10 +5,11 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use gridstore::bitmask::MmapBitmask;
 use gridstore::config::DEFAULT_REGION_SIZE_BLOCKS;
 use rand::RngExt;
+use rand::rngs::SmallRng;
 
 pub fn bench_bitmask_ops(c: &mut Criterion) {
     let distr = rand::distr::StandardUniform;
-    let rng = rand::rng();
+    let rng = rand::make_rng::<SmallRng>();
     let random_bitvec = rng
         .sample_iter::<bool, _>(distr)
         .take(1000 * DEFAULT_REGION_SIZE_BLOCKS)
@@ -24,7 +25,7 @@ pub fn bench_bitmask_ops(c: &mut Criterion) {
     });
 
     c.bench_function("find_available_blocks_in_slice", |b| {
-        let mut rng = rand::rng();
+        let mut rng = rand::make_rng::<SmallRng>();
         b.iter(|| {
             let bitslice = bitslice_iter.next().unwrap();
             let num_blocks = rng.random_range(1..10);

--- a/lib/gridstore/benches/flush_bench.rs
+++ b/lib/gridstore/benches/flush_bench.rs
@@ -4,6 +4,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use criterion::{Criterion, criterion_group, criterion_main};
 use gridstore::fixtures::{empty_storage, random_payload};
 use rand::RngExt;
+use rand::rngs::SmallRng;
 
 pub fn flush_bench(c: &mut Criterion) {
     let prepopulation_size = 10_000;
@@ -15,7 +16,7 @@ pub fn flush_bench(c: &mut Criterion) {
         c.bench_function(&bench_name, |b| {
             // Setup: Create a storage with a specified number of records
             let (_dir, mut storage) = empty_storage();
-            let mut rng = rand::rng();
+            let mut rng = rand::make_rng::<SmallRng>();
             let hw_counter = HardwareCounterCell::new();
             let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
 
@@ -53,7 +54,7 @@ pub fn flush_bench(c: &mut Criterion) {
         c.bench_function(&bench_name, |b| {
             // Setup: Create a storage with a specified number of records
             let (_dir, mut storage) = empty_storage();
-            let mut rng = rand::rng();
+            let mut rng = rand::make_rng::<SmallRng>();
             let hw_counter = HardwareCounterCell::new();
             let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
 

--- a/lib/gridstore/benches/random_data_bench.rs
+++ b/lib/gridstore/benches/random_data_bench.rs
@@ -2,13 +2,14 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use gridstore::fixtures::{empty_storage, random_payload};
+use rand::rngs::SmallRng;
 
 /// sized similarly to the real dataset for a fair comparison
 const PAYLOAD_COUNT: u32 = 100_000;
 
 pub fn random_data_bench(c: &mut Criterion) {
     let (_dir, mut storage) = empty_storage();
-    let mut rng = rand::rng();
+    let mut rng = rand::make_rng::<SmallRng>();
     c.bench_function("write random payload", |b| {
         let hw_counter = HardwareCounterCell::new();
         let hw_counter_ref = hw_counter.ref_payload_io_write_counter();

--- a/lib/gridstore/benches/real_data_bench.rs
+++ b/lib/gridstore/benches/real_data_bench.rs
@@ -9,6 +9,7 @@ use fs_err as fs;
 use fs_err::File;
 use gridstore::fixtures::{HM_FIELDS, Payload, empty_storage};
 use rand::RngExt;
+use rand::rngs::SmallRng;
 use serde_json::Value;
 
 /// Insert CSV data into the storage
@@ -114,7 +115,7 @@ pub fn real_data_data_bench(c: &mut Criterion) {
     });
 
     // delete 30% of the points
-    let mut rng = rand::rng();
+    let mut rng = rand::make_rng::<SmallRng>();
     for i in 0..storage.max_point_offset() {
         if rng.random_bool(0.3) {
             storage.delete_value(i).unwrap();

--- a/lib/quantization/benches/binary.rs
+++ b/lib/quantization/benches/binary.rs
@@ -13,12 +13,12 @@ use quantization::encoded_vectors_binary::{
 };
 use rand::{RngExt, SeedableRng};
 
-fn generate_number(rng: &mut rand::rngs::StdRng) -> f32 {
+fn generate_number(rng: &mut rand::rngs::SmallRng) -> f32 {
     let n = f32::signum(rng.random_range(-1.0..1.0));
     if n == 0.0 { 1.0 } else { n }
 }
 
-fn generate_vector(dim: usize, rng: &mut rand::rngs::StdRng) -> Vec<f32> {
+fn generate_vector(dim: usize, rng: &mut rand::rngs::SmallRng) -> Vec<f32> {
     (0..dim).map(|_| generate_number(rng)).collect()
 }
 
@@ -27,7 +27,7 @@ fn binary_bench(c: &mut Criterion) {
 
     let vectors_count = 100_000;
     let vector_dim = 1024;
-    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
     let mut vectors: Vec<Vec<f32>> = (0..vectors_count)
         .map(|_| generate_vector(vector_dim, &mut rng))
         .collect();
@@ -132,7 +132,7 @@ fn binary_scalar_query_bench_impl(c: &mut Criterion) {
 
     let vectors_count = 100_000;
     let vector_dim = 1024;
-    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(42);
     let mut vectors: Vec<Vec<f32>> = (0..vectors_count)
         .map(|_| generate_vector(vector_dim, &mut rng))
         .collect();

--- a/lib/quantization/benches/encode.rs
+++ b/lib/quantization/benches/encode.rs
@@ -6,13 +6,14 @@ use quantization::encoded_storage::TestEncodedStorageBuilder;
 use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
 use quantization::encoded_vectors_u8::{self, EncodedVectorsU8, ScalarQuantizationMethod};
 use rand::RngExt;
+use rand::rngs::SmallRng;
 
 fn encode_dot_bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("encode dot");
 
     let vectors_count = 100_000;
     let vector_dim = 1024;
-    let mut rng = rand::rng();
+    let mut rng = rand::make_rng::<SmallRng>();
     let mut list: Vec<f32> = Vec::new();
     for _ in 0..vectors_count {
         let vector: Vec<f32> = (0..vector_dim).map(|_| rng.random()).collect();
@@ -116,7 +117,7 @@ fn encode_l1_bench(c: &mut Criterion) {
 
     let vectors_count = 100_000;
     let vector_dim = 1024;
-    let mut rng = rand::rng();
+    let mut rng = rand::make_rng::<SmallRng>();
     let mut list: Vec<f32> = Vec::new();
     for _ in 0..vectors_count {
         let vector: Vec<f32> = (0..vector_dim).map(|_| rng.random()).collect();

--- a/lib/quantization/benches/hadamard_simd.rs
+++ b/lib/quantization/benches/hadamard_simd.rs
@@ -14,13 +14,13 @@ use quantization::turboquant::rotation::in_place_walsh_hadamard_transform;
 use quantization::turboquant::simd::hadamard::simd_arm::{wht_neon, wht_neon_radix16_4x};
 #[cfg(target_arch = "x86_64")]
 use quantization::turboquant::simd::hadamard::simd_x86::{wht_avx2, wht_avx2_radix16_4x};
-use rand::prelude::StdRng;
+use rand::prelude::SmallRng;
 use rand::{RngExt, SeedableRng};
 
 const SIZES: &[usize] = &[64, 128, 256, 512, 1024, 2048, 4096, 8192];
 
 fn make_input(n: usize) -> Vec<f64> {
-    let mut rng = StdRng::seed_from_u64(n as u64);
+    let mut rng = SmallRng::seed_from_u64(n as u64);
     (0..n).map(|_| rng.random_range(-1.0f64..1.0)).collect()
 }
 

--- a/lib/quantization/benches/p_square.rs
+++ b/lib/quantization/benches/p_square.rs
@@ -3,13 +3,16 @@ use std::hint::black_box;
 use criterion::{Criterion, criterion_group, criterion_main};
 use quantization::p_square::P2Quantile;
 use quantization::quantile::find_quantile_interval_per_coordinate_with_preprocess;
+use rand::RngExt;
+use rand::rngs::SmallRng;
 
 fn p_square(c: &mut Criterion) {
     let mut group = c.benchmark_group("p_square");
 
     let count = 10_000;
+    let mut rng = rand::make_rng::<SmallRng>();
     let data = (0..count)
-        .map(|_| rand::random::<f64>())
+        .map(|_| rng.random::<f64>())
         .collect::<Vec<f64>>();
     let quantile = 0.99;
 
@@ -49,12 +52,9 @@ fn p_square_vectors(c: &mut Criterion) {
 
     let count = 10_000;
     let dim = 1536;
+    let mut rng = rand::make_rng::<SmallRng>();
     let data = (0..count)
-        .map(|_| {
-            (0..dim)
-                .map(|_| rand::random::<f32>())
-                .collect::<Vec<f32>>()
-        })
+        .map(|_| (0..dim).map(|_| rng.random::<f32>()).collect::<Vec<f32>>())
         .collect::<Vec<Vec<f32>>>();
     let quantile = 0.99;
 

--- a/lib/quantization/benches/pq.rs
+++ b/lib/quantization/benches/pq.rs
@@ -6,13 +6,14 @@ use quantization::encoded_storage::TestEncodedStorageBuilder;
 use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
 use quantization::encoded_vectors_pq::{self, EncodedVectorsPQ};
 use rand::RngExt;
+use rand::rngs::SmallRng;
 
 fn encode_bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("encode");
 
     let vectors_count = 100_000;
     let vector_dim = 1024;
-    let mut rng = rand::rng();
+    let mut rng = rand::make_rng::<SmallRng>();
     let mut list: Vec<f32> = Vec::new();
     for _ in 0..vectors_count {
         let vector: Vec<f32> = (0..vector_dim).map(|_| rng.random()).collect();

--- a/lib/quantization/benches/pq.rs
+++ b/lib/quantization/benches/pq.rs
@@ -49,7 +49,7 @@ fn encode_bench(c: &mut Criterion) {
 
     group.bench_function("score random access pq", |b| {
         b.iter(|| {
-            let random_idx = rand::random::<u32>() % vectors_count as u32;
+            let random_idx = rng.random_range(0..vectors_count as u32);
             total += pq_encoded.score_point(&encoded_query, random_idx, &hardware_counter);
         });
     });

--- a/lib/quantization/benches/turbo_simd.rs
+++ b/lib/quantization/benches/turbo_simd.rs
@@ -18,7 +18,7 @@ use quantization::turboquant::simd::{
     score_1bit_internal_neon, score_2bit_internal_neon, score_2bit_internal_neon_sdot,
     score_4bit_internal_neon, score_4bit_internal_neon_sdot,
 };
-use rand::prelude::StdRng;
+use rand::prelude::SmallRng;
 use rand::seq::SliceRandom;
 use rand::{RngExt, SeedableRng};
 
@@ -45,7 +45,7 @@ struct VectorPool {
 impl VectorPool {
     fn with_packed_bytes(packed_bytes: usize, seed: u64) -> Self {
         let count = (POOL_BYTES / packed_bytes).max(1024);
-        let mut rng = StdRng::seed_from_u64(seed);
+        let mut rng = SmallRng::seed_from_u64(seed);
         let buf: Vec<u8> = (0..count * packed_bytes)
             .map(|_| rng.random_range(0..=u8::MAX))
             .collect();
@@ -84,7 +84,7 @@ impl VectorPool {
 }
 
 fn make_query(dim: usize) -> Vec<f32> {
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     (0..dim).map(|_| rng.random_range(-1.0_f32..1.0)).collect()
 }
 
@@ -386,7 +386,7 @@ fn bench_score_1bit_cold(c: &mut Criterion) {
 /// 12/16 rows show the linear cost of widening the query.
 fn bench_query1bit_vs_bq_hot(c: &mut Criterion) {
     let mut group = c.benchmark_group("query1bit_vs_bq_scalar8bits");
-    let mut rng_seed = StdRng::seed_from_u64(42);
+    let mut rng_seed = SmallRng::seed_from_u64(42);
     for &dim in DIMS_1BIT {
         let pool = VectorPool::new_1bit(dim, 7);
         let query_floats: Vec<f32> = (0..dim)

--- a/lib/quantization/benches/turboquant.rs
+++ b/lib/quantization/benches/turboquant.rs
@@ -6,7 +6,7 @@ use quantization::encoded_vectors::VectorParameters;
 use quantization::encoded_vectors_tq::{Metadata, new_turbo_quantizer_from_metadata};
 use quantization::turboquant::quantization::TurboQuantizer;
 use quantization::turboquant::{TQBits, TQMode, TQRotation};
-use rand::prelude::StdRng;
+use rand::prelude::SmallRng;
 use rand::{RngExt, SeedableRng};
 
 const DIMS: &[usize] = &[128, 384, 768, 1024, 1536, 4096];
@@ -27,7 +27,7 @@ fn make_tq(dim: usize, bits: TQBits) -> TurboQuantizer {
     new_turbo_quantizer_from_metadata(&metadata).expect("metadata is hand-constructed")
 }
 
-fn random_vector(dim: usize, rng: &mut StdRng) -> Vec<f32> {
+fn random_vector(dim: usize, rng: &mut SmallRng) -> Vec<f32> {
     (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect()
 }
 
@@ -43,7 +43,7 @@ fn bench_quantize(c: &mut Criterion) {
 
         for &dim in DIMS {
             let tq = make_tq(dim, bits);
-            let mut rng = StdRng::seed_from_u64(42);
+            let mut rng = SmallRng::seed_from_u64(42);
 
             group.bench_with_input(BenchmarkId::from_parameter(dim), &dim, |b, _| {
                 b.iter_batched(
@@ -70,7 +70,7 @@ fn bench_dot(c: &mut Criterion) {
 
         for &dim in DIMS {
             let tq = make_tq(dim, bits);
-            let mut rng = StdRng::seed_from_u64(42);
+            let mut rng = SmallRng::seed_from_u64(42);
 
             // Pre-quantize a vector so the bench measures only the dot path.
             let mut buf = vec![0.0f64; dim];
@@ -107,7 +107,7 @@ fn bench_dot_precomputed(c: &mut Criterion) {
 
         for &dim in DIMS {
             let tq = make_tq(dim, bits);
-            let mut rng = StdRng::seed_from_u64(42);
+            let mut rng = SmallRng::seed_from_u64(42);
 
             // Pre-quantize a vector so the bench measures only the dot path.
             let mut buf = vec![0.0f64; dim];

--- a/lib/segment/benches/boolean_filtering.rs
+++ b/lib/segment/benches/boolean_filtering.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::AtomicBool;
 use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use criterion::{Criterion, criterion_group, criterion_main};
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::{Rng, RngExt, SeedableRng};
 use segment::fixtures::payload_context_fixture::{
     create_id_tracker_fixture, create_payload_storage_fixture, create_plain_payload_index,
@@ -30,7 +30,7 @@ fn random_bool_filter<R: Rng + ?Sized>(rng: &mut R) -> Filter {
 pub fn plain_boolean_query_points(c: &mut Criterion) {
     let seed = 42;
 
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = SmallRng::seed_from_u64(seed);
     let mut group = c.benchmark_group("boolean-query-points");
 
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
@@ -61,7 +61,7 @@ pub fn plain_boolean_query_points(c: &mut Criterion) {
 pub fn struct_boolean_query_points(c: &mut Criterion) {
     let seed = 42;
 
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = SmallRng::seed_from_u64(seed);
 
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     let struct_index = create_struct_payload_index(dir.path(), NUM_POINTS, seed);
@@ -93,7 +93,7 @@ pub fn struct_boolean_query_points(c: &mut Criterion) {
 pub fn keyword_index_boolean_query_points(c: &mut Criterion) {
     let seed = 42;
 
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = SmallRng::seed_from_u64(seed);
 
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     let payload_storage = Arc::new(AtomicRefCell::new(

--- a/lib/segment/benches/buffered_update_bitslice.rs
+++ b/lib/segment/benches/buffered_update_bitslice.rs
@@ -6,7 +6,7 @@ use common::stored_bitslice::MmapBitSlice;
 use common::universal_io::{MmapFs, OpenOptions};
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::prelude::*;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use segment::common::buffered_update_bitslice::BufferedUpdateBitSlice;
 use tempfile::tempdir;
 
@@ -15,7 +15,7 @@ const FLAG_COUNT: usize = 1_000_000;
 const LOOKUP_COUNT: usize = 1_000_000;
 
 fn buffered_update_bitslice(c: &mut Criterion) {
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     let dir = tempdir().unwrap();
     let path = dir.path().join("bitslice.bin");
 

--- a/lib/segment/benches/conditional_search.rs
+++ b/lib/segment/benches/conditional_search.rs
@@ -8,7 +8,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use criterion::{Criterion, criterion_group, criterion_main};
 use itertools::Itertools;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 use segment::fixtures::payload_context_fixture::{
     create_plain_payload_index, create_struct_payload_index,
@@ -23,7 +23,7 @@ const CHECK_SAMPLE_SIZE: usize = 1000;
 fn conditional_plain_search_benchmark(c: &mut Criterion) {
     let seed = 42;
 
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = SmallRng::seed_from_u64(seed);
     let mut group = c.benchmark_group("conditional-search-group");
 
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
@@ -129,7 +129,7 @@ fn conditional_plain_search_benchmark(c: &mut Criterion) {
 }
 
 fn conditional_struct_search_benchmark(c: &mut Criterion) {
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     let mut group = c.benchmark_group("conditional-search-group");
 
     let seed = 42;

--- a/lib/segment/benches/dynamic_mmap_flags.rs
+++ b/lib/segment/benches/dynamic_mmap_flags.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::AtomicBool;
 
 use common::universal_io::{MmapFile, MmapFs, Populate};
 use criterion::{Criterion, criterion_group, criterion_main};
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 use segment::common::flags::dynamic_stored_flags::DynamicStoredFlags;
 use segment::common::operation_error::check_process_stopped;
@@ -13,7 +13,7 @@ use tempfile::tempdir;
 const FLAG_COUNT: usize = 50_000_000;
 
 fn dynamic_mmap_flag_count(c: &mut Criterion) {
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     let dir = tempdir().unwrap();
     let random_flags: Vec<bool> = iter::repeat_with(|| rng.random())
         .take(FLAG_COUNT)

--- a/lib/segment/benches/facets.rs
+++ b/lib/segment/benches/facets.rs
@@ -8,7 +8,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use ordered_float::OrderedFloat;
 use rand::distr::Distribution;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 use rand_distr::Zipf;
 use segment::data_types::facets::FacetParams;
@@ -70,7 +70,7 @@ fn uuid_str(n: u64) -> String {
 /// 1-dimensional vector just to register the point in the segment.
 fn build_facet_segment(path: &Path) -> Segment {
     let hw_counter = HardwareCounterCell::new();
-    let mut rng = StdRng::seed_from_u64(SEED);
+    let mut rng = SmallRng::seed_from_u64(SEED);
 
     let mut segment = build_simple_segment(path, 1, Distance::Dot).unwrap();
     let vector = [0.0];

--- a/lib/segment/benches/fixture.rs
+++ b/lib/segment/benches/fixture.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use common::types::PointOffsetType;
 use fs_err as fs;
 use rand::SeedableRng as _;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
 use segment::fixtures::index_fixtures::TestRawScorerProducer;
 use segment::index::hnsw_index::HnswM;
@@ -36,7 +36,9 @@ where
         .join(env!("CARGO_PKG_NAME"))
         .join(env!("CARGO_CRATE_NAME"))
         .join(format!(
-            "{num_vectors}-{dim}-{m}-{ef_construct}-{use_heuristic}-{:?}",
+            // The "smallrng" suffix keys the cache by RNG algorithm: the cached
+            // graph must match the vectors regenerated below.
+            "{num_vectors}-{dim}-{m}-{ef_construct}-{use_heuristic}-{:?}-smallrng",
             METRIC::distance(),
         ));
 
@@ -46,7 +48,7 @@ where
         METRIC::distance(),
         num_vectors,
         false,
-        &mut StdRng::seed_from_u64(42),
+        &mut SmallRng::seed_from_u64(42),
     );
 
     let graph_layers_path = GraphLayers::get_path(&path);
@@ -59,7 +61,7 @@ where
         let mut graph_layers_builder =
             GraphLayersBuilder::new(num_vectors, HnswM::new2(m), ef_construct, 10, use_heuristic);
 
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = SmallRng::seed_from_u64(42);
         for idx in 0..num_vectors {
             let level = graph_layers_builder.get_random_layer(&mut rng);
             graph_layers_builder.set_levels(idx as PointOffsetType, level);

--- a/lib/segment/benches/hnsw_build_asymptotic.rs
+++ b/lib/segment/benches/hnsw_build_asymptotic.rs
@@ -6,7 +6,8 @@ use std::cell::LazyCell;
 use common::iterator_ext::IteratorExt as _;
 use criterion::{Criterion, criterion_group, criterion_main};
 use itertools::Itertools;
-use rand::{RngExt, rng};
+use rand::RngExt;
+use rand::rngs::SmallRng;
 use segment::fixtures::index_fixtures::{TestRawScorerProducer, random_vector};
 use segment::index::hnsw_index::graph_layers::SearchAlgorithm;
 use segment::spaces::metric::Metric;
@@ -26,7 +27,7 @@ mod fixture;
 fn hnsw_build_asymptotic(c: &mut Criterion) {
     let mut group = c.benchmark_group("hnsw-index-build-asymptotic");
 
-    let mut rng = rng();
+    let mut rng = rand::make_rng::<SmallRng>();
 
     let setup_5k = LazyCell::new(|| {
         eprintln!();
@@ -95,7 +96,7 @@ fn hnsw_build_asymptotic(c: &mut Criterion) {
 
 fn scoring_vectors(c: &mut Criterion) {
     let mut group = c.benchmark_group("scoring-vector");
-    let mut rng = rng();
+    let mut rng = rand::make_rng::<SmallRng>();
     let points_per_cycle = 1000;
     let base_num_vectors = 10_000;
 
@@ -161,14 +162,14 @@ fn basic_scoring_vectors(c: &mut Criterion) {
 
     let num_vectors = base_num_vectors;
     let setup = LazyCell::new(|| {
-        let mut rng = rng();
+        let mut rng = rand::make_rng::<SmallRng>();
         (0..num_vectors)
             .map(|_| random_vector(&mut rng, DIM))
             .collect_vec()
     });
     group.bench_function("basic-score-point", |b| {
         let vectors = &*setup;
-        let mut rng = rng();
+        let mut rng = rand::make_rng::<SmallRng>();
         b.iter(|| {
             let query = random_vector(&mut rng, DIM);
             let points_to_score = (0..points_per_cycle).map(|_| rng.random_range(0..num_vectors));
@@ -182,14 +183,14 @@ fn basic_scoring_vectors(c: &mut Criterion) {
 
     let num_vectors = base_num_vectors * 2;
     let setup = LazyCell::new(|| {
-        let mut rng = rng();
+        let mut rng = rand::make_rng::<SmallRng>();
         (0..num_vectors)
             .map(|_| random_vector(&mut rng, DIM))
             .collect_vec()
     });
     group.bench_function("basic-score-point-10x", |b| {
         let vectors = &*setup;
-        let mut rng = rng();
+        let mut rng = rand::make_rng::<SmallRng>();
         b.iter(|| {
             let query = random_vector(&mut rng, DIM);
             let points_to_score = (0..points_per_cycle).map(|_| rng.random_range(0..num_vectors));

--- a/lib/segment/benches/hnsw_build_graph.rs
+++ b/lib/segment/benches/hnsw_build_graph.rs
@@ -4,7 +4,7 @@ mod prof;
 use common::types::PointOffsetType;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::SeedableRng;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use segment::fixtures::index_fixtures::TestRawScorerProducer;
 use segment::index::hnsw_index::HnswM;
 use segment::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
@@ -17,14 +17,14 @@ const EF_CONSTRUCT: usize = 64;
 const USE_HEURISTIC: bool = true;
 
 fn hnsw_benchmark(c: &mut Criterion) {
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     let vector_holder =
         TestRawScorerProducer::new(DIM, Distance::Cosine, NUM_VECTORS, false, &mut rng);
     let mut group = c.benchmark_group("hnsw-index-build-group");
     group.sample_size(10);
     group.bench_function("hnsw_index", |b| {
         b.iter(|| {
-            let mut rng = rand::rng();
+            let mut rng = rand::make_rng::<SmallRng>();
             let mut graph_layers_builder = GraphLayersBuilder::new(
                 NUM_VECTORS,
                 HnswM::new2(M),

--- a/lib/segment/benches/hnsw_incremental_build.rs
+++ b/lib/segment/benches/hnsw_incremental_build.rs
@@ -22,7 +22,7 @@ use fs_err::File;
 use itertools::Itertools as _;
 use ndarray::{ArrayView2, Axis};
 use ndarray_npy::ViewNpyExt;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::seq::SliceRandom as _;
 use rand::{Rng, SeedableRng as _};
 use rayon::iter::{
@@ -150,7 +150,7 @@ fn main() {
     let args = Args::parse();
     log::info!("args={args:?}");
 
-    let mut main_rng = StdRng::seed_from_u64(args.random_seed);
+    let mut main_rng = SmallRng::seed_from_u64(args.random_seed);
 
     let tmp_dir = Builder::new()
         .prefix("hnsw_incremental_build")
@@ -190,7 +190,7 @@ fn main() {
                     .collect_vec();
 
                 // Shuffle the dataset to avoid bias.
-                slices_vec.shuffle(&mut StdRng::from_rng(&mut main_rng));
+                slices_vec.shuffle(&mut SmallRng::from_rng(&mut main_rng));
 
                 // Last `arg_queries` vectors from the dataset are used as query vectors.
                 let query_vectors = slices_vec
@@ -203,13 +203,13 @@ fn main() {
             }
             // Generate random vectors.
             (Some(dimensions), None) => {
-                let mut rng = StdRng::from_rng(&mut main_rng);
+                let mut rng = SmallRng::from_rng(&mut main_rng);
                 let query_vectors = std::iter::repeat_with(|| random_vector(&mut rng, dimensions))
                     .take(args.queries)
                     .map(QueryVector::from)
                     .collect_vec();
 
-                let mut rng = StdRng::from_rng(&mut main_rng);
+                let mut rng = SmallRng::from_rng(&mut main_rng);
                 vectors_mem = std::iter::repeat_with(|| random_vector(&mut rng, dimensions))
                     .take(args.init_vectors + args.to_add * args.iterations)
                     .collect_vec();
@@ -229,7 +229,7 @@ fn main() {
 
     // Build initial segment and index it non-incrementally.
     let mut sliding_window = 0..args.init_vectors;
-    let mut rng = StdRng::from_rng(&mut main_rng);
+    let mut rng = SmallRng::from_rng(&mut main_rng);
     let mut last_segment = make_segment(
         &mut rng,
         tmp_dir.path(),
@@ -314,7 +314,7 @@ fn main() {
 }
 
 fn make_segment(
-    rng: &mut StdRng,
+    rng: &mut SmallRng,
     path: &Path,
     all_vectors: &[&[VectorElementType]],
     sliding_window: std::ops::Range<usize>,

--- a/lib/segment/benches/hnsw_search_graph.rs
+++ b/lib/segment/benches/hnsw_search_graph.rs
@@ -6,7 +6,7 @@ use std::hint::black_box;
 use common::types::PointOffsetType;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::SeedableRng;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use segment::fixtures::index_fixtures::random_vector;
 use segment::index::hnsw_index::graph_layers::SearchAlgorithm;
 use segment::spaces::simple::CosineMetric;
@@ -30,7 +30,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
     let (vector_holder, mut graph_layers) =
         fixture::make_cached_graph::<Metric>(NUM_VECTORS, DIM, M, EF_CONSTRUCT, USE_HEURISTIC);
 
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     group.bench_function("uncompressed", |b| {
         b.iter(|| {
             let query = random_vector(&mut rng, DIM);
@@ -53,7 +53,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
     });
 
     graph_layers.compress_ram();
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     group.bench_function("compressed", |b| {
         b.iter(|| {
             let query = random_vector(&mut rng, DIM);
@@ -77,7 +77,7 @@ fn hnsw_benchmark(c: &mut Criterion) {
 
     let mut plain_search_range: Vec<PointOffsetType> =
         (0..NUM_VECTORS as PointOffsetType).collect();
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     group.bench_function("plain", |b| {
         b.iter(|| {
             let query = random_vector(&mut rng, DIM);

--- a/lib/segment/benches/id_type_benchmark.rs
+++ b/lib/segment/benches/id_type_benchmark.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::RngExt;
+use rand::rngs::SmallRng;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -29,7 +30,7 @@ struct StructId {
 
 fn id_serialization_speed(c: &mut Criterion) {
     let mut group = c.benchmark_group("serialization-group");
-    let mut rng = rand::rng();
+    let mut rng = rand::make_rng::<SmallRng>();
 
     group.bench_function("u64", |b| {
         b.iter(|| {

--- a/lib/segment/benches/in_memory_id_tracker.rs
+++ b/lib/segment/benches/in_memory_id_tracker.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use common::types::PointOffsetType;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::RngExt;
+use rand::rngs::SmallRng;
 use segment::id_tracker::IdTracker;
 use segment::id_tracker::in_memory_id_tracker::InMemoryIdTracker;
 use segment::types::ExtendedPointId;
@@ -11,7 +12,7 @@ fn benchmark(c: &mut Criterion) {
     c.bench_function("idtracker", |b| {
         b.iter_custom(|i| {
             let mut id_tracker = InMemoryIdTracker::new();
-            let mut rand = rand::rng();
+            let mut rand = rand::make_rng::<SmallRng>();
 
             let ids: Vec<i32> = (0..i).map(|_| rand.random_range(0..100_000)).collect();
 

--- a/lib/segment/benches/map_benchmark.rs
+++ b/lib/segment/benches/map_benchmark.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::SeedableRng;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use segment::data_types::tiny_map::TinyMap;
 use segment::fixtures::index_fixtures::random_vector;
 
@@ -14,7 +14,7 @@ const DIM: usize = 100;
 fn small_map_obj(c: &mut Criterion) {
     let mut group = c.benchmark_group("small-map-obj-group");
 
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
     let default_key = "vector".to_string();
     let default_key_2 = "vector1".to_string();
     let default_key_3 = "vector2".to_string();

--- a/lib/segment/benches/metrics.rs
+++ b/lib/segment/benches/metrics.rs
@@ -3,7 +3,7 @@ mod prof;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use half::f16;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 use segment::data_types::vectors::{VectorElementTypeByte, VectorElementTypeHalf};
 use segment::spaces::metric::Metric;
@@ -64,7 +64,7 @@ const COUNT: usize = 100_000;
 fn byte_metrics_bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("byte-metrics-bench-group");
 
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
 
     let random_vectors_1: Vec<Vec<u8>> = (0..COUNT)
         .map(|_| (0..DIM).map(|_| rng.random_range(0..=255)).collect())
@@ -261,7 +261,7 @@ fn byte_metrics_bench(c: &mut Criterion) {
 fn half_metrics_bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("half-metrics-bench-group");
 
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
 
     let random_vectors_1: Vec<Vec<f16>> = (0..COUNT)
         .map(|_| {

--- a/lib/segment/benches/multi_vector_search.rs
+++ b/lib/segment/benches/multi_vector_search.rs
@@ -11,7 +11,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::flags::FeatureFlags;
 use common::progress_tracker::ProgressTracker;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use rand::prelude::StdRng;
+use rand::prelude::SmallRng;
 use rand::{Rng, SeedableRng};
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, only_default_multi_vector};
 use segment::entry::entry_point::SegmentEntry;
@@ -38,7 +38,7 @@ const TOP: usize = 10;
 // intent: bench `search` without filter
 fn multi_vector_search_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("multi-vector-search-group");
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rnd = SmallRng::seed_from_u64(42);
 
     let hnsw_index = make_segment_index(&mut rnd, Dot);
     group.bench_function("hnsw-multivec-search-dot", |b| {

--- a/lib/segment/benches/numeric_index_check_values.rs
+++ b/lib/segment/benches/numeric_index_check_values.rs
@@ -3,7 +3,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, MmapFs, Populate};
 use criterion::{Criterion, criterion_group, criterion_main};
-use rand::prelude::StdRng;
+use rand::prelude::SmallRng;
 use rand::{RngExt, SeedableRng};
 use segment::common::operation_error::OperationResult;
 use segment::index::field_index::numeric_index::NumericIndexRead;
@@ -16,7 +16,7 @@ mod prof;
 const NUM_POINTS: usize = 100000;
 const VALUES_PER_POINT: usize = 2;
 
-fn get_random_payloads(rng: &mut StdRng, num_points: usize) -> Vec<(PointOffsetType, f64)> {
+fn get_random_payloads(rng: &mut SmallRng, num_points: usize) -> Vec<(PointOffsetType, f64)> {
     let mut payloads = Vec::with_capacity(num_points);
     for i in 0..num_points {
         for _ in 0..VALUES_PER_POINT {
@@ -29,7 +29,7 @@ fn get_random_payloads(rng: &mut StdRng, num_points: usize) -> Vec<(PointOffsetT
 
 pub fn struct_numeric_check_values(c: &mut Criterion) {
     let seed = 42;
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = SmallRng::seed_from_u64(seed);
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
 
     let mut group = c.benchmark_group("numeric-check-values");

--- a/lib/segment/benches/range_filtering.rs
+++ b/lib/segment/benches/range_filtering.rs
@@ -9,7 +9,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use ordered_float::OrderedFloat;
-use rand::prelude::StdRng;
+use rand::prelude::SmallRng;
 use rand::{Rng, RngExt, SeedableRng};
 use segment::fixtures::payload_context_fixture::create_id_tracker_fixture;
 use segment::fixtures::payload_fixtures::{FLT_KEY, INT_KEY};
@@ -43,7 +43,7 @@ fn range_filtering(c: &mut Criterion) {
 
     let seed = 42;
 
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = SmallRng::seed_from_u64(seed);
 
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
 

--- a/lib/segment/benches/read_payloads.rs
+++ b/lib/segment/benches/read_payloads.rs
@@ -8,7 +8,7 @@ use common::types::PointOffsetType;
 use common::universal_io::IoUringFile;
 use common::universal_io::{MmapFile, UniversalWrite};
 use criterion::{Criterion, criterion_group, criterion_main};
-use rand::prelude::{SliceRandom, StdRng};
+use rand::prelude::{SliceRandom, SmallRng};
 use rand::{RngExt, SeedableRng};
 use segment::payload_json;
 use segment::payload_storage::payload_storage_impl::{PayloadStorageImpl, storage_dir};
@@ -33,7 +33,7 @@ fn bench(c: &mut Criterion) {
     let sequential_keys: Vec<_> = (0..READ_BATCH_SIZE as PointOffsetType).collect();
 
     let mut random_keys: Vec<_> = (0..POINT_COUNT as PointOffsetType).collect();
-    random_keys.shuffle(&mut StdRng::seed_from_u64(RNG_SEED));
+    random_keys.shuffle(&mut SmallRng::seed_from_u64(RNG_SEED));
     random_keys.truncate(READ_BATCH_SIZE);
 
     let mut group = c.benchmark_group("read-payloads");
@@ -86,7 +86,7 @@ where
         .expect("payload storage opened");
 
     if !storage_exists {
-        let mut rng = StdRng::seed_from_u64(RNG_SEED);
+        let mut rng = SmallRng::seed_from_u64(RNG_SEED);
         let hw_counter = HardwareCounterCell::disposable();
 
         for point_id in 0..POINT_COUNT as PointOffsetType {
@@ -104,7 +104,7 @@ where
     storage
 }
 
-fn random_payload(rng: &mut StdRng, point_id: PointOffsetType) -> Payload {
+fn random_payload(rng: &mut SmallRng, point_id: PointOffsetType) -> Payload {
     let tags: Vec<_> = (0..TAGS_COUNT)
         .map(|_| format!("tag-{}", rng.random_range(0..64)))
         .collect();

--- a/lib/segment/benches/read_vectors.rs
+++ b/lib/segment/benches/read_vectors.rs
@@ -8,7 +8,7 @@ use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::mmap::AdviceSetting;
 use common::types::PointOffsetType;
 use criterion::{Criterion, criterion_group, criterion_main};
-use rand::prelude::{SliceRandom, StdRng};
+use rand::prelude::{SliceRandom, SmallRng};
 use rand::{RngExt, SeedableRng};
 use segment::data_types::vectors::{TypedMultiDenseVectorRef, VectorElementType, VectorRef};
 use segment::types::{Distance, MultiVectorConfig};
@@ -42,7 +42,7 @@ fn bench(c: &mut Criterion) {
     let sequential_keys: Vec<_> = (0..READ_BATCH_SIZE as PointOffsetType).collect();
 
     let mut random_keys: Vec<_> = (0..POINT_COUNT as PointOffsetType).collect();
-    random_keys.shuffle(&mut StdRng::seed_from_u64(RNG_SEED));
+    random_keys.shuffle(&mut SmallRng::seed_from_u64(RNG_SEED));
     random_keys.truncate(READ_BATCH_SIZE);
 
     let mut group = c.benchmark_group("read-vectors");
@@ -106,7 +106,7 @@ fn storage_dense(path: &Path) -> AppendableMmapDenseVectorStorage<VectorElementT
     )
     .expect("appendable mmap dense storage opened");
 
-    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let mut rng = SmallRng::seed_from_u64(RNG_SEED);
     let mut vector_buffer = vec![0.0; VECTOR_DIM];
     let hw_counter = HardwareCounterCell::disposable();
 
@@ -135,7 +135,7 @@ fn storage_multi(path: &Path) -> AppendableMmapMultiDenseVectorStorage<VectorEle
     )
     .expect("appendable mmap multi dense storage opened");
 
-    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let mut rng = SmallRng::seed_from_u64(RNG_SEED);
     let mut vector_buffer = vec![0.0; MAX_VECTORS_PER_POINT * VECTOR_DIM];
     let hw_counter = HardwareCounterCell::disposable();
 
@@ -159,7 +159,7 @@ fn storage_sparse(path: &Path) -> MmapSparseVectorStorage {
     let mut storage =
         MmapSparseVectorStorage::open_or_create(path).expect("mmap sparse storage opened");
 
-    let mut rng = StdRng::seed_from_u64(RNG_SEED);
+    let mut rng = SmallRng::seed_from_u64(RNG_SEED);
     let hw_counter = HardwareCounterCell::disposable();
 
     for point_id in 0..POINT_COUNT as PointOffsetType {
@@ -177,7 +177,7 @@ fn storage_sparse(path: &Path) -> MmapSparseVectorStorage {
 }
 
 fn random_vector<'a>(
-    rng: &mut StdRng,
+    rng: &mut SmallRng,
     buffer: &'a mut [VectorElementType],
     dim: usize,
 ) -> &'a [VectorElementType] {

--- a/lib/segment/benches/sparse_index_build.rs
+++ b/lib/segment/benches/sparse_index_build.rs
@@ -12,7 +12,7 @@ use common::universal_io::MmapFs;
 use criterion::{Criterion, criterion_group, criterion_main};
 use half::f16;
 use rand::SeedableRng;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use segment::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
 use segment::fixtures::payload_context_fixture::create_id_tracker_fixture;
 use segment::index::VectorIndex;
@@ -38,7 +38,7 @@ fn sparse_vector_index_build_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("sparse-vector-build-group");
 
     let stopped = AtomicBool::new(false);
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rnd = SmallRng::seed_from_u64(42);
 
     let payload_dir = Builder::new().prefix("payload_dir").tempdir().unwrap();
     let storage_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();

--- a/lib/segment/benches/sparse_index_search.rs
+++ b/lib/segment/benches/sparse_index_search.rs
@@ -8,7 +8,7 @@ use dataset::Dataset;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use itertools::Itertools as _;
 use rand::SeedableRng;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use segment::fixtures::sparse_fixtures::fixture_sparse_index_from_iter;
 use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
 use segment::index::sparse_index::sparse_vector_index::{
@@ -35,13 +35,13 @@ const TOP: usize = 10;
 const FULL_SCAN_THRESHOLD: usize = 1; // low value to trigger index usage by default
 
 fn sparse_vector_index_search_benchmark(c: &mut Criterion) {
-    let mut rnd = StdRng::seed_from_u64(0);
+    let mut rnd = SmallRng::seed_from_u64(0);
     let query_vectors = (0..NUM_QUERIES)
         // Positive values to test pruning.
         .map(|_| random_positive_sparse_vector(&mut rnd, MAX_SPARSE_DIM))
         .collect::<Vec<_>>();
 
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rnd = SmallRng::seed_from_u64(42);
     let random_vectors = (0..NUM_VECTORS).map(|_| random_sparse_vector(&mut rnd, MAX_SPARSE_DIM));
     sparse_vector_index_search_benchmark_impl(c, "random-50k", random_vectors, &query_vectors);
 

--- a/lib/segment/benches/sparse_vector_storage.rs
+++ b/lib/segment/benches/sparse_vector_storage.rs
@@ -8,7 +8,7 @@ use common::generic_consts::Random;
 use common::types::PointOffsetType;
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::SeedableRng;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use segment::common::rocksdb_wrapper::{DB_VECTOR_CF, open_db};
 use segment::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
 use segment::vector_storage::sparse::simple_sparse_vector_storage::open_simple_sparse_vector_storage;
@@ -23,7 +23,7 @@ fn sparse_vector_storage_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("sparse-vector-storage-group");
 
     let stopped = AtomicBool::new(false);
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rnd = SmallRng::seed_from_u64(42);
     let storage_dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     let db = open_db(storage_dir.path(), &[DB_VECTOR_CF]).unwrap();
 

--- a/lib/segment/benches/turbo_vector_search.rs
+++ b/lib/segment/benches/turbo_vector_search.rs
@@ -28,6 +28,7 @@ use common::types::PointOffsetType;
 use criterion::measurement::WallTime;
 use criterion::{BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main};
 use rand::distr::StandardUniform;
+use rand::rngs::SmallRng;
 use rand::seq::{IteratorRandom, SliceRandom};
 use rand::{Rng, RngExt};
 use segment::data_types::vectors::{DenseVector, QueryVector};
@@ -57,12 +58,12 @@ fn random_vector(rng: &mut impl Rng, size: usize) -> DenseVector {
 }
 
 fn random_query() -> QueryVector {
-    QueryVector::from(random_vector(&mut rand::rng(), DIM))
+    QueryVector::from(random_vector(&mut rand::make_rng::<SmallRng>(), DIM))
 }
 
 /// Ids to score in one subset iteration: a shuffled sample without replacement.
 fn subset_ids() -> Vec<PointOffsetType> {
-    let mut rng = rand::rng();
+    let mut rng = rand::make_rng::<SmallRng>();
     let mut ids: Vec<PointOffsetType> = (0..VECTORS as PointOffsetType).sample(&mut rng, SUBSET);
     ids.shuffle(&mut rng);
     ids
@@ -72,7 +73,7 @@ fn subset_ids() -> Vec<PointOffsetType> {
 /// storage, then bulk-append the encoded bytes into the single-file layout,
 /// exactly as the optimizer does.
 fn build_dataset(dir: &Path) {
-    let mut rng = rand::rng();
+    let mut rng = rand::make_rng::<SmallRng>();
     let hw_counter = HardwareCounterCell::new();
 
     let encoder_dir = TempDir::new().expect("encoder tempdir created");

--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -5,6 +5,7 @@ use atomic_refcell::AtomicRefCell;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use rand::RngExt;
 use rand::distr::StandardUniform;
+use rand::rngs::SmallRng;
 use segment::data_types::vectors::{DenseVector, QueryVector};
 use segment::fixtures::payload_context_fixture::create_id_tracker_fixture;
 use segment::id_tracker::IdTrackerRead;
@@ -20,7 +21,7 @@ mod prof;
 const DIM: usize = 1024;
 
 fn random_vector(size: usize) -> DenseVector {
-    rand::rng()
+    rand::make_rng::<SmallRng>()
         .sample_iter(StandardUniform)
         .take(size)
         .collect()

--- a/lib/shard/benches/find_duplicated_points.rs
+++ b/lib/shard/benches/find_duplicated_points.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use criterion::{Criterion, criterion_group, criterion_main};
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::seq::IndexedMutRandom;
 use rand::{RngExt, SeedableRng};
 use segment::entry::entry_point::SegmentEntry;
@@ -17,7 +17,7 @@ const DUPLICATE_CHANCE: f64 = 0.1;
 const VERSION_RANGE: Range<u64> = 1..50;
 
 pub fn duplicate_bench(c: &mut Criterion) {
-    let mut rand = StdRng::seed_from_u64(42);
+    let mut rand = SmallRng::seed_from_u64(42);
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let vector = segment::data_types::vectors::only_default_vector(&[0.0; 4]);
 

--- a/lib/sparse/benches/search.rs
+++ b/lib/sparse/benches/search.rs
@@ -12,7 +12,7 @@ use fs_err as fs;
 use indicatif::{ProgressBar, ProgressDrawTarget};
 use itertools::Itertools;
 use rand::SeedableRng as _;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use sha2::Digest;
 use sparse::SearchScratchPool;
 use sparse::common::sparse_vector::{RemappedSparseVector, SparseVector};
@@ -62,7 +62,7 @@ pub fn bench_search(c: &mut Criterion) {
 }
 
 fn bench_uniform_random(c: &mut Criterion, name: &str, num_vectors: usize) {
-    let mut rnd = StdRng::seed_from_u64(42);
+    let mut rnd = SmallRng::seed_from_u64(42);
 
     let index = cached_ram_index(name, || {
         let mut rnd = rnd.fork();
@@ -239,6 +239,8 @@ fn cache_dir() -> PathBuf {
     Path::new(env!("CARGO_TARGET_TMPDIR"))
         .join(env!("CARGO_PKG_NAME"))
         .join(env!("CARGO_CRATE_NAME"))
+        // Keyed by RNG algorithm: cached indexes must match freshly generated queries.
+        .join("smallrng")
 }
 
 /// Load an [`InvertedIndexRam`] from the cache.

--- a/lib/trififo/benches/cache_comparison.rs
+++ b/lib/trififo/benches/cache_comparison.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use parking_lot::Mutex;
 use quick_cache::sync::Cache as QuickCache;
 use rand::distr::Distribution;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 use rand_distr::Zipf;
 use rayon::prelude::*;
@@ -78,7 +78,7 @@ static ALLOCATOR: Cap<alloc::System> = Cap::new(alloc::System, usize::MAX);
 
 /// Generate keys following a Zipf distribution (realistic hot/cold access pattern)
 fn generate_zipf_keys(n: usize, num_unique: usize, exponent: f64, seed: u64) -> Vec<Key> {
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = SmallRng::seed_from_u64(seed);
     let zipf = Zipf::new(num_unique as f64, exponent).unwrap();
 
     (0..n)
@@ -105,7 +105,7 @@ fn generate_scan_resistant_keys(
     scan_frequency: f64,
     seed: u64,
 ) -> Vec<Key> {
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = SmallRng::seed_from_u64(seed);
     let zipf = Zipf::new(num_unique as f64, 1.0).unwrap();
     let mut scan = (0..num_unique as u64).cycle();
 

--- a/lib/wal/benches/benchmark.rs
+++ b/lib/wal/benches/benchmark.rs
@@ -3,12 +3,13 @@ use std::hint::black_box;
 use crc::{CRC_32_ISCSI, Crc};
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::Rng;
+use rand::rngs::SmallRng;
 
 pub const CASTAGNOLI: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
 
 pub fn criterion_benchmark_4k(c: &mut Criterion) {
     let mut buffer = [0u8; 8192];
-    let mut rng = rand::rng();
+    let mut rng = rand::make_rng::<SmallRng>();
     rng.fill_bytes(&mut buffer);
 
     let mut group = c.benchmark_group("8k");
@@ -30,7 +31,7 @@ pub fn criterion_benchmark_4k(c: &mut Criterion) {
 
 pub fn criterion_benchmark_1024k(c: &mut Criterion) {
     let mut buffer = [0u8; 1048576];
-    let mut rng = rand::rng();
+    let mut rng = rand::make_rng::<SmallRng>();
     rng.fill_bytes(&mut buffer);
 
     let mut group = c.benchmark_group("1M");

--- a/lib/wal/examples/bench.rs
+++ b/lib/wal/examples/bench.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use docopt::Docopt;
 use hdrhistogram::Histogram;
 use rand::Rng;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use regex::Regex;
 use serde::Deserialize;
 use wal::Segment;
@@ -102,7 +102,7 @@ fn append(args: &Args) {
     let mut segment = Segment::create(path, segment_size).unwrap();
 
     let mut buf = vec![0; entry_size];
-    let mut small_rng = rand::make_rng::<StdRng>();
+    let mut small_rng = rand::make_rng::<SmallRng>();
     small_rng.fill_bytes(&mut buf);
 
     let mut append_hist = Histogram::<u64>::new_with_bounds(1, 60 * 60 * 1000, 2).unwrap();


### PR DESCRIPTION
## Benches: use SmallRng instead of ChaCha12-based generators

All benchmarks used `StdRng` or `rand::rng()` (ThreadRng). 

In rand 0.10 both are backed by the ChaCha12 block cipher, a cryptographically secure generator.

Benchmarks do not need crypto-strength randomness, and several draw random values inside the timed closure, so cipher work was included in the measurement itself.

This PR switches every bench target (47 files) to `SmallRng` (Xoshiro256++):

- `StdRng::seed_from_u64(seed)` -> `SmallRng::seed_from_u64(seed)`
- `rand::rng()` / `rng()` -> `rand::make_rng::<SmallRng>()` (seeded once from the
  thread RNG, then cheap per draw)

### RNG comparison (rand 0.10)

|  | Algorithm | Crypto-safe | Seedable / reproducible | Speed |
|---|---|---|---|---|
| `SmallRng` | Xoshiro256++ | no | yes | fastest: a few ns per draw, 32-byte state |
| `StdRng` | ChaCha12 | yes | yes | slower: block-buffered, per-call cost uneven |
| `ThreadRng` (`rand::rng()`) | ChaCha12 | yes | no (OS-seeded, reseeds periodically) | `StdRng` plus thread-local access overhead |

### Call sites where the RNG is drawn inside the timed section

These are the places where ChaCha12 previously contributed to the measured time
(line numbers as of this PR):

- `lib/collection/benches/hash_ring_bench.rs:25,32` (`random_range` next to a single ring lookup, RNG was a large share of the measurement)
- `lib/segment/benches/id_type_benchmark.rs:37,44,52,63,74,82,90,98,109,120,128` (`random_range` vs a tiny bincode serialize)
- `lib/segment/benches/numeric_index_check_values.rs:52,71` (`random_range` per index lookup)
- `lib/segment/benches/conditional_search.rs:40,58,75,77,100,116,158,175,177` (filter built inside `b.iter`)
- `lib/segment/benches/boolean_filtering.rs:48,78,132` (filter built inside `b.iter`)
- `lib/segment/benches/hnsw_search_graph.rs:36,59,83` (query vector generated inside the timed search loop)
- `lib/segment/benches/hnsw_build_asymptotic.rs:40,66,84,109,127,145,174,195` (query vector generated inside the timed search loops)
- `lib/segment/benches/hnsw_build_graph.rs:36` (`get_random_layer` per point during the timed build)
- `lib/collection/benches/batch_search_bench.rs:158,192` and `lib/collection/benches/batch_query_bench.rs:174,205,254,255,324,325` (query vectors generated inside `b.iter`; these three collection/asymptotic files used the imported-name `rng()` form)
- `lib/gridstore/benches/bitmask_bench.rs:31` (`random_range` per iteration)
- `lib/gridstore/benches/real_data_bench.rs:136` (`random_bool` gating flush, negligible but free)

The remaining files only use the RNG in fixture setup (`iter_batched` setup closures
or before the manual timer), so for them this change just speeds up bench startup.

### Notes

- Seeded benches now generate different datasets, so results are not comparable with
  runs from before this change.
- The HNSW graph cache (`segment/benches/fixture.rs`) and the sparse index cache
  (`sparse/benches/search.rs`) are now keyed by RNG algorithm, so pre-existing caches
  under `CARGO_TARGET_TMPDIR` are not silently reused against differently-generated
  vectors; they rebuild once on first run.
- Verified with `cargo check --benches` and `cargo clippy --benches` on all touched
  crates, plus `cargo +nightly fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
