### PR TITLE
Edge: request-specific structures for EdgeShardRead

### DIFF
--- a/lib/edge/publish/examples/src/bin/add-named-vector.rs
+++ b/lib/edge/publish/examples/src/bin/add-named-vector.rs
@@ -14,9 +14,9 @@ use qdrant_edge::external::serde_json::json;
 use qdrant_edge::{
     CreateVectorName, DeleteVectorName, DenseVectorConfig, Distance, EdgeConfig, EdgeShard,
     EdgeVectorParams, Modifier, NamedQuery, PointInsertOperations, PointOperations, PointStruct,
-    QueryEnum, QueryRequest, ScoringQuery, SparseVector, SparseVectorConfig, UpdateOperation,
-    Vector, VectorInternal, VectorNameConfig, VectorNameOperations, Vectors, WithPayloadInterface,
-    WithVector,
+    QueryEnum, QueryRequestBuilder, ScoringQuery, SparseVector, SparseVectorConfig,
+    UpdateOperation, Vector, VectorInternal, VectorNameConfig, VectorNameOperations, Vectors,
+    WithPayloadInterface,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -65,20 +65,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     );
 
     // Verify search works on the default vector
-    let results = shard.query(QueryRequest {
-        prefetches: vec![],
-        query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-            query: vec![0.1, 0.2, 0.3, 0.4].into(),
-            using: None,
-        }))),
-        filter: None,
-        score_threshold: None,
-        limit: 3,
-        offset: 0,
-        params: None,
-        with_vector: WithVector::Bool(false),
-        with_payload: WithPayloadInterface::Bool(true),
-    })?;
+    let results = shard.query(
+        QueryRequestBuilder::new(3)
+            .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+                query: vec![0.1, 0.2, 0.3, 0.4].into(),
+                using: None,
+            })))
+            .with_payload(WithPayloadInterface::Bool(true))
+            .build(),
+    )?;
     println!("Search on default vector: {} results", results.len());
     assert_eq!(results.len(), 3);
 
@@ -132,20 +127,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("Points after adding v2: {}", shard.info()?.points_count);
 
     // Search on the new vector - only points 4 and 5 have 'v2'
-    let results = shard.query(QueryRequest {
-        prefetches: vec![],
-        query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-            query: vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0].into(),
-            using: Some("v2".to_string()),
-        }))),
-        filter: None,
-        score_threshold: None,
-        limit: 5,
-        offset: 0,
-        params: None,
-        with_vector: WithVector::Bool(false),
-        with_payload: WithPayloadInterface::Bool(true),
-    })?;
+    let results = shard.query(
+        QueryRequestBuilder::new(5)
+            .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+                query: vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0].into(),
+                using: Some("v2".to_string()),
+            })))
+            .with_payload(WithPayloadInterface::Bool(true))
+            .build(),
+    )?;
     println!("Search on 'v2': {} results", results.len());
     assert!(!results.is_empty(), "Should find at least point 4 or 5");
 
@@ -188,20 +178,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     );
 
     // Search on sparse vector
-    let results = shard.query(QueryRequest {
-        prefetches: vec![],
-        query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-            query: VectorInternal::Sparse(SparseVector::new(vec![10, 25], vec![1.0, 0.5])?),
-            using: Some("keywords".to_string()),
-        }))),
-        filter: None,
-        score_threshold: None,
-        limit: 5,
-        offset: 0,
-        params: None,
-        with_vector: WithVector::Bool(false),
-        with_payload: WithPayloadInterface::Bool(true),
-    })?;
+    let results = shard.query(
+        QueryRequestBuilder::new(5)
+            .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+                query: VectorInternal::Sparse(SparseVector::new(vec![10, 25], vec![1.0, 0.5])?),
+                using: Some("keywords".to_string()),
+            })))
+            .with_payload(WithPayloadInterface::Bool(true))
+            .build(),
+    )?;
     println!("Search on 'keywords': {} results", results.len());
     assert!(!results.is_empty());
 
@@ -219,20 +204,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("Points after deleting v2: {}", shard.info()?.points_count);
 
     // Search on the default vector still works
