### PR TITLE
chore: make `VectorStorageRead::read_vector_bytes` mandatory

### DIFF
--- a/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/appendable_dense_vector_storage.rs
@@ -202,6 +202,14 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapDenseVectorS
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.get_bitslice()
     }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        self.read_dense_bytes::<P, U>(keys, callback)
+    }
 }
 
 impl<T: PrimitiveVectorElement> VectorStorage for AppendableMmapDenseVectorStorage<T> {

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -13,7 +13,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::mmap;
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, MmapFs, Populate, UniversalRead};
+use common::universal_io::{MmapFile, MmapFs, Populate, UniversalRead, UserData};
 use fs_err::{File, OpenOptions};
 
 use crate::common::Flusher;
@@ -404,6 +404,14 @@ where
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.vectors.as_ref().unwrap().deleted_vector_bitslice()
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        self.read_dense_bytes::<P, U>(keys, callback)
     }
 }
 

--- a/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
@@ -7,6 +7,7 @@ use common::bitvec::{BitSlice, BitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
+use common::universal_io::UserData;
 
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -14,7 +15,8 @@ use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::{
-    DenseVectorStorage, DenseVectorStorageRead, VectorStorage, VectorStorageEnum, VectorStorageRead,
+    DenseVectorStorage, DenseVectorStorageRead, VectorStorage, VectorStorageEnum,
+    VectorStorageRead, default_read_vector_bytes_impl,
 };
 
 /// Placeholder vector storage that contains no data.
@@ -151,6 +153,14 @@ impl VectorStorageRead for EmptyDenseVectorStorage {
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted_bitvec.as_bitslice()
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        default_read_vector_bytes_impl::<Self, P, U>(self, keys, callback)
     }
 }
 

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/read_ops.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/read_ops.rs
@@ -3,9 +3,10 @@ use std::borrow::Cow;
 use common::bitvec::BitSlice;
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UserData};
 
 use super::ReadOnlyImmutableDenseVectorStorage;
+use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::types::{Distance, VectorStorageDatatype};
@@ -24,11 +25,11 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorStorageRead<T>
             .expect("vector not found")
     }
 
-    fn read_dense_bytes<P: AccessPattern, U: Copy + common::universal_io::UserData>(
+    fn read_dense_bytes<P: AccessPattern, U: Copy + UserData>(
         &self,
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
-    ) -> crate::common::operation_error::OperationResult<()> {
+    ) -> OperationResult<()> {
         let (user_data, keys): (Vec<_>, Vec<_>) = keys.into_iter().unzip();
         self.vectors.for_each_in_batch(&keys, |idx, dense| {
             let user_data = user_data[idx];
@@ -41,7 +42,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorStorageRead<T>
         &self,
         keys: &[PointOffsetType],
         f: F,
-    ) -> crate::common::operation_error::OperationResult<()> {
+    ) -> OperationResult<()> {
         self.vectors.for_each_in_batch(keys, f)
     }
 }
@@ -97,6 +98,14 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
         self.vectors
             .get_vector_opt::<P>(key)
             .map(|vector| T::slice_to_float_cow(vector).into())
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        self.read_dense_bytes::<P, U>(keys, callback)
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {

--- a/lib/segment/src/vector_storage/dense/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/read_ops.rs
@@ -112,4 +112,12 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.as_bitslice()
     }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        self.read_dense_bytes::<P, U>(keys, callback)
+    }
 }

--- a/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
@@ -6,6 +6,7 @@ use common::bitvec::{BitSlice, BitSliceExt as _, BitVec, bitvec_set_deleted};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
+use common::universal_io::UserData;
 
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationResult, check_process_stopped};
@@ -16,7 +17,7 @@ use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::volatile_chunked_vectors::VolatileChunkedVectors;
 use crate::vector_storage::{
     DenseVectorStorage, DenseVectorStorageRead, VectorOffsetType, VectorStorage, VectorStorageEnum,
-    VectorStorageRead,
+    VectorStorageRead, default_read_vector_bytes_impl,
 };
 
 /// In-memory vector storage that is volatile
