### PR TITLE
docs: fix collection metadata removal description

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11328,7 +11328,7 @@
             ]
           },
           "metadata": {
-            "description": "Metadata to update for the collection. If provided, this will merge with existing metadata. To remove metadata, set it to an empty object.",
+            "description": "Metadata to update for the collection. If provided, this will merge with existing metadata. Individual keys can be removed by setting their value to `null`.",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/Payload"

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -315,7 +315,7 @@ pub struct UpdateCollection {
     #[validate(nested)]
     pub strict_mode_config: Option<StrictModeConfig>,
     /// Metadata to update for the collection. If provided, this will merge with existing metadata.
-    /// To remove metadata, set it to an empty object.
+    /// Individual keys can be removed by setting their value to `null`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Payload>,
 }


### PR DESCRIPTION
## Summary

The `UpdateCollection.metadata` API description claims:

> To remove metadata, set it to an empty object.

This never worked and was never intended to:

- The update path (`Collection::update_metadata`) merges the provided payload key by key via `merge_map`, so an empty object iterates over zero entries and leaves existing metadata untouched.
- Over gRPC an empty map is indistinguishable from an absent one, so it is converted to `None` and no update happens at all. Supporting empty-object clearing was explicitly rejected in the #7123 review for exactly this reason, to keep REST and gRPC consistent.

The mechanism that *was* implemented and tested in #7123 is per-key removal: `{"metadata": {"key": null}}` deletes `key` (the `Value::Null => dest.remove(key)` arm in `merge_map`).

This PR is docs-only: it fixes the doc comment on `UpdateCollection.metadata` and the corresponding description in the generated `docs/redoc/master/openapi.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)