### PR TITLE
Tests: use SmallRng for RNG-bound test data generation in segment

### DIFF
--- a/lib/segment/src/id_tracker/compressed/compressed_point_mappings.rs
+++ b/lib/segment/src/id_tracker/compressed/compressed_point_mappings.rs
@@ -14,7 +14,7 @@ use itertools::Itertools;
 use rand::RngExt;
 use rand::distr::Distribution;
 #[cfg(test)]
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 #[cfg(test)]
 use rand::seq::SliceRandom as _;
 #[cfg(test)]
@@ -183,7 +183,7 @@ impl CompressedPointMappings {
 
     /// Generate a random [`PointMappings`].
     #[cfg(test)]
-    pub fn random(rand: &mut StdRng, total_size: u32) -> Self {
+    pub fn random(rand: &mut SmallRng, total_size: u32) -> Self {
         Self::random_with_params(rand, total_size, total_size, 128)
     }
 
@@ -198,7 +198,7 @@ impl CompressedPointMappings {
     ///   (256 uuids + 256 u64s)
     #[cfg(test)]
     pub fn random_with_params(
-        rand: &mut StdRng,
+        rand: &mut SmallRng,
         total_size: u32,
         preserved_size: u32,
         bits_in_id: u8,

--- a/lib/segment/src/id_tracker/immutable_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/tests.rs
@@ -120,7 +120,7 @@ fn test_load_store() {
 /// ID tracker.
 #[test]
 fn test_store_load_mutated() {
-    let mut rng = StdRng::seed_from_u64(RAND_SEED);
+    let mut rng = SmallRng::seed_from_u64(RAND_SEED);
 
     let dir = Builder::new().prefix("storage_dir").tempdir().unwrap();
     let (dropped_points, custom_version) = {
@@ -288,7 +288,7 @@ fn test_point_deletion_persists_reload() {
 /// Tests de/serializing of whole `PointMappings`.
 #[test]
 fn test_point_mappings_de_serialization() {
-    let mut rng = StdRng::seed_from_u64(RAND_SEED);
+    let mut rng = SmallRng::seed_from_u64(RAND_SEED);
 
     let mut buf = vec![];
 
@@ -317,7 +317,7 @@ fn test_point_mappings_de_serialization() {
 /// Verifies that de/serializing works properly for empty `PointMappings`.
 #[test]
 fn test_point_mappings_de_serialization_empty() {
-    let mut rng = StdRng::seed_from_u64(RAND_SEED);
+    let mut rng = SmallRng::seed_from_u64(RAND_SEED);
     let mappings = CompressedPointMappings::random(&mut rng, 0);
 
     let mut buf = vec![];
@@ -336,7 +336,7 @@ fn test_point_mappings_de_serialization_empty() {
 /// Tests de/serializing of only single ID mappings.
 #[test]
 fn test_point_mappings_de_serialization_single() {
-    let mut rng = StdRng::seed_from_u64(RAND_SEED);
+    let mut rng = SmallRng::seed_from_u64(RAND_SEED);
 
     const SIZE: usize = 400_000;
 

--- a/lib/segment/src/id_tracker/mutable_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/tests.rs
@@ -120,7 +120,7 @@ fn test_load_store() {
 /// ID tracker.
 #[test]
 fn test_store_load_mutated() {
-    let mut rng = StdRng::seed_from_u64(RAND_SEED);
+    let mut rng = SmallRng::seed_from_u64(RAND_SEED);
 
     let segment_dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let (dropped_points, custom_version) = {
@@ -293,7 +293,7 @@ fn test_point_deletion_persists_reload() {
 /// Tests de/serializing of only single ID mappings.
 #[test]
 fn test_point_mappings_de_serialization_single() {
-    let mut rng = StdRng::seed_from_u64(RAND_SEED);
+    let mut rng = SmallRng::seed_from_u64(RAND_SEED);
 
     const SIZE: usize = 400_000;
 
@@ -590,7 +590,7 @@ fn simple_id_tracker_vs_mutable_tracker_congruence() {
     // Insert 100 random points into id_tracker
 
     let num_points = 200;
-    let mut rng = StdRng::seed_from_u64(RAND_SEED);
+    let mut rng = SmallRng::seed_from_u64(RAND_SEED);
 
     for _ in 0..num_points {
         // Generate num id in range from 0 to 100

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -606,7 +606,7 @@ mod tests {
     use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
     use itertools::Itertools;
     use rand::SeedableRng;
-    use rand::prelude::StdRng;
+    use rand::prelude::SmallRng;
     use rstest::rstest;
 
     use super::*;
@@ -716,7 +716,7 @@ mod tests {
         let num_vectors = 1000;
         let dim = 8;
 
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = SmallRng::seed_from_u64(42);
 
         // let (vector_holder, graph_layers_builder) =
         //     create_graph_layer::<M, _>(num_vectors, dim, false, &mut rng);
@@ -797,8 +797,8 @@ mod tests {
         let num_vectors = 1000;
         let dim = 8;
 
-        let mut rng = StdRng::seed_from_u64(42);
-        let mut rng2 = StdRng::seed_from_u64(42);
+        let mut rng = SmallRng::seed_from_u64(42);
+        let mut rng2 = SmallRng::seed_from_u64(42);
 
         let (vector_holder, graph_layers_builder) = create_graph_layer(
             num_vectors,
@@ -911,7 +911,7 @@ mod tests {
         const EF_CONSTRUCT: usize = 64;
         const USE_HEURISTIC: bool = true;
 
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = SmallRng::seed_from_u64(42);
 
         let vector_holder = TestRawScorerProducer::new(
             DIM,
@@ -969,7 +969,7 @@ mod tests {
         use std::time::{Duration, Instant};
 
         const DIM: usize = 4;
-        let mut rng = StdRng::seed_from_u64(42);
+        let mut rng = SmallRng::seed_from_u64(42);
 
         // Build a one-point graph the normal way. `link_new_point` sees an
         // empty entry-points list, takes the "new empty entry" branch, and

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -554,7 +554,7 @@ impl DenseTQVectorStorage for TurboVectorStorage {
 mod tests {
     use common::bitvec::BitSliceExt;
     use common::generic_consts::Random;
-    use rand::rngs::StdRng;
+    use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
     use tempfile::Builder;
 
@@ -565,7 +565,7 @@ mod tests {
     /// Deterministic test vectors in `[-1, 1]`, seeded so that the storage and
     /// the independent oracle observe exactly the same inputs across runs.
     fn make_vectors(dim: usize, count: usize, seed: u64) -> Vec<DenseVector> {
-        let mut rng = StdRng::seed_from_u64(seed);
+        let mut rng = SmallRng::seed_from_u64(seed);
         (0..count)
             .map(|_| {
                 let v: DenseVector = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
@@ -1470,7 +1470,7 @@ mod tests {
     }
 
     /// Random unit vector drawn from the scenario's RNG (one deterministic stream).
-    fn random_unit_vector(rng: &mut StdRng, dim: usize) -> DenseVector {
+    fn random_unit_vector(rng: &mut SmallRng, dim: usize) -> DenseVector {
         let v: DenseVector = (0..dim).map(|_| rng.random_range(-1.0f32..1.0)).collect();
         let norm = v.iter().map(|&x| x * x).sum::<f32>().sqrt();
         if norm == 0.0 {
@@ -1609,7 +1609,7 @@ mod tests {
     /// and the model in lockstep, flushing/dropping/reloading at random, then copy
     /// the result into the read-only single-file backend via `update_from`.
     fn run_model_scenario(dim: usize, distance: Distance, seed: u64, ops: usize) {
-        let mut rng = StdRng::seed_from_u64(seed);
+        let mut rng = SmallRng::seed_from_u64(seed);
         let oracle = Oracle::new(dim, distance);
         let dir = Builder::new().prefix("turbo_model_src").tempdir().unwrap();
         let dst_dir = Builder::new().prefix("turbo_model_dst").tempdir().unwrap();
@@ -1836,7 +1836,7 @@ mod tests {
         let inputs = make_vectors(DIM, COUNT, seed);
         let hw_counter = HardwareCounterCell::new();
 
-        let mut rng = StdRng::seed_from_u64(seed);
+        let mut rng = SmallRng::seed_from_u64(seed);
         let mut ids: Vec<PointOffsetType> = (0..COUNT as PointOffsetType)
             .chain(0..(COUNT / 2) as PointOffsetType)
             .collect();
@@ -1925,7 +1925,7 @@ mod tests {
         let inputs = make_vectors(DIM, COUNT, seed);
         let hw_counter = HardwareCounterCell::new();
 
-        let mut rng = StdRng::seed_from_u64(seed);
+        let mut rng = SmallRng::seed_from_u64(seed);
         let mut ids: Vec<PointOffsetType> = (0..COUNT as PointOffsetType)
             .chain(0..(COUNT / 2) as PointOffsetType)
             .collect();

--- a/lib/segment/src/vector_storage/turbo/multi.rs
+++ b/lib/segment/src/vector_storage/turbo/multi.rs
@@ -653,7 +653,7 @@ impl MultiTQVectorStorage for TurboMultiVectorStorage {
 #[cfg(test)]
 mod tests {
     use common::generic_consts::{Random, Sequential};
-    use rand::rngs::StdRng;
+    use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
     use tempfile::Builder;
 
@@ -663,7 +663,7 @@ mod tests {
 
     /// Deterministic multivectors of unit inner vectors; point `i` gets `(i % 4) + 1` inner vectors.
     fn make_multi_vectors(dim: usize, count: usize, seed: u64) -> Vec<MultiDenseVectorInternal> {
-        let mut rng = StdRng::seed_from_u64(seed);
+        let mut rng = SmallRng::seed_from_u64(seed);
         (0..count)
             .map(|i| {
                 let inner_count = (i % 4) + 1;
@@ -1040,7 +1040,7 @@ mod tests {
 
     /// Helper: one multivector of `count` distinct unit inner vectors.
     fn multi_of(dim: usize, count: usize, seed: u64) -> MultiDenseVectorInternal {
-        let mut rng = StdRng::seed_from_u64(seed);
+        let mut rng = SmallRng::seed_from_u64(seed);
         let flattened: Vec<f32> = (0..count)
             .flat_map(|_| {
                 let v: DenseVector = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
@@ -1482,7 +1482,7 @@ mod tests {
     }
 
     /// Random multivector with 1..=4 unit inner vectors from the scenario RNG.
-    fn random_multi(rng: &mut StdRng, dim: usize) -> MultiDenseVectorInternal {
+    fn random_multi(rng: &mut SmallRng, dim: usize) -> MultiDenseVectorInternal {
         let count = rng.random_range(1..=4usize);
         let flattened: Vec<f32> = (0..count)
             .flat_map(|_| {
@@ -1560,7 +1560,7 @@ mod tests {
     }
 
     fn run_model_scenario(dim: usize, distance: Distance, seed: u64, ops: usize) {
-        let mut rng = StdRng::seed_from_u64(seed);
+        let mut rng = SmallRng::seed_from_u64(seed);
         let oracle = Oracle::new(dim, distance);
         let dir = Builder::new()
             .prefix("turbo_multi_model_src")

--- a/lib/segment/src/vector_storage/turbo/test.rs
+++ b/lib/segment/src/vector_storage/turbo/test.rs
@@ -6,7 +6,7 @@
 
 use common::bitvec::BitSliceExt;
 use common::generic_consts::{Random, Sequential};
-use rand::rngs::StdRng;
+use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 use tempfile::Builder;
 
@@ -18,7 +18,7 @@ use crate::types::MultiVectorConfig;
 use crate::vector_storage::MultiTQVectorStorage;
 
 /// Random unit vector with a fixed fallback for an all-zero draw.
-fn random_unit_vector(rng: &mut StdRng, dim: usize) -> DenseVector {
+fn random_unit_vector(rng: &mut SmallRng, dim: usize) -> DenseVector {
     let v: DenseVector = (0..dim).map(|_| rng.random_range(-1.0f32..1.0)).collect();
     let norm = v.iter().map(|&x| x * x).sum::<f32>().sqrt();
     if norm == 0.0 {
@@ -212,7 +212,7 @@ fn congruent_upsert_read_all_distances() {
     ] {
         for dim in [1, 127, 128] {
             for seed in SEEDS {
-                let mut rng = StdRng::seed_from_u64(seed);
+                let mut rng = SmallRng::seed_from_u64(seed);
                 let dense_dir = Builder::new().prefix("tq_congr_dense").tempdir().unwrap();
                 let multi_dir = Builder::new().prefix("tq_congr_multi").tempdir().unwrap();
                 let hw = HardwareCounterCell::new();
@@ -244,7 +244,7 @@ fn congruent_upsert_read_all_distances() {
 /// fresh storages via `update_from` (the optimizer move) and check the
 /// destinations live and after a reload.
 fn run_congruence_scenario(dim: usize, distance: Distance, seed: u64, ops: usize) {
-    let mut rng = StdRng::seed_from_u64(seed);
+    let mut rng = SmallRng::seed_from_u64(seed);
     let dense_dir = Builder::new().prefix("tq_congr_dense").tempdir().unwrap();
     let multi_dir = Builder::new().prefix("tq_congr_multi").tempdir().unwrap();
     let dense_dst_dir = Builder::new()


### PR DESCRIPTION
## Tests: use SmallRng for RNG-bound test data generation in `segment`

Follow-up to #9887 (benches) and #9888 (`common` tests). This migrates the
`segment` unit tests where the RNG is a measurable share of the runtime from
`StdRng` (ChaCha12 in rand 0.10) to `SmallRng` (Xoshiro256++):

- `vector_storage/turbo/{test,multi,mod}.rs`: the turbo model tests, the four
  heaviest unit tests in the crate
- `index/hnsw_index/graph_layers_builder.rs` (test module): HNSW graph
  properties tests
- `id_tracker/{immutable,mutable}_id_tracker/tests.rs` and
  `id_tracker/compressed/compressed_point_mappings.rs`: the `#[cfg(test)]`
  `random()` / `random_with_params()` helpers name the RNG concretely in their
  signatures, so the type rename threads through both id-tracker test suites

### Measured impact (nextest, debug build, same filtered run)

| Test | StdRng | SmallRng |
|---|---|---|
| `turbo_model_test_random_ops_cosine` | 14.5s | 12.4s |
| `turbo_model_test_random_ops_dot` | 14.3s | 13.1s |
| `turbo_multi_model_test_random_ops_cosine` | 12.0s | 10.3s |
| `turbo_multi_model_test_random_ops_dot` | 10.3s | 9.9s |
| `test_hnsw_graph_properties::case_2_compressed` | 8.0s | 7.4s |
| `test_hnsw_graph_properties::case_1_uncompressed` | 7.1s | 6.5s |
| `test_hnsw_graph_properties::case_3_compressed_with_vectors` | 5.8s | 4.9s |
| `immutable_id_tracker::test_point_mappings_de_serialization_single` | 2.6s | 1.8s |

Single-run numbers, so treat the exact percentages loosely, but the direction
was consistent across every test (roughly 8-10 seconds of CPU per suite run).

Not migrated on purpose: the histogram tests (measured, insertion-bound, no
benefit) and the quantization integration tests (left to the in-flight rng
threading refactor to avoid conflicts).

### Why this is safe

- The seeded sequences change, so the generated datasets differ, but all
  affected tests pass, including the turbo model tests whose score comparisons
  carry tolerances, and the id-tracker/HNSW tests, which are self-consistency
  and structural-invariant checks rather than tuned-threshold assertions.
- Reproducibility is preserved: `SmallRng::seed_from_u64` is deterministic per
  rand version, same as `StdRng::seed_from_u64`.

Verified with `cargo nextest run -p segment --lib` on the affected filter
(49 passed), `cargo clippy -p segment --lib --tests`, and
`cargo +nightly fmt --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
