### PR TITLE
Handle queries on collections without shards

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -323,6 +323,10 @@ impl Collection {
             )
             .await?;
 
+        if all_shards_results.is_empty() {
+            return Ok(empty_batch_results(requests_batch.len()));
+        }
+
         let results_f = transposed_iter(all_shards_results)
             .zip(requests_batch.iter())
             .map(|(shards_results, request)| async {

--- a/lib/collection/src/tests/query_prefetch_offset_limit.rs
+++ b/lib/collection/src/tests/query_prefetch_offset_limit.rs
@@ -6,13 +6,13 @@ use ahash::AHashMap;
 use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use rand::{RngExt, rng};
-use segment::data_types::vectors::NamedQuery;
+use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, NamedQuery};
 use segment::types::{Distance, ExtendedPointId, WithPayloadInterface, WithVector};
 use shard::query::query_enum::QueryEnum;
 use tempfile::Builder;
 
 use crate::collection::{Collection, RequestShardTransfer};
-use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
+use crate::config::{CollectionConfigInternal, CollectionParams, ShardingMethod, WalConfig};
 use crate::operations::CollectionUpdateOperations;
 use crate::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,
@@ -21,6 +21,7 @@ use crate::operations::point_ops::{
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::shared_storage_config::SharedStorageConfig;
 use crate::operations::types::VectorsConfig;
+use crate::operations::universal_query::collection_query::CollectionQueryRequest;
 use crate::operations::universal_query::shard_query::{
     ScoringQuery, ShardPrefetch, ShardQueryRequest,
 };
@@ -32,6 +33,7 @@ use crate::shards::replica_set::replica_set_state::ReplicaState;
 use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_trait::WaitUntil;
+use crate::tests::fixtures::create_collection_config;
 
 const DIM: u64 = 4;
 const PEER_ID: u64 = 1;
@@ -132,6 +134,80 @@ async fn fixture() -> Collection {
         .expect("failed to insert points");
 
     collection
+}
+
+async fn empty_custom_sharded_collection() -> Collection {
+    let mut config = create_collection_config();
+    config.params.sharding_method = Some(ShardingMethod::Custom);
+
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+    let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();
+
+    Collection::new(
+        "test".to_string(),
+        PEER_ID,
+        collection_dir.path(),
+        snapshots_path.path(),
+        &config,
+        Arc::new(SharedStorageConfig::default()),
+        CollectionShardDistribution {
+            shards: AHashMap::new(),
+        },
+        None,
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
+        None,
+        None,
+        ResourceBudget::default(),
+        None,
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_query_empty_custom_sharded_collection() {
+    let collection = empty_custom_sharded_collection().await;
+
+    let request = CollectionQueryRequest {
+        prefetch: vec![],
+        query: None,
+        using: DEFAULT_VECTOR_NAME.to_owned(),
+        filter: None,
+        score_threshold: None,
+        limit: 1,
+        offset: 0,
+        params: None,
+        with_vector: WithVector::Bool(false),
+        with_payload: WithPayloadInterface::Bool(false),
+        lookup_from: None,
+    };
+
+    let query_batch = |requests| {
+        collection.query_batch(
+            requests,
+            |_| async { None },
+            None,
+            None,
+            None,
+            HwMeasurementAcc::new(),
+        )
+    };
+
+    let single_result = query_batch(vec![(request.clone(), ShardSelectorInternal::All)])
+        .await
+        .expect("querying an empty custom-sharded collection should succeed");
+    assert_eq!(single_result, vec![vec![]]);
+
+    let batch_result = query_batch(vec![
+        (request.clone(), ShardSelectorInternal::All),
+        (request, ShardSelectorInternal::All),
+    ])
+    .await
+    .expect("batch querying an empty custom-sharded collection should succeed");
+    assert_eq!(batch_result, vec![vec![], vec![]]);
 }
 
 /// Test that limit and offset works properly with prefetches.


### PR DESCRIPTION
### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

## Problem

Custom-sharded collections can validly have zero shards before any shard keys are created.

When the universal Query API fans a batch request out to such a collection, it receives no shard result vectors. The result aggregation path then passes an empty outer vector into `transposed_iter`, which asserts that its input is nonempty and panics.

For one input query, the correct response shape is:

```text
[[]]
```

rather than a panic or an empty outer response.

## Fix

Return an empty result list for each submitted query when shard fan-out produces no shard responses.

This preserves request batch cardinality:

- one query returns `[[]]`
- two queries return `[[], []]`

Queries involving one or more shards continue through the existing transposition and aggregation path unchanged.

## Tests

Add a public `Collection::query_batch` regression using a custom-sharded collection with no shard keys.

The regression verifies both one-query and two-query batch shapes.

## Validation

- Focused zero-shard query regression: passed
- `cargo +nightly fmt --all -- --check`: passed
- `cargo clippy --offline -p collection --all-targets -- -D warnings`: passed
- `git diff --check`: passed
- `cargo test --offline -p collection`: 247 passed, 1 failed, 1 ignored

The broad collection package run was **not** a completely clean pass. The single failure occurred in the randomized model harness after repeated quantization-storage `os error 22` failures and an optimizer timeout. Rerunning that harness by itself passed 1/1 with a different seed.

## AI disclosure

- [AI-assisted] `fb5d86104 Handle queries on collections without shards`

Initial prompt (abridged): inspect Qdrant for one real, reasonably scoped, previously unreported bug; prioritize panic paths reachable through valid input; reproduce it with a deterministic regression test; implement the smallest correct fix; run focused and broader validation; and stop after pushing the branch until pull-request creation is separately authorized.