### PR TITLE
Slice filtering condition: sliced scroll / deterministic sampling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7009,6 +7009,7 @@ dependencies = [
  "serde_json",
  "serde_variant",
  "sha2 0.11.0",
+ "siphasher 1.0.3",
  "smallvec",
  "sparse",
  "strum",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -9630,6 +9630,9 @@
             "$ref": "#/components/schemas/HasVectorCondition"
           },
           {
+            "$ref": "#/components/schemas/SliceCondition"
+          },
+          {
             "$ref": "#/components/schemas/NestedCondition"
           },
           {
@@ -10122,6 +10125,40 @@
         "properties": {
           "has_vector": {
             "type": "string"
+          }
+        }
+      },
+      "SliceCondition": {
+        "description": "Select points that fall into one of `total` disjoint deterministic slices of the id space, for parallel scans and reproducible sampling.",
+        "type": "object",
+        "required": [
+          "slice"
+        ],
+        "properties": {
+          "slice": {
+            "$ref": "#/components/schemas/Slice"
+          }
+        }
+      },
+      "Slice": {
+        "description": "One of `total` disjoint deterministic slices of the id space.\n\nA point belongs to the slice iff `hash(id) % total == index`, where `hash` is SipHash-2-4 with a zero key over the canonical id bytes: 8 little-endian bytes for numeric ids, the 16 RFC 4122 bytes for UUIDs. For a fixed `total`, slices `0..total` are disjoint and together cover all points; membership is uniform regardless of the id scheme and stable across queries, segments, platforms and Qdrant versions.\n\nSlices with different `total` values are correlated (same hash, no salt): e.g. slice `0` of `total: 4` is a strict subset of slice `0` of `total: 2`. This keeps a smaller sample contained in a larger one.",
+        "type": "object",
+        "required": [
+          "index",
+          "total"
+        ],
+        "properties": {
+          "total": {
+            "description": "Total number of disjoint slices the id space is split into",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 1
+          },
+          "index": {
+            "description": "Which slice to select, must be in `0..total`",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
           }
         }
       },

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -39,9 +39,9 @@ use super::qdrant::{
     KeywordIndexParams, KeywordPrefixParams, LookupLocation, MaxOptimizationThreads, Memory,
     MultiVectorComparator, MultiVectorConfig, OrderBy, OrderValue, Range, RawVector,
     RecommendStrategy, RetrievedPoint, SearchMatrixPair, SearchPointGroups, SearchPoints,
-    ShardKeySelector, StartFrom, StrictModeMultivector, StrictModeMultivectorConfig,
-    StrictModeSparse, StrictModeSparseConfig, TurboQuantBitSize, TurboQuantization,
-    UuidIndexParams, VectorsOutput, WithLookup, raw_query, start_from,
+    ShardKeySelector, SliceCondition, StartFrom, StrictModeMultivector,
+    StrictModeMultivectorConfig, StrictModeSparse, StrictModeSparseConfig, TurboQuantBitSize,
+    TurboQuantization, UuidIndexParams, VectorsOutput, WithLookup, raw_query, start_from,
 };
 use super::stemming_algorithm::StemmingParams;
 use super::{
@@ -1811,6 +1811,7 @@ pub fn grpc_condition_into_condition(
                 has_vector: has_vector.has_vector,
             },
         )),
+        ConditionOneOf::Slice(slice) => Some(segment::types::Condition::Slice(slice.try_into()?)),
     };
 
     Ok(condition)
@@ -1845,9 +1846,42 @@ impl From<segment::types::Condition> for Condition {
                     has_vector: has_vector.has_vector,
                 }))
             }
+            segment::types::Condition::Slice(slice) => {
+                Some(ConditionOneOf::Slice(SliceCondition::from(slice)))
+            }
         };
 
         Self { condition_one_of }
+    }
+}
+
+impl TryFrom<SliceCondition> for segment::types::SliceCondition {
+    type Error = Status;
+
+    fn try_from(value: SliceCondition) -> Result<Self, Self::Error> {
+        let SliceCondition { total, index } = value;
+        let total = std::num::NonZeroU32::new(total)
+            .ok_or_else(|| Status::invalid_argument("Slice total must be greater than 0"))?;
+        if index >= total.get() {
+            return Err(Status::invalid_argument(
+                "Slice index must be less than the total number of slices",
+            ));
+        }
+        Ok(Self {
+            slice: segment::types::Slice { total, index },
+        })
+    }
+}
+
+impl From<segment::types::SliceCondition> for SliceCondition {
+    fn from(value: segment::types::SliceCondition) -> Self {
+        let segment::types::SliceCondition {
+            slice: segment::types::Slice { total, index },
+        } = value;
+        Self {
+            total: total.get(),
+            index,
+        }
     }
 }
 

--- a/lib/api/src/grpc/proto/qdrant_common.proto
+++ b/lib/api/src/grpc/proto/qdrant_common.proto
@@ -45,6 +45,7 @@ message Condition {
     IsNullCondition is_null = 5;
     NestedCondition nested = 6;
     HasVectorCondition has_vector = 7;
+    SliceCondition slice = 8;
   }
 }
 
