### PR TITLE
[TQDT] upsert raw malformed blob multi + sparse vectors

### DIFF
--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use common::budget::ResourceBudget;
@@ -5,20 +6,28 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use common::types::DeferredBehavior;
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, VectorStructInternal};
-use segment::types::{PayloadFieldSchema, PayloadSchemaType, WithPayload, WithVector};
+use segment::types::{
+    Distance, MultiVectorConfig, PayloadFieldSchema, PayloadSchemaType, WithPayload, WithVector,
+};
 use shard::operations::CollectionUpdateOperations;
 use shard::operations::point_ops::{
     PointInsertOperationsInternal, PointOperations, PointStructPersisted, PointStructRawPersisted,
+    VectorPersisted, VectorStructPersisted,
 };
 use shard::segment_holder::FlushMode;
 use shard::wal::{SerdeWal, WalRawRecord};
+use sparse::common::sparse_vector::SparseVector;
 use tempfile::Builder;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 
 use crate::common::adaptive_handle::AdaptiveSearchHandle;
+use crate::config::{CollectionConfigInternal, CollectionParams};
 use crate::operations::shared_storage_config::SharedStorageConfig;
-use crate::operations::types::{CollectionError, PointRequestInternal};
+use crate::operations::types::{
+    CollectionError, Datatype, PointRequestInternal, SparseVectorParams, VectorsConfig,
+};
+use crate::operations::vector_params_builder::VectorParamsBuilder;
 use crate::shards::local_shard::LocalShard;
 use crate::shards::shard_trait::{ShardOperation, WaitUntil};
 use crate::tests::fixtures::*;
