### PR TITLE
fix(search): saturate limit and offset calculations

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -107,7 +107,7 @@ impl Collection {
 
         let max_limit = batch_request
             .iter()
-            .map(|req| req.limit + req.offset)
+            .map(ShardQueryRequest::limit_with_offset)
             .max()
             .unwrap_or(0);
 
@@ -119,7 +119,7 @@ impl Collection {
 
         for request in batch_request.iter() {
             let mut new_request = request.clone();
-            let request_limit = new_request.limit + new_request.offset;
+            let request_limit = new_request.limit_with_offset();
 
             let is_exact = request.params.as_ref().is_some_and(|p| p.exact);
 
@@ -756,8 +756,33 @@ fn intermediate_query_infos(request: &ShardQueryRequest) -> Vec<IntermediateQuer
             // Otherwise, we expect the root result
             vec![IntermediateQueryInfo {
                 scoring_query: request.query.as_ref(),
-                take: request.offset + request.limit,
+                take: request.limit_with_offset(),
             }]
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intermediate_query_limit_with_offset_saturates_on_overflow() {
+        let request = ShardQueryRequest {
+            prefetches: vec![],
+            query: None,
+            filter: None,
+            score_threshold: None,
+            limit: usize::MAX,
+            offset: 1,
+            params: None,
+            with_vector: WithVector::Bool(false),
+            with_payload: WithPayloadInterface::Bool(false),
+        };
+
+        let query_infos = intermediate_query_infos(&request);
+
+        assert_eq!(query_infos.len(), 1);
+        assert_eq!(query_infos[0].take, usize::MAX);
     }
 }

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -325,7 +325,7 @@ impl Collection {
                     .take(request.limit)
                     .collect()
             } else {
-                merged_iter.take(request.offset + request.limit).collect()
+                merged_iter.take(request.limit_with_offset()).collect()
             };
 
             top_results.push(top_res);

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -24,7 +24,7 @@ use shard::query::query_context::{fill_query_context, init_query_context};
 use shard::query::query_enum::QueryEnum;
 use shard::retrieve::record_internal::RecordInternal;
 use shard::retrieve::retrieve_blocking::{retrieve_blocking, retrieve_raw_blocking};
-use shard::search::CoreSearchRequestBatch;
+use shard::search::{CoreSearchRequest, CoreSearchRequestBatch};
 use shard::search_result_aggregator::BatchResultAggregator;
 use shard::segment_holder::locked::LockedSegmentHolder;
 use tokio_util::task::AbortOnDropHandle;
@@ -296,7 +296,7 @@ impl SegmentsSearcher {
             batch_request
                 .searches
                 .iter()
-                .map(|request| request.limit + request.offset)
+                .map(CoreSearchRequest::limit_with_offset)
                 .collect(),
             &further_results,
         );
@@ -682,7 +682,7 @@ fn search_in_segment(
             filter: search_query.filter.as_ref(),
             with_payload: WithPayload::from(with_payload_interface),
             with_vector: search_query.with_vector.clone().unwrap_or_default(),
-            top: search_query.limit + search_query.offset,
+            top: search_query.limit_with_offset(),
             params: search_query.params.as_ref(),
         };
 

--- a/lib/edge/src/search.rs
+++ b/lib/edge/src/search.rs
@@ -19,6 +19,7 @@ use crate::read_view::{EdgeReadView, ReadSegmentHandle};
 impl<H: ReadSegmentHandle> EdgeReadView<H> {
     /// This method is DEPRECATED and should be replaced with query.
     pub fn search(&self, search: CoreSearchRequest) -> OperationResult<Vec<ScoredPoint>> {
+        let limit_with_offset = search.limit_with_offset();
         let is_stopped_guard = StoppingGuard::new();
         let searches = [search];
         let query_context = init_query_context(
@@ -48,7 +49,7 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
             query,
             filter,
             params,
-            limit,
+            limit: _,
             offset,
             with_payload,
             with_vector,
@@ -69,7 +70,7 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
                 &with_payload,
                 &with_vector,
                 filter.as_ref(),
-                offset + limit,
+                limit_with_offset,
                 params.as_ref(),
                 &context.get_segment_query_context(),
             )?;
@@ -83,7 +84,7 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
             Ok(points)
         })?;
 
-        let mut aggregator = BatchResultAggregator::new([offset + limit]);
+        let mut aggregator = BatchResultAggregator::new([limit_with_offset]);
         aggregator.update_point_versions(points_by_segment.iter().flatten());
 
         for points in points_by_segment {

--- a/lib/shard/src/query/mod.rs
+++ b/lib/shard/src/query/mod.rs
@@ -51,6 +51,11 @@ pub struct ShardQueryRequest {
 }
 
 impl ShardQueryRequest {
+    /// Number of candidates required before applying the result offset.
+    pub fn limit_with_offset(&self) -> usize {
+        self.limit.saturating_add(self.offset)
+    }
+
     pub fn prefetches_depth(&self) -> usize {
         self.prefetches
             .iter()

--- a/lib/shard/src/query/tests.rs
+++ b/lib/shard/src/query/tests.rs
@@ -155,6 +155,34 @@ fn test_try_from_limit_offset_saturates_on_overflow() {
 }
 
 #[test]
+fn test_request_limit_with_offset_saturates_on_overflow() {
+    let shard_request = ShardQueryRequest {
+        prefetches: vec![],
+        query: None,
+        filter: None,
+        score_threshold: None,
+        limit: usize::MAX,
+        offset: 1,
+        params: None,
+        with_vector: WithVector::Bool(false),
+        with_payload: WithPayloadInterface::Bool(false),
+    };
+    assert_eq!(shard_request.limit_with_offset(), usize::MAX);
+
+    let core_request = CoreSearchRequest {
+        query: QueryEnum::Nearest(NamedQuery::new(VectorInternal::Dense(vec![1.0]), "full")),
+        filter: None,
+        params: None,
+        limit: usize::MAX,
+        offset: 1,
+        with_payload: None,
+        with_vector: None,
+        score_threshold: None,
+    };
+    assert_eq!(core_request.limit_with_offset(), usize::MAX);
+}
+
+#[test]
 fn test_try_from_no_prefetch() {
     let dummy_vector = vec![1.0, 2.0, 3.0];
     let request = ShardQueryRequest {

--- a/lib/shard/src/search.rs
+++ b/lib/shard/src/search.rs
@@ -33,6 +33,11 @@ pub struct CoreSearchRequest {
 }
 
 impl CoreSearchRequest {
+    /// Number of candidates required before applying the result offset.
+    pub fn limit_with_offset(&self) -> usize {
+        self.limit.saturating_add(self.offset)
+    }
+
     /// Request-specific [`LoadProfile`] for opening a read-only shard to serve exactly
     /// this search: only the queried vector's components and the filter's field indexes
     /// keep their configured placement.


### PR DESCRIPTION
## Summary
The change introduces a shared `limit_with_offset `calculation using `saturating_add `on both search request types and applies it to the remaining affected paths. It also adds a regression test for the downstream collection calculation using `usize::MAX` and an offset of one, confirming that the result clamps to `usize::MAX` instead of overflowing.

PR [#9321](https://github.com/qdrant/qdrant/pull/9321) addressed this in the shard query planner, but the collection search, segment search, result-merging, and Edge search paths still performed ordinary integer addition.

## Test Plan

- Added a regression test for the downstream collection query calculation using `limit = usize::MAX` and `offset = 1`.
- Added coverage for the new saturating calculation on both request types.
- Ran the focused collection regression: passed.
- Ran the focused shard regression: passed.
- Ran the complete collection library suite: 238 passed, 6 ignored.
- Ran the complete shard library suite: 106 passed.
- Ran `cargo check -p edge --locked`: passed.
- Ran formatting and whitespace checks: passed.
- Ran `cargo clippy --workspace --all-features` locally.


## Contributing with AI
The code change was assisted by AI. I have went through the code workflow first before making and reviewing this change. The description is written by me and the code changes are reviewed and tested.