@@ -62,6 +63,13 @@ message HasIdCondition {
 
 message HasVectorCondition {
   string has_vector = 1;
+}
+
+message SliceCondition {
+  // Total number of disjoint deterministic slices the id space is split into, must be >= 1
+  uint32 total = 1;
+  // Which slice to select, must be less than `total`
+  uint32 index = 2;
 }
 
 message NestedCondition {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -158,7 +158,7 @@ pub struct MinShould {
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Condition {
-    #[prost(oneof = "condition::ConditionOneOf", tags = "1, 2, 3, 4, 5, 6, 7")]
+    #[prost(oneof = "condition::ConditionOneOf", tags = "1, 2, 3, 4, 5, 6, 7, 8")]
     #[validate(nested)]
     pub condition_one_of: ::core::option::Option<condition::ConditionOneOf>,
 }
@@ -181,6 +181,8 @@ pub mod condition {
         Nested(super::NestedCondition),
         #[prost(message, tag = "7")]
         HasVector(super::HasVectorCondition),
+        #[prost(message, tag = "8")]
+        Slice(super::SliceCondition),
     }
 }
 #[derive(serde::Serialize)]
@@ -206,6 +208,16 @@ pub struct HasIdCondition {
 pub struct HasVectorCondition {
     #[prost(string, tag = "1")]
     pub has_vector: ::prost::alloc::string::String,
+}
+#[derive(serde::Serialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct SliceCondition {
+    /// Total number of disjoint deterministic slices the id space is split into, must be >= 1
+    #[prost(uint32, tag = "1")]
+    pub total: u32,
+    /// Which slice to select, must be less than `total`
+    #[prost(uint32, tag = "2")]
+    pub index: u32,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -229,6 +229,27 @@ impl Validate for grpc::condition::ConditionOneOf {
             ConditionOneOf::HasId(_) => Ok(()),
             ConditionOneOf::IsNull(_) => Ok(()),
             ConditionOneOf::HasVector(_) => Ok(()),
+            ConditionOneOf::Slice(slice_condition) => slice_condition.validate(),
+        }
+    }
+}
+
+impl Validate for grpc::SliceCondition {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        let grpc::SliceCondition { total, index } = self;
+        let mut errors = ValidationErrors::new();
+        if *total == 0 {
+            errors.add("total", ValidationError::new("must be greater than 0"));
+        } else if index >= total {
+            errors.add(
+                "index",
+                ValidationError::new("must be less than the total number of slices"),
+            );
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
         }
     }
 }

--- a/lib/collection/src/problems/unindexed_field.rs
+++ b/lib/collection/src/problems/unindexed_field.rs
@@ -388,6 +388,7 @@ impl<'a> Extractor<'a> {
             Condition::HasId(_) => return,
             Condition::CustomIdChecker(_) => return,
             Condition::HasVector(_) => return,
+            Condition::Slice(_) => return,
         };
 
         // An empty required-index set means the condition is a no-op (e.g.

--- a/lib/edge/python/src/lib.rs
+++ b/lib/edge/python/src/lib.rs
@@ -73,7 +73,8 @@ mod qdrant_edge {
         PyFieldCondition, PyFilter, PyGeoBoundingBox, PyGeoPoint, PyGeoPolygon, PyGeoRadius,
         PyHasIdCondition, PyHasVectorCondition, PyIsEmptyCondition, PyIsNullCondition, PyMatchAny,
         PyMatchExcept, PyMatchPhrase, PyMatchPrefix, PyMatchText, PyMatchTextAny, PyMatchValue,
-        PyMinShould, PyNestedCondition, PyRangeDateTime, PyRangeFloat, PyValuesCount,
+        PyMinShould, PyNestedCondition, PyRangeDateTime, PyRangeFloat, PySliceCondition,
+        PyValuesCount,
     };
     #[pymodule_export]
     use super::types::formula::{PyDecayKind, PyExpressionInterface, PyFormula};

--- a/lib/edge/python/src/types/filter/condition.rs
+++ b/lib/edge/python/src/types/filter/condition.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::num::NonZeroU32;
 
 use bytemuck::TransparentWrapper;
 use derive_more::Into;
@@ -27,6 +28,7 @@ impl FromPyObject<'_, '_> for PyCondition {
             IsNull(PyIsNullCondition),
             HasId(PyHasIdCondition),
             HasVector(PyHasVectorCondition),
+            Slice(PySliceCondition),
             Nested(PyNestedCondition),
             Filter(PyFilter),
         }
@@ -37,6 +39,7 @@ impl FromPyObject<'_, '_> for PyCondition {
             Helper::IsNull(is_null) => Condition::IsNull(is_null.into()),
             Helper::HasId(has_id) => Condition::HasId(has_id.into()),
             Helper::HasVector(has_vector) => Condition::HasVector(has_vector.into()),
+            Helper::Slice(slice) => Condition::Slice(slice.into()),
             Helper::Nested(nested) => Condition::Nested(nested.into()),
             Helper::Filter(filter) => Condition::Filter(filter.into()),
         };
