### PR TITLE
[io-bridge] split large reads into unordered chunks

### DIFF
--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -236,7 +236,7 @@ mod tests {
     use futures::stream::{BoxStream, StreamExt};
 
     use super::*;
-    use crate::AsyncWrite;
+    use crate::{AsyncWrite, OffsetByteStream};
 
     #[derive(Clone)]
     struct MockSource {
@@ -285,11 +285,15 @@ mod tests {
             &self,
             _path: &Path,
             from: u64,
-        ) -> impl Future<Output = Result<(u64, BoxStream<'static, Result<Bytes>>)>> + Send + 'static
-        {
+        ) -> impl Future<Output = Result<(u64, OffsetByteStream)>> + Send + 'static {
             let size = self.data.len() as u64;
             let tail = self.data.slice(from as usize..);
-            async move { Ok((size, futures::stream::once(async move { Ok(tail) }).boxed())) }
+            async move {
+                Ok((
+                    size,
+                    futures::stream::once(async move { Ok((0, tail)) }).boxed(),
+                ))
+            }
         }
 
         fn len(&self, _path: &Path) -> impl Future<Output = Result<u64>> + Send + 'static {
@@ -429,8 +433,7 @@ mod tests {
             &self,
             path: &Path,
             from: u64,
-        ) -> impl Future<Output = Result<(u64, BoxStream<'static, Result<Bytes>>)>> + Send + 'static
-        {
+        ) -> impl Future<Output = Result<(u64, OffsetByteStream)>> + Send + 'static {
             let result = match &*self.store.lock().unwrap() {
                 Some(data) => Ok((
                     data.len() as u64,
@@ -440,7 +443,10 @@ mod tests {
             };
             async move {
                 let (size, tail) = result?;
-                Ok((size, futures::stream::once(async move { Ok(tail) }).boxed()))
+                Ok((
+                    size,
+                    futures::stream::once(async move { Ok((0, tail)) }).boxed(),
+                ))
             }
         }
 

--- a/lib/common/io_bridge/src/lib.rs
+++ b/lib/common/io_bridge/src/lib.rs
@@ -119,6 +119,6 @@ mod tests;
 pub use file::BlobFile;
 pub use fs::BlobFs;
 pub use pipeline::BlobReadPipeline;
-pub use read::AsyncRead;
+pub use read::{AsyncRead, OffsetByteStream, with_running_offsets};
 pub use runtime::BridgeRuntime;
 pub use write::{AsyncAppend, AsyncWrite};

--- a/lib/common/io_bridge/src/pipeline/buffer.rs
+++ b/lib/common/io_bridge/src/pipeline/buffer.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::future::Future;
 use std::ops::Range;
 
@@ -91,74 +90,61 @@ async fn scatter_stream_into_buffer(
     align: usize,
 ) -> Result<AVec<u8, RuntimeAlign>> {
     let mut buf = AVec::<u8, RuntimeAlign>::with_capacity(align, expected_len);
-    // Written ranges so far as `start -> end`, disjoint and merged eagerly so
-    // the map stays small: an in-order stream collapses to a single entry, an
-    // out-of-order one holds an entry per "hole", bounded by the backend's
-    // concurrency window.
-    let mut written: BTreeMap<usize, usize> = BTreeMap::new();
+    // Disjoint runs of already-written bytes, grown/merged as chunks land.
+    // There are few in practice — an in-order stream is a single run, an
+    // out-of-order one adds a run per concurrent "hole" — so a linear scan is fast.
+    // Revisit if the run bound (`READ_CHUNK_CONCURRENCY` in `io_bridge_object_store`) grows large.
+    let mut runs: Vec<Range<usize>> = Vec::new();
     let mut bytes_written = 0usize;
     while let Some(chunk) = stream.next().await {
         let (offset, bytes) = chunk?;
         if bytes.is_empty() {
             continue;
         }
-        let (start, end) = usize::try_from(offset)
-            .ok()
-            .and_then(|start| Some((start, start.checked_add(bytes.len())?)))
-            .filter(|&(_, end)| end <= expected_len)
-            .ok_or_else(|| {
-                UniversalIoError::S3(
-                    format!(
-                        "over-read: chunk at offset {offset} of {} bytes exceeds a buffer of size \
+        let start = usize::try_from(offset).ok();
+        let end = start.and_then(|start| start.checked_add(bytes.len()));
+        let Some((start, end)) = start.zip(end).filter(|&(_, end)| end <= expected_len) else {
+            return Err(UniversalIoError::S3(
+                format!(
+                    "over-read: chunk at offset {offset} of {} bytes exceeds a buffer of size \
                      {expected_len}",
-                        bytes.len(),
-                    )
-                    .into(),
+                    bytes.len(),
                 )
-            })?;
-        let overlap_err = || {
-            UniversalIoError::S3(
+                .into(),
+            ));
+        };
+        if runs.iter().any(|run| run.start < end && start < run.end) {
+            return Err(UniversalIoError::S3(
                 format!("overlapping read: chunk {start}..{end} intersects already-received bytes")
                     .into(),
-            )
-        };
-
-        // Merge with a range ending exactly at `start` and/or one starting
-        // exactly at `end`; any true intersection is a protocol violation.
-        let mut new_start = start;
-        let mut new_end = end;
-        if let Some((&prev_start, &prev_end)) = written.range(..=start).next_back() {
-            if prev_end > start {
-                return Err(overlap_err());
-            }
-            if prev_end == start {
-                written.remove(&prev_start);
-                new_start = prev_start;
-            }
+            ));
         }
-        if let Some((&next_start, &next_end)) = written.range(start..).next() {
-            if next_start < end {
-                return Err(overlap_err());
-            }
-            if next_start == end {
-                written.remove(&next_start);
-                new_end = next_end;
-            }
-        }
-        // SAFETY: `end <= expected_len <= capacity`, and the checks above
-        // guarantee `start..end` is disjoint from every prior write.
+        // SAFETY: `end <= expected_len <= capacity`, and the check above
+        // guarantees `start..end` is disjoint from every prior write.
         unsafe {
             std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf.as_mut_ptr().add(start), bytes.len());
         }
-        written.insert(new_start, new_end);
         bytes_written += bytes.len();
+        // Grow an adjacent run or start a new one.
+        // Runs are disjoint, so each side matches at most once.
+        let before = runs.iter().position(|run| run.end == start);
+        let after = runs.iter().position(|run| run.start == end);
+        match (before, after) {
+            (Some(before), Some(after)) => {
+                runs[before].end = runs[after].end;
+                runs.swap_remove(after);
+            }
+            (Some(before), None) => runs[before].end = end,
+            (None, Some(after)) => runs[after].start = start,
+            (None, None) => runs.push(start..end),
+        }
     }
     // Every write was in-bounds and disjoint, so matching totals prove the
     // chunks tiled `0..expected_len` exactly; anything less means a gap.
     if bytes_written != expected_len {
-        return Err(UniversalIoError::S3Config {
-            description: format!("short read: expected {expected_len} bytes, got {bytes_written}"),
-        });
+        return Err(UniversalIoError::S3(
+            format!("short read: expected {expected_len} bytes, got {bytes_written}").into(),
+        ));
     }
     // SAFETY: the coverage check above proves every byte in `0..expected_len`
     // was written exactly once.

--- a/lib/common/io_bridge/src/pipeline/buffer.rs
+++ b/lib/common/io_bridge/src/pipeline/buffer.rs
@@ -104,20 +104,16 @@ async fn scatter_stream_into_buffer(
         let start = usize::try_from(offset).ok();
         let end = start.and_then(|start| start.checked_add(bytes.len()));
         let Some((start, end)) = start.zip(end).filter(|&(_, end)| end <= expected_len) else {
-            return Err(UniversalIoError::S3(
-                format!(
-                    "over-read: chunk at offset {offset} of {} bytes exceeds a buffer of size \
+            return Err(UniversalIoError::S3(Box::from(format!(
+                "over-read: chunk at offset {offset} of {} bytes exceeds a buffer of size \
                      {expected_len}",
-                    bytes.len(),
-                )
-                .into(),
-            ));
+                bytes.len(),
+            ))));
         };
         if runs.iter().any(|run| run.start < end && start < run.end) {
-            return Err(UniversalIoError::S3(
-                format!("overlapping read: chunk {start}..{end} intersects already-received bytes")
-                    .into(),
-            ));
+            return Err(UniversalIoError::S3(Box::from(format!(
+                "overlapping read: chunk {start}..{end} intersects already-received bytes"
+            ))));
         }
         // SAFETY: `end <= expected_len <= capacity`, and the check above
         // guarantees `start..end` is disjoint from every prior write.

--- a/lib/common/io_bridge/src/pipeline/buffer.rs
+++ b/lib/common/io_bridge/src/pipeline/buffer.rs
@@ -106,25 +106,30 @@ async fn scatter_stream_into_buffer(
             .ok()
             .and_then(|start| Some((start, start.checked_add(bytes.len())?)))
             .filter(|&(_, end)| end <= expected_len)
-            .ok_or_else(|| UniversalIoError::S3Config {
-                description: format!(
-                    "over-read: chunk at offset {offset} of {} bytes exceeds a buffer of size \
+            .ok_or_else(|| {
+                UniversalIoError::S3(
+                    format!(
+                        "over-read: chunk at offset {offset} of {} bytes exceeds a buffer of size \
                      {expected_len}",
-                    bytes.len(),
-                ),
+                        bytes.len(),
+                    )
+                    .into(),
+                )
             })?;
-        let overlap = || UniversalIoError::S3Config {
-            description: format!(
-                "overlapping read: chunk {start}..{end} intersects already-received bytes"
-            ),
+        let overlap_err = || {
+            UniversalIoError::S3(
+                format!("overlapping read: chunk {start}..{end} intersects already-received bytes")
+                    .into(),
+            )
         };
+
         // Merge with a range ending exactly at `start` and/or one starting
         // exactly at `end`; any true intersection is a protocol violation.
         let mut new_start = start;
         let mut new_end = end;
         if let Some((&prev_start, &prev_end)) = written.range(..=start).next_back() {
             if prev_end > start {
-                return Err(overlap());
+                return Err(overlap_err());
             }
             if prev_end == start {
                 written.remove(&prev_start);
@@ -133,7 +138,7 @@ async fn scatter_stream_into_buffer(
         }
         if let Some((&next_start, &next_end)) = written.range(start..).next() {
             if next_start < end {
-                return Err(overlap());
+                return Err(overlap_err());
             }
             if next_start == end {
                 written.remove(&next_start);

--- a/lib/common/io_bridge/src/pipeline/buffer.rs
+++ b/lib/common/io_bridge/src/pipeline/buffer.rs
@@ -1,14 +1,13 @@
+use std::collections::BTreeMap;
 use std::future::Future;
 use std::ops::Range;
 
-use aligned_vec::{AVec, RuntimeAlign, avec_rt};
-use bytes::Bytes;
+use aligned_vec::{AVec, RuntimeAlign};
 use common::universal_io::{Result, UniversalIoError};
 use futures::StreamExt as _;
-use futures::stream::BoxStream;
 
 use crate::file::BlobFile;
-use crate::read::AsyncRead;
+use crate::read::{AsyncRead, OffsetByteStream, with_running_offsets};
 
 /// Build the future that allocates an exact-size, `align`-aligned destination
 /// byte buffer, streams the backend read for `range` into it, and returns it as
@@ -28,13 +27,12 @@ pub fn read_into_byte_buffer<A: AsyncRead>(
     let stream_fut = file.inner.read_range(&file.path, range);
     async move {
         let stream = stream_fut.await?;
-        let buf = avec_rt!([align] | 0u8; len);
-        fold_stream_into_buffer(stream, buf).await
+        scatter_stream_into_buffer(with_running_offsets(stream), len, align).await
     }
 }
 
-/// Like [`read_into_byte_buffer`], but fetches the whole object in one GET,
-/// sizing the buffer from the response length (no separate `len`/HEAD).
+/// Like [`read_into_byte_buffer`], but fetches the whole object, sizing the
+/// buffer from the response length (no separate `len`/HEAD).
 pub fn read_whole_into_byte_buffer<A: AsyncRead + Clone>(
     file: &BlobFile<A>,
     align: usize,
@@ -43,9 +41,9 @@ pub fn read_whole_into_byte_buffer<A: AsyncRead + Clone>(
 }
 
 /// Like [`read_into_byte_buffer`], but fetches everything from byte offset
-/// `from` to the end of the object in one open-ended GET, sizing the buffer
-/// from the object's total length carried in the response — no separate
-/// `len`/HEAD round-trip on the happy path. `from == 0` reads the whole object.
+/// `from` to the end of the object, sizing the buffer from the object's total
+/// length carried in the response — no separate `len`/HEAD round-trip on the
+/// happy path. `from == 0` reads the whole object.
 ///
 /// An offset at or past the end has no tail to read. The backend reports that as
 /// an unsatisfiable-range error rather than an empty body, so the error path
@@ -67,42 +65,149 @@ pub fn read_from_into_byte_buffer<A: AsyncRead + Clone>(
             Err(err) => {
                 let eof = inner.len(&path).await?;
                 if from >= eof {
-                    return Ok(avec_rt!([align] | 0u8; 0));
+                    return Ok(AVec::new(align));
                 }
                 return Err(err);
             }
         };
         let len = size.saturating_sub(from) as usize;
-        let buf = avec_rt!([align] | 0u8; len);
-        fold_stream_into_buffer(stream, buf).await
+        scatter_stream_into_buffer(stream, len, align).await
     }
 }
 
-/// Copy every chunk of `stream` into `buf`, erroring if the streamed bytes
-/// don't exactly fill it.
-async fn fold_stream_into_buffer(
-    mut stream: BoxStream<'static, Result<Bytes>>,
-    mut buf: AVec<u8, RuntimeAlign>,
+/// Scatter every `(offset, bytes)` chunk of `stream` into a fresh
+/// `align`-aligned buffer of exactly `expected_len` bytes.
+///
+/// Chunks may arrive **out of order** (offsets are relative to the start of
+/// the stream, see [`AsyncRead::read_from`]); each is copied straight to its
+/// final position the moment it arrives, so a multi-request backend is never
+/// stalled behind in-order delivery. The buffer is allocated as capacity only
+/// — no zero pre-fill — and its length is set only after verifying the chunks
+/// were disjoint and covered the buffer exactly, so a malformed stream yields
+/// an error, never uninitialized or double-written bytes.
+async fn scatter_stream_into_buffer(
+    mut stream: OffsetByteStream,
+    expected_len: usize,
+    align: usize,
 ) -> Result<AVec<u8, RuntimeAlign>> {
-    let mut off = 0;
+    let mut buf = AVec::<u8, RuntimeAlign>::with_capacity(align, expected_len);
+    // Written ranges so far as `start -> end`, disjoint and merged eagerly so
+    // the map stays small: an in-order stream collapses to a single entry, an
+    // out-of-order one holds an entry per "hole", bounded by the backend's
+    // concurrency window.
+    let mut written: BTreeMap<usize, usize> = BTreeMap::new();
+    let mut bytes_written = 0usize;
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk?;
-        let end = off + chunk.len();
-        if end > buf.len() {
-            return Err(UniversalIoError::S3Config {
-                description: format!(
-                    "over-read: tried to write {end} bytes into a buffer of size {}",
-                    buf.len(),
-                ),
-            });
+        let (offset, bytes) = chunk?;
+        if bytes.is_empty() {
+            continue;
         }
-        buf[off..end].copy_from_slice(&chunk);
-        off = end;
+        let (start, end) = usize::try_from(offset)
+            .ok()
+            .and_then(|start| Some((start, start.checked_add(bytes.len())?)))
+            .filter(|&(_, end)| end <= expected_len)
+            .ok_or_else(|| UniversalIoError::S3Config {
+                description: format!(
+                    "over-read: chunk at offset {offset} of {} bytes exceeds a buffer of size \
+                     {expected_len}",
+                    bytes.len(),
+                ),
+            })?;
+        let overlap = || UniversalIoError::S3Config {
+            description: format!(
+                "overlapping read: chunk {start}..{end} intersects already-received bytes"
+            ),
+        };
+        // Merge with a range ending exactly at `start` and/or one starting
+        // exactly at `end`; any true intersection is a protocol violation.
+        let mut new_start = start;
+        let mut new_end = end;
+        if let Some((&prev_start, &prev_end)) = written.range(..=start).next_back() {
+            if prev_end > start {
+                return Err(overlap());
+            }
+            if prev_end == start {
+                written.remove(&prev_start);
+                new_start = prev_start;
+            }
+        }
+        if let Some((&next_start, &next_end)) = written.range(start..).next() {
+            if next_start < end {
+                return Err(overlap());
+            }
+            if next_start == end {
+                written.remove(&next_start);
+                new_end = next_end;
+            }
+        }
+        // SAFETY: `end <= expected_len <= capacity`, and the checks above
+        // guarantee `start..end` is disjoint from every prior write.
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf.as_mut_ptr().add(start), bytes.len());
+        }
+        written.insert(new_start, new_end);
+        bytes_written += bytes.len();
     }
-    if off != buf.len() {
+    // Every write was in-bounds and disjoint, so matching totals prove the
+    // chunks tiled `0..expected_len` exactly; anything less means a gap.
+    if bytes_written != expected_len {
         return Err(UniversalIoError::S3Config {
-            description: format!("short read: expected {} bytes, got {off}", buf.len()),
+            description: format!("short read: expected {expected_len} bytes, got {bytes_written}"),
         });
     }
+    // SAFETY: the coverage check above proves every byte in `0..expected_len`
+    // was written exactly once.
+    unsafe { buf.set_len(expected_len) };
     Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use futures::StreamExt as _;
+
+    use super::*;
+
+    fn scatter(
+        chunks: Vec<(u64, &'static [u8])>,
+        expected_len: usize,
+    ) -> Result<AVec<u8, RuntimeAlign>> {
+        let stream = futures::stream::iter(
+            chunks
+                .into_iter()
+                .map(|(offset, bytes)| Ok((offset, Bytes::from_static(bytes)))),
+        )
+        .boxed();
+        futures::executor::block_on(scatter_stream_into_buffer(stream, expected_len, 8))
+    }
+
+    #[test]
+    fn scatter_reassembles_out_of_order_chunks() {
+        let buf = scatter(vec![(5, b"world"), (0, b"hello")], 10).expect("scatter");
+        assert_eq!(&buf[..], b"helloworld");
+    }
+
+    #[test]
+    fn scatter_accepts_empty_stream_for_empty_buffer() {
+        let buf = scatter(vec![], 0).expect("scatter");
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn scatter_rejects_overlapping_chunks() {
+        let err = scatter(vec![(0, b"hello"), (3, b"xyz")], 8).unwrap_err();
+        assert!(err.to_string().contains("overlapping"), "{err}");
+    }
+
+    #[test]
+    fn scatter_rejects_gaps_as_short_read() {
+        let err = scatter(vec![(0, b"he"), (5, b"lo")], 7).unwrap_err();
+        assert!(err.to_string().contains("short read"), "{err}");
+    }
+
+    #[test]
+    fn scatter_rejects_chunks_past_the_end() {
+        let err = scatter(vec![(8, b"abc")], 10).unwrap_err();
+        assert!(err.to_string().contains("over-read"), "{err}");
+    }
 }

--- a/lib/common/io_bridge/src/read.rs
+++ b/lib/common/io_bridge/src/read.rs
@@ -53,9 +53,18 @@ pub trait AsyncRead: Send + Sync + Sized + 'static {
         range: Range<u64>,
     ) -> impl Future<Output = Result<BoxStream<'static, Result<Bytes>>>> + Send + 'static;
 
-    /// Fetch the object at `path` from byte offset `from` to its end in one
-    /// request — no separate `len`/HEAD round-trip. `from == 0` reads the whole
-    /// object.
+    /// Fetch the object at `path` from byte offset `from` to its end — no
+    /// separate `len`/HEAD round-trip. `from == 0` reads the whole object.
+    /// Implementations may split a large object into multiple range requests
+    /// behind the returned stream, but must yield the bytes of a single
+    /// consistent version of the object (or fail).
+    ///
+    /// Each stream item is `(offset, bytes)`: the position of that chunk
+    /// **relative to `from`**, plus its bytes. Chunks may arrive **out of
+    /// order** — a multi-request implementation is free to yield each range as
+    /// it completes — but must be disjoint and tile the tail exactly.
+    /// Sequential backends can tag an in-order stream with
+    /// [`with_running_offsets`].
     ///
     /// The returned `u64` is the **total size of the whole object, in bytes**
     /// (as reported by the GET response, e.g. parsed from `Content-Range`/
@@ -72,15 +81,14 @@ pub trait AsyncRead: Send + Sync + Sized + 'static {
         &self,
         path: &Path,
         from: u64,
-    ) -> impl Future<Output = Result<(u64, BoxStream<'static, Result<Bytes>>)>> + Send + 'static;
+    ) -> impl Future<Output = Result<(u64, OffsetByteStream)>> + Send + 'static;
 
-    /// Fetch the whole object at `path` in one request. Convenience for
+    /// Fetch the whole object at `path`. Convenience for
     /// [`read_from(path, 0)`](Self::read_from).
     fn read_whole(
         &self,
         path: &Path,
-    ) -> impl Future<Output = Result<(u64, BoxStream<'static, Result<Bytes>>)>> + Send + 'static
-    {
+    ) -> impl Future<Output = Result<(u64, OffsetByteStream)>> + Send + 'static {
         self.read_from(path, 0)
     }
 
@@ -92,4 +100,29 @@ pub trait AsyncRead: Send + Sync + Sized + 'static {
     }
 
     fn kind() -> UniversalKind;
+}
+
+/// Stream of `(offset, bytes)` chunks yielded by [`AsyncRead::read_from`]:
+/// each chunk's position relative to the requested start, plus its bytes.
+/// Chunks may arrive out of order; they must be disjoint and tile the tail
+/// exactly.
+pub type OffsetByteStream = BoxStream<'static, Result<(u64, Bytes)>>;
+
+/// Tag an in-order byte stream with running offsets, producing the
+/// `(offset, bytes)` item shape [`AsyncRead::read_from`] requires. For
+/// backends that deliver the tail as one sequential stream.
+pub fn with_running_offsets(
+    stream: impl futures::Stream<Item = Result<Bytes>> + Send + 'static,
+) -> OffsetByteStream {
+    use futures::StreamExt as _;
+    stream
+        .scan(0u64, |offset, item| {
+            let item = item.map(|bytes| {
+                let at = *offset;
+                *offset += bytes.len() as u64;
+                (at, bytes)
+            });
+            futures::future::ready(Some(item))
+        })
+        .boxed()
 }

--- a/lib/common/io_bridge/src/tests/whole_read.rs
+++ b/lib/common/io_bridge/src/tests/whole_read.rs
@@ -15,7 +15,7 @@ use common::universal_io::{
 };
 use futures::stream::{BoxStream, StreamExt};
 
-use crate::read::AsyncRead;
+use crate::read::{AsyncRead, OffsetByteStream};
 use crate::{BlobFile, BridgeRuntime};
 
 /// Request counters shared with every clone of a [`CountingSource`], so a test
@@ -95,8 +95,7 @@ impl AsyncRead for CountingSource {
         &self,
         _path: &Path,
         from: u64,
-    ) -> impl Future<Output = Result<(u64, BoxStream<'static, Result<Bytes>>)>> + Send + 'static
-    {
+    ) -> impl Future<Output = Result<(u64, OffsetByteStream)>> + Send + 'static {
         if from == 0 {
             self.counters.whole.fetch_add(1, Ordering::Relaxed);
         } else {
@@ -114,7 +113,10 @@ impl AsyncRead for CountingSource {
                 });
             }
             let tail = data.slice(from as usize..);
-            Ok((size, futures::stream::once(async move { Ok(tail) }).boxed()))
+            Ok((
+                size,
+                futures::stream::once(async move { Ok((0, tail)) }).boxed(),
+            ))
         }
     }
 

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -22,11 +22,24 @@ use std::time::SystemTime;
 use bytes::Bytes;
 use common::universal_io::{ListedFile, Result, UniversalIoError, UniversalKind};
 use futures::stream::{BoxStream, StreamExt, TryStreamExt};
-use io_bridge::{AsyncRead, AsyncWrite};
+use io_bridge::{AsyncRead, AsyncWrite, OffsetByteStream};
 use object_store::{GetOptions, GetRange, ObjectStore, ObjectStoreExt, PutPayload};
 
 use crate::append::AppendContext;
 use crate::backend::BlobBackend;
+
+/// Size of the bounded range GETs that [`AsyncRead::read_from`] splits a large
+/// object into. Bounds the blast radius of a dropped connection (a retry
+/// re-fetches one chunk, not the whole object) while staying large enough that
+/// the per-request round-trip stays amortized.
+const DEFAULT_READ_CHUNK_SIZE: u64 = 16 * 1024 * 1024;
+
+/// Number of follow-up chunk GETs a multi-part [`AsyncRead::read_from`] keeps
+/// in flight at once. Chunks are yielded as they complete (out of order,
+/// tagged with their offset); a larger value hides more per-request round-trip
+/// latency at the cost of buffering up to `concurrency * chunk_size` bytes
+/// ahead of the consumer.
+const READ_CHUNK_CONCURRENCY: usize = 32;
 
 /// [`AsyncRead`] handle over an object store. Holds the store as `Arc<S>` so it
 /// is cheap to clone; the object key is supplied per call.
@@ -41,6 +54,8 @@ pub struct ObjectStoreSource<S> {
     /// this source was built from a config (see
     /// [`BlobBackend::append_context`]).
     append: Option<AppendContext>,
+    /// Chunk size for multi-part [`AsyncRead::read_from`] reads.
+    chunk_size: u64,
 }
 
 impl<S> Clone for ObjectStoreSource<S> {
@@ -48,6 +63,7 @@ impl<S> Clone for ObjectStoreSource<S> {
         Self {
             store: self.store.clone(),
             append: self.append.clone(),
+            chunk_size: self.chunk_size,
         }
     }
 }
@@ -62,12 +78,22 @@ impl<S> ObjectStoreSource<S> {
         Self {
             store,
             append: None,
+            chunk_size: DEFAULT_READ_CHUNK_SIZE,
         }
     }
 
     /// Attach an [`AppendContext`] enabling the native append RPC.
     pub fn with_append_context(mut self, context: AppendContext) -> Self {
         self.append = Some(context);
+        self
+    }
+
+    /// Override the chunk size used by multi-part [`AsyncRead::read_from`]
+    /// reads. Must be non-zero.
+    #[cfg(test)]
+    fn with_chunk_size(mut self, chunk_size: u64) -> Self {
+        assert_ne!(chunk_size, 0, "read chunk size must be non-zero");
+        self.chunk_size = chunk_size;
         self
     }
 
@@ -88,6 +114,7 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
         Ok(Self {
             store: Arc::new(S::build_store(config)?),
             append: S::append_context(config)?,
+            chunk_size: DEFAULT_READ_CHUNK_SIZE,
         })
     }
 
@@ -157,12 +184,10 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
                 range: Some(GetRange::Bounded(range)),
                 ..Default::default()
             };
-            let result = store.get_opts(&key, opts).await.map_err(|err| match err {
-                object_store::Error::NotFound { .. } => UniversalIoError::NotFound {
-                    path: PathBuf::from(key.to_string()),
-                },
-                other => UniversalIoError::s3(other),
-            })?;
+            let result = store
+                .get_opts(&key, opts)
+                .await
+                .map_err(|err| map_get_err(err, &key))?;
             Ok(result.into_stream().map_err(UniversalIoError::s3).boxed())
         }
     }
@@ -171,28 +196,90 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
         &self,
         path: &Path,
         from: u64,
-    ) -> impl Future<Output = Result<(u64, BoxStream<'static, Result<Bytes>>)>> + Send + 'static
-    {
+    ) -> impl Future<Output = Result<(u64, OffsetByteStream)>> + Send + 'static {
         let store = self.store.clone();
         let key = build_key(path);
+        let chunk_size = self.chunk_size;
         async move {
-            // `from == 0` is a plain whole-object GET; a positive offset asks the
-            // backend for everything from `from` onward in a single open-ended
-            // GET (`Range: bytes=from-`). Either way the response carries the
-            // object's total size, so no separate HEAD is needed.
+            // Multi-part read: instead of one open-ended `Range: bytes=from-`
+            // GET, the object is fetched in bounded chunks of `chunk_size`. The
+            // first chunk doubles as the size probe — a bounded range response
+            // still carries the object's total size (`Content-Range`), so no
+            // separate HEAD is needed on the happy path.
             let opts = GetOptions {
-                range: (from > 0).then_some(GetRange::Offset(from)),
+                range: Some(GetRange::Bounded(from..from.saturating_add(chunk_size))),
                 ..Default::default()
             };
-            let result = store.get_opts(&key, opts).await.map_err(|err| match err {
-                object_store::Error::NotFound { .. } => UniversalIoError::NotFound {
-                    path: PathBuf::from(key.to_string()),
-                },
-                other => UniversalIoError::s3(other),
-            })?;
-            let size = result.meta.size;
-            let stream = result.into_stream().map_err(UniversalIoError::s3).boxed();
-            Ok((size, stream))
+            // Note: a bounded range is unsatisfiable on an empty object even at
+            // offset 0 — the at-or-past-end error the trait documents; callers
+            // that must tolerate an empty tail disambiguate with `len` (see
+            // `read_from_into_byte_buffer`).
+            let mut first = store
+                .get_opts(&key, opts)
+                .await
+                .map_err(|err| map_get_err(err, &key))?;
+            let total = first.meta.size;
+            // Follow-up chunks are pinned to the version the probe saw: a
+            // concurrent overwrite fails the read (HTTP 412) instead of
+            // silently stitching bytes from two object versions.
+            let e_tag = first.meta.e_tag.take();
+            let first_end = first.range.end;
+            let first_stream =
+                io_bridge::with_running_offsets(first.into_stream().map_err(UniversalIoError::s3));
+            if first_end >= total {
+                return Ok((total, first_stream));
+            }
+            // The probe revealed the total size, so all remaining ranges are
+            // known up front and up to `READ_CHUNK_CONCURRENCY` of them are
+            // downloaded concurrently. Each chunk body is collected *inside*
+            // its future: the unordered window only drives futures while it is
+            // polled, so a future that merely opened the response and handed
+            // back a body stream would stall the other transfers. Chunks are
+            // yielded the moment they complete, tagged with their tail-relative
+            // offsets — a slow or retried chunk never blocks delivery of the
+            // others. Peak buffering is `READ_CHUNK_CONCURRENCY * chunk_size`
+            // bytes ahead of the consumer.
+            let rest = futures::stream::iter((first_end..total).step_by(chunk_size as usize))
+                .map(move |start| {
+                    let store = store.clone();
+                    let key = key.clone();
+                    let e_tag = e_tag.clone();
+                    let end = start.saturating_add(chunk_size).min(total);
+                    async move {
+                        let opts = GetOptions {
+                            range: Some(GetRange::Bounded(start..end)),
+                            if_match: e_tag,
+                            ..Default::default()
+                        };
+                        let chunk = store
+                            .get_opts(&key, opts)
+                            .await
+                            .map_err(|err| map_get_err(err, &key))?;
+                        // Keep the body's frames as-is instead of coalescing
+                        // them into one contiguous `Bytes` — that would memcpy
+                        // nearly the whole object a second time. The consumer
+                        // scatters by offset, so per-frame tagging suffices.
+                        let mut offset = start - from;
+                        let frames: Vec<_> = chunk
+                            .into_stream()
+                            .map_err(UniversalIoError::s3)
+                            .map_ok(|frame| {
+                                let at = offset;
+                                offset += frame.len() as u64;
+                                (at, frame)
+                            })
+                            .try_collect()
+                            .await?;
+                        Ok::<_, UniversalIoError>(futures::stream::iter(
+                            frames.into_iter().map(Ok::<_, UniversalIoError>),
+                        ))
+                    }
+                })
+                .buffer_unordered(READ_CHUNK_CONCURRENCY)
+                .try_flatten();
+            // `select` polls both sides, so the follow-up window opens while
+            // the probe body is still streaming.
+            Ok((total, futures::stream::select(first_stream, rest).boxed()))
         }
     }
 
