### PR TITLE
Report effective (cgroup) CPU, RAM and disk in telemetry

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11774,12 +11774,14 @@
             "nullable": true
           },
           "ram_size": {
+            "description": "Effective total memory for this process in KiB (cgroup limit or host RAM).",
             "type": "integer",
             "format": "uint",
             "minimum": 0,
             "nullable": true
           },
           "disk_size": {
+            "description": "Size in KiB of the filesystem hosting Qdrant's /storage path (if not available, fallback to host disk size)",
             "type": "integer",
             "format": "uint",
             "minimum": 0,

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -270,8 +270,8 @@ pub fn check_resident_memory(
     Ok(())
 }
 
-/// Total system memory (or cgroup limit) in bytes. Cached once — total memory
-/// is effectively constant for a running process.
+/// Total system memory (or cgroup limit) in bytes.
+/// Memory allowance can change in a cgroup-limited node, so need to refresh the cache periodically.
 fn total_memory_bytes() -> u64 {
     segment::utils::mem::total_memory_bytes()
 }

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -273,9 +273,7 @@ pub fn check_resident_memory(
 /// Total system memory (or cgroup limit) in bytes. Cached once — total memory
 /// is effectively constant for a running process.
 fn total_memory_bytes() -> u64 {
-    use std::sync::OnceLock;
-    static TOTAL: OnceLock<u64> = OnceLock::new();
-    *TOTAL.get_or_init(|| segment::utils::mem::Mem::new().total_memory_bytes())
+    segment::utils::mem::total_memory_bytes()
 }
 
 /// Reject a disk-consuming update if the filesystem hosting Qdrant storage is

--- a/lib/segment/src/utils/mem.rs
+++ b/lib/segment/src/utils/mem.rs
@@ -1,3 +1,41 @@
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// Refresh interval for [`total_memory_bytes`]. Matches the disk-usage cache TTL
+/// so RAM and disk figures react to a live (in-place) cgroup/volume resize at
+/// the same cadence.
+const TOTAL_MEMORY_TTL: Duration = Duration::from_secs(5);
+
+/// Effective total memory in bytes — the cgroup memory limit when set, else the
+/// host total — served from a value refreshed at most once per
+/// [`TOTAL_MEMORY_TTL`].
+///
+/// [`Mem::new`] is not free (it builds a `sysinfo::System` and loads the cgroup
+/// memory controller), so this is preferable to `Mem::new().total_memory_bytes()`
+/// for callers that only need the total and may run repeatedly. A short TTL,
+/// rather than caching once, means an in-place memory-limit resize is reflected
+/// within a few seconds instead of only after a restart.
+pub fn total_memory_bytes() -> u64 {
+    static CACHE: Mutex<Option<(Instant, u64)>> = Mutex::new(None);
+
+    let now = Instant::now();
+
+    // Fast path: fresh cached value.
+    if let Ok(guard) = CACHE.lock()
+        && let Some((cached_at, value)) = *guard
+        && now.duration_since(cached_at) < TOTAL_MEMORY_TTL
+    {
+        return value;
+    }
+
+    // Miss or stale — recompute outside the lock, then store.
+    let value = Mem::new().total_memory_bytes();
+    if let Ok(mut guard) = CACHE.lock() {
+        *guard = Some((now, value));
+    }
+    value
+}
+
 #[derive(Debug)]
 pub struct Mem {
     #[cfg(target_os = "linux")]

--- a/lib/segment/src/utils/mem.rs
+++ b/lib/segment/src/utils/mem.rs
@@ -2,19 +2,11 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 /// Refresh interval for [`total_memory_bytes`]. Matches the disk-usage cache TTL
-/// so RAM and disk figures react to a live (in-place) cgroup/volume resize at
-/// the same cadence.
+/// so RAM and disk figures react to a live (in-place) cgroup/volume resize
 const TOTAL_MEMORY_TTL: Duration = Duration::from_secs(5);
 
-/// Effective total memory in bytes — the cgroup memory limit when set, else the
-/// host total — served from a value refreshed at most once per
-/// [`TOTAL_MEMORY_TTL`].
-///
-/// [`Mem::new`] is not free (it builds a `sysinfo::System` and loads the cgroup
-/// memory controller), so this is preferable to `Mem::new().total_memory_bytes()`
-/// for callers that only need the total and may run repeatedly. A short TTL,
-/// rather than caching once, means an in-place memory-limit resize is reflected
-/// within a few seconds instead of only after a restart.
+/// Returns current total memory in bytes (cgroup limit if set, else host), served from
+/// a cached value that refreshes at most once per [`TOTAL_MEMORY_TTL`].
 pub fn total_memory_bytes() -> u64 {
     static CACHE: Mutex<Option<(Instant, u64)>> = Mutex::new(None);
 

--- a/lib/segment/src/utils/mem.rs
+++ b/lib/segment/src/utils/mem.rs
@@ -1,28 +1,25 @@
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-/// Refresh interval for [`total_memory_bytes`]. Matches the disk-usage cache TTL
-/// so RAM and disk figures react to a live (in-place) cgroup/volume resize
-const TOTAL_MEMORY_TTL: Duration = Duration::from_secs(5);
+/// TTL for the cached total memory; matches the disk-usage cache.
+const CACHE_TTL: Duration = Duration::from_secs(5);
 
-/// Returns current total memory in bytes (cgroup limit if set, else host), served from
-/// a cached value that refreshes at most once per [`TOTAL_MEMORY_TTL`].
+static TOTAL_MEMORY_CACHE: Mutex<Option<(Instant, u64)>> = Mutex::new(None);
+
+/// Total memory in bytes (cgroup limit if set, else host), cached for `CACHE_TTL`
+/// since `Mem::new()` is not free. Short TTL keeps it in step with limit resizes.
 pub fn total_memory_bytes() -> u64 {
-    static CACHE: Mutex<Option<(Instant, u64)>> = Mutex::new(None);
-
     let now = Instant::now();
 
-    // Fast path: fresh cached value.
-    if let Ok(guard) = CACHE.lock()
+    if let Ok(guard) = TOTAL_MEMORY_CACHE.lock()
         && let Some((cached_at, value)) = *guard
-        && now.duration_since(cached_at) < TOTAL_MEMORY_TTL
+        && now.duration_since(cached_at) < CACHE_TTL
     {
         return value;
     }
 
-    // Miss or stale — recompute outside the lock, then store.
     let value = Mem::new().total_memory_bytes();
-    if let Ok(mut guard) = CACHE.lock() {
+    if let Ok(mut guard) = TOTAL_MEMORY_CACHE.lock() {
         *guard = Some((now, value));
     }
     value

--- a/lib/segment/src/utils/mem.rs
+++ b/lib/segment/src/utils/mem.rs
@@ -1,5 +1,6 @@
-use std::sync::Mutex;
 use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
 
 /// TTL for the cached total memory; matches the disk-usage cache.
 const CACHE_TTL: Duration = Duration::from_secs(5);
@@ -9,19 +10,17 @@ static TOTAL_MEMORY_CACHE: Mutex<Option<(Instant, u64)>> = Mutex::new(None);
 /// Total memory in bytes (cgroup limit if set, else host), cached for `CACHE_TTL`
 /// since `Mem::new()` is not free. Short TTL keeps it in step with limit resizes.
 pub fn total_memory_bytes() -> u64 {
+    let mut cache = TOTAL_MEMORY_CACHE.lock();
     let now = Instant::now();
 
-    if let Ok(guard) = TOTAL_MEMORY_CACHE.lock()
-        && let Some((cached_at, value)) = *guard
-        && now.duration_since(cached_at) < CACHE_TTL
+    if let Some((cached_at, value)) = *cache
+        && now.saturating_duration_since(cached_at) < CACHE_TTL
     {
         return value;
     }
 
     let value = Mem::new().total_memory_bytes();
-    if let Ok(mut guard) = TOTAL_MEMORY_CACHE.lock() {
-        *guard = Some((now, value));
-    }
+    *cache = Some((now, value));
     value
 }
 

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -241,13 +241,7 @@ fn get_system_data(storage_path: &Path) -> RunningEnvironmentTelemetry {
         is_docker: cfg!(unix) && Path::new("/.dockerenv").exists(),
         cores: Some(common::cpu::get_num_cpus()),
         cpu_cores_used: common::process_cpu_usage::process_cpu_usage_cores(),
-        // Effective memory: the cgroup limit when set, otherwise the host total
-        // (via `segment::utils::mem`, which wraps cgroups_rs + sysinfo). Cached,
-        // so no per-call `Mem` init. Reported in KiB to match the previous unit.
         ram_size: Some((segment::utils::mem::total_memory_bytes() / 1024) as usize),
-        // Capacity of the filesystem hosting Qdrant's storage (the data volume),
-        // not the container root fs. Reported in KiB to match `sys_info`. Uses
-        // the cached reader, shared with strict-mode disk checks.
         disk_size: common::disk_usage::disk_usage(storage_path)
             .map(|usage| (usage.total / 1024) as usize)
             .or_else(|| sys_info::disk_info().ok().map(|x| x.total as usize)),

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -41,11 +41,7 @@ pub struct RunningEnvironmentTelemetry {
     #[anonymize(false)]
     distribution_version: Option<String>,
     is_docker: bool,
-    /// Number of CPU cores Qdrant will actually use for sizing thread pools,
-    /// optimizer budget and segment counts. This is the effective count from
-    /// [`common::cpu::get_num_cpus`] (honors `QDRANT_NUM_CPUS` and the cgroup
-    /// CPU quota), not the host socket count — so a cgroup-limited node reports
-    /// its quota rather than the underlying machine's total cores.
+    // Number of CPU cores Qdrant will use (accounting for cgroup/host limits)
     #[anonymize(false)]
     cores: Option<usize>,
     /// Average number of CPU cores used by this process over roughly the last
@@ -54,12 +50,9 @@ pub struct RunningEnvironmentTelemetry {
     #[anonymize(false)]
     #[serde(skip_serializing_if = "Option::is_none")]
     cpu_cores_used: Option<f32>,
-    /// Effective total memory in KiB: the cgroup memory limit enforced on this
-    /// process when set (via [`segment::utils::mem::Mem`]), otherwise the host's
-    /// total RAM. A cgroup-limited node reports its cap, not the machine total.
+    /// Effective total memory for this process in KiB (cgroup limit or host RAM).
     ram_size: Option<usize>,
-    /// Capacity in KiB of the filesystem hosting Qdrant's storage path (the data
-    /// volume), rather than the container root filesystem.
+    /// Size in KiB of the filesystem hosting Qdrant's /storage path (if not available, fallback to host disk size)
     disk_size: Option<usize>,
     #[anonymize(false)]
     cpu_flags: String,

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -41,6 +41,11 @@ pub struct RunningEnvironmentTelemetry {
     #[anonymize(false)]
     distribution_version: Option<String>,
     is_docker: bool,
+    /// Number of CPU cores Qdrant will actually use for sizing thread pools,
+    /// optimizer budget and segment counts. This is the effective count from
+    /// [`common::cpu::get_num_cpus`] (honors `QDRANT_NUM_CPUS` and the cgroup
+    /// CPU quota), not the host socket count — so a cgroup-limited node reports
+    /// its quota rather than the underlying machine's total cores.
     #[anonymize(false)]
     cores: Option<usize>,
     /// Average number of CPU cores used by this process over roughly the last
@@ -49,7 +54,12 @@ pub struct RunningEnvironmentTelemetry {
     #[anonymize(false)]
     #[serde(skip_serializing_if = "Option::is_none")]
     cpu_cores_used: Option<f32>,
+    /// Effective total memory in KiB: the cgroup memory limit enforced on this
+    /// process when set (via [`segment::utils::mem::Mem`]), otherwise the host's
+    /// total RAM. A cgroup-limited node reports its cap, not the machine total.
     ram_size: Option<usize>,
+    /// Capacity in KiB of the filesystem hosting Qdrant's storage path (the data
+    /// volume), rather than the container root filesystem.
     disk_size: Option<usize>,
     #[anonymize(false)]
     cpu_flags: String,
@@ -122,7 +132,8 @@ impl AppBuildTelemetry {
                 .then(common::low_memory::low_memory_mode),
             hnsw_global_config: (detail.level >= DetailsLevel::Level1)
                 .then(|| settings.storage.hnsw_global_config.clone()),
-            system: (detail.level >= DetailsLevel::Level1).then(get_system_data),
+            system: (detail.level >= DetailsLevel::Level1)
+                .then(|| get_system_data(&settings.storage.storage_path)),
             jwt_rbac: settings.service.jwt_rbac,
             hide_jwt_dashboard: settings.service.hide_jwt_dashboard,
             audit: collect_audit_telemetry(settings.audit.as_ref(), detail),
@@ -157,7 +168,7 @@ fn collect_audit_telemetry(
     })
 }
 
-fn get_system_data() -> RunningEnvironmentTelemetry {
+fn get_system_data(storage_path: &Path) -> RunningEnvironmentTelemetry {
     let distribution = if let Ok(release) = sys_info::linux_os_release() {
         release.id
     } else {
@@ -228,10 +239,18 @@ fn get_system_data() -> RunningEnvironmentTelemetry {
         distribution,
         distribution_version,
         is_docker: cfg!(unix) && Path::new("/.dockerenv").exists(),
-        cores: sys_info::cpu_num().ok().map(|x| x as usize),
+        cores: Some(common::cpu::get_num_cpus()),
         cpu_cores_used: common::process_cpu_usage::process_cpu_usage_cores(),
-        ram_size: sys_info::mem_info().ok().map(|x| x.total as usize),
-        disk_size: sys_info::disk_info().ok().map(|x| x.total as usize),
+        // Effective memory: the cgroup limit when set, otherwise the host total
+        // (via `segment::utils::mem`, which wraps cgroups_rs + sysinfo). Cached,
+        // so no per-call `Mem` init. Reported in KiB to match the previous unit.
+        ram_size: Some((segment::utils::mem::total_memory_bytes() / 1024) as usize),
+        // Capacity of the filesystem hosting Qdrant's storage (the data volume),
+        // not the container root fs. Reported in KiB to match `sys_info`. Uses
+        // the cached reader, shared with strict-mode disk checks.
+        disk_size: common::disk_usage::disk_usage(storage_path)
+            .map(|usage| (usage.total / 1024) as usize)
+            .or_else(|| sys_info::disk_info().ok().map(|x| x.total as usize)),
         cpu_flags: cpu_flags.join(","),
         cpu_endian: Some(CpuEndian::current()),
         gpu_devices,


### PR DESCRIPTION
## Problem

The `system` block of app telemetry reports **host-level** resource figures that ignore the limits actually enforced on the Qdrant process:

| Field | Current source | What it reports |
|---|---|---|
| `cores` | `sys_info::cpu_num()` | host socket count |
| `ram_size` | `sys_info::mem_info()` | host total RAM |
| `disk_size` | `sys_info::disk_info()` | container **root** filesystem |

On any cgroup-limited deployment (Docker, Kubernetes pods, systemd slices, **and our cloud**) these overstate what Qdrant can actually use. It's misleading for capacity / oversubscription analysis, and it doesn't match how Qdrant already sizes itself internally — thread pools, optimizer budget and default segment count all use the effective CPU count (`common::cpu::get_num_cpus()`, which honors the cgroup CPU quota and `QDRANT_NUM_CPUS`).

Concretely, a managed 2 vCPU / ~2 GiB pod on a 16-core / 64 GiB host reports `cores: 16`, `ram_size: ~64 GiB`, and a `disk_size` for the wrong filesystem.

## Reproduce with current code

Run the released image on a host with more resources than the limit, pinning CPU + memory and putting storage on a separate volume:

```bash
docker run -d --name qd --cpus=2 --memory=1g \
  --mount type=tmpfs,destination=/qdrant/storage,tmpfs-size=536870912 \
  -e QDRANT__STORAGE__STORAGE_PATH=/qdrant/storage \
  qdrant/qdrant:latest

IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' qd)
curl -s "http://$IP:6333/telemetry?details_level=1" \
  | jq '.result.app.system | {cores, ram_size, disk_size}'
```

On a 22-core / ~15 GiB host, container limited to 2 CPU / 1 GiB / 512 MiB storage, this reports the **host** values instead of the limits:

```json
{
  "cores": 22,           // host, not the 2-CPU limit
  "ram_size": 15968496,  // KiB ≈ 15 GiB host total, not 1 GiB (1048576 KiB)
  "disk_size": 981132795 // KiB, host root fs — not the 512 MiB storage volume
}
```

The effective limits the kernel enforces are visible in the cgroup / mount:

```bash
docker run --rm --memory=1g debian:13 cat /sys/fs/cgroup/memory.max
# 1073741824   (exactly 1 GiB)
```

## Fix

Report the effective values instead, **reusing existing helpers** rather than adding new detection code:

- **`cores`** → `common::cpu::get_num_cpus()` — the number Qdrant already sizes itself by (cgroup CPU quota + `QDRANT_NUM_CPUS`).
- **`ram_size`** → `segment::utils::mem::total_memory_bytes()` — returns the cgroup memory limit when set (via `cgroups_rs`, cgroup v1/v2, resolving the process's own cgroup), otherwise the sysinfo host total. This is the same helper strict-mode already uses.
- **`disk_size`** → `common::disk_usage::disk_usage(storage_path)` — capacity of the filesystem hosting the storage path (the data volume), not the container root fs. Uses the existing TTL-cached reader; falls back to `sys_info::disk_info()`.

`ram_size` / `disk_size` stay in **KiB** to match the previous unit. `disk_size` remains **total capacity** (like the old field), only the measured filesystem changes.

### Caching / freshness

`Mem::new()` is not free (~100 µs: it builds a `sysinfo::System` and loads the cgroup memory controller), so `total_memory_bytes()` is cached. It uses a **5 s TTL** (matching the disk-usage cache) rather than caching once — so an **in-place** cgroup memory resize (k8s KEP-1287 / `docker update`) is reflected within a few seconds instead of only after a restart, consistent with how `cores` and `disk_size` already behave. The strict-mode helper in `collection` now delegates to this shared accessor (dropping its own `OnceLock`), so strict-mode memory checks become resize-aware too.

Measured per-call latency (release): `Mem::new()` ≈ **100 µs**, TTL-cache hit ≈ **28 ns**, static `OnceLock` ≈ **0.28 ns**. The TTL hit is ~3,500× cheaper than recomputing and effectively free vs. static, while keeping resize-awareness.

## Verification

**End-to-end, static values** — this branch's binary under `--cpus=2 --memory=1g` with storage on a 512 MiB tmpfs:

| Field | Stock `qdrant/qdrant:latest` | This branch | Enforced limit |
|---|---|---|---|
| `cores` | `22` (host) | `2` | `--cpus=2` ✅ |
| `ram_size` | `15968496` KiB (~15 GiB host) | `1048576` KiB | 1 GiB ✅ |
| `disk_size` | `981132795` KiB (host root fs) | `524288` KiB | 512 MiB volume ✅ |

**End-to-end, live resize** — start at `--memory=1g`, then `docker update --memory=2g` on the running container (same PID, no restart):

| Moment | cgroup `memory.max` | telemetry `ram_size` |
|---|---|---|
| t0 (1 GiB) | `1073741824` | `1048576` KiB ✅ |
| after `docker update --memory=2g` | `2147483648` | — |
| t+1 s (within TTL) | `2147483648` | `1048576` KiB (cached) |
| t+7 s (after TTL) | `2147483648` | `2097152` KiB ✅ refreshed live |

## Note for telemetry consumers

This **redefines** the meaning of `cores` / `ram_size` / `disk_size` from host to effective. Dashboards / analytics that assumed host values will see a discontinuity (old rows = host, new rows = effective).

`is_docker` is intentionally out of scope here — it detects Docker specifically via `/.dockerenv`, so it reads `false` under containerd/Kubernetes even when containerized. A container-aware replacement is a separate follow-up.