@@ -59,6 +62,7 @@ impl<'py> IntoPyObject<'py> for PyCondition {
             Condition::HasVector(has_vector) => {
                 PyHasVectorCondition(has_vector).into_bound_py_any(py)
             }
+            Condition::Slice(slice) => PySliceCondition(slice).into_bound_py_any(py),
             Condition::Nested(nested) => PyNestedCondition(nested).into_bound_py_any(py),
             Condition::Filter(filter) => PyFilter(filter).into_bound_py_any(py),
             Condition::CustomIdChecker(_) => {
@@ -86,6 +90,7 @@ impl Repr for PyCondition {
             Condition::IsNull(is_null) => PyIsNullCondition::wrap_ref(is_null).fmt(f),
             Condition::HasId(has_id) => PyHasIdCondition::wrap_ref(has_id).fmt(f),
             Condition::HasVector(has_vector) => PyHasVectorCondition::wrap_ref(has_vector).fmt(f),
+            Condition::Slice(slice) => PySliceCondition::wrap_ref(slice).fmt(f),
             Condition::Nested(nested) => PyNestedCondition::wrap_ref(nested).fmt(f),
             Condition::Filter(filter) => PyFilter::wrap_ref(filter).fmt(f),
             Condition::CustomIdChecker(_) => {
@@ -228,5 +233,55 @@ impl PyHasVectorCondition {
         let HasVectorCondition {
             has_vector: _vector,
         } = self.0;
+    }
+}
+
+#[pyclass(name = "SliceCondition", from_py_object)]
+#[derive(Clone, Debug, Into, TransparentWrapper)]
+#[repr(transparent)]
+pub struct PySliceCondition(pub SliceCondition);
+
+#[pyclass_repr]
+#[pymethods]
+impl PySliceCondition {
+    #[new]
+    pub fn new(total: u32, index: u32) -> PyResult<Self> {
+        let Some(total) = NonZeroU32::new(total) else {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "total must be greater than 0",
+            ));
+        };
+        if index >= total.get() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "index must be less than total",
+            ));
+        }
+        Ok(Self(SliceCondition {
+            slice: Slice { total, index },
+        }))
+    }
+
+    #[getter]
+    pub fn total(&self) -> u32 {
+        self.0.slice.total.get()
+    }
+
+    #[getter]
+    pub fn index(&self) -> u32 {
+        self.0.slice.index
+    }
+
+    pub fn __repr__(&self) -> String {
+        self.repr()
+    }
+}
+
+impl PySliceCondition {
+    fn _getters(self) {
+        // Every field should have a getter method
+        let Slice {
+            total: _total,
+            index: _index,
+        } = self.0.slice;
     }
 }