@@ -146,6 +147,14 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for VolatileDenseVectorStorage
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.as_bitslice()
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        default_read_vector_bytes_impl::<Self, P, U>(self, keys, callback)
     }
 }
 

--- a/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/appendable_mmap_multi_dense_vector_storage.rs
@@ -184,6 +184,25 @@ impl<T: PrimitiveVectorElement> AppendableMmapMultiDenseVectorStorage<T> {
         Ok(())
     }
 
+    fn for_each_flat_multi<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, Cow<'_, [T]>),
+    ) -> OperationResult<()> {
+        let row_offsets = self.offsets.resolve_rows::<P, _, _>(
+            keys.into_iter()
+                .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset)),
+        );
+
+        self.vectors.for_each_vector::<P, _>(
+            row_offsets.into_iter(),
+            |(user_data, point_offset), flattened| {
+                callback(user_data, point_offset, flattened);
+                Ok(())
+            },
+        )
+    }
+
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> OperationResult<()> {
@@ -332,26 +351,14 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapMultiDenseVe
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
     ) {
-        // Resolve offsets through the buffer first (so unflushed writes are seen),
-        // then reuse the row-side prefetch reader over `vectors`.
-        let row_offsets = self.offsets.resolve_rows::<P, _, _>(
-            keys.into_iter()
-                .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset)),
-        );
+        self.for_each_flat_multi::<P, U>(keys, |user_data, point_offset, flattened| {
+            let vector = CowVector::MultiDense(T::into_float_multivector(
+                flattened_to_multi_vector(flattened, self.vectors.dim()),
+            ));
 
-        self.vectors
-            .for_each_vector::<P, _>(
-                row_offsets.into_iter(),
-                |(user_data, point_offset), flattened| {
-                    let vector = CowVector::MultiDense(T::into_float_multivector(
-                        flattened_to_multi_vector(flattened, self.vectors.dim()),
-                    ));
-
-                    callback(user_data, point_offset, vector);
-                    Ok(())
-                },
-            )
-            .expect("read vectors");
+            callback(user_data, point_offset, vector);
+        })
+        .expect("read vectors");
     }
 
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
@@ -370,6 +377,20 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for AppendableMmapMultiDenseVe
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.get_bitslice()
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        self.for_each_flat_multi::<P, U>(keys, |user_data, point_offset, flattened| {
+            callback(
+                user_data,
+                point_offset,
+                bytemuck::cast_slice(flattened.as_ref()).to_vec(),
+            );
+        })
     }
 }
 

--- a/lib/segment/src/vector_storage/multi_dense/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/read_ops.rs
@@ -6,6 +6,7 @@ use common::types::PointOffsetType;
 use common::universal_io::{UniversalRead, UserData};
 
 use super::ReadOnlyChunkedMultiDenseVectorStorage;
+use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::{CowMultiVector, CowVector};
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::TypedMultiDenseVectorRef;
@@ -14,6 +15,28 @@ use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_stora
     flattened_to_multi_vector, read_multi_vector,
 };
 use crate::vector_storage::{MultiVectorStorageRead, VectorOffsetType, VectorStorageRead};
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyChunkedMultiDenseVectorStorage<T, S> {
+    fn for_each_flat_multi<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, &[T]),
+    ) -> OperationResult<()> {
+        let point_offsets = keys
+            .into_iter()
+            .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset));
+
+        super::for_each_vector::<P, _, _, _>(
+            &self.offsets,
+            &self.vectors,
+            point_offsets,
+            |(user_data, point_offset), flattened| {
+                callback(user_data, point_offset, flattened);
+                Ok(())
+            },
+        )
+    }
+}
 
 impl<T: PrimitiveVectorElement, S: UniversalRead> MultiVectorStorageRead<T>
     for ReadOnlyChunkedMultiDenseVectorStorage<T, S>
