### PR TITLE
Tests: use SmallRng for RNG-bound test data generation in common

### DIFF
--- a/lib/common/common/src/persisted_hashmap/fixtures.rs
+++ b/lib/common/common/src/persisted_hashmap/fixtures.rs
@@ -4,21 +4,21 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use rand::RngExt;
 use rand::distr::StandardUniform;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use crate::persisted_hashmap::Key;
 
 pub trait TestKey: Key + Ord + PartialEq<Self::Owned> {
     type Owned: Clone + Ord + Hash + Debug;
-    fn gen_key(rng: &mut StdRng, large: bool) -> Self::Owned;
+    fn gen_key(rng: &mut SmallRng, large: bool) -> Self::Owned;
     fn as_ref(owned: &Self::Owned) -> &Self;
     fn from_ref(this: &Self) -> Self::Owned;
 }
 
 impl TestKey for str {
     type Owned = String;
-    fn gen_key(rng: &mut StdRng, large: bool) -> Self::Owned {
+    fn gen_key(rng: &mut SmallRng, large: bool) -> Self::Owned {
         let range = if large { 5_000..=10_000 } else { 5..=32 };
         (0..rng.random_range(range))
             .map(|_| rng.random_range(b'a'..=b'z') as char)
@@ -34,7 +34,7 @@ impl TestKey for str {
 
 impl TestKey for i64 {
     type Owned = i64;
-    fn gen_key(rng: &mut StdRng, large: bool) -> Self::Owned {
+    fn gen_key(rng: &mut SmallRng, large: bool) -> Self::Owned {
         assert!(!large);
         rng.random()
     }
@@ -48,7 +48,7 @@ impl TestKey for i64 {
 
 impl TestKey for u128 {
     type Owned = u128;
-    fn gen_key(rng: &mut StdRng, large: bool) -> Self::Owned {
+    fn gen_key(rng: &mut SmallRng, large: bool) -> Self::Owned {
         assert!(!large);
         rng.random()
     }
@@ -63,14 +63,14 @@ impl TestKey for u128 {
 pub trait TestValue:
     Copy + Ord + Debug + FromBytes + IntoBytes + Immutable + KnownLayout + Sized
 {
-    fn gen_value(rng: &mut StdRng) -> Self;
+    fn gen_value(rng: &mut SmallRng) -> Self;
 }
 impl<T> TestValue for T
 where
     T: Copy + Ord + Debug + FromBytes + IntoBytes + Immutable + KnownLayout,
     StandardUniform: rand::distr::Distribution<T>,
 {
-    fn gen_value(rng: &mut StdRng) -> T {
+    fn gen_value(rng: &mut SmallRng) -> T {
         rng.random()
     }
 }

--- a/lib/common/common/src/persisted_hashmap/tests.rs
+++ b/lib/common/common/src/persisted_hashmap/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use itertools::{Itertools, assert_equal};
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::seq::SliceRandom;
 use rand::{RngExt, SeedableRng};
 
@@ -38,7 +38,7 @@ fn run_checks2<K: ?Sized + TestKey, V: TestValue>(
     entry_count: usize,
     large_keys: bool,
 ) {
-    let mut rng = StdRng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
 
     // Ground truth
     let mut orig = BTreeMap::<K::Owned, Vec<V>>::new();
@@ -129,7 +129,7 @@ fn run_mmap_checks<K: ?Sized + TestKey, V: TestValue>(
 
 fn run_uio_checks<K: ?Sized + TestKey, V: TestValue, S: UniversalRead>(
     mut r: Group<'_>,
-    mut rng: &mut StdRng,
+    mut rng: &mut SmallRng,
     uio: &UniversalHashMap<K, V, S>,
     orig: &BTreeMap<K::Owned, Vec<V>>,
     non_existing_keys: &[K::Owned],

--- a/lib/common/common/src/universal_io/disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/disk_cache/tests.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use fs_err as fs;
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
 use super::{BLOCK_SIZE, CacheController, CachedSlice};
@@ -96,7 +96,7 @@ const TOTAL_FLOATS: usize = NUM_VECTORS * VECTOR_DIM;
 
 /// Generate `NUM_VECTORS` vectors of `VECTOR_DIM` f32s using a seeded RNG.
 fn generate_vectors(seed: u64) -> Vec<f32> {
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = SmallRng::seed_from_u64(seed);
     (0..TOTAL_FLOATS).map(|_| rng.random::<f32>()).collect()
 }
 
@@ -170,7 +170,7 @@ fn test_cached_slice_vectors_random_access() {
 
     let cached_slice = CachedSlice::open(&cacher, &vectors_path).unwrap();
 
-    let mut rng = StdRng::seed_from_u64(123);
+    let mut rng = SmallRng::seed_from_u64(123);
 
     // Random single-element access.
     for _ in 0..5000 {


### PR DESCRIPTION
## Tests: use SmallRng for RNG-bound test data generation in `common`

Follow-up to #9887, this time on the test side. The `persisted_hashmap` and
`disk_cache` tests generate their datasets with `StdRng`, which in rand 0.10 is
the ChaCha12 block cipher. These tests are the most RNG-bound in the workspace:
string keys are generated with one `random_range` call per character, so the
crypto generator dominates the test runtime rather than the code under test.

This PR switches the three files to `SmallRng` (Xoshiro256++), a pure type
rename since the fixture signatures name the RNG concretely:

- `lib/common/common/src/persisted_hashmap/fixtures.rs`
- `lib/common/common/src/persisted_hashmap/tests.rs`
- `lib/common/common/src/universal_io/disk_cache/tests.rs`

### Measured impact (nextest, debug build)

| Test | StdRng | SmallRng |
|---|---|---|
| `persisted_hashmap::tests::test_k_str_v_u32` | 3.53s | 1.36s |
| `persisted_hashmap::tests::test_k_str_v_i64` | 3.22s | 1.43s |
| `persisted_hashmap::tests::test_k_str_v_u128` | 3.13s | 1.51s |
| `disk_cache::tests::test_cached_slice_vectors_random_access` | 0.53s | 0.17s |
| `disk_cache::tests::test_cached_slice_vectors_sequential` | 1.21s | 0.95s |

Roughly 6 seconds of CPU time saved per run of the `common` suite. The
fixed-width key variants (`test_k_i64_*`, `test_k_u128_*`) draw once per key
and are unaffected (~0.4s before and after), which confirms the string tests
were RNG-bound rather than hashmap-bound.

### Why this is safe

- All assertions in these tests are self-consistency checks: data is generated,
  written, read back, and compared against the same in-memory copy. Nothing
  depends on what a specific seed produces, so changing the generated sequences
  carries no retuning risk (unlike e.g. recall-threshold tests in `segment`).
- Reproducibility is preserved: `SmallRng::seed_from_u64` is just as
  deterministic per rand version as `StdRng::seed_from_u64`.

Verified with `cargo nextest run -p common` (106 passed), `cargo clippy -p
common --tests`, and `cargo +nightly fmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