--- a/lib/edge/src/reexports.rs
+++ b/lib/edge/src/reexports.rs
@@ -27,8 +27,9 @@ mod reexports_from_qdrant_crates {
         NestedCondition, Payload, PayloadFieldSchema, PayloadIndexInfo, PayloadSchemaParams,
         PayloadSchemaType, PayloadSelector, PayloadSelectorExclude, PayloadSelectorInclude,
         ProductQuantizationConfig, QuantizationConfig, QuantizationSearchParams, Range,
-        RangeInterface, ScalarQuantizationConfig, ScalarType, ScoredPoint, SearchParams,
-        ValueVariants, ValuesCount, VectorStorageDatatype, WithPayloadInterface, WithVector,
+        RangeInterface, ScalarQuantizationConfig, ScalarType, ScoredPoint, SearchParams, Slice,
+        SliceCondition, ValueVariants, ValuesCount, VectorStorageDatatype, WithPayloadInterface,
+        WithVector,
     };
     pub use segment::vector_storage::query::{
         ContextPair, ContextQuery, DiscoverQuery, FeedbackItem,

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -87,6 +87,7 @@ indexmap = { workspace = true }
 ahash = { workspace = true }
 self_cell.workspace = true
 sha2 = { workspace = true }
+siphasher = "1.0.3"
 smallvec = { workspace = true }
 strum = { workspace = true }
 byteorder = { workspace = true }

--- a/lib/segment/src/data_types/load_profile.rs
+++ b/lib/segment/src/data_types/load_profile.rs
@@ -222,7 +222,10 @@ fn collect_filter_keys(
                 continue;
             }
             // Id- and vector-level conditions read no payload index.
-            Condition::HasId(_) | Condition::HasVector(_) | Condition::CustomIdChecker(_) => {
+            Condition::HasId(_)
+            | Condition::HasVector(_)
+            | Condition::Slice(_)
+            | Condition::CustomIdChecker(_) => {
                 continue;
             }
         };

--- a/lib/segment/src/index/field_index/mod.rs
+++ b/lib/segment/src/index/field_index/mod.rs
@@ -116,6 +116,7 @@ impl CardinalityEstimation {
                     | Condition::IsNull(_)
                     | Condition::HasId(_)
                     | Condition::HasVector(_)
+                    | Condition::Slice(_)
                     | Condition::Nested(_)
                     | Condition::Filter(_)
                     | Condition::CustomIdChecker(_) => false,
@@ -126,6 +127,7 @@ impl CardinalityEstimation {
                     | Condition::IsEmpty(_)
                     | Condition::IsNull(_)
                     | Condition::HasVector(_)
+                    | Condition::Slice(_)
                     | Condition::Nested(_)
                     | Condition::Filter(_)
                     | Condition::CustomIdChecker(_) => false,
@@ -138,6 +140,7 @@ impl CardinalityEstimation {
                     | Condition::IsEmpty(_)
                     | Condition::IsNull(_)
                     | Condition::HasId(_)
+                    | Condition::Slice(_)
                     | Condition::Nested(_)
                     | Condition::Filter(_)
                     | Condition::CustomIdChecker(_) => false,

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -234,6 +234,7 @@ where
         | Condition::IsNull(_)
         | Condition::HasId(_)
         | Condition::HasVector(_)
+        | Condition::Slice(_)
         | Condition::Nested(_)
         | Condition::CustomIdChecker(_) => estimator(condition),
     }
@@ -386,6 +387,7 @@ mod tests {
             Condition::Filter(_) => panic!("unexpected Filter"),
             Condition::Nested(_) => panic!("unexpected Nested"),
             Condition::CustomIdChecker(_) => panic!("unexpected CustomIdChecker"),
+            Condition::Slice(_) => panic!("unexpected Slice"),
             Condition::Field(field) => match field.key.to_string().as_str() {
                 "color" => CardinalityEstimation {
                     primary_clauses: vec![PrimaryCondition::Condition(Box::new(field.clone()))],

--- a/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/condition_converter.rs
@@ -20,7 +20,7 @@ use crate::payload_storage::query_checker::{
     check_field_condition, check_is_empty_condition, check_is_null_condition, check_payload,
     select_nested_indexes,
 };
-use crate::types::{Condition, FieldCondition, OwnedPayloadRef, PayloadContainer};
+use crate::types::{Condition, FieldCondition, OwnedPayloadRef, PayloadContainer, Slice};
 use crate::vector_storage::VectorStorageRead;
 
 impl<'a, P, I, V, F> StructPayloadIndexReadView<'a, P, I, V, F>
@@ -152,6 +152,12 @@ where
                     },
                 }))
             }
+            Condition::Slice(slice_condition) => {
+                ConditionCheckerEnum::Dyn(Box::new(SliceConditionChecker {
+                    id_tracker,
+                    slice: slice_condition.slice,
+                }))
+            }
             Condition::CustomIdChecker(cond) => {
                 let segment_ids: AHashSet<_> = id_tracker
                     .point_mappings()
@@ -233,6 +239,25 @@ impl ConditionChecker for IdsConditionChecker {
 
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
         Ok(self.0.contains(&point_id))
+    }
+}
+
+/// For [`Condition::Slice`]. Resolves the external id and checks slice
+/// membership per candidate point; unlike [`IdsConditionChecker`] it does not
+/// materialize the matching id set, which holds `~points / total` entries.
+struct SliceConditionChecker<'a, I: IdTrackerRead> {
+    id_tracker: &'a I,
+    slice: Slice,
+}
+
+impl<I: IdTrackerRead> ConditionChecker for SliceConditionChecker<'_, I> {
+    type Error = OperationError;
+
+    fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
+        Ok(self
+            .id_tracker
+            .external_id(point_id)
+            .is_some_and(|external_id| self.slice.check(external_id)))
     }
 }
 

--- a/lib/segment/src/index/struct_payload_index/read_view/filtering.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/filtering.rs
@@ -153,6 +153,16 @@ where
                 .estimate_field_condition(field_condition, nested_path, hw_counter)?
                 .unwrap_or_else(|| CardinalityEstimation::unknown(self.available_point_count())),
 
+            Condition::Slice(slice_condition) => {
+                let available_points = self.available_point_count();
+                CardinalityEstimation {
+                    primary_clauses: vec![],
+                    min: 0,
+                    exp: available_points / slice_condition.slice.total.get() as usize,
+                    max: available_points,
+                }
+            }
+
             Condition::CustomIdChecker(cond) => {
                 cond.0.estimate_cardinality(self.available_point_count())
             }

--- a/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/optimizer.rs
@@ -145,6 +145,7 @@ where
                 | Condition::IsNull(_)
                 | Condition::HasId(_)
                 | Condition::HasVector(_)
+                | Condition::Slice(_)
                 | Condition::Nested(_)
                 | Condition::CustomIdChecker(_) => {
                     let estimation =

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -37,6 +37,7 @@ where
         | Condition::IsNull(_)
         | Condition::HasId(_)
         | Condition::HasVector(_)
+        | Condition::Slice(_)
         | Condition::Nested(_)
         | Condition::CustomIdChecker(_) => checker(condition),
     }
