### PR TITLE
Optimize debug build time (less generics)

### DIFF
--- a/lib/segment/src/data_types/vectors.rs
+++ b/lib/segment/src/data_types/vectors.rs
@@ -847,21 +847,21 @@ pub enum QueryVector {
 }
 
 impl TransformInto<QueryVector, VectorInternal, VectorInternal> for QueryVector {
-    fn transform<F>(self, mut f: F) -> OperationResult<QueryVector>
-    where
-        F: FnMut(VectorInternal) -> OperationResult<VectorInternal>,
-    {
+    fn transform(
+        self,
+        f: &dyn Fn(VectorInternal) -> OperationResult<VectorInternal>,
+    ) -> OperationResult<QueryVector> {
         match self {
             QueryVector::Nearest(v) => f(v).map(QueryVector::Nearest),
             QueryVector::RecommendBestScore(v) => {
-                Ok(QueryVector::RecommendBestScore(v.transform(&mut f)?))
+                Ok(QueryVector::RecommendBestScore(v.transform(f)?))
             }
             QueryVector::RecommendSumScores(v) => {
-                Ok(QueryVector::RecommendSumScores(v.transform(&mut f)?))
+                Ok(QueryVector::RecommendSumScores(v.transform(f)?))
             }
-            QueryVector::Discover(v) => Ok(QueryVector::Discover(v.transform(&mut f)?)),
-            QueryVector::Context(v) => Ok(QueryVector::Context(v.transform(&mut f)?)),
-            QueryVector::FeedbackNaive(v) => Ok(QueryVector::FeedbackNaive(v.transform(&mut f)?)),
+            QueryVector::Discover(v) => Ok(QueryVector::Discover(v.transform(f)?)),
+            QueryVector::Context(v) => Ok(QueryVector::Context(v.transform(f)?)),
+            QueryVector::FeedbackNaive(v) => Ok(QueryVector::FeedbackNaive(v.transform(f)?)),
         }
     }
 }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/search.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/search.rs
@@ -44,7 +44,7 @@ where
             check_process_stopped(&query_context.is_stopped())?;
 
             let search_results = if query_context.is_require_idf() {
-                let vector = (*vector).clone().transform(|mut vector| {
+                let vector = (*vector).clone().transform(&|mut vector| {
                     match &mut vector {
                         VectorInternal::Dense(_) | VectorInternal::MultiDense(_) => {
                             return Err(OperationError::WrongSparse);

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::marker::PhantomData;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{PointOffsetType, ScoreType};
@@ -11,35 +10,30 @@ use crate::types::QuantizationConfig;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
 
-pub struct QuantizedCustomQueryScorer<'a, TElement, TMetric, TEncodedVectors, TQuery>
+pub struct QuantizedCustomQueryScorer<'a, TEncodedVectors, TQuery>
 where
-    TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
     TEncodedVectors: quantization::EncodedVectors,
     TQuery: Query<TEncodedVectors::EncodedQuery>,
 {
     query: TQuery,
     quantized_storage: &'a TEncodedVectors,
-    metric: PhantomData<TMetric>,
-    element: PhantomData<TElement>,
     hardware_counter: HardwareCounterCell,
 }
 
-impl<'a, TElement, TMetric, TEncodedVectors, TQuery>
-    QuantizedCustomQueryScorer<'a, TElement, TMetric, TEncodedVectors, TQuery>
+impl<'a, TEncodedVectors, TQuery> QuantizedCustomQueryScorer<'a, TEncodedVectors, TQuery>
 where
-    TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
     TEncodedVectors: quantization::EncodedVectors,
     TQuery: Query<TEncodedVectors::EncodedQuery>,
 {
-    pub fn new<TOriginalQuery, TInputQuery>(
+    pub fn new<TElement, TMetric, TOriginalQuery, TInputQuery>(
         raw_query: TInputQuery,
         quantized_storage: &'a TEncodedVectors,
         quantization_config: &QuantizationConfig,
         mut hardware_counter: HardwareCounterCell,
     ) -> Self
     where
+        TElement: PrimitiveVectorElement,
+        TMetric: Metric<TElement>,
         TOriginalQuery: Query<TypedDenseVector<TElement>>
             + TransformInto<TQuery, TypedDenseVector<TElement>, TEncodedVectors::EncodedQuery>
             + Clone,
@@ -73,18 +67,14 @@ where
         Self {
             query,
             quantized_storage,
-            metric: PhantomData,
-            element: PhantomData,
             hardware_counter,
         }
     }
 }
 
-impl<TElement, TMetric, TEncodedVectors, TQuery> QueryScorer
-    for QuantizedCustomQueryScorer<'_, TElement, TMetric, TEncodedVectors, TQuery>
+impl<TEncodedVectors, TQuery> QueryScorer
+    for QuantizedCustomQueryScorer<'_, TEncodedVectors, TQuery>
 where
-    TElement: PrimitiveVectorElement,
-    TMetric: Metric<TElement>,
     TEncodedVectors: quantization::EncodedVectors,
     TQuery: Query<TEncodedVectors::EncodedQuery>,
 {

--- a/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_custom_query_scorer.rs
@@ -47,7 +47,7 @@ where
             + TransformInto<TOriginalQuery, DenseVector, TypedDenseVector<TElement>>,
     {
         let original_query: TOriginalQuery = raw_query
-            .transform(|raw_vector| {
+            .transform(&|raw_vector| {
                 let preprocessed_vector = TMetric::preprocess(raw_vector);
                 let original_vector = TypedDenseVector::from(TElement::slice_from_float_cow(
                     Cow::Owned(preprocessed_vector),
@@ -56,7 +56,7 @@ where
             })
             .unwrap();
         let query: TQuery = original_query
-            .transform(|original_vector| {
+            .transform(&|original_vector| {
                 let original_vector_prequantized = TElement::quantization_preprocess(
                     quantization_config,
                     TMetric::distance(),

--- a/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multi_custom_query_scorer.rs
@@ -56,7 +56,7 @@ where
             + TransformInto<TOriginalQuery, MultiDenseVectorInternal, TypedMultiDenseVector<TElement>>,
     {
         let original_query: TOriginalQuery = raw_query
-            .transform(|vector| {
+            .transform(&|vector| {
                 let mut preprocessed = Vec::new();
                 for slice in vector.multi_vectors() {
                     preprocessed.extend_from_slice(&TMetric::preprocess(slice.to_vec()));
@@ -70,7 +70,7 @@ where
             .unwrap();
 
         let query: TQuery = original_query
-            .transform(|original_vector| {
+            .transform(&|original_vector| {
                 let original_vector_prequantized = TElement::quantization_preprocess(
                     quantization_config,
                     TMetric::distance(),

--- a/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_scorer_builder.rs
@@ -235,7 +235,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
             }
             QueryVector::RecommendBestScore(reco_query) => {
                 let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-                let query_scorer = QuantizedCustomQueryScorer::<TElement, TMetric, _, _>::new(
+                let query_scorer = QuantizedCustomQueryScorer::new::<TElement, TMetric, _, _>(
                     RecoBestScoreQuery::from(reco_query),
                     quantized_storage,
                     quantization_config,
@@ -245,7 +245,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
             }
             QueryVector::RecommendSumScores(reco_query) => {
                 let reco_query: RecoQuery<DenseVector> = reco_query.transform_into()?;
-                let query_scorer = QuantizedCustomQueryScorer::<TElement, TMetric, _, _>::new(
+                let query_scorer = QuantizedCustomQueryScorer::new::<TElement, TMetric, _, _>(
                     RecoSumScoresQuery::from(reco_query),
                     quantized_storage,
                     quantization_config,
@@ -255,7 +255,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
             }
             QueryVector::Discover(discover_query) => {
                 let discover_query: DiscoverQuery<DenseVector> = discover_query.transform_into()?;
-                let query_scorer = QuantizedCustomQueryScorer::<TElement, TMetric, _, _>::new(
+                let query_scorer = QuantizedCustomQueryScorer::new::<TElement, TMetric, _, _>(
                     discover_query,
                     quantized_storage,
                     quantization_config,
@@ -265,7 +265,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
             }
             QueryVector::Context(context_query) => {
                 let context_query: ContextQuery<DenseVector> = context_query.transform_into()?;
-                let query_scorer = QuantizedCustomQueryScorer::<TElement, TMetric, _, _>::new(
+                let query_scorer = QuantizedCustomQueryScorer::new::<TElement, TMetric, _, _>(
                     context_query,
                     quantized_storage,
                     quantization_config,
@@ -276,7 +276,7 @@ impl<'a> QuantizedScorerBuilder<'a> {
             QueryVector::FeedbackNaive(feedback_query) => {
                 let feedback_query: NaiveFeedbackQuery<DenseVector> =
                     feedback_query.transform_into()?;
-                let query_scorer = QuantizedCustomQueryScorer::<TElement, TMetric, _, _>::new(
+                let query_scorer = QuantizedCustomQueryScorer::new::<TElement, TMetric, _, _>(
                     feedback_query.into_query(),
                     quantized_storage,
                     quantization_config,

--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -110,10 +110,11 @@ impl<T, U> TransformInto<ContextQuery<U>, T, U> for ContextQuery<T> {
 
 impl<T> Query<T> for ContextQuery<T> {
     fn score_by(&self, similarity: impl Fn(&T) -> ScoreType) -> ScoreType {
-        self.pairs
-            .iter()
-            .map(|pair| pair.loss_by(&similarity))
-            .sum()
+        let mut sum = 0.0;
+        for pair in &self.pairs {
+            sum += pair.loss_by(&similarity);
+        }
+        sum
     }
 }
 

--- a/lib/segment/src/vector_storage/query/context_query.rs
+++ b/lib/segment/src/vector_storage/query/context_query.rs
@@ -21,10 +21,10 @@ impl<T> ContextPair<T> {
         iter::once(&self.positive).chain(iter::once(&self.negative))
     }
 
-    pub fn transform<F, U>(self, mut f: F) -> OperationResult<ContextPair<U>>
-    where
-        F: FnMut(T) -> OperationResult<U>,
-    {
+    pub fn transform<U>(
+        self,
+        f: &dyn Fn(T) -> OperationResult<U>,
+    ) -> OperationResult<ContextPair<U>> {
         Ok(ContextPair {
             positive: f(self.positive)?,
             negative: f(self.negative)?,
@@ -98,14 +98,11 @@ impl<T> ContextQuery<T> {
 }
 
 impl<T, U> TransformInto<ContextQuery<U>, T, U> for ContextQuery<T> {
-    fn transform<F>(self, mut f: F) -> OperationResult<ContextQuery<U>>
-    where
-        F: FnMut(T) -> OperationResult<U>,
-    {
+    fn transform(self, f: &dyn Fn(T) -> OperationResult<U>) -> OperationResult<ContextQuery<U>> {
         Ok(ContextQuery::new(
             self.pairs
                 .into_iter()
-                .map(|pair| pair.transform(&mut f))
+                .map(|pair| pair.transform(f))
                 .try_collect()?,
         ))
     }

--- a/lib/segment/src/vector_storage/query/discover_query.rs
+++ b/lib/segment/src/vector_storage/query/discover_query.rs
@@ -51,15 +51,12 @@ impl<T> DiscoverQuery<T> {
 }
 
 impl<T, U> TransformInto<DiscoverQuery<U>, T, U> for DiscoverQuery<T> {
-    fn transform<F>(self, mut f: F) -> OperationResult<DiscoverQuery<U>>
-    where
-        F: FnMut(T) -> OperationResult<U>,
-    {
+    fn transform(self, f: &dyn Fn(T) -> OperationResult<U>) -> OperationResult<DiscoverQuery<U>> {
         Ok(DiscoverQuery::new(
             f(self.target)?,
             self.pairs
                 .into_iter()
-                .map(|pair| pair.transform(&mut f))
+                .map(|pair| pair.transform(f))
                 .try_collect()?,
         ))
     }

--- a/lib/segment/src/vector_storage/query/discover_query.rs
+++ b/lib/segment/src/vector_storage/query/discover_query.rs
@@ -42,11 +42,11 @@ impl<T> DiscoverQuery<T> {
     }
 
     fn rank_by(&self, similarity: impl Fn(&T) -> ScoreType) -> RankType {
-        self.pairs
-            .iter()
-            .map(|pair| pair.rank_by(&similarity))
-            // get overall rank
-            .sum()
+        let mut rank = 0;
+        for pair in &self.pairs {
+            rank += pair.rank_by(&similarity);
+        }
+        rank
     }
 }
 

--- a/lib/segment/src/vector_storage/query/feedback_query.rs
+++ b/lib/segment/src/vector_storage/query/feedback_query.rs
@@ -15,10 +15,10 @@ pub struct FeedbackItem<T> {
 }
 
 impl<T> FeedbackItem<T> {
-    pub fn transform<F, U>(self, mut f: F) -> OperationResult<FeedbackItem<U>>
-    where
-        F: FnMut(T) -> OperationResult<U>,
-    {
+    pub fn transform<U>(
+        self,
+        f: &dyn Fn(T) -> OperationResult<U>,
+    ) -> OperationResult<FeedbackItem<U>> {
         Ok(FeedbackItem {
             vector: f(self.vector)?,
             score: self.score,
@@ -57,10 +57,10 @@ impl<T> NaiveFeedbackQuery<T> {
 }
 
 impl<T, U> TransformInto<NaiveFeedbackQuery<U>, T, U> for NaiveFeedbackQuery<T> {
-    fn transform<F>(self, mut f: F) -> OperationResult<NaiveFeedbackQuery<U>>
-    where
-        F: FnMut(T) -> OperationResult<U>,
-    {
+    fn transform(
+        self,
+        f: &dyn Fn(T) -> OperationResult<U>,
+    ) -> OperationResult<NaiveFeedbackQuery<U>> {
         let Self {
             target,
             feedback,
@@ -70,7 +70,7 @@ impl<T, U> TransformInto<NaiveFeedbackQuery<U>, T, U> for NaiveFeedbackQuery<T> 
             target: f(target)?,
             feedback: feedback
                 .into_iter()
-                .map(|item| item.transform(&mut f))
+                .map(|item| item.transform(f))
                 .try_collect()?,
             coefficients,
         })
@@ -88,10 +88,10 @@ pub struct ContextPair<T> {
 }
 
 impl<T> ContextPair<T> {
-    pub fn transform<F, U>(self, mut f: F) -> OperationResult<ContextPair<U>>
-    where
-        F: FnMut(T) -> OperationResult<U>,
-    {
+    pub fn transform<U>(
+        self,
+        f: &dyn Fn(T) -> OperationResult<U>,
+    ) -> OperationResult<ContextPair<U>> {
         Ok(ContextPair {
             positive: f(self.positive)?,
             negative: f(self.negative)?,
@@ -175,10 +175,7 @@ impl<TVector: Clone> FeedbackQuery<TVector> {
 }
 
 impl<T, U> TransformInto<FeedbackQuery<U>, T, U> for FeedbackQuery<T> {
-    fn transform<F>(self, mut f: F) -> OperationResult<FeedbackQuery<U>>
-    where
-        F: FnMut(T) -> OperationResult<U>,
-    {
+    fn transform(self, f: &dyn Fn(T) -> OperationResult<U>) -> OperationResult<FeedbackQuery<U>> {
         let Self {
             target,
             context_pairs,
@@ -188,7 +185,7 @@ impl<T, U> TransformInto<FeedbackQuery<U>, T, U> for FeedbackQuery<T> {
             target: f(target)?,
             context_pairs: context_pairs
                 .into_iter()
-                .map(|pair| pair.transform(&mut f))
+                .map(|pair| pair.transform(f))
                 .try_collect()?,
             coefficients,
         })

--- a/lib/segment/src/vector_storage/query/mod.rs
+++ b/lib/segment/src/vector_storage/query/mod.rs
@@ -15,16 +15,14 @@ pub use reco_query::{RecoBestScoreQuery, RecoQuery, RecoSumScoresQuery};
 
 pub trait TransformInto<Output, T = DenseVector, U = DenseVector> {
     /// Change the underlying type of the query, or just process it in some way.
-    fn transform<F>(self, f: F) -> OperationResult<Output>
-    where
-        F: FnMut(T) -> OperationResult<U>;
+    fn transform(self, f: &dyn Fn(T) -> OperationResult<U>) -> OperationResult<Output>;
 
     fn transform_into(self) -> OperationResult<Output>
     where
         Self: Sized,
         T: TryInto<U, Error = OperationError>,
     {
-        self.transform(|v| v.try_into())
+        self.transform(&|v| v.try_into())
     }
 }
 

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -29,14 +29,10 @@ impl<T> RecoQuery<T> {
 }
 
 impl<T, U> TransformInto<RecoQuery<U>, T, U> for RecoQuery<T> {
-    fn transform<F>(self, mut f: F) -> OperationResult<RecoQuery<U>>
-    where
-        F: FnMut(T) -> OperationResult<U>,
-    {
-        Ok(RecoQuery::new(
-            self.positives.into_iter().map(&mut f).try_collect()?,
-            self.negatives.into_iter().map(&mut f).try_collect()?,
-        ))
+    fn transform(self, f: &dyn Fn(T) -> OperationResult<U>) -> OperationResult<RecoQuery<U>> {
+        let positives = self.positives.into_iter().map(f).try_collect()?;
+        let negatives = self.negatives.into_iter().map(f).try_collect()?;
+        Ok(RecoQuery::new(positives, negatives))
     }
 }
 
@@ -50,10 +46,10 @@ impl<T> From<RecoQuery<T>> for RecoBestScoreQuery<T> {
 }
 
 impl<T, U> TransformInto<RecoBestScoreQuery<U>, T, U> for RecoBestScoreQuery<T> {
-    fn transform<F>(self, f: F) -> OperationResult<RecoBestScoreQuery<U>>
-    where
-        F: FnMut(T) -> OperationResult<U>,
-    {
+    fn transform(
+        self,
+        f: &dyn Fn(T) -> OperationResult<U>,
+    ) -> OperationResult<RecoBestScoreQuery<U>> {
         Ok(RecoBestScoreQuery(self.0.transform(f)?))
     }
 }
@@ -99,10 +95,10 @@ impl<T> From<RecoQuery<T>> for RecoSumScoresQuery<T> {
 }
 
 impl<T, U> TransformInto<RecoSumScoresQuery<U>, T, U> for RecoSumScoresQuery<T> {
-    fn transform<F>(self, f: F) -> OperationResult<RecoSumScoresQuery<U>>
-    where
-        F: FnMut(T) -> OperationResult<U>,
-    {
+    fn transform(
+        self,
+        f: &dyn Fn(T) -> OperationResult<U>,
+    ) -> OperationResult<RecoSumScoresQuery<U>> {
         Ok(RecoSumScoresQuery(self.0.transform(f)?))
     }
 }

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -63,19 +63,22 @@ impl From<RecoBestScoreQuery<VectorInternal>> for QueryVector {
 impl<T> Query<T> for RecoBestScoreQuery<T> {
     fn score_by(&self, similarity: impl Fn(&T) -> ScoreType) -> ScoreType {
         // get similarities to all positives
-        let positive_similarities = self.0.positives.iter().map(&similarity);
+        let mut max_positive = ScoreType::NEG_INFINITY;
+        for vector in &self.0.positives {
+            let score = similarity(vector);
+            if score.total_cmp(&max_positive).is_gt() {
+                max_positive = score;
+            }
+        }
 
         // and all negatives
-        let negative_similarities = self.0.negatives.iter().map(&similarity);
-
-        // get max similarity to positives and max to negatives
-        let max_positive = positive_similarities
-            .max_by(|a, b| a.total_cmp(b))
-            .unwrap_or(ScoreType::NEG_INFINITY);
-
-        let max_negative = negative_similarities
-            .max_by(|a, b| a.total_cmp(b))
-            .unwrap_or(ScoreType::NEG_INFINITY);
+        let mut max_negative = ScoreType::NEG_INFINITY;
+        for vector in &self.0.negatives {
+            let score = similarity(vector);
+            if score.total_cmp(&max_negative).is_gt() {
+                max_negative = score;
+            }
+        }
 
         if max_positive > max_negative {
             scaled_fast_sigmoid(max_positive)
@@ -112,10 +115,16 @@ impl From<RecoSumScoresQuery<VectorInternal>> for QueryVector {
 impl<T> Query<T> for RecoSumScoresQuery<T> {
     fn score_by(&self, similarity: impl Fn(&T) -> ScoreType) -> ScoreType {
         // Sum all positive vectors scores
-        let positive_score: ScoreType = self.0.positives.iter().map(&similarity).sum();
+        let mut positive_score: ScoreType = 0.0;
+        for vector in &self.0.positives {
+            positive_score += similarity(vector);
+        }
 
         // Sum all negative vectors scores
-        let negative_score: ScoreType = self.0.negatives.iter().map(&similarity).sum();
+        let mut negative_score: ScoreType = 0.0;
+        for vector in &self.0.negatives {
+            negative_score += similarity(vector);
+        }
 
         // Subtract
         positive_score - negative_score

--- a/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/custom_query_scorer.rs
@@ -45,10 +45,8 @@ impl<
         TInputQuery: Query<DenseVector>
             + TransformInto<TStoredQuery, DenseVector, TypedDenseVector<TElement>>,
     {
-        let mut dim = 0;
         let query = query
-            .transform(|vector| {
-                dim = vector.len();
+            .transform(&|vector| {
                 let preprocessed_vector = TMetric::preprocess(vector);
                 Ok(TypedDenseVector::from(TElement::slice_from_float_cow(
                     Cow::from(preprocessed_vector),
@@ -56,6 +54,7 @@ impl<
             })
             .unwrap();
 
+        let dim = vector_storage.vector_dim();
         hardware_counter.set_cpu_multiplier(dim * size_of::<TElement>());
         if vector_storage.is_on_disk() {
             hardware_counter.set_vector_io_read_multiplier(dim * size_of::<TElement>());

--- a/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/multi_custom_query_scorer.rs
@@ -47,10 +47,8 @@ impl<
         TInputQuery: Query<MultiDenseVectorInternal>
             + TransformInto<TQuery, MultiDenseVectorInternal, TypedMultiDenseVector<TElement>>,
     {
-        let mut dim = 0;
         let query = query
-            .transform(|vector| {
-                dim = vector.dim;
+            .transform(&|vector| {
                 let mut preprocessed = DenseVector::new();
                 for slice in vector.multi_vectors() {
                     preprocessed.extend_from_slice(&TMetric::preprocess(slice.to_vec()));
@@ -63,6 +61,7 @@ impl<
             })
             .unwrap();
 
+        let dim = vector_storage.vector_dim();
         hardware_counter.set_cpu_multiplier(dim * size_of::<TElement>());
         if vector_storage.is_on_disk() {
             hardware_counter.set_vector_io_read_multiplier(dim * size_of::<TElement>());

--- a/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_custom_query_scorer.rs
@@ -30,7 +30,7 @@ impl<
         vector_storage: &'a TVectorStorage,
         mut hardware_counter: HardwareCounterCell,
     ) -> Self {
-        let query: TQuery = TransformInto::transform(query, |mut vector| {
+        let query: TQuery = TransformInto::transform(query, &|mut vector| {
             vector.sort_by_indices();
             Ok(vector)
         })

--- a/lib/segment/src/vector_storage/query_scorer/turbo_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/turbo_custom_query_scorer.rs
@@ -40,7 +40,7 @@ where
         // Preprocess (per distance) and precompute each sub-query vector once;
         // `preprocess_query` folds both steps together.
         let query: TQuery = raw_query
-            .transform(|raw_vector| Ok(storage.preprocess_query(raw_vector)))
+            .transform(&|raw_vector| Ok(storage.preprocess_query(raw_vector)))
             .unwrap();
 
         hardware_counter.set_cpu_multiplier(storage.quantized_vector_size());

--- a/lib/segment/src/vector_storage/query_scorer/turbo_multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/turbo_multi_custom_query_scorer.rs
@@ -39,7 +39,7 @@ where
     {
         // Preprocess and precompute every inner vector of each sub-query once.
         let query: TQuery = raw_query
-            .transform(|multi| Ok(storage.preprocess_query(&multi)))
+            .transform(&|multi| Ok(storage.preprocess_query(&multi)))
             .unwrap();
 
         hardware_counter.set_vector_io_read_multiplier(usize::from(storage.is_on_disk()));


### PR DESCRIPTION
This PR exorcizes a few generics that affect build times for `segment` unit tests.

How to find out what to cut:
- cargo llvm-lines
- asking an AI to write parser for elf dwarf debug section and find the most commonly appeared symbol names (automated variation of the what I did in https://github.com/qdrant/qdrant/pull/5556#issuecomment-2511534639)

# Benchmark

```sh
# warm up deps
cargo test --package segment --lib --no-run

for i in {1..10}; do
    # bust build cache
    echo "pub fn foo$RANDOM$RANDOM(){}" >> lib/segment/src/lib.rs

    # measure build time for incremental builds
    time cargo test --package segment --lib --no-run
done
```

Results:
- min build time: 13.8s -> 9.4s (-31%)
- median build time: 17.25s -> 11.52s (-33%)
- binary size: 662 MiB -> 362 MiB (-45%)

# Honorable mention

The generic function [`find_quantile_interval_per_coordinate_with_preprocess`](https://github.com/qdrant/qdrant/blob/c196d2eb1ade78efc26ec94d44dffe045327e76b/lib/quantization/src/quantile.rs#L130-L143) is responsible to 8% of the remaining build time. (shaving it off brings the median to 10.5s)

Tho I'm not familiar with this part of the code and it might be a part of a hot loop so I kept it as is.