@@ -107,23 +130,13 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
     ) {
-        let point_offsets = keys
-            .into_iter()
-            .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset));
+        self.for_each_flat_multi::<P, U>(keys, |user_data, point_offset, flattened| {
+            let vector = CowVector::MultiDense(T::into_float_multivector(
+                flattened_to_multi_vector(Cow::Borrowed(flattened), self.vectors.dim()),
+            ));
 
-        super::for_each_vector::<P, _, _, _>(
-            &self.offsets,
-            &self.vectors,
-            point_offsets,
-            |(user_data, point_offset), flattened| {
-                let vector = CowVector::MultiDense(T::into_float_multivector(
-                    flattened_to_multi_vector(Cow::Borrowed(flattened), self.vectors.dim()),
-                ));
-
-                callback(user_data, point_offset, vector);
-                Ok(())
-            },
-        )
+            callback(user_data, point_offset, vector);
+        })
         .expect("read vectors");
     }
 
@@ -142,5 +155,19 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.as_bitslice()
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        self.for_each_flat_multi::<P, U>(keys, |user_data, point_offset, flattened| {
+            callback(
+                user_data,
+                point_offset,
+                bytemuck::cast_slice(flattened).to_vec(),
+            );
+        })
     }
 }

--- a/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/multi_dense/volatile_multi_dense_vector_storage.rs
@@ -7,6 +7,7 @@ use common::bitvec::{BitSlice, BitSliceExt as _, BitVec, bitvec_set_deleted};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
+use common::universal_io::UserData;
 
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
@@ -18,7 +19,7 @@ use crate::vector_storage::common::CHUNK_SIZE;
 use crate::vector_storage::volatile_chunked_vectors::VolatileChunkedVectors;
 use crate::vector_storage::{
     MultiVectorStorage, MultiVectorStorageRead, VectorOffsetType, VectorStorage, VectorStorageEnum,
-    VectorStorageRead,
+    VectorStorageRead, default_read_vector_bytes_impl,
 };
 
 /// All fields are counting vectors and not dimensions.
@@ -317,6 +318,14 @@ impl<T: PrimitiveVectorElement> VectorStorageRead for VolatileMultiDenseVectorSt
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.as_bitslice()
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        default_read_vector_bytes_impl::<Self, P, U>(self, keys, callback)
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_write.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_write.rs
@@ -5,7 +5,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random};
 use common::mmap::{Advice, AdviceSetting, MmapFlusher};
 use common::types::PointOffsetType;
-use common::universal_io::{MmapFile, Populate, UniversalWrite};
+use common::universal_io::{MmapFile, Populate, UniversalWrite, UserData};
 
 use crate::common::operation_error::OperationResult;
 use crate::vector_storage::VectorOffsetType;
@@ -64,6 +64,22 @@ impl<S: UniversalWrite + Send + 'static> QuantizedChunkedStorage<S> {
         P: AccessPattern,
     {
         self.data.get_many::<P>(index as usize, count)
+    }
+
+    /// Batched counterpart of [`Self::get_many`]: invoke `callback` with the
+    /// concatenated records of each `(user_data, start, count)` range, batching
+    /// the underlying reads. Like [`Self::get_many`], a range must not
+    /// straddle a chunk boundary.
+    pub fn for_each_many<P, U>(
+        &self,
+        ranges: impl Iterator<Item = (U, PointOffsetType, u32)>,
+        callback: impl FnMut(U, Cow<'_, [u8]>) -> OperationResult<()>,
+    ) -> OperationResult<()>
+    where
+        P: AccessPattern,
+        U: UserData,
+    {
+        self.data.for_each_vector::<P, _>(ranges, callback)
     }
 }
 

--- a/lib/segment/src/vector_storage/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/read_only/read_ops.rs
@@ -239,4 +239,48 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             }
         }
     }