@@ -176,6 +177,10 @@ where
                     )
                 })
         }
+
+        Condition::Slice(slice_condition) => id_tracker
+            .and_then(|id_tracker| id_tracker.external_id(point_id))
+            .is_some_and(|external_id| slice_condition.slice.check(external_id)),
 
         Condition::CustomIdChecker(cond) => id_tracker
             .and_then(|id_tracker| id_tracker.external_id(point_id))
@@ -648,6 +653,73 @@ mod tests {
 
         let query = Filter::new_must(Condition::HasId(ids.into()));
         assert!(payload_checker.check(2, &query));
+    }
+
+    #[test]
+    fn test_slice_condition_checker() {
+        use std::num::NonZeroU32;
+
+        use uuid::Uuid;
+
+        use crate::types::{PointIdType, Slice, SliceCondition};
+
+        let payload_storage: PayloadStorageEnum =
+            PayloadStorageEnum::InMemory(InMemoryPayloadStorage::default());
+        let mut id_tracker = InMemoryIdTracker::new();
+
+        let external_ids: Vec<PointIdType> = (0..100_u64)
+            .map(PointIdType::NumId)
+            .chain((0..100_u128).map(|seed| {
+                PointIdType::Uuid(Uuid::from_u128(
+                    seed.wrapping_mul(0x0123_4567_89ab_cdef_fedc_ba98_7654_3210),
+                ))
+            }))
+            .collect();
+        for (offset, external_id) in external_ids.iter().enumerate() {
+            id_tracker
+                .set_link(*external_id, offset as PointOffsetType)
+                .unwrap();
+        }
+
+        let payload_checker = SimpleConditionChecker::new(
+            Arc::new(AtomicRefCell::new(payload_storage)),
+            Arc::new(AtomicRefCell::new(IdTrackerEnum::InMemoryIdTracker(
+                id_tracker,
+            ))),
+            HashMap::new(),
+        );
+
+        let total = NonZeroU32::new(5).unwrap();
+        let slice_filter = |index| {
+            Filter::new_must(Condition::Slice(SliceCondition {
+                slice: Slice { total, index },
+            }))
+        };
+
+        for offset in 0..external_ids.len() as PointOffsetType {
+            // Each point matches exactly one of the disjoint slices
+            let matching: Vec<u32> = (0..total.get())
+                .filter(|&index| payload_checker.check(offset, &slice_filter(index)))
+                .collect();
+            assert_eq!(matching.len(), 1, "point {offset} matched {matching:?}");
+
+            // must_not inverts membership
+            let inverted = Filter::new_must_not(Condition::Slice(SliceCondition {
+                slice: Slice {
+                    total,
+                    index: matching[0],
+                },
+            }));
+            assert!(!payload_checker.check(offset, &inverted));
+        }
+
+        // On 200 uniformly hashed ids every slice gets some points
+        for index in 0..total.get() {
+            assert!(
+                (0..external_ids.len() as PointOffsetType)
+                    .any(|offset| payload_checker.check(offset, &slice_filter(index))),
+            );
+        }
     }
 
     /// Regression test for <https://github.com/qdrant/qdrant/issues/8936>

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -8,6 +8,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{self, Display, Formatter};
 use std::hash::{self, Hash, Hasher};
 use std::mem;
+use std::num::NonZeroU32;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::str::FromStr;
@@ -3785,6 +3786,71 @@ impl FromIterator<PointIdType> for HasIdCondition {
     }
 }
 