@@ -1330,14 +1339,21 @@ async fn test_old_wal_filter_op_replays_with_apply_semantics() {
     shard.stop_gracefully().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_malformed_raw_upsert_is_skipped_on_wal_replay() {
+/// Shared driver for the bad-op WAL-replay reproducers: apply `valid_op`
+/// (point 1) and `bad_op` (point 2, must be rejected), then reload the shard
+/// so both ops replay from the WAL. `submit_update` writes to the WAL *before*
+/// applying, so the bad op survives its own failed apply — recovery must skip
+/// it and complete (a replay-aborting `ServiceError` fails this reload on
+/// every start: a crash loop), and only the valid point may survive.
+///
+/// Returns the bad op's rejection error for extra assertions.
+async fn assert_bad_op_skipped_on_wal_replay(
+    config: CollectionConfigInternal,
+    valid_op: CollectionUpdateOperations,
+    bad_op: CollectionUpdateOperations,
+) -> CollectionError {
     let _ = env_logger::builder().is_test(true).try_init();
     let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
-
-    // Single dense vector, dim 4, Distance::Dot (no cosine preprocessing, so the
-    // storage-native form is just the packed f32 bytes).
-    let config = create_collection_config();
     let collection_name = "test".to_string();
 
     let update_runtime = Handle::current();
@@ -1365,61 +1381,18 @@ async fn test_malformed_raw_upsert_is_skipped_on_wal_replay() {
 
     let hw_acc = HwMeasurementAcc::new();
 
-    // A dim-4 dense f32 vector is exactly 16 storage-native bytes; 12 bytes
-    // (3 floats) is a dimension mismatch the storage must reject.
-    let good_bytes: Vec<u8> = [1.0f32, 2.0, 3.0, 4.0]
-        .iter()
-        .flat_map(|f| f.to_ne_bytes())
-        .collect();
-    let bad_bytes: Vec<u8> = [1.0f32, 2.0, 3.0]
-        .iter()
-        .flat_map(|f| f.to_ne_bytes())
-        .collect();
-
-    let raw_upsert = |id: u64, bytes: Vec<u8>| {
-        CollectionUpdateOperations::PointOperation(PointOperations::UpsertPointsRaw(vec![
-            PointStructRawPersisted {
-                id: id.into(),
-                vectors: std::iter::once((DEFAULT_VECTOR_NAME.to_owned(), bytes)).collect(),
-                payload: None,
-            },
-        ]))
-    };
-
-    // Op 1: a valid raw point — applied and persisted to the WAL.
     shard
-        .update(
-            raw_upsert(1, good_bytes).into(),
-            WaitUntil::Visible,
-            None,
-            hw_acc.clone(),
-        )
+        .update(valid_op.into(), WaitUntil::Visible, None, hw_acc.clone())
         .await
-        .expect("valid raw upsert should succeed");
+        .expect("valid op should succeed");
 
-    // Op 2: a malformed raw point. `submit_update` writes to the WAL *before*
-    // applying, so this op survives its own failed apply and is replayed on
-    // reload. The apply must fail as a user error (`BadInput`), not a
-    // `ServiceError` — that is exactly what makes replay skip it.
     let err = shard
-        .update(
-            raw_upsert(2, bad_bytes).into(),
-            WaitUntil::Visible,
-            None,
-            hw_acc.clone(),
-        )
+        .update(bad_op.into(), WaitUntil::Visible, None, hw_acc.clone())
         .await
-        .expect_err("malformed raw upsert must be rejected");
-    assert!(
-        matches!(err, CollectionError::BadInput { .. }),
-        "malformed raw blob must be a BadInput user error (skipped on replay), got {err:?}",
-    );
+        .expect_err("bad op must be rejected");
 
     shard.stop_gracefully().await;
 
-    // Reload replays the WAL, including the malformed op. Before the fix this
-    // `LocalShard::load` would fail (or, in production, panic) because
-    // `load_from_wal` propagates the storage `ServiceError` and aborts recovery.
     let shard = LocalShard::load(
         0,
         collection_name,
@@ -1434,9 +1407,8 @@ async fn test_malformed_raw_upsert_is_skipped_on_wal_replay() {
         ResourceBudget::default(),
     )
     .await
-    .expect("shard must recover: the malformed raw op is skipped, not crash-looped");
+    .expect("shard must recover: the bad op is skipped, not crash-looped");
 
-    // The valid point survives; the malformed one was never stored.
     let request = Arc::new(PointRequestInternal {
         ids: vec![1.into(), 2.into()],
         with_payload: None,
@@ -1459,8 +1431,139 @@ async fn test_malformed_raw_upsert_is_skipped_on_wal_replay() {
     assert_eq!(
         present,
         vec![1.into()],
-        "only the valid point should survive; the malformed raw op must be skipped on replay",
+        "only the valid point should survive; the bad op must be skipped on replay",
     );
 
     shard.stop_gracefully().await;
+
+    err
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_malformed_raw_upsert_is_skipped_on_wal_replay() {
+    let raw_upsert = |id: u64, bytes: Vec<u8>| {
+        CollectionUpdateOperations::PointOperation(PointOperations::UpsertPointsRaw(vec![
+            PointStructRawPersisted {
+                id: id.into(),
+                vectors: std::iter::once((DEFAULT_VECTOR_NAME.to_owned(), bytes)).collect(),
+                payload: None,
+            },
+        ]))
+    };
+
+    // A dim-4 dense f32 vector is exactly 16 storage-native bytes; 12 bytes
+    // (3 floats) is a dimension mismatch the storage must reject.
+    let good_bytes: Vec<u8> = [1.0f32, 2.0, 3.0, 4.0]
+        .iter()
+        .flat_map(|f| f.to_ne_bytes())
+        .collect();
+    let bad_bytes: Vec<u8> = [1.0f32, 2.0, 3.0]
+        .iter()
+        .flat_map(|f| f.to_ne_bytes())
+        .collect();
+
+    // Single dense vector, dim 4, Distance::Dot (no cosine preprocessing, so
+    // the storage-native form is just the packed f32 bytes).
+    let err = assert_bad_op_skipped_on_wal_replay(
+        create_collection_config(),
+        raw_upsert(1, good_bytes),
+        raw_upsert(2, bad_bytes),
+    )
+    .await;
+
+    // The apply must fail as a user error (`BadInput`), not a `ServiceError` —
+    // that is exactly what makes replay skip it.
+    assert!(
+        matches!(err, CollectionError::BadInput { .. }),
+        "malformed raw blob must be a BadInput user error (skipped on replay), got {err:?}",
+    );
+}
+
+/// Sparse counterpart of [`test_malformed_raw_upsert_is_skipped_on_wal_replay`]:
+/// a raw sparse blob that doesn't decode as a stored sparse vector.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_malformed_sparse_raw_upsert_is_skipped_on_wal_replay() {
+    let sparse_name = "sparse";
+
+    // Sparse-only collection: one sparse vector, default index parameters.
+    let mut config = create_collection_config();
+    config.params = CollectionParams {
+        sparse_vectors: Some(BTreeMap::from([(
+            sparse_name.to_owned(),
+            SparseVectorParams {
+                index: None,
+                modifier: None,
+            },
+        )])),
+        ..CollectionParams::empty()
+    };
+
+    // A valid sparse point via the plain upsert path.
+    let valid_upsert = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::from(vec![PointStructPersisted {
+            id: 1.into(),
+            vector: VectorStructPersisted::Named(HashMap::from([(
+                sparse_name.to_owned(),
+                VectorPersisted::Sparse(
+                    SparseVector::new(vec![0, 2, 5], vec![0.5, 0.7, 0.9]).unwrap(),
+                ),
+            )])),
+            payload: None,
+        }]),
+    ));
+
+    // A raw upsert whose blob is not a decodable stored sparse vector.
+    let malformed_raw_upsert =
+        CollectionUpdateOperations::PointOperation(PointOperations::UpsertPointsRaw(vec![
+            PointStructRawPersisted {
+                id: 2.into(),
+                vectors: std::iter::once((sparse_name.to_owned(), vec![0_u8, 1, 2])).collect(),
+                payload: None,
+            },
+        ]));
+
+    assert_bad_op_skipped_on_wal_replay(config, valid_upsert, malformed_raw_upsert).await;
+}
+
+/// A multivector exceeding whole-chunk capacity in TurboQuant storage is only
+/// rejected during apply, after the WAL write. Public APIs can't produce one
+/// (`MAX_MULTIVECTOR_FLATTENED_LEN`); the internal API applies operations
+/// without that validation.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_over_capacity_multivector_upsert_is_skipped_on_wal_replay() {
+    // Test builds use a 512 KiB storage chunk; a Turbo4 record of a dim-128
+    // subvector is at least 64 bytes, so one chunk holds at most 8192 subvectors.
+    const DIM: usize = 128;
+    const OVER_CAPACITY_COUNT: usize = 9000;
+
+    // Single multivector with TurboQuant (Turbo4) storage.
+    let mut vector_params = VectorParamsBuilder::new(DIM as u64, Distance::Dot)
+        .with_datatype(Datatype::Turbo4)
+        .build();
+    vector_params.multivector_config = Some(MultiVectorConfig::default());
+
+    let mut config = create_collection_config();
+    config.params = CollectionParams {
+        vectors: VectorsConfig::Single(vector_params),
+        ..CollectionParams::empty()
+    };
+    // The over-capacity operation (~4.6 MB of f32 input) must fit a WAL segment.
+    config.wal_config.wal_capacity_mb = 16;
+
+    let multi_upsert = |id: u64, count: usize| {
+        CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+            PointInsertOperationsInternal::from(vec![PointStructPersisted {
+                id: id.into(),
+                vector: VectorStructPersisted::MultiDense(vec![vec![1.0; DIM]; count]),
+                payload: None,
+            }]),
+        ))
+    };
+
+    assert_bad_op_skipped_on_wal_replay(
+        config,
+        multi_upsert(1, 2),
+        multi_upsert(2, OVER_CAPACITY_COUNT),
+    )
+    .await;
 }

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/vector_index_impl.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/vector_index_impl.rs
@@ -201,7 +201,7 @@ impl<TInvertedIndex: InvertedIndex> VectorIndex for SparseVectorIndex<TInvertedI
         // inverted index needs the decoded values anyway, so decode and
         // delegate to the regular path.
         let sparse = vector
-            .map(|bytes| SparseVector::try_from(StoredSparseVector::try_from_bytes(bytes)?))
+            .map(StoredSparseVector::decode_untrusted_bytes)
             .transpose()?;
         self.update_vector(id, sparse.as_ref().map(VectorRef::from), hw_counter)
     }

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -611,8 +611,7 @@ mod tests {
                             .collect(),
                     ),
                     SPARSE_NAME => VectorInternal::Sparse(
-                        SparseVector::try_from(StoredSparseVector::try_from_bytes(bytes).unwrap())
-                            .unwrap(),
+                        StoredSparseVector::decode_untrusted_bytes(bytes).unwrap(),
                     ),
                     other => panic!("unexpected vector name {other}"),
                 };