+
+    fn available_vector_count(&self) -> usize {
+        match self {
+            VectorStorageReadEnum::Dense(s) => s.available_vector_count(),
+            VectorStorageReadEnum::DenseByte(s) => s.available_vector_count(),
+            VectorStorageReadEnum::DenseHalf(s) => s.available_vector_count(),
+            VectorStorageReadEnum::DenseChunked(s) => s.available_vector_count(),
+            VectorStorageReadEnum::DenseChunkedByte(s) => s.available_vector_count(),
+            VectorStorageReadEnum::DenseChunkedHalf(s) => s.available_vector_count(),
+            VectorStorageReadEnum::MultiDenseChunked(s) => s.available_vector_count(),
+            VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.available_vector_count(),
+            VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.available_vector_count(),
+            VectorStorageReadEnum::Sparse(s) => s.available_vector_count(),
+        }
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        match self {
+            VectorStorageReadEnum::Dense(s) => s.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageReadEnum::DenseByte(s) => s.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageReadEnum::DenseHalf(s) => s.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageReadEnum::DenseChunked(s) => s.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageReadEnum::DenseChunkedByte(s) => {
+                s.read_vector_bytes::<P, U>(keys, callback)
+            }
+            VectorStorageReadEnum::DenseChunkedHalf(s) => {
+                s.read_vector_bytes::<P, U>(keys, callback)
+            }
+            VectorStorageReadEnum::MultiDenseChunked(s) => {
+                s.read_vector_bytes::<P, U>(keys, callback)
+            }
+            VectorStorageReadEnum::MultiDenseChunkedByte(s) => {
+                s.read_vector_bytes::<P, U>(keys, callback)
+            }
+            VectorStorageReadEnum::MultiDenseChunkedHalf(s) => {
+                s.read_vector_bytes::<P, U>(keys, callback)
+            }
+            VectorStorageReadEnum::Sparse(s) => s.read_vector_bytes::<P, U>(keys, callback),
+        }
+    }
 }

--- a/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
@@ -7,6 +7,7 @@ use common::bitvec::{BitSlice, BitVec};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
+use common::universal_io::UserData;
 use sparse::common::sparse_vector::SparseVector;
 
 use crate::common::Flusher;
@@ -17,7 +18,7 @@ use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::sparse::SPARSE_VECTOR_DISTANCE;
 use crate::vector_storage::{
     SparseVectorStorage, SparseVectorStorageRead, VectorStorage, VectorStorageEnum,
-    VectorStorageRead,
+    VectorStorageRead, default_read_vector_bytes_impl,
 };
 
 /// Placeholder sparse vector storage that contains no data.
@@ -128,6 +129,14 @@ impl VectorStorageRead for EmptySparseVectorStorage {
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted_bitvec.as_bitslice()
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        default_read_vector_bytes_impl::<Self, P, U>(self, keys, callback)
     }
 }
 

--- a/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/mmap_sparse_vector_storage.rs
@@ -10,8 +10,8 @@ use common::iterator_ext::IteratorExt;
 use common::types::PointOffsetType;
 use common::universal_io::{MmapFile, MmapFs, Populate, UserData};
 use fs_err as fs;
-use gridstore::Gridstore;
 use gridstore::config::{Compression, StorageOptions};
+use gridstore::{Blob, Gridstore};
 use sparse::common::sparse_vector::SparseVector;
 
 use crate::common::flags::bitvec_flags::BitvecFlags;
@@ -328,6 +328,28 @@ impl VectorStorageRead for MmapSparseVectorStorage {
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.get_bitslice()
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        // Same batched pass as `read_vectors`, re-serializing the stored form
+        // instead of decoding it into a `SparseVector`.
+        self.storage.read_values::<P, _, _>(
+            keys.into_iter(),
+            move |user_data, point_offset, stored| {
+                let Some(stored) = stored else {
+                    return Ok(());
+                };
+
+                // TODO(uio): allow gridstore to return plain bytes.
+                callback(user_data, point_offset, Blob::to_bytes(&stored));
+                Ok(())
+            },
+            HardwareCounterCell::disposable().vector_io_read(),
+        )
     }
 }
 

--- a/lib/segment/src/vector_storage/sparse/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/read_ops.rs
@@ -3,6 +3,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random};
 use common::types::PointOffsetType;
 use common::universal_io::{UniversalRead, UserData};