+/// One of `total` disjoint deterministic slices of the id space.
+///
+/// A point belongs to the slice iff `hash(id) % total == index`, where `hash`
+/// is SipHash-2-4 with a zero key over the canonical id bytes: 8 little-endian
+/// bytes for numeric ids, the 16 RFC 4122 bytes for UUIDs. For a fixed
+/// `total`, slices `0..total` are disjoint and together cover all points;
+/// membership is uniform regardless of the id scheme and stable across
+/// queries, segments, platforms and Qdrant versions.
+///
+/// Slices with different `total` values are correlated (same hash, no salt):
+/// e.g. slice `0` of `total: 4` is a strict subset of slice `0` of `total: 2`.
+/// This keeps a smaller sample contained in a larger one.
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Slice {
+    /// Total number of disjoint slices the id space is split into
+    pub total: NonZeroU32,
+    /// Which slice to select, must be in `0..total`
+    pub index: u32,
+}
+
+impl Slice {
+    /// True iff `point_id` belongs to this slice.
+    pub fn check(&self, point_id: PointIdType) -> bool {
+        let Self { total, index } = self;
+        slice_point_id_hash(point_id) % u64::from(total.get()) == u64::from(*index)
+    }
+}
+
+/// SipHash-2-4 with a zero key over the canonical byte encoding of a point id:
+/// 8 little-endian bytes for [`ExtendedPointId::NumId`], the 16 RFC 4122 bytes
+/// for [`ExtendedPointId::Uuid`].
+///
+/// This value is a public API contract of [`SliceCondition`]: clients may
+/// reproduce it to predict slice membership locally, so it must never change.
+/// It is deliberately independent from [`StableHash`], which is native-endian
+/// and internal to resharding.
+pub fn slice_point_id_hash(point_id: ExtendedPointId) -> u64 {
+    let mut hasher = siphasher::sip::SipHasher24::new();
+    match point_id {
+        ExtendedPointId::NumId(num) => hasher.write(&num.to_le_bytes()),
+        ExtendedPointId::Uuid(uuid) => hasher.write(uuid.as_bytes()),
+    }
+    hasher.finish()
+}
+
+/// Select points that fall into one of `total` disjoint deterministic slices
+/// of the id space, for parallel scans and reproducible sampling.
+#[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Eq, Hash, Validate)]
+#[validate(schema(function = "validate_slice_condition"))]
+pub struct SliceCondition {
+    pub slice: Slice,
+}
+
+pub fn validate_slice_condition(condition: &SliceCondition) -> Result<(), ValidationError> {
+    let SliceCondition { slice } = condition;
+    let Slice { total, index } = slice;
+    if index < &total.get() {
+        Ok(())
+    } else {
+        Err(ValidationError::new(
+            "Slice index must be less than the total number of slices",
+        ))
+    }
+}
+
 /// Select points with payload for a specified nested field
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Validate, Hash)]
 pub struct Nested {
@@ -3837,6 +3903,8 @@ pub enum Condition {
     HasId(HasIdCondition),
     /// Check if point has vector assigned
     HasVector(HasVectorCondition),
+    /// Check if point id falls into a deterministic slice of the id space
+    Slice(SliceCondition),
     /// Nested filters
     Nested(NestedCondition),
     /// Nested filter
@@ -3858,6 +3926,7 @@ enum ConditionUntagged {
     IsNull(IsNullCondition),
     HasId(HasIdCondition),
     HasVector(HasVectorCondition),
+    Slice(SliceCondition),
     Nested(NestedCondition),
     Filter(Filter),
 
@@ -3873,6 +3942,7 @@ impl From<ConditionUntagged> for Condition {
             ConditionUntagged::IsNull(condition) => Condition::IsNull(condition),
             ConditionUntagged::HasId(condition) => Condition::HasId(condition),
             ConditionUntagged::HasVector(condition) => Condition::HasVector(condition),
+            ConditionUntagged::Slice(condition) => Condition::Slice(condition),
             ConditionUntagged::Nested(condition) => Condition::Nested(condition),
             ConditionUntagged::Filter(condition) => Condition::Filter(condition),
             ConditionUntagged::CustomIdChecker(condition) => Condition::CustomIdChecker(condition),
@@ -3969,6 +4039,7 @@ impl Condition {
             Condition::IsEmpty(_)
             | Condition::IsNull(_)
             | Condition::HasVector(_)
+            | Condition::Slice(_)
             | Condition::CustomIdChecker(_) => 0,
         }
     }
@@ -3984,7 +4055,8 @@ impl Condition {
             | Condition::IsNull(_)
             | Condition::CustomIdChecker(_)
             | Condition::HasId(_)
-            | Condition::HasVector(_) => 1,
+            | Condition::HasVector(_)
+            | Condition::Slice(_) => 1,
         }
     }
 
@@ -3995,7 +4067,10 @@ impl Condition {
             Condition::IsNull(is_null_condition) => Some(is_null_condition.is_null.key.clone()),
             Condition::Nested(nested_condition) => Some(nested_condition.array_key()),
             Condition::Filter(filter) => filter.iter_conditions().find_map(|c| c.targeted_key()),
-            Condition::HasId(_) | Condition::HasVector(_) | Condition::CustomIdChecker(_) => None,
+            Condition::HasId(_)
+            | Condition::HasVector(_)
+            | Condition::Slice(_)
+            | Condition::CustomIdChecker(_) => None,
         }
     }
 }