@@ -204,12 +291,7 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
                 .head(&key)
                 .await
                 .map(|meta| meta.size)
-                .map_err(|err| match err {
-                    object_store::Error::NotFound { .. } => UniversalIoError::NotFound {
-                        path: PathBuf::from(key.to_string()),
-                    },
-                    other => UniversalIoError::s3(other),
-                })
+                .map_err(|err| map_get_err(err, &key))
         }
     }
 
@@ -236,12 +318,10 @@ impl<S: BlobBackend> AsyncWrite for ObjectStoreSource<S> {
         let store = self.store.clone();
         let key = build_key(path);
         async move {
-            store.delete(&key).await.map_err(|err| match err {
-                object_store::Error::NotFound { .. } => UniversalIoError::NotFound {
-                    path: PathBuf::from(key.to_string()),
-                },
-                other => UniversalIoError::s3(other),
-            })
+            store
+                .delete(&key)
+                .await
+                .map_err(|err| map_get_err(err, &key))
         }
     }
 
@@ -261,6 +341,17 @@ impl<S: BlobBackend> AsyncWrite for ObjectStoreSource<S> {
 
 pub(crate) fn build_key(path: &Path) -> object_store::path::Path {
     object_store::path::Path::from(path.to_string_lossy().as_ref())
+}
+
+/// Map an [`object_store::Error`] into [`UniversalIoError`], surfacing
+/// `NotFound` with the object key as the path.
+fn map_get_err(err: object_store::Error, key: &object_store::path::Path) -> UniversalIoError {
+    match err {
+        object_store::Error::NotFound { .. } => UniversalIoError::NotFound {
+            path: PathBuf::from(key.to_string()),
+        },
+        other => UniversalIoError::s3(other),
+    }
 }
 
 fn build_dir_prefix(path: &Path) -> object_store::path::Path {
@@ -441,6 +532,137 @@ mod tests {
         assert_eq!(got[&1], b"hello");
         assert_eq!(got[&2], b"WORLD");
         assert_eq!(got[&3], b"xyz");
+    }
+
+    /// Drive `read_from` directly and reassemble the streamed `(offset, bytes)`
+    /// chunks, asserting they are disjoint and tile the tail exactly.
+    fn collect_read_from(
+        runtime: &BridgeRuntime,
+        source: &InMemorySource,
+        key: &str,
+        from: u64,
+    ) -> (u64, Vec<u8>) {
+        runtime.block_on(async {
+            let (total, mut stream) = source.read_from(Path::new(key), from).await.expect("read");
+            let mut pieces = Vec::new();
+            while let Some(chunk) = stream.next().await {
+                pieces.push(chunk.expect("chunk"));
+            }
+            pieces.sort_by_key(|(offset, _)| *offset);
+            let mut bytes = Vec::new();
+            for (offset, piece) in pieces {
+                assert_eq!(offset as usize, bytes.len(), "chunks must tile the tail");
+                bytes.extend_from_slice(&piece);
+            }
+            (total, bytes)
+        })
+    }
+
+    #[test]
+    fn read_from_in_chunks() {
+        let runtime = BridgeRuntime::global();
+        let store = inmemory_with(&runtime, &[("obj", b"0123456789")]);
+        let source = ObjectStoreSource::new(store).with_chunk_size(3);
+
+        let (total, bytes) = collect_read_from(&runtime, &source, "obj", 0);
+        assert_eq!(total, 10);
+        assert_eq!(bytes, b"0123456789");
+
+        let (total, bytes) = collect_read_from(&runtime, &source, "obj", 4);
+        assert_eq!(total, 10);
+        assert_eq!(bytes, b"456789");
+
+        // Tail smaller than one chunk: served entirely by the probe request.
+        let (total, bytes) = collect_read_from(&runtime, &source, "obj", 8);
+        assert_eq!(total, 10);
+        assert_eq!(bytes, b"89");
+    }
+
+    #[test]
+    fn read_from_more_chunks_than_concurrency_reassembles_exactly() {
+        let runtime = BridgeRuntime::global();
+        let store = Arc::new(InMemory::new());
+        let data: Vec<u8> = (0..=255).collect();
+        runtime.block_on(async {
+            store
+                .put(
+                    &object_store::path::Path::from("obj"),
+                    Bytes::from(data.clone()).into(),
+                )
+                .await
+                .unwrap();
+        });
+        // 7-byte chunks over 256 bytes: ~36 follow-up GETs racing through the
+        // unordered window; the offset-tagged chunks must tile the object
+        // exactly whatever order they complete in.
+        let source = ObjectStoreSource::new(store).with_chunk_size(7);
+        let (total, bytes) = collect_read_from(&runtime, &source, "obj", 0);
+        assert_eq!(total, 256);
+        assert_eq!(bytes, data);
+    }
+
+    /// A bounded probe on an empty object is an unsatisfiable range, so the
+    /// raw `read_from` errors; the pipeline's `len` disambiguation (see
+    /// `read_from_into_byte_buffer`) turns that into an empty buffer.
+    #[test]
+    fn read_whole_empty_object_yields_empty_buffer() {
+        let runtime = BridgeRuntime::global();
+        let store = inmemory_with(&runtime, &[("empty", b"")]);
+
+        let source = ObjectStoreSource::new(store.clone());
+        assert!(
+            runtime
+                .block_on(source.read_from(Path::new("empty"), 0))
+                .is_err(),
+            "bounded probe on an empty object is unsatisfiable"
+        );
+
+        let file = make_file(runtime, store, "empty");
+        let bytes = file.read_whole::<u8>().expect("read_whole");
+        assert!(bytes.is_empty());
+    }
+
+    #[test]
+    fn read_whole_through_blob_file_in_chunks() {
+        let runtime = BridgeRuntime::global();
+        let store = inmemory_with(&runtime, &[("obj", b"hello world")]);
+        let file = BlobFile::new(
+            ObjectStoreSource::new(store).with_chunk_size(4),
+            runtime,
+            PathBuf::from("obj"),
+        );
+        let cow = file.read_whole::<u8>().expect("read_whole");
+        assert_eq!(&cow[..], b"hello world");
+    }
+
+    #[test]
+    fn read_from_fails_on_concurrent_overwrite() {
+        let runtime = BridgeRuntime::global();
+        let store = inmemory_with(&runtime, &[("obj", b"0123456789")]);
+        let source = ObjectStoreSource::new(store.clone()).with_chunk_size(4);
+        runtime.block_on(async {
+            // The probe resolves inside `read_from` and pins the ETag; the
+            // follow-up GETs only go out once the stream is polled. Overwrite
+            // in between: every follow-up chunk must fail the `if_match`
+            // precondition rather than stitch bytes from two versions.
+            let (total, mut stream) = source.read_from(Path::new("obj"), 0).await.expect("read");
+            assert_eq!(total, 10);
+            store
+                .put(
+                    &object_store::path::Path::from("obj"),
+                    Bytes::from_static(b"XXXXXXXXXX").into(),
+                )
+                .await
+                .unwrap();
+            let mut results = Vec::new();
+            while let Some(item) = stream.next().await {
+                results.push(item);
+            }
+            assert!(
+                results.iter().any(Result::is_err),
+                "expected a precondition failure, got {results:?}"
+            );
+        });
     }
 
     #[test]

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -32,7 +32,7 @@ use crate::backend::BlobBackend;
 /// object into. Bounds the blast radius of a dropped connection (a retry
 /// re-fetches one chunk, not the whole object) while staying large enough that
 /// the per-request round-trip stays amortized.
-const DEFAULT_READ_CHUNK_SIZE: u64 = 16 * 1024 * 1024;
+const DEFAULT_READ_CHUNK_SIZE: u64 = 8 * 1024 * 1024;
 
 /// Number of follow-up chunk GETs a multi-part [`AsyncRead::read_from`] keeps
 /// in flight at once. Chunks are yielded as they complete (out of order,
@@ -219,9 +219,9 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
                 .await
                 .map_err(|err| map_get_err(err, &key))?;
             let total = first.meta.size;
-            // Follow-up chunks are pinned to the version the probe saw: a
-            // concurrent overwrite fails the read (HTTP 412) instead of
-            // silently stitching bytes from two object versions.
+            // Follow-up chunks are pinned to the version the probe saw.
+            // All major providers support `e-tag`. For now, we won't fail if
+            // it doesn't support it.
             let e_tag = first.meta.e_tag.take();
             let first_end = first.range.end;
             let first_stream =

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -39,7 +39,7 @@ const DEFAULT_READ_CHUNK_SIZE: u64 = 8 * 1024 * 1024;
 /// tagged with their offset); a larger value hides more per-request round-trip
 /// latency at the cost of buffering up to `concurrency * chunk_size` bytes
 /// ahead of the consumer.
-const READ_CHUNK_CONCURRENCY: usize = 32;
+const READ_CHUNK_CONCURRENCY: usize = 16;
 
 /// [`AsyncRead`] handle over an object store. Holds the store as `Arc<S>` so it
 /// is cheap to clone; the object key is supplied per call.

--- a/lib/common/io_bridge_uio_grpc/src/lib.rs
+++ b/lib/common/io_bridge_uio_grpc/src/lib.rs
@@ -42,7 +42,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use common::universal_io::{ListedFile, Result, UniversalKind};
 use futures::stream::{self, BoxStream, StreamExt as _};
-use io_bridge::{AsyncRead, BlobFile, BlobFs};
+use io_bridge::{AsyncRead, BlobFile, BlobFs, OffsetByteStream};
 use tokio::sync::OnceCell;
 use uio_grpc_client::Client;
 
@@ -183,8 +183,7 @@ impl AsyncRead for UioGrpcSource {
         &self,
         path: &Path,
         from: u64,
-    ) -> impl Future<Output = Result<(u64, BoxStream<'static, Result<Bytes>>)>> + Send + 'static
-    {
+    ) -> impl Future<Output = Result<(u64, OffsetByteStream)>> + Send + 'static {
         let inner = self.inner.clone();
         let path = path_to_string(path);
         async move {
@@ -199,13 +198,13 @@ impl AsyncRead for UioGrpcSource {
             if length == 0 {
                 // Nothing to read past `from`; yield the size with an empty body
                 // rather than issuing a zero-length range request.
-                let empty: BoxStream<'static, Result<Bytes>> = stream::empty().boxed();
+                let empty: OffsetByteStream = stream::empty().boxed();
                 return Ok((total, empty));
             }
             let stream = client
                 .read_bytes_stream_raw(&inner.collection, inner.shard_id, &path, from, length)
                 .await?;
-            Ok((total, stream))
+            Ok((total, io_bridge::with_running_offsets(stream)))
         }
     }
 


### PR DESCRIPTION
## Why
I found out we had inefficient reads when the range was large. For instance, a 3.7GB file was taking >30s to fetch, even under 10gbit network.

The main contributor to this bad performance was the zero-filling of `AVec`. Apparently the implementation is not very efficient, but more importantly, we can avoid zeroing entirely.

## What
After avoiding zeroing, the fetch was already at around 9-10 seconds.

This PR fixes this zeroing, but applies another optimization: to chunk the reads (unordered) and saturate bandwidth.

After this secondary optimization, it reads the file in <4s 🔥 

Assisted by AI ™️ 