+use gridstore::Blob;
 use sparse::common::sparse_vector::SparseVector;
 
 use super::ReadOnlySparseVectorStorage;
@@ -124,5 +125,27 @@ impl<S: UniversalRead> VectorStorageRead for ReadOnlySparseVectorStorage<S> {
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.as_bitslice()
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        // Same batched pass as `read_vectors`, re-serializing the stored form
+        // instead of decoding it into a `SparseVector`.
+        self.storage.read_values::<P, _, _>(
+            keys.into_iter(),
+            move |user_data, point_offset, stored| {
+                let Some(stored) = stored else {
+                    return Ok(());
+                };
+
+                // TODO(uio): allow gridstore to return plain bytes.
+                callback(user_data, point_offset, Blob::to_bytes(&stored));
+                Ok(())
+            },
+            HardwareCounterCell::disposable().vector_io_read(),
+        )
     }
 }

--- a/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/volatile_sparse_vector_storage.rs
@@ -6,6 +6,7 @@ use common::bitvec::{BitSlice, BitSliceExt as _, BitVec, bitvec_set_deleted};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random};
 use common::types::PointOffsetType;
+use common::universal_io::UserData;
 use sparse::common::sparse_vector::SparseVector;
 use sparse::common::types::{DimId, DimWeight};
 
@@ -16,7 +17,7 @@ use crate::data_types::vectors::VectorRef;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::{
     SparseVectorStorage, SparseVectorStorageRead, VectorStorage, VectorStorageEnum,
-    VectorStorageRead,
+    VectorStorageRead, default_read_vector_bytes_impl,
 };
 
 pub const SPARSE_VECTOR_DISTANCE: Distance = Distance::Dot;
@@ -198,6 +199,14 @@ impl VectorStorageRead for VolatileSparseVectorStorage {
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.as_bitslice()
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        default_read_vector_bytes_impl::<Self, P, U>(self, keys, callback)
     }
 }
 

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -435,6 +435,14 @@ impl VectorStorageRead for TurboVectorStorage {
     fn deleted_vector_bitslice(&self) -> &BitSlice {
         self.deleted.get_bitslice()
     }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        self.read_dense_tq_bytes::<P, U>(keys, callback)
+    }
 }
 
 impl VectorStorage for TurboVectorStorage {

--- a/lib/segment/src/vector_storage/turbo/multi.rs
+++ b/lib/segment/src/vector_storage/turbo/multi.rs
@@ -17,7 +17,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random};
 use common::mmap::AdviceSetting;
 use common::types::{PointOffsetType, ScoreType};
-use common::universal_io::{MmapFile, MmapFs, Populate};
+use common::universal_io::{MmapFile, MmapFs, Populate, UserData};
 use quantization::EncodedStorage;
 use quantization::turboquant::EncodedQueryTQ;
 use quantization::turboquant::quantization::TurboQuantizer;