@@ -4009,6 +4084,7 @@ impl Validate for Condition {
             | Condition::IsNull(_)
             | Condition::HasVector(_) => Ok(()),
             Condition::Field(field_condition) => field_condition.validate(),
+            Condition::Slice(slice_condition) => slice_condition.validate(),
             Condition::Nested(nested_condition) => nested_condition.validate(),
             Condition::Filter(filter) => filter.validate(),
             Condition::CustomIdChecker(_) => Ok(()),
@@ -4939,6 +5015,104 @@ mod tests {
         let nested_json = r#"{"nested": {"key": "items", "filter": {"must": []}}}"#;
         let condition: Condition = serde_json::from_str(nested_json).unwrap();
         assert_matches!(condition, Condition::Nested(_));
+
+        // SliceCondition
+        let slice_json = r#"{"slice": {"total": 8, "index": 3}}"#;
+        let condition: Condition = serde_json::from_str(slice_json).unwrap();
+        assert_matches!(condition, Condition::Slice(_));
+    }
+
+    #[test]
+    fn test_slice_condition_serde_and_validation() {
+        let condition: Condition =
+            serde_json::from_str(r#"{"slice": {"total": 8, "index": 3}}"#).unwrap();
+        let Condition::Slice(slice_condition) = &condition else {
+            panic!("expected slice condition, got {condition:?}");
+        };
+        assert_eq!(slice_condition.slice.total.get(), 8);
+        assert_eq!(slice_condition.slice.index, 3);
+        condition.validate().unwrap();
+
+        let serialized = serde_json::to_value(&condition).unwrap();
+        assert_eq!(
+            serialized,
+            serde_json::json!({"slice": {"total": 8, "index": 3}}),
+        );
+
+        // Zero total is rejected at deserialization
+        serde_json::from_str::<SliceCondition>(r#"{"slice": {"total": 0, "index": 0}}"#)
+            .unwrap_err();
+
+        // Out-of-range index is rejected by validation
+        let condition: Condition =
+            serde_json::from_str(r#"{"slice": {"total": 4, "index": 4}}"#).unwrap();
+        condition.validate().unwrap_err();
+    }
+
+    /// Frozen public contract: SipHash-2-4 with a zero key over canonical id
+    /// bytes (8 LE bytes for numeric ids, 16 RFC 4122 bytes for UUIDs).
+    /// Clients reproduce this hash to predict slice membership locally — if
+    /// this test fails, slice membership visibly changed for every existing
+    /// query and the change must be reverted.
+    #[test]
+    fn test_slice_point_id_hash_contract() {
+        // Vectors independently reproduced with a reference SipHash-2-4
+        // implementation outside this codebase.
+        let uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        assert_eq!(
+            slice_point_id_hash(ExtendedPointId::NumId(0)),
+            0xe849_e8bb_6ffe_2567,
+        );
+        assert_eq!(
+            slice_point_id_hash(ExtendedPointId::NumId(42)),
+            0x0fc2_553f_0761_9dd3,
+        );
+        assert_eq!(
+            slice_point_id_hash(ExtendedPointId::Uuid(uuid)),
+            0xf5d0_ca21_ba34_d504,
+        );
+    }
+
+    #[test]
+    fn test_slice_disjoint_and_exhaustive() {
+        let numeric_ids = (0..1000_u64).map(ExtendedPointId::NumId);
+        let uuid_ids = (0..1000_u128).map(|seed| {
+            ExtendedPointId::Uuid(Uuid::from_u128(
+                seed.wrapping_mul(0x0123_4567_89ab_cdef_fedc_ba98_7654_3210),
+            ))
+        });
+
+        for point_id in numeric_ids.chain(uuid_ids) {
+            // Exactly one slice of each total matches
+            for total in [1, 2, 5, 10] {
+                let total = NonZeroU32::new(total).unwrap();
+                (0..total.get())
+                    .filter(|&index| Slice { total, index }.check(point_id))
+                    .exactly_one()
+                    .unwrap();
+            }
+
+            // A finer slice is a subset of the coarser slice it maps onto:
+            // hash % 10 == index implies hash % 5 == index % 5
+            let fine_total = NonZeroU32::new(10).unwrap();
+            let fine_index = (0..fine_total.get())
+                .filter(|&index| {
+                    Slice {
+                        total: fine_total,
+                        index,
+                    }
+                    .check(point_id)
+                })
+                .exactly_one()
+                .unwrap();
+            assert!(
+                Slice {
+                    total: NonZeroU32::new(5).unwrap(),
+                    index: fine_index % 5,
+                }
+                .check(point_id)
+            );
+        }
     }
 
     #[test]

--- a/lib/shard/src/proxy_segment/vector_name_changes.rs
+++ b/lib/shard/src/proxy_segment/vector_name_changes.rs
@@ -299,6 +299,7 @@ impl ProxyVectorNameChanges {
                 Condition::IsEmpty(_) => {}
                 Condition::IsNull(_) => {}
                 Condition::HasId(_) => {}
+                Condition::Slice(_) => {}
                 Condition::CustomIdChecker(_) => {}
             }
         }
@@ -347,6 +348,7 @@ impl ProxyVectorNameChanges {
                 Condition::IsEmpty(_) => {}
                 Condition::IsNull(_) => {}
                 Condition::HasId(_) => {}
+                Condition::Slice(_) => {}
                 Condition::CustomIdChecker(_) => {}
             }
         }

--- a/tests/openapi/test_filter_slice.py
+++ b/tests/openapi/test_filter_slice.py
@@ -1,0 +1,113 @@
+import pytest
+
+from .helpers.collection_setup import drop_collection
+from .helpers.helpers import request_with_validation
+
+TOTAL_POINTS = 32
+
+
+@pytest.fixture(autouse=True, scope="module")
+def setup(collection_name):
+    create_collection(collection_name)
+    yield
+    drop_collection(collection_name=collection_name)
+
+
+def create_collection(collection_name):
+    drop_collection(collection_name)
+
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        body={
+            "vectors": {
+                "size": 2,
+                "distance": "Dot",
+            },
+        }
+    )
+    assert response.ok
+
+    # Half numeric ids, half UUIDs — slice membership must work for both
+    points = [
+        {"id": point_id, "vector": [0.1, 0.2]}
+        for point_id in range(TOTAL_POINTS // 2)
+    ] + [
+        {"id": f"00000000-0000-0000-0000-{seed:012x}", "vector": [0.1, 0.2]}
+        for seed in range(TOTAL_POINTS // 2)
+    ]
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': collection_name},
+        query_params={'wait': 'true'},
+        body={"points": points}
+    )
+    assert response.ok
+
+
+def scroll_slice(collection_name, total, index):
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {"must": [{"slice": {"total": total, "index": index}}]},
+            "limit": TOTAL_POINTS + 1,
+            "with_payload": False,
+            "with_vector": False,
+        }
+    )
+    assert response.ok
+    return {str(p['id']) for p in response.json()['result']['points']}
+
+
+def test_slice_partition(collection_name):
+    total = 4
+    seen = set()
+    for index in range(total):
+        ids = scroll_slice(collection_name, total, index)
+        assert not (seen & ids), "slices must be disjoint"
+        seen |= ids
+    assert len(seen) == TOTAL_POINTS, "slices must cover all points"
+
+
+def test_slice_must_not(collection_name):
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {"must_not": [{"slice": {"total": 4, "index": 0}}]},
+            "limit": TOTAL_POINTS + 1,
+            "with_payload": False,
+            "with_vector": False,
+        }
+    )
+    assert response.ok
+    inverted = {str(p['id']) for p in response.json()['result']['points']}
+    assert len(inverted) == TOTAL_POINTS - len(scroll_slice(collection_name, 4, 0))
+
+
+@pytest.mark.parametrize(
+    "slice_body, expected_status",
+    [
+        # index out of range: schema-valid, rejected by request validation
+        ({"total": 4, "index": 4}, 422),
+        # zero total: rejected at deserialization
+        ({"total": 0, "index": 0}, 400),
+    ],
+)
+def test_slice_invalid(collection_name, slice_body, expected_status):
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": {"must": [{"slice": slice_body}]},
+            "limit": 1,
+        }
+    )
+    assert response.status_code == expected_status


