### PR TITLE
fix(quantization): clip quantile outliers by value count, not vector count

### DIFF
--- a/lib/quantization/src/quantile.rs
+++ b/lib/quantization/src/quantile.rs
@@ -59,9 +59,12 @@ pub(crate) fn find_quantile_interval<'a>(
         return Ok(None);
     }
 
+    // Trim `(1 - quantile) / 2` of the pooled *values* per tail. The pool is
+    // `count * dim` flattened values, so the fraction is of `data_slice_len`,
+    // not of the vector count.
     let cut_index = std::cmp::min(
         (data_slice_len - 1) / 2,
-        (selected_vectors_count as f32 * (1.0 - quantile) / 2.0) as usize,
+        (data_slice_len as f32 * (1.0 - quantile) / 2.0) as usize,
     );
     let cut_index = std::cmp::max(cut_index, 1);
     let comparator = |a: &f32, b: &f32| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal);
@@ -375,5 +378,35 @@ mod tests {
                 "Max value is out of expected range: got {max}, expected ~{max_result}"
             );
         }
+    }
+
+    /// Regression: the quantile trim must be a fraction of the pooled
+    /// *values* (`count * dim`), not of the vectors. With `dim > 1` the old
+    /// code trimmed `dim`x too few, leaving outliers inside the clipped range.
+    #[test]
+    fn test_quantile_interval_clips_by_value_count() {
+        const DIM: usize = 8;
+        const COUNT: usize = 200; // >= 127 so the quantile path runs
+        const OUTLIERS_PER_TAIL: usize = 20;
+
+        // A tight [0, 1) bulk plus a few extreme values on each tail.
+        let mut values: Vec<f32> = (0..COUNT * DIM).map(|i| (i % 100) as f32 / 100.0).collect();
+        for i in 0..OUTLIERS_PER_TAIL {
+            values[i] = 1000.0;
+            values[COUNT * DIM - 1 - i] = -1000.0;
+        }
+        let vectors: Vec<Vec<f32>> = values.chunks(DIM).map(|c| c.to_vec()).collect();
+
+        let (min, max) =
+            find_quantile_interval(vectors.iter(), DIM, COUNT, 0.9, &AtomicBool::new(false))
+                .unwrap()
+                .expect("quantile interval should be computed");
+
+        // (1 - 0.9) / 2 = 5% per tail; of 1600 values that is 80, so all 20
+        // outliers per tail fall inside the trimmed region and the interval
+        // hugs the [0, 1) bulk. The old vector-count trim removed only ~10 per
+        // tail, leaving outliers and a range near +/-1000.
+        assert!(max < 100.0, "max not clipped, outliers leaked: {max}");
+        assert!(min > -100.0, "min not clipped, outliers leaked: {min}");
     }
 }


### PR DESCRIPTION
Closes #9902

`find_quantile_interval` picks the `(min, max)` range for u8 scalar quantization when a `quantile` is set. It flattens the sampled vectors into a pool of `count * dim` values and trims the extreme `(1 - quantile) / 2` from each tail. The trim count was taken from the number of vectors instead of the number of pooled values, so for `dim > 1` it trimmed about `dim` times too few and barely clipped outliers. This changes it to trim by the value-pool length (`data_slice_len`).

Added a regression test: 200 vectors x 8 dims with outliers on each tail and `quantile = 0.9`, asserting the returned range hugs the bulk instead of the outliers. It fails on the old code and passes with this change.

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### AI disclosure (per CONTRIBUTING.md)

- [AI] fix(quantization): clip quantile outliers by value count, not vector count - the one-line fix and the regression test were generated with AI assistance and reviewed by me.
- Initial prompt: "In lib/quantization/src/quantile.rs, find_quantile_interval computes the outlier-trim count from the number of sampled vectors instead of the flattened value count (count * dim); fix it to trim by the value-pool length and add a regression test proving outliers are clipped for dim > 1."