-    let results = shard.query(QueryRequest {
-        prefetches: vec![],
-        query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-            query: vec![0.1, 0.2, 0.3, 0.4].into(),
-            using: None,
-        }))),
-        filter: None,
-        score_threshold: None,
-        limit: 5,
-        offset: 0,
-        params: None,
-        with_vector: WithVector::Bool(false),
-        with_payload: WithPayloadInterface::Bool(true),
-    })?;
+    let results = shard.query(
+        QueryRequestBuilder::new(5)
+            .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+                query: vec![0.1, 0.2, 0.3, 0.4].into(),
+                using: None,
+            })))
+            .with_payload(WithPayloadInterface::Bool(true))
+            .build(),
+    )?;
     println!(
         "Search on default vector after deleting v2: {} results",
         results.len()
@@ -250,20 +230,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     let info = shard.info()?;
     println!("Reopened shard: {} points", info.points_count);
 
-    let results = shard.query(QueryRequest {
-        prefetches: vec![],
-        query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-            query: VectorInternal::Sparse(SparseVector::new(vec![10, 25], vec![1.0, 0.5])?),
-            using: Some("keywords".to_string()),
-        }))),
-        filter: None,
-        score_threshold: None,
-        limit: 5,
-        offset: 0,
-        params: None,
-        with_vector: WithVector::Bool(false),
-        with_payload: WithPayloadInterface::Bool(true),
-    })?;
+    let results = shard.query(
+        QueryRequestBuilder::new(5)
+            .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+                query: VectorInternal::Sparse(SparseVector::new(vec![10, 25], vec![1.0, 0.5])?),
+                using: Some("keywords".to_string()),
+            })))
+            .with_payload(WithPayloadInterface::Bool(true))
+            .build(),
+    )?;
     println!(
         "Search on 'keywords' after reopen: {} results",
         results.len()

--- a/lib/edge/publish/examples/src/bin/bm25-search.rs
+++ b/lib/edge/publish/examples/src/bin/bm25-search.rs
@@ -12,8 +12,8 @@ use qdrant_edge::bm25_embed::{EdgeBm25, EdgeBm25Config};
 use qdrant_edge::external::serde_json::json;
 use qdrant_edge::{
     EdgeConfig, EdgeShard, EdgeSparseVectorParams, Modifier, NamedQuery, PointInsertOperations,
-    PointOperations, PointStruct, QueryEnum, QueryRequest, ScoringQuery, UpdateOperation,
-    VectorInternal, Vectors, WithPayloadInterface, WithVector,
+    PointOperations, PointStruct, QueryEnum, QueryRequestBuilder, ScoringQuery, UpdateOperation,
+    VectorInternal, Vectors, WithPayloadInterface,
 };
 
 const SPARSE_VECTOR_NAME: &str = "text";
@@ -67,20 +67,15 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("Info: {:?}", shard.info()?);
 
     let query = bm25.embed_query("clever fox");
-    let results = shard.query(QueryRequest {
-        prefetches: vec![],
-        query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-            query: VectorInternal::from(query),
-            using: Some(SPARSE_VECTOR_NAME.to_string()),
-        }))),
-        filter: None,
-        score_threshold: None,
-        limit: 3,
-        offset: 0,
-        params: None,
-        with_vector: WithVector::Bool(false),
-        with_payload: WithPayloadInterface::Bool(true),
-    })?;
+    let results = shard.query(
+        QueryRequestBuilder::new(3)
+            .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+                query: VectorInternal::from(query),
+                using: Some(SPARSE_VECTOR_NAME.to_string()),
+            })))
+            .with_payload(WithPayloadInterface::Bool(true))
+            .build(),
+    )?;
 
     println!("Got {} results", results.len());
     for r in &results {

--- a/lib/edge/publish/examples/src/bin/demo.rs
+++ b/lib/edge/publish/examples/src/bin/demo.rs
@@ -11,8 +11,8 @@ use qdrant_edge::{
     Condition, CountRequest, CreateIndex, EdgeShard, FacetRequest, FieldCondition,
     FieldIndexOperations, Filter, Match, MatchTextAny, NamedQuery, PayloadFieldSchema,
     PayloadSchemaType, PointId, PointInsertOperations, PointOperations, PointStruct, QueryEnum,
-    QueryRequest, Range, ScoringQuery, ScrollRequest, SearchRequest, UpdateOperation, Vector,
-    Vectors, WithPayloadInterface, WithVector,
+    QueryRequestBuilder, Range, RetrieveRequestBuilder, ScoringQuery, ScrollRequestBuilder,
+    SearchRequestBuilder, UpdateOperation, Vector, Vectors, WithPayloadInterface, WithVector,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -95,20 +95,16 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("---- Query ----");
 
-    let result = shard.query(QueryRequest {
-        prefetches: vec![],
-        query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
-            query: vec![6.0, 9.0, 4.0, 2.0].into(),
-            using: None,
-        }))),
-        filter: None,
-        score_threshold: None,
-        limit: 10,
-        offset: 0,
-        params: None,
-        with_vector: WithVector::Bool(true),
-        with_payload: WithPayloadInterface::Bool(true),
-    })?;
+    let result = shard.query(
+        QueryRequestBuilder::new(10)
+            .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery {
+                query: vec![6.0, 9.0, 4.0, 2.0].into(),
+                using: None,
+            })))
+            .with_vector(WithVector::Bool(true))
+            .with_payload(WithPayloadInterface::Bool(true))
+            .build(),
+    )?;
 
     for point in &result {
         println!("{point:?}");
@@ -116,19 +112,18 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("---- Search ----");
 
-    let points = shard.search(SearchRequest {
-        query: QueryEnum::Nearest(NamedQuery {
-            query: vec![1.0, 1.0, 1.0, 1.0].into(),
-            using: None,
-        }),
-        filter: None,
-        params: None,
-        limit: 10,
-        offset: 0,
-        with_payload: Some(WithPayloadInterface::Bool(true)),
-        with_vector: Some(WithVector::Bool(true)),
-        score_threshold: None,
-    })?;
+    let points = shard.search(
+        SearchRequestBuilder::new(
+            QueryEnum::Nearest(NamedQuery {
+                query: vec![1.0, 1.0, 1.0, 1.0].into(),
+                using: None,
+            }),
+            10,
+        )
+        .with_payload(WithPayloadInterface::Bool(true))
+        .with_vector(WithVector::Bool(true))
+        .build(),
+    )?;
 
     for point in &points {
         println!("{point:?}");
@@ -159,19 +154,19 @@ fn main() -> Result<(), Box<dyn Error>> {
         must_not: None,
     };
 
-    let points = shard.search(SearchRequest {
-        query: QueryEnum::Nearest(NamedQuery {
-            query: vec![1.0, 1.0, 1.0, 1.0].into(),
-            using: None,
-        }),
-        filter: Some(search_filter),
-        params: None,
-        limit: 10,
-        offset: 0,
-        with_payload: Some(WithPayloadInterface::Bool(true)),
-        with_vector: Some(WithVector::Bool(true)),
-        score_threshold: None,
-    })?;
+    let points = shard.search(
+        SearchRequestBuilder::new(
+            QueryEnum::Nearest(NamedQuery {
+                query: vec![1.0, 1.0, 1.0, 1.0].into(),
+                using: None,
+            }),
+            10,
+        )
+        .filter(search_filter)
+        .with_payload(WithPayloadInterface::Bool(true))
+        .with_vector(WithVector::Bool(true))
+        .build(),
+    )?;
 
     for point in &points {
         println!("{point:?}");
@@ -180,9 +175,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("---- Retrieve ----");
 
     let points = shard.retrieve(
-        &[PointId::NumId(1)],
-        Some(WithPayloadInterface::Bool(true)),
-        Some(WithVector::Bool(true)),
+        RetrieveRequestBuilder::new(vec![PointId::NumId(1)])
+            .with_payload(WithPayloadInterface::Bool(true))
+            .with_vector(WithVector::Bool(true))
+            .build(),
     )?;
 
     for point in &points {
@@ -191,28 +187,16 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("---- Scroll ----");
 
-    let (scroll_result, mut next_offset) = shard.scroll(ScrollRequest {
-        offset: None,
-        limit: Some(2),
-        filter: None,
-        with_payload: None,
-        with_vector: WithVector::Bool(false),
-        order_by: None,
-    })?;
+    let (scroll_result, mut next_offset) =
+        shard.scroll(ScrollRequestBuilder::new().limit(2).build())?;
     for point in &scroll_result {
         println!("{point:?}");
     }
 
     while let Some(offset) = next_offset {
         println!("--- Next scroll (offset = {offset})---");
-        let (scroll_result, next) = shard.scroll(ScrollRequest {
-            offset: Some(offset),
-            limit: Some(2),
-            filter: None,
-            with_payload: None,
-            with_vector: WithVector::Bool(false),
-            order_by: None,
-        })?;
+        let (scroll_result, next) =
+            shard.scroll(ScrollRequestBuilder::new().offset(offset).limit(2).build())?;
         next_offset = next;
         for point in &scroll_result {
             println!("{point:?}");
@@ -221,10 +205,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("---- Count ----");
 
-    let count = shard.count(CountRequest {
-        filter: None,
-        exact: true,
-    })?;
+    let count = shard.count(CountRequest::new())?;
     println!("Total points count: {count}");
 
     println!("---- Facet ----");
@@ -236,12 +217,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }),
     ))?;
 
-    let response = shard.facet(FacetRequest {
-        key: "hello".try_into().unwrap(),
-        limit: 10,
-        filter: None,
-        exact: false,
-    })?;
+    let response = shard.facet(FacetRequest::new("hello".try_into().unwrap()))?;
 
     println!("Facet results ({} hits):", response.hits.len());
 

--- a/lib/edge/publish/examples/src/bin/facet_test.rs
+++ b/lib/edge/publish/examples/src/bin/facet_test.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 
 use examples::DATA_DIR;
 use qdrant_edge::{
-    Condition, EdgeShard, FacetRequest, FieldCondition, Filter, Match, ValueVariants,
+    Condition, EdgeShard, FacetRequest, FacetRequestBuilder, FieldCondition, Filter, Match,
+    ValueVariants,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -33,12 +34,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("Shard loaded. Points: {}", shard.info()?.points_count);
 
     println!("---- Test Facet on 'color' field ----");
-    let response = shard.facet(FacetRequest {
-        key: "color".try_into().unwrap(),
-        limit: 10,
-        filter: None,
-        exact: false,
-    })?;
+    let response = shard.facet(FacetRequest::new("color".try_into().unwrap()))?;
 
     println!("Facet results for 'color':");
     for hit in &response.hits {
@@ -46,12 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     println!("---- Test Facet on 'city' field ----");
-    let response = shard.facet(FacetRequest {
-        key: "city".try_into().unwrap(),
-        limit: 10,
-        filter: None,
-        exact: false,
-    })?;
+    let response = shard.facet(FacetRequest::new("city".try_into().unwrap()))?;
 
     println!("Facet results for 'city':");
     for hit in &response.hits {
@@ -64,12 +55,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         Match::new_value(ValueVariants::String("red".to_string())),
     )));
 
-    let response = shard.facet(FacetRequest {
-        key: "city".try_into().unwrap(),
-        limit: 10,
-        filter: Some(filter),
-        exact: false,
-    })?;
+    let response = shard.facet(
+        FacetRequestBuilder::new("city".try_into().unwrap())
+            .filter(filter)
+            .build(),
+    )?;
 
     println!("Facet results for 'city' where color='red':");
     for hit in &response.hits {

--- a/lib/edge/publish/examples/src/bin/fusion-query.rs
+++ b/lib/edge/publish/examples/src/bin/fusion-query.rs
@@ -5,9 +5,9 @@ use std::error::Error;
 use examples::{fill_dummy_data, load_new_shard};
 use qdrant_edge::external::ordered_float::OrderedFloat;
 use qdrant_edge::{
-    Condition, DEFAULT_VECTOR_NAME, FieldCondition, Filter, Fusion, Match, NamedQuery, Prefetch,
-    QueryEnum, QueryRequest, ScoringQuery, ValueVariants, VectorInternal, WithPayloadInterface,
-    WithVector,
+    Condition, DEFAULT_VECTOR_NAME, FieldCondition, Filter, Fusion, Match, NamedQuery,
+    PrefetchBuilder, QueryEnum, QueryRequestBuilder, ScoringQuery, ValueVariants, VectorInternal,
+    WithPayloadInterface, WithVector,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -21,37 +21,27 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Basic RRF fusion (equal weights)
     println!("=== Basic RRF Fusion ===");
-    let result = shard.query(QueryRequest {
-        prefetches: vec![
-            Prefetch {
-                prefetches: vec![],
-                query: Some(ScoringQuery::Vector(nearest([6.0, 9.0, 4.0, 2.0]))),
-                limit: 5,
-                params: None,
-                filter: None,
-                score_threshold: None,
-            },
-            Prefetch {
-                prefetches: vec![],
-                query: Some(ScoringQuery::Vector(nearest([1.0, -3.0, 2.0, 8.0]))),
-                limit: 5,
-                params: None,
-                filter: Some(search_filter.clone()),
-                score_threshold: None,
-            },
-        ],
-        query: Some(ScoringQuery::Fusion(Fusion::Rrf {
-            k: 2,
-            weights: None,
-        })),
-        filter: None,
-        score_threshold: None,
-        limit: 10,
-        offset: 0,
-        params: None,
-        with_vector: WithVector::Bool(true),
-        with_payload: WithPayloadInterface::Bool(true),
-    })?;
+    let result = shard.query(
+        QueryRequestBuilder::new(10)
+            .add_prefetch(
+                PrefetchBuilder::new(5)
+                    .query(ScoringQuery::Vector(nearest([6.0, 9.0, 4.0, 2.0])))
+                    .build(),
+            )
+            .add_prefetch(
+                PrefetchBuilder::new(5)
+                    .query(ScoringQuery::Vector(nearest([1.0, -3.0, 2.0, 8.0])))
+                    .filter(search_filter.clone())
+                    .build(),
+            )
+            .query(ScoringQuery::Fusion(Fusion::Rrf {
+                k: 2,
+                weights: None,
+            }))
+            .with_vector(WithVector::Bool(true))
+            .with_payload(WithPayloadInterface::Bool(true))
+            .build(),
+    )?;
 
     for point in &result {
         println!("{point:?}");
@@ -59,37 +49,27 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Weighted RRF fusion - first prefetch has 3x weight
     println!("\n=== Weighted RRF Fusion (3:1) ===");
-    let result = shard.query(QueryRequest {
-        prefetches: vec![
-            Prefetch {
-                prefetches: vec![],
-                query: Some(ScoringQuery::Vector(nearest([6.0, 9.0, 4.0, 2.0]))),
-                limit: 5,
-                params: None,
-                filter: None,
-                score_threshold: None,
-            },
-            Prefetch {
-                prefetches: vec![],
-                query: Some(ScoringQuery::Vector(nearest([1.0, -3.0, 2.0, 8.0]))),
-                limit: 5,
-                params: None,
-                filter: Some(search_filter),
-                score_threshold: None,
-            },
-        ],
-        query: Some(ScoringQuery::Fusion(Fusion::Rrf {
-            k: 2,
-            weights: Some(vec![OrderedFloat(3.0), OrderedFloat(1.0)]), // First prefetch has 3x weight
-        })),
-        filter: None,
-        score_threshold: None,
-        limit: 10,
-        offset: 0,
-        params: None,
-        with_vector: WithVector::Bool(true),
-        with_payload: WithPayloadInterface::Bool(true),
-    })?;
+    let result = shard.query(
+        QueryRequestBuilder::new(10)
+            .add_prefetch(
+                PrefetchBuilder::new(5)
+                    .query(ScoringQuery::Vector(nearest([6.0, 9.0, 4.0, 2.0])))
+                    .build(),
+            )
+            .add_prefetch(
+                PrefetchBuilder::new(5)
+                    .query(ScoringQuery::Vector(nearest([1.0, -3.0, 2.0, 8.0])))
+                    .filter(search_filter)
+                    .build(),
+            )
+            .query(ScoringQuery::Fusion(Fusion::Rrf {
+                k: 2,
+                weights: Some(vec![OrderedFloat(3.0), OrderedFloat(1.0)]), // First prefetch has 3x weight
+            }))
+            .with_vector(WithVector::Bool(true))
+            .with_payload(WithPayloadInterface::Bool(true))
+            .build(),
+    )?;
 
     for point in &result {
         println!("{point:?}");

--- a/lib/edge/publish/examples/src/bin/load-existing.rs
+++ b/lib/edge/publish/examples/src/bin/load-existing.rs
@@ -7,7 +7,7 @@ use examples::{TMP_DIR, load_new_shard};
 use qdrant_edge::external::serde_json::json;
 use qdrant_edge::external::uuid::Uuid;
 use qdrant_edge::{
-    EdgeShard, PointId, PointInsertOperations, PointOperations, PointStruct, ScrollRequest,
+    EdgeShard, PointId, PointInsertOperations, PointOperations, PointStruct, ScrollRequestBuilder,
     UpdateOperation, WithPayloadInterface, WithVector,
 };
 
@@ -62,28 +62,26 @@ fn main() -> Result<(), Box<dyn Error>> {
         ])),
     ))?;
 
-    let (expected_points, _) = edge.scroll(ScrollRequest {
-        offset: None,
-        limit: Some(5),
-        filter: None,
-        with_payload: Some(WithPayloadInterface::Bool(true)),
-        with_vector: WithVector::Bool(true),
-        order_by: None,
-    })?;
+    let (expected_points, _) = edge.scroll(
+        ScrollRequestBuilder::new()
+            .limit(5)
+            .with_payload(WithPayloadInterface::Bool(true))
+            .with_vector(WithVector::Bool(true))
+            .build(),
+    )?;
     println!("{expected_points:?}");
 
     // Re-load edge shard from disk, assert points are available
     drop(edge);
     let edge = EdgeShard::load(Path::new(TMP_DIR), None)?;
 
-    let (points, _) = edge.scroll(ScrollRequest {
-        offset: None,
-        limit: Some(5),
-        filter: None,
-        with_payload: Some(WithPayloadInterface::Bool(true)),
-        with_vector: WithVector::Bool(true),
-        order_by: None,
-    })?;
+    let (points, _) = edge.scroll(
+        ScrollRequestBuilder::new()
+            .limit(5)
+            .with_payload(WithPayloadInterface::Bool(true))
+            .with_vector(WithVector::Bool(true))
+            .build(),
+    )?;
     println!("{points:?}");
 
     assert_eq!(points, expected_points);

--- a/lib/edge/publish/examples/src/bin/mmr-query.rs
+++ b/lib/edge/publish/examples/src/bin/mmr-query.rs
@@ -5,29 +5,25 @@ use std::error::Error;
 use examples::{fill_dummy_data, load_new_shard};
 use qdrant_edge::external::ordered_float::OrderedFloat;
 use qdrant_edge::{
-    DEFAULT_VECTOR_NAME, Mmr, QueryRequest, ScoringQuery, WithPayloadInterface, WithVector,
+    DEFAULT_VECTOR_NAME, Mmr, QueryRequestBuilder, ScoringQuery, WithPayloadInterface, WithVector,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
     let shard = load_new_shard()?;
     fill_dummy_data(&shard)?;
 
-    let result = shard.query(QueryRequest {
-        prefetches: vec![],
-        query: Some(ScoringQuery::Mmr(Mmr {
-            vector: vec![6.0, 9.0, 4.0, 2.0].into(),
-            using: DEFAULT_VECTOR_NAME.to_string(),
-            lambda: OrderedFloat(0.9),
-            candidates_limit: 100,
-        })),
-        filter: None,
-        score_threshold: None,
-        limit: 10,
-        offset: 0,
-        params: None,
-        with_vector: WithVector::Bool(true),
-        with_payload: WithPayloadInterface::Bool(true),
-    })?;
+    let result = shard.query(
+        QueryRequestBuilder::new(10)
+            .query(ScoringQuery::Mmr(Mmr {
+                vector: vec![6.0, 9.0, 4.0, 2.0].into(),
+                using: DEFAULT_VECTOR_NAME.to_string(),
+                lambda: OrderedFloat(0.9),
+                candidates_limit: 100,
+            }))
+            .with_vector(WithVector::Bool(true))
+            .with_payload(WithPayloadInterface::Bool(true))
+            .build(),
+    )?;
 
     for point in &result {
         println!("{point:?}");

--- a/lib/edge/publish/examples/src/bin/restore-snapshot.rs
+++ b/lib/edge/publish/examples/src/bin/restore-snapshot.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use examples::DATA_DIR;
 use qdrant_edge::external::serde_json;
-use qdrant_edge::{EdgeShard, PointId, WithPayloadInterface, WithVector};
+use qdrant_edge::{EdgeShard, PointId, RetrieveRequestBuilder, WithPayloadInterface};
 
 const SNAPSHOT_URL: &str =
     "https://storage.googleapis.com/qdrant-benchmark-snapshots/test-shard.snapshot";
@@ -34,9 +34,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     let shard = EdgeShard::load(&recovered_path, None)?;
 
     let points = shard.retrieve(
-        &[PointId::NumId(1), PointId::NumId(2), PointId::NumId(3)],
-        Some(WithPayloadInterface::Bool(true)),
-        Some(WithVector::Bool(false)),
+        RetrieveRequestBuilder::new(vec![
+            PointId::NumId(1),
+            PointId::NumId(2),
+            PointId::NumId(3),
+        ])
+        .with_payload(WithPayloadInterface::Bool(true))
+        .build(),
     )?;
 
     for point in &points {
@@ -56,9 +60,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let shard = EdgeShard::load(&recovered_path, None)?;
 
     let points = shard.retrieve(
-        &[PointId::NumId(100500)],
-        Some(WithPayloadInterface::Bool(true)),
-        Some(WithVector::Bool(false)),
+        RetrieveRequestBuilder::new(vec![PointId::NumId(100500)])
+            .with_payload(WithPayloadInterface::Bool(true))
+            .build(),
     )?;
 
     for point in &points {

--- a/lib/edge/python/src/count.rs
+++ b/lib/edge/python/src/count.rs
@@ -1,15 +1,15 @@
 use bytemuck::TransparentWrapper as _;
 use derive_more::Into;
+use edge::CountRequest;
 use pyo3::prelude::*;
 use segment::types::Filter;
-use shard::count::CountRequestInternal;
 
 use crate::repr::*;
 use crate::types::PyFilter;
 
 #[pyclass(name = "CountRequest", from_py_object)]
 #[derive(Clone, Debug, Into)]
-pub struct PyCountRequest(CountRequestInternal);
+pub struct PyCountRequest(CountRequest);
 
 #[pyclass_repr]
 #[pymethods]
@@ -17,7 +17,7 @@ impl PyCountRequest {
     #[new]
     #[pyo3(signature = (exact = true, filter = None))]
     pub fn new(exact: bool, filter: Option<PyFilter>) -> Self {
-        Self(CountRequestInternal {
+        Self(CountRequest {
             filter: filter.map(Filter::from),
             exact,
         })

--- a/lib/edge/python/src/facet.rs
+++ b/lib/edge/python/src/facet.rs
@@ -1,17 +1,17 @@
 use bytemuck::{TransparentWrapper, TransparentWrapperAlloc as _};
 use derive_more::Into;
+use edge::FacetRequest;
 use pyo3::IntoPyObjectExt as _;
 use pyo3::prelude::*;
 use segment::data_types::facets::{FacetResponse, FacetValue, FacetValueHit};
 use segment::types::Filter;
-use shard::facet::FacetRequestInternal;
 
 use crate::repr::*;
 use crate::types::{PyFilter, PyJsonPath};
 
 #[pyclass(name = "FacetRequest", from_py_object)]
 #[derive(Clone, Debug, Into)]
-pub struct PyFacetRequest(FacetRequestInternal);
+pub struct PyFacetRequest(FacetRequest);
 
 #[pyclass_repr]
 #[pymethods]
@@ -19,7 +19,7 @@ impl PyFacetRequest {
     #[new]
     #[pyo3(signature = (key, limit = 10, exact = false, filter = None))]
     pub fn new(key: PyJsonPath, limit: usize, exact: bool, filter: Option<PyFilter>) -> Self {
-        Self(FacetRequestInternal {
+        Self(FacetRequest {
             key: key.into(),
             limit,
             filter: filter.map(Filter::from),

--- a/lib/edge/python/src/lib.rs
+++ b/lib/edge/python/src/lib.rs
@@ -172,12 +172,12 @@ impl PyEdgeShard {
         with_payload: Option<PyWithPayload>,
         with_vector: Option<PyWithVector>,
     ) -> Result<Vec<PyRecord>> {
-        let point_ids = PyPointId::peel_vec(point_ids);
-        let points = self.get_shard()?.retrieve(
-            &point_ids,
-            with_payload.map(WithPayloadInterface::from),
-            with_vector.map(WithVector::from),
-        )?;
+        let request = edge::RetrieveRequest {
+            point_ids: PyPointId::peel_vec(point_ids),
+            with_payload: with_payload.map(WithPayloadInterface::from),
+            with_vector: with_vector.map(WithVector::from),
+        };
+        let points = self.get_shard()?.retrieve(request)?;
         let points = PyRecord::wrap_vec(points);
         Ok(points)
     }

--- a/lib/edge/python/src/query.rs
+++ b/lib/edge/python/src/query.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use bytemuck::{TransparentWrapper, TransparentWrapperAlloc as _};
 use derive_more::Into;
+use edge::{Prefetch, QueryRequest};
 use ordered_float::OrderedFloat;
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyValueError;
@@ -18,7 +19,7 @@ use crate::repr::*;
 
 #[pyclass(name = "QueryRequest", from_py_object)]
 #[derive(Clone, Debug, Into)]
-pub struct PyQueryRequest(ShardQueryRequest);
+pub struct PyQueryRequest(QueryRequest);
 
 #[pyclass_repr]
 #[pymethods]
@@ -47,7 +48,7 @@ impl PyQueryRequest {
         score_threshold: Option<f32>,
         params: Option<PySearchParams>,
     ) -> Self {
-        Self(ShardQueryRequest {
+        Self(QueryRequest {
             prefetches: PyPrefetch::peel_vec(prefetches.unwrap_or_default()),
             limit,
             offset: offset.unwrap_or(0),
@@ -57,7 +58,7 @@ impl PyQueryRequest {
                 .unwrap_or_default(),
             query: query.map(ScoringQuery::from),
             filter: filter.map(Filter::from),
-            score_threshold: score_threshold.map(OrderedFloat),
+            score_threshold,
             params: params.map(SearchParams::from),
         })
     }
@@ -79,9 +80,7 @@ impl PyQueryRequest {
 
     #[getter]
     pub fn score_threshold(&self) -> Option<f32> {
-        self.0
-            .score_threshold
-            .map(|threshold| threshold.into_inner())
+        self.0.score_threshold
     }
 
     #[getter]
@@ -117,7 +116,7 @@ impl PyQueryRequest {
 impl PyQueryRequest {
     fn _getters(self) {
         // Every field should have a getter method
-        let ShardQueryRequest {
+        let QueryRequest {
             prefetches: _,
             query: _,
             filter: _,
@@ -134,7 +133,7 @@ impl PyQueryRequest {
 #[pyclass(name = "Prefetch", from_py_object)]
 #[derive(Clone, Debug, Into, TransparentWrapper)]
 #[repr(transparent)]
-pub struct PyPrefetch(ShardPrefetch);
+pub struct PyPrefetch(Prefetch);
 
 #[pyclass_repr]
 #[pymethods]
@@ -156,13 +155,13 @@ impl PyPrefetch {
         filter: Option<PyFilter>,
         score_threshold: Option<f32>,
     ) -> Self {
-        Self(ShardPrefetch {
+        Self(Prefetch {
             prefetches: PyPrefetch::peel_vec(prefetches.unwrap_or_default()),
             limit,
             query: query.map(ScoringQuery::from),
             params: params.map(SearchParams::from),
             filter: filter.map(Filter::from),
-            score_threshold: score_threshold.map(OrderedFloat),
+            score_threshold,
         })
     }
 
@@ -193,9 +192,7 @@ impl PyPrefetch {
 
     #[getter]
     pub fn score_threshold(&self) -> Option<f32> {
-        self.0
-            .score_threshold
-            .map(|threshold| threshold.into_inner())
+        self.0.score_threshold
     }
 
     pub fn __repr__(&self) -> String {
@@ -206,7 +203,7 @@ impl PyPrefetch {
 impl PyPrefetch {
     fn _getters(self) {
         // Every field should have a getter method
-        let ShardPrefetch {
+        let Prefetch {
             prefetches: _,
             query: _,
             limit: _,

--- a/lib/edge/python/src/scroll.rs
+++ b/lib/edge/python/src/scroll.rs
@@ -1,9 +1,9 @@
 use bytemuck::TransparentWrapper as _;
 use derive_more::Into;
+use edge::ScrollRequest;
 use pyo3::prelude::*;
 use segment::data_types::order_by::OrderByInterface;
 use segment::types::*;
-use shard::scroll::*;
 
 use crate::query::PyOrderBy;
 use crate::repr::*;
@@ -11,7 +11,7 @@ use crate::types::*;
 
 #[pyclass(name = "ScrollRequest", from_py_object)]
 #[derive(Clone, Debug, Into)]
-pub struct PyScrollRequest(ScrollRequestInternal);
+pub struct PyScrollRequest(ScrollRequest);
 
 #[pyclass_repr]
 #[pymethods]
@@ -33,7 +33,7 @@ impl PyScrollRequest {
         with_vector: Option<PyWithVector>,
         order_by: Option<PyOrderBy>,
     ) -> Self {
-        Self(ScrollRequestInternal {
+        Self(ScrollRequest {
             offset: offset.map(PointIdType::from),
             limit,
             filter: filter.map(Filter::from),
@@ -81,7 +81,7 @@ impl PyScrollRequest {
 impl PyScrollRequest {
     fn _getters(self) {
         // Every field should have a getter method
-        let ScrollRequestInternal {
+        let ScrollRequest {
             offset: _,
             limit: _,
             filter: _,

--- a/lib/edge/python/src/search.rs
+++ b/lib/edge/python/src/search.rs
@@ -1,16 +1,16 @@
 use bytemuck::TransparentWrapper;
 use derive_more::Into;
+use edge::SearchRequest;
 use ordered_float::OrderedFloat;
 use pyo3::prelude::*;
 use shard::query::query_enum::QueryEnum;
-use shard::search::CoreSearchRequest;
 
 use crate::repr::*;
 use crate::*;
 
 #[pyclass(name = "SearchRequest", from_py_object)]
 #[derive(Clone, Debug, Into)]
-pub struct PySearchRequest(CoreSearchRequest);
+pub struct PySearchRequest(SearchRequest);
 
 #[pyclass_repr]
 #[pymethods]
@@ -37,7 +37,7 @@ impl PySearchRequest {
         with_payload: Option<PyWithPayload>,
         score_threshold: Option<f32>,
     ) -> Self {
-        Self(CoreSearchRequest {
+        Self(SearchRequest {
             query: QueryEnum::from(query),
             limit,
             offset: offset.unwrap_or(0),
@@ -97,7 +97,7 @@ impl PySearchRequest {
 impl PySearchRequest {
     fn _getters(self) {
         // Every field should have a getter method
-        let CoreSearchRequest {
+        let SearchRequest {
             query: _,
             filter: _,
             params: _,

--- a/lib/edge/src/builders/count_request.rs
+++ b/lib/edge/src/builders/count_request.rs
@@ -1,0 +1,47 @@
+//! Fluent builder for [`CountRequest`].
+//!
+//! Builder fields mirror [`CountRequest`] explicitly so adding a field
+//! to the target struct forces a compile error here.
+
+use segment::types::Filter;
+
+use crate::requests::count::CountRequest;
+
+/// Fluent builder for [`CountRequest`].
+///
+/// Every field is optional and falls back to the [`CountRequest::new`] defaults.
+#[derive(Clone, Debug)]
+pub struct CountRequestBuilder {
+    filter: Option<Filter>,
+    exact: bool,
+}
+
+impl CountRequestBuilder {
+    pub fn new() -> Self {
+        let CountRequest { filter, exact } = CountRequest::new();
+        Self { filter, exact }
+    }
+
+    pub fn filter(mut self, filter: Filter) -> Self {
+        self.filter = Some(filter);
+        self
+    }
+
+    pub fn exact(mut self, exact: bool) -> Self {
+        self.exact = exact;
+        self
+    }
+
+    pub fn build(self) -> CountRequest {
+        // Exhaustively destructure Self and construct CountRequest:
+        // adding a field to either type forces a compile error here.
+        let Self { filter, exact } = self;
+        CountRequest { filter, exact }
+    }
+}
+
+impl Default for CountRequestBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/lib/edge/src/builders/facet_request.rs
+++ b/lib/edge/src/builders/facet_request.rs
@@ -1,0 +1,70 @@
+//! Fluent builder for [`FacetRequest`].
+//!
+//! Builder fields mirror [`FacetRequest`] explicitly so adding a field
+//! to the target struct forces a compile error here.
+
+use segment::json_path::JsonPath;
+use segment::types::Filter;
+
+use crate::requests::facet::FacetRequest;
+
+/// Fluent builder for [`FacetRequest`].
+///
+/// `key` is required and passed through [`Self::new`]; every other field is
+/// optional and falls back to the [`FacetRequest::new`] defaults.
+#[derive(Clone, Debug)]
+pub struct FacetRequestBuilder {
+    key: JsonPath,
+    limit: usize,
+    filter: Option<Filter>,
+    exact: bool,
+}
+
+impl FacetRequestBuilder {
+    pub fn new(key: JsonPath) -> Self {
+        let FacetRequest {
+            key,
+            limit,
+            filter,
+            exact,
+        } = FacetRequest::new(key);
+        Self {
+            key,
+            limit,
+            filter,
+            exact,
+        }
+    }
+
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.limit = limit;
+        self
+    }
+
+    pub fn filter(mut self, filter: Filter) -> Self {
+        self.filter = Some(filter);
+        self
+    }
+
+    pub fn exact(mut self, exact: bool) -> Self {
+        self.exact = exact;
+        self
+    }
+
+    pub fn build(self) -> FacetRequest {
+        // Exhaustively destructure Self and construct FacetRequest:
+        // adding a field to either type forces a compile error here.
+        let Self {
+            key,
+            limit,
+            filter,
+            exact,
+        } = self;
+        FacetRequest {
+            key,
+            limit,
+            filter,
+            exact,
+        }
+    }
+}

--- a/lib/edge/src/builders/group_request.rs
+++ b/lib/edge/src/builders/group_request.rs
@@ -1,0 +1,54 @@
+//! Fluent builder for [`GroupRequest`].
+//!
+//! Builder fields mirror [`GroupRequest`] explicitly so adding a field
+//! to the target struct forces a compile error here.
+
+use segment::json_path::JsonPath;
+
+use crate::requests::grouping::GroupRequest;
+use crate::requests::query::QueryRequest;
+
+/// Fluent builder for [`GroupRequest`].
+///
+/// All fields are required and passed through [`Self::new`].
+#[derive(Clone, Debug)]
+pub struct GroupRequestBuilder {
+    query: QueryRequest,
+    group_by: JsonPath,
+    groups: usize,
+    group_size: usize,
+}
+
+impl GroupRequestBuilder {
+    pub fn new(query: QueryRequest, group_by: JsonPath, groups: usize, group_size: usize) -> Self {
+        let GroupRequest {
+            query,
+            group_by,
+            groups,
+            group_size,
+        } = GroupRequest::new(query, group_by, groups, group_size);
+        Self {
+            query,
+            group_by,
+            groups,
+            group_size,
+        }
+    }
+
+    pub fn build(self) -> GroupRequest {
+        // Exhaustively destructure Self and construct GroupRequest:
+        // adding a field to either type forces a compile error here.
+        let Self {
+            query,
+            group_by,
+            groups,
+            group_size,
+        } = self;
+        GroupRequest {
+            query,
+            group_by,
+            groups,
+            group_size,
+        }
+    }
+}

--- a/lib/edge/src/builders/mod.rs
+++ b/lib/edge/src/builders/mod.rs
@@ -1,9 +1,27 @@
-//! Fluent builders for user-facing edge crate configuration.
+//! Fluent builders for user-facing edge crate configuration and requests.
 
+pub mod count_request;
 pub mod edge_config;
 pub mod edge_sparse_vector_params;
 pub mod edge_vector_params;
+pub mod facet_request;
+pub mod group_request;
+pub mod prefetch;
+pub mod query_request;
+pub mod retrieve_request;
+pub mod scroll_request;
+pub mod search_matrix_request;
+pub mod search_request;
 
+pub use count_request::CountRequestBuilder;
 pub use edge_config::EdgeConfigBuilder;
 pub use edge_sparse_vector_params::EdgeSparseVectorParamsBuilder;
 pub use edge_vector_params::EdgeVectorParamsBuilder;
+pub use facet_request::FacetRequestBuilder;
+pub use group_request::GroupRequestBuilder;
+pub use prefetch::PrefetchBuilder;
+pub use query_request::QueryRequestBuilder;
+pub use retrieve_request::RetrieveRequestBuilder;
+pub use scroll_request::ScrollRequestBuilder;
+pub use search_matrix_request::SearchMatrixRequestBuilder;
+pub use search_request::SearchRequestBuilder;

--- a/lib/edge/src/builders/prefetch.rs
+++ b/lib/edge/src/builders/prefetch.rs
@@ -1,0 +1,97 @@
+//! Fluent builder for [`Prefetch`].
+//!
+//! Builder fields mirror [`Prefetch`] explicitly so adding a field
+//! to the target struct forces a compile error here.
+
+use common::types::ScoreType;
+use segment::types::{Filter, SearchParams};
+use shard::query::ScoringQuery;
+
+use crate::requests::query::Prefetch;
+
+/// Fluent builder for [`Prefetch`].
+///
+/// `limit` is required and passed through [`Self::new`]; every other field is
+/// optional and falls back to the [`Prefetch::new`] defaults.
+#[derive(Clone, Debug)]
+pub struct PrefetchBuilder {
+    prefetches: Vec<Prefetch>,
+    query: Option<ScoringQuery>,
+    limit: usize,
+    params: Option<SearchParams>,
+    filter: Option<Filter>,
+    score_threshold: Option<ScoreType>,
+}
+
+impl PrefetchBuilder {
+    pub fn new(limit: usize) -> Self {
+        let Prefetch {
+            prefetches,
+            query,
+            limit,
+            params,
+            filter,
+            score_threshold,
+        } = Prefetch::new(limit);
+        Self {
+            prefetches,
+            query,
+            limit,
+            params,
+            filter,
+            score_threshold,
+        }
+    }
+
+    /// Replaces the whole nested prefetch list; see [`Self::add_prefetch`] to append one stage.
+    pub fn prefetches(mut self, prefetches: Vec<Prefetch>) -> Self {
+        self.prefetches = prefetches;
+        self
+    }
+
+    pub fn add_prefetch(mut self, prefetch: Prefetch) -> Self {
+        self.prefetches.push(prefetch);
+        self
+    }
+
+    pub fn query(mut self, query: ScoringQuery) -> Self {
+        self.query = Some(query);
+        self
+    }
+
+    pub fn params(mut self, params: SearchParams) -> Self {
+        self.params = Some(params);
+        self
+    }
+
+    pub fn filter(mut self, filter: Filter) -> Self {
+        self.filter = Some(filter);
+        self
+    }
+
+    pub fn score_threshold(mut self, score_threshold: ScoreType) -> Self {
+        self.score_threshold = Some(score_threshold);
+        self
+    }
+
+    pub fn build(self) -> Prefetch {
+        // Exhaustively destructure Self and construct Prefetch:
+        // adding a field to either type forces a compile error here.
+        let Self {
+            prefetches,
+            query,
+            limit,
+            params,
+            filter,
+            score_threshold,
+        } = self;
+        Prefetch {
+            prefetches,
+            query,
+            limit,
+            params,
+            filter,
+            score_threshold,
+        }
+    }
+}

--- a/lib/edge/src/builders/query_request.rs
+++ b/lib/edge/src/builders/query_request.rs
@@ -1,0 +1,127 @@
+//! Fluent builder for [`QueryRequest`].
+//!
+//! Builder fields mirror [`QueryRequest`] explicitly so adding a field
+//! to the target struct forces a compile error here.
+
+use common::types::ScoreType;
+use segment::types::{Filter, SearchParams, WithPayloadInterface, WithVector};
+use shard::query::ScoringQuery;
+
+use crate::requests::query::{Prefetch, QueryRequest};
+
+/// Fluent builder for [`QueryRequest`].
+///
+/// `limit` is required and passed through [`Self::new`]; every other field is
+/// optional and falls back to the [`QueryRequest::new`] defaults.
+#[derive(Clone, Debug)]
+pub struct QueryRequestBuilder {
+    prefetches: Vec<Prefetch>,
+    query: Option<ScoringQuery>,
+    filter: Option<Filter>,
+    score_threshold: Option<ScoreType>,
+    limit: usize,
+    offset: usize,
+    params: Option<SearchParams>,
+    with_vector: WithVector,
+    with_payload: WithPayloadInterface,
+}
+
+impl QueryRequestBuilder {
+    pub fn new(limit: usize) -> Self {
+        let QueryRequest {
+            prefetches,
+            query,
+            filter,
+            score_threshold,
+            limit,
+            offset,
+            params,
+            with_vector,
+            with_payload,
+        } = QueryRequest::new(limit);
+        Self {
+            prefetches,
+            query,
+            filter,
+            score_threshold,
+            limit,
+            offset,
+            params,
+            with_vector,
+            with_payload,
+        }
+    }
+
+    /// Replaces the whole prefetch list; see [`Self::add_prefetch`] to append one stage.
+    pub fn prefetches(mut self, prefetches: Vec<Prefetch>) -> Self {
+        self.prefetches = prefetches;
+        self
+    }
+
+    pub fn add_prefetch(mut self, prefetch: Prefetch) -> Self {
+        self.prefetches.push(prefetch);
+        self
+    }
+
+    pub fn query(mut self, query: ScoringQuery) -> Self {
+        self.query = Some(query);
+        self
+    }
+
+    pub fn filter(mut self, filter: Filter) -> Self {
+        self.filter = Some(filter);
+        self
+    }
+
+    pub fn score_threshold(mut self, score_threshold: ScoreType) -> Self {
+        self.score_threshold = Some(score_threshold);
+        self
+    }
+
+    pub fn offset(mut self, offset: usize) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    pub fn params(mut self, params: SearchParams) -> Self {
+        self.params = Some(params);
+        self
+    }
+
+    pub fn with_vector(mut self, with_vector: WithVector) -> Self {
+        self.with_vector = with_vector;
+        self
+    }
+
+    pub fn with_payload(mut self, with_payload: WithPayloadInterface) -> Self {
+        self.with_payload = with_payload;
+        self
+    }
+
+    pub fn build(self) -> QueryRequest {
+        // Exhaustively destructure Self and construct QueryRequest:
+        // adding a field to either type forces a compile error here.
+        let Self {
+            prefetches,
+            query,
+            filter,
+            score_threshold,
+            limit,
+            offset,
+            params,
+            with_vector,
+            with_payload,
+        } = self;
+        QueryRequest {
+            prefetches,
+            query,
+            filter,
+            score_threshold,
+            limit,
+            offset,
+            params,
+            with_vector,
+            with_payload,
+        }
+    }
+}

--- a/lib/edge/src/builders/retrieve_request.rs
+++ b/lib/edge/src/builders/retrieve_request.rs
@@ -1,0 +1,59 @@
+//! Fluent builder for [`RetrieveRequest`].
+//!
+//! Builder fields mirror [`RetrieveRequest`] explicitly so adding a field
+//! to the target struct forces a compile error here.
+
+use segment::types::{ExtendedPointId, WithPayloadInterface, WithVector};
+
+use crate::requests::retrieve::RetrieveRequest;
+
+/// Fluent builder for [`RetrieveRequest`].
+///
+/// `point_ids` is required and passed through [`Self::new`]; every other field
+/// is optional and falls back to the [`RetrieveRequest::new`] defaults.
+#[derive(Clone, Debug)]
+pub struct RetrieveRequestBuilder {
+    point_ids: Vec<ExtendedPointId>,
+    with_payload: Option<WithPayloadInterface>,
+    with_vector: Option<WithVector>,
+}
+
+impl RetrieveRequestBuilder {
+    pub fn new(point_ids: Vec<ExtendedPointId>) -> Self {
+        let RetrieveRequest {
+            point_ids,
+            with_payload,
+            with_vector,
+        } = RetrieveRequest::new(point_ids);
+        Self {
+            point_ids,
+            with_payload,
+            with_vector,
+        }
+    }
+
+    pub fn with_payload(mut self, with_payload: WithPayloadInterface) -> Self {
+        self.with_payload = Some(with_payload);
+        self
+    }
+
+    pub fn with_vector(mut self, with_vector: WithVector) -> Self {
+        self.with_vector = Some(with_vector);
+        self
+    }
+
+    pub fn build(self) -> RetrieveRequest {
+        // Exhaustively destructure Self and construct RetrieveRequest:
+        // adding a field to either type forces a compile error here.
+        let Self {
+            point_ids,
+            with_payload,
+            with_vector,
+        } = self;
+        RetrieveRequest {
+            point_ids,
+            with_payload,
+            with_vector,
+        }
+    }
+}

--- a/lib/edge/src/builders/scroll_request.rs
+++ b/lib/edge/src/builders/scroll_request.rs
@@ -1,0 +1,100 @@
+//! Fluent builder for [`ScrollRequest`].
+//!
+//! Builder fields mirror [`ScrollRequest`] explicitly so adding a field
+//! to the target struct forces a compile error here.
+
+use segment::data_types::order_by::OrderByInterface;
+use segment::types::{Filter, PointIdType, WithPayloadInterface, WithVector};
+
+use crate::requests::scroll::ScrollRequest;
+
+/// Fluent builder for [`ScrollRequest`].
+///
+/// Every field is optional and falls back to the [`ScrollRequest::new`] defaults.
+#[derive(Clone, Debug)]
+pub struct ScrollRequestBuilder {
+    offset: Option<PointIdType>,
+    limit: Option<usize>,
+    filter: Option<Filter>,
+    with_payload: Option<WithPayloadInterface>,
+    with_vector: WithVector,
+    order_by: Option<OrderByInterface>,
+}
+
+impl ScrollRequestBuilder {
+    pub fn new() -> Self {
+        let ScrollRequest {
+            offset,
+            limit,
+            filter,
+            with_payload,
+            with_vector,
+            order_by,
+        } = ScrollRequest::new();
+        Self {
+            offset,
+            limit,
+            filter,
+            with_payload,
+            with_vector,
+            order_by,
+        }
+    }
+
+    pub fn offset(mut self, offset: PointIdType) -> Self {
+        self.offset = Some(offset);
+        self
+    }
+
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    pub fn filter(mut self, filter: Filter) -> Self {
+        self.filter = Some(filter);
+        self
+    }
+
+    pub fn with_payload(mut self, with_payload: WithPayloadInterface) -> Self {
+        self.with_payload = Some(with_payload);
+        self
+    }
+
+    pub fn with_vector(mut self, with_vector: WithVector) -> Self {
+        self.with_vector = with_vector;
+        self
+    }
+
+    pub fn order_by(mut self, order_by: OrderByInterface) -> Self {
+        self.order_by = Some(order_by);
+        self
+    }
+
+    pub fn build(self) -> ScrollRequest {
+        // Exhaustively destructure Self and construct ScrollRequest:
+        // adding a field to either type forces a compile error here.
+        let Self {
+            offset,
+            limit,
+            filter,
+            with_payload,
+            with_vector,
+            order_by,
+        } = self;
+        ScrollRequest {
+            offset,
+            limit,
+            filter,
+            with_payload,
+            with_vector,
+            order_by,
+        }
+    }
+}
+
+impl Default for ScrollRequestBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/lib/edge/src/builders/search_matrix_request.rs
+++ b/lib/edge/src/builders/search_matrix_request.rs
@@ -1,0 +1,60 @@
+//! Fluent builder for [`SearchMatrixRequest`].
+//!
+//! Builder fields mirror [`SearchMatrixRequest`] explicitly so adding a field
+//! to the target struct forces a compile error here.
+
+use segment::types::{Filter, VectorNameBuf};
+
+use crate::requests::matrix::SearchMatrixRequest;
+
+/// Fluent builder for [`SearchMatrixRequest`].
+///
+/// `sample_size`, `limit_per_sample` and `using` are required and passed through
+/// [`Self::new`]; every other field is optional and falls back to the
+/// [`SearchMatrixRequest::new`] defaults.
+#[derive(Clone, Debug)]
+pub struct SearchMatrixRequestBuilder {
+    sample_size: usize,
+    limit_per_sample: usize,
+    filter: Option<Filter>,
+    using: VectorNameBuf,
+}
+
+impl SearchMatrixRequestBuilder {
+    pub fn new(sample_size: usize, limit_per_sample: usize, using: VectorNameBuf) -> Self {
+        let SearchMatrixRequest {
+            sample_size,
+            limit_per_sample,
+            filter,
+            using,
+        } = SearchMatrixRequest::new(sample_size, limit_per_sample, using);
+        Self {
+            sample_size,
+            limit_per_sample,
+            filter,
+            using,
+        }
+    }
+
+    pub fn filter(mut self, filter: Filter) -> Self {
+        self.filter = Some(filter);
+        self
+    }
+
+    pub fn build(self) -> SearchMatrixRequest {
+        // Exhaustively destructure Self and construct SearchMatrixRequest:
+        // adding a field to either type forces a compile error here.
+        let Self {
+            sample_size,
+            limit_per_sample,
+            filter,
+            using,
+        } = self;
+        SearchMatrixRequest {
+            sample_size,
+            limit_per_sample,
+            filter,
+            using,
+        }
+    }
+}

--- a/lib/edge/src/builders/search_request.rs
+++ b/lib/edge/src/builders/search_request.rs
@@ -1,0 +1,106 @@
+//! Fluent builder for [`SearchRequest`].
+//!
+//! Builder fields mirror [`SearchRequest`] explicitly so adding a field
+//! to the target struct forces a compile error here.
+
+use common::types::ScoreType;
+use segment::types::{Filter, SearchParams, WithPayloadInterface, WithVector};
+use shard::query::query_enum::QueryEnum;
+
+use crate::requests::search::SearchRequest;
+
+/// Fluent builder for [`SearchRequest`].
+///
+/// `query` and `limit` are required and passed through [`Self::new`]; every
+/// other field is optional and falls back to the [`SearchRequest::new`] defaults.
+#[derive(Clone, Debug)]
+pub struct SearchRequestBuilder {
+    query: QueryEnum,
+    filter: Option<Filter>,
+    params: Option<SearchParams>,
+    limit: usize,
+    offset: usize,
+    with_payload: Option<WithPayloadInterface>,
+    with_vector: Option<WithVector>,
+    score_threshold: Option<ScoreType>,
+}
+
+impl SearchRequestBuilder {
+    pub fn new(query: QueryEnum, limit: usize) -> Self {
+        let SearchRequest {
+            query,
+            filter,
+            params,
+            limit,
+            offset,
+            with_payload,
+            with_vector,
+            score_threshold,
+        } = SearchRequest::new(query, limit);
+        Self {
+            query,
+            filter,
+            params,
+            limit,
+            offset,
+            with_payload,
+            with_vector,
+            score_threshold,
+        }
+    }
+
+    pub fn filter(mut self, filter: Filter) -> Self {
+        self.filter = Some(filter);
+        self
+    }
+
+    pub fn params(mut self, params: SearchParams) -> Self {
+        self.params = Some(params);
+        self
+    }
+
+    pub fn offset(mut self, offset: usize) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    pub fn with_payload(mut self, with_payload: WithPayloadInterface) -> Self {
+        self.with_payload = Some(with_payload);
+        self
+    }
+
+    pub fn with_vector(mut self, with_vector: WithVector) -> Self {
+        self.with_vector = Some(with_vector);
+        self
+    }
+
+    pub fn score_threshold(mut self, score_threshold: ScoreType) -> Self {
+        self.score_threshold = Some(score_threshold);
+        self
+    }
+
+    pub fn build(self) -> SearchRequest {
+        // Exhaustively destructure Self and construct SearchRequest:
+        // adding a field to either type forces a compile error here.
+        let Self {
+            query,
+            filter,
+            params,
+            limit,
+            offset,
+            with_payload,
+            with_vector,
+            score_threshold,
+        } = self;
+        SearchRequest {
+            query,
+            filter,
+            params,
+            limit,
+            offset,
+            with_payload,
+            with_vector,
+            score_threshold,
+        }
+    }
+}

--- a/lib/edge/src/edge_shard/optimize.rs
+++ b/lib/edge/src/edge_shard/optimize.rs
@@ -164,7 +164,6 @@ mod tests {
     use fs_err as fs;
     use segment::data_types::vectors::{VectorInternal, VectorStructInternal};
     use segment::types::{Distance, ExtendedPointId, WithPayloadInterface, WithVector};
-    use shard::count::CountRequestInternal;
     use shard::operations::CollectionUpdateOperations::{PointOperation, VectorNameOperation};
     use shard::operations::VectorNameOperations;
     use shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
@@ -175,7 +174,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::config::vectors::EdgeVectorParams;
-    use crate::{EdgeConfig, EdgeShard};
+    use crate::{CountRequest, EdgeConfig, EdgeShard, RetrieveRequestBuilder};
 
     const VECTOR_NAME: &str = "edge-test-vector";
 
@@ -198,12 +197,7 @@ mod tests {
         let reopened = EdgeShard::load(dir.path(), None).unwrap();
         assert_eq!(reopened.info().unwrap().segments_count, 2);
 
-        let count = reopened
-            .count(CountRequestInternal {
-                filter: None,
-                exact: true,
-            })
-            .unwrap();
+        let count = reopened.count(CountRequest::new()).unwrap();
         assert_eq!(
             count, 1,
             "exact count should deduplicate point ids across segments"
@@ -345,12 +339,7 @@ mod tests {
 
         // All duplicated segments contained the same point (id=1). After merge,
         // the exact count should deduplicate across remaining segments.
-        let count = reopened
-            .count(CountRequestInternal {
-                filter: None,
-                exact: true,
-            })
-            .unwrap();
+        let count = reopened.count(CountRequest::new()).unwrap();
         assert_eq!(count, 1, "merged shard should have exactly one point");
 
         assert_points_retrievable_with_vectors(&reopened, &[1]);
@@ -490,20 +479,16 @@ mod tests {
         assert!(optimized, "25% deletion should trigger vacuum");
 
         // Verify point count
-        let count = shard
-            .count(CountRequestInternal {
-                filter: None,
-                exact: true,
-            })
-            .unwrap();
+        let count = shard.count(CountRequest::new()).unwrap();
         assert_eq!(count, 750, "should have 750 remaining points after vacuum");
 
         // Verify deleted points are gone
         let deleted_results = shard
             .retrieve(
-                &deleted_ids,
-                Some(WithPayloadInterface::Bool(false)),
-                Some(WithVector::Bool(false)),
+                RetrieveRequestBuilder::new(deleted_ids.clone())
+                    .with_payload(WithPayloadInterface::Bool(false))
+                    .with_vector(WithVector::Bool(false))
+                    .build(),
             )
             .unwrap();
         assert!(
@@ -545,24 +530,14 @@ mod tests {
         // in the result, `points_optimized == 0` and the function returns false.
         let _optimized = shard.optimize().unwrap();
 
-        let count = shard
-            .count(CountRequestInternal {
-                filter: None,
-                exact: true,
-            })
-            .unwrap();
+        let count = shard.count(CountRequest::new()).unwrap();
         assert_eq!(count, 0, "all points should be gone after vacuum");
 
         // Shard should still be functional — can insert new points
         shard
             .update(PointOperation(UpsertPoints(PointsList(vec![point(9999)]))))
             .unwrap();
-        let count = shard
-            .count(CountRequestInternal {
-                filter: None,
-                exact: true,
-            })
-            .unwrap();
+        let count = shard.count(CountRequest::new()).unwrap();
         assert_eq!(count, 1, "shard should accept new points after full vacuum");
 
         assert_points_retrievable_with_vectors(&shard, &[9999]);
@@ -674,12 +649,7 @@ mod tests {
 
         // The duplicated segments each had 750 surviving points (same IDs).
         // After merge, the shard should be functional with correct data.
-        let count = reopened
-            .count(CountRequestInternal {
-                filter: None,
-                exact: true,
-            })
-            .unwrap();
+        let count = reopened.count(CountRequest::new()).unwrap();
         assert_eq!(
             count, 750,
             "merged shard should preserve surviving points without double-counting"
@@ -722,12 +692,7 @@ mod tests {
         // Reload the shard
         let reopened = EdgeShard::load(dir.path(), None).unwrap();
 
-        let count = reopened
-            .count(CountRequestInternal {
-                filter: None,
-                exact: true,
-            })
-            .unwrap();
+        let count = reopened.count(CountRequest::new()).unwrap();
         assert_eq!(count, 750, "point count should be preserved across reload");
 
         // Verify specific points survive reload with correct vectors
@@ -789,9 +754,10 @@ mod tests {
         // No data loss on the surviving vector.
         let results = reopened
             .retrieve(
-                &[ExtendedPointId::NumId(1)],
-                Some(WithPayloadInterface::Bool(false)),
-                Some(WithVector::Bool(true)),
+                RetrieveRequestBuilder::new(vec![ExtendedPointId::NumId(1)])
+                    .with_payload(WithPayloadInterface::Bool(false))
+                    .with_vector(WithVector::Bool(true))
+                    .build(),
             )
             .unwrap();
         assert_eq!(results.len(), 1, "point should survive the merge");
@@ -867,9 +833,10 @@ mod tests {
             .collect::<Vec<_>>();
         let results = shard
             .retrieve(
-                &point_ids,
-                Some(WithPayloadInterface::Bool(false)),
-                Some(WithVector::Bool(true)),
+                RetrieveRequestBuilder::new(point_ids)
+                    .with_payload(WithPayloadInterface::Bool(false))
+                    .with_vector(WithVector::Bool(true))
+                    .build(),
             )
             .unwrap();
         assert_eq!(

--- a/lib/edge/src/edge_shard/shard_read.rs
+++ b/lib/edge/src/edge_shard/shard_read.rs
@@ -3,16 +3,14 @@ use std::sync::Arc;
 
 use segment::common::operation_error::OperationResult;
 use segment::data_types::facets::FacetResponse;
-use segment::types::{ExtendedPointId, PointIdType, ScoredPoint, WithPayloadInterface, WithVector};
-use shard::count::CountRequestInternal;
-use shard::facet::FacetRequestInternal;
+use segment::types::{PointIdType, ScoredPoint};
 use shard::locked_segment::LockedSegment;
-use shard::query::ShardQueryRequest;
 use shard::retrieve::record_internal::RecordInternal;
-use shard::scroll::ScrollRequestInternal;
-use shard::search::CoreSearchRequest;
 
 use crate::read_view::{EdgeShardRead, ReadViewProvider};
+use crate::requests::{
+    CountRequest, FacetRequest, QueryRequest, RetrieveRequest, ScrollRequest, SearchRequest,
+};
 use crate::{EdgeConfig, EdgeShard, ShardInfo};
 
 /// The read-write shard's segments are heterogeneous — `Segment` and `ProxySegment` coexist during
@@ -46,35 +44,30 @@ impl ReadViewProvider for EdgeShard {
 /// shared implementation.
 impl EdgeShard {
     /// This method is DEPRECATED and should be replaced with query.
-    pub fn search(&self, search: CoreSearchRequest) -> OperationResult<Vec<ScoredPoint>> {
-        EdgeShardRead::search(self, search)
+    pub fn search(&self, request: SearchRequest) -> OperationResult<Vec<ScoredPoint>> {
+        EdgeShardRead::search(self, request)
     }
 
-    pub fn query(&self, request: ShardQueryRequest) -> OperationResult<Vec<ScoredPoint>> {
+    pub fn query(&self, request: QueryRequest) -> OperationResult<Vec<ScoredPoint>> {
         EdgeShardRead::query(self, request)
     }
 
     pub fn scroll(
         &self,
-        request: ScrollRequestInternal,
+        request: ScrollRequest,
     ) -> OperationResult<(Vec<RecordInternal>, Option<PointIdType>)> {
         EdgeShardRead::scroll(self, request)
     }
 
-    pub fn retrieve(
-        &self,
-        point_ids: &[ExtendedPointId],
-        with_payload: Option<WithPayloadInterface>,
-        with_vector: Option<WithVector>,
-    ) -> OperationResult<Vec<RecordInternal>> {
-        EdgeShardRead::retrieve(self, point_ids, with_payload, with_vector)
+    pub fn retrieve(&self, request: RetrieveRequest) -> OperationResult<Vec<RecordInternal>> {
+        EdgeShardRead::retrieve(self, request)
     }
 
-    pub fn count(&self, request: CountRequestInternal) -> OperationResult<usize> {
+    pub fn count(&self, request: CountRequest) -> OperationResult<usize> {
         EdgeShardRead::count(self, request)
     }
 
-    pub fn facet(&self, request: FacetRequestInternal) -> OperationResult<FacetResponse> {
+    pub fn facet(&self, request: FacetRequest) -> OperationResult<FacetResponse> {
         EdgeShardRead::facet(self, request)
     }
 

--- a/lib/edge/src/lib.rs
+++ b/lib/edge/src/lib.rs
@@ -5,13 +5,18 @@ mod edge_shard;
 mod read_only;
 mod read_view;
 mod reexports;
+mod requests;
 mod types;
 pub use types::*;
 
 #[cfg(test)]
 mod test_helpers;
 
-pub use builders::{EdgeConfigBuilder, EdgeSparseVectorParamsBuilder, EdgeVectorParamsBuilder};
+pub use builders::{
+    CountRequestBuilder, EdgeConfigBuilder, EdgeSparseVectorParamsBuilder, EdgeVectorParamsBuilder,
+    FacetRequestBuilder, GroupRequestBuilder, PrefetchBuilder, QueryRequestBuilder,
+    RetrieveRequestBuilder, ScrollRequestBuilder, SearchMatrixRequestBuilder, SearchRequestBuilder,
+};
 pub use config::optimizers::EdgeOptimizersConfig;
 pub use config::shard::EdgeConfig;
 pub use config::vectors::{EdgeSparseVectorParams, EdgeVectorParams};
@@ -19,9 +24,10 @@ pub use edge_shard::EdgeShard;
 pub use read_only::{
     LocalSegmentEnumerator, ManifestSegmentEnumerator, ReadOnlyEdgeShard, SegmentEnumerator,
 };
-pub use read_view::{
-    EdgeShardRead, Group, GroupRequest, ReadSegmentHandle, SearchMatrixRequest,
-    SearchMatrixResponse, ShardInfo,
-};
+pub use read_view::{EdgeShardRead, Group, ReadSegmentHandle, SearchMatrixResponse, ShardInfo};
 pub use reexports::*;
+pub use requests::{
+    CountRequest, FacetRequest, GroupRequest, Prefetch, QueryRequest, RetrieveRequest,
+    ScrollRequest, SearchMatrixRequest, SearchRequest,
+};
 pub use shard::segment_manifest::{SegmentManifestState, SegmentsManifest};

--- a/lib/edge/src/read_only/tests.rs
+++ b/lib/edge/src/read_only/tests.rs
@@ -11,13 +11,11 @@ use common::universal_io::{MmapFile, MmapFs};
 use segment::common::operation_error::OperationResult;
 use segment::data_types::vectors::{VectorInternal, VectorStructInternal};
 use segment::types::{Distance, ExtendedPointId, WithPayloadInterface, WithVector};
-use shard::count::CountRequestInternal;
 use shard::files::{SEGMENTS_PATH, segment_manifest_path};
 use shard::operations::CollectionUpdateOperations::PointOperation;
 use shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
 use shard::operations::point_ops::PointOperations::{DeletePoints, UpsertPoints};
 use shard::operations::point_ops::{PointStructPersisted, VectorStructPersisted};
-use shard::scroll::ScrollRequestInternal;
 use uuid::Uuid;
 
 use crate::config::vectors::EdgeVectorParams;
@@ -26,7 +24,7 @@ use crate::read_only::{
     LocalSegmentEnumerator, ManifestSegmentEnumerator, ReadOnlyEdgeShard, SegmentEnumerator,
 };
 use crate::read_view::EdgeShardRead;
-use crate::{EdgeConfig, EdgeShard};
+use crate::{CountRequest, EdgeConfig, EdgeShard, RetrieveRequestBuilder, ScrollRequestBuilder};
 
 const VECTOR_NAME: &str = "edge-ro-test-vector";
 
@@ -91,34 +89,22 @@ fn open_follower(path: &std::path::Path) -> ReadOnlyEdgeShard<MmapFile> {
 }
 
 fn exact_count(follower: &ReadOnlyEdgeShard<MmapFile>) -> usize {
-    follower
-        .count(CountRequestInternal {
-            filter: None,
-            exact: true,
-        })
-        .unwrap()
+    follower.count(CountRequest::new()).unwrap()
 }
 
 fn leader_exact_count(leader: &EdgeShard) -> usize {
-    leader
-        .count(CountRequestInternal {
-            filter: None,
-            exact: true,
-        })
-        .unwrap()
+    leader.count(CountRequest::new()).unwrap()
 }
 
 /// Scrolled point ids (sorted) visible to the follower.
 fn scrolled_ids(follower: &ReadOnlyEdgeShard<MmapFile>) -> Vec<ExtendedPointId> {
     let (records, _) = follower
-        .scroll(ScrollRequestInternal {
-            offset: None,
-            limit: Some(10_000),
-            filter: None,
-            with_payload: Some(WithPayloadInterface::Bool(false)),
-            with_vector: WithVector::Bool(false),
-            order_by: None,
-        })
+        .scroll(
+            ScrollRequestBuilder::new()
+                .limit(10_000)
+                .with_payload(WithPayloadInterface::Bool(false))
+                .build(),
+        )
         .unwrap();
     let mut ids = records.into_iter().map(|r| r.id).collect::<Vec<_>>();
     ids.sort_unstable();
@@ -133,9 +119,10 @@ fn assert_follower_vectors(follower: &ReadOnlyEdgeShard<MmapFile>, ids: &[u64]) 
         .collect::<Vec<_>>();
     let results = follower
         .retrieve(
-            &point_ids,
-            Some(WithPayloadInterface::Bool(false)),
-            Some(WithVector::Bool(true)),
+            RetrieveRequestBuilder::new(point_ids)
+                .with_payload(WithPayloadInterface::Bool(false))
+                .with_vector(WithVector::Bool(true))
+                .build(),
         )
         .unwrap();
     assert_eq!(results.len(), ids.len(), "expected all ids retrievable");
@@ -191,14 +178,10 @@ fn follower_with_load_profile_serves_reads() {
     upsert(&leader, 1..=100);
     leader.flush();
 
-    let scroll_request = ScrollRequestInternal {
-        offset: None,
-        limit: Some(10_000),
-        filter: None,
-        with_payload: Some(WithPayloadInterface::Bool(false)),
-        with_vector: WithVector::Bool(false),
-        order_by: None,
-    };
+    let scroll_request = ScrollRequestBuilder::new()
+        .limit(10_000)
+        .with_payload(WithPayloadInterface::Bool(false))
+        .build();
 
     let follower = ReadOnlyEdgeShard::<MmapFile>::open_with_enumerator(
         MmapFs,

--- a/lib/edge/src/read_view/mod.rs
+++ b/lib/edge/src/read_view/mod.rs
@@ -9,7 +9,7 @@ use rayon::{ThreadPool, ThreadPoolBuilder};
 use segment::common::operation_error::{OperationError, OperationResult};
 
 pub use self::handle::ReadSegmentHandle;
-pub use self::ops::{Group, GroupRequest, SearchMatrixRequest, SearchMatrixResponse, ShardInfo};
+pub use self::ops::{Group, SearchMatrixResponse, ShardInfo};
 pub use self::shard_read::EdgeShardRead;
 pub(crate) use self::shard_read::ReadViewProvider;
 use crate::EdgeConfig;

--- a/lib/edge/src/read_view/ops/grouping.rs
+++ b/lib/edge/src/read_view/ops/grouping.rs
@@ -1,20 +1,10 @@
 use segment::common::operation_error::OperationResult;
-use segment::json_path::JsonPath;
 pub use shard::grouping::Group;
 use shard::grouping::{GroupByDriver, RequestBudget};
 use shard::query::{self, ShardQueryRequest};
 
 use crate::read_view::{EdgeReadView, ReadSegmentHandle};
-
-/// Group the results of a base query by a payload field.
-pub struct GroupRequest {
-    /// Base scoring query. Its `limit`/`offset`/`with_payload`/`filter` are adjusted
-    /// here; the query vector, params, prefetch and score_threshold are honoured.
-    pub query: ShardQueryRequest,
-    pub group_by: JsonPath,
-    pub groups: usize,
-    pub group_size: usize,
-}
+use crate::requests::GroupRequest;
 
 impl<H: ReadSegmentHandle> EdgeReadView<H> {
     pub(crate) fn query_groups(&self, request: GroupRequest) -> OperationResult<Vec<Group>> {
@@ -24,6 +14,7 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
             groups,
             group_size,
         } = request;
+        let query = ShardQueryRequest::from(query);
 
         let order = query::query_result_order(query.query.as_ref(), |vector_name| {
             self.config.get_distance(vector_name)
@@ -51,31 +42,22 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
 mod tests {
     use segment::data_types::groups::GroupId;
     use segment::data_types::vectors::{NamedQuery, VectorInternal};
-    use segment::types::{WithPayloadInterface, WithVector};
     use shard::query::ScoringQuery;
     use shard::query::query_enum::QueryEnum;
 
     use super::*;
-    use crate::EdgeShardRead;
     use crate::test_helpers::{
         VECTOR_NAME, point_with_group, point_with_group_values, test_config, upsert,
     };
+    use crate::{EdgeShardRead, QueryRequest, QueryRequestBuilder};
 
-    fn base_query() -> ShardQueryRequest {
-        ShardQueryRequest {
-            prefetches: vec![],
-            query: Some(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery::new(
+    fn base_query() -> QueryRequest {
+        QueryRequestBuilder::new(0)
+            .query(ScoringQuery::Vector(QueryEnum::Nearest(NamedQuery::new(
                 VectorInternal::from(vec![1.0]),
                 VECTOR_NAME.to_string(),
-            )))),
-            filter: None,
-            score_threshold: None,
-            limit: 0,
-            offset: 0,
-            params: None,
-            with_vector: WithVector::Bool(false),
-            with_payload: WithPayloadInterface::Bool(false),
-        }
+            ))))
+            .build()
     }
 
     #[test]
@@ -93,12 +75,12 @@ mod tests {
         );
 
         let groups = shard
-            .query_groups(GroupRequest {
-                query: base_query(),
-                group_by: "group".parse().unwrap(),
-                groups: 2,
-                group_size: 5,
-            })
+            .query_groups(GroupRequest::new(
+                base_query(),
+                "group".parse().unwrap(),
+                2,
+                5,
+            ))
             .unwrap();
 
         assert_eq!(groups.len(), 2);
@@ -125,12 +107,12 @@ mod tests {
         );
 
         let groups = shard
-            .query_groups(GroupRequest {
-                query: base_query(),
-                group_by: "group".parse().unwrap(),
-                groups: 2,
-                group_size: 2,
-            })
+            .query_groups(GroupRequest::new(
+                base_query(),
+                "group".parse().unwrap(),
+                2,
+                2,
+            ))
             .unwrap();
 
         assert_eq!(groups.len(), 2);

--- a/lib/edge/src/read_view/ops/matrix.rs
+++ b/lib/edge/src/read_view/ops/matrix.rs
@@ -2,23 +2,14 @@ use ahash::AHashSet;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::data_types::vectors::NamedQuery;
 use segment::types::{
-    Condition, Filter, HasIdCondition, HasVectorCondition, PointIdType, ScoredPoint, VectorNameBuf,
+    Condition, Filter, HasIdCondition, HasVectorCondition, PointIdType, ScoredPoint,
     WithPayloadInterface, WithVector,
 };
 use shard::query::query_enum::QueryEnum;
 use shard::query::{SampleInternal, ScoringQuery, ShardQueryRequest};
 
 use crate::read_view::{EdgeReadView, ReadSegmentHandle};
-
-/// A single-shard distance-matrix request: sample `sample_size` random points that
-/// carry the `using` vector, then find each sample's `limit_per_sample` nearest
-/// neighbours restricted to the sampled set.
-pub struct SearchMatrixRequest {
-    pub sample_size: usize,
-    pub limit_per_sample: usize,
-    pub filter: Option<Filter>,
-    pub using: VectorNameBuf,
-}
+use crate::requests::SearchMatrixRequest;
 
 #[derive(Debug, Default)]
 pub struct SearchMatrixResponse {

--- a/lib/edge/src/read_view/ops/mod.rs
+++ b/lib/edge/src/read_view/ops/mod.rs
@@ -11,6 +11,6 @@ mod retrieve;
 mod scroll;
 mod search;
 
-pub use self::grouping::{Group, GroupRequest};
+pub use self::grouping::Group;
 pub use self::info::ShardInfo;
-pub use self::matrix::{SearchMatrixRequest, SearchMatrixResponse};
+pub use self::matrix::SearchMatrixResponse;

--- a/lib/edge/src/read_view/shard_read.rs
+++ b/lib/edge/src/read_view/shard_read.rs
@@ -4,19 +4,15 @@ use std::sync::Arc;
 use rayon::ThreadPool;
 use segment::common::operation_error::OperationResult;
 use segment::data_types::facets::FacetResponse;
-use segment::types::{ExtendedPointId, PointIdType, ScoredPoint, WithPayloadInterface, WithVector};
-use shard::count::CountRequestInternal;
-use shard::facet::FacetRequestInternal;
-use shard::query::ShardQueryRequest;
+use segment::types::{PointIdType, ScoredPoint};
 use shard::retrieve::record_internal::RecordInternal;
-use shard::scroll::ScrollRequestInternal;
-use shard::search::CoreSearchRequest;
 
-use super::{
-    EdgeReadView, Group, GroupRequest, ReadSegmentHandle, SearchMatrixRequest,
-    SearchMatrixResponse, ShardInfo,
-};
+use super::{EdgeReadView, Group, ReadSegmentHandle, SearchMatrixResponse, ShardInfo};
 use crate::EdgeConfig;
+use crate::requests::{
+    CountRequest, FacetRequest, GroupRequest, QueryRequest, RetrieveRequest, ScrollRequest,
+    SearchMatrixRequest, SearchRequest,
+};
 
 mod sealed {
     /// Empty marker supertrait of [`EdgeShardRead`](super::EdgeShardRead). Unnameable outside the
@@ -50,6 +46,9 @@ pub(crate) trait ReadViewProvider {
 /// Read API shared by the read-write [`EdgeShard`](crate::EdgeShard) and the read-only follower
 /// shard.
 ///
+/// Every method takes its edge request type from [`crate::requests`]; the blanket impl converts
+/// it into the internal request the read logic executes.
+///
 /// A shard only implements the crate-private snapshot provider; this trait comes for free through
 /// a blanket impl whose methods build an [`EdgeReadView`] from that snapshot and run the shared
 /// logic, so the read code is never duplicated and the snapshot plumbing stays invisible to crate
@@ -61,25 +60,20 @@ pub trait EdgeShardRead: sealed::Sealed {
     fn path(&self) -> &Path;
 
     /// This method is DEPRECATED and should be replaced with query.
-    fn search(&self, search: CoreSearchRequest) -> OperationResult<Vec<ScoredPoint>>;
+    fn search(&self, request: SearchRequest) -> OperationResult<Vec<ScoredPoint>>;
 
-    fn query(&self, request: ShardQueryRequest) -> OperationResult<Vec<ScoredPoint>>;
+    fn query(&self, request: QueryRequest) -> OperationResult<Vec<ScoredPoint>>;
 
     fn scroll(
         &self,
-        request: ScrollRequestInternal,
+        request: ScrollRequest,
     ) -> OperationResult<(Vec<RecordInternal>, Option<PointIdType>)>;
 
-    fn retrieve(
-        &self,
-        point_ids: &[ExtendedPointId],
-        with_payload: Option<WithPayloadInterface>,
-        with_vector: Option<WithVector>,
-    ) -> OperationResult<Vec<RecordInternal>>;
+    fn retrieve(&self, request: RetrieveRequest) -> OperationResult<Vec<RecordInternal>>;
 
-    fn count(&self, request: CountRequestInternal) -> OperationResult<usize>;
+    fn count(&self, request: CountRequest) -> OperationResult<usize>;
 
-    fn facet(&self, request: FacetRequestInternal) -> OperationResult<FacetResponse>;
+    fn facet(&self, request: FacetRequest) -> OperationResult<FacetResponse>;
 
     fn search_matrix(&self, request: SearchMatrixRequest) -> OperationResult<SearchMatrixResponse>;
 
@@ -97,36 +91,36 @@ impl<T: ReadViewProvider + ?Sized> EdgeShardRead for T {
         ReadViewProvider::path(self)
     }
 
-    fn search(&self, search: CoreSearchRequest) -> OperationResult<Vec<ScoredPoint>> {
-        view(self).search(search)
+    fn search(&self, request: SearchRequest) -> OperationResult<Vec<ScoredPoint>> {
+        view(self).search(request.into())
     }
 
-    fn query(&self, request: ShardQueryRequest) -> OperationResult<Vec<ScoredPoint>> {
-        view(self).query(request)
+    fn query(&self, request: QueryRequest) -> OperationResult<Vec<ScoredPoint>> {
+        view(self).query(request.into())
     }
 
     fn scroll(
         &self,
-        request: ScrollRequestInternal,
+        request: ScrollRequest,
     ) -> OperationResult<(Vec<RecordInternal>, Option<PointIdType>)> {
-        view(self).scroll(request)
+        view(self).scroll(request.into())
     }
 
-    fn retrieve(
-        &self,
-        point_ids: &[ExtendedPointId],
-        with_payload: Option<WithPayloadInterface>,
-        with_vector: Option<WithVector>,
-    ) -> OperationResult<Vec<RecordInternal>> {
-        view(self).retrieve(point_ids, with_payload, with_vector)
+    fn retrieve(&self, request: RetrieveRequest) -> OperationResult<Vec<RecordInternal>> {
+        let RetrieveRequest {
+            point_ids,
+            with_payload,
+            with_vector,
+        } = request;
+        view(self).retrieve(&point_ids, with_payload, with_vector)
     }
 
-    fn count(&self, request: CountRequestInternal) -> OperationResult<usize> {
-        view(self).count(request)
+    fn count(&self, request: CountRequest) -> OperationResult<usize> {
+        view(self).count(request.into())
     }
 
-    fn facet(&self, request: FacetRequestInternal) -> OperationResult<FacetResponse> {
-        view(self).facet(request)
+    fn facet(&self, request: FacetRequest) -> OperationResult<FacetResponse> {
+        view(self).facet(request.into())
     }
 
     fn search_matrix(&self, request: SearchMatrixRequest) -> OperationResult<SearchMatrixResponse> {

--- a/lib/edge/src/reexports.rs
+++ b/lib/edge/src/reexports.rs
@@ -35,8 +35,6 @@ mod reexports_from_qdrant_crates {
         NaiveFeedbackCoefficients as NaiveFeedbackStrategy,
         NaiveFeedbackQuery as FeedbackNaiveQuery, RecoQuery as RecommendQuery,
     };
-    pub use shard::count::CountRequestInternal as CountRequest;
-    pub use shard::facet::FacetRequestInternal as FacetRequest;
     pub use shard::operations::payload_ops::{DeletePayloadOp, PayloadOps, SetPayloadOp};
     pub use shard::operations::point_ops::{
         ConditionalInsertOperationInternal as ConditionalInsertOperation, PointIdsList,
@@ -55,11 +53,8 @@ mod reexports_from_qdrant_crates {
     pub use shard::query::query_enum::QueryEnum;
     pub use shard::query::{
         FusionInternal as Fusion, MmrInternal as Mmr, SampleInternal as Sample, ScoringQuery,
-        ShardPrefetch as Prefetch, ShardQueryRequest as QueryRequest,
     };
     pub use shard::retrieve::record_internal::RecordInternal as Record;
-    pub use shard::scroll::ScrollRequestInternal as ScrollRequest;
-    pub use shard::search::CoreSearchRequest as SearchRequest;
     pub use sparse::common::sparse_vector::SparseVector;
 }
 pub use reexports_from_qdrant_crates::*;

--- a/lib/edge/src/requests/conversions/count.rs
+++ b/lib/edge/src/requests/conversions/count.rs
@@ -1,0 +1,10 @@
+use shard::count::CountRequestInternal;
+
+use crate::requests::count::CountRequest;
+
+impl From<CountRequest> for CountRequestInternal {
+    fn from(request: CountRequest) -> Self {
+        let CountRequest { filter, exact } = request;
+        CountRequestInternal { filter, exact }
+    }
+}

--- a/lib/edge/src/requests/conversions/facet.rs
+++ b/lib/edge/src/requests/conversions/facet.rs
@@ -1,0 +1,20 @@
+use shard::facet::FacetRequestInternal;
+
+use crate::requests::facet::FacetRequest;
+
+impl From<FacetRequest> for FacetRequestInternal {
+    fn from(request: FacetRequest) -> Self {
+        let FacetRequest {
+            key,
+            limit,
+            filter,
+            exact,
+        } = request;
+        FacetRequestInternal {
+            key,
+            limit,
+            filter,
+            exact,
+        }
+    }
+}

--- a/lib/edge/src/requests/conversions/mod.rs
+++ b/lib/edge/src/requests/conversions/mod.rs
@@ -1,0 +1,14 @@
+//! Conversions from the edge request types into the internal request types the read path
+//! executes, grouped by request type. Every conversion destructures both sides exhaustively:
+//! a field added to an internal request type (or to an edge request type) fails compilation
+//! here instead of being silently dropped.
+//!
+//! [`RetrieveRequest`](crate::RetrieveRequest), [`SearchMatrixRequest`](crate::SearchMatrixRequest)
+//! and [`GroupRequest`](crate::GroupRequest) have no internal counterpart struct — the read path
+//! consumes them directly — so they have no conversion module.
+
+mod count;
+mod facet;
+mod query;
+mod scroll;
+mod search;

--- a/lib/edge/src/requests/conversions/query.rs
+++ b/lib/edge/src/requests/conversions/query.rs
@@ -1,0 +1,52 @@
+use ordered_float::OrderedFloat;
+use shard::query::{ShardPrefetch, ShardQueryRequest};
+
+use crate::requests::query::{Prefetch, QueryRequest};
+
+impl From<QueryRequest> for ShardQueryRequest {
+    fn from(request: QueryRequest) -> Self {
+        let QueryRequest {
+            prefetches,
+            query,
+            filter,
+            score_threshold,
+            limit,
+            offset,
+            params,
+            with_vector,
+            with_payload,
+        } = request;
+        ShardQueryRequest {
+            prefetches: prefetches.into_iter().map(ShardPrefetch::from).collect(),
+            query,
+            filter,
+            score_threshold: score_threshold.map(OrderedFloat),
+            limit,
+            offset,
+            params,
+            with_vector,
+            with_payload,
+        }
+    }
+}
+
+impl From<Prefetch> for ShardPrefetch {
+    fn from(prefetch: Prefetch) -> Self {
+        let Prefetch {
+            prefetches,
+            query,
+            limit,
+            params,
+            filter,
+            score_threshold,
+        } = prefetch;
+        ShardPrefetch {
+            prefetches: prefetches.into_iter().map(ShardPrefetch::from).collect(),
+            query,
+            limit,
+            params,
+            filter,
+            score_threshold: score_threshold.map(OrderedFloat),
+        }
+    }
+}

--- a/lib/edge/src/requests/conversions/scroll.rs
+++ b/lib/edge/src/requests/conversions/scroll.rs
@@ -1,0 +1,24 @@
+use shard::scroll::ScrollRequestInternal;
+
+use crate::requests::scroll::ScrollRequest;
+
+impl From<ScrollRequest> for ScrollRequestInternal {
+    fn from(request: ScrollRequest) -> Self {
+        let ScrollRequest {
+            offset,
+            limit,
+            filter,
+            with_payload,
+            with_vector,
+            order_by,
+        } = request;
+        ScrollRequestInternal {
+            offset,
+            limit,
+            filter,
+            with_payload,
+            with_vector,
+            order_by,
+        }
+    }
+}

--- a/lib/edge/src/requests/conversions/search.rs
+++ b/lib/edge/src/requests/conversions/search.rs
@@ -1,0 +1,28 @@
+use shard::search::CoreSearchRequest;
+
+use crate::requests::search::SearchRequest;
+
+impl From<SearchRequest> for CoreSearchRequest {
+    fn from(request: SearchRequest) -> Self {
+        let SearchRequest {
+            query,
+            filter,
+            params,
+            limit,
+            offset,
+            with_payload,
+            with_vector,
+            score_threshold,
+        } = request;
+        CoreSearchRequest {
+            query,
+            filter,
+            params,
+            limit,
+            offset,
+            with_payload,
+            with_vector,
+            score_threshold,
+        }
+    }
+}

--- a/lib/edge/src/requests/count.rs
+++ b/lib/edge/src/requests/count.rs
@@ -1,0 +1,28 @@
+use segment::types::Filter;
+
+/// Count request — counts the number of points which match the given conditions.
+/// If no filter is provided, the count of all points in the shard is returned.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CountRequest {
+    /// Look only for points which satisfy these conditions.
+    pub filter: Option<Filter>,
+    /// If true, count the exact number of points. If false, count the approximate number of
+    /// points faster. The approximate count might be unreliable while segments are being
+    /// optimized. Default: true.
+    pub exact: bool,
+}
+
+impl CountRequest {
+    pub fn new() -> Self {
+        Self {
+            filter: None,
+            exact: true,
+        }
+    }
+}
+
+impl Default for CountRequest {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/lib/edge/src/requests/facet.rs
+++ b/lib/edge/src/requests/facet.rs
@@ -1,0 +1,28 @@
+use segment::json_path::JsonPath;
+use segment::types::Filter;
+use shard::facet::FacetRequestInternal;
+
+/// Facet request — counts the number of points for each unique value of a payload key.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FacetRequest {
+    /// Payload key to facet on.
+    pub key: JsonPath,
+    /// Maximum number of facet hits to return. Default: 10.
+    pub limit: usize,
+    /// Look only for points which satisfy these conditions.
+    pub filter: Option<Filter>,
+    /// If true, count the exact number of points for each value.
+    /// If false, count the approximate number of points faster. Default: false.
+    pub exact: bool,
+}
+
+impl FacetRequest {
+    pub fn new(key: JsonPath) -> Self {
+        Self {
+            key,
+            limit: FacetRequestInternal::DEFAULT_LIMIT,
+            filter: None,
+            exact: false,
+        }
+    }
+}

--- a/lib/edge/src/requests/grouping.rs
+++ b/lib/edge/src/requests/grouping.rs
@@ -1,0 +1,29 @@
+use segment::json_path::JsonPath;
+
+use crate::requests::query::QueryRequest;
+
+/// Group the results of a base query by a payload field.
+#[derive(Clone, Debug, PartialEq)]
+pub struct GroupRequest {
+    /// Base scoring query. Its `limit`/`offset`/`with_payload`/`filter` are adjusted
+    /// by the grouping driver; the query vector, params, prefetch and score_threshold
+    /// are honoured.
+    pub query: QueryRequest,
+    /// Payload field to group by.
+    pub group_by: JsonPath,
+    /// Maximum number of groups to return.
+    pub groups: usize,
+    /// Maximum number of hits per group.
+    pub group_size: usize,
+}
+
+impl GroupRequest {
+    pub fn new(query: QueryRequest, group_by: JsonPath, groups: usize, group_size: usize) -> Self {
+        Self {
+            query,
+            group_by,
+            groups,
+            group_size,
+        }
+    }
+}

--- a/lib/edge/src/requests/matrix.rs
+++ b/lib/edge/src/requests/matrix.rs
@@ -1,0 +1,27 @@
+use segment::types::{Filter, VectorNameBuf};
+
+/// A single-shard distance-matrix request: sample `sample_size` random points that
+/// carry the `using` vector, then find each sample's `limit_per_sample` nearest
+/// neighbours restricted to the sampled set.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SearchMatrixRequest {
+    /// How many random points to sample.
+    pub sample_size: usize,
+    /// How many nearest neighbours to return per sampled point.
+    pub limit_per_sample: usize,
+    /// Look only for points which satisfy these conditions.
+    pub filter: Option<Filter>,
+    /// Name of the vector the sampled points are compared by.
+    pub using: VectorNameBuf,
+}
+
+impl SearchMatrixRequest {
+    pub fn new(sample_size: usize, limit_per_sample: usize, using: VectorNameBuf) -> Self {
+        Self {
+            sample_size,
+            limit_per_sample,
+            filter: None,
+            using,
+        }
+    }
+}

--- a/lib/edge/src/requests/mod.rs
+++ b/lib/edge/src/requests/mod.rs
@@ -1,0 +1,27 @@
+//! Edge-specific request types for [`EdgeShardRead`](crate::EdgeShardRead), one file per request.
+//!
+//! Every request is an edge-owned struct with public fields: a `new` constructor takes the
+//! required parameters and defaults the rest, so new optional parameters can be added without
+//! breaking callers. Fluent builders live in [`crate::builders`]. Conversions into the internal
+//! request types executed by the read path are grouped per request in [`conversions`], with
+//! exhaustive destructuring on both sides, so a field added to an internal request type fails
+//! compilation there instead of being silently dropped.
+
+pub mod conversions;
+pub mod count;
+pub mod facet;
+pub mod grouping;
+pub mod matrix;
+pub mod query;
+pub mod retrieve;
+pub mod scroll;
+pub mod search;
+
+pub use count::CountRequest;
+pub use facet::FacetRequest;
+pub use grouping::GroupRequest;
+pub use matrix::SearchMatrixRequest;
+pub use query::{Prefetch, QueryRequest};
+pub use retrieve::RetrieveRequest;
+pub use scroll::ScrollRequest;
+pub use search::SearchRequest;

--- a/lib/edge/src/requests/query.rs
+++ b/lib/edge/src/requests/query.rs
@@ -1,0 +1,75 @@
+use common::types::ScoreType;
+use segment::types::{Filter, SearchParams, WithPayloadInterface, WithVector};
+use shard::query::ScoringQuery;
+
+/// Universal query over an edge shard: a scoring query with optional prefetch stages.
+#[derive(Clone, Debug, PartialEq)]
+pub struct QueryRequest {
+    /// Sub-requests resolved first; their results form the candidate set the top-level
+    /// `query` re-scores.
+    pub prefetches: Vec<Prefetch>,
+    /// How to score the candidates. `None` scrolls by id instead of scoring.
+    pub query: Option<ScoringQuery>,
+    /// Look only for points which satisfy these conditions.
+    pub filter: Option<Filter>,
+    /// Exclude results with a worse score than this.
+    pub score_threshold: Option<ScoreType>,
+    /// Max number of results to return.
+    pub limit: usize,
+    /// Offset of the first result to return. May be used to paginate results.
+    /// Note: large offset values may cause performance issues.
+    pub offset: usize,
+    /// Search params for when there is no prefetch.
+    pub params: Option<SearchParams>,
+    /// Options for specifying which vectors to include into the response. Default is false.
+    pub with_vector: WithVector,
+    /// Select which payload to return with the response. Default is false.
+    pub with_payload: WithPayloadInterface,
+}
+
+impl QueryRequest {
+    pub fn new(limit: usize) -> Self {
+        Self {
+            prefetches: Vec::new(),
+            query: None,
+            filter: None,
+            score_threshold: None,
+            limit,
+            offset: 0,
+            params: None,
+            with_vector: WithVector::Bool(false),
+            with_payload: WithPayloadInterface::Bool(false),
+        }
+    }
+}
+
+/// One prefetch stage of a [`QueryRequest`]: produces the candidate set its parent re-scores.
+/// Prefetches nest, forming a candidate-resolution tree evaluated leaves-first.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Prefetch {
+    /// Nested sub-prefetches resolved before this one.
+    pub prefetches: Vec<Prefetch>,
+    /// How to score this stage's candidates. `None` scrolls by id instead of scoring.
+    pub query: Option<ScoringQuery>,
+    /// Max number of candidates this stage passes to its parent.
+    pub limit: usize,
+    /// Additional search params.
+    pub params: Option<SearchParams>,
+    /// Look only for points which satisfy these conditions.
+    pub filter: Option<Filter>,
+    /// Exclude candidates with a worse score than this.
+    pub score_threshold: Option<ScoreType>,
+}
+
+impl Prefetch {
+    pub fn new(limit: usize) -> Self {
+        Self {
+            prefetches: Vec::new(),
+            query: None,
+            limit,
+            params: None,
+            filter: None,
+            score_threshold: None,
+        }
+    }
+}

--- a/lib/edge/src/requests/retrieve.rs
+++ b/lib/edge/src/requests/retrieve.rs
@@ -1,0 +1,23 @@
+use segment::types::{ExtendedPointId, WithPayloadInterface, WithVector};
+
+/// Retrieve points by their ids. The response preserves the requested id order and skips
+/// ids that do not exist in the shard.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RetrieveRequest {
+    /// Ids of the points to retrieve.
+    pub point_ids: Vec<ExtendedPointId>,
+    /// Select which payload to return with the response. Default is true.
+    pub with_payload: Option<WithPayloadInterface>,
+    /// Options for specifying which vectors to include into the response. Default is false.
+    pub with_vector: Option<WithVector>,
+}
+
+impl RetrieveRequest {
+    pub fn new(point_ids: Vec<ExtendedPointId>) -> Self {
+        Self {
+            point_ids,
+            with_payload: None,
+            with_vector: None,
+        }
+    }
+}

--- a/lib/edge/src/requests/scroll.rs
+++ b/lib/edge/src/requests/scroll.rs
@@ -1,0 +1,47 @@
+use segment::data_types::load_profile::LoadProfile;
+use segment::data_types::order_by::OrderByInterface;
+use segment::types::{Filter, PointIdType, WithPayloadInterface, WithVector};
+use shard::scroll::ScrollRequestInternal;
+
+/// Scroll request — paginate over all points which match the given conditions.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ScrollRequest {
+    /// Start ID to read points from.
+    pub offset: Option<PointIdType>,
+    /// Page size. Default: 10.
+    pub limit: Option<usize>,
+    /// Look only for points which satisfy these conditions. If not provided — all points.
+    pub filter: Option<Filter>,
+    /// Select which payload to return with the response. Default is true.
+    pub with_payload: Option<WithPayloadInterface>,
+    /// Options for specifying which vectors to include into the response. Default is false.
+    pub with_vector: WithVector,
+    /// Order the records by a payload field instead of by id.
+    pub order_by: Option<OrderByInterface>,
+}
+
+impl ScrollRequest {
+    pub fn new() -> Self {
+        Self {
+            offset: None,
+            limit: None,
+            filter: None,
+            with_payload: None,
+            with_vector: WithVector::Bool(false),
+            order_by: None,
+        }
+    }
+
+    /// Request-specific [`LoadProfile`] for opening a read-only shard to serve exactly
+    /// this scroll: no vector components are warmed, and only the field indexes the
+    /// filter and `order_by` read keep their configured placement.
+    pub fn load_profile(&self) -> LoadProfile {
+        ScrollRequestInternal::from(self.clone()).load_profile()
+    }
+}
+
+impl Default for ScrollRequest {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/lib/edge/src/requests/search.rs
+++ b/lib/edge/src/requests/search.rs
@@ -1,0 +1,52 @@
+use common::types::ScoreType;
+use segment::data_types::load_profile::LoadProfile;
+use segment::types::{Filter, SearchParams, WithPayloadInterface, WithVector};
+use shard::query::query_enum::QueryEnum;
+use shard::search::CoreSearchRequest;
+
+/// Single-query vector search over an edge shard.
+///
+/// DEPRECATED together with [`EdgeShardRead::search`](crate::EdgeShardRead::search): prefer
+/// [`QueryRequest`](crate::QueryRequest) and [`EdgeShardRead::query`](crate::EdgeShardRead::query).
+#[derive(Clone, Debug, PartialEq)]
+pub struct SearchRequest {
+    /// Every kind of query that can be performed on segment level.
+    pub query: QueryEnum,
+    /// Look only for points which satisfy these conditions.
+    pub filter: Option<Filter>,
+    /// Additional search params.
+    pub params: Option<SearchParams>,
+    /// Max number of results to return.
+    pub limit: usize,
+    /// Offset of the first result to return. May be used to paginate results.
+    /// Note: large offset values may cause performance issues.
+    pub offset: usize,
+    /// Select which payload to return with the response. Default is false.
+    pub with_payload: Option<WithPayloadInterface>,
+    /// Options for specifying which vectors to include into the response. Default is false.
+    pub with_vector: Option<WithVector>,
+    /// Exclude results with a worse score than this.
+    pub score_threshold: Option<ScoreType>,
+}
+
+impl SearchRequest {
+    pub fn new(query: QueryEnum, limit: usize) -> Self {
+        Self {
+            query,
+            filter: None,
+            params: None,
+            limit,
+            offset: 0,
+            with_payload: None,
+            with_vector: None,
+            score_threshold: None,
+        }
+    }
+
+    /// Request-specific [`LoadProfile`] for opening a read-only shard to serve exactly
+    /// this search: only the queried vector's components and the filter's field indexes
+    /// keep their configured placement.
+    pub fn load_profile(&self) -> LoadProfile {
+        CoreSearchRequest::from(self.clone()).load_profile()
+    }
+}


### PR DESCRIPTION
## Motivation

The `EdgeShardRead` interface exposed to edge users was a mixture of internal types (`ScrollRequestInternal`, `CoreSearchRequest`, `ShardQueryRequest`), explicit parameter enumeration (`retrieve`), and ad-hoc custom types (`GroupRequest`, `SearchMatrixRequest`). Re-exporting internals under nicer names doesn't change their nature: introducing a new parameter breaks backward compatibility, and building on top of the interface is hard (see #9374).

## What this does

Every read method now takes an **edge-owned request struct** from the new `src/requests/` module (one file per request type):

- `SearchRequest`, `QueryRequest` + `Prefetch`, `ScrollRequest`, `CountRequest`, `FacetRequest`, `SearchMatrixRequest`, `GroupRequest`, and a new `RetrieveRequest` replacing `retrieve`'s parameter triple.
- Each struct has public fields and a `new(...)` constructor that enforces the required parameters and defaults the rest — new optional parameters can be added without breaking callers.
- Each has a fluent builder in `src/builders/` (no macros, in the existing `EdgeVectorParamsBuilder` style: `new(required)` seeded by exhaustively destructuring `Struct::new(...)`, setters, `build()` with exhaustive destructuring). All builders are re-exported from the crate root.
- Fields mirror the internal types one-to-one, except `score_threshold` is a plain `ScoreType` instead of `OrderedFloat`.

## Compile-time coverage of new parameters

`requests/conversions/` holds `From<EdgeType> for InternalType` impls grouped by request type, always compiled. They construct and destructure with **full field lists, no `..`**, in both directions:

- a field added to an internal request type (e.g. `ScrollRequestInternal`) fails compilation in the conversion — the same PR that adds the parameter must decide whether to expose it on the edge type;
- a field added to an edge type cascades through the conversion, the builder, the python bindings' constructors/`_getters`, until every surface handles it.

`RetrieveRequest`/`SearchMatrixRequest`/`GroupRequest` have no internal counterpart struct (the read path consumes them directly), documented in `conversions/mod.rs`.

## Compatibility

- The old re-export aliases are replaced by the edge types **under the same names** (`qdrant_edge::ScrollRequest` etc.), so downstream construction sites keep working — the `shard_query` tool compiled unchanged, and the published Rust examples needed only the (now nicer) builder form.
- `load_profile()` is provided on the edge `SearchRequest`/`ScrollRequest` (delegating through the conversion) for pre-open profile derivation.
- Python bindings wrap the edge types; the Python-facing API is unchanged.
- Published examples (`publish/examples/`) rewritten to use builders; verified by regenerating the amalgamated crate and running `demo` end-to-end (regenerated `publish/qdrant-edge/src` itself stays gitignored).

Component types (`Filter`, `SearchParams`, `ScoringQuery`, `QueryEnum`, …) remain re-exported internals — the mirroring boundary is deliberately the request envelope only. Update operations are out of scope and would be a follow-up of similar shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)