### PR DESCRIPTION
## What

New filter condition selecting points by a deterministic slice of the id space:

```json
{ "slice": { "total": 8, "index": 3 } }
```

A point matches iff `stable_hash(id) % total == index`. For a fixed `total`, slices `0..total` are disjoint and together cover all points.

## Why

- **Parallel full scans** (export, migration, offline re-embedding): each worker scrolls its own `index` — disjoint, exhaustive streams, ES sliced-scroll style. Previously impossible server-side: `has_id` is a set, `range` is payload-only, and UUID collections can't fake it with id ranges.
- **Reproducible sampling**: unlike `sample: random`, the same slice is the same subset on every query — recall eval, train/test splits, canaries. Composes with any other filter condition (stratified sampling for free).

## Hash contract (frozen)

SipHash-2-4 with a zero key over canonical id bytes: 8 little-endian bytes for numeric ids, the 16 RFC 4122 bytes for UUIDs. Hash-based rather than raw `id % n` because user id schemes (snowflake, strided, timestamp-derived) make arithmetic modulo silently biased or empty; the hash is uniform regardless of id scheme.

Deliberately independent of the internal resharding ring hash (which is native-endian `StableHash` and must stay internal). Clients can reproduce the hash to predict membership locally; the contract is locked by test vectors independently reproduced with a reference SipHash-2-4 implementation.

Slices of different `total`s are intentionally correlated (no salt): slice `0` of `total: 4` ⊂ slice `0` of `total: 2`, so a smaller sample stays contained in a larger one.

## Implementation notes

- Evaluated per candidate point via id_tracker external-id lookup — no payload index, no materialized id set (the matching set is `~points/total`, too big to collect like `CustomIdChecker` does).
- Cardinality estimation: `exp = points / total`, `min = 0`, `max = points`, no primary clause.
- Validation: `total >= 1` via `NonZeroU32` at deserialization, `index < total` via validator (REST) and message validation + conversion (gRPC). Both reject at request time — never silently-empty results.
- Not supported inside `nested` (same as `has_id`).
- gRPC: `SliceCondition` at `condition_one_of` tag 8; OpenAPI regenerated via `tools/generate_openapi_models.sh`.
- Edge python bindings get `SliceCondition` as well.

## Testing

- Unit: hash contract vectors (cross-checked against an external reference implementation), disjoint/exhaustive/subset properties over numeric + UUID ids, serde round-trip, validation failures, condition checker semantics incl. `must_not`.
- E2E against a live single-node server (REST + gRPC): 200 points (100 numeric + 100 UUID), disjointness and exhaustiveness across 5 slices on both the plain and struct payload index paths with identical membership, filtered HNSW search, count API, composition with payload filters, and both validation error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)