@@ -229,15 +229,53 @@ impl TurboMultiVectorStorage {
 
     /// Decode the full multivector behind an offset record.
     fn dequantize_multi(&self, offset: MultivectorMmapOffset) -> CowVector<'_> {
-        let mut flattened = Vec::with_capacity(offset.count as usize * self.dim);
-        for inner_id in offset.offset..offset.offset + offset.count {
-            let encoded = self.storage.get_vector_data(inner_id);
-            self.dequantize_inner_into(&encoded, &mut flattened);
+        let records = self
+            .storage
+            .get_many::<Random>(offset.offset, offset.count as usize)
+            // SAFETY: `fresh_range_start` guarantees ranges never straddle across a boundary.
+            .expect("Multivector not found");
+        self.dequantize_records(&records)
+    }
+
+    /// Decode concatenated encoded records (the
+    /// [`MultiTQVectorStorage::get_multi_tq`] form) into a multivector.
+    fn dequantize_records(&self, records: &[u8]) -> CowVector<'_> {
+        let record_size = self.quantizer.quantized_size();
+        let mut flattened = Vec::with_capacity(records.len() / record_size * self.dim);
+        for encoded in records.chunks_exact(record_size) {
+            self.dequantize_inner_into(encoded, &mut flattened);
         }
         CowVector::MultiDense(CowMultiVector::Owned(TypedMultiDenseVector {
             flattened_vectors: flattened,
             dim: self.dim,
         }))
+    }
+
+    /// Two-pass batched read for records. First offsets, then vectors.
+    fn for_each_record_range<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, &[u8]),
+    ) -> OperationResult<()> {
+        let offset_keys = keys
+            .into_iter()
+            .map(|(user_data, key)| ((user_data, key), key, 1));
+
+        let mut ranges = Vec::with_capacity(offset_keys.size_hint().0);
+        self.offsets
+            .for_each_vector::<P, _>(offset_keys, |(user_data, key), record| {
+                let &[offset] = record.as_ref() else {
+                    unreachable!("multi-vector offsets are stored as vectors of length 1");
+                };
+                ranges.push(((user_data, key), offset.offset, offset.count));
+                Ok(())
+            })?;
+
+        self.storage
+            .for_each_many::<P, _>(ranges.into_iter(), |(user_data, key), records| {
+                callback(user_data, key, records.as_ref());
+                Ok(())
+            })
     }
 
     /// Start of a fresh range for `count` records, never straddling a chunk
@@ -538,6 +576,28 @@ impl VectorStorageRead for TurboMultiVectorStorage {
         } else {
             0
         }
+    }
+
+    fn read_vectors<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
+    ) {
+        self.for_each_record_range::<P, _>(keys, |user_data, key, records| {
+            callback(user_data, key, self.dequantize_records(records));
+        })
+        .expect("read TQ multivectors");
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        self.for_each_record_range::<P, _>(keys, |user_data, key, records| {
+            // Concatenated encoded records per point
+            callback(user_data, key, records.to_vec());
+        })
     }
 }
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -182,24 +182,37 @@ pub trait VectorStorageRead {
     /// the storage-native serialized bytes of each vector. Offsets without a
     /// stored value are skipped; storage read failures propagate as errors.
     ///
-    /// The default reads one vector at a time; [`VectorStorageEnum`] routes
-    /// dense storages through their batched
-    /// [`DenseVectorStorageRead::read_dense_bytes`] readers, so bulk raw reads
-    /// keep the same read pipelining as [`Self::read_vectors`] (io_uring
-    /// submission batching for on-disk storages).
+    /// On-disk storages batch the underlying reads, so bulk raw reads keep the
+    /// same read pipelining as [`Self::read_vectors`] (io_uring submission
+    /// batching / mmap prefetch). In-RAM storages with no batched reader opt
+    /// into [`default_read_vector_bytes_impl`] explicitly.
     fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
         &self,
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
-        mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
-    ) -> OperationResult<()> {
-        for (user_data, key) in keys {
-            let Some(bytes) = self.vector_bytes_opt::<P>(key)? else {
-                continue;
-            };
-            callback(user_data, key, bytes);
-        }
-        Ok(())
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()>;
+}
+
+/// Per-key fallback for [`VectorStorageRead::read_vector_bytes`], for storages
+/// without a batched byte reader: one [`VectorStorageRead::vector_bytes_opt`]
+/// read per offset, no pipelining.
+pub fn default_read_vector_bytes_impl<VS, P, U>(
+    vector_storage: &VS,
+    keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+    mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+) -> OperationResult<()>
+where
+    VS: VectorStorageRead + ?Sized,
+    P: AccessPattern,
+    U: Copy + UserData,
+{
+    for (user_data, key) in keys {
+        let Some(bytes) = vector_storage.vector_bytes_opt::<P>(key)? else {
+            continue;
+        };
+        callback(user_data, key, bytes);
     }
+    Ok(())
 }
 
 /// Trait for vector storage with mutating operations.
@@ -953,23 +966,6 @@ fn insert_sparse_bytes<S: VectorStorage>(
     storage.insert_vector(key, VectorRef::from(&sparse), hw_counter)
 }
 
