### PR TITLE
Change Rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://qdrant.tech/"
 repository = "https://github.com/qdrant/qdrant"
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.97"
 default-run = "qdrant"
 
 [lints]


### PR DESCRIPTION
Rust version 1.94 causes compilation error:
```
error[E0658]: use of unstable library feature `cfg_select`
error[E0658]: use of unstable library feature `ptr_as_ref_unchecked`
```