@@ -728,9 +727,8 @@ mod tests {
         };
         assert_eq!(name, SPARSE_NAME);
         assert_eq!(raw_name, SPARSE_NAME);
-        let decoded = VectorInternal::Sparse(
-            SparseVector::try_from(StoredSparseVector::try_from_bytes(bytes).unwrap()).unwrap(),
-        );
+        let decoded =
+            VectorInternal::Sparse(StoredSparseVector::decode_untrusted_bytes(bytes).unwrap());
         assert_eq!(vector, &decoded);
 
         // Point 2 is untouched: same vector names in both results.

--- a/lib/segment/src/vector_storage/sparse/stored_sparse_vectors.rs
+++ b/lib/segment/src/vector_storage/sparse/stored_sparse_vectors.rs
@@ -15,11 +15,22 @@ pub struct StoredSparseVector {
 }
 
 impl StoredSparseVector {
-    /// Fallible counterpart of [`Blob::from_bytes`], for deserializing bytes
-    /// that arrive from outside this storage (e.g. raw point relocation).
-    pub(crate) fn try_from_bytes(data: &[u8]) -> Result<Self, OperationError> {
-        bincode::deserialize(data).map_err(|err| {
-            OperationError::service_error(format!("Failed to decode sparse vector bytes: {err}"))
+    /// Fallible counterpart of [`Blob::from_bytes`], for decoding bytes that
+    /// arrive from outside this storage (e.g. raw point relocation).
+    ///
+    /// Any failure is a user error (`WrongVectorBytesSize`), not a
+    /// `ServiceError`: the blob is untrusted input, and a malformed blob that
+    /// reached the WAL is skipped on replay instead of crash-looping recovery.
+    /// Reads of already-stored data use `TryFrom` instead, where a failure is
+    /// genuine corruption (service error).
+    pub(crate) fn decode_untrusted_bytes(data: &[u8]) -> Result<SparseVector, OperationError> {
+        let stored: StoredSparseVector = bincode::deserialize(data).map_err(|err| {
+            OperationError::wrong_vector_bytes_size(format!("Malformed sparse vector blob: {err}"))
+        })?;
+        SparseVector::try_from(stored).map_err(|_| {
+            OperationError::wrong_vector_bytes_size(
+                "Malformed sparse vector blob: index out of u32 range",
+            )
         })
     }
 

--- a/lib/segment/src/vector_storage/turbo/multi.rs
+++ b/lib/segment/src/vector_storage/turbo/multi.rs
@@ -151,6 +151,14 @@ pub fn open_appendable_turbo_multi_vector_storage(
     })
 }
 
+/// Rejection message for a multivector that cannot fit a whole storage chunk
+/// ([`TurboMultiVectorStorage::fresh_range_start`] returning `None`). Single
+/// source of truth for both write paths; only the error class differs by call
+/// site (user error on ingest, service error on the optimizer merge).
+fn exceeds_chunk_capacity_message(count: PointOffsetType) -> String {
+    format!("Multivector of {count} subvectors exceeds the chunk capacity")
+}
+
 impl TurboMultiVectorStorage {
     /// Offset record for `key`, if the point exists.
     fn get_offset<P: AccessPattern>(&self, key: PointOffsetType) -> Option<MultivectorMmapOffset> {
@@ -279,21 +287,21 @@ impl TurboMultiVectorStorage {
     }
 
     /// Start of a fresh range for `count` records, never straddling a chunk
-    /// boundary: skips the tail when the range wouldn't fit it, errors when
-    /// even a whole chunk can't hold it.
-    fn fresh_range_start(&self, count: PointOffsetType) -> OperationResult<PointOffsetType> {
+    /// boundary: skips the tail when the range wouldn't fit it, `None` when
+    /// even a whole chunk can't hold it. Callers classify the `None` case via
+    /// [`exceeds_chunk_capacity_message`]: user error on the ingest path,
+    /// service error on the optimizer merge.
+    fn fresh_range_start(&self, count: PointOffsetType) -> Option<PointOffsetType> {
         let start = self.storage.vectors_count() as PointOffsetType;
         let left = self.storage.get_remaining_chunk_keys(start);
         if count as usize <= left {
-            return Ok(start);
+            return Some(start);
         }
         let next_chunk = start + left as PointOffsetType;
         if count as usize > self.storage.get_remaining_chunk_keys(next_chunk) {
-            return Err(OperationError::service_error(format!(
-                "Multivector of {count} subvectors exceeds the chunk capacity",
-            )));
+            return None;
         }
-        Ok(next_chunk)
+        Some(next_chunk)
     }
 
     /// Record range for upserting `count` records at `key`: reuse the existing
@@ -311,8 +319,18 @@ impl TurboMultiVectorStorage {
             .unwrap_or_default();
 
         if count > offset.capacity {
+            // Ingest path (`insert_multi` / `insert_multi_tq_bytes`): the count
+            // comes from the operation, so an over-capacity multivector is user
+            // error (`WrongVectorBytesSize`), not `ServiceError` — the op is
+            // already in the WAL and must be skipped on replay instead of
+            // crash-looping recovery. The public API can't produce one
+            // (`MAX_MULTIVECTOR_FLATTENED_LEN`), but the internal API applies
+            // operations without that validation.
+            let fresh_start = self.fresh_range_start(count).ok_or_else(|| {
+                OperationError::wrong_vector_bytes_size(exceeds_chunk_capacity_message(count))
+            })?;
             offset = MultivectorMmapOffset {
-                offset: self.fresh_range_start(count)?,
+                offset: fresh_start,
                 count,
                 capacity: count,
             };
@@ -687,7 +705,11 @@ impl MultiTQVectorStorage for TurboMultiVectorStorage {
 
             let count = (blob.len() / record_size) as u32;
             let key = self.offsets.len() as PointOffsetType;
-            let inner_start = self.fresh_range_start(count)?;
+            // Optimizer merge of already-stored data: over-capacity here is
+            // genuine corruption, kept as a service error.
+            let inner_start = self.fresh_range_start(count).ok_or_else(|| {
+                OperationError::service_error(exceeds_chunk_capacity_message(count))
+            })?;
             for (i, record) in blob.chunks_exact(record_size).enumerate() {
                 self.storage.upsert_vector(
                     inner_start + i as PointOffsetType,

--- a/lib/segment/src/vector_storage/turbo/multi.rs
+++ b/lib/segment/src/vector_storage/turbo/multi.rs
@@ -319,13 +319,8 @@ impl TurboMultiVectorStorage {
             .unwrap_or_default();
 
         if count > offset.capacity {
-            // Ingest path (`insert_multi` / `insert_multi_tq_bytes`): the count
-            // comes from the operation, so an over-capacity multivector is user
-            // error (`WrongVectorBytesSize`), not `ServiceError` — the op is
-            // already in the WAL and must be skipped on replay instead of
-            // crash-looping recovery. The public API can't produce one
-            // (`MAX_MULTIVECTOR_FLATTENED_LEN`), but the internal API applies
-            // operations without that validation.
+            // User error so WAL replay skips the op instead of crash-looping.
+            // Reachable only internally (no `MAX_MULTIVECTOR_FLATTENED_LEN` check).
             let fresh_start = self.fresh_range_start(count).ok_or_else(|| {
                 OperationError::wrong_vector_bytes_size(exceeds_chunk_capacity_message(count))
             })?;

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -964,7 +964,7 @@ fn insert_sparse_bytes<S: VectorStorage>(
     bytes: &[u8],
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<()> {
-    let sparse = SparseVector::try_from(StoredSparseVector::try_from_bytes(bytes)?)?;
+    let sparse = StoredSparseVector::decode_untrusted_bytes(bytes)?;
     storage.insert_vector(key, VectorRef::from(&sparse), hw_counter)
 }
 


### PR DESCRIPTION
Continuation of #9886, fixing the same issue for sparse and multi-vectors.

This PR also does a minor refactor to tests, reducing boilerplate and adds two new tests reproducing the WAL-Replay-loop issue.