### PR TITLE
skip zero runs when appending files to snapshot tar archives

### DIFF
--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -5,7 +5,6 @@ use common::fs::read_json;
 use common::storage_version::StorageVersion as _;
 use common::tar_ext::BuilderExt;
 use common::tar_unpack::tar_unpack_file;
-use fs_err::File;
 use segment::types::SnapshotFormat;
 use segment::utils::fs::move_all;
 use shard::files::PAYLOAD_INDEX_CONFIG_FILE;
@@ -80,7 +79,7 @@ impl Collection {
                 ))
             })?;
 
-        let tar = BuilderExt::new_seekable_owned(File::create(snapshot_temp_arc_file.path())?);
+        let tar = BuilderExt::new_file(snapshot_temp_arc_file.path())?;
 
         // Create snapshot of each shard
         {

--- a/lib/collection/src/shards/local_shard/snapshot_tests.rs
+++ b/lib/collection/src/shards/local_shard/snapshot_tests.rs
@@ -59,6 +59,7 @@ fn test_snapshot_all() {
         None,
     )
     .unwrap();
+    tar.blocking_finish().unwrap();
 
     let after_ids = holder
         .read()
@@ -146,6 +147,7 @@ fn test_snapshot_includes_segment_manifest() {
         None,
     )
     .unwrap();
+    tar.blocking_finish().unwrap();
 
     // The manifest sits at the snapshot root, next to (not inside) `segments/`.
     let manifest_entry_path = SEGMENT_MANIFEST_FILE.to_string();

--- a/lib/collection/src/shards/local_shard/snapshot_tests.rs
+++ b/lib/collection/src/shards/local_shard/snapshot_tests.rs
@@ -41,7 +41,7 @@ fn test_snapshot_all() {
     let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
     let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
     let snapshot_file = Builder::new().suffix(".snapshot.tar").tempfile().unwrap();
-    let tar = tar_ext::BuilderExt::new_seekable_owned(File::create(snapshot_file.path()).unwrap());
+    let tar = tar_ext::BuilderExt::new_file(snapshot_file.path()).unwrap();
 
     let payload_schema_file = dir.path().join("payload.schema");
     let schema: Arc<SaveOnDisk<PayloadIndexSchema>> =
@@ -114,7 +114,7 @@ fn test_snapshot_includes_segment_manifest() {
     let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
     let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
     let snapshot_file = Builder::new().suffix(".snapshot.tar").tempfile().unwrap();
-    let tar = tar_ext::BuilderExt::new_seekable_owned(File::create(snapshot_file.path()).unwrap());
+    let tar = tar_ext::BuilderExt::new_file(snapshot_file.path()).unwrap();
 
     let payload_schema_file = dir.path().join("payload.schema");
     let schema: Arc<SaveOnDisk<PayloadIndexSchema>> =

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -18,7 +18,7 @@ use common::save_on_disk::SaveOnDisk;
 use common::tar_ext::BuilderExt;
 use common::tar_unpack::tar_unpack_file;
 use fs_err as fs;
-use fs_err::{File, tokio as tokio_fs};
+use fs_err::tokio as tokio_fs;
 use futures::{Future, StreamExt, TryStreamExt as _, stream};
 use itertools::Itertools;
 use segment::json_path::JsonPath;
@@ -1170,7 +1170,7 @@ impl ShardHolder {
         let snapshots_path = snapshots_path.to_path_buf();
         let snapshot_manager = shard.get_snapshots_storage_manager()?;
 
-        let tar = BuilderExt::new_seekable_owned(File::create(temp_file.path())?);
+        let tar = BuilderExt::new_file(temp_file.path())?;
 
         let snapshot_creator = shard
             .create_snapshot(

--- a/lib/common/common/src/tar_ext.rs
+++ b/lib/common/common/src/tar_ext.rs
@@ -43,6 +43,12 @@ struct BlowFuseOnDrop<W: Write + Seek> {
 struct FusedWriteSeek<W> {
     output: W,
     enabled: Arc<AtomicBool>,
+    /// When true, all-zero writes are accumulated into `pending_hole` instead of
+    /// being written out. Only enabled while appending file contents; headers and
+    /// the archive footer are always written densely.
+    skip_holes: bool,
+    /// Bytes of an all-zero run not yet materialized in `output`.
+    pending_hole: u64,
 }
 
 impl<W: Write + Seek> BlowFuseOnDrop<W> {
@@ -58,26 +64,71 @@ impl<W: Write + Seek> Drop for BlowFuseOnDrop<W> {
     }
 }
 
-impl<W: Write> Write for FusedWriteSeek<W> {
+impl<W: Write + Seek> FusedWriteSeek<W> {
+    /// Materialize the pending all-zero run in `output`, by seeking over all but the
+    /// last byte and writing that byte, so the output has the exact logical length
+    /// even if nothing is written after the run. Falls back to writing the zeros for
+    /// non-seekable aka streaming outputs.
+    fn materialize_pending_hole(&mut self) -> io::Result<()> {
+        if self.pending_hole == 0 {
+            return Ok(());
+        }
+        let pending = self.pending_hole;
+        self.pending_hole = 0;
+        match self.output.seek(io::SeekFrom::Current(pending as i64 - 1)) {
+            Ok(_) => self.output.write_all(&[0]),
+            Err(err) if err.kind() == io::ErrorKind::NotSeekable => {
+                self.skip_holes = false;
+                write_zeros(&mut self.output, pending)
+            }
+            Err(err) => Err(err),
+        }
+    }
+}
+
+impl<W: Write + Seek> Write for FusedWriteSeek<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if !self.enabled.load(Ordering::Acquire) {
             // This error shouldn't be observable. It might appear only in
             // `tar::Builder::drop`, and will be ignored there.
             return Err(io::Error::other("Using WriteBox after it is disabled"));
         }
+        // Sparse storage files (e.g. preallocated mmap pages) are mostly holes, which
+        // the dense copy in `tar::Builder` reads as long runs of zeros. Skip them with
+        // a seek to keep the archive logically identical while only writing physical
+        // data. `tar`'s own sparse-entry support does this better (the extracted file
+        // is sparse again), but it only engages on Linux/Android/FreeBSD.
+        if self.skip_holes && !buf.is_empty() && buf.iter().all(|&byte| byte == 0) {
+            self.pending_hole += buf.len() as u64;
+            return Ok(buf.len());
+        }
+        self.materialize_pending_hole()?;
         self.output.write(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
         // This method is never called by `tar::Builder`.
+        self.materialize_pending_hole()?;
         self.output.flush()
     }
 }
 
-impl<W: Seek> Seek for FusedWriteSeek<W> {
+impl<W: Write + Seek> Seek for FusedWriteSeek<W> {
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        // Relative seeks must observe the true position.
+        self.materialize_pending_hole()?;
         self.output.seek(pos)
     }
+}
+
+fn write_zeros<W: Write>(output: &mut W, mut count: u64) -> io::Result<()> {
+    let zeros = [0u8; 4096];
+    while count > 0 {
+        let n = count.min(zeros.len() as u64) as usize;
+        output.write_all(&zeros[..n])?;
+        count -= n as u64;
+    }
+    Ok(())
 }
 
 impl BuilderExt<OwnedOutput> {
@@ -118,6 +169,8 @@ impl<W: Write + Seek> BuilderExt<W> {
                     tar::Builder::new(FusedWriteSeek {
                         output,
                         enabled: Arc::clone(&enabled),
+                        skip_holes: false,
+                        pending_hole: 0,
                     })
                     .tap_mut(|tar| tar.sparse(true)),
                 ),
@@ -173,10 +226,13 @@ impl<W: Write + Seek> BuilderExt<W> {
     /// Use [`BuilderExt::append_file`] instead.
     pub fn blocking_append_file(&self, src: &Path, dst: &Path) -> io::Result<()> {
         let dst = join_relative(&self.path, dst)?;
-        self.tar
-            .blocking_lock()
-            .tar()
-            .append_path_with_name(src, dst)
+        let mut tar = self.tar.blocking_lock();
+        let tar = tar.tar();
+        tar.get_mut().skip_holes = true;
+        let result = tar.append_path_with_name(src, dst);
+        let output = tar.get_mut();
+        output.skip_holes = false;
+        result.and(output.materialize_pending_hole())
     }
 
     /// Append a directory to the tar archive.
@@ -186,7 +242,13 @@ impl<W: Write + Seek> BuilderExt<W> {
     /// This function panics if called within an asynchronous execution context.
     pub fn blocking_append_dir_all(&self, src: &Path, dst: &Path) -> io::Result<()> {
         let dst = join_relative(&self.path, dst)?;
-        self.tar.blocking_lock().tar().append_dir_all(dst, src)
+        let mut tar = self.tar.blocking_lock();
+        let tar = tar.tar();
+        tar.get_mut().skip_holes = true;
+        let result = tar.append_dir_all(dst, src);
+        let output = tar.get_mut();
+        output.skip_holes = false;
+        result.and(output.materialize_pending_hole())
     }
 
     /// Append a new entry to the tar archive with the given file contents.
@@ -382,5 +444,97 @@ mod tests {
             .unwrap()
             .unwrap();
         tar.blocking_finish().unwrap();
+    }
+
+    // -------------------------------------------------------------------------
+    // --------------------------- Hole skipping tests -------------------------
+    // -------------------------------------------------------------------------
+
+    /// Counts the bytes physically written, to observe hole skipping.
+    struct CountingWriter {
+        inner: io::Cursor<Vec<u8>>,
+        written: u64,
+    }
+
+    impl Write for CountingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.written += buf.len() as u64;
+            self.inner.write(buf)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.inner.flush()
+        }
+    }
+
+    impl Seek for CountingWriter {
+        fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+            self.inner.seek(pos)
+        }
+    }
+
+    /// Contents mimicking a preallocated sparse storage page: data at the start,
+    /// a long run of zeros, data in the middle, and a zero run at the end.
+    fn zero_heavy_contents() -> Vec<u8> {
+        let mut contents = vec![0_u8; 4 * 1024 * 1024];
+        contents[..6].copy_from_slice(b"header");
+        contents[2 * 1024 * 1024..2 * 1024 * 1024 + 4].copy_from_slice(b"data");
+        contents
+    }
+
+    fn unpack_single_entry(archive: &[u8]) -> Vec<u8> {
+        let mut ar = tar::Archive::new(io::Cursor::new(archive));
+        let mut entries = ar.entries().unwrap();
+        let mut entry = entries.next().unwrap().unwrap();
+        let mut contents = Vec::new();
+        io::Read::read_to_end(&mut entry, &mut contents).unwrap();
+        assert!(entries.next().is_none());
+        contents
+    }
+
+    #[test]
+    fn test_append_file_skips_zero_runs() {
+        let contents = zero_heavy_contents();
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("page_0.dat");
+        std::fs::write(&src, &contents).unwrap();
+
+        let mut output = CountingWriter {
+            inner: io::Cursor::new(Vec::new()),
+            written: 0,
+        };
+        let tar = BuilderExt::new_seekable_borrowed(&mut output);
+        tar.blocking_append_file(&src, Path::new("page_0.dat"))
+            .unwrap();
+        tar.blocking_finish().unwrap();
+
+        // The archive is logically complete but the zero runs were seeked over,
+        // not written (headers + data + footer stay well under one zero run).
+        let archive = output.inner.into_inner();
+        assert!(archive.len() as u64 > contents.len() as u64);
+        assert!(
+            output.written < 64 * 1024,
+            "expected zero runs to be skipped, but {} bytes were written",
+            output.written
+        );
+
+        assert_eq!(unpack_single_entry(&archive), contents);
+    }
+
+    #[test]
+    fn test_append_file_streaming_writes_zero_runs() {
+        let contents = zero_heavy_contents();
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("page_0.dat");
+        std::fs::write(&src, &contents).unwrap();
+
+        // Streaming aka non-seekable output: holes must be written out as zeros.
+        let mut archive = Vec::new();
+        let tar = BuilderExt::new_streaming_borrowed(&mut archive);
+        tar.blocking_append_file(&src, Path::new("page_0.dat"))
+            .unwrap();
+        tar.blocking_finish().unwrap();
+
+        assert_eq!(unpack_single_entry(&archive), contents);
     }
 }

--- a/lib/common/common/src/tar_ext.rs
+++ b/lib/common/common/src/tar_ext.rs
@@ -5,9 +5,12 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use fs_err::File;
 use tap::Tap;
 use tokio::sync::Mutex;
 use tokio::task::JoinError;
+
+use crate::zeros::WriteZerosExt as _;
 
 /// A wrapper around [`tar::Builder`] that:
 /// 1. Usable both in sync and async contexts.
@@ -43,12 +46,6 @@ struct BlowFuseOnDrop<W: Write + Seek> {
 struct FusedWriteSeek<W> {
     output: W,
     enabled: Arc<AtomicBool>,
-    /// When true, all-zero writes are accumulated into `pending_hole` instead of
-    /// being written out. Only enabled while appending file contents; headers and
-    /// the archive footer are always written densely.
-    skip_holes: bool,
-    /// Bytes of an all-zero run not yet materialized in `output`.
-    pending_hole: u64,
 }
 
 impl<W: Write + Seek> BlowFuseOnDrop<W> {
@@ -64,75 +61,35 @@ impl<W: Write + Seek> Drop for BlowFuseOnDrop<W> {
     }
 }
 
-impl<W: Write + Seek> FusedWriteSeek<W> {
-    /// Materialize the pending all-zero run in `output`, by seeking over all but the
-    /// last byte and writing that byte, so the output has the exact logical length
-    /// even if nothing is written after the run. Falls back to writing the zeros for
-    /// non-seekable aka streaming outputs.
-    fn materialize_pending_hole(&mut self) -> io::Result<()> {
-        if self.pending_hole == 0 {
-            return Ok(());
-        }
-        let pending = self.pending_hole;
-        self.pending_hole = 0;
-        match self.output.seek(io::SeekFrom::Current(pending as i64 - 1)) {
-            Ok(_) => self.output.write_all(&[0]),
-            Err(err) if err.kind() == io::ErrorKind::NotSeekable => {
-                self.skip_holes = false;
-                write_zeros(&mut self.output, pending)
-            }
-            Err(err) => Err(err),
-        }
-    }
-}
-
-impl<W: Write + Seek> Write for FusedWriteSeek<W> {
+impl<W: Write> Write for FusedWriteSeek<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if !self.enabled.load(Ordering::Acquire) {
             // This error shouldn't be observable. It might appear only in
             // `tar::Builder::drop`, and will be ignored there.
             return Err(io::Error::other("Using WriteBox after it is disabled"));
         }
-        // Sparse storage files (e.g. preallocated mmap pages) are mostly holes, which
-        // the dense copy in `tar::Builder` reads as long runs of zeros. Skip them with
-        // a seek to keep the archive logically identical while only writing physical
-        // data. `tar`'s own sparse-entry support does this better (the extracted file
-        // is sparse again), but it only engages on Linux/Android/FreeBSD.
-        if self.skip_holes && !buf.is_empty() && buf.iter().all(|&byte| byte == 0) {
-            self.pending_hole += buf.len() as u64;
-            return Ok(buf.len());
-        }
-        self.materialize_pending_hole()?;
         self.output.write(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
         // This method is never called by `tar::Builder`.
-        self.materialize_pending_hole()?;
         self.output.flush()
     }
 }
 
-impl<W: Write + Seek> Seek for FusedWriteSeek<W> {
+impl<W: Seek> Seek for FusedWriteSeek<W> {
     fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
-        // Relative seeks must observe the true position.
-        self.materialize_pending_hole()?;
         self.output.seek(pos)
     }
 }
 
-fn write_zeros<W: Write>(output: &mut W, mut count: u64) -> io::Result<()> {
-    let zeros = [0u8; 4096];
-    while count > 0 {
-        let n = count.min(zeros.len() as u64) as usize;
-        output.write_all(&zeros[..n])?;
-        count -= n as u64;
-    }
-    Ok(())
-}
-
 impl BuilderExt<OwnedOutput> {
-    pub fn new_seekable_owned(output: impl Write + Seek + Send + 'static) -> Self {
+    pub fn new_file(path: &Path) -> io::Result<Self> {
+        let f = File::create(path)?;
+        Ok(Self::new_seekable_owned(SparseWriter::new(f)))
+    }
+
+    fn new_seekable_owned(output: impl Write + Seek + Send + 'static) -> Self {
         Self::new(Box::new(output))
     }
 
@@ -142,7 +99,8 @@ impl BuilderExt<OwnedOutput> {
 }
 
 impl<'a> BuilderExt<BorrowedOutput<'a>> {
-    pub fn new_seekable_borrowed(output: impl Write + Seek + 'a) -> Self {
+    #[cfg(test)]
+    fn new_seekable_borrowed(output: impl Write + Seek + 'a) -> Self {
         Self::new(Box::new(output))
     }
 
@@ -169,8 +127,6 @@ impl<W: Write + Seek> BuilderExt<W> {
                     tar::Builder::new(FusedWriteSeek {
                         output,
                         enabled: Arc::clone(&enabled),
-                        skip_holes: false,
-                        pending_hole: 0,
                     })
                     .tap_mut(|tar| tar.sparse(true)),
                 ),
@@ -226,13 +182,10 @@ impl<W: Write + Seek> BuilderExt<W> {
     /// Use [`BuilderExt::append_file`] instead.
     pub fn blocking_append_file(&self, src: &Path, dst: &Path) -> io::Result<()> {
         let dst = join_relative(&self.path, dst)?;
-        let mut tar = self.tar.blocking_lock();
-        let tar = tar.tar();
-        tar.get_mut().skip_holes = true;
-        let result = tar.append_path_with_name(src, dst);
-        let output = tar.get_mut();
-        output.skip_holes = false;
-        result.and(output.materialize_pending_hole())
+        self.tar
+            .blocking_lock()
+            .tar()
+            .append_path_with_name(src, dst)
     }
 
     /// Append a directory to the tar archive.
@@ -242,13 +195,7 @@ impl<W: Write + Seek> BuilderExt<W> {
     /// This function panics if called within an asynchronous execution context.
     pub fn blocking_append_dir_all(&self, src: &Path, dst: &Path) -> io::Result<()> {
         let dst = join_relative(&self.path, dst)?;
-        let mut tar = self.tar.blocking_lock();
-        let tar = tar.tar();
-        tar.get_mut().skip_holes = true;
-        let result = tar.append_dir_all(dst, src);
-        let output = tar.get_mut();
-        output.skip_holes = false;
-        result.and(output.materialize_pending_hole())
+        self.tar.blocking_lock().tar().append_dir_all(dst, src)
     }
 
     /// Append a new entry to the tar archive with the given file contents.
@@ -330,6 +277,105 @@ fn join_relative(base: &Path, rel_path: &Path) -> io::Result<PathBuf> {
     }
 
     Ok(base.join(rel_path))
+}
+
+/// [`Write`] impl that skips writing zero-byte sequences and uses [`Seek`]
+/// instead.
+///
+/// I.e. [`SparseWriter<File>`] writes tar archives as fs-sparse files.
+///
+/// Caveat: "doesn't write zeros" implies it wouldn't overwrite/clear old pre-
+/// existing data (if any). [`BuilderExt::new_file`] is OK because it wraps
+/// newly created empty file, and this module don't expose other ways to create
+/// [`SparseWriter`].
+///
+/// # Rationale
+///
+/// Terminology first:
+///
+/// - "fs-sparse" are files that are sparse on a filesystem level.
+///   E.g., Qdrant WAL files are usually sparse. Keywords: `lseek(SEEK_HOLE)`,
+///   see <https://en.wikipedia.org/wiki/Sparse_file>.
+///
+/// - "tar-sparse" entries - on-wire format that `tar` implementations use to
+///   encode sparse files. Keywords: tar header, `type='s'`, see
+///   <http://www.gnu.org/software/tar/manual/html_node/Sparse-Formats.html>.
+///
+/// The problem: On macOS, tar-rs doesn't (yet) encode fs-sparse files as
+/// tar-sparse entries, due to reliability issues.
+/// See <https://github.com/qdrant/qdrant/issues/9858>.
+///
+/// Our workaround: if we can't write tar archives with tar-sparse entries,
+/// let's write tar archives as fs-sparse files instead.
+struct SparseWriter<W: Write + Seek> {
+    output: W,
+    /// Bytes of an all-zero run not yet materialized in `output`.
+    pending_hole: u64,
+    /// True unless [`io::ErrorKind::NotSeekable`] encountered.
+    is_seekable: bool,
+}
+
+impl<W: Write + Seek> SparseWriter<W> {
+    fn new(output: W) -> Self {
+        Self {
+            output,
+            pending_hole: 0,
+            is_seekable: true,
+        }
+    }
+
+    fn materialize_pending_hole(&mut self) -> io::Result<()> {
+        match self.pending_hole {
+            0 => Ok(()),
+            // Avoid seeks for very small holes.
+            pending @ ..=4096 => {
+                self.pending_hole = 0;
+                self.output.write_zeros(pending as usize)
+            }
+            pending => {
+                self.pending_hole = 0;
+                match self.output.seek(io::SeekFrom::Current(pending as i64 - 1)) {
+                    Ok(_) => self.output.write_all(&[0]),
+                    Err(err) if err.kind() == io::ErrorKind::NotSeekable => {
+                        self.is_seekable = false;
+                        self.output.write_zeros(pending as usize)
+                    }
+                    Err(err) => Err(err),
+                }
+            }
+        }
+    }
+}
+
+impl<W: Write + Seek> Drop for SparseWriter<W> {
+    fn drop(&mut self) {
+        // We use `SparseWriter` only for `std::fs::File`, so it's crash-safe
+        // to performs writes in `Drop` (unlike `SyncIoBridge`).
+        let _ = self.materialize_pending_hole();
+    }
+}
+
+impl<W: Write + Seek> Write for SparseWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if self.is_seekable && !buf.is_empty() && buf.iter().all(|&byte| byte == 0) {
+            self.pending_hole += buf.len() as u64;
+            return Ok(buf.len());
+        }
+        self.materialize_pending_hole()?;
+        self.output.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.materialize_pending_hole()?;
+        self.output.flush()
+    }
+}
+
+impl<W: Write + Seek> Seek for SparseWriter<W> {
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        self.materialize_pending_hole()?;
+        self.output.seek(pos)
+    }
 }
 
 /// A wrapper that provides "dummy" [`io::Seek`] implementation to [`io::Write`] stream.
@@ -497,13 +543,13 @@ mod tests {
         let contents = zero_heavy_contents();
         let dir = tempfile::tempdir().unwrap();
         let src = dir.path().join("page_0.dat");
-        std::fs::write(&src, &contents).unwrap();
+        fs_err::write(&src, &contents).unwrap();
 
         let mut output = CountingWriter {
             inner: io::Cursor::new(Vec::new()),
             written: 0,
         };
-        let tar = BuilderExt::new_seekable_borrowed(&mut output);
+        let tar = BuilderExt::new_seekable_borrowed(SparseWriter::new(&mut output));
         tar.blocking_append_file(&src, Path::new("page_0.dat"))
             .unwrap();
         tar.blocking_finish().unwrap();
@@ -525,16 +571,16 @@ mod tests {
     fn test_append_dir_all_skips_zero_runs() {
         let dir = tempfile::tempdir().unwrap();
         let src = dir.path().join("storage");
-        std::fs::create_dir_all(src.join("nested")).unwrap();
+        fs_err::create_dir_all(src.join("nested")).unwrap();
         let contents = zero_heavy_contents();
-        std::fs::write(src.join("nested").join("page_0.dat"), &contents).unwrap();
-        std::fs::write(src.join("meta.json"), b"{}").unwrap();
+        fs_err::write(src.join("nested").join("page_0.dat"), &contents).unwrap();
+        fs_err::write(src.join("meta.json"), b"{}").unwrap();
 
         let mut output = CountingWriter {
             inner: io::Cursor::new(Vec::new()),
             written: 0,
         };
-        let tar = BuilderExt::new_seekable_borrowed(&mut output);
+        let tar = BuilderExt::new_seekable_borrowed(SparseWriter::new(&mut output));
         tar.blocking_append_dir_all(&src, Path::new("storage"))
             .unwrap();
         tar.blocking_finish().unwrap();
@@ -548,15 +594,13 @@ mod tests {
         );
 
         let unpack_dir = tempfile::tempdir().unwrap();
-        tar::Archive::new(io::Cursor::new(archive))
-            .unpack(unpack_dir.path())
-            .unwrap();
+        crate::tar_unpack::tar_unpack_reader(io::Cursor::new(archive), unpack_dir.path()).unwrap();
         let unpacked = unpack_dir.path().join("storage");
         assert_eq!(
-            std::fs::read(unpacked.join("nested").join("page_0.dat")).unwrap(),
+            fs_err::read(unpacked.join("nested").join("page_0.dat")).unwrap(),
             contents
         );
-        assert_eq!(std::fs::read(unpacked.join("meta.json")).unwrap(), b"{}");
+        assert_eq!(fs_err::read(unpacked.join("meta.json")).unwrap(), b"{}");
     }
 
     #[test]
@@ -564,15 +608,37 @@ mod tests {
         let contents = zero_heavy_contents();
         let dir = tempfile::tempdir().unwrap();
         let src = dir.path().join("page_0.dat");
-        std::fs::write(&src, &contents).unwrap();
+        fs_err::write(&src, &contents).unwrap();
 
         // Streaming aka non-seekable output: holes must be written out as zeros.
         let mut archive = Vec::new();
-        let tar = BuilderExt::new_streaming_borrowed(&mut archive);
+        let tar = BuilderExt::new_seekable_borrowed(SparseWriter::new(SeekWrapper(&mut archive)));
         tar.blocking_append_file(&src, Path::new("page_0.dat"))
             .unwrap();
         tar.blocking_finish().unwrap();
 
         assert_eq!(unpack_single_entry(&archive), contents);
+    }
+
+    #[test]
+    fn test_drop_without_finish_keeps_entry_data() {
+        let contents = zero_heavy_contents();
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("page_0.dat");
+        fs_err::write(&src, &contents).unwrap();
+        let archive_path = dir.path().join("archive.tar");
+
+        // ast-grep-ignore: tar-builder-unfinished
+        let tar = BuilderExt::new_file(&archive_path).unwrap();
+        tar.blocking_append_file(&src, Path::new("page_0.dat"))
+            .unwrap();
+        drop(tar);
+
+        let len = fs_err::metadata(&archive_path).unwrap().len();
+        assert!(
+            len >= contents.len() as u64,
+            "archive truncated to {len} bytes, the entry data alone is {} bytes",
+            contents.len(),
+        );
     }
 }

--- a/lib/common/common/src/tar_ext.rs
+++ b/lib/common/common/src/tar_ext.rs
@@ -522,6 +522,44 @@ mod tests {
     }
 
     #[test]
+    fn test_append_dir_all_skips_zero_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("storage");
+        std::fs::create_dir_all(src.join("nested")).unwrap();
+        let contents = zero_heavy_contents();
+        std::fs::write(src.join("nested").join("page_0.dat"), &contents).unwrap();
+        std::fs::write(src.join("meta.json"), b"{}").unwrap();
+
+        let mut output = CountingWriter {
+            inner: io::Cursor::new(Vec::new()),
+            written: 0,
+        };
+        let tar = BuilderExt::new_seekable_borrowed(&mut output);
+        tar.blocking_append_dir_all(&src, Path::new("storage"))
+            .unwrap();
+        tar.blocking_finish().unwrap();
+
+        let archive = output.inner.into_inner();
+        assert!(archive.len() as u64 > contents.len() as u64);
+        assert!(
+            output.written < 64 * 1024,
+            "expected zero runs to be skipped, but {} bytes were written",
+            output.written
+        );
+
+        let unpack_dir = tempfile::tempdir().unwrap();
+        tar::Archive::new(io::Cursor::new(archive))
+            .unpack(unpack_dir.path())
+            .unwrap();
+        let unpacked = unpack_dir.path().join("storage");
+        assert_eq!(
+            std::fs::read(unpacked.join("nested").join("page_0.dat")).unwrap(),
+            contents
+        );
+        assert_eq!(std::fs::read(unpacked.join("meta.json")).unwrap(), b"{}");
+    }
+
+    #[test]
     fn test_append_file_streaming_writes_zero_runs() {
         let contents = zero_heavy_contents();
         let dir = tempfile::tempdir().unwrap();

--- a/lib/common/common/src/tar_ext.rs
+++ b/lib/common/common/src/tar_ext.rs
@@ -83,6 +83,8 @@ impl<W: Seek> Seek for FusedWriteSeek<W> {
     }
 }
 
+/// NOTE: don't forget to explicitly finalize the archive with
+/// [`Self::finish`]/[`Self::blocking_finish`].
 impl BuilderExt<OwnedOutput> {
     pub fn new_file(path: &Path) -> io::Result<Self> {
         let f = File::create(path)?;
@@ -98,6 +100,7 @@ impl BuilderExt<OwnedOutput> {
     }
 }
 
+/// See the NOTE above.
 impl<'a> BuilderExt<BorrowedOutput<'a>> {
     #[cfg(test)]
     fn new_seekable_borrowed(output: impl Write + Seek + 'a) -> Self {
@@ -450,6 +453,7 @@ mod tests {
     #[tokio::test]
     async fn test_dummy_drop_fail() {
         let data = Arc::new(Mutex::new(Vec::new()));
+        // ast-grep-ignore: tar-builder-unfinished
         let tar = BuilderExt::new_seekable_owned(DummyBridgeWriter(true, Arc::clone(&data)));
         drop(tar);
         assert_eq!(data.lock().await.len(), 0);
@@ -458,6 +462,7 @@ mod tests {
     #[tokio::test]
     async fn test_dummy_drop_ok() {
         let data = Arc::new(Mutex::new(Vec::new()));
+        // ast-grep-ignore: tar-builder-unfinished
         let tar = BuilderExt::new_seekable_owned(DummyBridgeWriter(false, Arc::clone(&data)));
         drop(tar);
         assert_eq!(data.lock().await.len(), 0);
@@ -476,6 +481,7 @@ mod tests {
 
     #[test]
     fn test_write_fail() {
+        // ast-grep-ignore: tar-builder-unfinished
         let tar = BuilderExt::new_streaming_borrowed(Vec::new());
         tar.blocking_append_data(b"foo", Path::new("foo")).unwrap();
         let result = tar.blocking_write_fn(Path::new("foo"), |writer| writer.write_all(b"bar"));

--- a/lib/segment/src/segment/snapshot.rs
+++ b/lib/segment/src/segment/snapshot.rs
@@ -99,8 +99,14 @@ impl SnapshotEntry for Segment {
             SnapshotFormat::Regular => {
                 tar.blocking_write_fn(Path::new(&format!("{segment_id}.tar")), |writer| {
                     let tar = tar_ext::BuilderExt::new_streaming_borrowed(writer);
-                    let tar = tar.descend(Path::new(SNAPSHOT_PATH))?;
-                    snapshot_files(self, temp_path, &tar, include_if)
+                    snapshot_files(
+                        self,
+                        temp_path,
+                        &tar.descend(Path::new(SNAPSHOT_PATH))?,
+                        include_if,
+                    )?;
+                    tar.blocking_finish()?;
+                    OperationResult::Ok(())
                 })??;
             }
             SnapshotFormat::Streamable => {

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -11,7 +11,6 @@ use common::tar_ext;
 use common::tar_unpack::tar_unpack_file;
 use common::types::{DeferredBehavior, PointOffsetType};
 use fs_err as fs;
-use fs_err::File;
 use ordered_float::OrderedFloat;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
@@ -246,8 +245,7 @@ fn test_snapshot(#[case] format: SnapshotFormat) {
     segment.flush(true).unwrap();
 
     // snapshotting!
-    let tar =
-        tar_ext::BuilderExt::new_seekable_owned(File::create(parent_snapshot_tar.path()).unwrap());
+    let tar = tar_ext::BuilderExt::new_file(parent_snapshot_tar.path()).unwrap();
     segment
         .take_snapshot(temp_dir.path(), &tar, format, None)
         .unwrap();
@@ -367,8 +365,7 @@ fn test_snapshot_streamable_without_files_wrapper() {
     segment.flush(true).unwrap();
 
     // Take a streamable snapshot, which produces a `<segment_id>/files/...` layout.
-    let tar =
-        tar_ext::BuilderExt::new_seekable_owned(File::create(parent_snapshot_tar.path()).unwrap());
+    let tar = tar_ext::BuilderExt::new_file(parent_snapshot_tar.path()).unwrap();
     segment
         .take_snapshot(temp_dir.path(), &tar, SnapshotFormat::Streamable, None)
         .unwrap();

--- a/lib/segment/src/segment/tests/test_immutable_payload_index_files.rs
+++ b/lib/segment/src/segment/tests/test_immutable_payload_index_files.rs
@@ -484,7 +484,6 @@ fn payload_index_files_are_immutable_after_build() {
 fn snapshot_roundtrip_recovers_block_index_sidecars(#[case] format: crate::types::SnapshotFormat) {
     use common::tar_ext;
     use common::tar_unpack::tar_unpack_file;
-    use fs_err::File;
 
     use crate::entry::snapshot_entry::SnapshotEntry as _;
 
@@ -531,8 +530,7 @@ fn snapshot_roundtrip_recovers_block_index_sidecars(#[case] format: crate::types
         .suffix(".tar")
         .tempfile()
         .unwrap();
-    let tar =
-        tar_ext::BuilderExt::new_seekable_owned(File::create(parent_snapshot_tar.path()).unwrap());
+    let tar = tar_ext::BuilderExt::new_file(parent_snapshot_tar.path()).unwrap();
     segment
         .take_snapshot(snapshot_temp.path(), &tar, format, None)
         .unwrap();

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -8,7 +8,6 @@ use std::sync::atomic::AtomicBool;
 use common::tar_ext;
 use common::tar_unpack::tar_unpack_file;
 use fs_err as fs;
-use fs_err::File;
 use rstest::rstest;
 use segment::data_types::index::{IntegerIndexParams, KeywordIndexParams};
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, only_default_vector};
@@ -166,8 +165,7 @@ fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
         .unwrap();
 
     // snapshotting!
-    let tar =
-        tar_ext::BuilderExt::new_seekable_owned(File::create(parent_snapshot_tar.path()).unwrap());
+    let tar = tar_ext::BuilderExt::new_file(parent_snapshot_tar.path()).unwrap();
     segment
         .take_snapshot(temp_dir.path(), &tar, format, None)
         .unwrap();

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -505,7 +505,7 @@ fn test_take_snapshot() {
 
     let snapshot_file = Builder::new().suffix(".snapshot.tar").tempfile().unwrap();
     eprintln!("Snapshot into {:?}", snapshot_file.path());
-    let tar = tar_ext::BuilderExt::new_seekable_owned(File::create(snapshot_file.path()).unwrap());
+    let tar = tar_ext::BuilderExt::new_file(snapshot_file.path()).unwrap();
     let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
     let temp_dir2 = Builder::new().prefix("temp_dir").tempdir().unwrap();
     proxy_segment

--- a/tools/ast-grep/rules/tar-builder-unfinished.yml
+++ b/tools/ast-grep/rules/tar-builder-unfinished.yml
@@ -1,0 +1,63 @@
+id: tar-builder-unfinished
+language: rust
+severity: error
+message: >-
+  `tar_ext::BuilderExt` is constructed here, but never `finish()`ed in this
+  scope.
+note: |
+  `tar_ext::BuilderExt` does *not* finalize the archive on drop.
+  Call `blocking_finish()` (sync) or `finish().await` (async) on the builder
+  explicitly.
+ignores:
+  - lib/edge/publish/**
+utils:
+  # `fn` or closure body — the innermost one is the scope we search.
+  scope:
+    any:
+      - kind: function_item
+      - kind: closure_expression
+  # `$VAR.finish()` / `$VAR.blocking_finish()`. When the constructor result is
+  # not bound to a name, `$VAR` stays free and matches any receiver.
+  finish-call:
+    any:
+      - kind: call_expression
+        has:
+          field: function
+          kind: field_expression
+          all:
+            - has: { field: value, pattern: $VAR }
+            - has: { field: field, regex: '^(blocking_)?finish$' }
+      # Macro bodies are unparsed tokens, e.g. `assert!(tar.finish().await…)`.
+      - kind: token_tree
+        regex: '\.(blocking_)?finish\s*\('
+rule:
+  kind: call_expression
+  all:
+    # `[tar_ext::]BuilderExt::{new_file,new_{seekable,streaming}_{owned,borrowed}}(…)`
+    - has:
+        field: function
+        kind: scoped_identifier
+        all:
+          - has:
+              field: path
+              regex: '\bBuilderExt$'
+          - has:
+              field: name
+              regex: '^new_(file|(seekable|streaming)_(owned|borrowed))$'
+    # Bind the name the builder is stored under, if any. The constructor is
+    # usually wrapped in `?` or `.unwrap()`, so climb until the `let`, but not
+    # past the innermost scope.
+    - any:
+        - inside:
+            kind: let_declaration
+            stopBy: { matches: scope }
+            has: { field: pattern, pattern: $VAR }
+        - not:
+            inside:
+              kind: let_declaration
+              stopBy: { matches: scope }
+    - inside:
+        matches: scope
+        stopBy: { matches: scope }
+        not:
+          has: { matches: finish-call, stopBy: end }

--- a/tools/ast-grep/tests/tar-builder-unfinished.yml
+++ b/tools/ast-grep/tests/tar-builder-unfinished.yml
@@ -1,0 +1,67 @@
+id: tar-builder-unfinished
+valid:
+  # Bound builder, sync finish.
+  - |
+    fn pack(path: &Path) -> io::Result<()> {
+        let tar = tar_ext::BuilderExt::new_file(path)?;
+        tar.blocking_append_data(b"foo", Path::new("foo"))?;
+        tar.blocking_finish()
+    }
+  # Bound builder, async finish.
+  - |
+    async fn pack(path: &Path) -> io::Result<()> {
+        let tar = BuilderExt::new_file(path).unwrap();
+        tar.append_data(data, Path::new("foo")).await?;
+        tar.finish().await
+    }
+  # Unbound builder, chained finish.
+  - |
+    fn pack(path: &Path) -> io::Result<()> {
+        BuilderExt::new_file(path)?.blocking_finish()
+    }
+  # Finish inside a macro body.
+  - |
+    async fn pack(path: &Path) {
+        let tar = BuilderExt::new_file(path).unwrap();
+        assert!(tar.finish().await.is_ok());
+    }
+  # Finish inside a nested async block, still within the same fn.
+  - |
+    fn pack(temp_file: &NamedTempFile) -> CollectionResult<impl Future> {
+        let tar = BuilderExt::new_file(temp_file.path())?;
+        shard.create_snapshot(tar.clone())?;
+        Ok(async move {
+            tar.finish().await?;
+            Ok(())
+        })
+    }
+  # Same method name on a type other than BuilderExt.
+  - |
+    fn pack(path: &Path) -> io::Result<()> {
+        let writer = zip::Writer::new_file(path)?;
+        writer.blocking_append_data(b"foo", Path::new("foo"))
+    }
+invalid:
+  # Bound builder, never finished.
+  - |
+    fn pack(path: &Path) -> io::Result<()> {
+        let tar = tar_ext::BuilderExt::new_file(path)?;
+        tar.blocking_append_data(b"foo", Path::new("foo"))
+    }
+  # Streaming builder, never finished.
+  - |
+    fn pack(output: impl Write) {
+        let tar = BuilderExt::new_streaming_owned(output);
+        tar.blocking_append_data(b"foo", Path::new("foo")).unwrap();
+    }
+  # The builder in the closure is not finished; finishing the outer builder
+  # does not help.
+  - |
+    fn pack(tar: &tar_ext::BuilderExt, writer: &mut dyn Write) -> io::Result<()> {
+        tar.blocking_write_fn(Path::new("inner.tar"), |writer| {
+            let tar = tar_ext::BuilderExt::new_streaming_borrowed(writer);
+            let tar = tar.descend(Path::new("snapshot"))?;
+            snapshot_files(&tar)
+        })??;
+        tar.blocking_finish()
+    }


### PR DESCRIPTION
Fixes #9858 

Snapshot creation dense-copies sparse storage files on platforms where tar-rs's
sparse-entry support is not compiled (it is cfg-gated to Linux/Android/FreeBSD, so
macOS and Windows fall back). Preallocated 32 MiB pages (gridstore payload storage,
sparse vectors, text index) and WAL segments are mostly holes, so a 62 MB collection
produced ~5.6 GB of snapshot writes; background snapshots stalled 60–120 s and
tripped the model-testing harness's snapshot hang panic on macOS.

This change makes `blocking_append_file`/`blocking_append_dir_all` skip all-zero
write buffers with a forward seek, materializing each run exactly (seek to the last
byte, write it) before any non-zero write, external seek, flush, or the next entry.
The archive stays logically byte-identical — no format change, restore path
untouched — and non-seekable streaming outputs fall back to writing the zeros.
Headers and the archive footer are always written densely.

Verified with the soak seed from #9858: before, the run panicked with
`background snapshot did not finish within 120s`; after, it completes cleanly
(35,635 ops, 118 snapshots, ~31 min) with a stall watchdog confirming no snapshot
stalls, and a stack sample showing no tar frames during the only quiet period
(the end-of-run reload verification). Added unit tests for the write reduction
(counting writer: < 64 KiB physically written for a 4 MiB zero-heavy file) and the
streaming fallback roundtrip; segment/collection/shard snapshot suites pass.

A complementary upstream fix would be adding `target_os = "macos"` to tar-rs's
sparse cfg gates (APFS supports `SEEK_HOLE` and `_PC_MIN_HOLE_SIZE`); this change
stands on its own either way and also covers filesystems without hole reporting.


### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?


