### PR TITLE
Recover from appendable segment overflow

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -41,9 +41,7 @@ impl CollectionUpdater {
                     } else {
                         log::error!("Update operation failed: {collection_error}")
                     }
-                } else if !segments.read().failed_operation.is_empty()
-                    && segments.write().failed_operation.remove(&op_num)
-                {
+                } else if segments.write().failed_operation.remove(&op_num) {
                     // A previously failed operation declined non-transiently on re-apply: it can
                     // never succeed anymore (e.g. later operations deleted the points it
                     // references). Drop it so it stops pinning the WAL acknowledge forever.

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -30,7 +30,17 @@ impl CollectionUpdater {
                 if collection_error.is_transient() {
                     let mut write_segments = segments.write();
                     write_segments.failed_operation.insert(op_num);
-                    log::error!("Update operation failed: {collection_error}")
+                    if collection_error.is_out_of_appendable_capacity() {
+                        // Expected backpressure rather than a failure: the update worker retries
+                        // inline and recovery re-applies the operation once the optimizer
+                        // provisions a fresh appendable segment.
+                        log::debug!(
+                            "Update operation {op_num} ran out of appendable capacity, \
+                             it will be retried: {collection_error}"
+                        )
+                    } else {
+                        log::error!("Update operation failed: {collection_error}")
+                    }
                 } else if !segments.read().failed_operation.is_empty()
                     && segments.write().failed_operation.remove(&op_num)
                 {

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -146,6 +146,91 @@ mod tests {
         PointOperations, PointStructPersisted, VectorStructPersisted,
     };
 
+    /// `failed_operation` pins the WAL acknowledge, so every transition in and out of it is
+    /// load-bearing: an entry that is never removed stalls the acknowledge forever, and one that
+    /// is removed too eagerly drops an operation that still needed re-applying.
+    fn failed_operations(segments: &LockedSegmentHolder) -> Vec<SeqNumberType> {
+        segments.read().failed_operation.iter().copied().collect()
+    }
+
+    fn empty_holder() -> LockedSegmentHolder {
+        LockedSegmentHolder::new(SegmentHolder::default())
+    }
+
+    #[test]
+    fn test_transient_failure_is_queued_for_recovery() {
+        let segments = empty_holder();
+
+        CollectionUpdater::handle_update_result(
+            &segments,
+            42,
+            &Err(CollectionError::service_error("all segments at the cap")),
+        );
+
+        assert_eq!(
+            failed_operations(&segments),
+            vec![42],
+            "a transient failure must be queued so recovery re-applies it",
+        );
+    }
+
+    #[test]
+    fn test_successful_reapply_clears_failed_operation() {
+        let segments = empty_holder();
+        segments.write().failed_operation.extend([42, 43]);
+
+        CollectionUpdater::handle_update_result(&segments, 42, &Ok(1));
+
+        assert_eq!(
+            failed_operations(&segments),
+            vec![43],
+            "a successful re-apply must unpin its own operation and leave the others",
+        );
+    }
+
+    #[test]
+    fn test_non_transient_decline_on_reapply_drops_failed_operation() {
+        let segments = empty_holder();
+        segments.write().failed_operation.extend([42, 43]);
+
+        // A queued operation can start declining once later operations changed what it sees, e.g.
+        // deleted the points it references. It can never succeed again, so holding the acknowledge
+        // for it would stall the WAL forever.
+        CollectionUpdater::handle_update_result(
+            &segments,
+            42,
+            &Err(CollectionError::PointNotFound {
+                missed_point_id: 1.into(),
+            }),
+        );
+
+        assert_eq!(
+            failed_operations(&segments),
+            vec![43],
+            "a queued operation that declines can never succeed, it must stop pinning the WAL",
+        );
+    }
+
+    #[test]
+    fn test_non_transient_decline_of_unqueued_operation_keeps_others() {
+        let segments = empty_holder();
+        segments.write().failed_operation.extend([42]);
+
+        // First-time decline of an unrelated operation: it was never queued, and it must not
+        // disturb the operation that is.
+        CollectionUpdater::handle_update_result(
+            &segments,
+            99,
+            &Err(CollectionError::bad_input("malformed".to_string())),
+        );
+
+        assert_eq!(
+            failed_operations(&segments),
+            vec![42],
+            "declining a never-queued operation must not touch the recovery queue",
+        );
+    }
+
     #[test]
     fn test_sync_ops() {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -31,6 +31,16 @@ impl CollectionUpdater {
                     let mut write_segments = segments.write();
                     write_segments.failed_operation.insert(op_num);
                     log::error!("Update operation failed: {collection_error}")
+                } else if !segments.read().failed_operation.is_empty()
+                    && segments.write().failed_operation.remove(&op_num)
+                {
+                    // A previously failed operation declined non-transiently on re-apply: it can
+                    // never succeed anymore (e.g. later operations deleted the points it
+                    // references). Drop it so it stops pinning the WAL acknowledge forever.
+                    log::warn!(
+                        "Update operation {op_num} declined on re-apply, dropping it: \
+                         {collection_error}"
+                    )
                 } else {
                     log::warn!("Update operation declined: {collection_error}")
                 }

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -222,26 +222,6 @@ mod tests {
     }
 
     #[test]
-    fn test_non_transient_decline_of_unqueued_operation_keeps_others() {
-        let segments = empty_holder();
-        segments.write().failed_operation.extend([42]);
-
-        // First-time decline of an unrelated operation: it was never queued, and it must not
-        // disturb the operation that is.
-        CollectionUpdater::handle_update_result(
-            &segments,
-            99,
-            &Err(CollectionError::bad_input("malformed".to_string())),
-        );
-
-        assert_eq!(
-            failed_operations(&segments),
-            vec![42],
-            "declining a never-queued operation must not touch the recovery queue",
-        );
-    }
-
-    #[test]
     fn test_sync_ops() {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -6,7 +6,7 @@ use shard::segment_holder::locked::LockedSegmentHolder;
 use shard::update::*;
 
 use crate::operations::CollectionUpdateOperations;
-use crate::operations::types::{CollectionError, CollectionResult};
+use crate::operations::types::{CollectionError, CollectionResult, FailedUpdateDisposition};
 use crate::shards::update_tracker::UpdateTracker;
 
 /// Implementation of the update operation
@@ -26,33 +26,35 @@ impl CollectionUpdater {
                     segments.write().failed_operation.remove(&op_num);
                 }
             }
-            Err(collection_error) => {
-                if collection_error.is_transient() {
-                    let mut write_segments = segments.write();
-                    write_segments.failed_operation.insert(op_num);
-                    if collection_error.is_out_of_appendable_capacity() {
-                        // Expected backpressure rather than a failure: the update worker retries
-                        // inline and recovery re-applies the operation once the optimizer
-                        // provisions a fresh appendable segment.
-                        log::debug!(
-                            "Update operation {op_num} ran out of appendable capacity, \
-                             it will be retried: {collection_error}"
+            Err(collection_error) => match collection_error.failed_update_disposition() {
+                FailedUpdateDisposition::Backpressure => {
+                    segments.write().failed_operation.insert(op_num);
+                    // Expected backpressure rather than a failure: the update worker retries
+                    // inline and recovery re-applies the operation once the optimizer provisions
+                    // a fresh appendable segment.
+                    log::debug!(
+                        "Update operation {op_num} ran out of appendable capacity, \
+                         it will be retried: {collection_error}"
+                    )
+                }
+                FailedUpdateDisposition::Transient => {
+                    segments.write().failed_operation.insert(op_num);
+                    log::error!("Update operation failed: {collection_error}")
+                }
+                FailedUpdateDisposition::Permanent => {
+                    if segments.write().failed_operation.remove(&op_num) {
+                        // A previously failed operation declined permanently on re-apply: it can
+                        // never succeed anymore (e.g. later operations deleted the points it
+                        // references). Drop it so it stops pinning the WAL acknowledge forever.
+                        log::warn!(
+                            "Update operation {op_num} declined on re-apply, dropping it: \
+                             {collection_error}"
                         )
                     } else {
-                        log::error!("Update operation failed: {collection_error}")
+                        log::warn!("Update operation declined: {collection_error}")
                     }
-                } else if segments.write().failed_operation.remove(&op_num) {
-                    // A previously failed operation declined non-transiently on re-apply: it can
-                    // never succeed anymore (e.g. later operations deleted the points it
-                    // references). Drop it so it stops pinning the WAL acknowledge forever.
-                    log::warn!(
-                        "Update operation {op_num} declined on re-apply, dropping it: \
-                         {collection_error}"
-                    )
-                } else {
-                    log::warn!("Update operation declined: {collection_error}")
                 }
-            }
+            },
         }
     }
 

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -64,6 +64,7 @@ impl CollectionUpdater {
         operation: CollectionUpdateOperations,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
+        max_segment_size_bytes: Option<std::num::NonZeroUsize>,
         hw_counter: &HardwareCounterCell,
     ) -> CollectionResult<usize> {
         // Use block_in_place here to avoid blocking the current async executor
@@ -82,16 +83,29 @@ impl CollectionUpdater {
 
             match operation {
                 CollectionUpdateOperations::PointOperation(point_operation) => {
-                    process_point_operation(&segments_guard, op_num, point_operation, hw_counter)
+                    process_point_operation(
+                        &segments_guard,
+                        op_num,
+                        point_operation,
+                        max_segment_size_bytes,
+                        hw_counter,
+                    )
                 }
                 CollectionUpdateOperations::VectorOperation(vector_operation) => {
-                    process_vector_operation(&segments_guard, op_num, vector_operation, hw_counter)
+                    process_vector_operation(
+                        &segments_guard,
+                        op_num,
+                        vector_operation,
+                        max_segment_size_bytes,
+                        hw_counter,
+                    )
                 }
                 CollectionUpdateOperations::PayloadOperation(payload_operation) => {
                     process_payload_operation(
                         &segments_guard,
                         op_num,
                         payload_operation,
+                        max_segment_size_bytes,
                         hw_counter,
                     )
                 }
@@ -248,6 +262,7 @@ mod tests {
             Some(10.into()),
             None,
             &points,
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -279,7 +294,7 @@ mod tests {
 
         let hw_counter = HardwareCounterCell::new();
 
-        let res = upsert_points(&segments.read(), 100, &points, &hw_counter);
+        let res = upsert_points(&segments.read(), 100, &points, None, &hw_counter);
         assert_matches!(res, Ok(1));
 
         let records = retrieve_blocking(
@@ -317,6 +332,7 @@ mod tests {
             PointOperations::DeletePoints {
                 ids: vec![500.into()],
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -361,6 +377,7 @@ mod tests {
                 filter: None,
                 key: None,
             }),
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -400,6 +417,7 @@ mod tests {
                 keys: vec!["color".parse().unwrap(), "empty".parse().unwrap()],
                 filter: None,
             }),
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -446,6 +464,7 @@ mod tests {
             PayloadOps::ClearPayload {
                 points: vec![2.into()],
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -518,6 +537,7 @@ mod tests {
                 filter: None,
                 key: Some(meta_key_path.clone()),
             }),
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -582,6 +602,7 @@ mod tests {
                 filter: None,
                 key: Some(meta_key_path.clone()),
             }),
+            None,
             &hw_counter,
         )
         .unwrap();

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -6,7 +6,7 @@ use shard::segment_holder::locked::LockedSegmentHolder;
 use shard::update::*;
 
 use crate::operations::CollectionUpdateOperations;
-use crate::operations::types::{CollectionError, CollectionResult, FailedUpdateDisposition};
+use crate::operations::types::{CollectionError, CollectionResult, UpdateFailureKind};
 use crate::shards::update_tracker::UpdateTracker;
 
 /// Implementation of the update operation
@@ -26,8 +26,8 @@ impl CollectionUpdater {
                     segments.write().failed_operation.remove(&op_num);
                 }
             }
-            Err(collection_error) => match collection_error.failed_update_disposition() {
-                FailedUpdateDisposition::Backpressure => {
+            Err(collection_error) => match collection_error.update_failure_kind() {
+                UpdateFailureKind::Backpressure => {
                     segments.write().failed_operation.insert(op_num);
                     // Expected backpressure rather than a failure: the update worker retries
                     // inline and recovery re-applies the operation once the optimizer provisions
@@ -37,11 +37,11 @@ impl CollectionUpdater {
                          it will be retried: {collection_error}"
                     )
                 }
-                FailedUpdateDisposition::Transient => {
+                UpdateFailureKind::Transient => {
                     segments.write().failed_operation.insert(op_num);
                     log::error!("Update operation failed: {collection_error}")
                 }
-                FailedUpdateDisposition::Permanent => {
+                UpdateFailureKind::Permanent => {
                     if segments.write().failed_operation.remove(&op_num) {
                         // A previously failed operation declined permanently on re-apply: it can
                         // never succeed anymore (e.g. later operations deleted the points it

--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -159,64 +159,45 @@ mod tests {
     /// `failed_operation` pins the WAL acknowledge, so every transition in and out of it is
     /// load-bearing: an entry that is never removed stalls the acknowledge forever, and one that
     /// is removed too eagerly drops an operation that still needed re-applying.
-    fn failed_operations(segments: &LockedSegmentHolder) -> Vec<SeqNumberType> {
-        segments.read().failed_operation.iter().copied().collect()
-    }
-
-    fn empty_holder() -> LockedSegmentHolder {
-        LockedSegmentHolder::new(SegmentHolder::default())
-    }
-
     #[test]
-    fn test_transient_failure_is_queued_for_recovery() {
-        let segments = empty_holder();
+    fn test_failed_operation_queue_lifecycle() {
+        let segments = LockedSegmentHolder::new(SegmentHolder::default());
+        let failed_operations = |segments: &LockedSegmentHolder| -> Vec<SeqNumberType> {
+            segments.read().failed_operation.iter().copied().collect()
+        };
 
+        // A transient failure queues for recovery.
         CollectionUpdater::handle_update_result(
             &segments,
             42,
             &Err(CollectionError::service_error("all segments at the cap")),
         );
-
         assert_eq!(
             failed_operations(&segments),
             vec![42],
             "a transient failure must be queued so recovery re-applies it",
         );
-    }
 
-    #[test]
-    fn test_successful_reapply_clears_failed_operation() {
-        let segments = empty_holder();
-        segments.write().failed_operation.extend([42, 43]);
-
+        // A successful re-apply unpins its own operation and leaves the others queued.
+        segments.write().failed_operation.insert(43);
         CollectionUpdater::handle_update_result(&segments, 42, &Ok(1));
-
         assert_eq!(
             failed_operations(&segments),
             vec![43],
             "a successful re-apply must unpin its own operation and leave the others",
         );
-    }
 
-    #[test]
-    fn test_non_transient_decline_on_reapply_drops_failed_operation() {
-        let segments = empty_holder();
-        segments.write().failed_operation.extend([42, 43]);
-
-        // A queued operation can start declining once later operations changed what it sees, e.g.
-        // deleted the points it references. It can never succeed again, so holding the acknowledge
-        // for it would stall the WAL forever.
+        // A queued operation that declines permanently can never succeed again (e.g. later
+        // operations deleted the points it references) and must stop pinning the WAL.
         CollectionUpdater::handle_update_result(
             &segments,
-            42,
+            43,
             &Err(CollectionError::PointNotFound {
                 missed_point_id: 1.into(),
             }),
         );
-
-        assert_eq!(
-            failed_operations(&segments),
-            vec![43],
+        assert!(
+            failed_operations(&segments).is_empty(),
             "a queued operation that declines can never succeed, it must stop pinning the WAL",
         );
     }

--- a/lib/collection/src/collection_manager/fixtures.rs
+++ b/lib/collection/src/collection_manager/fixtures.rs
@@ -14,18 +14,42 @@ use segment::segment_constructor::simple_segment_constructor::{
     VECTOR1_NAME, VECTOR2_NAME, build_segment_with_two_named_vecs, build_simple_segment,
 };
 use segment::types::{Distance, HnswGlobalConfig, Payload, PointIdType, SeqNumberType};
+use shard::operations::OperationWithClockTag;
 use shard::operations::optimization::OptimizerThresholds;
 use shard::segment_holder::locked::LockedSegmentHolder;
+use shard::wal::{SerdeWal, WalRawRecord};
 
 use crate::collection_manager::holders::segment_holder::SegmentHolder;
 use crate::collection_manager::optimizers::indexing_optimizer::IndexingOptimizer;
 use crate::collection_manager::optimizers::merge_optimizer::MergeOptimizer;
 use crate::config::CollectionParams;
+use crate::operations::CollectionUpdateOperations;
+use crate::operations::payload_ops::{PayloadOps, SetPayloadOp};
 use crate::operations::types::VectorsConfig;
 use crate::operations::vector_params_builder::VectorParamsBuilder;
 use crate::optimizers_builder::build_segment_optimizer_config;
 
 pub const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A `set_payload` on explicit points. On points living in a non-appendable segment this forces a
+/// CoW move, which is what needs insert capacity.
+pub fn set_payload_op(points: &[u64], color: &str) -> CollectionUpdateOperations {
+    CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(SetPayloadOp {
+        payload: payload_json! {"color": color},
+        points: Some(points.iter().map(|id| (*id).into()).collect()),
+        filter: None,
+        key: None,
+    }))
+}
+
+/// Append `operation` to the WAL, returning its op number.
+pub fn write_op(
+    wal: &mut SerdeWal<OperationWithClockTag>,
+    operation: &CollectionUpdateOperations,
+) -> SeqNumberType {
+    wal.write(&WalRawRecord::new(&OperationWithClockTag::new(operation.clone(), None)).unwrap())
+        .unwrap()
+}
 
 pub fn empty_segment(path: &Path) -> Segment {
     build_simple_segment(path, 4, Distance::Dot).unwrap()

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -1179,10 +1179,6 @@ mod tests {
         let segment_a_id = holder.add_new(segment_a);
         let segment_b_id = holder.add_new(segment_b);
 
-        // Add a small empty appendable segment so that after indexing the other
-        // two, there is still an appendable target for upserts. We don't really
-        // need it (the holder creates one on demand), but it makes assertions
-        // about which segment overgrows clearer.
         let locked_holder = LockedSegmentHolder::new(holder);
 
         // --- 2. Run indexing optimizer to convert both segments to indexed

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -41,7 +41,8 @@ mod tests {
     use shard::segment_holder::locked::LockedSegmentHolder;
     use shard::segment_holder::{FlushMode, SegmentId};
     use shard::update::{
-        process_field_index_operation, process_payload_operation, process_point_operation,
+        PAYLOAD_OP_BATCH_SIZE, process_field_index_operation, process_payload_operation,
+        process_point_operation,
     };
     use tempfile::Builder;
 
@@ -1321,7 +1322,6 @@ mod tests {
 
         // --- 4. Verify no segment exceeds max_segment_size (plus the documented one-batch
         // overshoot tolerance of the per-batch capacity check), and every point survived. ---
-        const PAYLOAD_OP_BATCH_SIZE: usize = 32;
         let point_size_bytes = dim * size_of::<f32>();
         let batch_tolerance_bytes = PAYLOAD_OP_BATCH_SIZE * point_size_bytes;
 

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -1125,20 +1125,21 @@ mod tests {
         );
     }
 
-    /// Reproduction for segment overgrow on `set_payload_by_filter`.
+    /// Regression test for segment overgrow on `set_payload_by_filter` (#9158).
     ///
-    /// Hypothesis (under test):
-    ///   When all points of a collection live in immutable (indexed) segments and
-    ///   `set_payload` is executed via a filter that matches all points, the
-    ///   `apply_points_with_conditional_move` mechanism CoW-moves every matched
-    ///   point into a single (random) appendable segment.
+    /// When all points of a collection live in immutable (indexed) segments and
+    /// `set_payload` is executed via a filter that matches all points, the
+    /// `apply_points_with_conditional_move` mechanism CoW-moves every matched
+    /// point into an appendable segment. With the appendable segment size cap
+    /// armed, the operation fails with the recoverable `OutOfAppendableCapacity`
+    /// error once every appendable segment reaches the cap, instead of growing
+    /// one past `max_segment_size`.
     ///
-    ///   This appendable segment is not size-checked during the move, so its
-    ///   resulting size can exceed the configured `max_segment_size`.
-    ///
-    /// This test currently FAILS by design: it is a reproduction for the
-    /// unfixed segment overgrow bug. It will pass once the underlying issue
-    /// is addressed.
+    /// In production the failed operation wakes the optimizer, whose wake-up
+    /// provisions a fresh appendable segment and re-applies the operation from
+    /// `failed_operation` recovery. This test drives that loop synchronously:
+    /// fail, ensure capacity, retry with the same op number (already-applied
+    /// points are skipped by their point version).
     #[test]
     fn test_set_payload_by_filter_does_not_overgrow_segment() {
         init();
@@ -1250,6 +1251,19 @@ mod tests {
             "Expected at least 2 indexed segments after optimization, got {indexed_count}",
         );
 
+        // Arm the appendable segment size cap, as `UpdateHandler::run_workers` does on a real
+        // shard.
+        locked_holder
+            .write()
+            .set_max_segment_size_bytes(std::num::NonZeroUsize::new(max_segment_size_bytes));
+
+        let payload_schema_file = segments_dir.path().join("payload.schema");
+        let payload_index_schema: std::sync::Arc<
+            common::save_on_disk::SaveOnDisk<shard::payload_index_schema::PayloadIndexSchema>,
+        > = std::sync::Arc::new(
+            common::save_on_disk::SaveOnDisk::load_or_init_default(payload_schema_file).unwrap(),
+        );
+
         // --- 3. Run set_payload by filter that matches ALL points. ---
         // An empty filter matches every point in the collection.
         let payload: segment::types::Payload = payload_json! {"new_field": "value"};
@@ -1265,19 +1279,57 @@ mod tests {
             },
         );
 
-        let result = process_payload_operation(
-            &locked_holder.read(),
-            opnum.next().unwrap(),
-            payload_op,
-            &hw_counter,
-        );
+        // Drive the recovery loop synchronously: the operation fails with the recoverable
+        // capacity error once all appendable segments reach the cap; the optimizer wake-up
+        // provisions a fresh appendable segment and recovery re-applies the operation under
+        // the same op number, resuming where it stopped.
+        let payload_op_num = opnum.next().unwrap();
+        let mut capacity_failures = 0;
+        let result = loop {
+            let result = process_payload_operation(
+                &locked_holder.read(),
+                payload_op_num,
+                payload_op.clone(),
+                &hw_counter,
+            );
+            match result {
+                Err(err) if err.is_out_of_appendable_capacity() && capacity_failures < 8 => {
+                    capacity_failures += 1;
+                    let created =
+                        crate::update_workers::UpdateWorkers::ensure_appendable_segment_with_capacity(
+                            &locked_holder,
+                            index_optimizer.segments_path(),
+                            index_optimizer.segment_optimizer_config(),
+                            index_optimizer.threshold_config(),
+                            payload_index_schema.clone(),
+                        )
+                        .unwrap();
+                    assert!(
+                        created,
+                        "a capacity error implies all appendable segments are at the cap, \
+                         so the ensure step must create a fresh one",
+                    );
+                }
+                other => break other,
+            }
+        };
 
         assert!(
             result.is_ok(),
-            "set_payload_by_filter should succeed: {result:?}",
+            "set_payload_by_filter should succeed after capacity recovery: {result:?}",
+        );
+        assert!(
+            capacity_failures > 0,
+            "the operation should have hit the capacity error at least once",
         );
 
-        // --- 4. Verify no segment exceeds max_segment_size. ---
+        // --- 4. Verify no segment exceeds max_segment_size (plus the documented one-batch
+        // overshoot tolerance of the per-batch capacity check), and every point survived. ---
+        const PAYLOAD_OP_BATCH_SIZE: usize = 32;
+        let point_size_bytes = dim * size_of::<f32>();
+        let batch_tolerance_bytes = PAYLOAD_OP_BATCH_SIZE * point_size_bytes;
+
+        let mut total_points = 0;
         let largest_segment_bytes = locked_holder
             .read()
             .iter()
@@ -1291,14 +1343,21 @@ mod tests {
                     info.num_points,
                     info.num_vectors,
                 );
+                total_points += info.num_points;
                 size
             })
             .max()
             .unwrap_or_default();
 
+        assert_eq!(
+            total_points as u64,
+            2 * points_per_segment,
+            "every point must survive the capacity recovery",
+        );
         assert!(
-            largest_segment_bytes <= max_segment_size_bytes,
-            "A segment overgrew the configured max_segment_size: largest={largest_segment_bytes} bytes, max={max_segment_size_bytes} bytes",
+            largest_segment_bytes <= max_segment_size_bytes + batch_tolerance_bytes,
+            "A segment overgrew the configured max_segment_size: largest={largest_segment_bytes} bytes, \
+             max={max_segment_size_bytes} bytes, tolerance={batch_tolerance_bytes} bytes",
         );
     }
 }

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -40,7 +40,9 @@ mod tests {
     use shard::optimizers::segment_optimizer::SegmentOptimizer;
     use shard::segment_holder::locked::LockedSegmentHolder;
     use shard::segment_holder::{FlushMode, SegmentId};
-    use shard::update::{process_field_index_operation, process_point_operation};
+    use shard::update::{
+        process_field_index_operation, process_payload_operation, process_point_operation,
+    };
     use tempfile::Builder;
 
     use super::*;
@@ -1120,6 +1122,183 @@ mod tests {
         assert!(
             any_hnsw,
             "an HNSW index should have been created to promote the deferred points",
+        );
+    }
+
+    /// Reproduction for segment overgrow on `set_payload_by_filter`.
+    ///
+    /// Hypothesis (under test):
+    ///   When all points of a collection live in immutable (indexed) segments and
+    ///   `set_payload` is executed via a filter that matches all points, the
+    ///   `apply_points_with_conditional_move` mechanism CoW-moves every matched
+    ///   point into a single (random) appendable segment.
+    ///
+    ///   This appendable segment is not size-checked during the move, so its
+    ///   resulting size can exceed the configured `max_segment_size`.
+    ///
+    /// This test currently FAILS by design: it is a reproduction for the
+    /// unfixed segment overgrow bug. It will pass once the underlying issue
+    /// is addressed.
+    #[test]
+    fn test_set_payload_by_filter_does_not_overgrow_segment() {
+        init();
+
+        let dim = 256;
+        // Each random_segment with 200 points and 256-dim f32 vectors has roughly
+        // ~200 KB of vector data on its own, well above the threshold below.
+        let points_per_segment = 200u64;
+        // Use a small max segment size so the combined indexed size exceeds it,
+        // but each individual indexed segment fits below it.
+        let max_segment_size_kb = 300;
+
+        let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
+        let segments_temp_dir = Builder::new()
+            .prefix("segments_temp_dir")
+            .tempdir()
+            .unwrap();
+        let mut opnum = 101..1_000_000;
+
+        // --- 1. Build two sizeable random segments (initially appendable). ---
+        let segment_a = random_segment(
+            segments_dir.path(),
+            opnum.next().unwrap(),
+            points_per_segment,
+            dim,
+        );
+        let segment_b = random_segment(
+            segments_dir.path(),
+            opnum.next().unwrap(),
+            points_per_segment,
+            dim,
+        );
+
+        let segment_config = segment_a.segment_config.clone();
+
+        let mut holder = SegmentHolder::default();
+        let segment_a_id = holder.add_new(segment_a);
+        let segment_b_id = holder.add_new(segment_b);
+
+        // Add a small empty appendable segment so that after indexing the other
+        // two, there is still an appendable target for upserts. We don't really
+        // need it (the holder creates one on demand), but it makes assertions
+        // about which segment overgrows clearer.
+        let locked_holder = LockedSegmentHolder::new(holder);
+
+        // --- 2. Run indexing optimizer to convert both segments to indexed
+        // (non-appendable) segments. ---
+        let index_optimizer = new_indexing_optimizer(
+            2,
+            OptimizerThresholds {
+                max_segment_size_kb,
+                memmap_threshold_kb: 1_000_000,
+                indexing_threshold_kb: 10, // Always optimize / index
+                deferred_internal_id: None,
+            },
+            segments_dir.path().to_owned(),
+            segments_temp_dir.path().to_owned(),
+            CollectionParams {
+                vectors: VectorsConfig::Single(
+                    VectorParamsBuilder::new(
+                        segment_config.vector_data[DEFAULT_VECTOR_NAME].size as u64,
+                        segment_config.vector_data[DEFAULT_VECTOR_NAME].distance,
+                    )
+                    .build(),
+                ),
+                ..CollectionParams::empty()
+            },
+            Default::default(),
+            HnswGlobalConfig::default(),
+            Default::default(),
+        );
+
+        // Index both raw segments. Each gets converted into an indexed
+        // non-appendable segment and a fresh empty appendable segment is
+        // created by the optimizer.
+        index_optimizer.optimize_for_test(locked_holder.clone(), vec![segment_a_id]);
+        index_optimizer.optimize_for_test(locked_holder.clone(), vec![segment_b_id]);
+
+        // Sanity check: we now have indexed segments larger combined than the
+        // configured max segment size.
+        let indexed_total: usize = locked_holder
+            .read()
+            .iter()
+            .map(|(_sid, segment)| {
+                let segment = segment.get().read();
+                if segment.is_appendable() {
+                    0
+                } else {
+                    segment
+                        .max_available_vectors_size_in_bytes()
+                        .unwrap_or_default()
+                }
+            })
+            .sum();
+        let max_segment_size_bytes = max_segment_size_kb * 1024;
+        assert!(
+            indexed_total > max_segment_size_bytes,
+            "Expected combined indexed size ({indexed_total}) to exceed max_segment_size ({max_segment_size_bytes})",
+        );
+
+        // Sanity: at least 2 indexed (non-appendable) segments exist.
+        let indexed_count = locked_holder
+            .read()
+            .iter()
+            .filter(|(_sid, segment)| !segment.get().read().is_appendable())
+            .count();
+        assert!(
+            indexed_count >= 2,
+            "Expected at least 2 indexed segments after optimization, got {indexed_count}",
+        );
+
+        // --- 3. Run set_payload by filter that matches ALL points. ---
+        // An empty filter matches every point in the collection.
+        let payload: segment::types::Payload = payload_json! {"new_field": "value"};
+
+        let hw_counter = HardwareCounterCell::new();
+
+        let payload_op = crate::operations::payload_ops::PayloadOps::SetPayload(
+            crate::operations::payload_ops::SetPayloadOp {
+                payload,
+                points: None,
+                filter: Some(segment::types::Filter::default()),
+                key: None,
+            },
+        );
+
+        let result = process_payload_operation(
+            &locked_holder.read(),
+            opnum.next().unwrap(),
+            payload_op,
+            &hw_counter,
+        );
+
+        assert!(
+            result.is_ok(),
+            "set_payload_by_filter should succeed: {result:?}",
+        );
+
+        // --- 4. Verify no segment exceeds max_segment_size. ---
+        let largest_segment_bytes = locked_holder
+            .read()
+            .iter()
+            .map(|(sid, segment)| {
+                let s = segment.get().read();
+                let size = s.max_available_vectors_size_in_bytes().unwrap_or_default();
+                let info = s.info().unwrap();
+                log::info!(
+                    "segment {sid:?}: appendable={} num_points={} num_vectors={} size_bytes={size}",
+                    s.is_appendable(),
+                    info.num_points,
+                    info.num_vectors,
+                );
+                size
+            })
+            .max()
+            .unwrap_or_default();
+
+        assert!(
+            largest_segment_bytes <= max_segment_size_bytes,
+            "A segment overgrew the configured max_segment_size: largest={largest_segment_bytes} bytes, max={max_segment_size_bytes} bytes",
         );
     }
 }

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -1224,12 +1224,11 @@ mod tests {
             .sum();
         let max_segment_size_bytes = max_segment_size_kb * 1024;
 
-        // Guarantee the recovery path is actually exercised. Each appendable segment can absorb
-        // data only until it reaches `max_segment_size`, so if the data to move exceeds the
-        // combined capacity of every currently-appendable segment, the first apply must run out
-        // of eligible destinations and hit `OutOfAppendableCapacity` at least once (asserted via
-        // `capacity_failures > 0` below). Without this, extra empty appendable segments could
-        // silently absorb the whole move and turn this into a no-op regression test.
+        // Guarantee the recovery path is exercised: with the data to move exceeding the combined
+        // capacity of every appendable segment, the first apply must hit
+        // `OutOfAppendableCapacity` at least once (asserted via `capacity_failures > 0` below).
+        // Without this, spare appendable segments could silently absorb the whole move and turn
+        // this into a no-op regression test.
         let appendable_count = locked_holder
             .read()
             .iter()

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -1248,6 +1248,24 @@ mod tests {
             "Expected at least 2 indexed segments after optimization, got {indexed_count}",
         );
 
+        // Guarantee the recovery path is actually exercised. Each appendable segment can absorb
+        // data only until it reaches `max_segment_size`, so if the data to move exceeds the
+        // combined capacity of every currently-appendable segment, the first apply must run out
+        // of eligible destinations and hit `OutOfAppendableCapacity` at least once (asserted via
+        // `capacity_failures > 0` below). Without this, extra empty appendable segments could
+        // silently absorb the whole move and turn this into a no-op regression test.
+        let appendable_count = locked_holder
+            .read()
+            .iter()
+            .filter(|(_sid, segment)| segment.get().read().is_appendable())
+            .count();
+        assert!(
+            indexed_total > appendable_count * max_segment_size_bytes,
+            "Data to move ({indexed_total}) must exceed the combined appendable capacity \
+             ({appendable_count} segments * {max_segment_size_bytes} bytes) so a capacity \
+             failure is forced",
+        );
+
         // Arm the appendable segment size cap, as `UpdateHandler::run_workers` does on a real
         // shard.
         locked_holder

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -634,6 +634,7 @@ mod tests {
             &locked_holder.read(),
             opnum.next().unwrap(),
             insert_point_ops,
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -699,6 +700,7 @@ mod tests {
             &locked_holder.read(),
             opnum.next().unwrap(),
             insert_point_ops,
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -1241,11 +1243,9 @@ mod tests {
              failure is forced",
         );
 
-        // Arm the appendable segment size cap, as `UpdateHandler::run_workers` does on a real
+        // The size cap the apply path is driven with, as the update worker passes it on a real
         // shard.
-        locked_holder
-            .write()
-            .set_max_segment_size_bytes(std::num::NonZeroUsize::new(max_segment_size_bytes));
+        let cap = std::num::NonZeroUsize::new(max_segment_size_bytes);
 
         let payload_schema_file = segments_dir.path().join("payload.schema");
         let payload_index_schema: std::sync::Arc<
@@ -1280,6 +1280,7 @@ mod tests {
                 &locked_holder.read(),
                 payload_op_num,
                 payload_op.clone(),
+                cap,
                 &hw_counter,
             );
             match result {

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -1130,7 +1130,7 @@ mod tests {
 
     /// Regression test for segment overgrow on `set_payload` by filter (#9158): with every point
     /// in immutable (indexed) segments, a filter matching all of them CoW-moves each one into an
-    /// appendable segment. With the size cap armed this must fail with the recoverable
+    /// appendable segment. With a size cap passed to the apply path this must fail with the recoverable
     /// `OutOfAppendableCapacity` once every appendable segment reaches the cap, instead of
     /// growing one past `max_segment_size`.
     ///

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -1208,8 +1208,6 @@ mod tests {
         index_optimizer.optimize_for_test(locked_holder.clone(), vec![segment_a_id]);
         index_optimizer.optimize_for_test(locked_holder.clone(), vec![segment_b_id]);
 
-        // Sanity check: we now have indexed segments larger combined than the
-        // configured max segment size.
         let indexed_total: usize = locked_holder
             .read()
             .iter()
@@ -1225,21 +1223,6 @@ mod tests {
             })
             .sum();
         let max_segment_size_bytes = max_segment_size_kb * 1024;
-        assert!(
-            indexed_total > max_segment_size_bytes,
-            "Expected combined indexed size ({indexed_total}) to exceed max_segment_size ({max_segment_size_bytes})",
-        );
-
-        // Sanity: at least 2 indexed (non-appendable) segments exist.
-        let indexed_count = locked_holder
-            .read()
-            .iter()
-            .filter(|(_sid, segment)| !segment.get().read().is_appendable())
-            .count();
-        assert!(
-            indexed_count >= 2,
-            "Expected at least 2 indexed segments after optimization, got {indexed_count}",
-        );
 
         // Guarantee the recovery path is actually exercised. Each appendable segment can absorb
         // data only until it reaches `max_segment_size`, so if the data to move exceeds the
@@ -1340,18 +1323,12 @@ mod tests {
         let largest_segment_bytes = locked_holder
             .read()
             .iter()
-            .map(|(sid, segment)| {
-                let s = segment.get().read();
-                let size = s.max_available_vectors_size_in_bytes().unwrap_or_default();
-                let info = s.info().unwrap();
-                log::info!(
-                    "segment {sid:?}: appendable={} num_points={} num_vectors={} size_bytes={size}",
-                    s.is_appendable(),
-                    info.num_points,
-                    info.num_vectors,
-                );
-                total_points += info.num_points;
-                size
+            .map(|(_sid, segment)| {
+                let segment = segment.get().read();
+                total_points += segment.info().unwrap().num_points;
+                segment
+                    .max_available_vectors_size_in_bytes()
+                    .unwrap_or_default()
             })
             .max()
             .unwrap_or_default();

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -1126,21 +1126,14 @@ mod tests {
         );
     }
 
-    /// Regression test for segment overgrow on `set_payload_by_filter` (#9158).
+    /// Regression test for segment overgrow on `set_payload` by filter (#9158): with every point
+    /// in immutable (indexed) segments, a filter matching all of them CoW-moves each one into an
+    /// appendable segment. With the size cap armed this must fail with the recoverable
+    /// `OutOfAppendableCapacity` once every appendable segment reaches the cap, instead of
+    /// growing one past `max_segment_size`.
     ///
-    /// When all points of a collection live in immutable (indexed) segments and
-    /// `set_payload` is executed via a filter that matches all points, the
-    /// `apply_points_with_conditional_move` mechanism CoW-moves every matched
-    /// point into an appendable segment. With the appendable segment size cap
-    /// armed, the operation fails with the recoverable `OutOfAppendableCapacity`
-    /// error once every appendable segment reaches the cap, instead of growing
-    /// one past `max_segment_size`.
-    ///
-    /// In production the failed operation wakes the optimizer, whose wake-up
-    /// provisions a fresh appendable segment and re-applies the operation from
-    /// `failed_operation` recovery. This test drives that loop synchronously:
-    /// fail, ensure capacity, retry with the same op number (already-applied
-    /// points are skipped by their point version).
+    /// Drives the production recovery loop synchronously: fail, ensure capacity (the optimizer
+    /// wake-up step), retry under the same op number (already-applied points skip by version).
     #[test]
     fn test_set_payload_by_filter_does_not_overgrow_segment() {
         init();

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -76,7 +76,7 @@ fn test_update_proxy_segments() {
                 payload: None,
             },
         ];
-        upsert_points(&segments.read(), 1000 + i, &points, &hw_counter).unwrap();
+        upsert_points(&segments.read(), 1000 + i, &points, None, &hw_counter).unwrap();
     }
 
     let all_ids = segments
@@ -138,7 +138,7 @@ fn test_move_points_to_copy_on_write() {
 
     // Points should be marked as deleted in proxy segment
     // and moved to another appendable segment (segment2)
-    upsert_points(&segments.read(), 1001, &points, &hw_counter).unwrap();
+    upsert_points(&segments.read(), 1001, &points, None, &hw_counter).unwrap();
 
     let points = vec![
         PointStructPersisted {
@@ -153,7 +153,7 @@ fn test_move_points_to_copy_on_write() {
         },
     ];
 
-    upsert_points(&segments.read(), 1002, &points, &hw_counter).unwrap();
+    upsert_points(&segments.read(), 1002, &points, None, &hw_counter).unwrap();
 
     let segments_write = segments.write();
 
@@ -250,7 +250,7 @@ fn test_upsert_points_in_smallest_segment() {
             payload: None,
         })
         .collect();
-    upsert_points(&segments.read(), 1000, &points, &hw_counter).unwrap();
+    upsert_points(&segments.read(), 1000, &points, None, &hw_counter).unwrap();
 
     // Segment 1 and 2 are over capacity, we expect to have the new points in segment 3
     {
@@ -467,7 +467,7 @@ fn test_proxy_shared_updates() {
 
     let ids = vec![idx1, idx2];
 
-    set_payload(&holder, 30, &payload, &ids, &None, &hw_counter).unwrap();
+    set_payload(&holder, 30, &payload, &ids, &None, None, &hw_counter).unwrap();
 
     // Points should still be accessible in both proxies through write segment
     for &point_id in &ids {
@@ -604,7 +604,7 @@ fn test_proxy_shared_updates_same_version() {
 
     let ids = vec![idx1, idx2];
 
-    set_payload(&holder, 20, &payload, &ids, &None, &hw_counter).unwrap();
+    set_payload(&holder, 20, &payload, &ids, &None, None, &hw_counter).unwrap();
 
     // Points should still be accessible in both proxies through write segment
     for &point_id in &ids {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1924,3 +1924,28 @@ impl PeerMetadata {
         self.version != *defaults::QDRANT_VERSION
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The update worker recognizes the capacity condition by message prefix, because the typed
+    /// variant does not survive the conversion below. This locks the whole chain: the variant's
+    /// message, the conversion into a service error, and the detection. Asserting on
+    /// `OperationError` alone would still pass if the conversion started wrapping the message.
+    #[test]
+    fn test_out_of_appendable_capacity_survives_conversion() {
+        let err = CollectionError::from(OperationError::OutOfAppendableCapacity {
+            max_segment_size_bytes: 1024,
+        });
+
+        assert!(
+            err.is_out_of_appendable_capacity(),
+            "the update worker would stop retrying capacity failures: {err}",
+        );
+        assert!(
+            err.is_transient(),
+            "failed-operation recovery must re-apply the operation",
+        );
+    }
+}

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1098,16 +1098,25 @@ impl CollectionError {
 
     /// Whether this is the flattened [`OperationError::OutOfAppendableCapacity`] error: all
     /// appendable segments reached `max_segment_size`. The typed variant does not survive the
-    /// conversion to a (transient) shard-unavailable error, so it is recognized by its message
-    /// prefix, which a test on the variant locks in place.
+    /// conversion to a (transient) shard-unavailable error, so it is recognized by its message,
+    /// which a test on the variant locks in place.
+    ///
+    /// Matched anywhere in the message rather than at its start: a replica that reports the
+    /// condition over gRPC comes back as a service error wrapping the status text, and the
+    /// replica set must recognize that form too or it deactivates a replica that recovers on
+    /// its own.
+    #[expect(clippy::wildcard_enum_match_arm, reason = "error handling")]
     pub fn is_out_of_appendable_capacity(&self) -> bool {
-        matches!(
-            self,
-            Self::ShardUnavailable { description }
-                if description.starts_with(
-                    segment::common::operation_error::OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX,
-                )
-        )
+        let message = match self {
+            // Raised on this peer.
+            Self::ShardUnavailable { description } => description.as_str(),
+            // Reported by a remote replica, wrapped in the gRPC status text.
+            Self::ServiceError { error, .. } => error.as_str(),
+            _ => return false,
+        };
+
+        message
+            .contains(segment::common::operation_error::OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX)
     }
 
     pub fn is_missing_point(&self) -> bool {
@@ -1930,9 +1939,9 @@ impl PeerMetadata {
 mod tests {
     use super::*;
 
-    /// The update worker recognizes the capacity condition by message prefix, because the typed
-    /// variant does not survive the conversion below. This locks the whole chain: the variant's
-    /// message, the conversion into a service error, and the detection. Asserting on
+    /// The update worker recognizes the capacity condition by message, because the typed variant
+    /// does not survive the conversion below. This locks the whole chain: the variant's message,
+    /// the conversion into a shard-unavailable error, and the detection. Asserting on
     /// `OperationError` alone would still pass if the conversion started wrapping the message.
     #[test]
     fn test_out_of_appendable_capacity_survives_conversion() {
@@ -1947,6 +1956,24 @@ mod tests {
         assert!(
             err.is_transient(),
             "failed-operation recovery must re-apply the operation",
+        );
+    }
+
+    /// A replica reporting the condition sends it as an unavailable status carrying the error
+    /// message (see the `StorageError` conversion), which comes back as a service error wrapping
+    /// that text. The replica set must still recognize it, or it deactivates a replica that
+    /// recovers on its own.
+    #[test]
+    fn test_out_of_appendable_capacity_survives_remote_round_trip() {
+        let err = CollectionError::from(OperationError::OutOfAppendableCapacity {
+            max_segment_size_bytes: 1024,
+        });
+
+        let remote_err = CollectionError::from(tonic::Status::unavailable(err.to_string()));
+
+        assert!(
+            remote_err.is_out_of_appendable_capacity(),
+            "the replica set would deactivate the reporting replica: {remote_err}",
         );
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1098,13 +1098,13 @@ impl CollectionError {
 
     /// Whether this is the flattened [`OperationError::OutOfAppendableCapacity`] error: all
     /// appendable segments reached `max_segment_size`. The typed variant does not survive the
-    /// conversion to a (transient) service error, so it is recognized by its message prefix,
-    /// which a test on the variant locks in place.
+    /// conversion to a (transient) shard-unavailable error, so it is recognized by its message
+    /// prefix, which a test on the variant locks in place.
     pub fn is_out_of_appendable_capacity(&self) -> bool {
         matches!(
             self,
-            Self::ServiceError { error, .. }
-                if error.starts_with(
+            Self::ShardUnavailable { description }
+                if description.starts_with(
                     segment::common::operation_error::OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX,
                 )
         )
@@ -1189,10 +1189,11 @@ impl From<OperationError> for CollectionError {
             OperationError::VariableTypeError { .. } => Self::bad_input(err.to_string()),
             OperationError::NonFiniteNumber { .. } => Self::bad_input(err.to_string()),
             // Normally handled by segment provisioning before reaching this conversion; if it
-            // leaks, stay transient so failed-operation recovery re-applies the operation.
-            OperationError::OutOfAppendableCapacity { .. } => Self::ServiceError {
-                error: err.to_string(),
-                backtrace: None,
+            // leaks, stay transient so failed-operation recovery re-applies the operation. It is
+            // temporary backpressure rather than an internal failure, so it maps to the
+            // unavailable (503) family instead of a service error (500).
+            OperationError::OutOfAppendableCapacity { .. } => Self::ShardUnavailable {
+                description: err.to_string(),
             },
         }
     }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1096,6 +1096,20 @@ impl CollectionError {
         matches!(self, Self::PreConditionFailed { .. })
     }
 
+    /// Whether this is the flattened [`OperationError::OutOfAppendableCapacity`] error: all
+    /// appendable segments reached `max_segment_size`. The typed variant does not survive the
+    /// conversion to a (transient) service error, so it is recognized by its message prefix,
+    /// which a test on the variant locks in place.
+    pub fn is_out_of_appendable_capacity(&self) -> bool {
+        matches!(
+            self,
+            Self::ServiceError { error, .. }
+                if error.starts_with(
+                    segment::common::operation_error::OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX,
+                )
+        )
+    }
+
     pub fn is_missing_point(&self) -> bool {
         #[expect(clippy::wildcard_enum_match_arm, reason = "error handling")]
         match self {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -2125,13 +2125,10 @@ mod tests {
             err.is_out_of_appendable_capacity(),
             "the replica set would deactivate the reporting replica: {err}",
         );
-    }
 
-    /// An untagged `Unavailable` status is any other transient unavailability, not the capacity
-    /// condition; the guard must keep it out of the recovery path.
-    #[test]
-    fn test_untagged_unavailable_is_not_capacity() {
-        let err = CollectionError::from(tonic::Status::unavailable("peer down"));
-        assert!(!err.is_out_of_appendable_capacity());
+        // An untagged `Unavailable` is any other transient unavailability, not the capacity
+        // condition; it must keep its generic handling.
+        let untagged = CollectionError::from(tonic::Status::unavailable("peer down"));
+        assert!(!untagged.is_out_of_appendable_capacity());
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -991,7 +991,10 @@ impl UpdateFailureKind {
     /// Whether the failed operation sits in `failed_operation` awaiting recovery (and thus pins
     /// the WAL acknowledge).
     pub fn queues_for_recovery(self) -> bool {
-        !matches!(self, Self::Permanent)
+        match self {
+            Self::Backpressure | Self::Transient => true,
+            Self::Permanent => false,
+        }
     }
 }
 

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1406,7 +1406,9 @@ impl From<tonic::Status> for CollectionError {
             // A replica reporting a shard-unavailable condition tags the status with its reason
             // metadata; rebuild the typed reason so the replica set recognizes a self-healing
             // capacity failure structurally instead of matching the message text. An untagged
-            // `Unavailable` is any other transient unavailability and keeps the generic handling.
+            // `Unavailable` is any other transient unavailability and keeps the pre-existing
+            // generic mapping to a transient service error, deliberately unchanged by this
+            // conversion's restructuring.
             tonic::Code::Unavailable => {
                 match ShardUnavailableReason::from_metadata(err.metadata()) {
                     Some(reason) => Self::ShardUnavailable {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -2060,17 +2060,18 @@ impl PeerMetadata {
 mod tests {
     use super::*;
 
-    /// The capacity condition carries a typed reason through the `OperationError` conversion, so
-    /// the update worker and replica set detect it structurally rather than by message text.
+    /// The capacity condition carries a typed reason through the `OperationError` conversion (so
+    /// consumers detect it structurally, not by message text), and the failure disposition is the
+    /// single policy for what happens to a failed operation: queued dispositions pin the WAL
+    /// acknowledge for recovery, a permanent one must not (or the acknowledge stalls forever).
     #[test]
-    fn test_out_of_appendable_capacity_is_typed() {
-        let err = CollectionError::from(OperationError::OutOfAppendableCapacity {
+    fn test_capacity_condition_typed_and_dispositions() {
+        let capacity = CollectionError::from(OperationError::OutOfAppendableCapacity {
             max_segment_size_bytes: 1024,
         });
-
         assert!(
             matches!(
-                err,
+                capacity,
                 CollectionError::ShardUnavailable {
                     reason: ShardUnavailableReason::OutOfAppendableCapacity {
                         max_segment_size_bytes: 1024,
@@ -2078,28 +2079,10 @@ mod tests {
                     ..
                 }
             ),
-            "capacity failures must carry the typed reason with its payload: {err}",
+            "capacity failures must carry the typed reason with its payload: {capacity}",
         );
-        assert!(
-            err.is_out_of_appendable_capacity(),
-            "the update worker would stop retrying capacity failures: {err}",
-        );
-        assert!(
-            err.is_transient(),
-            "failed-operation recovery must re-apply the operation",
-        );
-    }
-
-    /// The disposition is the single policy for what happens to a failed operation: queued
-    /// dispositions pin the WAL acknowledge for recovery, a permanent one must not (or the
-    /// acknowledge stalls forever). Each arm is load-bearing for a different consumer: the
-    /// updater's queue/drop choice, recovery's abort/skip choice, and the worker's optimizer
-    /// nudge.
-    #[test]
-    fn test_failed_update_disposition() {
-        let capacity = CollectionError::from(OperationError::OutOfAppendableCapacity {
-            max_segment_size_bytes: 1024,
-        });
+        assert!(capacity.is_out_of_appendable_capacity());
+        assert!(capacity.is_transient());
         assert_eq!(
             capacity.failed_update_disposition(),
             FailedUpdateDisposition::Backpressure,

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -949,8 +949,33 @@ pub enum CollectionError {
         retry_after: Option<Duration>,
     },
     #[error("Shard temporarily unavailable: {description}")]
-    ShardUnavailable { description: String },
+    ShardUnavailable {
+        description: String,
+        reason: ShardUnavailableReason,
+    },
 }
+
+/// Why a shard reported itself temporarily unavailable. Carried as a type rather than parsed out
+/// of the error message, and preserved across the gRPC boundary via status metadata, so the
+/// update worker and replica set recognize the recoverable capacity condition structurally.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShardUnavailableReason {
+    /// Every appendable segment reached `max_segment_size`, so there is no destination for new or
+    /// moved points. Recoverable: the optimizer provisions a fresh appendable segment and the
+    /// operation is re-applied, so a replica reporting it self-heals and must not be deactivated.
+    OutOfAppendableCapacity { max_segment_size_bytes: usize },
+    /// Any other transient unavailability (peer down, transfer in flight, ...).
+    Unspecified,
+}
+
+/// gRPC status metadata key carrying the [`ShardUnavailableReason`] across the wire, so a replica
+/// set recognizes a remote capacity condition structurally instead of by message text.
+pub const SHARD_UNAVAILABLE_REASON_METADATA_KEY: &str = "x-qdrant-shard-unavailable-reason";
+/// [`SHARD_UNAVAILABLE_REASON_METADATA_KEY`] value marking
+/// [`ShardUnavailableReason::OutOfAppendableCapacity`].
+pub const OUT_OF_APPENDABLE_CAPACITY_REASON: &str = "out-of-appendable-capacity";
+/// Metadata key carrying the `max_segment_size` bytes alongside the capacity reason.
+pub const MAX_SEGMENT_SIZE_METADATA_KEY: &str = "x-qdrant-max-segment-size-bytes";
 
 /// Which rate limiter rejected an operation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1064,6 +1089,7 @@ impl CollectionError {
     pub fn shard_unavailable(description: impl Into<String>) -> Self {
         Self::ShardUnavailable {
             description: description.into(),
+            reason: ShardUnavailableReason::Unspecified,
         }
     }
 
@@ -1096,27 +1122,18 @@ impl CollectionError {
         matches!(self, Self::PreConditionFailed { .. })
     }
 
-    /// Whether this is the flattened [`OperationError::OutOfAppendableCapacity`] error: all
-    /// appendable segments reached `max_segment_size`. The typed variant does not survive the
-    /// conversion to a (transient) shard-unavailable error, so it is recognized by its message,
-    /// which a test on the variant locks in place.
-    ///
-    /// Matched anywhere in the message rather than at its start: a replica that reports the
-    /// condition over gRPC comes back as a service error wrapping the status text, and the
-    /// replica set must recognize that form too or it deactivates a replica that recovers on
-    /// its own.
-    #[expect(clippy::wildcard_enum_match_arm, reason = "error handling")]
+    /// Whether this is the recoverable "all appendable segments reached `max_segment_size`"
+    /// condition. Matched on the typed [`ShardUnavailableReason`], including when a remote replica
+    /// reported it: the reason survives the gRPC round trip via status metadata (see the
+    /// `From<tonic::Status>` decoder here and the `StorageError` -> `Status` encoder).
     pub fn is_out_of_appendable_capacity(&self) -> bool {
-        let message = match self {
-            // Raised on this peer.
-            Self::ShardUnavailable { description } => description.as_str(),
-            // Reported by a remote replica, wrapped in the gRPC status text.
-            Self::ServiceError { error, .. } => error.as_str(),
-            _ => return false,
-        };
-
-        message
-            .contains(segment::common::operation_error::OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX)
+        matches!(
+            self,
+            Self::ShardUnavailable {
+                reason: ShardUnavailableReason::OutOfAppendableCapacity { .. },
+                ..
+            }
+        )
     }
 
     pub fn is_missing_point(&self) -> bool {
@@ -1201,8 +1218,13 @@ impl From<OperationError> for CollectionError {
             // leaks, stay transient so failed-operation recovery re-applies the operation. It is
             // temporary backpressure rather than an internal failure, so it maps to the
             // unavailable (503) family instead of a service error (500).
-            OperationError::OutOfAppendableCapacity { .. } => Self::ShardUnavailable {
+            OperationError::OutOfAppendableCapacity {
+                max_segment_size_bytes,
+            } => Self::ShardUnavailable {
                 description: err.to_string(),
+                reason: ShardUnavailableReason::OutOfAppendableCapacity {
+                    max_segment_size_bytes,
+                },
             },
         }
     }
@@ -1293,6 +1315,30 @@ impl From<tonic::Status> for CollectionError {
                 Self::RateLimitExceeded {
                     description: err.to_string(),
                     retry_after,
+                }
+            }
+            // A replica reporting a shard-unavailable condition tags the status with its reason
+            // metadata; rebuild the typed reason so the replica set recognizes a self-healing
+            // capacity failure structurally instead of matching the message text. An untagged
+            // `Unavailable` keeps the generic handling in the catch-all below.
+            tonic::Code::Unavailable
+                if err
+                    .metadata()
+                    .get(SHARD_UNAVAILABLE_REASON_METADATA_KEY)
+                    .and_then(|value| value.to_str().ok())
+                    == Some(OUT_OF_APPENDABLE_CAPACITY_REASON) =>
+            {
+                let max_segment_size_bytes = err
+                    .metadata()
+                    .get(MAX_SEGMENT_SIZE_METADATA_KEY)
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(|value| value.parse::<usize>().ok())
+                    .unwrap_or(0);
+                Self::ShardUnavailable {
+                    description: format!("Tonic status error: {err}"),
+                    reason: ShardUnavailableReason::OutOfAppendableCapacity {
+                        max_segment_size_bytes,
+                    },
                 }
             }
             tonic::Code::Ok
@@ -1939,16 +1985,26 @@ impl PeerMetadata {
 mod tests {
     use super::*;
 
-    /// The update worker recognizes the capacity condition by message, because the typed variant
-    /// does not survive the conversion below. This locks the whole chain: the variant's message,
-    /// the conversion into a shard-unavailable error, and the detection. Asserting on
-    /// `OperationError` alone would still pass if the conversion started wrapping the message.
+    /// The capacity condition carries a typed reason through the `OperationError` conversion, so
+    /// the update worker and replica set detect it structurally rather than by message text.
     #[test]
-    fn test_out_of_appendable_capacity_survives_conversion() {
+    fn test_out_of_appendable_capacity_is_typed() {
         let err = CollectionError::from(OperationError::OutOfAppendableCapacity {
             max_segment_size_bytes: 1024,
         });
 
+        assert!(
+            matches!(
+                err,
+                CollectionError::ShardUnavailable {
+                    reason: ShardUnavailableReason::OutOfAppendableCapacity {
+                        max_segment_size_bytes: 1024,
+                    },
+                    ..
+                }
+            ),
+            "capacity failures must carry the typed reason with its payload: {err}",
+        );
         assert!(
             err.is_out_of_appendable_capacity(),
             "the update worker would stop retrying capacity failures: {err}",
@@ -1959,21 +2015,33 @@ mod tests {
         );
     }
 
-    /// A replica reporting the condition sends it as an unavailable status carrying the error
-    /// message (see the `StorageError` conversion), which comes back as a service error wrapping
-    /// that text. The replica set must still recognize it, or it deactivates a replica that
-    /// recovers on its own.
+    /// A replica reports the condition as an `Unavailable` status tagged with reason metadata (the
+    /// `StorageError` -> `Status` encoder attaches it; tested storage-side). Decoding that status
+    /// must rebuild the typed reason, or the replica set deactivates a replica that self-heals.
     #[test]
-    fn test_out_of_appendable_capacity_survives_remote_round_trip() {
-        let err = CollectionError::from(OperationError::OutOfAppendableCapacity {
-            max_segment_size_bytes: 1024,
-        });
+    fn test_out_of_appendable_capacity_decoded_from_status_metadata() {
+        let mut status = tonic::Status::unavailable("shard is out of appendable capacity");
+        status.metadata_mut().insert(
+            SHARD_UNAVAILABLE_REASON_METADATA_KEY,
+            OUT_OF_APPENDABLE_CAPACITY_REASON.parse().unwrap(),
+        );
+        status
+            .metadata_mut()
+            .insert(MAX_SEGMENT_SIZE_METADATA_KEY, "1024".parse().unwrap());
 
-        let remote_err = CollectionError::from(tonic::Status::unavailable(err.to_string()));
+        let err = CollectionError::from(status);
 
         assert!(
-            remote_err.is_out_of_appendable_capacity(),
-            "the replica set would deactivate the reporting replica: {remote_err}",
+            err.is_out_of_appendable_capacity(),
+            "the replica set would deactivate the reporting replica: {err}",
         );
+    }
+
+    /// An untagged `Unavailable` status is any other transient unavailability, not the capacity
+    /// condition; the guard must keep it out of the recovery path.
+    #[test]
+    fn test_untagged_unavailable_is_not_capacity() {
+        let err = CollectionError::from(tonic::Status::unavailable("peer down"));
+        assert!(!err.is_out_of_appendable_capacity());
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1203,13 +1203,17 @@ impl CollectionError {
     /// [`ShardUnavailableReason::to_metadata_pairs`] / [`ShardUnavailableReason::from_metadata`]
     /// codec pair).
     pub fn is_out_of_appendable_capacity(&self) -> bool {
-        matches!(
-            self,
-            Self::ShardUnavailable {
-                reason: ShardUnavailableReason::OutOfAppendableCapacity { .. },
-                ..
-            }
-        )
+        #[expect(
+            clippy::wildcard_enum_match_arm,
+            reason = "only the typed reason matters"
+        )]
+        match self {
+            Self::ShardUnavailable { reason, .. } => match reason {
+                ShardUnavailableReason::OutOfAppendableCapacity { .. } => true,
+                ShardUnavailableReason::Unspecified => false,
+            },
+            _ => false,
+        }
     }
 
     /// How the update pipeline handles this error when an operation fails: see

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1301,10 +1301,9 @@ impl From<OperationError> for CollectionError {
             OperationError::MissingMapIndexForFacet { .. } => Self::bad_input(err.to_string()),
             OperationError::VariableTypeError { .. } => Self::bad_input(err.to_string()),
             OperationError::NonFiniteNumber { .. } => Self::bad_input(err.to_string()),
-            // Normally handled by segment provisioning before reaching this conversion; if it
-            // leaks, stay transient so failed-operation recovery re-applies the operation. It is
-            // temporary backpressure rather than an internal failure, so it maps to the
-            // unavailable (503) family instead of a service error (500).
+            // Temporary backpressure rather than an internal failure: transient, so
+            // failed-operation recovery re-applies the operation, and in the unavailable (503)
+            // family instead of a service error (500).
             OperationError::OutOfAppendableCapacity {
                 max_segment_size_bytes,
             } => Self::ShardUnavailable {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -968,6 +968,33 @@ pub enum ShardUnavailableReason {
     Unspecified,
 }
 
+/// What happens to a failed update operation, derived from the error by
+/// [`CollectionError::failed_update_disposition`].
+///
+/// Queued dispositions put the operation in `failed_operation`, which pins the WAL acknowledge
+/// until recovery re-applies it; a [`Permanent`](Self::Permanent) failure must never queue (and
+/// is dropped if it was queued), or the acknowledge stalls forever on an operation that cannot
+/// succeed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailedUpdateDisposition {
+    /// Expected backpressure: every appendable segment reached the size cap. Queued for
+    /// recovery; the optimizer provisions a fresh segment and the operation is re-applied.
+    Backpressure,
+    /// Any other transient failure. Queued for recovery and retried on later wake-ups.
+    Transient,
+    /// The operation can never succeed (bad input, references deleted points, ...). Not queued;
+    /// recovery skips it, exactly like WAL replay does on shard load.
+    Permanent,
+}
+
+impl FailedUpdateDisposition {
+    /// Whether the failed operation sits in `failed_operation` awaiting recovery (and thus pins
+    /// the WAL acknowledge).
+    pub fn queues_for_recovery(self) -> bool {
+        !matches!(self, Self::Permanent)
+    }
+}
+
 /// gRPC status metadata key carrying the [`ShardUnavailableReason`] across the wire, so a replica
 /// set recognizes a remote capacity condition structurally instead of by message text.
 pub const SHARD_UNAVAILABLE_REASON_METADATA_KEY: &str = "x-qdrant-shard-unavailable-reason";
@@ -1134,6 +1161,20 @@ impl CollectionError {
                 ..
             }
         )
+    }
+
+    /// How the update pipeline handles this error when an operation fails: see
+    /// [`FailedUpdateDisposition`]. The single origin of that policy; the updater queueing the
+    /// failure, recovery deciding to abort or skip, and the update worker nudging the optimizer
+    /// all derive from it.
+    pub fn failed_update_disposition(&self) -> FailedUpdateDisposition {
+        if self.is_out_of_appendable_capacity() {
+            FailedUpdateDisposition::Backpressure
+        } else if self.is_transient() {
+            FailedUpdateDisposition::Transient
+        } else {
+            FailedUpdateDisposition::Permanent
+        }
     }
 
     pub fn is_missing_point(&self) -> bool {
@@ -2013,6 +2054,38 @@ mod tests {
             err.is_transient(),
             "failed-operation recovery must re-apply the operation",
         );
+    }
+
+    /// The disposition is the single policy for what happens to a failed operation: queued
+    /// dispositions pin the WAL acknowledge for recovery, a permanent one must not (or the
+    /// acknowledge stalls forever). Each arm is load-bearing for a different consumer: the
+    /// updater's queue/drop choice, recovery's abort/skip choice, and the worker's optimizer
+    /// nudge.
+    #[test]
+    fn test_failed_update_disposition() {
+        let capacity = CollectionError::from(OperationError::OutOfAppendableCapacity {
+            max_segment_size_bytes: 1024,
+        });
+        assert_eq!(
+            capacity.failed_update_disposition(),
+            FailedUpdateDisposition::Backpressure,
+        );
+
+        let transient = CollectionError::service_error("segment flush failed");
+        assert_eq!(
+            transient.failed_update_disposition(),
+            FailedUpdateDisposition::Transient,
+        );
+
+        let permanent = CollectionError::bad_input("malformed".to_string());
+        assert_eq!(
+            permanent.failed_update_disposition(),
+            FailedUpdateDisposition::Permanent,
+        );
+
+        assert!(FailedUpdateDisposition::Backpressure.queues_for_recovery());
+        assert!(FailedUpdateDisposition::Transient.queues_for_recovery());
+        assert!(!FailedUpdateDisposition::Permanent.queues_for_recovery());
     }
 
     /// A replica reports the condition as an `Unavailable` status tagged with reason metadata (the

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -969,14 +969,14 @@ pub enum ShardUnavailableReason {
 }
 
 /// What happens to a failed update operation, derived from the error by
-/// [`CollectionError::failed_update_disposition`].
+/// [`CollectionError::update_failure_kind`].
 ///
-/// Queued dispositions put the operation in `failed_operation`, which pins the WAL acknowledge
+/// Queued kinds put the operation in `failed_operation`, which pins the WAL acknowledge
 /// until recovery re-applies it; a [`Permanent`](Self::Permanent) failure must never queue (and
 /// is dropped if it was queued), or the acknowledge stalls forever on an operation that cannot
 /// succeed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum FailedUpdateDisposition {
+pub enum UpdateFailureKind {
     /// Expected backpressure: every appendable segment reached the size cap. Queued for
     /// recovery; the optimizer provisions a fresh segment and the operation is re-applied.
     Backpressure,
@@ -987,7 +987,7 @@ pub enum FailedUpdateDisposition {
     Permanent,
 }
 
-impl FailedUpdateDisposition {
+impl UpdateFailureKind {
     /// Whether the failed operation sits in `failed_operation` awaiting recovery (and thus pins
     /// the WAL acknowledge).
     pub fn queues_for_recovery(self) -> bool {
@@ -1210,16 +1210,16 @@ impl CollectionError {
     }
 
     /// How the update pipeline handles this error when an operation fails: see
-    /// [`FailedUpdateDisposition`]. The single origin of that policy; the updater queueing the
+    /// [`UpdateFailureKind`]. The single origin of that policy; the updater queueing the
     /// failure, recovery deciding to abort or skip, and the update worker nudging the optimizer
     /// all derive from it.
-    pub fn failed_update_disposition(&self) -> FailedUpdateDisposition {
+    pub fn update_failure_kind(&self) -> UpdateFailureKind {
         if self.is_out_of_appendable_capacity() {
-            FailedUpdateDisposition::Backpressure
+            UpdateFailureKind::Backpressure
         } else if self.is_transient() {
-            FailedUpdateDisposition::Transient
+            UpdateFailureKind::Transient
         } else {
-            FailedUpdateDisposition::Permanent
+            UpdateFailureKind::Permanent
         }
     }
 
@@ -2062,11 +2062,11 @@ mod tests {
     use super::*;
 
     /// The capacity condition carries a typed reason through the `OperationError` conversion (so
-    /// consumers detect it structurally, not by message text), and the failure disposition is the
-    /// single policy for what happens to a failed operation: queued dispositions pin the WAL
+    /// consumers detect it structurally, not by message text), and the failure kind is the
+    /// single policy for what happens to a failed operation: queued kinds pin the WAL
     /// acknowledge for recovery, a permanent one must not (or the acknowledge stalls forever).
     #[test]
-    fn test_capacity_condition_typed_and_dispositions() {
+    fn test_capacity_condition_typed_and_failure_kinds() {
         let capacity = CollectionError::from(OperationError::OutOfAppendableCapacity {
             max_segment_size_bytes: 1024,
         });
@@ -2085,25 +2085,25 @@ mod tests {
         assert!(capacity.is_out_of_appendable_capacity());
         assert!(capacity.is_transient());
         assert_eq!(
-            capacity.failed_update_disposition(),
-            FailedUpdateDisposition::Backpressure,
+            capacity.update_failure_kind(),
+            UpdateFailureKind::Backpressure,
         );
 
         let transient = CollectionError::service_error("segment flush failed");
         assert_eq!(
-            transient.failed_update_disposition(),
-            FailedUpdateDisposition::Transient,
+            transient.update_failure_kind(),
+            UpdateFailureKind::Transient,
         );
 
         let permanent = CollectionError::bad_input("malformed".to_string());
         assert_eq!(
-            permanent.failed_update_disposition(),
-            FailedUpdateDisposition::Permanent,
+            permanent.update_failure_kind(),
+            UpdateFailureKind::Permanent,
         );
 
-        assert!(FailedUpdateDisposition::Backpressure.queues_for_recovery());
-        assert!(FailedUpdateDisposition::Transient.queues_for_recovery());
-        assert!(!FailedUpdateDisposition::Permanent.queues_for_recovery());
+        assert!(UpdateFailureKind::Backpressure.queues_for_recovery());
+        assert!(UpdateFailureKind::Transient.queues_for_recovery());
+        assert!(!UpdateFailureKind::Permanent.queues_for_recovery());
     }
 
     /// A replica reports the condition as an `Unavailable` status tagged with reason metadata (the

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -997,12 +997,57 @@ impl FailedUpdateDisposition {
 
 /// gRPC status metadata key carrying the [`ShardUnavailableReason`] across the wire, so a replica
 /// set recognizes a remote capacity condition structurally instead of by message text.
-pub const SHARD_UNAVAILABLE_REASON_METADATA_KEY: &str = "x-qdrant-shard-unavailable-reason";
+const SHARD_UNAVAILABLE_REASON_METADATA_KEY: &str = "x-qdrant-shard-unavailable-reason";
 /// [`SHARD_UNAVAILABLE_REASON_METADATA_KEY`] value marking
 /// [`ShardUnavailableReason::OutOfAppendableCapacity`].
-pub const OUT_OF_APPENDABLE_CAPACITY_REASON: &str = "out-of-appendable-capacity";
+const OUT_OF_APPENDABLE_CAPACITY_REASON: &str = "out-of-appendable-capacity";
 /// Metadata key carrying the `max_segment_size` bytes alongside the capacity reason.
-pub const MAX_SEGMENT_SIZE_METADATA_KEY: &str = "x-qdrant-max-segment-size-bytes";
+const MAX_SEGMENT_SIZE_METADATA_KEY: &str = "x-qdrant-max-segment-size-bytes";
+
+impl ShardUnavailableReason {
+    /// The gRPC status metadata pairs that carry this reason across the wire; the inverse of
+    /// [`Self::from_metadata`], and the only two places that know the format. Empty for
+    /// [`Unspecified`](Self::Unspecified): only the capacity condition needs to be recognized
+    /// structurally by the receiving replica set.
+    pub fn to_metadata_pairs(&self) -> Vec<(&'static str, String)> {
+        match self {
+            Self::OutOfAppendableCapacity {
+                max_segment_size_bytes,
+            } => vec![
+                (
+                    SHARD_UNAVAILABLE_REASON_METADATA_KEY,
+                    OUT_OF_APPENDABLE_CAPACITY_REASON.to_string(),
+                ),
+                (
+                    MAX_SEGMENT_SIZE_METADATA_KEY,
+                    max_segment_size_bytes.to_string(),
+                ),
+            ],
+            Self::Unspecified => Vec::new(),
+        }
+    }
+
+    /// Rebuild the reason a remote peer attached via [`Self::to_metadata_pairs`]. `None` for an
+    /// untagged status: any other transient unavailability, which must keep its generic handling
+    /// (an [`Unspecified`](Self::Unspecified) reason is deliberately not distinguishable from no
+    /// reason on the wire).
+    pub fn from_metadata(metadata: &tonic::metadata::MetadataMap) -> Option<Self> {
+        let tag = metadata
+            .get(SHARD_UNAVAILABLE_REASON_METADATA_KEY)
+            .and_then(|value| value.to_str().ok())?;
+        if tag != OUT_OF_APPENDABLE_CAPACITY_REASON {
+            return None;
+        }
+        let max_segment_size_bytes = metadata
+            .get(MAX_SEGMENT_SIZE_METADATA_KEY)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(0);
+        Some(Self::OutOfAppendableCapacity {
+            max_segment_size_bytes,
+        })
+    }
+}
 
 /// Which rate limiter rejected an operation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1152,7 +1197,8 @@ impl CollectionError {
     /// Whether this is the recoverable "all appendable segments reached `max_segment_size`"
     /// condition. Matched on the typed [`ShardUnavailableReason`], including when a remote replica
     /// reported it: the reason survives the gRPC round trip via status metadata (see the
-    /// `From<tonic::Status>` decoder here and the `StorageError` -> `Status` encoder).
+    /// [`ShardUnavailableReason::to_metadata_pairs`] / [`ShardUnavailableReason::from_metadata`]
+    /// codec pair).
     pub fn is_out_of_appendable_capacity(&self) -> bool {
         matches!(
             self,
@@ -1361,25 +1407,14 @@ impl From<tonic::Status> for CollectionError {
             // A replica reporting a shard-unavailable condition tags the status with its reason
             // metadata; rebuild the typed reason so the replica set recognizes a self-healing
             // capacity failure structurally instead of matching the message text. An untagged
-            // `Unavailable` keeps the generic handling in the catch-all below.
-            tonic::Code::Unavailable
-                if err
-                    .metadata()
-                    .get(SHARD_UNAVAILABLE_REASON_METADATA_KEY)
-                    .and_then(|value| value.to_str().ok())
-                    == Some(OUT_OF_APPENDABLE_CAPACITY_REASON) =>
-            {
-                let max_segment_size_bytes = err
-                    .metadata()
-                    .get(MAX_SEGMENT_SIZE_METADATA_KEY)
-                    .and_then(|value| value.to_str().ok())
-                    .and_then(|value| value.parse::<usize>().ok())
-                    .unwrap_or(0);
-                Self::ShardUnavailable {
-                    description: format!("Tonic status error: {err}"),
-                    reason: ShardUnavailableReason::OutOfAppendableCapacity {
-                        max_segment_size_bytes,
+            // `Unavailable` is any other transient unavailability and keeps the generic handling.
+            tonic::Code::Unavailable => {
+                match ShardUnavailableReason::from_metadata(err.metadata()) {
+                    Some(reason) => Self::ShardUnavailable {
+                        description: format!("Tonic status error: {err}"),
+                        reason,
                     },
+                    None => Self::service_error(format!("Tonic status error: {err}")),
                 }
             }
             tonic::Code::Ok
@@ -1388,7 +1423,6 @@ impl From<tonic::Status> for CollectionError {
             | tonic::Code::Aborted
             | tonic::Code::OutOfRange
             | tonic::Code::Unimplemented
-            | tonic::Code::Unavailable
             | tonic::Code::DataLoss
             | tonic::Code::Unauthenticated => {
                 Self::service_error(format!("Tonic status error: {err}"))

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -329,9 +329,9 @@ pub fn build_optimizers(
         )),
     ]);
 
-    // Returned alongside so shard-level consumers (the appendable-segment size cap armed in
-    // `UpdateHandler::run_workers`) share the exact resolution the optimizers were built with,
-    // instead of re-deriving it or reaching into the optimizer list.
+    // Returned alongside so shard-level consumers (the appendable-segment size cap the
+    // `UpdateHandler` hands to its workers) share the exact resolution the optimizers were built
+    // with, instead of re-deriving it or reaching into the optimizer list.
     (optimizers, threshold_config)
 }
 

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -278,7 +278,7 @@ pub fn build_optimizers(
     hnsw_config: &HnswConfig,
     hnsw_global_config: &HnswGlobalConfig,
     quantization_config: &Option<QuantizationConfig>,
-) -> Arc<Vec<Arc<Optimizer>>> {
+) -> (Arc<Vec<Arc<Optimizer>>>, OptimizerThresholds) {
     let segments_path = shard_path.join(SEGMENTS_PATH);
     let temp_segments_path = shard_path.join(TEMP_SEGMENTS_PATH);
     let segment_config =
@@ -293,7 +293,7 @@ pub fn build_optimizers(
         ),
     );
 
-    Arc::new(vec![
+    let optimizers: Arc<Vec<Arc<Optimizer>>> = Arc::new(vec![
         Arc::new(MergeOptimizer::new(
             optimizers_config.get_number_segments(),
             threshold_config,
@@ -327,7 +327,12 @@ pub fn build_optimizers(
             *hnsw_config,
             hnsw_global_config.clone(),
         )),
-    ])
+    ]);
+
+    // Returned alongside so shard-level consumers (the appendable-segment size cap armed in
+    // `UpdateHandler::run_workers`) share the exact resolution the optimizers were built with,
+    // instead of re-deriving it or reaching into the optimizer list.
+    (optimizers, threshold_config)
 }
 
 #[cfg(test)]

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -741,11 +741,29 @@ impl LocalShard {
         // shard serves updates) and would fail the whole shard load. The cap re-arms after the
         // replay, before the remaining WAL tail is queued to the update worker, where recovery
         // is live.
-        let max_segment_size_bytes = {
+        //
+        // Restored by a guard rather than inline: the replay below returns early on several
+        // error paths, and leaving the cap disarmed there would let the shard run uncapped for
+        // its whole lifetime.
+        struct RearmCapOnDrop<'a> {
+            segments: &'a LockedSegmentHolder,
+            cap: Option<std::num::NonZeroUsize>,
+        }
+
+        impl Drop for RearmCapOnDrop<'_> {
+            fn drop(&mut self) {
+                self.segments.write().set_max_segment_size_bytes(self.cap);
+            }
+        }
+
+        let rearm_cap = {
             let mut segments = self.segments.write();
             let cap = segments.max_segment_size_bytes();
             segments.set_max_segment_size_bytes(None);
-            cap
+            RearmCapOnDrop {
+                segments: &self.segments,
+                cap,
+            }
         };
 
         let from = wal.first_index();
@@ -948,10 +966,9 @@ impl LocalShard {
         }
 
         // Synchronous replay is done; re-arm the appendable-segment size cap for the queued WAL
-        // tail and everything after.
-        self.segments
-            .write()
-            .set_max_segment_size_bytes(max_segment_size_bytes);
+        // tail and everything after. Explicit rather than left to the end of the function, so the
+        // cap is back before the tail reaches the update worker.
+        drop(rearm_cap);
 
         bar.finish();
         if !show_progress_bar {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -735,6 +735,19 @@ impl LocalShard {
         let mut newest_clocks = self.wal.newest_clocks.lock().await;
         let wal = self.wal.wal.lock().await;
 
+        // Disarm the appendable-segment size cap for the synchronous replay below: it applies
+        // operations exactly as they were originally accepted. A capacity error here could not
+        // recover (recovery runs on optimizer wake-ups, which only process signals once the
+        // shard serves updates) and would fail the whole shard load. The cap re-arms after the
+        // replay, before the remaining WAL tail is queued to the update worker, where recovery
+        // is live.
+        let max_segment_size_bytes = {
+            let mut segments = self.segments.write();
+            let cap = segments.max_segment_size_bytes();
+            segments.set_max_segment_size_bytes(None);
+            cap
+        };
+
         let from = wal.first_index();
         let last_wal_index = from + wal.len(false);
 
@@ -933,6 +946,12 @@ impl LocalShard {
             // version.
             segments.flush_all(FlushMode::Sync, true)?;
         }
+
+        // Synchronous replay is done; re-arm the appendable-segment size cap for the queued WAL
+        // tail and everything after.
+        self.segments
+            .write()
+            .set_max_segment_size_bytes(max_segment_size_bytes);
 
         bar.finish();
         if !show_progress_bar {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -736,15 +736,11 @@ impl LocalShard {
         let wal = self.wal.wal.lock().await;
 
         // Disarm the appendable-segment size cap for the synchronous replay below: it applies
-        // operations exactly as they were originally accepted. A capacity error here could not
-        // recover (recovery runs on optimizer wake-ups, which only process signals once the
-        // shard serves updates) and would fail the whole shard load. The cap re-arms after the
-        // replay, before the remaining WAL tail is queued to the update worker, where recovery
-        // is live.
-        //
-        // Restored by a guard rather than inline: the replay below returns early on several
-        // error paths, and leaving the cap disarmed there would let the shard run uncapped for
-        // its whole lifetime.
+        // operations exactly as originally accepted, and a capacity error here could not recover
+        // (optimizer wake-ups only process signals once the shard serves updates) and would fail
+        // the whole shard load. Restored by a drop guard because the replay returns early on
+        // several error paths; left disarmed there, the shard would run uncapped for its whole
+        // lifetime.
         struct RearmCapOnDrop<'a> {
             segments: &'a LockedSegmentHolder,
             cap: Option<std::num::NonZeroUsize>,

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -739,15 +739,6 @@ impl LocalShard {
         let mut newest_clocks = self.wal.newest_clocks.lock().await;
         let wal = self.wal.wal.lock().await;
 
-        // Disarm the appendable-segment size cap for the synchronous replay below: it applies
-        // operations exactly as originally accepted, and a capacity error here could not recover
-        // (optimizer wake-ups only process signals once the shard serves updates) and would fail
-        // the whole shard load. Re-armed below from the update handler, the cap's authority, once
-        // the replay succeeds. Every error return in between fails the whole shard load, after
-        // which this shard object is discarded (panic or dummy-shard replacement), so a disarmed
-        // cap cannot leak into a serving shard.
-        self.segments.write().set_max_segment_size_bytes(None);
-
         let from = wal.first_index();
         let last_wal_index = from + wal.len(false);
 
@@ -889,6 +880,11 @@ impl LocalShard {
                 update.operation,
                 self.update_operation_lock.clone(),
                 self.update_tracker.clone(),
+                // Synchronous replay applies operations exactly as originally accepted, without
+                // the appendable-segment size cap: a capacity error here could not recover
+                // (optimizer wake-ups only process signals once the shard serves updates) and
+                // would fail the whole shard load.
+                None,
                 &HardwareCounterCell::disposable(), // Internal operation, no measurement needed.
             ) {
                 Err(err @ CollectionError::ServiceError { error, backtrace }) => {
@@ -946,14 +942,6 @@ impl LocalShard {
             // version.
             segments.flush_all(FlushMode::Sync, true)?;
         }
-
-        // Synchronous replay is done; re-arm the appendable-segment size cap here rather than at
-        // the end of the function, so the cap is back before the queued WAL tail reaches the
-        // update worker.
-        let max_segment_size_bytes = self.update_handler.lock().await.max_segment_size_bytes;
-        self.segments
-            .write()
-            .set_max_segment_size_bytes(max_segment_size_bytes);
 
         bar.finish();
         if !show_progress_bar {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -742,15 +742,11 @@ impl LocalShard {
         // Disarm the appendable-segment size cap for the synchronous replay below: it applies
         // operations exactly as originally accepted, and a capacity error here could not recover
         // (optimizer wake-ups only process signals once the shard serves updates) and would fail
-        // the whole shard load. Re-armed below once the replay succeeds. Every error return in
-        // between fails the whole shard load, after which this shard object is discarded (panic
-        // or dummy-shard replacement), so a disarmed cap cannot leak into a serving shard.
-        let armed_cap = {
-            let mut segments = self.segments.write();
-            let cap = segments.max_segment_size_bytes();
-            segments.set_max_segment_size_bytes(None);
-            cap
-        };
+        // the whole shard load. Re-armed below from the update handler, the cap's authority, once
+        // the replay succeeds. Every error return in between fails the whole shard load, after
+        // which this shard object is discarded (panic or dummy-shard replacement), so a disarmed
+        // cap cannot leak into a serving shard.
+        self.segments.write().set_max_segment_size_bytes(None);
 
         let from = wal.first_index();
         let last_wal_index = from + wal.len(false);
@@ -954,7 +950,10 @@ impl LocalShard {
         // Synchronous replay is done; re-arm the appendable-segment size cap here rather than at
         // the end of the function, so the cap is back before the queued WAL tail reaches the
         // update worker.
-        self.segments.write().set_max_segment_size_bytes(armed_cap);
+        let max_segment_size_bytes = self.update_handler.lock().await.max_segment_size_bytes;
+        self.segments
+            .write()
+            .set_max_segment_size_bytes(max_segment_size_bytes);
 
         bar.finish();
         if !show_progress_bar {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -738,28 +738,14 @@ impl LocalShard {
         // Disarm the appendable-segment size cap for the synchronous replay below: it applies
         // operations exactly as originally accepted, and a capacity error here could not recover
         // (optimizer wake-ups only process signals once the shard serves updates) and would fail
-        // the whole shard load. Restored by a drop guard because the replay returns early on
-        // several error paths; left disarmed there, the shard would run uncapped for its whole
-        // lifetime.
-        struct RearmCapOnDrop<'a> {
-            segments: &'a LockedSegmentHolder,
-            cap: Option<std::num::NonZeroUsize>,
-        }
-
-        impl Drop for RearmCapOnDrop<'_> {
-            fn drop(&mut self) {
-                self.segments.write().set_max_segment_size_bytes(self.cap);
-            }
-        }
-
-        let rearm_cap = {
+        // the whole shard load. Re-armed below once the replay succeeds. Every error return in
+        // between fails the whole shard load, after which this shard object is discarded (panic
+        // or dummy-shard replacement), so a disarmed cap cannot leak into a serving shard.
+        let armed_cap = {
             let mut segments = self.segments.write();
             let cap = segments.max_segment_size_bytes();
             segments.set_max_segment_size_bytes(None);
-            RearmCapOnDrop {
-                segments: &self.segments,
-                cap,
-            }
+            cap
         };
 
         let from = wal.first_index();
@@ -961,10 +947,10 @@ impl LocalShard {
             segments.flush_all(FlushMode::Sync, true)?;
         }
 
-        // Synchronous replay is done; re-arm the appendable-segment size cap for the queued WAL
-        // tail and everything after. Explicit rather than left to the end of the function, so the
-        // cap is back before the tail reaches the update worker.
-        drop(rearm_cap);
+        // Synchronous replay is done; re-arm the appendable-segment size cap here rather than at
+        // the end of the function, so the cap is back before the queued WAL tail reaches the
+        // update worker.
+        self.segments.write().set_max_segment_size_bytes(armed_cap);
 
         bar.finish();
         if !show_progress_bar {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -257,6 +257,7 @@ impl LocalShard {
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         wal: SerdeWal<OperationWithClockTag>,
         optimizers: Arc<Vec<Arc<Optimizer>>>,
+        max_segment_size_bytes: Option<std::num::NonZeroUsize>,
         optimizer_resource_budget: ResourceBudget,
         shard_path: &Path,
         clocks: LocalShardClocks,
@@ -291,6 +292,7 @@ impl LocalShard {
             shared_storage_config.clone(),
             payload_index_schema.clone(),
             optimizers.clone(),
+            max_segment_size_bytes,
             optimizers_log.clone(),
             total_optimized_points.clone(),
             optimizer_resource_budget.clone(),
@@ -492,7 +494,7 @@ impl LocalShard {
         }
 
         clear_temp_segments(shard_path);
-        let optimizers = build_optimizers(
+        let (optimizers, optimizer_thresholds) = build_optimizers(
             shard_path,
             collection_config.clone(),
             &collection_config_read.params,
@@ -536,6 +538,7 @@ impl LocalShard {
             payload_index_schema,
             wal,
             optimizers,
+            optimizer_thresholds.max_segment_size_bytes(),
             optimizer_resource_budget,
             shard_path,
             clocks,
@@ -680,7 +683,7 @@ impl LocalShard {
         let wal: SerdeWal<OperationWithClockTag> =
             SerdeWal::new(&wal_path, (&config.wal_config).into())?;
 
-        let optimizers = build_optimizers(
+        let (optimizers, optimizer_thresholds) = build_optimizers(
             shard_path,
             collection_config.clone(),
             &config.params,
@@ -703,6 +706,7 @@ impl LocalShard {
             payload_index_schema,
             wal,
             optimizers,
+            optimizer_thresholds.max_segment_size_bytes(),
             optimizer_resource_budget,
             shard_path,
             LocalShardClocks::default(),

--- a/lib/collection/src/shards/local_shard/optimizer_config_update_tests.rs
+++ b/lib/collection/src/shards/local_shard/optimizer_config_update_tests.rs
@@ -148,6 +148,69 @@ mod tests {
         shard.stop_gracefully().await;
     }
 
+    /// The appendable-segment size cap must reach the segment holder through the real wiring
+    /// (resolved optimizer thresholds -> `UpdateHandler` field -> `run_workers` arming), both at
+    /// shard creation and on optimizer config updates. The capacity tests arm the holder directly
+    /// to isolate the mechanism, so without this test the arming in `run_workers` could be
+    /// deleted, silently disabling the whole capacity recovery, and the suite would stay green.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn optimizer_config_update_arms_segment_size_cap() {
+        let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+        let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+        let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+        let payload_index_schema =
+            Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
+        let mut config = create_collection_config();
+        config.optimizer_config.max_segment_size = Some(100);
+
+        let update_runtime = Handle::current();
+        let search_runtime = AdaptiveSearchHandle::current_for_tests();
+        let shard = LocalShard::build(
+            0,
+            "test".to_string(),
+            collection_dir.path(),
+            Arc::new(RwLock::new(config.clone())),
+            Arc::new(Default::default()),
+            payload_index_schema,
+            update_runtime.clone(),
+            search_runtime.clone(),
+            ResourceBudget::default(),
+            config.optimizer_config.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            shard
+                .segments
+                .read()
+                .max_segment_size_bytes()
+                .map(|c| c.get()),
+            Some(100 * 1024),
+            "shard creation must arm the holder with the configured cap",
+        );
+
+        {
+            let mut shard_config = shard.collection_config.write().await;
+            shard_config.optimizer_config.max_segment_size = Some(200);
+        }
+
+        shard.on_optimizer_config_update().await.unwrap();
+
+        assert_eq!(
+            shard
+                .segments
+                .read()
+                .max_segment_size_bytes()
+                .map(|c| c.get()),
+            Some(200 * 1024),
+            "an optimizer config update must re-arm the holder with the new cap",
+        );
+
+        shard.stop_gracefully().await;
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn optimizer_config_update_clears_optimizer_errors() {
         let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();

--- a/lib/collection/src/shards/local_shard/optimizer_config_update_tests.rs
+++ b/lib/collection/src/shards/local_shard/optimizer_config_update_tests.rs
@@ -97,8 +97,12 @@ mod tests {
     use crate::shards::shard_trait::ShardOperation;
     use crate::tests::fixtures::create_collection_config;
 
+    /// Config-dependent `UpdateHandler` fields must refresh through the real wiring, at shard
+    /// creation and on optimizer config updates. For `max_segment_size` this is what the capacity
+    /// suites cannot cover: they pass the cap to the apply path directly, so without this
+    /// assertion the config value could silently stop reaching the workers.
     #[tokio::test(flavor = "multi_thread")]
-    async fn optimizer_config_update_refreshes_prevent_unoptimized_flag() {
+    async fn optimizer_config_update_refreshes_update_handler_fields() {
         let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
         let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
         let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
@@ -107,61 +111,6 @@ mod tests {
 
         let mut config = create_collection_config();
         config.optimizer_config.prevent_unoptimized = Some(false);
-
-        let update_runtime = Handle::current();
-        let search_runtime = AdaptiveSearchHandle::current_for_tests();
-        let shard = LocalShard::build(
-            0,
-            "test".to_string(),
-            collection_dir.path(),
-            Arc::new(RwLock::new(config.clone())),
-            Arc::new(Default::default()),
-            payload_index_schema,
-            update_runtime.clone(),
-            search_runtime.clone(),
-            ResourceBudget::default(),
-            config.optimizer_config.clone(),
-        )
-        .await
-        .unwrap();
-
-        assert!(!shard.update_handler.lock().await.prevent_unoptimized);
-
-        {
-            let mut shard_config = shard.collection_config.write().await;
-            shard_config.optimizer_config.prevent_unoptimized = Some(true);
-        }
-
-        shard.on_optimizer_config_update().await.unwrap();
-
-        assert!(shard.update_handler.lock().await.prevent_unoptimized);
-
-        {
-            let mut shard_config = shard.collection_config.write().await;
-            shard_config.optimizer_config.prevent_unoptimized = Some(false);
-        }
-
-        shard.on_optimizer_config_update().await.unwrap();
-
-        assert!(!shard.update_handler.lock().await.prevent_unoptimized);
-
-        shard.stop_gracefully().await;
-    }
-
-    /// The appendable-segment size cap must reach the segment holder through the real wiring
-    /// (resolved optimizer thresholds -> `UpdateHandler` field -> `run_workers` arming), both at
-    /// shard creation and on optimizer config updates. The capacity tests arm the holder directly
-    /// to isolate the mechanism, so without this test the arming in `run_workers` could be
-    /// deleted, silently disabling the whole capacity recovery, and the suite would stay green.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn optimizer_config_update_arms_segment_size_cap() {
-        let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
-        let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
-        let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
-        let payload_index_schema =
-            Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
-
-        let mut config = create_collection_config();
         config.optimizer_config.max_segment_size = Some(100);
 
         let update_runtime = Handle::current();
@@ -181,32 +130,42 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(
-            shard
-                .segments
-                .read()
-                .max_segment_size_bytes()
-                .map(|c| c.get()),
-            Some(100 * 1024),
-            "shard creation must arm the holder with the configured cap",
-        );
+        {
+            let update_handler = shard.update_handler.lock().await;
+            assert!(!update_handler.prevent_unoptimized);
+            assert_eq!(
+                update_handler.max_segment_size_bytes,
+                std::num::NonZeroUsize::new(100 * 1024),
+                "shard creation must resolve the configured cap into the update handler",
+            );
+        }
 
         {
             let mut shard_config = shard.collection_config.write().await;
+            shard_config.optimizer_config.prevent_unoptimized = Some(true);
             shard_config.optimizer_config.max_segment_size = Some(200);
         }
 
         shard.on_optimizer_config_update().await.unwrap();
 
-        assert_eq!(
-            shard
-                .segments
-                .read()
-                .max_segment_size_bytes()
-                .map(|c| c.get()),
-            Some(200 * 1024),
-            "an optimizer config update must re-arm the holder with the new cap",
-        );
+        {
+            let update_handler = shard.update_handler.lock().await;
+            assert!(update_handler.prevent_unoptimized);
+            assert_eq!(
+                update_handler.max_segment_size_bytes,
+                std::num::NonZeroUsize::new(200 * 1024),
+                "an optimizer config update must refresh the cap the workers are handed",
+            );
+        }
+
+        {
+            let mut shard_config = shard.collection_config.write().await;
+            shard_config.optimizer_config.prevent_unoptimized = Some(false);
+        }
+
+        shard.on_optimizer_config_update().await.unwrap();
+
+        assert!(!shard.update_handler.lock().await.prevent_unoptimized);
 
         shard.stop_gracefully().await;
     }

--- a/lib/collection/src/shards/local_shard/updaters.rs
+++ b/lib/collection/src/shards/local_shard/updaters.rs
@@ -111,7 +111,7 @@ impl LocalShard {
         // config if it changed again while we were waiting.
         let config = self.collection_config.read().await;
 
-        let new_optimizers = build_optimizers(
+        let (new_optimizers, new_optimizer_thresholds) = build_optimizers(
             &self.path,
             self.collection_config.clone(),
             &config.params,
@@ -122,6 +122,7 @@ impl LocalShard {
         );
 
         update_handler.optimizers = new_optimizers.clone();
+        update_handler.max_segment_size_bytes = new_optimizer_thresholds.max_segment_size_bytes();
         update_handler.flush_interval_sec = config.optimizer_config.flush_interval_sec;
         update_handler.max_optimization_threads = config.optimizer_config.max_optimization_threads;
         update_handler.prevent_unoptimized = config

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -737,6 +737,16 @@ impl ShardReplicaSet {
                 continue;
             }
 
+            // Ignore capacity errors: every appendable segment of that replica reached
+            // `max_segment_size`, which is local, expected and self-healing. The operation is
+            // queued in `failed_operation` and pins the WAL acknowledge, so the optimizer
+            // wake-up provisions a fresh appendable segment and recovery re-applies it. Marking
+            // the replica dead over it would force a full transfer to recover a replica that
+            // catches up on its own.
+            if err.is_out_of_appendable_capacity() {
+                continue;
+            }
+
             if err.is_transient() || peer_state == ReplicaState::Initializing {
                 // If the error is transient, we should not deactivate the peer
                 // before allowing other operations to continue.
@@ -875,6 +885,7 @@ mod tests {
 
     use common::budget::ResourceBudget;
     use common::save_on_disk::SaveOnDisk;
+    use segment::common::operation_error::OperationError;
     use segment::types::Distance;
     use tempfile::{Builder, TempDir};
     use tokio::runtime::Handle;
@@ -972,6 +983,42 @@ mod tests {
 
         assert_eq!(rs.highest_replica_peer_id(), Some(5));
         assert_eq!(rs.highest_alive_replica_peer_id(), Some(4));
+    }
+
+    /// A replica that ran out of appendable capacity must keep its state: the operation is
+    /// pinned in `failed_operation` and re-applied once the optimizer provisions a fresh
+    /// appendable segment, so deactivating would force a full transfer to recover a replica
+    /// that catches up on its own.
+    #[tokio::test]
+    async fn test_capacity_failure_does_not_deactivate_replica() {
+        let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+        let rs = new_shard_replica_set(&collection_dir).await;
+
+        for peer_id in [1, 2, 3] {
+            rs.set_replica_state(peer_id, ReplicaState::Active)
+                .await
+                .unwrap();
+        }
+
+        let capacity_failures = vec![(
+            2,
+            CollectionError::from(OperationError::OutOfAppendableCapacity {
+                max_segment_size_bytes: 1024,
+            }),
+        )];
+        let wait_for_deactivation =
+            rs.handle_failed_replicas(&capacity_failures, &rs.replica_state.read(), false);
+
+        assert!(!wait_for_deactivation);
+        assert!(!rs.is_locally_disabled(2));
+
+        // Any other transient failure still deactivates the replica.
+        let service_failures = vec![(3, CollectionError::service_error("something went wrong"))];
+        let wait_for_deactivation =
+            rs.handle_failed_replicas(&service_failures, &rs.replica_state.read(), false);
+
+        assert!(wait_for_deactivation);
+        assert!(rs.is_locally_disabled(3));
     }
 
     const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -189,7 +189,9 @@ impl ShardReplicaSet {
             self.forward_update(leader_peer, operation, wait, timeout, ordering, hw_measurement_acc)
                 .await
                 .map_err(|err| {
-                    if err.is_transient() {
+                    // A leader that ran out of appendable capacity recovers on its own, so it is
+                    // not deactivated over that either (see `handle_failed_replicas`).
+                    if err.is_transient() && !err.is_out_of_appendable_capacity() {
                         // Deactivate the peer if forwarding failed with transient error
                         let replica_state = self.replica_state.read();
 

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -7,6 +8,7 @@ use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use parking_lot::Mutex;
+use segment::common::BYTES_IN_KB;
 use segment::types::SeqNumberType;
 use shard::operations::CollectionUpdateOperations;
 use shard::segment_holder::locked::LockedSegmentHolder;
@@ -189,6 +191,25 @@ impl UpdateHandler {
     }
 
     pub fn run_workers(&mut self, update_receiver: Receiver<UpdateSignal>) {
+        // Mirror the resolved optimizer size threshold into the segment holder, both on shard
+        // creation and on optimizer config updates (which restart the workers). With the cap set,
+        // the update path reports `OutOfAppendableCapacity` instead of growing an appendable
+        // segment past `max_segment_size`; the failed operation then wakes the optimizer, whose
+        // capacity-ensure step provisions a fresh appendable segment, and failed-operation
+        // recovery re-applies the operation. Synchronous WAL replay disarms the cap for its own
+        // window (see `load_from_wal`), since no recovery loop is processing signals there.
+        if let Some(optimizer) = self.optimizers.first() {
+            let max_segment_size_bytes = NonZeroUsize::new(
+                optimizer
+                    .threshold_config()
+                    .max_segment_size_kb
+                    .saturating_mul(BYTES_IN_KB),
+            );
+            self.segments
+                .write()
+                .set_max_segment_size_bytes(max_segment_size_bytes);
+        }
+
         let (tx, rx) = mpsc::channel(self.shared_storage_config.update_queue_size);
 
         // Optimization notifier is triggered when a new optimization is finished

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -189,13 +189,12 @@ impl UpdateHandler {
     }
 
     pub fn run_workers(&mut self, update_receiver: Receiver<UpdateSignal>) {
-        // Mirror the resolved optimizer size threshold into the segment holder, both on shard
-        // creation and on optimizer config updates (which restart the workers). With the cap set,
-        // the update path reports `OutOfAppendableCapacity` instead of growing an appendable
-        // segment past `max_segment_size`; the failed operation then wakes the optimizer, whose
-        // capacity-ensure step provisions a fresh appendable segment, and failed-operation
+        // Mirror the resolved optimizer size threshold into the segment holder, on shard creation
+        // and on optimizer config updates (which restart the workers). With the cap set, the
+        // update path reports `OutOfAppendableCapacity` instead of growing an appendable segment
+        // past `max_segment_size`; the optimizer wake-up then provisions a fresh segment and
         // recovery re-applies the operation. Synchronous WAL replay disarms the cap for its own
-        // window (see `load_from_wal`), since no recovery loop is processing signals there.
+        // window (see `load_from_wal`).
         if let Some(optimizer) = self.optimizers.first() {
             self.segments
                 .write()

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -78,6 +79,10 @@ pub struct UpdateHandler {
     payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
     /// List of used optimizers
     pub optimizers: Arc<Vec<Arc<Optimizer>>>,
+    /// Appendable-segment size cap, from the same threshold resolution the optimizers were built
+    /// with (`build_optimizers` returns both). `run_workers` arms the segment holder with it.
+    /// This parameter depends on the optimizer config and should be updated accordingly.
+    pub max_segment_size_bytes: Option<NonZeroUsize>,
     /// Log of optimizer statuses
     optimizers_log: Arc<Mutex<TrackerLog>>,
     /// Total number of optimized points since last start
@@ -143,6 +148,7 @@ impl UpdateHandler {
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         optimizers: Arc<Vec<Arc<Optimizer>>>,
+        max_segment_size_bytes: Option<NonZeroUsize>,
         optimizers_log: Arc<Mutex<TrackerLog>>,
         total_optimized_points: Arc<AtomicUsize>,
         optimizer_resource_budget: ResourceBudget,
@@ -163,6 +169,7 @@ impl UpdateHandler {
             shared_storage_config,
             payload_index_schema,
             optimizers,
+            max_segment_size_bytes,
             segments,
             update_worker: None,
             update_worker_cancel: CancellationToken::new(),
@@ -189,17 +196,15 @@ impl UpdateHandler {
     }
 
     pub fn run_workers(&mut self, update_receiver: Receiver<UpdateSignal>) {
-        // Mirror the resolved optimizer size threshold into the segment holder, on shard creation
-        // and on optimizer config updates (which restart the workers). With the cap set, the
-        // update path reports `OutOfAppendableCapacity` instead of growing an appendable segment
-        // past `max_segment_size`; the optimizer wake-up then provisions a fresh segment and
-        // recovery re-applies the operation. Synchronous WAL replay disarms the cap for its own
-        // window (see `load_from_wal`).
-        if let Some(optimizer) = self.optimizers.first() {
-            self.segments
-                .write()
-                .set_max_segment_size_bytes(optimizer.threshold_config().max_segment_size_bytes());
-        }
+        // Arm the appendable-segment size cap, on shard creation and on optimizer config updates
+        // (which restart the workers). With the cap set, the update path reports
+        // `OutOfAppendableCapacity` instead of growing an appendable segment past
+        // `max_segment_size`; the optimizer wake-up then provisions a fresh segment and recovery
+        // re-applies the operation. Synchronous WAL replay disarms the cap for its own window
+        // (see `load_from_wal`).
+        self.segments
+            .write()
+            .set_max_segment_size_bytes(self.max_segment_size_bytes);
 
         let (tx, rx) = mpsc::channel(self.shared_storage_config.update_queue_size);
 

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -1,4 +1,3 @@
-use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -8,7 +7,6 @@ use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use parking_lot::Mutex;
-use segment::common::BYTES_IN_KB;
 use segment::types::SeqNumberType;
 use shard::operations::CollectionUpdateOperations;
 use shard::segment_holder::locked::LockedSegmentHolder;
@@ -199,15 +197,9 @@ impl UpdateHandler {
         // recovery re-applies the operation. Synchronous WAL replay disarms the cap for its own
         // window (see `load_from_wal`), since no recovery loop is processing signals there.
         if let Some(optimizer) = self.optimizers.first() {
-            let max_segment_size_bytes = NonZeroUsize::new(
-                optimizer
-                    .threshold_config()
-                    .max_segment_size_kb
-                    .saturating_mul(BYTES_IN_KB),
-            );
             self.segments
                 .write()
-                .set_max_segment_size_bytes(max_segment_size_bytes);
+                .set_max_segment_size_bytes(optimizer.threshold_config().max_segment_size_bytes());
         }
 
         let (tx, rx) = mpsc::channel(self.shared_storage_config.update_queue_size);

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -80,7 +80,8 @@ pub struct UpdateHandler {
     /// List of used optimizers
     pub optimizers: Arc<Vec<Arc<Optimizer>>>,
     /// Appendable-segment size cap, from the same threshold resolution the optimizers were built
-    /// with (`build_optimizers` returns both). `run_workers` arms the segment holder with it.
+    /// with (`build_optimizers` returns both). Handed to the update and optimization workers,
+    /// which pass it down the apply path; synchronous WAL replay passes `None` instead.
     /// This parameter depends on the optimizer config and should be updated accordingly.
     pub max_segment_size_bytes: Option<NonZeroUsize>,
     /// Log of optimizer statuses
@@ -196,16 +197,6 @@ impl UpdateHandler {
     }
 
     pub fn run_workers(&mut self, update_receiver: Receiver<UpdateSignal>) {
-        // Arm the appendable-segment size cap, on shard creation and on optimizer config updates
-        // (which restart the workers). With the cap set, the update path reports
-        // `OutOfAppendableCapacity` instead of growing an appendable segment past
-        // `max_segment_size`; the optimizer wake-up then provisions a fresh segment and recovery
-        // re-applies the operation. Synchronous WAL replay disarms the cap for its own window
-        // (see `load_from_wal`).
-        self.segments
-            .write()
-            .set_max_segment_size_bytes(self.max_segment_size_bytes);
-
         let (tx, rx) = mpsc::channel(self.shared_storage_config.update_queue_size);
 
         // Optimization notifier is triggered when a new optimization is finished
@@ -225,6 +216,7 @@ impl UpdateHandler {
                 self.max_optimization_threads,
                 self.has_triggered_optimizers.clone(),
                 self.payload_index_schema.clone(),
+                self.max_segment_size_bytes,
                 self.scroll_read_lock.clone(),
                 self.update_tracker.clone(),
                 optimization_finished_sender,
@@ -252,6 +244,7 @@ impl UpdateHandler {
             scroll_read_lock,
             update_tracker,
             self.prevent_unoptimized,
+            self.max_segment_size_bytes,
             optimization_finished_receiver,
             applied_seq_handler,
             cancel,

--- a/lib/collection/src/update_workers/flush_workers.rs
+++ b/lib/collection/src/update_workers/flush_workers.rs
@@ -142,3 +142,61 @@ impl UpdateWorkers {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use common::counter::hardware_counter::HardwareCounterCell;
+    use segment::data_types::vectors::only_default_vector;
+    use segment::entry::entry_point::SegmentEntry as _;
+    use shard::segment_holder::SegmentHolder;
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::collection_manager::fixtures::empty_segment;
+
+    /// `failed_operation` is what keeps a failed operation replayable: it caps the version the
+    /// flush worker acknowledges in the WAL, so the entry stays on disk until the operation is
+    /// re-applied. Both halves of the recovery contract rest on this, queueing a transient failure
+    /// and dropping one that can never succeed again.
+    #[test]
+    fn test_failed_operation_pins_wal_acknowledge() {
+        let dir = Builder::new().prefix("segments").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        let mut segment = empty_segment(dir.path());
+        segment
+            .upsert_point(
+                10,
+                1.into(),
+                only_default_vector(&[1.0, 0.0, 1.0, 1.0]),
+                &hw_counter,
+            )
+            .unwrap();
+
+        let mut holder = SegmentHolder::default();
+        holder.add_new(segment);
+        let segments = LockedSegmentHolder::new(holder);
+        segments.read().flush_all(FlushMode::Sync, true).unwrap();
+
+        assert_eq!(
+            UpdateWorkers::flush_segments(segments.clone()).unwrap(),
+            10,
+            "with nothing queued the acknowledge follows the persisted version",
+        );
+
+        segments.write().failed_operation.insert(5);
+        assert_eq!(
+            UpdateWorkers::flush_segments(segments.clone()).unwrap(),
+            5,
+            "a queued operation must hold the acknowledge below itself",
+        );
+
+        // Dropping the entry is what a non-transient decline does, and it must release the pin.
+        segments.write().failed_operation.remove(&5);
+        assert_eq!(
+            UpdateWorkers::flush_segments(segments.clone()).unwrap(),
+            10,
+            "dropping the queued operation must let the acknowledge advance again",
+        );
+    }
+}

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -156,8 +156,15 @@ impl UpdateWorkers {
                 // recovery resumes where it stopped (applied points are skipped by version).
                 // Progress-guarded: if the provisioned segment stayed empty, the next wake-up
                 // creates nothing and this re-signal chain stops.
-                if created_appendable_segment {
-                    let _ = sender.try_send(OptimizerSignal::Nop);
+                // `try_send` rather than an awaited send: this is our own signal channel, so
+                // awaiting a full one would deadlock the loop that drains it.
+                if created_appendable_segment
+                    && let Err(err) = sender.try_send(OptimizerSignal::Nop)
+                {
+                    log::warn!(
+                        "Could not re-signal the optimizer to continue capacity recovery, \
+                         it resumes on the next wake-up: {err}"
+                    );
                 }
                 let _ = optimization_finished_sender.send(());
                 continue;

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -576,3 +576,124 @@ impl UpdateWorkers {
         Ok(0)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+
+    use common::counter::hardware_accumulator::HwMeasurementAcc;
+    use common::types::DeferredBehavior;
+    use segment::data_types::vectors::only_default_vector;
+    use segment::entry::entry_point::SegmentEntry as _;
+    use segment::payload_json;
+    use segment::types::{PayloadContainer, WithPayload};
+    use shard::operations::OperationWithClockTag;
+    use shard::retrieve::retrieve_blocking::retrieve_blocking;
+    use shard::segment_holder::SegmentHolder;
+    use shard::wal::{SerdeWal, WalRawRecord};
+    use tempfile::Builder;
+    use wal::WalOptions;
+
+    use super::*;
+    use crate::collection_manager::fixtures::{TEST_TIMEOUT, empty_segment};
+    use crate::operations::CollectionUpdateOperations;
+    use crate::operations::payload_ops::{PayloadOps, SetPayloadOp};
+    use crate::shards::update_tracker::UpdateTracker;
+
+    fn set_payload_op(point_id: u64, color: &str) -> CollectionUpdateOperations {
+        CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(SetPayloadOp {
+            payload: payload_json! {"color": color},
+            points: Some(vec![point_id.into()]),
+            filter: None,
+            key: None,
+        }))
+    }
+
+    /// A queued operation can start declining non-transiently once later operations changed the
+    /// state it sees. Recovery used to propagate that error, which aborted the whole pass and left
+    /// the operation queued, so every later wake-up retried the same doomed operation and the WAL
+    /// acknowledge never advanced. It must be skipped instead, exactly like WAL replay does.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_try_recover_skips_declined_operation_and_continues() {
+        let segments_dir = Builder::new().prefix("segments").tempdir().unwrap();
+        let wal_dir = Builder::new().prefix("wal").tempdir().unwrap();
+
+        // Seed the point at version 0 so the replayed operations below, whose op numbers are WAL
+        // indices starting at 0, are not skipped as already applied.
+        let hw_counter = HardwareCounterCell::new();
+        let mut segment = empty_segment(segments_dir.path());
+        segment
+            .upsert_point(
+                0,
+                1.into(),
+                only_default_vector(&[1.0, 0.0, 1.0, 1.0]),
+                &hw_counter,
+            )
+            .unwrap();
+
+        let mut holder = SegmentHolder::default();
+        holder.add_new(segment);
+        let segments = LockedSegmentHolder::new(holder);
+
+        let mut wal: SerdeWal<OperationWithClockTag> =
+            SerdeWal::new(wal_dir.path(), WalOptions::default()).unwrap();
+
+        // Declines with `PointNotFound`, which is not transient: point 999 does not exist.
+        let declining_op_num = wal
+            .write(
+                &WalRawRecord::new(&OperationWithClockTag::new(
+                    set_payload_op(999, "red"),
+                    None,
+                ))
+                .unwrap(),
+            )
+            .unwrap();
+        // Queued behind it, and must still be applied once the declined one is skipped.
+        wal.write(
+            &WalRawRecord::new(&OperationWithClockTag::new(set_payload_op(1, "blue"), None))
+                .unwrap(),
+        )
+        .unwrap();
+
+        segments.write().failed_operation.insert(declining_op_num);
+
+        UpdateWorkers::try_recover(
+            segments.clone(),
+            Arc::new(TokioMutex::new(wal)),
+            Arc::new(tokio::sync::RwLock::new(())),
+            UpdateTracker::default(),
+        )
+        .await
+        .expect("a declined operation must not abort recovery");
+
+        assert!(
+            segments.read().failed_operation.is_empty(),
+            "the declined operation must stop pinning the WAL acknowledge",
+        );
+
+        let is_stopped = AtomicBool::new(false);
+        let records = retrieve_blocking(
+            segments,
+            &[1.into()],
+            &WithPayload::from(true),
+            &false.into(),
+            TEST_TIMEOUT,
+            &is_stopped,
+            HwMeasurementAcc::new(),
+            DeferredBehavior::VisibleOnly,
+        )
+        .unwrap();
+
+        assert_eq!(
+            records[&1.into()]
+                .payload
+                .as_ref()
+                .and_then(|payload| payload
+                    .get_value(&"color".parse().unwrap())
+                    .first()
+                    .cloned()),
+            Some(&serde_json::json!("blue")),
+            "recovery must keep applying the operations queued behind the declined one",
+        );
+    }
+}

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -467,23 +467,14 @@ impl UpdateWorkers {
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
     ) -> OperationResult<bool> {
         let no_segment_with_capacity = {
-            let segments_read = segments.read();
-            segments_read
-                .appendable_segments_ids()
-                .into_iter()
-                .filter_map(|segment_id| segments_read.get(segment_id))
-                .all(|segment| {
-                    let max_vector_size_bytes = segment
-                        .get()
-                        .read()
-                        .max_available_vectors_size_in_bytes()
-                        .unwrap_or_default();
-                    let max_segment_size_bytes = thresholds_config
-                        .max_segment_size_kb
-                        .saturating_mul(segment::common::BYTES_IN_KB);
-
-                    max_vector_size_bytes >= max_segment_size_bytes
-                })
+            let max_segment_size_bytes = std::num::NonZeroUsize::new(
+                thresholds_config
+                    .max_segment_size_kb
+                    .saturating_mul(segment::common::BYTES_IN_KB),
+            );
+            !segments
+                .read()
+                .has_appendable_segment_with_capacity(max_segment_size_bytes)
         };
 
         if no_segment_with_capacity {
@@ -547,14 +538,31 @@ impl UpdateWorkers {
                             "Failed to read WAL during recovery: {e}"
                         ))
                     })?;
-                    CollectionUpdater::update(
+                    let result = CollectionUpdater::update(
                         &segments,
                         op_num,
                         operation.operation,
                         update_operation_lock.clone(),
                         update_tracker.clone(),
                         &HardwareCounterCell::disposable(), // Internal operation, no measurement needed
-                    )?;
+                    );
+                    match result {
+                        Ok(_) => {}
+                        // Abort recovery and retry on a later wake-up.
+                        Err(err) if err.is_transient() => return Err(err),
+                        // A non-transient decline can never succeed; skip it like WAL replay
+                        // does on shard load, instead of aborting recovery forever. A replayed
+                        // operation can legitimately decline this way when later (already
+                        // applied) operations changed the state it sees, e.g. deleted one of
+                        // its points. `CollectionUpdater` already dropped it from
+                        // `failed_operation`, unblocking the WAL acknowledge.
+                        Err(err) => {
+                            log::warn!(
+                                "Skipping failed operation {op_num} during recovery, \
+                                 it was declined: {err}"
+                            );
+                        }
+                    }
                 }
             }
         };

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -110,17 +110,21 @@ impl UpdateWorkers {
 
             // Ensure we have at least one appendable segment with enough capacity
             // Source required parameters from first optimizer
-            let result = Self::ensure_appendable_segment_with_capacity(
+            let created_appendable_segment = match Self::ensure_appendable_segment_with_capacity(
                 &segments,
                 some_optimizer.segments_path(),
                 some_optimizer.segment_optimizer_config(),
                 some_optimizer.threshold_config(),
                 payload_index_schema.clone(),
-            );
-            if let Err(err) = result {
-                log::error!("Failed to ensure there are appendable segments with capacity: {err}");
-                panic!("Failed to ensure there are appendable segments with capacity: {err}");
-            }
+            ) {
+                Ok(created) => created,
+                Err(err) => {
+                    log::error!(
+                        "Failed to ensure there are appendable segments with capacity: {err}"
+                    );
+                    panic!("Failed to ensure there are appendable segments with capacity: {err}");
+                }
+            };
 
             // Backstop: reconcile the segment manifest with the live segment set. Registration
             // normally happens at each publication site via the `NewSegmentToken`; this wake-up is
@@ -144,6 +148,17 @@ impl UpdateWorkers {
             .await
             .is_err()
             {
+                // Failed-operation recovery could not complete. When this wake-up just
+                // provisioned a fresh appendable segment, the failure is likely
+                // `OutOfAppendableCapacity` part-way through an operation that moves more data
+                // than one segment holds: it filled the new segment and needs another. Wake
+                // ourselves again so the next capacity-ensure provisions the next segment and
+                // recovery resumes where it stopped (applied points are skipped by version).
+                // Progress-guarded: if the provisioned segment stayed empty, the next wake-up
+                // creates nothing and this re-signal chain stops.
+                if created_appendable_segment {
+                    let _ = sender.try_send(OptimizerSignal::Nop);
+                }
                 let _ = optimization_finished_sender.send(());
                 continue;
             }
@@ -442,13 +457,15 @@ impl UpdateWorkers {
     /// created.
     ///
     /// Capacity is determined based on `optimizers.max_segment_size_kb`.
+    ///
+    /// Returns whether a new segment was created.
     pub fn ensure_appendable_segment_with_capacity(
         segments: &LockedSegmentHolder,
         segments_path: &Path,
         segment_config: &SegmentOptimizerConfig,
         thresholds_config: &OptimizerThresholds,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
-    ) -> OperationResult<()> {
+    ) -> OperationResult<bool> {
         let no_segment_with_capacity = {
             let segments_read = segments.read();
             segments_read
@@ -486,7 +503,7 @@ impl UpdateWorkers {
             write_guard.add_new_locked(new_segment);
         }
 
-        Ok(())
+        Ok(no_segment_with_capacity)
     }
 
     /// Trigger optimizers when CPU budget is available

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -55,6 +55,7 @@ impl UpdateWorkers {
         max_handles: Option<usize>,
         has_triggered_optimizers: Arc<AtomicBool>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
+        max_segment_size_bytes: Option<std::num::NonZeroUsize>,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
         optimization_finished_sender: watch::Sender<()>,
@@ -140,6 +141,7 @@ impl UpdateWorkers {
                 wal.clone(),
                 update_operation_lock.clone(),
                 update_tracker.clone(),
+                max_segment_size_bytes,
             )
             .await
             .is_err()
@@ -517,6 +519,7 @@ impl UpdateWorkers {
         wal: LockedWal,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
+        max_segment_size_bytes: Option<std::num::NonZeroUsize>,
     ) -> CollectionResult<usize> {
         // Try to re-apply everything starting from the first failed operation
         let first_failed_operation_option = segments.read().failed_operation.iter().cloned().min();
@@ -536,6 +539,7 @@ impl UpdateWorkers {
                         operation.operation,
                         update_operation_lock.clone(),
                         update_tracker.clone(),
+                        max_segment_size_bytes,
                         &HardwareCounterCell::disposable(), // Internal operation, no measurement needed
                     );
                     match result {
@@ -627,6 +631,7 @@ mod tests {
             Arc::new(TokioMutex::new(wal)),
             Arc::new(tokio::sync::RwLock::new(())),
             UpdateTracker::default(),
+            None,
         )
         .await
         .expect("a declined operation must not abort recovery");

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -110,21 +110,17 @@ impl UpdateWorkers {
 
             // Ensure we have at least one appendable segment with enough capacity
             // Source required parameters from first optimizer
-            let created_appendable_segment = match Self::ensure_appendable_segment_with_capacity(
+            let created_appendable_segment = Self::ensure_appendable_segment_with_capacity(
                 &segments,
                 some_optimizer.segments_path(),
                 some_optimizer.segment_optimizer_config(),
                 some_optimizer.threshold_config(),
                 payload_index_schema.clone(),
-            ) {
-                Ok(created) => created,
-                Err(err) => {
-                    log::error!(
-                        "Failed to ensure there are appendable segments with capacity: {err}"
-                    );
-                    panic!("Failed to ensure there are appendable segments with capacity: {err}");
-                }
-            };
+            )
+            .unwrap_or_else(|err| {
+                log::error!("Failed to ensure there are appendable segments with capacity: {err}");
+                panic!("Failed to ensure there are appendable segments with capacity: {err}");
+            });
 
             // Backstop: reconcile the segment manifest with the live segment set. Registration
             // normally happens at each publication site via the `NewSegmentToken`; this wake-up is

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -473,16 +473,9 @@ impl UpdateWorkers {
         thresholds_config: &OptimizerThresholds,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
     ) -> OperationResult<bool> {
-        let no_segment_with_capacity = {
-            let max_segment_size_bytes = std::num::NonZeroUsize::new(
-                thresholds_config
-                    .max_segment_size_kb
-                    .saturating_mul(segment::common::BYTES_IN_KB),
-            );
-            !segments
-                .read()
-                .has_appendable_segment_with_capacity(max_segment_size_bytes)
-        };
+        let no_segment_with_capacity = !segments
+            .read()
+            .has_appendable_segment_with_capacity(thresholds_config.max_segment_size_bytes());
 
         if no_segment_with_capacity {
             log::debug!("Creating new appendable segment, all existing segments are over capacity");

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -548,10 +548,12 @@ impl UpdateWorkers {
                     );
                     match result {
                         Ok(_) => {}
-                        // Abort recovery and retry on a later wake-up.
-                        Err(err) if err.is_transient() => return Err(err),
-                        // A non-transient decline can never succeed; skip it like WAL replay
-                        // does on shard load, instead of aborting recovery forever. A replayed
+                        // Still queued: abort recovery and retry on a later wake-up.
+                        Err(err) if err.failed_update_disposition().queues_for_recovery() => {
+                            return Err(err);
+                        }
+                        // A permanent decline can never succeed; skip it like WAL replay does
+                        // on shard load, instead of aborting recovery forever. A replayed
                         // operation can legitimately decline this way when later (already
                         // applied) operations changed the state it sees, e.g. deleted one of
                         // its points. `CollectionUpdater` already dropped it from

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -148,16 +148,12 @@ impl UpdateWorkers {
             .await
             .is_err()
             {
-                // Failed-operation recovery could not complete. When this wake-up just
-                // provisioned a fresh appendable segment, the failure is likely
-                // `OutOfAppendableCapacity` part-way through an operation that moves more data
-                // than one segment holds: it filled the new segment and needs another. Wake
-                // ourselves again so the next capacity-ensure provisions the next segment and
-                // recovery resumes where it stopped (applied points are skipped by version).
-                // Progress-guarded: if the provisioned segment stayed empty, the next wake-up
-                // creates nothing and this re-signal chain stops.
-                // `try_send` rather than an awaited send: this is our own signal channel, so
-                // awaiting a full one would deadlock the loop that drains it.
+                // Recovery could not complete. If this wake-up just provisioned a fresh segment,
+                // an operation moving more data than one segment holds likely filled it and
+                // needs another: re-signal so the next wake-up provisions it and recovery
+                // resumes (applied points skip by version). Progress-guarded: an empty
+                // provisioned segment stops the chain. `try_send` because awaiting our own full
+                // signal channel would deadlock the loop that drains it.
                 if created_appendable_segment
                     && let Err(err) = sender.try_send(OptimizerSignal::Nop)
                 {
@@ -580,29 +576,19 @@ mod tests {
     use common::types::DeferredBehavior;
     use segment::data_types::vectors::only_default_vector;
     use segment::entry::entry_point::SegmentEntry as _;
-    use segment::payload_json;
     use segment::types::{PayloadContainer, WithPayload};
     use shard::operations::OperationWithClockTag;
     use shard::retrieve::retrieve_blocking::retrieve_blocking;
     use shard::segment_holder::SegmentHolder;
-    use shard::wal::{SerdeWal, WalRawRecord};
+    use shard::wal::SerdeWal;
     use tempfile::Builder;
     use wal::WalOptions;
 
     use super::*;
-    use crate::collection_manager::fixtures::{TEST_TIMEOUT, empty_segment};
-    use crate::operations::CollectionUpdateOperations;
-    use crate::operations::payload_ops::{PayloadOps, SetPayloadOp};
+    use crate::collection_manager::fixtures::{
+        TEST_TIMEOUT, empty_segment, set_payload_op, write_op,
+    };
     use crate::shards::update_tracker::UpdateTracker;
-
-    fn set_payload_op(point_id: u64, color: &str) -> CollectionUpdateOperations {
-        CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(SetPayloadOp {
-            payload: payload_json! {"color": color},
-            points: Some(vec![point_id.into()]),
-            filter: None,
-            key: None,
-        }))
-    }
 
     /// A queued operation can start declining non-transiently once later operations changed the
     /// state it sees. Recovery used to propagate that error, which aborted the whole pass and left
@@ -634,21 +620,9 @@ mod tests {
             SerdeWal::new(wal_dir.path(), WalOptions::default()).unwrap();
 
         // Declines with `PointNotFound`, which is not transient: point 999 does not exist.
-        let declining_op_num = wal
-            .write(
-                &WalRawRecord::new(&OperationWithClockTag::new(
-                    set_payload_op(999, "red"),
-                    None,
-                ))
-                .unwrap(),
-            )
-            .unwrap();
+        let declining_op_num = write_op(&mut wal, &set_payload_op(&[999], "red"));
         // Queued behind it, and must still be applied once the declined one is skipped.
-        wal.write(
-            &WalRawRecord::new(&OperationWithClockTag::new(set_payload_op(1, "blue"), None))
-                .unwrap(),
-        )
-        .unwrap();
+        write_op(&mut wal, &set_payload_op(&[1], "blue"));
 
         segments.write().failed_operation.insert(declining_op_num);
 

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -541,7 +541,7 @@ impl UpdateWorkers {
                     match result {
                         Ok(_) => {}
                         // Still queued: abort recovery and retry on a later wake-up.
-                        Err(err) if err.failed_update_disposition().queues_for_recovery() => {
+                        Err(err) if err.update_failure_kind().queues_for_recovery() => {
                             return Err(err);
                         }
                         // A permanent decline can never succeed; skip it like WAL replay does

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -833,9 +833,19 @@ mod tests {
             false,
         );
 
+        // Cancel once the first apply has failed and queued the operation, not after a fixed
+        // delay: from that point the worker is provably past picking the operation up and into
+        // the retry logic, so cancelling cannot race the outer receive loop and drop the
+        // feedback channel instead.
+        let queued = segments.clone();
         let cancel_after = cancel.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(200)).await;
+            loop {
+                if !queued.read().failed_operation.is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
             cancel_after.cancel();
         });
 

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -74,11 +74,6 @@ impl UpdateWorkers {
                     wait_for_deferred,
                     hw_measurements,
                 }) => {
-                    let collection_name_clone = collection_name.clone();
-                    let wal_clone = wal.clone();
-                    let update_operation_lock_clone = update_operation_lock.clone();
-                    let update_tracker_clone = update_tracker.clone();
-
                     let operation = if let Some(operation) = operation {
                         *operation
                     } else {
@@ -119,21 +114,82 @@ impl UpdateWorkers {
                     };
 
                     let wait = sender.is_some();
-                    let segments_clone = segments.clone();
-                    let operation_result = tokio::task::spawn_blocking(move || {
-                        Self::update_worker_internal(
-                            collection_name_clone,
-                            operation,
-                            op_num,
-                            wait,
-                            wal_clone,
-                            segments_clone,
-                            update_operation_lock_clone,
-                            update_tracker_clone,
-                            hw_measurements,
-                        )
-                    })
-                    .await;
+
+                    // Apply the operation, retrying inline when it failed because every
+                    // appendable segment reached the size cap: wake the optimizer (its wake-up
+                    // provisions a fresh appendable segment) and re-apply once capacity is
+                    // back. Re-applying is safe: points already applied are skipped by their
+                    // version, exactly as in WAL replay. The caller thus sees added latency
+                    // instead of a transient failure. Should capacity not reappear in time,
+                    // fall through with the error: the operation is queued in
+                    // `failed_operation` and asynchronous recovery re-applies it later.
+                    //
+                    // Retry rounds are bounded, and each round only proceeds once capacity is
+                    // actually available, so every round makes progress worth a segment's
+                    // capacity.
+                    const CAPACITY_RETRIES_MAX: usize = 64;
+                    const CAPACITY_POLL_INTERVAL: std::time::Duration =
+                        std::time::Duration::from_millis(5);
+                    const CAPACITY_WAIT_PER_ROUND: std::time::Duration =
+                        std::time::Duration::from_secs(5);
+
+                    let mut capacity_retries = 0;
+                    let operation_result = loop {
+                        let collection_name_clone = collection_name.clone();
+                        let operation_clone = operation.clone();
+                        let wal_clone = wal.clone();
+                        let segments_clone = segments.clone();
+                        let update_operation_lock_clone = update_operation_lock.clone();
+                        let update_tracker_clone = update_tracker.clone();
+                        let hw_measurements_clone = hw_measurements.clone();
+                        let result = tokio::task::spawn_blocking(move || {
+                            Self::update_worker_internal(
+                                collection_name_clone,
+                                operation_clone,
+                                op_num,
+                                wait,
+                                wal_clone,
+                                segments_clone,
+                                update_operation_lock_clone,
+                                update_tracker_clone,
+                                hw_measurements_clone,
+                            )
+                        })
+                        .await;
+
+                        let out_of_capacity =
+                            matches!(&result, Ok(Err(err)) if err.is_out_of_appendable_capacity());
+                        if !out_of_capacity || capacity_retries >= CAPACITY_RETRIES_MAX {
+                            break result;
+                        }
+                        capacity_retries += 1;
+
+                        // Capacity may already be back: the optimizer wake-up triggered by a
+                        // previous operation provisions concurrently. Otherwise wake it up and
+                        // wait for the fresh segment.
+                        let has_capacity = |segments: &LockedSegmentHolder| {
+                            let segments_read = segments.read();
+                            let cap = segments_read.max_segment_size_bytes();
+                            segments_read.has_appendable_segment_with_capacity(cap)
+                        };
+                        if !has_capacity(&segments) {
+                            let _ = optimize_sender.send(OptimizerSignal::Nop).await;
+
+                            let round_deadline = Instant::now() + CAPACITY_WAIT_PER_ROUND;
+                            let capacity_appeared = loop {
+                                if has_capacity(&segments) {
+                                    break true;
+                                }
+                                if Instant::now() >= round_deadline {
+                                    break false;
+                                }
+                                tokio::time::sleep(CAPACITY_POLL_INTERVAL).await;
+                            };
+                            if !capacity_appeared {
+                                break result;
+                            }
+                        }
+                    };
 
                     let res = match operation_result {
                         Ok(Ok(update_res)) => optimize_sender

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -146,14 +146,23 @@ impl UpdateWorkers {
                             Some(operation) => operation,
                             None => {
                                 let wal_clone = wal.clone();
-                                let reread = tokio::task::spawn_blocking(move || {
+                                let read_result = tokio::task::spawn_blocking(move || {
                                     wal_clone.blocking_lock().read_raw_record(op_num)
                                 })
-                                .await
-                                .ok()
-                                .flatten()
-                                .and_then(|record| record.deserialize().ok())
-                                .map(|deserialized| deserialized.operation);
+                                .await;
+                                let reread = match read_result {
+                                    Ok(record) => record
+                                        .and_then(|record| record.deserialize().ok())
+                                        .map(|deserialized| deserialized.operation),
+                                    // A panicked or cancelled blocking task is not a missing
+                                    // record: surface the real failure instead of masking it as
+                                    // one. Breaking with an applied-operation error rather than
+                                    // the join error keeps the transient handling below, which
+                                    // nudges the optimizer to recover the queued operation.
+                                    Err(join_error) => {
+                                        break Ok(Err(CollectionError::from(join_error)));
+                                    }
+                                };
                                 match reread {
                                     Some(operation) => operation,
                                     None => {
@@ -628,7 +637,8 @@ mod tests {
     /// A capacity failure must not surface to the client: the worker signals the optimizer, waits
     /// for the fresh appendable segment and re-applies the operation, so the caller sees added
     /// latency instead of an error. The re-apply reads the operation back from the WAL rather than
-    /// keeping a clone, so this also locks that the queued operation is readable at its op number.
+    /// keeping a clone, so this also verifies that the queued operation is readable at its op
+    /// number.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_update_worker_retries_capacity_failure_inline() {
         let segments_dir = Builder::new().prefix("segments").tempdir().unwrap();

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -137,7 +137,7 @@ impl UpdateWorkers {
 
                     let mut operation = Some(operation);
                     let mut retry_deadline = None;
-                    let mut capacity_retries = 0;
+                    let mut retried_before = false;
                     let operation_result = loop {
                         // The first attempt consumes the operation; the rare retry rounds
                         // re-read it from WAL instead of deep-cloning every operation on the
@@ -199,7 +199,8 @@ impl UpdateWorkers {
                         if Instant::now() >= deadline {
                             break result;
                         }
-                        capacity_retries += 1;
+                        let repeat_retry = retried_before;
+                        retried_before = true;
 
                         // Capacity may already be back: the optimizer wake-up triggered by a
                         // previous operation provisions concurrently. Otherwise wake it up and
@@ -234,7 +235,7 @@ impl UpdateWorkers {
                             if !capacity_appeared {
                                 break result;
                             }
-                        } else if capacity_retries > 1 {
+                        } else if repeat_retry {
                             // Consecutive immediate retries mean this wait predicate and the
                             // apply path keep disagreeing (a segment can measure differently
                             // under momentary lock contention): back off briefly instead of

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -476,3 +476,190 @@ impl UpdateWorkers {
         result
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+    use std::sync::atomic::AtomicBool;
+    use std::time::Duration;
+
+    use common::counter::hardware_counter::HardwareCounterCell;
+    use common::types::DeferredBehavior;
+    use segment::data_types::vectors::only_default_vector;
+    use segment::entry::entry_point::SegmentEntry as _;
+    use segment::payload_json;
+    use segment::types::{PayloadContainer, WithPayload};
+    use shard::operations::OperationWithClockTag;
+    use shard::retrieve::retrieve_blocking::retrieve_blocking;
+    use shard::segment_holder::SegmentHolder;
+    use shard::wal::{SerdeWal, WalRawRecord};
+    use tempfile::Builder;
+    use tokio::sync::{Mutex as TokioMutex, mpsc};
+    use wal::WalOptions;
+
+    use super::*;
+    use crate::collection_manager::fixtures::{TEST_TIMEOUT, empty_segment};
+    use crate::operations::payload_ops::{PayloadOps, SetPayloadOp};
+
+    /// Fixture segments hold dim-4 f32 vectors: 16 bytes per point.
+    const TEST_POINT_SIZE_BYTES: usize = 16;
+
+    /// An operation that has to CoW-move `points` out of their non-appendable segment, which is
+    /// what needs insert capacity.
+    fn set_payload_op(points: &[u64], color: &str) -> CollectionUpdateOperations {
+        CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(SetPayloadOp {
+            payload: payload_json! {"color": color},
+            points: Some(points.iter().map(|id| (*id).into()).collect()),
+            filter: None,
+            key: None,
+        }))
+    }
+
+    /// A capacity failure must not surface to the client: the worker signals the optimizer, waits
+    /// for the fresh appendable segment and re-applies the operation, so the caller sees added
+    /// latency instead of an error. The re-apply reads the operation back from the WAL rather than
+    /// keeping a clone, so this also locks that the queued operation is readable at its op number.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_update_worker_retries_capacity_failure_inline() {
+        let segments_dir = Builder::new().prefix("segments").tempdir().unwrap();
+        let wal_dir = Builder::new().prefix("wal").tempdir().unwrap();
+        let shard_dir = Builder::new().prefix("shard").tempdir().unwrap();
+
+        let hw_counter = HardwareCounterCell::new();
+        let vector = only_default_vector(&[1.0, 0.0, 1.0, 1.0]);
+
+        // The points to move live in a non-appendable segment, so setting their payload needs a
+        // CoW move into an appendable one. Seeded at version 0 so the replayed operation, whose
+        // op number is a WAL index, is not skipped as already applied.
+        let mut non_appendable = empty_segment(segments_dir.path());
+        for point_id in [1u64, 2] {
+            non_appendable
+                .upsert_point(0, point_id.into(), vector.clone(), &hw_counter)
+                .unwrap();
+        }
+        non_appendable.appendable_flag = false;
+
+        // The only appendable segment, already at the cap of two points.
+        let mut appendable = empty_segment(segments_dir.path());
+        for point_id in [100u64, 101] {
+            appendable
+                .upsert_point(0, point_id.into(), vector.clone(), &hw_counter)
+                .unwrap();
+        }
+
+        let mut holder = SegmentHolder::default();
+        holder.add_new(non_appendable);
+        holder.add_new(appendable);
+        holder.set_max_segment_size_bytes(NonZeroUsize::new(2 * TEST_POINT_SIZE_BYTES));
+        let segments = LockedSegmentHolder::new(holder);
+
+        let mut wal: SerdeWal<OperationWithClockTag> =
+            SerdeWal::new(wal_dir.path(), WalOptions::default()).unwrap();
+        // Filler so the operation under test lands above the seeded point version of 0.
+        wal.write(
+            &WalRawRecord::new(&OperationWithClockTag::new(
+                set_payload_op(&[], "filler"),
+                None,
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        let operation = set_payload_op(&[1, 2], "blue");
+        let op_num = wal
+            .write(
+                &WalRawRecord::new(&OperationWithClockTag::new(operation.clone(), None)).unwrap(),
+            )
+            .unwrap();
+        assert!(op_num > 0, "the operation must outrank the seeded points");
+
+        let (update_sender, update_receiver) = mpsc::channel(8);
+        let (optimize_sender, mut optimize_receiver) = mpsc::channel(8);
+        let (optimization_finished_sender, optimization_finished_receiver) = watch::channel(());
+
+        // Stands in for the optimization worker: its wake-up provisions one fresh appendable
+        // segment. Provisioning only once also asserts that a single round is enough here.
+        let optimizer_segments = segments.clone();
+        let optimizer_dir = segments_dir.path().to_owned();
+        let optimizer = tokio::spawn(async move {
+            let mut provisioned = 0;
+            while let Some(signal) = optimize_receiver.recv().await {
+                if matches!(signal, OptimizerSignal::Nop) && provisioned == 0 {
+                    provisioned += 1;
+                    let fresh = empty_segment(&optimizer_dir);
+                    optimizer_segments.write().add_new(fresh);
+                    let _ = optimization_finished_sender.send(());
+                }
+            }
+            provisioned
+        });
+
+        let worker = tokio::spawn(UpdateWorkers::update_worker_fn(
+            "test_collection".to_string(),
+            update_receiver,
+            optimize_sender,
+            Arc::new(TokioMutex::new(wal)),
+            segments.clone(),
+            Arc::new(tokio::sync::RwLock::new(())),
+            UpdateTracker::default(),
+            false,
+            optimization_finished_receiver,
+            Arc::new(AppliedSeqHandler::load_or_init(shard_dir.path(), op_num)),
+            CancellationToken::new(),
+        ));
+
+        let (feedback_sender, feedback_receiver) = oneshot::channel();
+        update_sender
+            .send(UpdateSignal::Operation(OperationData {
+                op_num,
+                operation: Some(Box::new(operation)),
+                sender: Some(feedback_sender),
+                wait_for_deferred: false,
+                hw_measurements: HwMeasurementAcc::disposable(),
+            }))
+            .await
+            .unwrap();
+
+        let result = tokio::time::timeout(Duration::from_secs(60), feedback_receiver)
+            .await
+            .expect("the worker must answer within the retry budget")
+            .expect("the worker must not drop the feedback channel");
+        result.expect("the inline retry must turn the capacity failure into a success");
+
+        assert!(
+            segments.read().failed_operation.is_empty(),
+            "the successful re-apply must unpin the WAL acknowledge",
+        );
+
+        let is_stopped = AtomicBool::new(false);
+        let records = retrieve_blocking(
+            segments,
+            &[1.into(), 2.into()],
+            &WithPayload::from(true),
+            &false.into(),
+            TEST_TIMEOUT,
+            &is_stopped,
+            HwMeasurementAcc::new(),
+            DeferredBehavior::VisibleOnly,
+        )
+        .unwrap();
+        assert_eq!(records.len(), 2, "both moved points must survive the retry");
+        for record in records.values() {
+            assert_eq!(
+                record.payload.as_ref().and_then(|payload| payload
+                    .get_value(&"color".parse().unwrap())
+                    .first()
+                    .cloned()),
+                Some(&serde_json::json!("blue")),
+                "the retry must actually apply the operation, not just report success",
+            );
+        }
+
+        drop(update_sender);
+        worker.await.unwrap();
+        assert_eq!(
+            optimizer.await.unwrap(),
+            1,
+            "the worker must have signalled the optimizer to provision capacity",
+        );
+    }
+}

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -124,16 +124,19 @@ impl UpdateWorkers {
                     // fall through with the error: the operation is queued in
                     // `failed_operation` and asynchronous recovery re-applies it later.
                     //
-                    // Retry rounds are bounded, and each round only proceeds once capacity is
-                    // actually available, so every round makes progress worth a segment's
-                    // capacity.
-                    const CAPACITY_RETRIES_MAX: usize = 64;
+                    // Retries are bounded by a wall-clock budget rather than a round count:
+                    // rounds differ wildly in cost, and this worker handles one operation at a
+                    // time, so the budget is exactly what a single operation may hold the
+                    // shard's update queue for.
+                    const CAPACITY_RETRY_BUDGET: std::time::Duration =
+                        std::time::Duration::from_secs(30);
                     const CAPACITY_WAIT_SLICE: std::time::Duration =
                         std::time::Duration::from_millis(100);
                     const CAPACITY_WAIT_PER_ROUND: std::time::Duration =
                         std::time::Duration::from_secs(5);
 
                     let mut operation = Some(operation);
+                    let mut retry_deadline = None;
                     let mut capacity_retries = 0;
                     let operation_result = loop {
                         // The first attempt consumes the operation; the rare retry rounds
@@ -186,7 +189,14 @@ impl UpdateWorkers {
 
                         let out_of_capacity =
                             matches!(&result, Ok(Err(err)) if err.is_out_of_appendable_capacity());
-                        if !out_of_capacity || capacity_retries >= CAPACITY_RETRIES_MAX {
+                        if !out_of_capacity {
+                            break result;
+                        }
+                        // The budget clock starts at the first capacity failure, so it covers
+                        // the retries only and not the initial apply.
+                        let deadline = *retry_deadline
+                            .get_or_insert_with(|| Instant::now() + CAPACITY_RETRY_BUDGET);
+                        if Instant::now() >= deadline {
                             break result;
                         }
                         capacity_retries += 1;
@@ -206,7 +216,8 @@ impl UpdateWorkers {
                             // the timeout slice doubles as a fallback re-check, since not
                             // every wake-up path fires the signal promptly.
                             let mut optimization_finished = optimization_finished_receiver.clone();
-                            let round_deadline = Instant::now() + CAPACITY_WAIT_PER_ROUND;
+                            let round_deadline =
+                                deadline.min(Instant::now() + CAPACITY_WAIT_PER_ROUND);
                             let capacity_appeared = loop {
                                 if has_capacity(&segments) {
                                     break true;

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -128,15 +128,42 @@ impl UpdateWorkers {
                     // actually available, so every round makes progress worth a segment's
                     // capacity.
                     const CAPACITY_RETRIES_MAX: usize = 64;
-                    const CAPACITY_POLL_INTERVAL: std::time::Duration =
-                        std::time::Duration::from_millis(5);
+                    const CAPACITY_WAIT_SLICE: std::time::Duration =
+                        std::time::Duration::from_millis(100);
                     const CAPACITY_WAIT_PER_ROUND: std::time::Duration =
                         std::time::Duration::from_secs(5);
 
+                    let mut operation = Some(operation);
                     let mut capacity_retries = 0;
                     let operation_result = loop {
+                        // The first attempt consumes the operation; the rare retry rounds
+                        // re-read it from WAL instead of deep-cloning every operation on the
+                        // hot path.
+                        let attempt_operation = match operation.take() {
+                            Some(operation) => operation,
+                            None => {
+                                let wal_clone = wal.clone();
+                                let reread = tokio::task::spawn_blocking(move || {
+                                    wal_clone.blocking_lock().read_raw_record(op_num)
+                                })
+                                .await
+                                .ok()
+                                .flatten()
+                                .and_then(|record| record.deserialize().ok())
+                                .map(|deserialized| deserialized.operation);
+                                match reread {
+                                    Some(operation) => operation,
+                                    None => {
+                                        break Ok(Err(CollectionError::service_error(format!(
+                                            "Operation {op_num} could not be re-read from WAL \
+                                             for a capacity retry"
+                                        ))));
+                                    }
+                                }
+                            }
+                        };
+
                         let collection_name_clone = collection_name.clone();
-                        let operation_clone = operation.clone();
                         let wal_clone = wal.clone();
                         let segments_clone = segments.clone();
                         let update_operation_lock_clone = update_operation_lock.clone();
@@ -145,7 +172,7 @@ impl UpdateWorkers {
                         let result = tokio::task::spawn_blocking(move || {
                             Self::update_worker_internal(
                                 collection_name_clone,
-                                operation_clone,
+                                attempt_operation,
                                 op_num,
                                 wait,
                                 wal_clone,
@@ -175,19 +202,33 @@ impl UpdateWorkers {
                         if !has_capacity(&segments) {
                             let _ = optimize_sender.send(OptimizerSignal::Nop).await;
 
+                            // Wake early on the optimizer's `optimization_finished` signal;
+                            // the timeout slice doubles as a fallback re-check, since not
+                            // every wake-up path fires the signal promptly.
+                            let mut optimization_finished = optimization_finished_receiver.clone();
                             let round_deadline = Instant::now() + CAPACITY_WAIT_PER_ROUND;
                             let capacity_appeared = loop {
                                 if has_capacity(&segments) {
                                     break true;
                                 }
-                                if Instant::now() >= round_deadline {
+                                let now = Instant::now();
+                                if now >= round_deadline {
                                     break false;
                                 }
-                                tokio::time::sleep(CAPACITY_POLL_INTERVAL).await;
+                                let slice = CAPACITY_WAIT_SLICE.min(round_deadline - now);
+                                let _ =
+                                    tokio::time::timeout(slice, optimization_finished.changed())
+                                        .await;
                             };
                             if !capacity_appeared {
                                 break result;
                             }
+                        } else if capacity_retries > 1 {
+                            // Consecutive immediate retries mean this wait predicate and the
+                            // apply path keep disagreeing (a segment can measure differently
+                            // under momentary lock contention): back off briefly instead of
+                            // hot-looping full re-applications.
+                            tokio::time::sleep(CAPACITY_WAIT_SLICE).await;
                         }
                     };
 

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -201,6 +201,13 @@ impl UpdateWorkers {
                         if !out_of_capacity {
                             break result;
                         }
+                        // Stop retrying once this worker is asked to stop: `wait_workers_stops`
+                        // awaits this task, so a retry in flight would hold up shard drops and
+                        // the worker restart an optimizer config update performs. The operation
+                        // stays queued in `failed_operation`, where recovery picks it up.
+                        if cancel.is_cancelled() {
+                            break result;
+                        }
                         // The budget clock starts at the first capacity failure, so it covers
                         // the retries only and not the initial apply.
                         let deadline = *retry_deadline
@@ -237,9 +244,14 @@ impl UpdateWorkers {
                                     break false;
                                 }
                                 let slice = CAPACITY_WAIT_SLICE.min(round_deadline - now);
-                                let _ =
-                                    tokio::time::timeout(slice, optimization_finished.changed())
-                                        .await;
+                                tokio::select! {
+                                    biased; // biased to check cancellation first
+                                    _ = cancel.cancelled() => break false,
+                                    _ = tokio::time::timeout(
+                                        slice,
+                                        optimization_finished.changed(),
+                                    ) => {}
+                                }
                             };
                             if !capacity_appeared {
                                 break result;
@@ -572,6 +584,7 @@ mod tests {
         mpsc::Sender<UpdateSignal>,
         JoinHandle<Receiver<UpdateSignal>>,
         JoinHandle<usize>,
+        CancellationToken,
     ) {
         let (update_sender, update_receiver) = mpsc::channel(8);
         let (optimize_sender, mut optimize_receiver) = mpsc::channel(8);
@@ -594,6 +607,7 @@ mod tests {
         });
 
         let last_wal_index = wal.first_index() + wal.len(false);
+        let cancel = CancellationToken::new();
         let worker = tokio::spawn(UpdateWorkers::update_worker_fn(
             "test_collection".to_string(),
             update_receiver,
@@ -605,10 +619,10 @@ mod tests {
             false,
             optimization_finished_receiver,
             Arc::new(AppliedSeqHandler::load_or_init(shard_dir, last_wal_index)),
-            CancellationToken::new(),
+            cancel.clone(),
         ));
 
-        (update_sender, worker, optimizer)
+        (update_sender, worker, optimizer, cancel)
     }
 
     async fn submit(
@@ -666,7 +680,7 @@ mod tests {
             .unwrap();
         assert!(op_num > 0, "the operation must outrank the seeded points");
 
-        let (update_sender, worker, optimizer) = spawn_worker(
+        let (update_sender, worker, optimizer, _cancel) = spawn_worker(
             segments.clone(),
             wal,
             shard_dir.path(),
@@ -749,7 +763,7 @@ mod tests {
             .unwrap();
 
         // The stand-in optimizer never provisions, so capacity never returns.
-        let (update_sender, worker, optimizer) = spawn_worker(
+        let (update_sender, worker, optimizer, _cancel) = spawn_worker(
             segments.clone(),
             wal,
             shard_dir.path(),
@@ -781,6 +795,80 @@ mod tests {
         optimizer.await.unwrap();
     }
 
+    /// A retry in flight must give up as soon as the worker is asked to stop: `wait_workers_stops`
+    /// awaits this task, so holding on for the round wait would delay shard drops and the worker
+    /// restart an optimizer config update performs. Fails without the cancellation checks, where
+    /// the worker keeps waiting for capacity for a full `CAPACITY_WAIT_PER_ROUND`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_update_worker_stops_retrying_when_cancelled() {
+        let segments_dir = Builder::new().prefix("segments").tempdir().unwrap();
+        let wal_dir = Builder::new().prefix("wal").tempdir().unwrap();
+        let shard_dir = Builder::new().prefix("shard").tempdir().unwrap();
+
+        let segments = segments_at_capacity(segments_dir.path());
+
+        let mut wal: SerdeWal<OperationWithClockTag> =
+            SerdeWal::new(wal_dir.path(), WalOptions::default()).unwrap();
+        wal.write(
+            &WalRawRecord::new(&OperationWithClockTag::new(
+                set_payload_op(&[], "filler"),
+                None,
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        let operation = set_payload_op(&[1, 2], "blue");
+        let op_num = wal
+            .write(
+                &WalRawRecord::new(&OperationWithClockTag::new(operation.clone(), None)).unwrap(),
+            )
+            .unwrap();
+
+        // The stand-in optimizer never provisions, so the worker settles into the retry wait.
+        let (update_sender, worker, optimizer, cancel) = spawn_worker(
+            segments.clone(),
+            wal,
+            shard_dir.path(),
+            segments_dir.path(),
+            false,
+        );
+
+        let cancel_after = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            cancel_after.cancel();
+        });
+
+        let started = Instant::now();
+        let err = submit(&update_sender, op_num, operation)
+            .await
+            .expect_err("a cancelled worker cannot apply the operation");
+        assert!(
+            err.is_out_of_appendable_capacity(),
+            "expected the capacity error, got: {err}",
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "the worker must abandon the retry on cancellation, took {:?}",
+            started.elapsed(),
+        );
+
+        assert_eq!(
+            segments
+                .read()
+                .failed_operation
+                .iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![op_num],
+            "the abandoned operation stays queued for recovery",
+        );
+
+        drop(update_sender);
+        worker.await.unwrap();
+        optimizer.await.unwrap();
+    }
+
     /// The retry re-reads the operation from WAL instead of keeping a clone on the hot path. If it
     /// is not there, the worker must report that rather than silently reporting success or hanging.
     #[tokio::test(flavor = "multi_thread")]
@@ -805,7 +893,7 @@ mod tests {
         // only the retry goes looking for it on disk.
         let op_num = wal.first_index() + wal.len(false) + 5;
 
-        let (update_sender, worker, optimizer) = spawn_worker(
+        let (update_sender, worker, optimizer, _cancel) = spawn_worker(
             segments.clone(),
             wal,
             shard_dir.path(),

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -141,7 +141,18 @@ impl UpdateWorkers {
                             .await
                             .and(Ok(update_res))
                             .map_err(|send_err| send_err.into()),
-                        Ok(Err(err)) => Err(err),
+                        Ok(Err(err)) => {
+                            // A transient failure (e.g. all appendable segments reached
+                            // `max_segment_size`) was queued in `failed_operation`. Wake the
+                            // optimizer so its capacity-ensure step can provision a fresh
+                            // appendable segment and `try_recover` re-applies the operation.
+                            // `Nop` rather than `Operation`: it must run recovery even when
+                            // optimization handles are maxed out.
+                            if err.is_transient() {
+                                let _ = optimize_sender.send(OptimizerSignal::Nop).await;
+                            }
+                            Err(err)
+                        }
                         Err(err) => Err(CollectionError::from(err)),
                     };
 

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -480,6 +480,7 @@ impl UpdateWorkers {
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroUsize;
+    use std::path::Path;
     use std::sync::atomic::AtomicBool;
     use std::time::Duration;
 
@@ -495,6 +496,7 @@ mod tests {
     use shard::wal::{SerdeWal, WalRawRecord};
     use tempfile::Builder;
     use tokio::sync::{Mutex as TokioMutex, mpsc};
+    use tokio::task::JoinHandle;
     use wal::WalOptions;
 
     use super::*;
@@ -515,23 +517,16 @@ mod tests {
         }))
     }
 
-    /// A capacity failure must not surface to the client: the worker signals the optimizer, waits
-    /// for the fresh appendable segment and re-applies the operation, so the caller sees added
-    /// latency instead of an error. The re-apply reads the operation back from the WAL rather than
-    /// keeping a clone, so this also locks that the queued operation is readable at its op number.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_update_worker_retries_capacity_failure_inline() {
-        let segments_dir = Builder::new().prefix("segments").tempdir().unwrap();
-        let wal_dir = Builder::new().prefix("wal").tempdir().unwrap();
-        let shard_dir = Builder::new().prefix("shard").tempdir().unwrap();
-
+    /// Points 1 and 2 in a non-appendable segment, plus the only appendable segment already at the
+    /// cap: any CoW move out of the first has nowhere to land.
+    ///
+    /// The points are seeded at version 0 so a replayed operation, whose op number is a WAL index,
+    /// is not skipped as already applied.
+    fn segments_at_capacity(segments_dir: &Path) -> LockedSegmentHolder {
         let hw_counter = HardwareCounterCell::new();
         let vector = only_default_vector(&[1.0, 0.0, 1.0, 1.0]);
 
-        // The points to move live in a non-appendable segment, so setting their payload needs a
-        // CoW move into an appendable one. Seeded at version 0 so the replayed operation, whose
-        // op number is a WAL index, is not skipped as already applied.
-        let mut non_appendable = empty_segment(segments_dir.path());
+        let mut non_appendable = empty_segment(segments_dir);
         for point_id in [1u64, 2] {
             non_appendable
                 .upsert_point(0, point_id.into(), vector.clone(), &hw_counter)
@@ -539,8 +534,7 @@ mod tests {
         }
         non_appendable.appendable_flag = false;
 
-        // The only appendable segment, already at the cap of two points.
-        let mut appendable = empty_segment(segments_dir.path());
+        let mut appendable = empty_segment(segments_dir);
         for point_id in [100u64, 101] {
             appendable
                 .upsert_point(0, point_id.into(), vector.clone(), &hw_counter)
@@ -551,7 +545,97 @@ mod tests {
         holder.add_new(non_appendable);
         holder.add_new(appendable);
         holder.set_max_segment_size_bytes(NonZeroUsize::new(2 * TEST_POINT_SIZE_BYTES));
-        let segments = LockedSegmentHolder::new(holder);
+        LockedSegmentHolder::new(holder)
+    }
+
+    /// Start an update worker with a stand-in optimization worker.
+    ///
+    /// The stand-in provisions one fresh appendable segment on its first `Nop` when
+    /// `provision_capacity` is set, mimicking the capacity-ensure step of a real wake-up. It
+    /// reports how many it provisioned, which doubles as an assertion that the worker asked.
+    fn spawn_worker(
+        segments: LockedSegmentHolder,
+        wal: SerdeWal<OperationWithClockTag>,
+        shard_dir: &Path,
+        segments_dir: &Path,
+        provision_capacity: bool,
+    ) -> (
+        mpsc::Sender<UpdateSignal>,
+        JoinHandle<Receiver<UpdateSignal>>,
+        JoinHandle<usize>,
+    ) {
+        let (update_sender, update_receiver) = mpsc::channel(8);
+        let (optimize_sender, mut optimize_receiver) = mpsc::channel(8);
+        let (optimization_finished_sender, optimization_finished_receiver) = watch::channel(());
+
+        let optimizer_segments = segments.clone();
+        let optimizer_dir = segments_dir.to_owned();
+        let optimizer = tokio::spawn(async move {
+            let mut provisioned = 0;
+            while let Some(signal) = optimize_receiver.recv().await {
+                if matches!(signal, OptimizerSignal::Nop) && provision_capacity && provisioned == 0
+                {
+                    provisioned += 1;
+                    let fresh = empty_segment(&optimizer_dir);
+                    optimizer_segments.write().add_new(fresh);
+                    let _ = optimization_finished_sender.send(());
+                }
+            }
+            provisioned
+        });
+
+        let last_wal_index = wal.first_index() + wal.len(false);
+        let worker = tokio::spawn(UpdateWorkers::update_worker_fn(
+            "test_collection".to_string(),
+            update_receiver,
+            optimize_sender,
+            Arc::new(TokioMutex::new(wal)),
+            segments,
+            Arc::new(tokio::sync::RwLock::new(())),
+            UpdateTracker::default(),
+            false,
+            optimization_finished_receiver,
+            Arc::new(AppliedSeqHandler::load_or_init(shard_dir, last_wal_index)),
+            CancellationToken::new(),
+        ));
+
+        (update_sender, worker, optimizer)
+    }
+
+    async fn submit(
+        update_sender: &mpsc::Sender<UpdateSignal>,
+        op_num: SeqNumberType,
+        operation: CollectionUpdateOperations,
+    ) -> CollectionResult<InternalUpdateResult> {
+        let (feedback_sender, feedback_receiver) = oneshot::channel();
+        update_sender
+            .send(UpdateSignal::Operation(OperationData {
+                op_num,
+                operation: Some(Box::new(operation)),
+                sender: Some(feedback_sender),
+                wait_for_deferred: false,
+                hw_measurements: HwMeasurementAcc::disposable(),
+            }))
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(60), feedback_receiver)
+            .await
+            .expect("the worker must answer within the retry budget")
+            .expect("the worker must not drop the feedback channel")
+    }
+
+    /// A capacity failure must not surface to the client: the worker signals the optimizer, waits
+    /// for the fresh appendable segment and re-applies the operation, so the caller sees added
+    /// latency instead of an error. The re-apply reads the operation back from the WAL rather than
+    /// keeping a clone, so this also locks that the queued operation is readable at its op number.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_update_worker_retries_capacity_failure_inline() {
+        let segments_dir = Builder::new().prefix("segments").tempdir().unwrap();
+        let wal_dir = Builder::new().prefix("wal").tempdir().unwrap();
+        let shard_dir = Builder::new().prefix("shard").tempdir().unwrap();
+
+        let segments = segments_at_capacity(segments_dir.path());
 
         let mut wal: SerdeWal<OperationWithClockTag> =
             SerdeWal::new(wal_dir.path(), WalOptions::default()).unwrap();
@@ -572,58 +656,17 @@ mod tests {
             .unwrap();
         assert!(op_num > 0, "the operation must outrank the seeded points");
 
-        let (update_sender, update_receiver) = mpsc::channel(8);
-        let (optimize_sender, mut optimize_receiver) = mpsc::channel(8);
-        let (optimization_finished_sender, optimization_finished_receiver) = watch::channel(());
-
-        // Stands in for the optimization worker: its wake-up provisions one fresh appendable
-        // segment. Provisioning only once also asserts that a single round is enough here.
-        let optimizer_segments = segments.clone();
-        let optimizer_dir = segments_dir.path().to_owned();
-        let optimizer = tokio::spawn(async move {
-            let mut provisioned = 0;
-            while let Some(signal) = optimize_receiver.recv().await {
-                if matches!(signal, OptimizerSignal::Nop) && provisioned == 0 {
-                    provisioned += 1;
-                    let fresh = empty_segment(&optimizer_dir);
-                    optimizer_segments.write().add_new(fresh);
-                    let _ = optimization_finished_sender.send(());
-                }
-            }
-            provisioned
-        });
-
-        let worker = tokio::spawn(UpdateWorkers::update_worker_fn(
-            "test_collection".to_string(),
-            update_receiver,
-            optimize_sender,
-            Arc::new(TokioMutex::new(wal)),
+        let (update_sender, worker, optimizer) = spawn_worker(
             segments.clone(),
-            Arc::new(tokio::sync::RwLock::new(())),
-            UpdateTracker::default(),
-            false,
-            optimization_finished_receiver,
-            Arc::new(AppliedSeqHandler::load_or_init(shard_dir.path(), op_num)),
-            CancellationToken::new(),
-        ));
+            wal,
+            shard_dir.path(),
+            segments_dir.path(),
+            true,
+        );
 
-        let (feedback_sender, feedback_receiver) = oneshot::channel();
-        update_sender
-            .send(UpdateSignal::Operation(OperationData {
-                op_num,
-                operation: Some(Box::new(operation)),
-                sender: Some(feedback_sender),
-                wait_for_deferred: false,
-                hw_measurements: HwMeasurementAcc::disposable(),
-            }))
+        submit(&update_sender, op_num, operation)
             .await
-            .unwrap();
-
-        let result = tokio::time::timeout(Duration::from_secs(60), feedback_receiver)
-            .await
-            .expect("the worker must answer within the retry budget")
-            .expect("the worker must not drop the feedback channel");
-        result.expect("the inline retry must turn the capacity failure into a success");
+            .expect("the inline retry must turn the capacity failure into a success");
 
         assert!(
             segments.read().failed_operation.is_empty(),
@@ -660,6 +703,120 @@ mod tests {
             optimizer.await.unwrap(),
             1,
             "the worker must have signalled the optimizer to provision capacity",
+        );
+    }
+
+    /// When capacity never comes back, the worker stops waiting and reports the capacity error.
+    /// The operation must then be queued in `failed_operation` so asynchronous recovery owns it,
+    /// and stay pinned there so the WAL keeps it replayable.
+    ///
+    /// Takes one `CAPACITY_WAIT_PER_ROUND` to run: the round wait is what expires here, well
+    /// before the overall retry budget, which is only a backstop for rounds that keep seeing
+    /// capacity appear and still fail.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_update_worker_hands_over_to_recovery_when_capacity_never_appears() {
+        let segments_dir = Builder::new().prefix("segments").tempdir().unwrap();
+        let wal_dir = Builder::new().prefix("wal").tempdir().unwrap();
+        let shard_dir = Builder::new().prefix("shard").tempdir().unwrap();
+
+        let segments = segments_at_capacity(segments_dir.path());
+
+        let mut wal: SerdeWal<OperationWithClockTag> =
+            SerdeWal::new(wal_dir.path(), WalOptions::default()).unwrap();
+        wal.write(
+            &WalRawRecord::new(&OperationWithClockTag::new(
+                set_payload_op(&[], "filler"),
+                None,
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        let operation = set_payload_op(&[1, 2], "blue");
+        let op_num = wal
+            .write(
+                &WalRawRecord::new(&OperationWithClockTag::new(operation.clone(), None)).unwrap(),
+            )
+            .unwrap();
+
+        // The stand-in optimizer never provisions, so capacity never returns.
+        let (update_sender, worker, optimizer) = spawn_worker(
+            segments.clone(),
+            wal,
+            shard_dir.path(),
+            segments_dir.path(),
+            false,
+        );
+
+        let err = submit(&update_sender, op_num, operation)
+            .await
+            .expect_err("without capacity the operation cannot succeed");
+        assert!(
+            err.is_out_of_appendable_capacity(),
+            "expected the capacity error, got: {err}",
+        );
+
+        assert_eq!(
+            segments
+                .read()
+                .failed_operation
+                .iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![op_num],
+            "the operation must be queued for recovery and pin the WAL acknowledge",
+        );
+
+        drop(update_sender);
+        worker.await.unwrap();
+        optimizer.await.unwrap();
+    }
+
+    /// The retry re-reads the operation from WAL instead of keeping a clone on the hot path. If it
+    /// is not there, the worker must report that rather than silently reporting success or hanging.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_update_worker_reports_unreadable_wal_record_on_retry() {
+        let segments_dir = Builder::new().prefix("segments").tempdir().unwrap();
+        let wal_dir = Builder::new().prefix("wal").tempdir().unwrap();
+        let shard_dir = Builder::new().prefix("shard").tempdir().unwrap();
+
+        let segments = segments_at_capacity(segments_dir.path());
+
+        let mut wal: SerdeWal<OperationWithClockTag> =
+            SerdeWal::new(wal_dir.path(), WalOptions::default()).unwrap();
+        wal.write(
+            &WalRawRecord::new(&OperationWithClockTag::new(
+                set_payload_op(&[], "filler"),
+                None,
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        // Past the end of the WAL: the first attempt uses the operation passed with the signal, and
+        // only the retry goes looking for it on disk.
+        let op_num = wal.first_index() + wal.len(false) + 5;
+
+        let (update_sender, worker, optimizer) = spawn_worker(
+            segments.clone(),
+            wal,
+            shard_dir.path(),
+            segments_dir.path(),
+            true,
+        );
+
+        let err = submit(&update_sender, op_num, set_payload_op(&[1, 2], "blue"))
+            .await
+            .expect_err("the retry cannot proceed without the operation");
+        assert!(
+            err.to_string().contains("could not be re-read from WAL"),
+            "expected the re-read failure, got: {err}",
+        );
+
+        drop(update_sender);
+        worker.await.unwrap();
+        assert_eq!(
+            optimizer.await.unwrap(),
+            1,
+            "the worker must have reached the retry, which is what re-reads the WAL",
         );
     }
 }

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -377,7 +377,7 @@ impl UpdateWorkers {
                             // appendable segment and `try_recover` re-applies the operation.
                             // `Nop` rather than `Operation`: it must run recovery even when
                             // optimization handles are maxed out.
-                            if err.failed_update_disposition().queues_for_recovery() {
+                            if err.update_failure_kind().queues_for_recovery() {
                                 let _ = optimize_sender.send(OptimizerSignal::Nop).await;
                             }
                             Err(err)

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -123,13 +123,12 @@ struct CapacityRetry<'a> {
 }
 
 impl CapacityRetry<'_> {
-    /// Apply `operation`, retrying inline when it fails because every appendable segment reached
-    /// the size cap. Each retry wakes the optimizer (its wake-up provisions a fresh appendable
-    /// segment) and re-applies once capacity is back; already-applied points are skipped by their
-    /// version, exactly as in WAL replay, so the caller sees added latency instead of a transient
-    /// failure. If capacity does not reappear within [`CAPACITY_RETRY_BUDGET`], or the worker is
-    /// cancelled, the capacity error is returned: the operation is queued in `failed_operation`
-    /// and asynchronous recovery re-applies it later.
+    /// Apply `operation`, retrying inline on capacity failures: wake the optimizer (its wake-up
+    /// provisions a fresh appendable segment) and re-apply once capacity is back, with
+    /// already-applied points skipped by version as in WAL replay, so the caller sees latency
+    /// instead of a transient failure. On cancellation or a spent [`CAPACITY_RETRY_BUDGET`] the
+    /// capacity error is returned; the operation stays queued in `failed_operation` for
+    /// asynchronous recovery.
     async fn run(
         &self,
         operation: CollectionUpdateOperations,
@@ -618,33 +617,39 @@ mod tests {
     use common::types::DeferredBehavior;
     use segment::data_types::vectors::only_default_vector;
     use segment::entry::entry_point::SegmentEntry as _;
-    use segment::payload_json;
     use segment::types::{PayloadContainer, WithPayload};
     use shard::operations::OperationWithClockTag;
     use shard::retrieve::retrieve_blocking::retrieve_blocking;
     use shard::segment_holder::SegmentHolder;
-    use shard::wal::{SerdeWal, WalRawRecord};
+    use shard::wal::SerdeWal;
     use tempfile::Builder;
     use tokio::sync::{Mutex as TokioMutex, mpsc};
     use tokio::task::JoinHandle;
     use wal::WalOptions;
 
     use super::*;
-    use crate::collection_manager::fixtures::{TEST_TIMEOUT, empty_segment};
-    use crate::operations::payload_ops::{PayloadOps, SetPayloadOp};
+    use crate::collection_manager::fixtures::{
+        TEST_TIMEOUT, empty_segment, set_payload_op, write_op,
+    };
 
     /// Fixture segments hold dim-4 f32 vectors: 16 bytes per point.
     const TEST_POINT_SIZE_BYTES: usize = 16;
 
-    /// An operation that has to CoW-move `points` out of their non-appendable segment, which is
-    /// what needs insert capacity.
-    fn set_payload_op(points: &[u64], color: &str) -> CollectionUpdateOperations {
-        CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(SetPayloadOp {
-            payload: payload_json! {"color": color},
-            points: Some(points.iter().map(|id| (*id).into()).collect()),
-            filter: None,
-            key: None,
-        }))
+    /// A WAL holding a filler operation (so the operation under test outranks the seeded point
+    /// version of 0) followed by the `set_payload` on points 1 and 2 that needs CoW capacity.
+    fn wal_with_move_op(
+        wal_dir: &Path,
+    ) -> (
+        SerdeWal<OperationWithClockTag>,
+        CollectionUpdateOperations,
+        SeqNumberType,
+    ) {
+        let mut wal = SerdeWal::new(wal_dir, WalOptions::default()).unwrap();
+        write_op(&mut wal, &set_payload_op(&[], "filler"));
+        let operation = set_payload_op(&[1, 2], "blue");
+        let op_num = write_op(&mut wal, &operation);
+        assert!(op_num > 0, "the operation must outrank the seeded points");
+        (wal, operation, op_num)
     }
 
     /// Points 1 and 2 in a non-appendable segment, plus the only appendable segment already at the
@@ -769,25 +774,7 @@ mod tests {
         let shard_dir = Builder::new().prefix("shard").tempdir().unwrap();
 
         let segments = segments_at_capacity(segments_dir.path());
-
-        let mut wal: SerdeWal<OperationWithClockTag> =
-            SerdeWal::new(wal_dir.path(), WalOptions::default()).unwrap();
-        // Filler so the operation under test lands above the seeded point version of 0.
-        wal.write(
-            &WalRawRecord::new(&OperationWithClockTag::new(
-                set_payload_op(&[], "filler"),
-                None,
-            ))
-            .unwrap(),
-        )
-        .unwrap();
-        let operation = set_payload_op(&[1, 2], "blue");
-        let op_num = wal
-            .write(
-                &WalRawRecord::new(&OperationWithClockTag::new(operation.clone(), None)).unwrap(),
-            )
-            .unwrap();
-        assert!(op_num > 0, "the operation must outrank the seeded points");
+        let (wal, operation, op_num) = wal_with_move_op(wal_dir.path());
 
         let (update_sender, worker, optimizer, _cancel) = spawn_worker(
             segments.clone(),
@@ -853,23 +840,7 @@ mod tests {
         let shard_dir = Builder::new().prefix("shard").tempdir().unwrap();
 
         let segments = segments_at_capacity(segments_dir.path());
-
-        let mut wal: SerdeWal<OperationWithClockTag> =
-            SerdeWal::new(wal_dir.path(), WalOptions::default()).unwrap();
-        wal.write(
-            &WalRawRecord::new(&OperationWithClockTag::new(
-                set_payload_op(&[], "filler"),
-                None,
-            ))
-            .unwrap(),
-        )
-        .unwrap();
-        let operation = set_payload_op(&[1, 2], "blue");
-        let op_num = wal
-            .write(
-                &WalRawRecord::new(&OperationWithClockTag::new(operation.clone(), None)).unwrap(),
-            )
-            .unwrap();
+        let (wal, operation, op_num) = wal_with_move_op(wal_dir.path());
 
         // The stand-in optimizer never provisions, so capacity never returns.
         let (update_sender, worker, optimizer, _cancel) = spawn_worker(
@@ -915,23 +886,7 @@ mod tests {
         let shard_dir = Builder::new().prefix("shard").tempdir().unwrap();
 
         let segments = segments_at_capacity(segments_dir.path());
-
-        let mut wal: SerdeWal<OperationWithClockTag> =
-            SerdeWal::new(wal_dir.path(), WalOptions::default()).unwrap();
-        wal.write(
-            &WalRawRecord::new(&OperationWithClockTag::new(
-                set_payload_op(&[], "filler"),
-                None,
-            ))
-            .unwrap(),
-        )
-        .unwrap();
-        let operation = set_payload_op(&[1, 2], "blue");
-        let op_num = wal
-            .write(
-                &WalRawRecord::new(&OperationWithClockTag::new(operation.clone(), None)).unwrap(),
-            )
-            .unwrap();
+        let (wal, operation, op_num) = wal_with_move_op(wal_dir.path());
 
         // The stand-in optimizer never provisions, so the worker settles into the retry wait.
         let (update_sender, worker, optimizer, cancel) = spawn_worker(
@@ -1000,14 +955,7 @@ mod tests {
 
         let mut wal: SerdeWal<OperationWithClockTag> =
             SerdeWal::new(wal_dir.path(), WalOptions::default()).unwrap();
-        wal.write(
-            &WalRawRecord::new(&OperationWithClockTag::new(
-                set_payload_op(&[], "filler"),
-                None,
-            ))
-            .unwrap(),
-        )
-        .unwrap();
+        write_op(&mut wal, &set_payload_op(&[], "filler"));
         // Past the end of the WAL: the first attempt uses the operation passed with the signal, and
         // only the retry goes looking for it on disk.
         let op_num = wal.first_index() + wal.len(false) + 5;

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use cancel::CancellationToken;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
@@ -33,6 +33,245 @@ fn send_feedback(
         feedback.send(result).unwrap_or_else(|_| {
             log::debug!("Can't report operation {op_num} result. Assume already not required");
         });
+    }
+}
+
+/// How long a single operation may hold the shard's update queue while retrying a capacity
+/// failure. Wall-clock rather than a round count: rounds differ wildly in cost, and this worker
+/// handles one operation at a time, so the budget is exactly what a single operation may hold the
+/// queue for.
+const CAPACITY_RETRY_BUDGET: Duration = Duration::from_secs(30);
+/// Poll slice while waiting for the optimizer to provision capacity; also the backoff between
+/// consecutive immediate re-applies.
+const CAPACITY_WAIT_SLICE: Duration = Duration::from_millis(100);
+/// Cap on one wake-and-wait round, so a single round cannot consume the whole retry budget.
+const CAPACITY_WAIT_PER_ROUND: Duration = Duration::from_secs(5);
+
+/// Outcome of [`CapacityRetry::wait_for_optimizer`].
+enum OptimizerWait {
+    /// The wanted segment state appeared.
+    Satisfied,
+    /// The worker was cancelled while waiting.
+    Cancelled,
+    /// The deadline passed before the state appeared.
+    TimedOut,
+}
+
+/// Outcome of one [`wait_optimizer_round`].
+enum OptimizerRound {
+    /// The optimizer reported it finished a cycle (`optimization_finished` fired).
+    Progressed,
+    /// The wait slice elapsed without a signal (only possible when a slice is given); the caller
+    /// re-checks its condition.
+    SliceElapsed,
+    /// The cancellation token fired.
+    Cancelled,
+    /// The optimizer's notifier closed, i.e. the optimization worker stopped.
+    Stopped,
+}
+
+/// Re-signal the optimizer and wait for it to make progress. This is the one place both the
+/// capacity retry and the deferred-points wait poke the optimizer (`Nop`, in case the previous
+/// signal was consumed without launching an optimization) and wait on `optimization_finished`.
+/// Returns when the optimizer reports progress, the optional `slice` elapses (a fallback re-check
+/// for callers whose condition can change without a signal), cancellation fires, or the notifier
+/// closes. Callers own the surrounding loop, their readiness predicate, and any extra abort.
+async fn wait_optimizer_round(
+    optimize_sender: &Sender<OptimizerSignal>,
+    optimization_finished: &mut watch::Receiver<()>,
+    cancel: &CancellationToken,
+    slice: Option<Duration>,
+) -> OptimizerRound {
+    let _ = optimize_sender.try_send(OptimizerSignal::Nop);
+    let changed = optimization_finished.changed();
+    match slice {
+        Some(slice) => tokio::select! {
+            biased; // biased to check cancellation first
+            _ = cancel.cancelled() => OptimizerRound::Cancelled,
+            result = tokio::time::timeout(slice, changed) => match result {
+                Ok(Ok(())) => OptimizerRound::Progressed,
+                Ok(Err(_)) => OptimizerRound::Stopped,
+                Err(_elapsed) => OptimizerRound::SliceElapsed,
+            },
+        },
+        None => tokio::select! {
+            biased;
+            _ = cancel.cancelled() => OptimizerRound::Cancelled,
+            result = changed => match result {
+                Ok(()) => OptimizerRound::Progressed,
+                Err(_) => OptimizerRound::Stopped,
+            },
+        },
+    }
+}
+
+/// The shared collaborators the update worker threads into applying one operation with capacity
+/// retry. Grouping them keeps [`CapacityRetry::run`] and [`CapacityRetry::wait_for_optimizer`]
+/// from re-taking the same eight values as arguments.
+struct CapacityRetry<'a> {
+    collection_name: &'a CollectionId,
+    wal: &'a LockedWal,
+    segments: &'a LockedSegmentHolder,
+    update_operation_lock: &'a Arc<tokio::sync::RwLock<()>>,
+    update_tracker: &'a UpdateTracker,
+    optimize_sender: &'a Sender<OptimizerSignal>,
+    optimization_finished: &'a watch::Receiver<()>,
+    cancel: &'a CancellationToken,
+}
+
+impl CapacityRetry<'_> {
+    /// Apply `operation`, retrying inline when it fails because every appendable segment reached
+    /// the size cap. Each retry wakes the optimizer (its wake-up provisions a fresh appendable
+    /// segment) and re-applies once capacity is back; already-applied points are skipped by their
+    /// version, exactly as in WAL replay, so the caller sees added latency instead of a transient
+    /// failure. If capacity does not reappear within [`CAPACITY_RETRY_BUDGET`], or the worker is
+    /// cancelled, the capacity error is returned: the operation is queued in `failed_operation`
+    /// and asynchronous recovery re-applies it later.
+    async fn run(
+        &self,
+        operation: CollectionUpdateOperations,
+        op_num: SeqNumberType,
+        wait: bool,
+        hw_measurements: HwMeasurementAcc,
+    ) -> Result<CollectionResult<usize>, tokio::task::JoinError> {
+        let has_capacity = |segments: &LockedSegmentHolder| {
+            let segments_read = segments.read();
+            let cap = segments_read.max_segment_size_bytes();
+            segments_read.has_appendable_segment_with_capacity(cap)
+        };
+
+        let mut operation = Some(operation);
+        let mut retry_deadline = None;
+        let mut retried_before = false;
+        loop {
+            // The first attempt consumes the operation; the rare retry rounds re-read it from WAL
+            // instead of deep-cloning every operation on the hot path.
+            let attempt_operation = match operation.take() {
+                Some(operation) => operation,
+                None => {
+                    let wal_clone = self.wal.clone();
+                    let read_result = tokio::task::spawn_blocking(move || {
+                        wal_clone.blocking_lock().read_raw_record(op_num)
+                    })
+                    .await;
+                    let reread = match read_result {
+                        Ok(record) => record
+                            .and_then(|record| record.deserialize().ok())
+                            .map(|deserialized| deserialized.operation),
+                        // A panicked or cancelled blocking task is not a missing record: surface
+                        // the real failure instead of masking it as one. Returning an
+                        // applied-operation error rather than the join error keeps the transient
+                        // handling at the call site, which nudges the optimizer to recover the
+                        // queued operation.
+                        Err(join_error) => return Ok(Err(CollectionError::from(join_error))),
+                    };
+                    match reread {
+                        Some(operation) => operation,
+                        None => {
+                            return Ok(Err(CollectionError::service_error(format!(
+                                "Operation {op_num} could not be re-read from WAL for a capacity \
+                                 retry"
+                            ))));
+                        }
+                    }
+                }
+            };
+
+            let result = tokio::task::spawn_blocking({
+                let collection_name = self.collection_name.clone();
+                let wal = self.wal.clone();
+                let segments = self.segments.clone();
+                let update_operation_lock = self.update_operation_lock.clone();
+                let update_tracker = self.update_tracker.clone();
+                let hw_measurements = hw_measurements.clone();
+                move || {
+                    UpdateWorkers::update_worker_internal(
+                        collection_name,
+                        attempt_operation,
+                        op_num,
+                        wait,
+                        wal,
+                        segments,
+                        update_operation_lock,
+                        update_tracker,
+                        hw_measurements,
+                    )
+                }
+            })
+            .await;
+
+            let out_of_capacity =
+                matches!(&result, Ok(Err(err)) if err.is_out_of_appendable_capacity());
+            if !out_of_capacity {
+                return result;
+            }
+            // Stop retrying once this worker is asked to stop: `wait_workers_stops` awaits this
+            // task, so a retry in flight would hold up shard drops and the worker restart an
+            // optimizer config update performs. The operation stays queued in `failed_operation`,
+            // where recovery picks it up.
+            if self.cancel.is_cancelled() {
+                return result;
+            }
+            // The budget clock starts at the first capacity failure, so it covers the retries only
+            // and not the initial apply.
+            let deadline =
+                *retry_deadline.get_or_insert_with(|| Instant::now() + CAPACITY_RETRY_BUDGET);
+            if Instant::now() >= deadline {
+                return result;
+            }
+            let repeat_retry = retried_before;
+            retried_before = true;
+
+            // Capacity may already be back: the optimizer wake-up triggered by a previous
+            // operation provisions concurrently. Otherwise wake it up and wait for the fresh
+            // segment.
+            if !has_capacity(self.segments) {
+                let round_deadline = deadline.min(Instant::now() + CAPACITY_WAIT_PER_ROUND);
+                match self.wait_for_optimizer(round_deadline, has_capacity).await {
+                    OptimizerWait::Satisfied => {}
+                    OptimizerWait::Cancelled | OptimizerWait::TimedOut => return result,
+                }
+            } else if repeat_retry {
+                // Consecutive immediate retries mean this wait predicate and the apply path keep
+                // disagreeing (a segment can measure differently under momentary lock contention):
+                // back off briefly instead of hot-looping full re-applications.
+                tokio::time::sleep(CAPACITY_WAIT_SLICE).await;
+            }
+        }
+    }
+
+    /// Wait until `ready(segments)` holds, cancellation fires, or `deadline` passes, driving the
+    /// optimizer via [`wait_optimizer_round`] each round. The slice timeout is a fallback re-check,
+    /// since capacity can also appear from a concurrent operation's optimizer wake-up without an
+    /// `optimization_finished` signal.
+    async fn wait_for_optimizer(
+        &self,
+        deadline: Instant,
+        ready: impl Fn(&LockedSegmentHolder) -> bool,
+    ) -> OptimizerWait {
+        let mut optimization_finished = self.optimization_finished.clone();
+        loop {
+            if ready(self.segments) {
+                return OptimizerWait::Satisfied;
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                return OptimizerWait::TimedOut;
+            }
+            let slice = CAPACITY_WAIT_SLICE.min(deadline - now);
+            // Progressed / SliceElapsed / Stopped all just re-check the predicate and deadline: a
+            // stopped optimizer cannot flip the predicate, so the deadline ends the wait.
+            if let OptimizerRound::Cancelled = wait_optimizer_round(
+                self.optimize_sender,
+                &mut optimization_finished,
+                self.cancel,
+                Some(slice),
+            )
+            .await
+            {
+                return OptimizerWait::Cancelled;
+            }
+        }
     }
 }
 
@@ -115,155 +354,21 @@ impl UpdateWorkers {
 
                     let wait = sender.is_some();
 
-                    // Apply the operation, retrying inline when it failed because every
-                    // appendable segment reached the size cap: wake the optimizer (its wake-up
-                    // provisions a fresh appendable segment) and re-apply once capacity is
-                    // back. Re-applying is safe: points already applied are skipped by their
-                    // version, exactly as in WAL replay. The caller thus sees added latency
-                    // instead of a transient failure. Should capacity not reappear in time,
-                    // fall through with the error: the operation is queued in
-                    // `failed_operation` and asynchronous recovery re-applies it later.
-                    //
-                    // Retries are bounded by a wall-clock budget rather than a round count:
-                    // rounds differ wildly in cost, and this worker handles one operation at a
-                    // time, so the budget is exactly what a single operation may hold the
-                    // shard's update queue for.
-                    const CAPACITY_RETRY_BUDGET: std::time::Duration =
-                        std::time::Duration::from_secs(30);
-                    const CAPACITY_WAIT_SLICE: std::time::Duration =
-                        std::time::Duration::from_millis(100);
-                    const CAPACITY_WAIT_PER_ROUND: std::time::Duration =
-                        std::time::Duration::from_secs(5);
-
-                    let mut operation = Some(operation);
-                    let mut retry_deadline = None;
-                    let mut retried_before = false;
-                    let operation_result = loop {
-                        // The first attempt consumes the operation; the rare retry rounds
-                        // re-read it from WAL instead of deep-cloning every operation on the
-                        // hot path.
-                        let attempt_operation = match operation.take() {
-                            Some(operation) => operation,
-                            None => {
-                                let wal_clone = wal.clone();
-                                let read_result = tokio::task::spawn_blocking(move || {
-                                    wal_clone.blocking_lock().read_raw_record(op_num)
-                                })
-                                .await;
-                                let reread = match read_result {
-                                    Ok(record) => record
-                                        .and_then(|record| record.deserialize().ok())
-                                        .map(|deserialized| deserialized.operation),
-                                    // A panicked or cancelled blocking task is not a missing
-                                    // record: surface the real failure instead of masking it as
-                                    // one. Breaking with an applied-operation error rather than
-                                    // the join error keeps the transient handling below, which
-                                    // nudges the optimizer to recover the queued operation.
-                                    Err(join_error) => {
-                                        break Ok(Err(CollectionError::from(join_error)));
-                                    }
-                                };
-                                match reread {
-                                    Some(operation) => operation,
-                                    None => {
-                                        break Ok(Err(CollectionError::service_error(format!(
-                                            "Operation {op_num} could not be re-read from WAL \
-                                             for a capacity retry"
-                                        ))));
-                                    }
-                                }
-                            }
-                        };
-
-                        let collection_name_clone = collection_name.clone();
-                        let wal_clone = wal.clone();
-                        let segments_clone = segments.clone();
-                        let update_operation_lock_clone = update_operation_lock.clone();
-                        let update_tracker_clone = update_tracker.clone();
-                        let hw_measurements_clone = hw_measurements.clone();
-                        let result = tokio::task::spawn_blocking(move || {
-                            Self::update_worker_internal(
-                                collection_name_clone,
-                                attempt_operation,
-                                op_num,
-                                wait,
-                                wal_clone,
-                                segments_clone,
-                                update_operation_lock_clone,
-                                update_tracker_clone,
-                                hw_measurements_clone,
-                            )
-                        })
-                        .await;
-
-                        let out_of_capacity =
-                            matches!(&result, Ok(Err(err)) if err.is_out_of_appendable_capacity());
-                        if !out_of_capacity {
-                            break result;
-                        }
-                        // Stop retrying once this worker is asked to stop: `wait_workers_stops`
-                        // awaits this task, so a retry in flight would hold up shard drops and
-                        // the worker restart an optimizer config update performs. The operation
-                        // stays queued in `failed_operation`, where recovery picks it up.
-                        if cancel.is_cancelled() {
-                            break result;
-                        }
-                        // The budget clock starts at the first capacity failure, so it covers
-                        // the retries only and not the initial apply.
-                        let deadline = *retry_deadline
-                            .get_or_insert_with(|| Instant::now() + CAPACITY_RETRY_BUDGET);
-                        if Instant::now() >= deadline {
-                            break result;
-                        }
-                        let repeat_retry = retried_before;
-                        retried_before = true;
-
-                        // Capacity may already be back: the optimizer wake-up triggered by a
-                        // previous operation provisions concurrently. Otherwise wake it up and
-                        // wait for the fresh segment.
-                        let has_capacity = |segments: &LockedSegmentHolder| {
-                            let segments_read = segments.read();
-                            let cap = segments_read.max_segment_size_bytes();
-                            segments_read.has_appendable_segment_with_capacity(cap)
-                        };
-                        if !has_capacity(&segments) {
-                            let _ = optimize_sender.send(OptimizerSignal::Nop).await;
-
-                            // Wake early on the optimizer's `optimization_finished` signal;
-                            // the timeout slice doubles as a fallback re-check, since not
-                            // every wake-up path fires the signal promptly.
-                            let mut optimization_finished = optimization_finished_receiver.clone();
-                            let round_deadline =
-                                deadline.min(Instant::now() + CAPACITY_WAIT_PER_ROUND);
-                            let capacity_appeared = loop {
-                                if has_capacity(&segments) {
-                                    break true;
-                                }
-                                let now = Instant::now();
-                                if now >= round_deadline {
-                                    break false;
-                                }
-                                let slice = CAPACITY_WAIT_SLICE.min(round_deadline - now);
-                                tokio::select! {
-                                    biased; // biased to check cancellation first
-                                    _ = cancel.cancelled() => break false,
-                                    _ = tokio::time::timeout(
-                                        slice,
-                                        optimization_finished.changed(),
-                                    ) => {}
-                                }
-                            };
-                            if !capacity_appeared {
-                                break result;
-                            }
-                        } else if repeat_retry {
-                            // Consecutive immediate retries mean this wait predicate and the
-                            // apply path keep disagreeing (a segment can measure differently
-                            // under momentary lock contention): back off briefly instead of
-                            // hot-looping full re-applications.
-                            tokio::time::sleep(CAPACITY_WAIT_SLICE).await;
-                        }
-                    };
+                    // Apply the operation, retrying inline when every appendable segment reached
+                    // the size cap so the caller sees added latency instead of a transient
+                    // failure. See `CapacityRetry::run`.
+                    let operation_result = CapacityRetry {
+                        collection_name: &collection_name,
+                        wal: &wal,
+                        segments: &segments,
+                        update_operation_lock: &update_operation_lock,
+                        update_tracker: &update_tracker,
+                        optimize_sender: &optimize_sender,
+                        optimization_finished: &optimization_finished_receiver,
+                        cancel: &cancel,
+                    }
+                    .run(operation, op_num, wait, hw_measurements)
+                    .await;
 
                     let res = match operation_result {
                         Ok(Ok(update_res)) => optimize_sender
@@ -404,39 +509,40 @@ impl UpdateWorkers {
                 return Ok(());
             }
 
-            // The only way to make deferred points visible is optimization.
-            // Send Nop to re-trigger optimizers in case the previous signal was
-            // consumed without launching an optimization.
-            let _ = optimize_sender.try_send(OptimizerSignal::Nop);
-
-            // Wait for the optimizer to check conditions or complete an optimization.
-            // Also wake up if the update handler is restarted (e.g. config change via
-            // consensus) or the caller's receiver is dropped (e.g. update_local's
-            // outer timeout fired). Without the `closed()` branch, this select would
-            // park forever under max_optimization_threads=0 (the optimizer skips
-            // without notifying), leaking the detached task.
+            // The only way to make deferred points visible is optimization. Poke it and wait for
+            // progress through the shared round, racing the caller giving up (its receiver
+            // dropped, e.g. update_local's outer timeout fired). Without that race the wait could
+            // park forever under max_optimization_threads=0 (the optimizer skips without
+            // notifying), leaking the detached task.
             log::debug!("waiting for optimization to allow updates");
             tokio::select! {
                 biased;
-                _ = cancel.cancelled() => {
-                    log::debug!("wait_for_deferred_points_ready: update worker cancelled");
-                    return Err(CollectionError::cancelled(
-                        "Deferred points wait interrupted: update worker restarted"
-                    ));
-                }
                 _ = feedback_sender.closed() => {
                     log::debug!("wait_for_deferred_points_ready: caller no longer waiting");
                     return Err(CollectionError::cancelled(
                         "Deferred points wait interrupted: caller timed out",
                     ));
                 }
-                result = optimization_finished_receiver.changed() => {
-                    if let Err(err) = result {
-                        log::warn!("wait_for_deferred_points_ready: optimization notifier closed: {err}");
+                round = wait_optimizer_round(
+                    optimize_sender,
+                    optimization_finished_receiver,
+                    cancel,
+                    None,
+                ) => match round {
+                    OptimizerRound::Cancelled => {
+                        log::debug!("wait_for_deferred_points_ready: update worker cancelled");
                         return Err(CollectionError::cancelled(
-                            "Deferred points wait interrupted: optimization worker stopped"
+                            "Deferred points wait interrupted: update worker restarted",
                         ));
                     }
+                    OptimizerRound::Stopped => {
+                        log::warn!("wait_for_deferred_points_ready: optimization notifier closed");
+                        return Err(CollectionError::cancelled(
+                            "Deferred points wait interrupted: optimization worker stopped",
+                        ));
+                    }
+                    // No slice is given, so `SliceElapsed` cannot occur; both loop and re-check.
+                    OptimizerRound::Progressed | OptimizerRound::SliceElapsed => {}
                 }
             }
         }

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -380,13 +380,13 @@ impl UpdateWorkers {
                             .and(Ok(update_res))
                             .map_err(|send_err| send_err.into()),
                         Ok(Err(err)) => {
-                            // A transient failure (e.g. all appendable segments reached
-                            // `max_segment_size`) was queued in `failed_operation`. Wake the
+                            // A queued failure (e.g. all appendable segments reached
+                            // `max_segment_size`) sits in `failed_operation`. Wake the
                             // optimizer so its capacity-ensure step can provision a fresh
                             // appendable segment and `try_recover` re-applies the operation.
                             // `Nop` rather than `Operation`: it must run recovery even when
                             // optimization handles are maxed out.
-                            if err.is_transient() {
+                            if err.failed_update_disposition().queues_for_recovery() {
                                 let _ = optimize_sender.send(OptimizerSignal::Nop).await;
                             }
                             Err(err)

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -44,7 +44,10 @@ const CAPACITY_RETRY_BUDGET: Duration = Duration::from_secs(30);
 /// Poll slice while waiting for the optimizer to provision capacity; also the backoff between
 /// consecutive immediate re-applies.
 const CAPACITY_WAIT_SLICE: Duration = Duration::from_millis(100);
-/// Cap on one wake-and-wait round, so a single round cannot consume the whole retry budget.
+/// How long one wake-and-wait round may wait for capacity to appear. If it expires, the retry
+/// gives up and hands the operation to asynchronous recovery: an optimizer that produced nothing
+/// for this long is unlikely to within the budget, which only backstops repeated rounds where
+/// capacity keeps appearing and the re-apply still fails (an operation spanning many segments).
 const CAPACITY_WAIT_PER_ROUND: Duration = Duration::from_secs(5);
 
 /// Outcome of [`CapacityRetry::wait_for_optimizer`].

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -161,10 +161,8 @@ impl CapacityRetry<'_> {
                             .and_then(|record| record.deserialize().ok())
                             .map(|deserialized| deserialized.operation),
                         // A panicked or cancelled blocking task is not a missing record: surface
-                        // the real failure instead of masking it as one. Returning an
-                        // applied-operation error rather than the join error keeps the transient
-                        // handling at the call site, which nudges the optimizer to recover the
-                        // queued operation.
+                        // the real failure as a transient error, so the call site still nudges
+                        // the optimizer to recover the queued operation.
                         Err(join_error) => return Ok(Err(CollectionError::from(join_error))),
                     };
                     match reread {

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -111,6 +112,7 @@ struct CapacityRetry<'a> {
     segments: &'a LockedSegmentHolder,
     update_operation_lock: &'a Arc<tokio::sync::RwLock<()>>,
     update_tracker: &'a UpdateTracker,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     optimize_sender: &'a Sender<OptimizerSignal>,
     optimization_finished: &'a watch::Receiver<()>,
     cancel: &'a CancellationToken,
@@ -131,9 +133,9 @@ impl CapacityRetry<'_> {
         hw_measurements: HwMeasurementAcc,
     ) -> Result<CollectionResult<usize>, tokio::task::JoinError> {
         let has_capacity = |segments: &LockedSegmentHolder| {
-            let segments_read = segments.read();
-            let cap = segments_read.max_segment_size_bytes();
-            segments_read.has_appendable_segment_with_capacity(cap)
+            segments
+                .read()
+                .has_appendable_segment_with_capacity(self.max_segment_size_bytes)
         };
 
         let mut operation = Some(operation);
@@ -177,6 +179,7 @@ impl CapacityRetry<'_> {
                 let segments = self.segments.clone();
                 let update_operation_lock = self.update_operation_lock.clone();
                 let update_tracker = self.update_tracker.clone();
+                let max_segment_size_bytes = self.max_segment_size_bytes;
                 let hw_measurements = hw_measurements.clone();
                 move || {
                     UpdateWorkers::update_worker_internal(
@@ -188,6 +191,7 @@ impl CapacityRetry<'_> {
                         segments,
                         update_operation_lock,
                         update_tracker,
+                        max_segment_size_bytes,
                         hw_measurements,
                     )
                 }
@@ -283,6 +287,7 @@ impl UpdateWorkers {
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
         prevent_unoptimized: bool,
+        max_segment_size_bytes: Option<NonZeroUsize>,
         optimization_finished_receiver: watch::Receiver<()>,
         applied_seq_handler: Arc<AppliedSeqHandler>,
         cancel: CancellationToken,
@@ -357,6 +362,7 @@ impl UpdateWorkers {
                         segments: &segments,
                         update_operation_lock: &update_operation_lock,
                         update_tracker: &update_tracker,
+                        max_segment_size_bytes,
                         optimize_sender: &optimize_sender,
                         optimization_finished: &optimization_finished_receiver,
                         cancel: &cancel,
@@ -552,6 +558,7 @@ impl UpdateWorkers {
         segments: LockedSegmentHolder,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
+        max_segment_size_bytes: Option<NonZeroUsize>,
         hw_measurements: HwMeasurementAcc,
     ) -> CollectionResult<usize> {
         // If wait flag is set, explicitly flush WAL first
@@ -578,6 +585,7 @@ impl UpdateWorkers {
                 operation,
                 update_operation_lock.clone(),
                 update_tracker.clone(),
+                max_segment_size_bytes,
                 &hw_measurements.get_counter_cell(),
             )
         });
@@ -669,8 +677,12 @@ mod tests {
         let mut holder = SegmentHolder::default();
         holder.add_new(non_appendable);
         holder.add_new(appendable);
-        holder.set_max_segment_size_bytes(NonZeroUsize::new(2 * TEST_POINT_SIZE_BYTES));
         LockedSegmentHolder::new(holder)
+    }
+
+    /// The cap under which the [`segments_at_capacity`] appendable segment is already full.
+    fn test_cap() -> Option<NonZeroUsize> {
+        NonZeroUsize::new(2 * TEST_POINT_SIZE_BYTES)
     }
 
     /// Start an update worker with a stand-in optimization worker, which provisions one fresh
@@ -720,6 +732,7 @@ mod tests {
             Arc::new(tokio::sync::RwLock::new(())),
             UpdateTracker::default(),
             false,
+            test_cap(),
             optimization_finished_receiver,
             Arc::new(AppliedSeqHandler::load_or_init(shard_dir, last_wal_index)),
             cancel.clone(),

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -52,11 +52,8 @@ const CAPACITY_WAIT_PER_ROUND: Duration = Duration::from_secs(5);
 
 /// Outcome of [`CapacityRetry::wait_for_optimizer`].
 enum OptimizerWait {
-    /// The wanted segment state appeared.
     Satisfied,
-    /// The worker was cancelled while waiting.
     Cancelled,
-    /// The deadline passed before the state appeared.
     TimedOut,
 }
 
@@ -73,12 +70,10 @@ enum OptimizerRound {
     Stopped,
 }
 
-/// Re-signal the optimizer and wait for it to make progress. This is the one place both the
-/// capacity retry and the deferred-points wait poke the optimizer (`Nop`, in case the previous
-/// signal was consumed without launching an optimization) and wait on `optimization_finished`.
-/// Returns when the optimizer reports progress, the optional `slice` elapses (a fallback re-check
-/// for callers whose condition can change without a signal), cancellation fires, or the notifier
-/// closes. Callers own the surrounding loop, their readiness predicate, and any extra abort.
+/// Re-signal the optimizer (`Nop`, in case the previous signal was consumed without launching an
+/// optimization) and wait on `optimization_finished`: the one wake-and-wait shared by the
+/// capacity retry and the deferred-points wait. Returns on progress, an elapsed `slice` (a
+/// fallback re-check), cancellation, or a closed notifier; callers own the loop and predicate.
 async fn wait_optimizer_round(
     optimize_sender: &Sender<OptimizerSignal>,
     optimization_finished: &mut watch::Receiver<()>,
@@ -109,8 +104,7 @@ async fn wait_optimizer_round(
 }
 
 /// The shared collaborators the update worker threads into applying one operation with capacity
-/// retry. Grouping them keeps [`CapacityRetry::run`] and [`CapacityRetry::wait_for_optimizer`]
-/// from re-taking the same eight values as arguments.
+/// retry.
 struct CapacityRetry<'a> {
     collection_name: &'a CollectionId,
     wal: &'a LockedWal,
@@ -650,11 +644,9 @@ mod tests {
         (wal, operation, op_num)
     }
 
-    /// Points 1 and 2 in a non-appendable segment, plus the only appendable segment already at the
-    /// cap: any CoW move out of the first has nowhere to land.
-    ///
-    /// The points are seeded at version 0 so a replayed operation, whose op number is a WAL index,
-    /// is not skipped as already applied.
+    /// Points 1 and 2 in a non-appendable segment, plus the only appendable segment already at
+    /// the cap: a CoW move has nowhere to land. Points are seeded at version 0 so replayed
+    /// operations (op number = WAL index) are not skipped as already applied.
     fn segments_at_capacity(segments_dir: &Path) -> LockedSegmentHolder {
         let hw_counter = HardwareCounterCell::new();
         let vector = only_default_vector(&[1.0, 0.0, 1.0, 1.0]);
@@ -681,11 +673,10 @@ mod tests {
         LockedSegmentHolder::new(holder)
     }
 
-    /// Start an update worker with a stand-in optimization worker.
-    ///
-    /// The stand-in provisions one fresh appendable segment on its first `Nop` when
-    /// `provision_capacity` is set, mimicking the capacity-ensure step of a real wake-up. It
-    /// reports how many it provisioned, which doubles as an assertion that the worker asked.
+    /// Start an update worker with a stand-in optimization worker, which provisions one fresh
+    /// appendable segment on its first `Nop` when `provision_capacity` is set (mimicking the
+    /// capacity-ensure step) and reports how many it provisioned, doubling as an assertion that
+    /// the worker asked.
     fn spawn_worker(
         segments: LockedSegmentHolder,
         wal: SerdeWal<OperationWithClockTag>,

--- a/lib/edge/src/edge_shard/update.rs
+++ b/lib/edge/src/edge_shard/update.rs
@@ -35,14 +35,19 @@ impl EdgeShard {
         let segments_guard = self.segments.read();
 
         let result = match operation {
-            CollectionUpdateOperations::PointOperation(point_operation) => {
-                process_point_operation(&segments_guard, operation_id, point_operation, &hw_counter)
-            }
+            CollectionUpdateOperations::PointOperation(point_operation) => process_point_operation(
+                &segments_guard,
+                operation_id,
+                point_operation,
+                None,
+                &hw_counter,
+            ),
             CollectionUpdateOperations::VectorOperation(vector_operation) => {
                 process_vector_operation(
                     &segments_guard,
                     operation_id,
                     vector_operation,
+                    None,
                     &hw_counter,
                 )
             }
@@ -51,6 +56,7 @@ impl EdgeShard {
                     &segments_guard,
                     operation_id,
                     payload_operation,
+                    None,
                     &hw_counter,
                 )
             }

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -94,8 +94,8 @@ pub enum OperationError {
     /// the operation; already-applied points are skipped by their point version.
     ///
     /// The message must keep starting with [`OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX`]: the
-    /// collection-level error conversion flattens this variant into a generic service error, and
-    /// the update worker recognizes the condition by that prefix.
+    /// collection-level error conversion flattens this variant into a generic shard-unavailable
+    /// error, and the update worker recognizes the condition by that prefix.
     #[error(
         "All appendable segments reached the maximum segment size of {max_segment_size_bytes} bytes"
     )]

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -92,11 +92,20 @@ pub enum OperationError {
     /// All appendable segments reached `max_segment_size`, so there is no valid destination for
     /// new or moved points. Recoverable by provisioning a fresh appendable segment and re-applying
     /// the operation; already-applied points are skipped by their point version.
+    ///
+    /// The message must keep starting with [`OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX`]: the
+    /// collection-level error conversion flattens this variant into a generic service error, and
+    /// the update worker recognizes the condition by that prefix.
     #[error(
         "All appendable segments reached the maximum segment size of {max_segment_size_bytes} bytes"
     )]
     OutOfAppendableCapacity { max_segment_size_bytes: usize },
 }
+
+/// Message prefix of [`OperationError::OutOfAppendableCapacity`], for recognizing the condition
+/// after the variant is flattened into an untyped error (locked by a test below).
+pub const OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX: &str =
+    "All appendable segments reached the maximum segment size";
 
 impl OperationError {
     /// Create a new service error with a description and a backtrace
@@ -438,6 +447,18 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+
+    #[test]
+    fn test_out_of_appendable_capacity_message_prefix() {
+        let err = OperationError::OutOfAppendableCapacity {
+            max_segment_size_bytes: 1024,
+        };
+        assert!(
+            err.to_string()
+                .starts_with(OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX),
+            "the update worker recognizes the flattened error by this prefix",
+        );
+    }
 
     #[test]
     fn test_not_found_classification() {

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -93,19 +93,14 @@ pub enum OperationError {
     /// new or moved points. Recoverable by provisioning a fresh appendable segment and re-applying
     /// the operation; already-applied points are skipped by their point version.
     ///
-    /// The message must keep starting with [`OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX`]: the
-    /// collection-level error conversion flattens this variant into a generic shard-unavailable
-    /// error, and the update worker recognizes the condition by that prefix.
+    /// The collection-level conversion preserves this condition as a typed
+    /// `ShardUnavailableReason::OutOfAppendableCapacity`, so consumers recognize it structurally
+    /// rather than by the message text.
     #[error(
         "All appendable segments reached the maximum segment size of {max_segment_size_bytes} bytes"
     )]
     OutOfAppendableCapacity { max_segment_size_bytes: usize },
 }
-
-/// Message prefix of [`OperationError::OutOfAppendableCapacity`], for recognizing the condition
-/// after the variant is flattened into an untyped error (locked by a test below).
-pub const OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX: &str =
-    "All appendable segments reached the maximum segment size";
 
 impl OperationError {
     /// Create a new service error with a description and a backtrace
@@ -447,18 +442,6 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
-
-    #[test]
-    fn test_out_of_appendable_capacity_message_prefix() {
-        let err = OperationError::OutOfAppendableCapacity {
-            max_segment_size_bytes: 1024,
-        };
-        assert!(
-            err.to_string()
-                .starts_with(OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX),
-            "the update worker recognizes the flattened error by this prefix",
-        );
-    }
 
     #[test]
     fn test_not_found_classification() {

--- a/lib/shard/src/operations/optimization.rs
+++ b/lib/shard/src/operations/optimization.rs
@@ -1,6 +1,9 @@
+use std::num::NonZeroUsize;
+
 use common::progress_tracker::ProgressTree;
 use common::types::PointOffsetType;
 use schemars::JsonSchema;
+use segment::common::BYTES_IN_KB;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -128,4 +131,14 @@ pub struct OptimizerThresholds {
     pub memmap_threshold_kb: usize,
     pub indexing_threshold_kb: usize,
     pub deferred_internal_id: Option<PointOffsetType>,
+}
+
+impl OptimizerThresholds {
+    /// The appendable-segment size cap in bytes, or `None` when `max_segment_size_kb` is zero
+    /// (uncapped). The single derivation of the cap: the shard arms the segment holder with it, the
+    /// update path checks destinations against it, and the optimizer's ensure step provisions
+    /// against it, so the three cannot disagree on what "full" means.
+    pub fn max_segment_size_bytes(&self) -> Option<NonZeroUsize> {
+        NonZeroUsize::new(self.max_segment_size_kb.saturating_mul(BYTES_IN_KB))
+    }
 }

--- a/lib/shard/src/resolve.rs
+++ b/lib/shard/src/resolve.rs
@@ -313,7 +313,7 @@ mod tests {
         let CollectionUpdateOperations::PointOperation(op) = resolved else {
             unreachable!()
         };
-        process_point_operation(&holder, 100, op, &hw_counter).unwrap();
+        process_point_operation(&holder, 100, op, None, &hw_counter).unwrap();
         delete_points_by_filter(&twin_holder, 100, &filter, &hw_counter).unwrap();
 
         let remaining = points_by_filter(&holder, &filter, &hw_counter).unwrap();

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -8,6 +8,7 @@ mod tests;
 
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::sync::Arc;
@@ -135,6 +136,16 @@ pub struct SegmentHolder {
     /// funnels through [`add_existing_locked`](Self::add_existing_locked) and
     /// [`remove`](Self::remove), which reconcile it.
     segment_manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>,
+
+    /// Soft cap on appendable segment size for the update path, mirroring the resolved optimizer
+    /// `max_segment_size_kb` threshold (set by the shard on load and on optimizer config updates).
+    ///
+    /// When set, the update path avoids inserting or CoW-moving points into appendable segments
+    /// whose vector size already reached the cap, and reports
+    /// [`OperationError::OutOfAppendableCapacity`] when no appendable segment is below it. `None`
+    /// disables capacity checks (the pre-existing behavior: any appendable segment is a valid
+    /// destination, regardless of size).
+    max_segment_size_bytes: Option<NonZeroUsize>,
 }
 
 impl Drop for SegmentHolder {
@@ -620,9 +631,115 @@ impl SegmentHolder {
             .collect()
     }
 
+    /// Set the soft cap on appendable segment size used by the update path.
+    ///
+    /// Mirrors the resolved optimizer `max_segment_size_kb` threshold; `None` disables capacity
+    /// checks. See [`SegmentHolder::max_segment_size_bytes`].
+    pub fn set_max_segment_size_bytes(&mut self, max_segment_size_bytes: Option<NonZeroUsize>) {
+        self.max_segment_size_bytes = max_segment_size_bytes;
+    }
+
+    pub fn max_segment_size_bytes(&self) -> Option<NonZeroUsize> {
+        self.max_segment_size_bytes
+    }
+
+    /// Whether at least one appendable segment is below the given size cap.
+    ///
+    /// `false` when there are no appendable segments at all. With no cap, any appendable segment
+    /// counts as having capacity. Segments that cannot be read-locked right now count as having
+    /// capacity: the cap is a soft limit and liveness wins over precision.
+    pub fn has_appendable_segment_with_capacity(
+        &self,
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> bool {
+        let appendable_segments = self.appendable_segments_ids();
+        !appendable_segments.is_empty()
+            && appendable_segments
+                .iter()
+                .any(|segment_id| self.segment_has_capacity(*segment_id, max_segment_size_bytes))
+    }
+
+    /// Whether the given segment's measured size is below the given cap.
+    ///
+    /// Unmeasurable segments (gone, read-lock contention, size errors) count as having capacity,
+    /// so that the soft cap never blocks progress on measurement issues alone.
+    fn segment_has_capacity(
+        &self,
+        segment_id: SegmentId,
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> bool {
+        let Some(max_segment_size_bytes) = max_segment_size_bytes else {
+            return true;
+        };
+        let Some(locked_segment) = self.get(segment_id) else {
+            return true;
+        };
+        let Some(segment) = locked_segment.get().try_read() else {
+            return true;
+        };
+        match segment.max_available_vectors_size_in_bytes() {
+            Ok(size) => size < max_segment_size_bytes.get(),
+            Err(err) => {
+                log::error!("Failed to get segment size, ignoring: {err}");
+                true
+            }
+        }
+    }
+
+    /// Appendable segments eligible as write destinations under the configured size cap, with
+    /// their measured sizes.
+    ///
+    /// Segments that cannot be measured right now (read-lock contention, size errors) stay
+    /// eligible and report `None`: the cap is a soft limit and liveness wins over precision.
+    /// With no cap configured, every appendable segment is eligible.
+    ///
+    /// This is the single origin of [`OperationError::OutOfAppendableCapacity`], returned when
+    /// appendable segments exist but every measurable one reached the cap. The updater recovers
+    /// by signalling the optimizer (whose wake-up provisions a fresh appendable segment) and
+    /// re-applying the operation; already-applied points are then skipped by their point version.
+    fn appendable_segments_with_capacity(
+        &self,
+    ) -> OperationResult<Vec<(SegmentId, Option<usize>)>> {
+        let appendable_segments = self.appendable_segments_ids();
+
+        let mut eligible = Vec::with_capacity(appendable_segments.len());
+        for segment_id in &appendable_segments {
+            let Some(locked_segment) = self.get(*segment_id) else {
+                continue;
+            };
+            let size = match locked_segment.get().try_read() {
+                None => None,
+                Some(segment) => match segment.max_available_vectors_size_in_bytes() {
+                    Ok(size) => Some(size),
+                    Err(err) => {
+                        log::error!("Failed to get segment size, ignoring: {err}");
+                        None
+                    }
+                },
+            };
+            let under_cap = match (size, self.max_segment_size_bytes) {
+                (Some(size), Some(max_segment_size_bytes)) => size < max_segment_size_bytes.get(),
+                _ => true,
+            };
+            if under_cap {
+                eligible.push((*segment_id, size));
+            }
+        }
+
+        if eligible.is_empty()
+            && !appendable_segments.is_empty()
+            && let Some(max_segment_size_bytes) = self.max_segment_size_bytes
+        {
+            return Err(OperationError::OutOfAppendableCapacity {
+                max_segment_size_bytes: max_segment_size_bytes.get(),
+            });
+        }
+        Ok(eligible)
+    }
+
     /// Get a random appendable segment
     ///
-    /// If you want the smallest segment, use `random_appendable_segment_with_capacity` instead.
+    /// If you want the smallest segment, use `smallest_appendable_segment` instead.
     pub fn random_appendable_segment(&self) -> Option<LockedSegment> {
         let segment_ids: Vec<_> = self.appendable_segments_ids();
         segment_ids
@@ -637,38 +754,38 @@ impl SegmentHolder {
     ///
     /// This attempts a non-blocking read-lock on all segments to find the smallest one. Segments
     /// that cannot be read-locked at this time are skipped. If no segment can be read-locked at
-    /// all, a random one is returned.
+    /// all, a random one is returned without a size check.
+    ///
+    /// # Errors
+    ///
+    /// - [`OperationError::OutOfAppendableCapacity`] when a size cap is configured and every
+    ///   measurable segment reached it (see
+    ///   [`appendable_segments_with_capacity`](Self::appendable_segments_with_capacity)).
+    /// - Service error when there are no appendable segments at all.
     ///
     /// If capacity is not important use `random_appendable_segment` instead because it is cheaper.
-    pub fn smallest_appendable_segment(&self) -> Option<LockedSegment> {
-        let segment_ids: Vec<_> = self.appendable_segments_ids();
+    pub fn smallest_appendable_segment(&self) -> OperationResult<LockedSegment> {
+        let candidates = self.appendable_segments_with_capacity()?;
 
-        // Try a non-blocking read lock on all segments and return the smallest one
-        let smallest_segment = segment_ids
+        // Prefer the smallest measurable candidate; fall back to a random one when none could
+        // be measured.
+        let chosen = candidates
             .iter()
-            .filter_map(|segment_id| self.get(*segment_id))
-            .filter_map(|locked_segment| {
-                match locked_segment
-                    .get()
-                    .try_read()
-                    .map(|segment| segment.max_available_vectors_size_in_bytes())?
-                {
-                    Ok(size) => Some((locked_segment, size)),
-                    Err(err) => {
-                        log::error!("Failed to get segment size, ignoring: {err}");
-                        None
-                    }
-                }
-            })
-            .min_by_key(|(_, segment_size)| *segment_size);
-        if let Some((smallest_segment, _)) = smallest_segment {
-            return Some(LockedSegment::clone(smallest_segment));
-        }
+            .filter_map(|(segment_id, size)| size.map(|size| (*segment_id, size)))
+            .min_by_key(|(_, size)| *size)
+            .map(|(segment_id, _)| segment_id)
+            .or_else(|| {
+                candidates
+                    .choose(&mut rand::rng())
+                    .map(|(segment_id, _)| *segment_id)
+            });
 
-        // Fall back to picking a random segment
-        segment_ids
-            .choose(&mut rand::rng())
-            .and_then(|idx| self.appendable_segments.get(idx).cloned())
+        chosen
+            .and_then(|segment_id| self.appendable_segments.get(&segment_id))
+            .cloned()
+            .ok_or_else(|| {
+                OperationError::service_error("No appendable segments exist, expected at least one")
+            })
     }
 
     /// Selects point ids, which is stored in this segment
@@ -1004,6 +1121,13 @@ impl SegmentHolder {
         // Choose random appendable segment from this
         let appendable_segments = self.appendable_segments_ids();
 
+        // CoW-move destination candidates below the size cap. Computed lazily on the first point
+        // that actually needs a move — a batch that applies fully in place must not fail just
+        // because all appendable segments are full — and reused for the rest of this call.
+        // Callers batch points (e.g. 32 per call), so capacity is checked once per batch, not
+        // per point; a destination may overshoot the cap by at most one batch worth of points.
+        let mut eligible_segments: Option<Vec<SegmentId>> = None;
+
         let mut applied_points: AHashSet<PointIdType> = Default::default();
         let stopped = AtomicBool::new(false);
 
@@ -1020,8 +1144,22 @@ impl SegmentHolder {
             let is_applied = if can_apply_operation {
                 point_operation(point_id, write_segment)?
             } else {
+                let destination_candidates: &[SegmentId] = if self.max_segment_size_bytes.is_some()
+                {
+                    if eligible_segments.is_none() {
+                        let eligible = self
+                            .appendable_segments_with_capacity()?
+                            .into_iter()
+                            .map(|(segment_id, _size)| segment_id)
+                            .collect();
+                        eligible_segments = Some(eligible);
+                    }
+                    eligible_segments.as_ref().unwrap()
+                } else {
+                    &appendable_segments
+                };
                 self.aloha_random_write(
-                    &appendable_segments,
+                    destination_candidates,
                     |appendable_idx, appendable_write_segment| {
                         // If we are moving point from one segment to another,
                         // we must guarantee, that data in new segment will be persisted before

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -645,66 +645,35 @@ impl SegmentHolder {
 
     /// Whether at least one appendable segment is below the given size cap.
     ///
-    /// `false` when there are no appendable segments at all. With no cap, any appendable segment
-    /// counts as having capacity. Segments that cannot be read-locked right now count as having
-    /// capacity: the cap is a soft limit and liveness wins over precision.
+    /// `false` when there are no appendable segments at all. Eligibility follows
+    /// [`eligible_appendable_segments`](Self::eligible_appendable_segments) with the given cap.
     pub fn has_appendable_segment_with_capacity(
         &self,
         max_segment_size_bytes: Option<NonZeroUsize>,
     ) -> bool {
-        let appendable_segments = self.appendable_segments_ids();
-        !appendable_segments.is_empty()
-            && appendable_segments
-                .iter()
-                .any(|segment_id| self.segment_has_capacity(*segment_id, max_segment_size_bytes))
+        !self
+            .eligible_appendable_segments(max_segment_size_bytes)
+            .is_empty()
     }
 
-    /// Whether the given segment's measured size is below the given cap.
-    ///
-    /// Unmeasurable segments (gone, read-lock contention, size errors) count as having capacity,
-    /// so that the soft cap never blocks progress on measurement issues alone.
-    fn segment_has_capacity(
-        &self,
-        segment_id: SegmentId,
-        max_segment_size_bytes: Option<NonZeroUsize>,
-    ) -> bool {
-        let Some(max_segment_size_bytes) = max_segment_size_bytes else {
-            return true;
-        };
-        let Some(locked_segment) = self.get(segment_id) else {
-            return true;
-        };
-        let Some(segment) = locked_segment.get().try_read() else {
-            return true;
-        };
-        match segment.max_available_vectors_size_in_bytes() {
-            Ok(size) => size < max_segment_size_bytes.get(),
-            Err(err) => {
-                log::error!("Failed to get segment size, ignoring: {err}");
-                true
-            }
-        }
-    }
-
-    /// Appendable segments eligible as write destinations under the configured size cap, with
-    /// their measured sizes.
+    /// Appendable segments below the given size cap, with their measured sizes.
     ///
     /// Segments that cannot be measured right now (read-lock contention, size errors) stay
     /// eligible and report `None`: the cap is a soft limit and liveness wins over precision.
-    /// With no cap configured, every appendable segment is eligible.
+    /// With no cap, every appendable segment is eligible.
     ///
-    /// This is the single origin of [`OperationError::OutOfAppendableCapacity`], returned when
-    /// appendable segments exist but every measurable one reached the cap. The updater recovers
-    /// by signalling the optimizer (whose wake-up provisions a fresh appendable segment) and
-    /// re-applying the operation; already-applied points are then skipped by their point version.
-    fn appendable_segments_with_capacity(
+    /// Single origin of the eligibility semantics: every capacity decision (the destination
+    /// filter, the capacity error, the updater's wait predicate, the optimizer's ensure step)
+    /// derives from this list so they can never disagree.
+    fn eligible_appendable_segments(
         &self,
-    ) -> OperationResult<Vec<(SegmentId, Option<usize>)>> {
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> Vec<(SegmentId, Option<usize>)> {
         let appendable_segments = self.appendable_segments_ids();
 
         let mut eligible = Vec::with_capacity(appendable_segments.len());
-        for segment_id in &appendable_segments {
-            let Some(locked_segment) = self.get(*segment_id) else {
+        for segment_id in appendable_segments {
+            let Some(locked_segment) = self.get(segment_id) else {
                 continue;
             };
             let size = match locked_segment.get().try_read() {
@@ -717,17 +686,31 @@ impl SegmentHolder {
                     }
                 },
             };
-            let under_cap = match (size, self.max_segment_size_bytes) {
+            let under_cap = match (size, max_segment_size_bytes) {
                 (Some(size), Some(max_segment_size_bytes)) => size < max_segment_size_bytes.get(),
                 _ => true,
             };
             if under_cap {
-                eligible.push((*segment_id, size));
+                eligible.push((segment_id, size));
             }
         }
+        eligible
+    }
+
+    /// Appendable segments eligible as write destinations under the configured size cap, with
+    /// their measured sizes.
+    ///
+    /// This is the single origin of [`OperationError::OutOfAppendableCapacity`], returned when
+    /// appendable segments exist but every measurable one reached the cap. The updater recovers
+    /// by signalling the optimizer (whose wake-up provisions a fresh appendable segment) and
+    /// re-applying the operation; already-applied points are then skipped by their point version.
+    fn appendable_segments_with_capacity(
+        &self,
+    ) -> OperationResult<Vec<(SegmentId, Option<usize>)>> {
+        let eligible = self.eligible_appendable_segments(self.max_segment_size_bytes);
 
         if eligible.is_empty()
-            && !appendable_segments.is_empty()
+            && !self.appendable_segments.is_empty()
             && let Some(max_segment_size_bytes) = self.max_segment_size_bytes
         {
             return Err(OperationError::OutOfAppendableCapacity {

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -722,29 +722,28 @@ impl SegmentHolder {
 
     /// CoW-move destination candidates for one `apply_points_with_conditional_move` call.
     ///
-    /// With no size cap armed, every appendable segment qualifies (`all_appendable`, computed
-    /// once by the caller). With a cap, the eligible list is computed lazily on the first point
-    /// that actually needs a move (a batch that applies fully in place must not fail just
-    /// because all appendable segments are full) and cached in `eligible` for the rest of the
-    /// call. Callers batch points (e.g. 32 per call), so capacity is checked once per batch,
-    /// not per point; a destination may overshoot the cap by at most one batch worth of points.
+    /// Computed lazily on the first point that actually needs a move (a batch that applies
+    /// fully in place must not fail just because all appendable segments are full, nor pay for
+    /// the lookup) and cached in `candidates` for the rest of the call. With no size cap armed,
+    /// every appendable segment qualifies; with a cap, only segments below it do. Callers batch
+    /// points (e.g. 32 per call), so capacity is checked once per batch, not per point; a
+    /// destination may overshoot the cap by at most one batch worth of points.
     fn cow_destination_candidates<'a>(
         &self,
-        eligible: &'a mut Option<Vec<SegmentId>>,
-        all_appendable: &'a [SegmentId],
+        candidates: &'a mut Option<Vec<SegmentId>>,
     ) -> OperationResult<&'a [SegmentId]> {
-        if self.max_segment_size_bytes.is_none() {
-            return Ok(all_appendable);
+        if candidates.is_none() {
+            let computed = if self.max_segment_size_bytes.is_some() {
+                self.appendable_segments_with_capacity()?
+                    .into_iter()
+                    .map(|(segment_id, _size)| segment_id)
+                    .collect()
+            } else {
+                self.appendable_segments_ids()
+            };
+            *candidates = Some(computed);
         }
-        if eligible.is_none() {
-            let candidates = self
-                .appendable_segments_with_capacity()?
-                .into_iter()
-                .map(|(segment_id, _size)| segment_id)
-                .collect();
-            *eligible = Some(candidates);
-        }
-        Ok(eligible.as_ref().unwrap())
+        Ok(candidates.as_ref().unwrap())
     }
 
     /// Get a random appendable segment
@@ -1128,12 +1127,9 @@ impl SegmentHolder {
             &mut Payload,
         ),
     {
-        // Choose random appendable segment from this
-        let appendable_segments = self.appendable_segments_ids();
-
         // Lazily-computed CoW-move destination candidates, shared across this call; see
         // `cow_destination_candidates`.
-        let mut eligible_segments: Option<Vec<SegmentId>> = None;
+        let mut destination_cache: Option<Vec<SegmentId>> = None;
 
         let mut applied_points: AHashSet<PointIdType> = Default::default();
         let stopped = AtomicBool::new(false);
@@ -1152,7 +1148,7 @@ impl SegmentHolder {
                 point_operation(point_id, write_segment)?
             } else {
                 let destination_candidates =
-                    self.cow_destination_candidates(&mut eligible_segments, &appendable_segments)?;
+                    self.cow_destination_candidates(&mut destination_cache)?;
                 self.aloha_random_write(
                     destination_candidates,
                     |appendable_idx, appendable_write_segment| {

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -136,13 +136,6 @@ pub struct SegmentHolder {
     /// funnels through [`add_existing_locked`](Self::add_existing_locked) and
     /// [`remove`](Self::remove), which reconcile it.
     segment_manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>,
-
-    /// Soft cap on appendable segment size for the update path, mirroring the resolved optimizer
-    /// `max_segment_size_kb` threshold (set by the shard on load and on optimizer config
-    /// updates). When set, the update path avoids inserting or CoW-moving points into appendable
-    /// segments at the cap and reports [`OperationError::OutOfAppendableCapacity`] when none is
-    /// below it; `None` disables capacity checks (any appendable segment is a valid destination).
-    max_segment_size_bytes: Option<NonZeroUsize>,
 }
 
 impl Drop for SegmentHolder {
@@ -628,18 +621,6 @@ impl SegmentHolder {
             .collect()
     }
 
-    /// Set the soft cap on appendable segment size used by the update path.
-    ///
-    /// Mirrors the resolved optimizer `max_segment_size_kb` threshold; `None` disables capacity
-    /// checks. See [`SegmentHolder::max_segment_size_bytes`].
-    pub fn set_max_segment_size_bytes(&mut self, max_segment_size_bytes: Option<NonZeroUsize>) {
-        self.max_segment_size_bytes = max_segment_size_bytes;
-    }
-
-    pub fn max_segment_size_bytes(&self) -> Option<NonZeroUsize> {
-        self.max_segment_size_bytes
-    }
-
     /// Whether at least one appendable segment is below the given size cap.
     ///
     /// `false` when there are no appendable segments at all. Eligibility follows
@@ -693,8 +674,8 @@ impl SegmentHolder {
         eligible
     }
 
-    /// Appendable segments eligible as write destinations under the configured size cap, with
-    /// their measured sizes.
+    /// Appendable segments eligible as write destinations under the given size cap, with their
+    /// measured sizes.
     ///
     /// This is the single origin of [`OperationError::OutOfAppendableCapacity`], returned when
     /// appendable segments exist but every measurable one reached the cap. The updater recovers
@@ -702,12 +683,13 @@ impl SegmentHolder {
     /// re-applying the operation; already-applied points are then skipped by their point version.
     fn appendable_segments_with_capacity(
         &self,
+        max_segment_size_bytes: Option<NonZeroUsize>,
     ) -> OperationResult<Vec<(SegmentId, Option<usize>)>> {
-        let eligible = self.eligible_appendable_segments(self.max_segment_size_bytes);
+        let eligible = self.eligible_appendable_segments(max_segment_size_bytes);
 
         if eligible.is_empty()
             && !self.appendable_segments.is_empty()
-            && let Some(max_segment_size_bytes) = self.max_segment_size_bytes
+            && let Some(max_segment_size_bytes) = max_segment_size_bytes
         {
             return Err(OperationError::OutOfAppendableCapacity {
                 max_segment_size_bytes: max_segment_size_bytes.get(),
@@ -725,10 +707,11 @@ impl SegmentHolder {
     fn cow_destination_candidates<'a>(
         &self,
         candidates: &'a mut Option<Vec<SegmentId>>,
+        max_segment_size_bytes: Option<NonZeroUsize>,
     ) -> OperationResult<&'a [SegmentId]> {
         if candidates.is_none() {
-            let computed = if self.max_segment_size_bytes.is_some() {
-                self.appendable_segments_with_capacity()?
+            let computed = if max_segment_size_bytes.is_some() {
+                self.appendable_segments_with_capacity(max_segment_size_bytes)?
                     .into_iter()
                     .map(|(segment_id, _size)| segment_id)
                     .collect()
@@ -767,8 +750,11 @@ impl SegmentHolder {
     /// - Service error when there are no appendable segments at all.
     ///
     /// If capacity is not important use `random_appendable_segment` instead because it is cheaper.
-    pub fn smallest_appendable_segment(&self) -> OperationResult<LockedSegment> {
-        let candidates = self.appendable_segments_with_capacity()?;
+    pub fn smallest_appendable_segment(
+        &self,
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> OperationResult<LockedSegment> {
+        let candidates = self.appendable_segments_with_capacity(max_segment_size_bytes)?;
 
         // Prefer the smallest measurable candidate; fall back to a random one when none could
         // be measured.
@@ -1110,6 +1096,7 @@ impl SegmentHolder {
         ids: &[PointIdType],
         mut point_operation: F,
         mut point_cow_operation: G,
+        max_segment_size_bytes: Option<NonZeroUsize>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<AHashSet<PointIdType>>
     where
@@ -1141,8 +1128,8 @@ impl SegmentHolder {
             let is_applied = if can_apply_operation {
                 point_operation(point_id, write_segment)?
             } else {
-                let destination_candidates =
-                    self.cow_destination_candidates(&mut destination_cache)?;
+                let destination_candidates = self
+                    .cow_destination_candidates(&mut destination_cache, max_segment_size_bytes)?;
                 self.aloha_random_write(
                     destination_candidates,
                     |appendable_idx, appendable_write_segment| {

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -138,13 +138,10 @@ pub struct SegmentHolder {
     segment_manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>,
 
     /// Soft cap on appendable segment size for the update path, mirroring the resolved optimizer
-    /// `max_segment_size_kb` threshold (set by the shard on load and on optimizer config updates).
-    ///
-    /// When set, the update path avoids inserting or CoW-moving points into appendable segments
-    /// whose vector size already reached the cap, and reports
-    /// [`OperationError::OutOfAppendableCapacity`] when no appendable segment is below it. `None`
-    /// disables capacity checks (the pre-existing behavior: any appendable segment is a valid
-    /// destination, regardless of size).
+    /// `max_segment_size_kb` threshold (set by the shard on load and on optimizer config
+    /// updates). When set, the update path avoids inserting or CoW-moving points into appendable
+    /// segments at the cap and reports [`OperationError::OutOfAppendableCapacity`] when none is
+    /// below it; `None` disables capacity checks (any appendable segment is a valid destination).
     max_segment_size_bytes: Option<NonZeroUsize>,
 }
 
@@ -656,15 +653,14 @@ impl SegmentHolder {
             .is_empty()
     }
 
-    /// Appendable segments below the given size cap, with their measured sizes.
+    /// Appendable segments below the given size cap, with their measured sizes. Segments that
+    /// cannot be measured right now (read-lock contention, size errors) stay eligible and report
+    /// `None`: the cap is soft and liveness wins over precision. With no cap, every appendable
+    /// segment is eligible.
     ///
-    /// Segments that cannot be measured right now (read-lock contention, size errors) stay
-    /// eligible and report `None`: the cap is a soft limit and liveness wins over precision.
-    /// With no cap, every appendable segment is eligible.
-    ///
-    /// Single origin of the eligibility semantics: every capacity decision (the destination
-    /// filter, the capacity error, the updater's wait predicate, the optimizer's ensure step)
-    /// derives from this list so they can never disagree.
+    /// Single origin of the eligibility semantics: every capacity decision (destination filter,
+    /// capacity error, the updater's wait predicate, the optimizer's ensure step) derives from
+    /// this list so they can never disagree.
     fn eligible_appendable_segments(
         &self,
         max_segment_size_bytes: Option<NonZeroUsize>,

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -720,6 +720,33 @@ impl SegmentHolder {
         Ok(eligible)
     }
 
+    /// CoW-move destination candidates for one `apply_points_with_conditional_move` call.
+    ///
+    /// With no size cap armed, every appendable segment qualifies (`all_appendable`, computed
+    /// once by the caller). With a cap, the eligible list is computed lazily on the first point
+    /// that actually needs a move (a batch that applies fully in place must not fail just
+    /// because all appendable segments are full) and cached in `eligible` for the rest of the
+    /// call. Callers batch points (e.g. 32 per call), so capacity is checked once per batch,
+    /// not per point; a destination may overshoot the cap by at most one batch worth of points.
+    fn cow_destination_candidates<'a>(
+        &self,
+        eligible: &'a mut Option<Vec<SegmentId>>,
+        all_appendable: &'a [SegmentId],
+    ) -> OperationResult<&'a [SegmentId]> {
+        if self.max_segment_size_bytes.is_none() {
+            return Ok(all_appendable);
+        }
+        if eligible.is_none() {
+            let candidates = self
+                .appendable_segments_with_capacity()?
+                .into_iter()
+                .map(|(segment_id, _size)| segment_id)
+                .collect();
+            *eligible = Some(candidates);
+        }
+        Ok(eligible.as_ref().unwrap())
+    }
+
     /// Get a random appendable segment
     ///
     /// If you want the smallest segment, use `smallest_appendable_segment` instead.
@@ -1104,11 +1131,8 @@ impl SegmentHolder {
         // Choose random appendable segment from this
         let appendable_segments = self.appendable_segments_ids();
 
-        // CoW-move destination candidates below the size cap. Computed lazily on the first point
-        // that actually needs a move — a batch that applies fully in place must not fail just
-        // because all appendable segments are full — and reused for the rest of this call.
-        // Callers batch points (e.g. 32 per call), so capacity is checked once per batch, not
-        // per point; a destination may overshoot the cap by at most one batch worth of points.
+        // Lazily-computed CoW-move destination candidates, shared across this call; see
+        // `cow_destination_candidates`.
         let mut eligible_segments: Option<Vec<SegmentId>> = None;
 
         let mut applied_points: AHashSet<PointIdType> = Default::default();
@@ -1127,20 +1151,8 @@ impl SegmentHolder {
             let is_applied = if can_apply_operation {
                 point_operation(point_id, write_segment)?
             } else {
-                let destination_candidates: &[SegmentId] = if self.max_segment_size_bytes.is_some()
-                {
-                    if eligible_segments.is_none() {
-                        let eligible = self
-                            .appendable_segments_with_capacity()?
-                            .into_iter()
-                            .map(|(segment_id, _size)| segment_id)
-                            .collect();
-                        eligible_segments = Some(eligible);
-                    }
-                    eligible_segments.as_ref().unwrap()
-                } else {
-                    &appendable_segments
-                };
+                let destination_candidates =
+                    self.cow_destination_candidates(&mut eligible_segments, &appendable_segments)?;
                 self.aloha_random_write(
                     destination_candidates,
                     |appendable_idx, appendable_write_segment| {

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -716,14 +716,12 @@ impl SegmentHolder {
         Ok(eligible)
     }
 
-    /// CoW-move destination candidates for one `apply_points_with_conditional_move` call.
-    ///
-    /// Computed lazily on the first point that actually needs a move (a batch that applies
-    /// fully in place must not fail just because all appendable segments are full, nor pay for
-    /// the lookup) and cached in `candidates` for the rest of the call. With no size cap armed,
-    /// every appendable segment qualifies; with a cap, only segments below it do. Callers batch
-    /// points (e.g. 32 per call), so capacity is checked once per batch, not per point; a
-    /// destination may overshoot the cap by at most one batch worth of points.
+    /// CoW-move destination candidates for one `apply_points_with_conditional_move` call,
+    /// computed lazily on the first point that actually needs a move (a batch applying fully in
+    /// place must not fail on capacity, nor pay for the lookup) and cached for the rest of the
+    /// call. Without a size cap every appendable segment qualifies; with one, only segments
+    /// below it. Callers batch points (e.g. 32 per call), so capacity is checked per batch and
+    /// a destination may overshoot the cap by at most one batch worth of points.
     fn cow_destination_candidates<'a>(
         &self,
         candidates: &'a mut Option<Vec<SegmentId>>,

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -64,6 +64,7 @@ fn test_apply_to_appendable() {
             |point_id, _, _, _| {
                 moved_to_appendable.push(point_id);
             },
+            None,
             &HardwareCounterCell::new(),
         )
         .unwrap();
@@ -188,6 +189,7 @@ fn test_apply_and_move_old_versions(
                 Ok(true)
             },
             |point_id, _, _, _| processed_points2.push(point_id),
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -279,6 +281,7 @@ fn test_cow_operation() {
                 );
                 payload.0.insert(PAYLOAD_KEY.to_string(), 2.into());
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -343,6 +346,7 @@ fn test_cow_move_append_only_single_slot() {
                 );
                 payload.0.insert(PAYLOAD_KEY.to_string(), 2.into());
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -462,6 +466,7 @@ fn test_cow_move_does_not_degrade_turbo_vectors() {
                 &[point_id],
                 |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
                 |_, _, _, _| {}, // no-op: a pure move
+                None,
                 &hw_counter,
             )
             .unwrap();
@@ -593,6 +598,7 @@ fn test_cow_move_overlay_preserves_untouched_turbo_vector() {
                     VectorInternal::Dense(fresh_replace.clone()),
                 );
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -691,6 +697,7 @@ fn test_cow_move_delete_name_preserves_survivor() {
             |_, raw_vectors, _, _| {
                 raw_vectors.retain(|(name, _)| name != DROP);
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -788,6 +795,7 @@ fn test_cow_move_allows_role_config_differences() {
             &[point_id],
             |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
             |_, _, _, _| {}, // no-op: a pure move
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -2008,6 +2016,7 @@ fn test_cow_skips_delete_when_destination_is_deferred() {
             &[100.into()],
             |_, _| unreachable!("point is in non-appendable, should take CoW path"),
             |_, _, _, _| {},
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -2175,6 +2184,7 @@ fn test_cow_deletes_source_when_destination_is_not_deferred() {
             &[100.into()],
             |_, _| unreachable!("point is in non-appendable, should take CoW path"),
             |_, _, _, _| {},
+            None,
             &hw_counter,
         )
         .unwrap();

--- a/lib/shard/src/update/mod.rs
+++ b/lib/shard/src/update/mod.rs
@@ -15,8 +15,9 @@ use segment::types::{Payload, SeqNumberType};
 pub use self::field_index::{create_field_index, delete_field_index};
 pub(crate) use self::helpers::{points_by_filter, select_excluded_by_filter_ids};
 pub use self::payload::{
-    clear_payload, clear_payload_by_filter, delete_payload, delete_payload_by_filter,
-    overwrite_payload, overwrite_payload_by_filter, set_payload, set_payload_by_filter,
+    PAYLOAD_OP_BATCH_SIZE, clear_payload, clear_payload_by_filter, delete_payload,
+    delete_payload_by_filter, overwrite_payload, overwrite_payload_by_filter, set_payload,
+    set_payload_by_filter,
 };
 pub(crate) use self::points::retain_conditional_upsert_points;
 pub use self::points::{

--- a/lib/shard/src/update/mod.rs
+++ b/lib/shard/src/update/mod.rs
@@ -8,6 +8,8 @@ mod points;
 mod tests;
 mod vectors;
 
+use std::num::NonZeroUsize;
+
 use common::counter::hardware_counter::HardwareCounterCell;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::types::{Payload, SeqNumberType};
@@ -37,6 +39,7 @@ pub fn process_point_operation(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     point_operation: PointOperations,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     match point_operation {
@@ -47,12 +50,22 @@ pub fn process_point_operation(
                 // touches no segment; bump so WAL can acknowledge it.
                 segments.bump_max_segment_version_overwrite(op_num);
             }
-            let res = upsert_points(segments, op_num, points.iter(), hw_counter)?;
+            let res = upsert_points(
+                segments,
+                op_num,
+                points.iter(),
+                max_segment_size_bytes,
+                hw_counter,
+            )?;
             Ok(res)
         }
-        PointOperations::UpsertPointsConditional(operation) => {
-            conditional_upsert(segments, op_num, operation, hw_counter)
-        }
+        PointOperations::UpsertPointsConditional(operation) => conditional_upsert(
+            segments,
+            op_num,
+            operation,
+            max_segment_size_bytes,
+            hw_counter,
+        ),
         PointOperations::DeletePoints { ids } => delete_points(segments, op_num, &ids, hw_counter),
         PointOperations::DeletePointsByFilter(filter) => {
             delete_points_by_filter(segments, op_num, &filter, hw_counter)
@@ -64,6 +77,7 @@ pub fn process_point_operation(
                 operation.from_id,
                 operation.to_id,
                 &operation.points,
+                max_segment_size_bytes,
                 hw_counter,
             )?;
             Ok(deleted + new + updated)
@@ -73,7 +87,13 @@ pub fn process_point_operation(
                 // An empty upsert touches no segment; bump so WAL can acknowledge it.
                 segments.bump_max_segment_version_overwrite(op_num);
             }
-            let res = upsert_points_raw(segments, op_num, points.iter(), hw_counter)?;
+            let res = upsert_points_raw(
+                segments,
+                op_num,
+                points.iter(),
+                max_segment_size_bytes,
+                hw_counter,
+            )?;
             Ok(res)
         }
         PointOperations::SyncPointsRaw(operation) => {
@@ -83,6 +103,7 @@ pub fn process_point_operation(
                 operation.from_id,
                 operation.to_id,
                 &operation.points,
+                max_segment_size_bytes,
                 hw_counter,
             )?;
             Ok(deleted + new + updated)
@@ -112,18 +133,33 @@ pub fn process_vector_operation(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     vector_operation: VectorOperations,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     match vector_operation {
-        VectorOperations::UpdateVectors(update_vectors) => {
-            update_vectors_conditional(segments, op_num, update_vectors, hw_counter)
-        }
-        VectorOperations::DeleteVectors(ids, vector_names) => {
-            delete_vectors(segments, op_num, &ids.points, &vector_names, hw_counter)
-        }
-        VectorOperations::DeleteVectorsByFilter(filter, vector_names) => {
-            delete_vectors_by_filter(segments, op_num, &filter, &vector_names, hw_counter)
-        }
+        VectorOperations::UpdateVectors(update_vectors) => update_vectors_conditional(
+            segments,
+            op_num,
+            update_vectors,
+            max_segment_size_bytes,
+            hw_counter,
+        ),
+        VectorOperations::DeleteVectors(ids, vector_names) => delete_vectors(
+            segments,
+            op_num,
+            &ids.points,
+            &vector_names,
+            max_segment_size_bytes,
+            hw_counter,
+        ),
+        VectorOperations::DeleteVectorsByFilter(filter, vector_names) => delete_vectors_by_filter(
+            segments,
+            op_num,
+            &filter,
+            &vector_names,
+            max_segment_size_bytes,
+            hw_counter,
+        ),
     }
 }
 
@@ -131,15 +167,32 @@ pub fn process_payload_operation(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     payload_operation: PayloadOps,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     match payload_operation {
         PayloadOps::SetPayload(sp) => {
             let payload: Payload = sp.payload;
             if let Some(points) = sp.points {
-                set_payload(segments, op_num, &payload, &points, &sp.key, hw_counter)
+                set_payload(
+                    segments,
+                    op_num,
+                    &payload,
+                    &points,
+                    &sp.key,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else if let Some(filter) = sp.filter {
-                set_payload_by_filter(segments, op_num, &payload, &filter, &sp.key, hw_counter)
+                set_payload_by_filter(
+                    segments,
+                    op_num,
+                    &payload,
+                    &filter,
+                    &sp.key,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(
@@ -149,9 +202,23 @@ pub fn process_payload_operation(
         }
         PayloadOps::DeletePayload(dp) => {
             if let Some(points) = dp.points {
-                delete_payload(segments, op_num, &points, &dp.keys, hw_counter)
+                delete_payload(
+                    segments,
+                    op_num,
+                    &points,
+                    &dp.keys,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else if let Some(filter) = dp.filter {
-                delete_payload_by_filter(segments, op_num, &filter, &dp.keys, hw_counter)
+                delete_payload_by_filter(
+                    segments,
+                    op_num,
+                    &filter,
+                    &dp.keys,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(
@@ -160,17 +227,31 @@ pub fn process_payload_operation(
             }
         }
         PayloadOps::ClearPayload { ref points, .. } => {
-            clear_payload(segments, op_num, points, hw_counter)
+            clear_payload(segments, op_num, points, max_segment_size_bytes, hw_counter)
         }
         PayloadOps::ClearPayloadByFilter(ref filter) => {
-            clear_payload_by_filter(segments, op_num, filter, hw_counter)
+            clear_payload_by_filter(segments, op_num, filter, max_segment_size_bytes, hw_counter)
         }
         PayloadOps::OverwritePayload(sp) => {
             let payload: Payload = sp.payload;
             if let Some(points) = sp.points {
-                overwrite_payload(segments, op_num, &payload, &points, hw_counter)
+                overwrite_payload(
+                    segments,
+                    op_num,
+                    &payload,
+                    &points,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else if let Some(filter) = sp.filter {
-                overwrite_payload_by_filter(segments, op_num, &payload, &filter, hw_counter)
+                overwrite_payload_by_filter(
+                    segments,
+                    op_num,
+                    &payload,
+                    &filter,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(

--- a/lib/shard/src/update/payload.rs
+++ b/lib/shard/src/update/payload.rs
@@ -8,8 +8,11 @@ use segment::types::{Filter, Payload, PayloadKeyType, PointIdType, SeqNumberType
 use super::helpers::{check_unprocessed_points, points_by_filter};
 use crate::segment_holder::SegmentHolder;
 
-/// Batch size when modifying payload
-const PAYLOAD_OP_BATCH_SIZE: usize = 32;
+/// Batch size when modifying payload.
+///
+/// Also the overshoot bound of the appendable segment size cap: capacity is checked once per
+/// batch, so a CoW-move destination can grow past the cap by at most this many points.
+pub const PAYLOAD_OP_BATCH_SIZE: usize = 32;
 
 pub fn set_payload(
     segments: &SegmentHolder,

--- a/lib/shard/src/update/payload.rs
+++ b/lib/shard/src/update/payload.rs
@@ -1,5 +1,7 @@
 //! Payload operations: set, delete, clear and overwrite payloads.
 
+use std::num::NonZeroUsize;
+
 use common::counter::hardware_counter::HardwareCounterCell;
 use segment::common::operation_error::OperationResult;
 use segment::json_path::JsonPath;
@@ -20,6 +22,7 @@ pub fn set_payload(
     payload: &Payload,
     points: &[PointIdType],
     key: &Option<JsonPath>,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let mut total_updated_points = 0;
@@ -33,6 +36,7 @@ pub fn set_payload(
                 Some(key) => old_payload.merge_by_key(payload, key),
                 None => old_payload.merge(payload),
             },
+            max_segment_size_bytes,
             hw_counter,
         )?;
 
@@ -55,10 +59,19 @@ pub fn set_payload_by_filter(
     payload: &Payload,
     filter: &Filter,
     key: &Option<JsonPath>,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let affected_points = points_by_filter(segments, filter, hw_counter)?;
-    let points_updated = set_payload(segments, op_num, payload, &affected_points, key, hw_counter)?;
+    let points_updated = set_payload(
+        segments,
+        op_num,
+        payload,
+        &affected_points,
+        key,
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
 
     if points_updated == 0 {
         // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.
@@ -74,6 +87,7 @@ pub fn delete_payload(
     op_num: SeqNumberType,
     points: &[PointIdType],
     keys: &[PayloadKeyType],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let mut total_deleted_points = 0;
@@ -94,6 +108,7 @@ pub fn delete_payload(
                     payload.remove(key);
                 }
             },
+            max_segment_size_bytes,
             hw_counter,
         )?;
 
@@ -115,10 +130,18 @@ pub fn delete_payload_by_filter(
     op_num: SeqNumberType,
     filter: &Filter,
     keys: &[PayloadKeyType],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let affected_points = points_by_filter(segments, filter, hw_counter)?;
-    let points_updated = delete_payload(segments, op_num, &affected_points, keys, hw_counter)?;
+    let points_updated = delete_payload(
+        segments,
+        op_num,
+        &affected_points,
+        keys,
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
 
     if points_updated == 0 {
         // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.
@@ -133,6 +156,7 @@ pub fn clear_payload(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: &[PointIdType],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let mut total_updated_points = 0;
@@ -143,6 +167,7 @@ pub fn clear_payload(
             batch,
             |id, write_segment| write_segment.clear_payload(op_num, id, hw_counter),
             |_, _, _, payload| payload.0.clear(),
+            max_segment_size_bytes,
             hw_counter,
         )?;
         check_unprocessed_points(batch, &updated_points)?;
@@ -163,10 +188,17 @@ pub fn clear_payload_by_filter(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     filter: &Filter,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let points_to_clear = points_by_filter(segments, filter, hw_counter)?;
-    let points_cleared = clear_payload(segments, op_num, &points_to_clear, hw_counter)?;
+    let points_cleared = clear_payload(
+        segments,
+        op_num,
+        &points_to_clear,
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
 
     if points_cleared == 0 {
         // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.
@@ -182,6 +214,7 @@ pub fn overwrite_payload(
     op_num: SeqNumberType,
     payload: &Payload,
     points: &[PointIdType],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let mut total_updated_points = 0;
@@ -194,6 +227,7 @@ pub fn overwrite_payload(
             |_, _, _, old_payload| {
                 *old_payload = payload.clone();
             },
+            max_segment_size_bytes,
             hw_counter,
         )?;
 
@@ -215,11 +249,18 @@ pub fn overwrite_payload_by_filter(
     op_num: SeqNumberType,
     payload: &Payload,
     filter: &Filter,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let affected_points = points_by_filter(segments, filter, hw_counter)?;
-    let points_updated =
-        overwrite_payload(segments, op_num, payload, &affected_points, hw_counter)?;
+    let points_updated = overwrite_payload(
+        segments,
+        op_num,
+        payload,
+        &affected_points,
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
 
     if points_updated == 0 {
         // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.

--- a/lib/shard/src/update/points/sync.rs
+++ b/lib/shard/src/update/points/sync.rs
@@ -1,5 +1,6 @@
 //! Point syncs: replace a point range with the given set, plain and raw.
 
+use std::num::NonZeroUsize;
 use std::sync::atomic::AtomicBool;
 
 use ahash::{AHashMap, AHashSet};
@@ -31,9 +32,18 @@ pub fn sync_points(
     from_id: Option<PointIdType>,
     to_id: Option<PointIdType>,
     points: &[PointStructPersisted],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<(usize, usize, usize)> {
-    sync_points_impl(segments, op_num, from_id, to_id, points, hw_counter)
+    sync_points_impl(
+        segments,
+        op_num,
+        from_id,
+        to_id,
+        points,
+        max_segment_size_bytes,
+        hw_counter,
+    )
 }
 
 /// Same as [`sync_points`], but for points carrying raw vector bytes verbatim.
@@ -43,9 +53,18 @@ pub fn sync_points_raw(
     from_id: Option<PointIdType>,
     to_id: Option<PointIdType>,
     points: &[PointStructRawPersisted],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<(usize, usize, usize)> {
-    sync_points_impl(segments, op_num, from_id, to_id, points, hw_counter)
+    sync_points_impl(
+        segments,
+        op_num,
+        from_id,
+        to_id,
+        points,
+        max_segment_size_bytes,
+        hw_counter,
+    )
 }
 
 /// A point struct that can be compared against its stored counterpart, to
@@ -83,6 +102,7 @@ fn sync_points_impl<P>(
     from_id: Option<PointIdType>,
     to_id: Option<PointIdType>,
     points: &[P],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<(usize, usize, usize)>
 where
@@ -137,7 +157,13 @@ where
     });
 
     // 5. Upsert points which differ from the stored ones
-    let num_replaced = upsert_points_impl(segments, op_num, points_to_update, hw_counter)?;
+    let num_replaced = upsert_points_impl(
+        segments,
+        op_num,
+        points_to_update,
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
     debug_assert!(
         num_replaced <= num_updated,
         "number of replaced points cannot be greater than points to update ({num_replaced} <= {num_updated})",

--- a/lib/shard/src/update/points/upsert.rs
+++ b/lib/shard/src/update/points/upsert.rs
@@ -187,12 +187,16 @@ where
 
         res += updated_points.len();
         // Insert new points, which was not updated or existed
-        let new_point_ids = ids_chunk
+        let new_point_ids: Vec<PointIdType> = ids_chunk
             .iter()
             .copied()
-            .filter(|x| !updated_points.contains(x));
+            .filter(|x| !updated_points.contains(x))
+            .collect();
 
-        {
+        // Only look up an insert destination when there is something to insert: the lookup
+        // fails with `OutOfAppendableCapacity` when all appendable segments are at the size
+        // cap, and a chunk that updated every point in place needs no capacity at all.
+        if !new_point_ids.is_empty() {
             let default_write_segment = segments.smallest_appendable_segment()?;
 
             let segment_arc = default_write_segment.get();

--- a/lib/shard/src/update/points/upsert.rs
+++ b/lib/shard/src/update/points/upsert.rs
@@ -209,7 +209,7 @@ where
                 )?);
             }
             RwLockWriteGuard::unlock_fair(write_segment);
-        };
+        }
     }
 
     Ok(res)

--- a/lib/shard/src/update/points/upsert.rs
+++ b/lib/shard/src/update/points/upsert.rs
@@ -4,7 +4,7 @@ use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::DeferredBehavior;
 use parking_lot::RwLockWriteGuard;
-use segment::common::operation_error::{OperationError, OperationResult};
+use segment::common::operation_error::OperationResult;
 use segment::data_types::named_vectors::NamedVectors;
 use segment::entry::entry_point::SegmentEntry;
 use segment::types::{Filter, Payload, PointIdType, SeqNumberType, VectorNameBuf};
@@ -193,12 +193,7 @@ where
             .filter(|x| !updated_points.contains(x));
 
         {
-            let default_write_segment =
-                segments.smallest_appendable_segment().ok_or_else(|| {
-                    OperationError::service_error(
-                        "No appendable segments exist, expected at least one",
-                    )
-                })?;
+            let default_write_segment = segments.smallest_appendable_segment()?;
 
             let segment_arc = default_write_segment.get();
             let mut write_segment = segment_arc.write();

--- a/lib/shard/src/update/points/upsert.rs
+++ b/lib/shard/src/update/points/upsert.rs
@@ -199,17 +199,18 @@ where
         )?;
 
         res += updated_points.len();
-        // Insert new points, which was not updated or existed
-        let new_point_ids: Vec<PointIdType> = ids_chunk
+        // Insert new points, which were not updated or existed. Peekable rather than collected:
+        // only their existence is needed before iterating them below.
+        let mut new_point_ids = ids_chunk
             .iter()
             .copied()
             .filter(|x| !updated_points.contains(x))
-            .collect();
+            .peekable();
 
         // Only look up an insert destination when there is something to insert: the lookup
         // fails with `OutOfAppendableCapacity` when all appendable segments are at the size
         // cap, and a chunk that updated every point in place needs no capacity at all.
-        if !new_point_ids.is_empty() {
+        if new_point_ids.peek().is_some() {
             let default_write_segment =
                 segments.smallest_appendable_segment(max_segment_size_bytes)?;
 

--- a/lib/shard/src/update/points/upsert.rs
+++ b/lib/shard/src/update/points/upsert.rs
@@ -1,5 +1,7 @@
 //! Point upserts: plain, conditional and raw.
 
+use std::num::NonZeroUsize;
+
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::DeferredBehavior;
@@ -29,12 +31,13 @@ pub fn upsert_points<'a, T>(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: T,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize>
 where
     T: IntoIterator<Item = &'a PointStructPersisted>,
 {
-    upsert_points_impl(segments, op_num, points, hw_counter)
+    upsert_points_impl(segments, op_num, points, max_segment_size_bytes, hw_counter)
 }
 
 /// Same as [`upsert_points`], but for points carrying raw vector bytes verbatim.
@@ -42,12 +45,13 @@ pub fn upsert_points_raw<'a, T>(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: T,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize>
 where
     T: IntoIterator<Item = &'a PointStructRawPersisted>,
 {
-    upsert_points_impl(segments, op_num, points, hw_counter)
+    upsert_points_impl(segments, op_num, points, max_segment_size_bytes, hw_counter)
 }
 
 /// Drop from `points_op` every point that the conditional-upsert
@@ -98,6 +102,7 @@ pub fn conditional_upsert(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     operation: ConditionalInsertOperationInternal,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let ConditionalInsertOperationInternal {
@@ -109,7 +114,13 @@ pub fn conditional_upsert(
     retain_conditional_upsert_points(segments, &mut points_op, condition, update_mode, hw_counter)?;
 
     let points = points_op.into_point_vec();
-    let upserted_points = upsert_points(segments, op_num, points.iter(), hw_counter)?;
+    let upserted_points = upsert_points(
+        segments,
+        op_num,
+        points.iter(),
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
 
     if upserted_points == 0 {
         // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.
@@ -163,6 +174,7 @@ pub(super) fn upsert_points_impl<'a, P>(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: impl IntoIterator<Item = &'a P>,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize>
 where
@@ -182,6 +194,7 @@ where
             |id, raw_vectors, updated_vectors, old_payload| {
                 points_map[&id].write_moved(raw_vectors, updated_vectors, old_payload)
             },
+            max_segment_size_bytes,
             hw_counter,
         )?;
 
@@ -197,7 +210,8 @@ where
         // fails with `OutOfAppendableCapacity` when all appendable segments are at the size
         // cap, and a chunk that updated every point in place needs no capacity at all.
         if !new_point_ids.is_empty() {
-            let default_write_segment = segments.smallest_appendable_segment()?;
+            let default_write_segment =
+                segments.smallest_appendable_segment(max_segment_size_bytes)?;
 
             let segment_arc = default_write_segment.get();
             let mut write_segment = segment_arc.write();

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -935,7 +935,7 @@ fn test_capacity_error_when_all_appendable_at_cap() {
     // Setting payload on the points of the non-appendable segment needs to CoW-move them,
     // but no appendable segment is below the cap: the operation must fail with the
     // recoverable capacity error instead of growing the full destination further.
-    let points: Vec<PointIdType> = (1..=5).map(Into::into).collect();
+    let points: Vec<PointIdType> = (1..=5u64).map(PointIdType::from).collect();
     let err = set_payload(
         &holder,
         100,

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -7,7 +8,8 @@ use segment::entry::ReadSegmentEntry as _;
 use segment::entry::entry_point::SegmentEntry as _;
 use segment::payload_json;
 use segment::types::{
-    Condition, FieldCondition, Filter, Match, MatchValue, PayloadKeyType, ValueVariants,
+    Condition, FieldCondition, Filter, Match, MatchValue, PayloadKeyType, PointIdType,
+    ValueVariants,
 };
 use tempfile::Builder;
 
@@ -18,8 +20,8 @@ use crate::operations::point_ops::PointStructRawPersisted;
 use crate::segment_holder::{FlushMode, SegmentHolder};
 use crate::update::{
     clear_payload_by_filter, create_field_index, delete_payload_by_filter, delete_points_by_filter,
-    delete_vectors_by_filter, overwrite_payload_by_filter, set_payload_by_filter, sync_points_raw,
-    upsert_points_raw,
+    delete_vectors_by_filter, overwrite_payload_by_filter, set_payload, set_payload_by_filter,
+    sync_points_raw, upsert_points_raw,
 };
 
 #[test]
@@ -898,5 +900,62 @@ fn create_field_index_pins_pending_payload_state() {
     assert!(
         hits.is_empty(),
         "filtered reads must agree with payload storage: the row was cleared",
+    );
+}
+
+/// Fixtures use dim-4 f32 vectors: 16 bytes per point.
+const TEST_POINT_SIZE_BYTES: usize = 16;
+
+#[test]
+fn test_capacity_error_when_all_appendable_at_cap() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let mut non_appendable = build_segment_1(dir.path()); // points 1-5
+    non_appendable.appendable_flag = false;
+
+    // Fill the only appendable segment up to the cap of 2 points.
+    let mut appendable = empty_segment(dir.path());
+    for point_id in [100u64, 101] {
+        appendable
+            .upsert_point(
+                10,
+                point_id.into(),
+                only_default_vector(&[1.0, 0.0, 1.0, 0.0]),
+                &hw_counter,
+            )
+            .unwrap();
+    }
+
+    let mut holder = SegmentHolder::default();
+    holder.add_new(non_appendable);
+    holder.add_new(appendable);
+    holder.set_max_segment_size_bytes(NonZeroUsize::new(2 * TEST_POINT_SIZE_BYTES));
+
+    // Setting payload on the points of the non-appendable segment needs to CoW-move them,
+    // but no appendable segment is below the cap: the operation must fail with the
+    // recoverable capacity error instead of growing the full destination further.
+    let points: Vec<PointIdType> = (1..=5).map(Into::into).collect();
+    let err = set_payload(
+        &holder,
+        100,
+        &payload_json! {"town": "Amsterdam"},
+        &points,
+        &None,
+        &hw_counter,
+    )
+    .expect_err("no appendable segment below the cap can accept the moved points");
+    assert!(
+        err.is_out_of_appendable_capacity(),
+        "expected OutOfAppendableCapacity, got: {err}",
+    );
+
+    // The insert path reports the same error instead of writing past the cap.
+    let err = holder
+        .smallest_appendable_segment()
+        .expect_err("even the smallest appendable segment is at the cap");
+    assert!(
+        err.is_out_of_appendable_capacity(),
+        "expected OutOfAppendableCapacity, got: {err}",
     );
 }

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -127,7 +127,7 @@ fn test_upsert_points_raw_moves_point_from_non_appendable() {
         },
     ];
 
-    let updated = upsert_points_raw(&holder, 100, points.iter(), &hw_counter).unwrap();
+    let updated = upsert_points_raw(&holder, 100, points.iter(), None, &hw_counter).unwrap();
     assert_eq!(updated, 1);
 
     {
@@ -189,6 +189,7 @@ fn test_sync_points_raw() {
         None,
         None,
         &[point_2, point_3, point_100],
+        None,
         &hw_counter,
     )
     .unwrap();
@@ -383,7 +384,7 @@ fn test_set_payload_by_filter_deferred_filter_matches_deferred() {
     let filter = city_filter("Amsterdam");
     let payload: segment::types::Payload = payload_json! {"color": "red"};
     let updated =
-        set_payload_by_filter(&holder, 10, &payload, &filter, &None, &hw_counter).unwrap();
+        set_payload_by_filter(&holder, 10, &payload, &filter, &None, None, &hw_counter).unwrap();
 
     assert!(updated > 0, "Should have updated at least one point");
 }
@@ -409,7 +410,7 @@ fn test_set_payload_by_filter_deferred_filter_matches_old_copy() {
     let filter = city_filter("Berlin");
     let payload: segment::types::Payload = payload_json! {"color": "red"};
     let updated =
-        set_payload_by_filter(&holder, 10, &payload, &filter, &None, &hw_counter).unwrap();
+        set_payload_by_filter(&holder, 10, &payload, &filter, &None, None, &hw_counter).unwrap();
 
     assert_eq!(
         updated, 0,
@@ -453,7 +454,7 @@ fn test_delete_payload_by_filter_deferred_filter_matches_deferred() {
 
     let filter = city_filter("Amsterdam");
     let keys: Vec<PayloadKeyType> = vec!["city".parse().unwrap()];
-    let updated = delete_payload_by_filter(&holder, 10, &filter, &keys, &hw_counter).unwrap();
+    let updated = delete_payload_by_filter(&holder, 10, &filter, &keys, None, &hw_counter).unwrap();
 
     assert!(updated > 0, "Should have updated at least one point");
 }
@@ -478,7 +479,7 @@ fn test_delete_payload_by_filter_deferred_filter_matches_old_copy() {
 
     let filter = city_filter("Berlin");
     let keys: Vec<PayloadKeyType> = vec!["city".parse().unwrap()];
-    let updated = delete_payload_by_filter(&holder, 10, &filter, &keys, &hw_counter).unwrap();
+    let updated = delete_payload_by_filter(&holder, 10, &filter, &keys, None, &hw_counter).unwrap();
 
     assert_eq!(
         updated, 0,
@@ -521,7 +522,7 @@ fn test_clear_payload_by_filter_deferred_filter_matches_deferred() {
     holder.add_new(appendable);
 
     let filter = city_filter("Amsterdam");
-    let updated = clear_payload_by_filter(&holder, 10, &filter, &hw_counter).unwrap();
+    let updated = clear_payload_by_filter(&holder, 10, &filter, None, &hw_counter).unwrap();
 
     assert!(updated > 0, "Should have updated at least one point");
 }
@@ -545,7 +546,7 @@ fn test_clear_payload_by_filter_deferred_filter_matches_old_copy() {
     let sid_app = holder.add_new(appendable);
 
     let filter = city_filter("Berlin");
-    let updated = clear_payload_by_filter(&holder, 10, &filter, &hw_counter).unwrap();
+    let updated = clear_payload_by_filter(&holder, 10, &filter, None, &hw_counter).unwrap();
 
     assert_eq!(
         updated, 0,
@@ -589,7 +590,8 @@ fn test_overwrite_payload_by_filter_deferred_filter_matches_deferred() {
 
     let filter = city_filter("Amsterdam");
     let payload: segment::types::Payload = payload_json! {"color": "red"};
-    let updated = overwrite_payload_by_filter(&holder, 10, &payload, &filter, &hw_counter).unwrap();
+    let updated =
+        overwrite_payload_by_filter(&holder, 10, &payload, &filter, None, &hw_counter).unwrap();
 
     assert!(updated > 0, "Should have updated at least one point");
 }
@@ -614,7 +616,8 @@ fn test_overwrite_payload_by_filter_deferred_filter_matches_old_copy() {
 
     let filter = city_filter("Berlin");
     let payload: segment::types::Payload = payload_json! {"color": "red"};
-    let updated = overwrite_payload_by_filter(&holder, 10, &payload, &filter, &hw_counter).unwrap();
+    let updated =
+        overwrite_payload_by_filter(&holder, 10, &payload, &filter, None, &hw_counter).unwrap();
 
     assert_eq!(
         updated, 0,
@@ -659,7 +662,7 @@ fn test_delete_vectors_by_filter_deferred_filter_matches_deferred() {
     let filter = city_filter("Amsterdam");
     let vector_names = vec![DEFAULT_VECTOR_NAME.into()];
     let deleted =
-        delete_vectors_by_filter(&holder, 10, &filter, &vector_names, &hw_counter).unwrap();
+        delete_vectors_by_filter(&holder, 10, &filter, &vector_names, None, &hw_counter).unwrap();
 
     assert!(deleted > 0, "Should have deleted at least one vector");
 }
@@ -685,7 +688,7 @@ fn test_delete_vectors_by_filter_deferred_filter_matches_old_copy() {
     let filter = city_filter("Berlin");
     let vector_names = vec![DEFAULT_VECTOR_NAME.into()];
     let deleted =
-        delete_vectors_by_filter(&holder, 10, &filter, &vector_names, &hw_counter).unwrap();
+        delete_vectors_by_filter(&holder, 10, &filter, &vector_names, None, &hw_counter).unwrap();
 
     assert_eq!(
         deleted, 0,
@@ -796,7 +799,7 @@ fn test_upsert_cow_move_replaces_whole_point() {
     seed(&mut in_place);
     let mut holder = SegmentHolder::default();
     let sid = holder.add_new(in_place);
-    upsert_points(&holder, 101, [&incoming], &hw_counter).unwrap();
+    upsert_points(&holder, 101, [&incoming], None, &hw_counter).unwrap();
     let segment = holder.get(sid).unwrap().get();
     check(&*segment.read(), "in-place");
 
@@ -811,7 +814,7 @@ fn test_upsert_cow_move_replaces_whole_point() {
     let mut holder = SegmentHolder::default();
     holder.add_new(source);
     let sid = holder.add_new(destination);
-    upsert_points(&holder, 101, [&incoming], &hw_counter).unwrap();
+    upsert_points(&holder, 101, [&incoming], None, &hw_counter).unwrap();
     let segment = holder.get(sid).unwrap().get();
     check(&*segment.read(), "CoW move");
 }
@@ -930,7 +933,7 @@ fn test_capacity_error_when_all_appendable_at_cap() {
     let mut holder = SegmentHolder::default();
     holder.add_new(non_appendable);
     holder.add_new(appendable);
-    holder.set_max_segment_size_bytes(NonZeroUsize::new(2 * TEST_POINT_SIZE_BYTES));
+    let max_segment_size_bytes = NonZeroUsize::new(2 * TEST_POINT_SIZE_BYTES);
 
     // Setting payload on the points of the non-appendable segment needs to CoW-move them,
     // but no appendable segment is below the cap: the operation must fail with the
@@ -942,6 +945,7 @@ fn test_capacity_error_when_all_appendable_at_cap() {
         &payload_json! {"town": "Amsterdam"},
         &points,
         &None,
+        max_segment_size_bytes,
         &hw_counter,
     )
     .expect_err("no appendable segment below the cap can accept the moved points");
@@ -952,7 +956,7 @@ fn test_capacity_error_when_all_appendable_at_cap() {
 
     // The insert path reports the same error instead of writing past the cap.
     let err = holder
-        .smallest_appendable_segment()
+        .smallest_appendable_segment(max_segment_size_bytes)
         .expect_err("even the smallest appendable segment is at the cap");
     assert!(
         err.is_out_of_appendable_capacity(),

--- a/lib/shard/src/update/vectors.rs
+++ b/lib/shard/src/update/vectors.rs
@@ -1,5 +1,7 @@
 //! Named-vector operations: update and delete vectors of existing points.
 
+use std::num::NonZeroUsize;
+
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use segment::common::operation_error::OperationResult;
@@ -17,6 +19,7 @@ pub fn update_vectors_conditional(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: UpdateVectorsOp,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let UpdateVectorsOp {
@@ -25,7 +28,7 @@ pub fn update_vectors_conditional(
     } = points;
 
     let Some(filter_condition) = update_filter else {
-        return update_vectors(segments, op_num, points, hw_counter);
+        return update_vectors(segments, op_num, points, max_segment_size_bytes, hw_counter);
     };
 
     let point_ids: Vec<_> = points.iter().map(|point| point.id).collect();
@@ -34,7 +37,7 @@ pub fn update_vectors_conditional(
         select_excluded_by_filter_ids(segments, point_ids, filter_condition, hw_counter)?;
 
     points.retain(|p| !points_to_exclude.contains(&p.id));
-    update_vectors(segments, op_num, points, hw_counter)
+    update_vectors(segments, op_num, points, max_segment_size_bytes, hw_counter)
 }
 
 /// Update the specified named vectors of a point, keeping unspecified vectors intact.
@@ -42,6 +45,7 @@ fn update_vectors(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: Vec<PointVectorsPersisted>,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     // Build a map of vectors to update per point, merge updates on same point ID
@@ -70,6 +74,7 @@ fn update_vectors(
                     updated_vectors.insert_ref(vector_name, vector_ref);
                 }
             },
+            max_segment_size_bytes,
             hw_counter,
         )?;
         check_unprocessed_points(batch, &updated_points)?;
@@ -91,6 +96,7 @@ pub fn delete_vectors(
     op_num: SeqNumberType,
     points: &[PointIdType],
     vector_names: &[VectorNameBuf],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let mut total_deleted_points = 0;
@@ -109,6 +115,7 @@ pub fn delete_vectors(
             |_, raw_vectors, _, _| {
                 raw_vectors.retain(|(name, _)| !vector_names.contains(name));
             },
+            max_segment_size_bytes,
             hw_counter,
         )?;
         check_unprocessed_points(batch, &modified_points)?;
@@ -130,11 +137,18 @@ pub fn delete_vectors_by_filter(
     op_num: SeqNumberType,
     filter: &Filter,
     vector_names: &[VectorNameBuf],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let affected_points = points_by_filter(segments, filter, hw_counter)?;
-    let vectors_deleted =
-        delete_vectors(segments, op_num, &affected_points, vector_names, hw_counter)?;
+    let vectors_deleted = delete_vectors(
+        segments,
+        op_num,
+        &affected_points,
+        vector_names,
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
 
     if vectors_deleted == 0 {
         // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -12,7 +12,11 @@ use collection::operations::config_diff::{
     CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff,
 };
 use collection::operations::conversions::sharding_method_from_proto;
-use collection::operations::types::{SparseVectorsConfig, VectorsConfigDiff};
+use collection::operations::types::{
+    MAX_SEGMENT_SIZE_METADATA_KEY, OUT_OF_APPENDABLE_CAPACITY_REASON,
+    SHARD_UNAVAILABLE_REASON_METADATA_KEY, ShardUnavailableReason, SparseVectorsConfig,
+    VectorsConfigDiff,
+};
 use segment::types::{StrictModeConfig, StrictModeMultivectorConfig, StrictModeSparseConfig};
 use tonic::Status;
 use tonic::metadata::MetadataValue;
@@ -54,7 +58,24 @@ impl From<StorageError> for Status {
                 }
                 tonic::Code::ResourceExhausted
             }
-            StorageError::ShardUnavailable { .. } => tonic::Code::Unavailable,
+            StorageError::ShardUnavailable { reason, .. } => {
+                // Carry the reason across the wire so the receiving replica set recognizes a
+                // self-healing capacity condition structurally rather than by message text.
+                if let ShardUnavailableReason::OutOfAppendableCapacity {
+                    max_segment_size_bytes,
+                } = reason
+                {
+                    metadata_headers.insert(
+                        SHARD_UNAVAILABLE_REASON_METADATA_KEY,
+                        OUT_OF_APPENDABLE_CAPACITY_REASON.to_string(),
+                    );
+                    metadata_headers.insert(
+                        MAX_SEGMENT_SIZE_METADATA_KEY,
+                        max_segment_size_bytes.to_string(),
+                    );
+                }
+                tonic::Code::Unavailable
+            }
             StorageError::EmptyPartialSnapshot { .. } => tonic::Code::FailedPrecondition,
         };
         let mut status = Status::new(error_code, error.to_string());
@@ -390,6 +411,26 @@ impl From<ConsensusThreadStatus> for grpc::ConsensusThreadStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn out_of_appendable_capacity_survives_grpc_round_trip() {
+        // Encode a capacity failure to a gRPC status, then decode it back: the typed reason must
+        // survive so a replica set recognizes the self-healing condition on a remote replica
+        // rather than deactivating it.
+        let collection_err = collection::operations::types::CollectionError::from(
+            segment::common::operation_error::OperationError::OutOfAppendableCapacity {
+                max_segment_size_bytes: 1024,
+            },
+        );
+        let status = Status::from(StorageError::from(collection_err));
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+
+        let round_tripped = collection::operations::types::CollectionError::from(status);
+        assert!(
+            round_tripped.is_out_of_appendable_capacity(),
+            "the replica set would deactivate a replica that self-heals: {round_tripped}",
+        );
+    }
 
     fn create_request(
         vector_memory: Option<grpc::Memory>,

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -12,11 +12,7 @@ use collection::operations::config_diff::{
     CollectionParamsDiff, HnswConfigDiff, OptimizersConfigDiff, QuantizationConfigDiff,
 };
 use collection::operations::conversions::sharding_method_from_proto;
-use collection::operations::types::{
-    MAX_SEGMENT_SIZE_METADATA_KEY, OUT_OF_APPENDABLE_CAPACITY_REASON,
-    SHARD_UNAVAILABLE_REASON_METADATA_KEY, ShardUnavailableReason, SparseVectorsConfig,
-    VectorsConfigDiff,
-};
+use collection::operations::types::{SparseVectorsConfig, VectorsConfigDiff};
 use segment::types::{StrictModeConfig, StrictModeMultivectorConfig, StrictModeSparseConfig};
 use tonic::Status;
 use tonic::metadata::MetadataValue;
@@ -61,19 +57,7 @@ impl From<StorageError> for Status {
             StorageError::ShardUnavailable { reason, .. } => {
                 // Carry the reason across the wire so the receiving replica set recognizes a
                 // self-healing capacity condition structurally rather than by message text.
-                if let ShardUnavailableReason::OutOfAppendableCapacity {
-                    max_segment_size_bytes,
-                } = reason
-                {
-                    metadata_headers.insert(
-                        SHARD_UNAVAILABLE_REASON_METADATA_KEY,
-                        OUT_OF_APPENDABLE_CAPACITY_REASON.to_string(),
-                    );
-                    metadata_headers.insert(
-                        MAX_SEGMENT_SIZE_METADATA_KEY,
-                        max_segment_size_bytes.to_string(),
-                    );
-                }
+                metadata_headers.extend(reason.to_metadata_pairs());
                 tonic::Code::Unavailable
             }
             StorageError::EmptyPartialSnapshot { .. } => tonic::Code::FailedPrecondition,

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -2,7 +2,7 @@ use std::backtrace::Backtrace;
 use std::io::Error as IoError;
 use std::time::Duration;
 
-use collection::operations::types::CollectionError;
+use collection::operations::types::{CollectionError, ShardUnavailableReason};
 use collection::shards::shard::ShardId;
 use tempfile::PersistError;
 use thiserror::Error;
@@ -46,7 +46,10 @@ pub enum StorageError {
         retry_after: Option<Duration>,
     },
     #[error("Shard temporarily unavailable: {description}")]
-    ShardUnavailable { description: String },
+    ShardUnavailable {
+        description: String,
+        reason: ShardUnavailableReason,
+    },
     #[error("Partial snapshot for shard {shard_id} contains no changes")]
     EmptyPartialSnapshot { shard_id: ShardId },
 }
@@ -184,8 +187,9 @@ impl StorageError {
                 description,
                 retry_after,
             },
-            CollectionError::ShardUnavailable { .. } => StorageError::ShardUnavailable {
+            CollectionError::ShardUnavailable { reason, .. } => StorageError::ShardUnavailable {
                 description: overriding_description,
+                reason,
             },
         }
     }
@@ -243,9 +247,13 @@ impl From<CollectionError> for StorageError {
                 description,
                 retry_after,
             },
-            CollectionError::ShardUnavailable { description } => {
-                StorageError::ShardUnavailable { description }
-            }
+            CollectionError::ShardUnavailable {
+                description,
+                reason,
+            } => StorageError::ShardUnavailable {
+                description,
+                reason,
+            },
         }
     }
 }


### PR DESCRIPTION
## Problem

Filter-based payload/vector operations CoW-move points from immutable segments into an appendable segment with **no size check** (`set_payload` by filter is the reproduced case). When every appendable segment has reached `max_segment_size`, such a write either grows a segment past the cap or, with the cap armed, fails with no way to recover. Fixes #9158 (the repro PR, superseded once this lands).

## Approach

Rather than provisioning capacity inside the update path, let the update **fail recoverably** and reuse the machinery already around it:

```
client write ──> update worker ──> apply
                      │
                      ▼
        OutOfAppendableCapacity            (1) produced: ALL appendable segments at the cap
                      │
                      ▼
        transient ShardUnavailable         (2) classified: typed reason, preserved across
        with typed reason                      error conversions and gRPC status metadata
                      │
        ┌─────────────┼──────────────────────────────┐
        ▼             ▼                              ▼
  (3) queued in    optimizer signalled (Nop)   (5) inline retry (30s budget):
  failed_operation        │                        wait for fresh segment,
  pins WAL ack            ▼                        re-apply from WAL,
  survives restart  (4) wake-up provisions         caller sees latency,
                    fresh appendable segment,      not an error
                    try_recover re-applies
                    from WAL (applied points
                    skip by version)

  (6) a replica set receiving the typed reason keeps the reporting replica active:
      it self-heals through (3)-(5) instead of being deactivated and fully transferred
```

1. **Produce** a typed, recoverable `OutOfAppendableCapacity` when no appendable segment is under the cap.
2. **Classify** it as a transient shard-unavailable condition that survives locally and across gRPC.
3. **Queue durably** in `failed_operation`, pinning the WAL acknowledge so it survives restarts.
4. **Recover**: the optimizer wake-up provisions a fresh appendable segment and re-applies (already-applied points skip by version, as in WAL replay).
5. **Absorb** for the caller: the update worker retries inline within a budget, so the common case sees latency, not an error.
6. **Stay resilient** in a cluster: a replica that hits capacity self-heals and is not deactivated.

Two single-origin rules keep the parts from disagreeing: the capacity **check** has one source (`SegmentHolder::eligible_appendable_segments`, backing the write-destination filter, the error, the updater's wait predicate, and the optimizer's ensure step) and the cap **value** has one derivation (`OptimizerThresholds::max_segment_size_bytes`, resolved once by `build_optimizers`).

**Why the cap is threaded through the apply path as a parameter** (the `max_segment_size_bytes: Option<NonZeroUsize>` on `CollectionUpdater::update` and the `process_*` functions), rather than stored on the segment holder: the cap is not a property of the segment set, it is a property of *who is applying and why*. The same operation must apply **capped** when a live client writes it (a recovery loop is running to heal capacity failures) and **uncapped** when synchronous WAL replay re-applies it at shard load (the operations were already accepted once, and no recovery loop runs there, so a capacity failure could only fail the whole shard load). With holder state, that distinction has to be expressed *temporally*: arm the cap when workers start, disarm it around the replay window, restore it on every exit path, and keep config updates, worker restarts, and replay strictly sequenced so none of them clobbers another; each of those is an invariant a reviewer must verify and a future edit can silently break. As a parameter, the distinction is *structural*: the update and optimization workers pass the value `UpdateHandler` handed them, the one replay call site passes `None`, and there is no mutable cap state anywhere, hence nothing to arm, disarm, restore, or sequence. The cost is one extra argument on the apply-path signatures; that churn is mechanical and marked as skimmable below.

```
collection config ──build_optimizers (one resolution)──> UpdateHandler.max_segment_size_bytes
                                                                      │ (handed at worker spawn)
                          ┌───────────────────────────────────────────┤
                          ▼                                           ▼
                   update worker                              optimization worker
                   apply(..., Some(cap))                      try_recover(..., Some(cap))

                   WAL replay at shard load (load_from_wal): apply(..., None), uncapped
```

## Behavior changes visible from outside

- `max_segment_size` is now enforced as a **soft cap** on appendable segments. Capacity is checked once per 32-point batch, so a destination can overshoot by at most one batch. `max_segment_size_kb = 0` means uncapped.
- A write that hits the cap sees **added latency** (optimizer round trip, 30s worst case) instead of overgrowing a segment. If capacity cannot be provisioned in time, the caller gets a retriable 503 and the operation still completes asynchronously.
- A capacity failure that escapes to a client is now **503 `Unavailable`** with a typed reason, not a 500 internal error.
- A replica (or leader) out of appendable capacity is **no longer deactivated**, so it recovers in place instead of forcing a full shard transfer.

## How to review

28 files, ~2100 lines, roughly 55% tests (the growth over earlier revisions is mechanical signature threading of the cap parameter). **Review the final tree in the order below (dependency order), not commit-by-commit**: the history is an iteration log, not a review structure. Steps 1-3 are mostly mechanical plumbing; the load-bearing logic concentrates in steps 4 and 5.

### 1. Producer: the error and where it is raised (~250 lines, start here)

- `segment/src/common/operation_error.rs`: the recoverable `OutOfAppendableCapacity` variant.
- `shard/src/operations/optimization.rs`: `OptimizerThresholds::max_segment_size_bytes`, the single derivation of the cap value.
- `shard/src/segment_holder/mod.rs` *(heavy)*: `eligible_appendable_segments` plus `cow_destination_candidates`, the lazily-computed destination lookup `apply_points_with_conditional_move` calls per point batch. The cap arrives as a `max_segment_size_bytes: Option<NonZeroUsize>` parameter; the holder carries no cap state.
- `shard/src/update/{mod,payload,vectors,points/*}.rs` + `tests.rs`: the apply path threads the cap parameter from the `process_*` dispatchers down to the destination lookups and raises the error when no destination qualifies. Mostly mechanical signature threading.

**Check:** the error means **all** appendable segments are over the cap (an eligibility filter, never a picked-one check; otherwise an operation can loop forever with two or more appendable segments). Segments that cannot be measured right now (lock contention, size error) stay eligible: the cap is soft and liveness wins over precision. A batch that applies fully in place must never fail on capacity (the destination lookup is lazy; upsert chunks with nothing to insert skip it entirely).

### 2. Classification: typed end to end (~200 lines)

- `collection/src/operations/types.rs` *(heavy)*: `ShardUnavailableReason` and its `to_metadata_pairs` / `from_metadata` codec pair (the only two places that know the wire format, next to the private key constants); the `OperationError` conversion; typed `is_out_of_appendable_capacity`; the `From<tonic::Status>` decoder built on the codec.
- `storage/src/content_manager/errors.rs`: threads the reason through both `StorageError` conversions.
- `storage/src/content_manager/conversions.rs`: attaches the codec's metadata pairs to the outgoing status (mirroring the existing `retry-after` header) so a replica set recognizes a remote capacity condition structurally instead of parsing status text.

**Check:** only an `Unavailable` status **tagged** with the reason metadata decodes back to the capacity condition; an untagged transient error must keep its generic handling.

### 3. Durability (~190 lines, mostly tests)

- `collection/src/operations/types.rs`: `CollectionError::update_failure_kind()`, the single policy for what happens to a failed operation (`Backpressure` and `Transient` queue for recovery and pin the WAL acknowledge; `Permanent` never queues and is dropped if it was queued). Its three consumers are the updater below, recovery's abort-or-skip choice (step 4), and the update worker's optimizer nudge (step 5).
- `collection/src/collection_manager/collection_updater.rs`: a flat match on the failure kind: queue a transient failure in `failed_operation`; drop a queued operation that declines permanently on re-apply (it can never succeed again, e.g. a later operation deleted its points), matching WAL replay on shard load.
- `collection/src/update_workers/flush_workers.rs` *(test only)*: locks the WAL-acknowledge pin.

**Check:** every transition in and out of `failed_operation` is accounted for. An entry never removed stalls the WAL acknowledge forever; one removed too eagerly loses an operation that still needed re-applying.

### 4. Recovery: the healer (~410 lines; the big regression test lives here)

- `collection/src/update_workers/optimization_worker.rs`: `ensure_appendable_segment_with_capacity` (now reports whether it created a segment), `try_recover` (skips permanently-declined operations instead of aborting forever), and the re-signal for multi-segment operations.
- `collection/src/update_handler.rs` + `optimizers_builder.rs` + `shards/local_shard/updaters.rs`: `build_optimizers` returns the resolved `OptimizerThresholds` alongside the optimizers it built; `UpdateHandler` carries the cap as a config-dependent field (set at construction and on optimizer config updates) and hands it to the update and optimization workers it spawns.
- `collection/src/shards/local_shard/optimizer_config_update_tests.rs` *(test only)*: asserts the config value reaches the `UpdateHandler` field at shard creation and after a config update; the capacity suites pass the cap to the apply path directly, so this is the wiring lock.
- `collection/src/shards/local_shard/mod.rs`: the synchronous WAL replay call passes `None` for the cap, structurally; no recovery loop runs during replay, and the operations were already accepted once.
- `collection/src/collection_manager/optimizers/indexing_optimizer.rs` *(mostly the end-to-end overgrow regression test)*.

**Check:** the re-signal chain is progress-guarded (`created_appendable_segment`), so an operation larger than one segment provisions segment after segment while an empty provisioned segment stops the chain. Synchronous replay applies uncapped because its call site passes `None`; there is no cap state to restore, so no exit-path or sequencing concerns exist. Recovery aborts on transient errors (retried next wake-up) but skips non-transient declines. The regression test provably forces the failure: setup asserts the data to move exceeds the **combined** capacity of every appendable segment, and `capacity_failures > 0` is asserted, so it cannot silently degrade to a no-op.

### 5. Client-facing latency: the inline retry (~690 lines, ~2/3 tests, the biggest single file)

- `collection/src/update_workers/update_worker.rs`: the `CapacityRetry` helper (`run` holds the retry loop). The wake-and-wait step is factored into `wait_optimizer_round`, shared with `wait_for_deferred_points_ready` (the one pre-existing function this PR edits).

**Reviewer note: this is load-bearing, not an optional optimization.** Without it, an ordinary client write that hits the cap returns a transient `ShardUnavailable` to the caller; the async path recovers it in the background, but the call has already failed. The model-testing harness, which unwraps every write, fails without it.

**Check:** retries re-read the operation from WAL rather than deep-cloning every operation on the hot path, and a missing record surfaces as an error, never a silent success. The inline retry and background recovery cannot double-apply: both serialize through `CollectionUpdater::update`'s exclusive update lock, and re-applied points are skipped by version (skipped points count as applied, so a re-apply cannot spuriously decline). Cancellation is checked before and inside every wait, so shard drops and the worker restart of an optimizer config update are not held up. Retry rounds are gated on capacity actually being present; a round that waits 5s without capacity appearing hands the operation over to async recovery early, well before the 30s budget.

### 6. Cluster resilience (~50 lines)

- `collection/src/shards/replica_set/update.rs`: a replica or leader that hits capacity is not deactivated; deactivating would force a full shard transfer to recover a replica that catches up on its own.

**Check:** only the typed capacity reason is exempted; every other transient failure still deactivates as before.

## Tests

- The #9158 overgrow regression on `set_payload` by filter, driven through synchronous recovery, with the capacity failure provably forced (see step 4).
- Capacity eligibility and error unit tests in the segment holder; the write path failing with `OutOfAppendableCapacity` when all appendables are at the cap.
- `failed_operation` queue transitions, recovery skipping a declined operation and continuing, and the WAL-acknowledge pin.
- Typed reason: the `OperationError` conversion carries reason + payload; a metadata-tagged `Unavailable` decodes back while an untagged one does not; a full `OperationError -> CollectionError -> StorageError -> Status -> CollectionError` gRPC round-trip preserves it.
- Inline retry: success after provisioning, hand-over to recovery when capacity never appears, abandon on cancellation, and the WAL re-read failure path. The `wait_optimizer_round` refactor is behavior-preserving, covered by these plus the deferred-points and WAL-recovery suites.
- Replica set: a capacity failure does not deactivate the replica; other transient failures still do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
