### PR TITLE
Make UniversalRead::read_batch generic over the callback error type

### DIFF
--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -7,7 +7,7 @@ use common::mmap::AdviceSetting;
 #[cfg(target_os = "linux")]
 use common::universal_io::IoUringFs;
 use common::universal_io::{
-    MmapFs, OpenOptions, Populate, ReadRange, UniversalRead, UniversalReadFs,
+    MmapFs, OpenOptions, Populate, ReadRange, UniversalIoError, UniversalRead, UniversalReadFs,
 };
 use criterion::{Criterion, criterion_group, criterion_main};
 use fs_err as fs;
@@ -126,7 +126,7 @@ fn read_benches<T: bytemuck::Pod + Send, Fs: UniversalReadFs>(
                 })
                 .map(|range| ((), range));
             storage
-                .read_batch::<Random, T, ()>(ranges, |(), chunk| {
+                .read_batch::<Random, T, (), UniversalIoError>(ranges, |(), chunk| {
                     for &item in bytemuck::cast_slice::<T, u64>(chunk) {
                         sum = sum.wrapping_add(item);
                     }
@@ -149,7 +149,7 @@ fn read_benches<T: bytemuck::Pod + Send, Fs: UniversalReadFs>(
                 })
                 .map(|range| ((), range));
             storage
-                .read_batch::<Sequential, T, ()>(ranges, |(), chunk| {
+                .read_batch::<Sequential, T, (), UniversalIoError>(ranges, |(), chunk| {
                     for &item in bytemuck::cast_slice::<T, u64>(chunk) {
                         sum = sum.wrapping_add(item);
                     }
@@ -166,12 +166,15 @@ fn read_benches<T: bytemuck::Pod + Send, Fs: UniversalReadFs>(
             b.iter(|| {
                 let mut sum = 0u64;
                 storage
-                    .read_batch::<Sequential, T, ()>(ranges_full_file::<T>(), |(), chunk| {
-                        for &item in bytemuck::cast_slice::<T, u64>(chunk) {
-                            sum = sum.wrapping_add(item);
-                        }
-                        Ok(())
-                    })
+                    .read_batch::<Sequential, T, (), UniversalIoError>(
+                        ranges_full_file::<T>(),
+                        |(), chunk| {
+                            for &item in bytemuck::cast_slice::<T, u64>(chunk) {
+                                sum = sum.wrapping_add(item);
+                            }
+                            Ok(())
+                        },
+                    )
                     .unwrap();
                 black_box(sum);
             })

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -86,10 +86,13 @@ fn test_io_uring_read_batch_read_iter() -> Result<()> {
     // --- read_batch (callback API) ---
     let mut batch_results = Vec::new();
 
-    file.read_batch::<Sequential, _>(ranges.into_iter().enumerate(), |idx, items| {
-        batch_results.push((idx, items.to_vec()));
-        Ok(())
-    })?;
+    file.read_batch::<Sequential, _, UniversalIoError>(
+        ranges.into_iter().enumerate(),
+        |idx, items| {
+            batch_results.push((idx, items.to_vec()));
+            Ok(())
+        },
+    )?;
 
     batch_results.sort_by_key(|&(idx, _)| idx);
 

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -216,11 +216,11 @@ impl UniversalRead for MmapFile {
     }
 
     /// Override the default pipeline-based for better performance.
-    fn read_batch<P: AccessPattern, T: Item, U: UserData>(
+    fn read_batch<P: AccessPattern, T: Item, U: UserData, E: From<UniversalIoError>>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-        mut callback: impl FnMut(U, &[T]) -> Result<()>,
-    ) -> Result<()> {
+        mut callback: impl FnMut(U, &[T]) -> Result<(), E>,
+    ) -> Result<(), E> {
         let bytes = self.as_bytes::<P>();
         for (user_data, range) in ranges {
             let items = read_bytemuck::<T>(bytes, range)?;

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -35,7 +35,10 @@ where
 
         // Read one byte per block purely to fault each block into the local
         // cache; the bytes themselves are discarded.
-        self.read_batch::<Sequential, u8, ()>(one_byte_per_block, |(), _bytes| Ok(()))?;
+        self.read_batch::<Sequential, u8, (), UniversalIoError>(
+            one_byte_per_block,
+            |(), _bytes| Ok(()),
+        )?;
 
         Ok(())
     }

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -754,7 +754,7 @@ mod tests_mod {
             .collect();
 
         let mut seen = vec![false; ranges.len()];
-        file.read_batch::<Random, u8, usize>(ranges.clone(), |i, bytes| {
+        file.read_batch::<Random, u8, usize, UniversalIoError>(ranges.clone(), |i, bytes| {
             let start = ranges[i].1.byte_offset as usize;
             assert_eq!(bytes, &scn.data[start..start + 100]);
             assert!(!seen[i]);

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use super::{Item, ReadPipeline, UniversalReadFs, UserData};
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Sequential};
-use crate::universal_io::{ReadBytesItem, ReadRange, Result, UniversalKind};
+use crate::universal_io::{ReadBytesItem, ReadRange, Result, UniversalIoError, UniversalKind};
 
 /// Per-file handle for universal read access.
 ///
@@ -81,15 +81,21 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
         self.read::<Sequential, T>(range)
     }
 
-    fn read_batch<P, T, U>(
+    /// The callback's error type `E` is generic so callers whose callbacks
+    /// fail with their own error type (e.g. `OperationError`) can use `?`
+    /// directly instead of smuggling the error out of an infallible callback.
+    /// `E` is not inferable from an `Ok(())`-only callback — such callers
+    /// annotate it (usually via the turbofish).
+    fn read_batch<P, T, U, E>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-        mut callback: impl FnMut(U, &[T]) -> Result<()>,
-    ) -> Result<()>
+        mut callback: impl FnMut(U, &[T]) -> Result<(), E>,
+    ) -> Result<(), E>
     where
         P: AccessPattern,
         T: Item,
         U: UserData,
+        E: From<UniversalIoError>,
     {
         let mut pipeline = Self::ReadPipeline::<'_, U>::new()?;
         let mut ranges = ranges.into_iter();

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -10,8 +10,8 @@ use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::traits::UniversalReadFileOps;
 use crate::universal_io::{
-    Item, ListedFile, OpenOptions, ReadBytesItem, ReadRange, Result, UniversalKind, UniversalRead,
-    UniversalReadFs, UserData,
+    Item, ListedFile, OpenOptions, ReadBytesItem, ReadRange, Result, UniversalIoError,
+    UniversalKind, UniversalRead, UniversalReadFs, UserData,
 };
 
 #[derive(Debug, TransparentWrapper)]
@@ -131,17 +131,18 @@ where
     }
 
     #[inline]
-    fn read_batch<P, T, U>(
+    fn read_batch<P, T, U, E>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-        callback: impl FnMut(U, &[T]) -> Result<()>,
-    ) -> Result<()>
+        callback: impl FnMut(U, &[T]) -> Result<(), E>,
+    ) -> Result<(), E>
     where
         P: AccessPattern,
         T: Item,
         U: UserData,
+        E: From<UniversalIoError>,
     {
-        self.0.read_batch::<P, T, U>(ranges, callback)
+        self.0.read_batch::<P, T, U, E>(ranges, callback)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -8,7 +8,8 @@ use bytemuck::TransparentWrapper;
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
     ByteOffset, FileIndex, Flusher, Item, OpenOptions, ReadRange, Result, UniversalAppend,
-    UniversalFlush, UniversalKind, UniversalRead, UniversalReadFs, UniversalWrite, UserData,
+    UniversalFlush, UniversalIoError, UniversalKind, UniversalRead, UniversalReadFs,
+    UniversalWrite, UserData,
 };
 
 /// A wrapper around [`UniversalRead`]/[`UniversalWrite`] that binds the element
@@ -81,16 +82,17 @@ where
     }
 
     #[inline]
-    pub fn read_batch<P, U>(
+    pub fn read_batch<P, U, E>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-        callback: impl FnMut(U, &[T]) -> Result<()>,
-    ) -> Result<()>
+        callback: impl FnMut(U, &[T]) -> Result<(), E>,
+    ) -> Result<(), E>
     where
         P: AccessPattern,
         U: UserData,
+        E: From<UniversalIoError>,
     {
-        self.inner.read_batch::<P, T, U>(ranges, callback)
+        self.inner.read_batch::<P, T, U, E>(ranges, callback)
     }
 
     #[inline]

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -364,7 +364,7 @@ mod tests {
             (3u32, ReadRange::new(10, 3)),
         ];
         let mut got: std::collections::HashMap<u32, Vec<u8>> = std::collections::HashMap::new();
-        file.read_batch::<common::generic_consts::Random, u8, _>(inputs, |u, s| {
+        file.read_batch::<common::generic_consts::Random, u8, _, common::universal_io::UniversalIoError>(inputs, |u, s| {
             got.insert(u, s.to_vec());
             Ok(())
         })

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -433,7 +433,7 @@ mod tests {
             (3u32, ReadRange::new(10, 3)),
         ];
         let mut got: std::collections::HashMap<u32, Vec<u8>> = std::collections::HashMap::new();
-        file.read_batch::<common::generic_consts::Random, u8, _>(inputs, |u, s| {
+        file.read_batch::<common::generic_consts::Random, u8, _, common::universal_io::UniversalIoError>(inputs, |u, s| {
             got.insert(u, s.to_vec());
             Ok(())
         })

--- a/lib/common/io_bridge_object_store/src/tests/integration.rs
+++ b/lib/common/io_bridge_object_store/src/tests/integration.rs
@@ -90,7 +90,7 @@ fn test_read_batch_parallel() {
         .map(|i| (i, ReadRange::new(u64::from(i) * 16, 16)))
         .collect();
     let mut got: std::collections::HashMap<u32, Vec<u8>> = Default::default();
-    file.read_batch::<common::generic_consts::Random, u8, _>(inputs, |user_data, slice| {
+    file.read_batch::<common::generic_consts::Random, u8, _, common::universal_io::UniversalIoError>(inputs, |user_data, slice| {
         got.insert(user_data, slice.to_vec());
         Ok(())
     })

--- a/lib/segment/src/id_tracker/disk_id_tracker/mappings.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/mappings.rs
@@ -82,22 +82,13 @@ pub trait DiskMappingsSource {
         external_ids: impl IntoIterator<Item = PointIdType>,
         mut on_live: impl FnMut(PointIdType, PointOffsetType),
     ) -> OperationResult<()> {
-        // Use `first_err` instead of `?` to avoid UniversalIoError vs OperationResult problems
-        let mut first_err = None;
         self.mapping_reader()
             .lookup_batch(external_ids, |id, offset| {
-                match self.point_deleted(offset) {
-                    Ok(false) => on_live(id, offset),
-                    Ok(true) => {}
-                    Err(err) => {
-                        first_err.get_or_insert(err);
-                    }
+                if !self.point_deleted(offset)? {
+                    on_live(id, offset);
                 }
-            })?;
-        match first_err {
-            Some(err) => Err(err),
-            None => Ok(()),
-        }
+                Ok(())
+            })
     }
 }
 

--- a/lib/segment/src/id_tracker/disk_id_tracker/read_only/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/read_only/id_tracker_read.rs
@@ -8,7 +8,7 @@ use common::universal_io::{ReadRange, UniversalRead};
 use itertools::Itertools as _;
 
 use super::ReadOnlyDiskIdTracker;
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::disk_id_tracker::mappings::{DiskMappingsSource, log_lookup_err};
 use crate::id_tracker::disk_id_tracker::reader::DiskMappingReader;
 use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
@@ -108,12 +108,15 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyDiskIdTracker<S> {
                 (internal_id, range)
             });
         self.versions
-            .read_batch::<Random, PointOffsetType>(ranges, |internal_id, values| {
-                if let Some(&version) = values.first() {
-                    callback(internal_id, version);
-                }
-                Ok(())
-            })?;
+            .read_batch::<Random, PointOffsetType, OperationError>(
+                ranges,
+                |internal_id, values| {
+                    if let Some(&version) = values.first() {
+                        callback(internal_id, version);
+                    }
+                    Ok(())
+                },
+            )?;
 
         Ok(())
     }

--- a/lib/segment/src/id_tracker/disk_id_tracker/reader/lookup.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/reader/lookup.rs
@@ -5,7 +5,7 @@ use common::universal_io::{ReadRange, UniversalRead};
 use uuid::Uuid;
 
 use super::DiskMappingReader;
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::disk_id_tracker::on_disk_format::{
     NUM_ENTRY_SIZE, UUID_ENTRY_SIZE, decode_external, decode_num_block, decode_uuid_block,
 };
@@ -119,7 +119,8 @@ impl<S: UniversalRead> DiskMappingReader<S> {
     /// completes; absent ids are dropped. Delivery is in read-completion order,
     /// not input order — the id is rebuilt from `is_uuid` + key, so callers
     /// never need the input position. Deletion is NOT applied (same contract as
-    /// `lookup`); storage errors propagate.
+    /// `lookup`); storage errors and `on_found` errors propagate, aborting the
+    /// pass.
     ///
     /// Ids are not grouped by block up front: a block is one ~16 KiB DiskCache
     /// block, so reads landing in the same block are deduplicated by the cache
@@ -128,7 +129,7 @@ impl<S: UniversalRead> DiskMappingReader<S> {
     pub fn lookup_batch(
         &self,
         external_ids: impl IntoIterator<Item = PointIdType>,
-        mut on_found: impl FnMut(PointIdType, PointOffsetType),
+        mut on_found: impl FnMut(PointIdType, PointOffsetType) -> OperationResult<()>,
     ) -> OperationResult<()> {
         // Each read is tagged with `(is_uuid, key)` so the callback can pick the
         // decoder, binary-search, and rebuild the id. Ids outside every block
@@ -148,7 +149,7 @@ impl<S: UniversalRead> DiskMappingReader<S> {
             });
 
         self.e2i
-            .read_batch::<common::generic_consts::Random, u8, (bool, u128)>(
+            .read_batch::<common::generic_consts::Random, u8, (bool, u128), OperationError>(
                 ranges,
                 |(is_uuid, key), bytes| {
                     let entries = if is_uuid {
@@ -162,13 +163,11 @@ impl<S: UniversalRead> DiskMappingReader<S> {
                         } else {
                             PointIdType::NumId(key as u64)
                         };
-                        on_found(id, entries[pos].1);
+                        on_found(id, entries[pos].1)?;
                     }
                     Ok(())
                 },
-            )?;
-
-        Ok(())
+            )
     }
 
     /// Internal→external lookup ignoring deletion. `Ok(None)` for out-of-range
@@ -208,7 +207,7 @@ impl<S: UniversalRead> DiskMappingReader<S> {
             });
 
         self.i2e
-            .read_batch::<common::generic_consts::Random, u8, PointOffsetType>(
+            .read_batch::<common::generic_consts::Random, u8, PointOffsetType, OperationError>(
                 ranges,
                 |offset, bytes| {
                     let value = u128::from_le_bytes(bytes.try_into().expect("16 data bytes"));
@@ -218,9 +217,7 @@ impl<S: UniversalRead> DiskMappingReader<S> {
                     );
                     Ok(())
                 },
-            )?;
-
-        Ok(())
+            )
     }
 
     /// One 16-byte i2e read; the `is_uuid` flag comes from the RAM-resident

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
@@ -114,15 +114,17 @@ impl<V: ZerocopyPostingValue, S: UniversalRead> OnDiskPostings<V, S> {
         // parsed (copied) out of the read bytes, so nothing borrows the file past
         // the read — `read_batch` is sufficient here, no pipeline needed.
         let mut headers: Vec<HeaderResult> = Vec::with_capacity(valid_ranges.len());
-        self.storage
-            .read_batch::<Random, u8, _>(valid_ranges, |token_id, bytes| {
+        self.storage.read_batch::<Random, u8, _, UniversalIoError>(
+            valid_ranges,
+            |token_id, bytes| {
                 headers.push(
                     PostingListHeader::read_from_prefix(bytes)
                         .map(|(header, _)| (token_id, header))
                         .map_err(UniversalIoError::from),
                 );
                 Ok(())
-            })?;
+            },
+        )?;
 
         Ok(HeadersBatch {
             headers,

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index/lifecycle.rs
@@ -34,25 +34,29 @@ impl<S: UniversalRead> ImmutableGeoIndex<S> {
         let mut points_map_offsets = Vec::with_capacity(num_entries + 1);
         let mut points_map_ids = Vec::new();
 
-        index.storage.points_map_ids.read_batch::<Random, _>(
-            points_map_entries
-                .iter()
-                .map(|item| ReadRange {
-                    byte_offset: u64::from(item.ids_start) * size_of::<PointOffsetType>() as u64,
-                    length: u64::from(item.ids_end.saturating_sub(item.ids_start)),
-                })
-                .enumerate(),
-            |i, ids| {
-                points_map_hashes.push(points_map_entries[i].hash.normalize());
-                points_map_offsets.push(points_map_ids.len() as u32);
-                for &id in ids {
-                    if index.storage.deleted.is_active(id) {
-                        points_map_ids.push(id);
+        index
+            .storage
+            .points_map_ids
+            .read_batch::<Random, _, OperationError>(
+                points_map_entries
+                    .iter()
+                    .map(|item| ReadRange {
+                        byte_offset: u64::from(item.ids_start)
+                            * size_of::<PointOffsetType>() as u64,
+                        length: u64::from(item.ids_end.saturating_sub(item.ids_start)),
+                    })
+                    .enumerate(),
+                |i, ids| {
+                    points_map_hashes.push(points_map_entries[i].hash.normalize());
+                    points_map_offsets.push(points_map_ids.len() as u32);
+                    for &id in ids {
+                        if index.storage.deleted.is_active(id) {
+                            points_map_ids.push(id);
+                        }
                     }
-                }
-                Ok(())
-            },
-        )?;
+                    Ok(())
+                },
+            )?;
         points_map_offsets.push(points_map_ids.len() as u32);
         drop(points_map_entries);
 

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
@@ -578,13 +578,15 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         // non-deleted point ids.
         let mut points = AHashSet::new();
         let deleted = &self.storage.deleted;
-        self.storage.points_map_ids.read_batch::<Random, _>(
-            point_map_ranges.into_iter().enumerate(),
-            |_idx, values| {
-                points.extend(values.iter().copied().filter(|&id| deleted.is_active(id)));
-                Ok(())
-            },
-        )?;
+        self.storage
+            .points_map_ids
+            .read_batch::<Random, _, OperationError>(
+                point_map_ranges.into_iter().enumerate(),
+                |_idx, values| {
+                    points.extend(values.iter().copied().filter(|&id| deleted.is_active(id)));
+                    Ok(())
+                },
+            )?;
 
         Ok(points)
     }

--- a/lib/segment/src/index/field_index/on_disk_point_to_values.rs
+++ b/lib/segment/src/index/field_index/on_disk_point_to_values.rs
@@ -300,32 +300,37 @@ where
         });
         let mut value_reads = Vec::new();
         self.store
-            .read_batch::<Random, MmapRange, _>(range_reads, |point_id, ranges| {
-                let MmapRange { start, count } = ranges[0];
+            .read_batch::<Random, MmapRange, _, OperationError>(
+                range_reads,
+                |point_id, ranges| {
+                    let MmapRange { start, count } = ranges[0];
 
-                // Use next point's start as end offset for this one.
-                let end = ranges.get(1).map_or(file_len, |next| next.start);
-                let length = end - start;
+                    // Use next point's start as end offset for this one.
+                    let end = ranges.get(1).map_or(file_len, |next| next.start);
+                    let length = end - start;
 
-                // Mirror `values_iter`: account the per-point access overhead
-                // plus the length of the values.
-                hw_cell.incr_delta(MMAP_PTV_ACCESS_OVERHEAD + length as usize);
+                    // Mirror `values_iter`: account the per-point access overhead
+                    // plus the length of the values.
+                    hw_cell.incr_delta(MMAP_PTV_ACCESS_OVERHEAD + length as usize);
 
-                if count > 0 {
-                    value_reads.push((point_id, count as usize, ReadRange::new(start, length)));
-                }
-                Ok(())
-            })?;
+                    if count > 0 {
+                        value_reads.push((point_id, count as usize, ReadRange::new(start, length)));
+                    }
+                    Ok(())
+                },
+            )?;
 
         // Batch 2: Read and pass the values to the callback as `ValuesIter`s.
         let value_reads = value_reads
             .into_iter()
             .map(|(point_id, count, range)| ((point_id, count), range));
-        self.store
-            .read_batch::<Random, u8, _>(value_reads, |(point_id, count), bytes| {
+        self.store.read_batch::<Random, u8, _, OperationError>(
+            value_reads,
+            |(point_id, count), bytes| {
                 callback(point_id, ValuesIter::new(Cow::Borrowed(bytes), count));
                 Ok(())
-            })?;
+            },
+        )?;
 
         Ok(())
     }

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -17,7 +17,7 @@ use common::universal_io::{
 use fs_err::{File, OpenOptions};
 
 use crate::common::error_logging::LogError;
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
 use crate::vector_storage::query_scorer::is_read_with_prefetch_efficient;
@@ -200,7 +200,8 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectorData<T, S>
         };
 
         // access pattern does not matter for io_uring
-        self.storage.read_batch::<Random, _>(ranges, callback)?;
+        self.storage
+            .read_batch::<Random, _, OperationError>(ranges, callback)?;
         Ok(())
     }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
@@ -13,7 +13,7 @@ use fs_err as fs;
 use memmap2::MmapMut;
 
 use super::{MultivectorOffset, MultivectorOffsetsStorage};
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::vector_storage::VectorOffsetType;
 use crate::vector_storage::chunked_vectors::{ChunkedVectors, ChunkedVectorsRead};
 
@@ -236,7 +236,7 @@ impl<S: UniversalRead> MultivectorOffsetsStorage for MultivectorOffsetsStorageMm
         });
 
         self.offsets
-            .read_batch::<Random, _>(ranges, |idx, offset| {
+            .read_batch::<Random, _, OperationError>(ranges, |idx, offset| {
                 let [offset] = offset else {
                     unreachable!("multi-vector offsets are stored as a single-element slice");
                 };

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -97,7 +97,8 @@ impl<S: UniversalRead> QuantizedStorage<S> {
             };
 
             // Access pattern does not matter for io_uring.
-            self.storage.read_batch::<Random, u8, _>(ranges, callback)?;
+            self.storage
+                .read_batch::<Random, u8, _, OperationError>(ranges, callback)?;
             return Ok(());
         }
 

--- a/src/tonic/api/storage_read_api/mod.rs
+++ b/src/tonic/api/storage_read_api/mod.rs
@@ -345,10 +345,13 @@ where
                 .map_err(io_error_to_status)?;
             let mut results = ranges.iter().map(|_| Vec::new()).collect::<Vec<_>>();
             storage
-                .read_batch::<Random, u8, _>(ranges.into_iter().enumerate(), |idx, chunk| {
-                    results[idx].extend_from_slice(chunk);
-                    Ok(())
-                })
+                .read_batch::<Random, u8, _, UniversalIoError>(
+                    ranges.into_iter().enumerate(),
+                    |idx, chunk| {
+                        results[idx].extend_from_slice(chunk);
+                        Ok(())
+                    },
+                )
                 .map_err(io_error_to_status)?;
 
             Ok::<_, Status>(results)


### PR DESCRIPTION
Follow-up to #9809, as suggested in https://github.com/qdrant/qdrant/pull/9809#discussion_r3616030931.

`UniversalRead::read_batch` is now `read_batch<P, T, U, E>` with `E: From<UniversalIoError>` and a callback returning `Result<(), E>`, mirroring the existing `Gridstore::read_batch_from_pages<P, U, E>` shape. The `MmapFile` override, the `ReadOnly` forwarding impl, and `TypedStorage::read_batch` follow.

Payoff: `DiskMappingReader::lookup_batch` takes a fallible `OperationResult<()>` callback, so `resolve_internal_batch` now uses `?` on the deleted check inside the callback — the `first_err` capture (and its "UniversalIoError vs OperationResult problems" comment) is gone.

Cost: `E` cannot be inferred from an `Ok(())`-only callback (the trailing `?` conversion does not pin it), so existing infallible call sites name it in the turbofish — `OperationError` in segment code, `UniversalIoError` where the enclosing function returns io errors. This trade-off is documented on the trait method.

Behavior note: an error returned by the callback (or, for `resolve_internal_batch`, by the deleted check) now aborts the batch pass at that point instead of completing the remaining reads and erroring afterwards.

`read_iter`/`read_bytes_iter` are deliberately left non-generic — nothing needs it and it would double the churn.

All changes are internal API refactoring; no functional changes to external behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)