-/// Per-key fallback for [`VectorStorageRead::read_vector_bytes`], for storages
-/// without a batched byte reader: one read per offset, no pipelining.
-/// Offsets without a stored value are skipped.
-fn read_vector_bytes_one_by_one<P: AccessPattern, U: Copy + UserData>(
-    storage: &VectorStorageEnum,
-    keys: impl IntoIterator<Item = (U, PointOffsetType)>,
-    mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
-) -> OperationResult<()> {
-    for (user_data, key) in keys {
-        let Some(bytes) = storage.vector_bytes_opt::<P>(key)? else {
-            continue;
-        };
-        callback(user_data, key, bytes);
-    }
-    Ok(())
-}
-
 impl VectorStorageRead for VectorStorageEnum {
     fn with_vector_bytes_opt<P: AccessPattern, R>(
         &self,
@@ -1077,51 +1073,54 @@ impl VectorStorageRead for VectorStorageEnum {
         callback: impl FnMut(U, PointOffsetType, Vec<u8>),
     ) -> OperationResult<()> {
         match self {
-            // Dense storages have batched byte readers that keep the read
-            // pipelining of `read_vectors`.
-            VectorStorageEnum::DenseVolatile(v) => v.read_dense_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::DenseVolatile(v) => v.read_vector_bytes::<P, U>(keys, callback),
             #[cfg(test)]
-            VectorStorageEnum::DenseVolatileByte(v) => v.read_dense_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::DenseVolatileByte(v) => v.read_vector_bytes::<P, U>(keys, callback),
             #[cfg(test)]
-            VectorStorageEnum::DenseVolatileHalf(v) => v.read_dense_bytes::<P, U>(keys, callback),
-            VectorStorageEnum::DenseMemmap(v) => v.read_dense_bytes::<P, U>(keys, callback),
-            VectorStorageEnum::DenseMemmapByte(v) => v.read_dense_bytes::<P, U>(keys, callback),
-            VectorStorageEnum::DenseMemmapHalf(v) => v.read_dense_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::DenseVolatileHalf(v) => v.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::DenseMemmap(v) => v.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::DenseMemmapByte(v) => v.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::DenseMemmapHalf(v) => v.read_vector_bytes::<P, U>(keys, callback),
 
             #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUring(v) => v.read_dense_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::DenseUring(v) => v.read_vector_bytes::<P, U>(keys, callback),
             #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringByte(v) => v.read_dense_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::DenseUringByte(v) => v.read_vector_bytes::<P, U>(keys, callback),
             #[cfg(target_os = "linux")]
-            VectorStorageEnum::DenseUringHalf(v) => v.read_dense_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::DenseUringHalf(v) => v.read_vector_bytes::<P, U>(keys, callback),
 
             VectorStorageEnum::DenseAppendableMemmap(v) => {
-                v.read_dense_bytes::<P, U>(keys, callback)
+                v.read_vector_bytes::<P, U>(keys, callback)
             }
             VectorStorageEnum::DenseAppendableMemmapByte(v) => {
-                v.read_dense_bytes::<P, U>(keys, callback)
+                v.read_vector_bytes::<P, U>(keys, callback)
             }
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => {
-                v.read_dense_bytes::<P, U>(keys, callback)
+                v.read_vector_bytes::<P, U>(keys, callback)
             }
-            VectorStorageEnum::DenseTurbo(v) => v.read_dense_tq_bytes::<P, U>(keys, callback),
-            // No batched byte readers here (yet): sparse and multi-dense read
-            // one vector at a time.
-            VectorStorageEnum::SparseVolatile(_)
-            | VectorStorageEnum::SparseMmap(_)
-            | VectorStorageEnum::MultiDenseVolatile(_)
-            | VectorStorageEnum::MultiDenseAppendableMemmap(_)
-            | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
-            | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
-            | VectorStorageEnum::MultiDenseTurbo(_)
-            | VectorStorageEnum::EmptyDense(_)
-            | VectorStorageEnum::EmptySparse(_) => {
-                read_vector_bytes_one_by_one::<P, U>(self, keys, callback)
+            VectorStorageEnum::DenseTurbo(v) => v.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::SparseMmap(v) => v.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => {
+                v.read_vector_bytes::<P, U>(keys, callback)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => {
+                v.read_vector_bytes::<P, U>(keys, callback)
+            }
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => {
+                v.read_vector_bytes::<P, U>(keys, callback)
+            }
+            VectorStorageEnum::MultiDenseTurbo(v) => v.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::SparseVolatile(v) => v.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::MultiDenseVolatile(v) => v.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::EmptyDense(v) => v.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::EmptySparse(v) => v.read_vector_bytes::<P, U>(keys, callback),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileByte(v) => {
+                v.read_vector_bytes::<P, U>(keys, callback)
             }
             #[cfg(test)]
-            VectorStorageEnum::MultiDenseVolatileByte(_)
-            | VectorStorageEnum::MultiDenseVolatileHalf(_) => {
-                read_vector_bytes_one_by_one::<P, U>(self, keys, callback)
+            VectorStorageEnum::MultiDenseVolatileHalf(v) => {
+                v.read_vector_bytes::<P, U>(keys, callback)
             }
         }
     }
@@ -1571,6 +1570,44 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::MultiDenseTurbo(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::EmptyDense(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::EmptySparse(v) => v.deleted_vector_bitslice(),
+        }
+    }
+
+    fn available_vector_count(&self) -> usize {
+        match self {
+            VectorStorageEnum::DenseVolatile(v) => v.available_vector_count(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileByte(v) => v.available_vector_count(),
+            #[cfg(test)]
+            VectorStorageEnum::DenseVolatileHalf(v) => v.available_vector_count(),
+            VectorStorageEnum::DenseMemmap(v) => v.available_vector_count(),
+            VectorStorageEnum::DenseMemmapByte(v) => v.available_vector_count(),
+            VectorStorageEnum::DenseMemmapHalf(v) => v.available_vector_count(),
+
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUring(v) => v.available_vector_count(),
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringByte(v) => v.available_vector_count(),
+            #[cfg(target_os = "linux")]
+            VectorStorageEnum::DenseUringHalf(v) => v.available_vector_count(),
+
+            VectorStorageEnum::DenseAppendableMemmap(v) => v.available_vector_count(),
+            VectorStorageEnum::DenseAppendableMemmapByte(v) => v.available_vector_count(),
+            VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.available_vector_count(),
+            VectorStorageEnum::DenseTurbo(v) => v.available_vector_count(),
+            VectorStorageEnum::SparseVolatile(v) => v.available_vector_count(),
+            VectorStorageEnum::SparseMmap(v) => v.available_vector_count(),
+            VectorStorageEnum::MultiDenseVolatile(v) => v.available_vector_count(),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileByte(v) => v.available_vector_count(),
+            #[cfg(test)]
+            VectorStorageEnum::MultiDenseVolatileHalf(v) => v.available_vector_count(),
+            VectorStorageEnum::MultiDenseAppendableMemmap(v) => v.available_vector_count(),
+            VectorStorageEnum::MultiDenseAppendableMemmapByte(v) => v.available_vector_count(),
+            VectorStorageEnum::MultiDenseAppendableMemmapHalf(v) => v.available_vector_count(),
+            VectorStorageEnum::MultiDenseTurbo(v) => v.available_vector_count(),
+            VectorStorageEnum::EmptyDense(v) => v.available_vector_count(),
+            VectorStorageEnum::EmptySparse(v) => v.available_vector_count(),
         }
     }
 }


### PR DESCRIPTION
Currently, `VectorStorageRead::read_vector_bytes` had a default implementation, which silently let us **not** use the batched methods, even when we had all the building blocks for them.

This PR makes it mandatory, and also:
- homogenizes enum dispatch
- implements batch `read_vector_bytes` methods for multivector storages