### PR TITLE
[TQDT] Support Turbo4 in the read-only vector storage path

### DIFF
--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -29,7 +29,7 @@ use crate::vector_storage::quantized::quantized_vectors::{
 use crate::vector_storage::turbo::TurboVectorStorage;
 use crate::vector_storage::turbo::multi::TurboMultiVectorStorage;
 use crate::vector_storage::{
-    DenseTQVectorStorage, DenseVectorStorage, MultiTQVectorStorage, MultiVectorStorage,
+    DenseTQVectorStorageRead, DenseVectorStorage, MultiTQVectorStorageRead, MultiVectorStorage,
     VectorStorageEnum, VectorStorageRead,
 };
 

--- a/lib/segment/src/segment_constructor/batched_reader.rs
+++ b/lib/segment/src/segment_constructor/batched_reader.rs
@@ -14,9 +14,9 @@ use crate::data_types::named_vectors::CowMultiVector;
 use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
 use crate::types::CompactExtendedPointId;
 use crate::vector_storage::{
-    DenseTQVectorStorage, DenseVectorStorage, DenseVectorStorageRead, MultiTQVectorStorage,
-    MultiVectorStorage, MultiVectorStorageRead, SparseVectorStorage, SparseVectorStorageRead,
-    VectorStorageEnum, VectorStorageRead,
+    DenseTQVectorStorage, DenseTQVectorStorageRead, DenseVectorStorage, DenseVectorStorageRead,
+    MultiTQVectorStorage, MultiTQVectorStorageRead, MultiVectorStorage, MultiVectorStorageRead,
+    SparseVectorStorage, SparseVectorStorageRead, VectorStorageEnum, VectorStorageRead,
 };
 
 /// Define location of the point source during segment construction.

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_only.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_only.rs
@@ -2,10 +2,10 @@ use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::generic_consts::Random;
+use common::generic_consts::{AccessPattern, Random};
 use common::mmap::{AdviceSetting, MmapFlusher};
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs, UserData};
 
 use crate::common::operation_error::OperationResult;
 use crate::vector_storage::VectorOffsetType;
@@ -55,6 +55,29 @@ impl<S: UniversalRead> QuantizedChunkedStorageRead<S> {
 
     pub fn clear_cache(&self) -> OperationResult<()> {
         self.data.clear_cache()
+    }
+
+    /// Concatenated records `[index, index + count)` in one contiguous read.
+    /// `None` if out of bounds or the range straddles a chunk boundary
+    /// (read-only counterpart of [`super::QuantizedChunkedStorage::get_many`]).
+    pub fn get_many<P: AccessPattern>(
+        &self,
+        index: PointOffsetType,
+        count: usize,
+    ) -> Option<Cow<'_, [u8]>> {
+        self.data.get_many::<P>(index as VectorOffsetType, count)
+    }
+
+    /// Batched counterpart of [`Self::get_many`]: invoke `callback` with the
+    /// concatenated records of each `(user_data, start, count)` range, batching
+    /// the underlying reads. Like [`Self::get_many`], a range must not straddle
+    /// a chunk boundary.
+    pub fn for_each_many<P: AccessPattern, U: UserData>(
+        &self,
+        ranges: impl Iterator<Item = (U, PointOffsetType, u32)>,
+        callback: impl FnMut(U, Cow<'_, [u8]>) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        self.data.for_each_vector::<P, _>(ranges, callback)
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/create.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/create.rs
@@ -21,7 +21,7 @@ use crate::vector_storage::quantized::quantized_multivector_storage::Multivector
 use crate::vector_storage::turbo::TurboVectorStorage;
 use crate::vector_storage::turbo::multi::TurboMultiVectorStorage;
 use crate::vector_storage::{
-    DenseTQVectorStorage, DenseVectorStorage, MultiTQVectorStorage, MultiVectorStorage,
+    DenseTQVectorStorageRead, DenseVectorStorage, MultiTQVectorStorageRead, MultiVectorStorage,
     VectorStorageEnum, VectorStorageRead,
 };
 

--- a/lib/segment/src/vector_storage/query_scorer/turbo_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/turbo_custom_query_scorer.rs
@@ -4,34 +4,34 @@ use common::types::{PointOffsetType, ScoreType};
 use quantization::turboquant::EncodedQueryTQ;
 
 use crate::data_types::vectors::DenseVector;
-use crate::vector_storage::DenseTQVectorStorage;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
-use crate::vector_storage::turbo::TurboVectorStorage;
-use crate::vector_storage::vector_storage_base::VectorStorageRead;
+use crate::vector_storage::turbo::TurboScoring;
 
 /// Raw scorer for multi-vector queries (reco / discover / context / feedback)
-/// against a [`TurboVectorStorage`].
+/// against a dense TurboQuant storage ([`TurboScoring`]).
 ///
 /// Each sub-query vector is preprocessed and precomputed once at construction;
 /// scoring a stored point reads its encoded bytes a single time and folds the
 /// per-example similarities through the query's own combinator (`score_by`).
-pub struct TurboCustomQueryScorer<'a, TQuery>
+pub struct TurboCustomQueryScorer<'a, TStorage, TQuery>
 where
+    TStorage: TurboScoring,
     TQuery: Query<EncodedQueryTQ>,
 {
     query: TQuery,
-    storage: &'a TurboVectorStorage,
+    storage: &'a TStorage,
     hardware_counter: HardwareCounterCell,
 }
 
-impl<'a, TQuery> TurboCustomQueryScorer<'a, TQuery>
+impl<'a, TStorage, TQuery> TurboCustomQueryScorer<'a, TStorage, TQuery>
 where
+    TStorage: TurboScoring,
     TQuery: Query<EncodedQueryTQ>,
 {
     pub fn new<TInputQuery>(
         raw_query: TInputQuery,
-        storage: &'a TurboVectorStorage,
+        storage: &'a TStorage,
         mut hardware_counter: HardwareCounterCell,
     ) -> Self
     where
@@ -58,8 +58,9 @@ where
     }
 }
 
-impl<TQuery> QueryScorer for TurboCustomQueryScorer<'_, TQuery>
+impl<TStorage, TQuery> QueryScorer for TurboCustomQueryScorer<'_, TStorage, TQuery>
 where
+    TStorage: TurboScoring,
     TQuery: Query<EncodedQueryTQ>,
 {
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/turbo_multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/turbo_multi_custom_query_scorer.rs
@@ -7,31 +7,32 @@ use quantization::turboquant::EncodedQueryTQ;
 use crate::data_types::vectors::MultiDenseVectorInternal;
 use crate::vector_storage::query::{Query, TransformInto};
 use crate::vector_storage::query_scorer::QueryScorer;
-use crate::vector_storage::turbo::multi::TurboMultiVectorStorage;
-use crate::vector_storage::vector_storage_base::VectorStorageRead;
+use crate::vector_storage::turbo::multi::TurboMultiScoring;
 
 /// Raw scorer for multi-vector queries (reco / discover / context / feedback)
-/// against a [`TurboMultiVectorStorage`].
+/// against a multivector TurboQuant storage ([`TurboMultiScoring`]).
 ///
 /// Each sub-query multivector is preprocessed and precomputed once at
 /// construction; scoring a stored point reads its encoded records once and
 /// folds the per-example MaxSim similarities through the query's combinator.
-pub struct TurboMultiCustomQueryScorer<'a, TQuery>
+pub struct TurboMultiCustomQueryScorer<'a, TStorage, TQuery>
 where
+    TStorage: TurboMultiScoring,
     TQuery: Query<Vec<EncodedQueryTQ>>,
 {
     query: TQuery,
-    storage: &'a TurboMultiVectorStorage,
+    storage: &'a TStorage,
     hardware_counter: HardwareCounterCell,
 }
 
-impl<'a, TQuery> TurboMultiCustomQueryScorer<'a, TQuery>
+impl<'a, TStorage, TQuery> TurboMultiCustomQueryScorer<'a, TStorage, TQuery>
 where
+    TStorage: TurboMultiScoring,
     TQuery: Query<Vec<EncodedQueryTQ>>,
 {
     pub fn new<TInputQuery>(
         raw_query: TInputQuery,
-        storage: &'a TurboMultiVectorStorage,
+        storage: &'a TStorage,
         mut hardware_counter: HardwareCounterCell,
     ) -> Self
     where
@@ -53,8 +54,9 @@ where
     }
 }
 
-impl<TQuery> QueryScorer for TurboMultiCustomQueryScorer<'_, TQuery>
+impl<TStorage, TQuery> QueryScorer for TurboMultiCustomQueryScorer<'_, TStorage, TQuery>
 where
+    TStorage: TurboMultiScoring,
     TQuery: Query<Vec<EncodedQueryTQ>>,
 {
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/turbo_multi_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/turbo_multi_query_scorer.rs
@@ -6,24 +6,24 @@ use quantization::turboquant::EncodedQueryTQ;
 
 use crate::data_types::vectors::MultiDenseVectorInternal;
 use crate::vector_storage::query_scorer::QueryScorer;
-use crate::vector_storage::turbo::multi::TurboMultiVectorStorage;
-use crate::vector_storage::vector_storage_base::VectorStorageRead;
+use crate::vector_storage::turbo::multi::TurboMultiScoring;
 
-/// Asymmetric MaxSim raw scorer for [`TurboMultiVectorStorage`].
+/// Asymmetric MaxSim raw scorer for a multivector TurboQuant storage
+/// ([`TurboMultiScoring`]).
 ///
 /// Holds every inner query vector precomputed once (rotation + SIMD encoding)
 /// and scores the multi-query against a stored point's TurboQuant records via
 /// MaxSim, delegating the arithmetic and the sign convention to the storage.
-pub struct TurboMultiQueryScorer<'a> {
+pub struct TurboMultiQueryScorer<'a, TStorage: TurboMultiScoring> {
     query: Vec<EncodedQueryTQ>,
-    storage: &'a TurboMultiVectorStorage,
+    storage: &'a TStorage,
     hardware_counter: HardwareCounterCell,
 }
 
-impl<'a> TurboMultiQueryScorer<'a> {
+impl<'a, TStorage: TurboMultiScoring> TurboMultiQueryScorer<'a, TStorage> {
     pub fn new(
         raw_query: &MultiDenseVectorInternal,
-        storage: &'a TurboMultiVectorStorage,
+        storage: &'a TStorage,
         mut hardware_counter: HardwareCounterCell,
     ) -> Self {
         // Preprocess (per distance) and precompute each inner query vector once.
@@ -39,7 +39,7 @@ impl<'a> TurboMultiQueryScorer<'a> {
     }
 }
 
-impl QueryScorer for TurboMultiQueryScorer<'_> {
+impl<TStorage: TurboMultiScoring> QueryScorer for TurboMultiQueryScorer<'_, TStorage> {
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         self.storage
             .score_point_max_similarity(&self.query, idx, &self.hardware_counter)

--- a/lib/segment/src/vector_storage/query_scorer/turbo_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/turbo_query_scorer.rs
@@ -4,26 +4,24 @@ use common::types::{PointOffsetType, ScoreType};
 use quantization::turboquant::EncodedQueryTQ;
 
 use crate::data_types::vectors::DenseVector;
-use crate::vector_storage::DenseTQVectorStorage;
 use crate::vector_storage::query_scorer::QueryScorer;
-use crate::vector_storage::turbo::TurboVectorStorage;
-use crate::vector_storage::vector_storage_base::VectorStorageRead;
+use crate::vector_storage::turbo::TurboScoring;
 
-/// Asymmetric raw scorer for [`TurboVectorStorage`].
+/// Asymmetric raw scorer for a dense TurboQuant storage ([`TurboScoring`]).
 ///
 /// Holds the query precomputed once (rotation + SIMD encoding) and scores it
 /// against the stored TurboQuant bytes, delegating the actual arithmetic and
 /// the metric sign convention to the storage.
-pub struct TurboQueryScorer<'a> {
+pub struct TurboQueryScorer<'a, TStorage: TurboScoring> {
     query: EncodedQueryTQ,
-    storage: &'a TurboVectorStorage,
+    storage: &'a TStorage,
     hardware_counter: HardwareCounterCell,
 }
 
-impl<'a> TurboQueryScorer<'a> {
+impl<'a, TStorage: TurboScoring> TurboQueryScorer<'a, TStorage> {
     pub fn new(
         query: DenseVector,
-        storage: &'a TurboVectorStorage,
+        storage: &'a TStorage,
         mut hardware_counter: HardwareCounterCell,
     ) -> Self {
         // Preprocess (per distance) and precompute the query once, so the
@@ -45,7 +43,7 @@ impl<'a> TurboQueryScorer<'a> {
     }
 }
 
-impl QueryScorer for TurboQueryScorer<'_> {
+impl<TStorage: TurboScoring> QueryScorer for TurboQueryScorer<'_, TStorage> {
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         let bytes = self.storage.get_quantized_vector(idx);
         self.hardware_counter.vector_io_read().incr();

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -34,8 +34,8 @@ use crate::vector_storage::query_scorer::turbo_multi_custom_query_scorer::TurboM
 use crate::vector_storage::query_scorer::turbo_multi_query_scorer::TurboMultiQueryScorer;
 use crate::vector_storage::query_scorer::turbo_query_scorer::TurboQueryScorer;
 use crate::vector_storage::sparse::volatile_sparse_vector_storage::VolatileSparseVectorStorage;
-use crate::vector_storage::turbo::TurboVectorStorage;
-use crate::vector_storage::turbo::multi::TurboMultiVectorStorage;
+use crate::vector_storage::turbo::TurboScoring;
+use crate::vector_storage::turbo::multi::TurboMultiScoring;
 
 pub trait RawScorer {
     fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoreType]);
@@ -84,7 +84,7 @@ pub fn new_raw_scorer<'a>(
         VectorStorageEnum::DenseAppendableMemmap(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
         VectorStorageEnum::DenseAppendableMemmapByte(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
         VectorStorageEnum::DenseAppendableMemmapHalf(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
-        VectorStorageEnum::DenseTurbo(vs) => raw_turbo_scorer_impl(query, vs, hc),
+        VectorStorageEnum::DenseTurbo(vs) => raw_turbo_scorer_impl(query, vs.as_ref(), hc),
         VectorStorageEnum::SparseVolatile(vs) => raw_sparse_scorer_volatile(query, vs, hc),
         VectorStorageEnum::SparseMmap(vs) => raw_sparse_scorer_impl(query, vs, hc),
         VectorStorageEnum::MultiDenseVolatile(vs) => raw_multi_scorer_impl(query, vs, hc),
@@ -101,7 +101,9 @@ pub fn new_raw_scorer<'a>(
         VectorStorageEnum::MultiDenseAppendableMemmapHalf(vs) => {
             raw_multi_scorer_impl(query, vs.as_ref(), hc)
         }
-        VectorStorageEnum::MultiDenseTurbo(vs) => raw_turbo_multi_scorer_impl(query, vs, hc),
+        VectorStorageEnum::MultiDenseTurbo(vs) => {
+            raw_turbo_multi_scorer_impl(query, vs.as_ref(), hc)
+        }
         VectorStorageEnum::EmptyDense(vs) => raw_scorer_impl(query, vs, hc),
         VectorStorageEnum::EmptySparse(vs) => raw_sparse_scorer_impl(query, vs, hc),
     }
@@ -326,16 +328,9 @@ fn new_scorer_with_metric<
     }
 }
 
-/// Build a [`RawScorer`] for a [`TurboVectorStorage`].
-///
-/// The metric is selected at runtime from the storage's distance (no generic
-/// `TMetric`): query preprocessing and the score sign convention live inside
-/// [`TurboVectorStorage`], so the scorers here only carry the precomputed
-/// query. `Nearest` uses the asymmetric [`TurboQueryScorer`]; the multi-vector
-/// queries use [`TurboCustomQueryScorer`].
-pub fn raw_turbo_scorer_impl<'a>(
+pub fn raw_turbo_scorer_impl<'a, TStorage: TurboScoring>(
     query: QueryVector,
-    vector_storage: &'a TurboVectorStorage,
+    vector_storage: &'a TStorage,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match query {
@@ -387,14 +382,9 @@ pub fn raw_turbo_scorer_impl<'a>(
     }
 }
 
-/// Build a [`RawScorer`] for a [`TurboMultiVectorStorage`].
-///
-/// Mirror of [`raw_turbo_scorer_impl`] for multivectors: `Nearest` uses the
-/// MaxSim [`TurboMultiQueryScorer`]; the multi-vector queries use
-/// [`TurboMultiCustomQueryScorer`].
-pub fn raw_turbo_multi_scorer_impl<'a>(
+pub fn raw_turbo_multi_scorer_impl<'a, TStorage: TurboMultiScoring>(
     query: QueryVector,
-    vector_storage: &'a TurboMultiVectorStorage,
+    vector_storage: &'a TStorage,
     hardware_counter: HardwareCounterCell,
 ) -> OperationResult<Box<dyn RawScorer + 'a>> {
     match query {

--- a/lib/segment/src/vector_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/read_only/lifecycle.rs
@@ -4,13 +4,16 @@ use common::mmap::{Advice, AdviceSetting};
 use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs};
 
 use super::VectorStorageReadEnum;
-use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
 use crate::types::{VectorDataConfig, VectorStorageDatatype, VectorStorageType};
 use crate::vector_storage::dense::read_only::{
     ReadOnlyChunkedDenseVectorStorage, ReadOnlyImmutableDenseVectorStorage,
 };
 use crate::vector_storage::multi_dense::read_only::ReadOnlyChunkedMultiDenseVectorStorage;
+use crate::vector_storage::turbo::read_only::{
+    ReadOnlyTurboMultiVectorStorage, ReadOnlyTurboVectorStorage,
+};
 
 /// How the [`VectorStorageType`] maps onto the read-only open path: mmap
 /// advice, whether the storage is populated on open, and whether it uses the
@@ -77,9 +80,9 @@ impl<S: UniversalRead> VectorStorageReadEnum<S> {
                         fs, path, advice, populate,
                     )
                 }
-                VectorStorageDatatype::Turbo4 => Err(OperationError::service_error(
-                    "Turbo4 datatype storage is not yet supported",
-                )),
+                VectorStorageDatatype::Turbo4 => {
+                    ReadOnlyTurboMultiVectorStorage::<S>::preopen(fs, path, advice, populate)
+                }
             };
         }
 
@@ -101,9 +104,9 @@ impl<S: UniversalRead> VectorStorageReadEnum<S> {
                         fs, path, advice, populate,
                     )
                 }
-                VectorStorageDatatype::Turbo4 => Err(OperationError::service_error(
-                    "Turbo4 datatype storage is not yet supported",
-                )),
+                VectorStorageDatatype::Turbo4 => {
+                    ReadOnlyTurboVectorStorage::<S>::preopen(fs, path, true, populate)
+                }
             }
         } else {
             match datatype {
@@ -119,9 +122,9 @@ impl<S: UniversalRead> VectorStorageReadEnum<S> {
                     VectorElementTypeHalf,
                     S,
                 >::preopen(fs, path, populate),
-                VectorStorageDatatype::Turbo4 => Err(OperationError::service_error(
-                    "Turbo4 datatype storage is not yet supported",
-                )),
+                VectorStorageDatatype::Turbo4 => {
+                    ReadOnlyTurboVectorStorage::<S>::preopen(fs, path, false, populate)
+                }
             }
         }
     }
@@ -183,9 +186,15 @@ impl<S: UniversalRead> VectorStorageReadEnum<S> {
                     )?,
                 )),
                 VectorStorageDatatype::Turbo4 => {
-                    return Err(OperationError::service_error(
-                        "Turbo4 datatype storage is not yet supported",
-                    ));
+                    Self::MultiDenseTurbo(Box::new(ReadOnlyTurboMultiVectorStorage::open(
+                        fs,
+                        path,
+                        dim,
+                        distance,
+                        multivector_config,
+                        advice,
+                        populate,
+                    )?))
                 }
             }));
         }
@@ -208,11 +217,9 @@ impl<S: UniversalRead> VectorStorageReadEnum<S> {
                         fs, path, dim, distance, advice, populate,
                     )?))
                 }
-                VectorStorageDatatype::Turbo4 => {
-                    return Err(OperationError::service_error(
-                        "Turbo4 datatype storage is not yet supported",
-                    ));
-                }
+                VectorStorageDatatype::Turbo4 => Self::DenseTurbo(Box::new(
+                    ReadOnlyTurboVectorStorage::open(fs, path, dim, distance, true, populate)?,
+                )),
             }
         } else {
             match datatype {
@@ -225,11 +232,9 @@ impl<S: UniversalRead> VectorStorageReadEnum<S> {
                 VectorStorageDatatype::Float16 => Self::DenseHalf(Box::new(
                     ReadOnlyImmutableDenseVectorStorage::open(fs, path, dim, distance, populate)?,
                 )),
-                VectorStorageDatatype::Turbo4 => {
-                    return Err(OperationError::service_error(
-                        "Turbo4 datatype storage is not yet supported",
-                    ));
-                }
+                VectorStorageDatatype::Turbo4 => Self::DenseTurbo(Box::new(
+                    ReadOnlyTurboVectorStorage::open(fs, path, dim, distance, false, populate)?,
+                )),
             }
         }))
     }

--- a/lib/segment/src/vector_storage/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/read_only/live_reload.rs
@@ -45,6 +45,12 @@ impl<S: UniversalRead> LiveReload for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => {
                 s.live_reload(fs, deleted_points, new_points, hw_counter)
             }
+            VectorStorageReadEnum::DenseTurbo(s) => {
+                s.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            VectorStorageReadEnum::MultiDenseTurbo(s) => {
+                s.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
             VectorStorageReadEnum::Sparse(s) => {
                 s.live_reload(fs, deleted_points, new_points, hw_counter)
             }

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -10,8 +10,12 @@ use crate::vector_storage::dense::read_only::{
 };
 use crate::vector_storage::multi_dense::read_only::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::vector_storage::sparse::read_only::ReadOnlySparseVectorStorage;
+use crate::vector_storage::turbo::read_only::{
+    ReadOnlyTurboMultiVectorStorage, ReadOnlyTurboVectorStorage,
+};
 use crate::vector_storage::{
     RawScorer, RawScorerBuilder, raw_multi_scorer_impl, raw_scorer_impl, raw_sparse_scorer_impl,
+    raw_turbo_multi_scorer_impl, raw_turbo_scorer_impl,
 };
 
 mod lifecycle;
@@ -32,6 +36,8 @@ pub enum VectorStorageReadEnum<S: UniversalRead> {
     MultiDenseChunked(Box<ReadOnlyChunkedMultiDenseVectorStorage<VectorElementType, S>>),
     MultiDenseChunkedByte(Box<ReadOnlyChunkedMultiDenseVectorStorage<VectorElementTypeByte, S>>),
     MultiDenseChunkedHalf(Box<ReadOnlyChunkedMultiDenseVectorStorage<VectorElementTypeHalf, S>>),
+    DenseTurbo(Box<ReadOnlyTurboVectorStorage<S>>),
+    MultiDenseTurbo(Box<ReadOnlyTurboMultiVectorStorage<S>>),
     Sparse(Box<ReadOnlySparseVectorStorage<S>>),
 }
 
@@ -66,6 +72,12 @@ impl<S: UniversalRead> RawScorerBuilder for VectorStorageReadEnum<S> {
             }
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => {
                 raw_multi_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::DenseTurbo(s) => {
+                raw_turbo_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::MultiDenseTurbo(s) => {
+                raw_turbo_multi_scorer_impl(query, s.as_ref(), hardware_counter)
             }
             VectorStorageReadEnum::Sparse(s) => {
                 raw_sparse_scorer_impl(query, s.as_ref(), hardware_counter)
@@ -531,6 +543,245 @@ mod tests {
         assert_eq!(storage.deleted_vector_count(), deleted_ids.len());
         for &id in &deleted_ids {
             assert!(storage.is_deleted_vector(id));
+        }
+    }
+
+    fn turbo_config(
+        storage_type: VectorStorageType,
+        multivector_config: Option<MultiVectorConfig>,
+    ) -> VectorDataConfig {
+        VectorDataConfig {
+            size: DIM,
+            distance: Distance::Dot,
+            storage_type,
+            index: Indexes::Plain {},
+            quantization_config: None,
+            multivector_config,
+            datatype: Some(VectorStorageDatatype::Turbo4),
+        }
+    }
+
+    #[test]
+    fn read_only_turbo_dense_round_trip() {
+        use std::borrow::Cow;
+        use std::sync::atomic::AtomicBool;
+
+        use crate::data_types::vectors::QueryVector;
+        use crate::vector_storage::turbo::{
+            TurboVectorStorage, open_appendable_turbo_vector_storage, open_turbo_vector_storage,
+        };
+        use crate::vector_storage::{DenseTQVectorStorage, raw_turbo_scorer_impl};
+
+        const COUNT: PointOffsetType = 300;
+
+        let mut rng = StdRng::seed_from_u64(17);
+        let hw = HardwareCounterCell::disposable();
+        let stopped = AtomicBool::new(false);
+        let vectors: Vec<DenseVector> = (0..COUNT).map(|_| rand_vec(&mut rng)).collect();
+        let mut deleted_ids = Vec::new();
+
+        let ref_dir = Builder::new().prefix("ro_turbo_ref").tempdir().unwrap();
+        let mut reference =
+            open_appendable_turbo_vector_storage(ref_dir.path(), DIM, Distance::Dot, false)
+                .unwrap();
+        for (id, vector) in vectors.iter().enumerate() {
+            reference
+                .insert_vector(id as PointOffsetType, VectorRef::from(vector), &hw)
+                .unwrap();
+        }
+        for id in 0..COUNT {
+            if rng.random_bool(0.1) {
+                reference.delete_vector(id).unwrap();
+                deleted_ids.push(id);
+            }
+        }
+        reference.flusher()().unwrap();
+
+        let encoded: Vec<(Vec<u8>, bool)> = (0..COUNT)
+            .map(|id| {
+                (
+                    reference.get_quantized_vector(id).to_vec(),
+                    reference.is_deleted_vector(id),
+                )
+            })
+            .collect();
+
+        for storage_type in [VectorStorageType::Mmap, VectorStorageType::ChunkedMmap] {
+            let dir = Builder::new().prefix("ro_turbo").tempdir().unwrap();
+
+            let mut target: TurboVectorStorage = match storage_type {
+                VectorStorageType::Mmap => {
+                    open_turbo_vector_storage(dir.path(), DIM, Distance::Dot, false).unwrap()
+                }
+                VectorStorageType::ChunkedMmap => {
+                    open_appendable_turbo_vector_storage(dir.path(), DIM, Distance::Dot, false)
+                        .unwrap()
+                }
+                VectorStorageType::InRamMmap
+                | VectorStorageType::InRamChunkedMmap
+                | VectorStorageType::Memory
+                | VectorStorageType::Empty => {
+                    unreachable!("unexpected storage type {storage_type:?}")
+                }
+            };
+            let mut source = encoded
+                .iter()
+                .map(|(bytes, deleted)| (Cow::Borrowed(bytes.as_slice()), *deleted));
+            target.update_from(&mut source, &stopped).unwrap();
+            target.flusher()().unwrap();
+
+            let ro = VectorStorageReadEnum::<MmapFile>::open(
+                &MmapFs,
+                &turbo_config(storage_type, None),
+                dir.path(),
+                None,
+            )
+            .unwrap()
+            .unwrap();
+
+            assert!(
+                matches!(ro, VectorStorageReadEnum::DenseTurbo(_)),
+                "{storage_type:?} should route to DenseTurbo",
+            );
+            assert_eq!(ro.total_vector_count(), vectors.len());
+            assert_eq!(ro.deleted_vector_count(), deleted_ids.len());
+            for id in 0..COUNT {
+                assert_eq!(
+                    ro.is_deleted_vector(id),
+                    deleted_ids.contains(&id),
+                    "{storage_type:?} deleted flag @{id}",
+                );
+            }
+
+            for id in [0, 7, 42, COUNT - 1] {
+                let ro_vec: DenseVector =
+                    ro.get_vector::<Random>(id).to_owned().try_into().unwrap();
+                let ref_vec: DenseVector = reference
+                    .get_vector::<Random>(id)
+                    .to_owned()
+                    .try_into()
+                    .unwrap();
+                assert_eq!(ro_vec, ref_vec, "{storage_type:?} get_vector @{id}");
+            }
+
+            ro.read_vector_bytes::<Random, _>((0..COUNT).map(|id| ((), id)), |(), id, bytes| {
+                assert_eq!(
+                    bytes, encoded[id as usize].0,
+                    "{storage_type:?} raw bytes @{id}",
+                );
+            })
+            .unwrap();
+
+            let query = QueryVector::Nearest(vectors[3].clone().into());
+            let ro_scorer = ro
+                .build_raw_scorer(query.clone(), HardwareCounterCell::disposable())
+                .unwrap();
+            let ref_scorer =
+                raw_turbo_scorer_impl(query, &reference, HardwareCounterCell::disposable())
+                    .unwrap();
+            for id in 0..COUNT {
+                assert_eq!(
+                    ro_scorer.score_point(id),
+                    ref_scorer.score_point(id),
+                    "{storage_type:?} score @{id}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn read_only_turbo_multi_round_trip() {
+        use crate::data_types::vectors::QueryVector;
+        use crate::vector_storage::turbo::multi::open_appendable_turbo_multi_vector_storage;
+        use crate::vector_storage::{MultiTQVectorStorageRead, raw_turbo_multi_scorer_impl};
+
+        const COUNT: PointOffsetType = 128;
+        let multivector_config = MultiVectorConfig::default();
+        let dir = Builder::new().prefix("ro_turbo_multi").tempdir().unwrap();
+        let mut rng = StdRng::seed_from_u64(23);
+        let hw = HardwareCounterCell::disposable();
+
+        let multis: Vec<MultiDenseVectorInternal> = (0..COUNT)
+            .map(|_| {
+                let n = rng.random_range(1..=3usize);
+                let flattened: Vec<f32> = std::iter::repeat_with(|| rng.random_range(-1.0..1.0))
+                    .take(n * DIM)
+                    .collect();
+                MultiDenseVectorInternal::new(flattened, DIM)
+            })
+            .collect();
+        let mut deleted_ids = Vec::new();
+
+        let mut writable = open_appendable_turbo_multi_vector_storage(
+            dir.path(),
+            DIM,
+            Distance::Dot,
+            multivector_config,
+            false,
+        )
+        .unwrap();
+        for (id, multi) in multis.iter().enumerate() {
+            writable
+                .insert_vector(
+                    id as PointOffsetType,
+                    TypedMultiDenseVectorRef::from(multi).into(),
+                    &hw,
+                )
+                .unwrap();
+        }
+        for id in 0..COUNT {
+            if rng.random_bool(0.1) {
+                writable.delete_vector(id).unwrap();
+                deleted_ids.push(id);
+            }
+        }
+        writable.flusher()().unwrap();
+
+        let ro = VectorStorageReadEnum::<MmapFile>::open(
+            &MmapFs,
+            &turbo_config(VectorStorageType::ChunkedMmap, Some(multivector_config)),
+            dir.path(),
+            None,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert!(
+            matches!(ro, VectorStorageReadEnum::MultiDenseTurbo(_)),
+            "multivector Turbo4 should route to MultiDenseTurbo",
+        );
+        assert_eq!(ro.total_vector_count(), multis.len());
+        assert_eq!(ro.deleted_vector_count(), deleted_ids.len());
+        for id in 0..COUNT {
+            assert_eq!(
+                ro.is_deleted_vector(id),
+                deleted_ids.contains(&id),
+                "deleted flag @{id}",
+            );
+        }
+
+        ro.read_vector_bytes::<Random, _>((0..COUNT).map(|id| ((), id)), |(), id, bytes| {
+            assert_eq!(
+                bytes,
+                writable.get_multi_tq::<Random>(id).to_vec(),
+                "raw records @{id}",
+            );
+        })
+        .unwrap();
+
+        let query = QueryVector::Nearest(multis[5].clone().into());
+        let ro_scorer = ro
+            .build_raw_scorer(query.clone(), HardwareCounterCell::disposable())
+            .unwrap();
+        let wr_scorer =
+            raw_turbo_multi_scorer_impl(query, &writable, HardwareCounterCell::disposable())
+                .unwrap();
+        for id in 0..COUNT {
+            assert_eq!(
+                ro_scorer.score_point(id),
+                wr_scorer.score_point(id),
+                "score @{id}",
+            );
         }
     }
 }

--- a/lib/segment/src/vector_storage/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/read_only/read_ops.rs
@@ -8,7 +8,8 @@ use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::{
-    DenseVectorStorageRead, MultiVectorStorageRead, SparseVectorStorageRead, VectorStorageRead,
+    DenseTQVectorStorageRead, DenseVectorStorageRead, MultiTQVectorStorageRead,
+    MultiVectorStorageRead, SparseVectorStorageRead, VectorStorageRead,
 };
 
 impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
@@ -27,6 +28,8 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => {
                 s.size_of_available_vectors_in_bytes()
             }
+            VectorStorageReadEnum::DenseTurbo(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => s.size_of_available_vectors_in_bytes(),
             VectorStorageReadEnum::Sparse(s) => s.size_of_available_vectors_in_bytes(),
         }
     }
@@ -42,6 +45,8 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunked(s) => s.distance(),
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.distance(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.distance(),
+            VectorStorageReadEnum::DenseTurbo(s) => s.distance(),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => s.distance(),
             VectorStorageReadEnum::Sparse(s) => s.distance(),
         }
     }
@@ -57,6 +62,8 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunked(s) => s.datatype(),
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.datatype(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.datatype(),
+            VectorStorageReadEnum::DenseTurbo(s) => s.datatype(),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => s.datatype(),
             VectorStorageReadEnum::Sparse(s) => s.datatype(),
         }
     }
@@ -72,6 +79,8 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunked(s) => s.is_on_disk(),
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.is_on_disk(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.is_on_disk(),
+            VectorStorageReadEnum::DenseTurbo(s) => s.is_on_disk(),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => s.is_on_disk(),
             VectorStorageReadEnum::Sparse(s) => s.is_on_disk(),
         }
     }
@@ -87,6 +96,8 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunked(s) => s.total_vector_count(),
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.total_vector_count(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.total_vector_count(),
+            VectorStorageReadEnum::DenseTurbo(s) => s.total_vector_count(),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => s.total_vector_count(),
             VectorStorageReadEnum::Sparse(s) => s.total_vector_count(),
         }
     }
@@ -102,6 +113,8 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunked(s) => s.get_vector::<P>(key),
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.get_vector::<P>(key),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.get_vector::<P>(key),
+            VectorStorageReadEnum::DenseTurbo(s) => s.get_vector::<P>(key),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => s.get_vector::<P>(key),
             VectorStorageReadEnum::Sparse(s) => s.get_vector::<P>(key),
         }
     }
@@ -125,6 +138,8 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => {
                 s.read_vectors::<P, U>(keys, callback)
             }
+            VectorStorageReadEnum::DenseTurbo(s) => s.read_vectors::<P, U>(keys, callback),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => s.read_vectors::<P, U>(keys, callback),
             VectorStorageReadEnum::Sparse(s) => s.read_vectors::<P, U>(keys, callback),
         }
     }
@@ -140,6 +155,8 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunked(s) => s.get_vector_opt::<P>(key),
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.get_vector_opt::<P>(key),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.get_vector_opt::<P>(key),
+            VectorStorageReadEnum::DenseTurbo(s) => s.get_vector_opt::<P>(key),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => s.get_vector_opt::<P>(key),
             VectorStorageReadEnum::Sparse(s) => s.get_vector_opt::<P>(key),
         }
     }
@@ -155,6 +172,8 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunked(s) => s.is_deleted_vector(key),
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.is_deleted_vector(key),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.is_deleted_vector(key),
+            VectorStorageReadEnum::DenseTurbo(s) => s.is_deleted_vector(key),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => s.is_deleted_vector(key),
             VectorStorageReadEnum::Sparse(s) => s.is_deleted_vector(key),
         }
     }
@@ -170,6 +189,8 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunked(s) => s.deleted_vector_count(),
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.deleted_vector_count(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.deleted_vector_count(),
+            VectorStorageReadEnum::DenseTurbo(s) => s.deleted_vector_count(),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => s.deleted_vector_count(),
             VectorStorageReadEnum::Sparse(s) => s.deleted_vector_count(),
         }
     }
@@ -185,6 +206,8 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunked(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.deleted_vector_bitslice(),
+            VectorStorageReadEnum::DenseTurbo(s) => s.deleted_vector_bitslice(),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::Sparse(s) => s.deleted_vector_bitslice(),
         }
     }
@@ -214,6 +237,10 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => {
                 Ok(s.with_multi_bytes_opt::<P, R>(key, f))
             }
+            VectorStorageReadEnum::DenseTurbo(s) => Ok(s.with_dense_tq_bytes_opt::<P, R>(key, f)),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => {
+                Ok(s.with_multi_tq_bytes_opt::<P, R>(key, f))
+            }
             VectorStorageReadEnum::Sparse(s) => s.with_sparse_bytes_opt::<P, R>(key, f),
         }
     }
@@ -234,7 +261,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             | VectorStorageReadEnum::DenseChunkedHalf(_)
             | VectorStorageReadEnum::MultiDenseChunked(_)
             | VectorStorageReadEnum::MultiDenseChunkedByte(_)
-            | VectorStorageReadEnum::MultiDenseChunkedHalf(_) => {
+            | VectorStorageReadEnum::MultiDenseChunkedHalf(_)
+            | VectorStorageReadEnum::DenseTurbo(_)
+            | VectorStorageReadEnum::MultiDenseTurbo(_) => {
                 self.with_vector_bytes_opt::<P, _>(key, <[u8]>::to_vec)
             }
         }
@@ -251,6 +280,8 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunked(s) => s.available_vector_count(),
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.available_vector_count(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.available_vector_count(),
+            VectorStorageReadEnum::DenseTurbo(s) => s.available_vector_count(),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => s.available_vector_count(),
             VectorStorageReadEnum::Sparse(s) => s.available_vector_count(),
         }
     }
@@ -278,6 +309,10 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
                 s.read_vector_bytes::<P, U>(keys, callback)
             }
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => {
+                s.read_vector_bytes::<P, U>(keys, callback)
+            }
+            VectorStorageReadEnum::DenseTurbo(s) => s.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => {
                 s.read_vector_bytes::<P, U>(keys, callback)
             }
             VectorStorageReadEnum::Sparse(s) => s.read_vector_bytes::<P, U>(keys, callback),

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -9,6 +9,7 @@
 //! **not** `DenseVectorStorage<T>`.
 
 pub mod multi;
+pub mod read_only;
 #[cfg(test)]
 mod test;
 mod turbo_encoded_vectors;
@@ -36,7 +37,9 @@ use crate::data_types::vectors::{DenseVector, VectorElementType, VectorRef};
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use crate::types::{Distance, VectorStorageDatatype};
-use crate::vector_storage::{DenseTQVectorStorage, VectorStorage, VectorStorageRead};
+use crate::vector_storage::{
+    DenseTQVectorStorage, DenseTQVectorStorageRead, VectorStorage, VectorStorageRead,
+};
 
 // TurboQuant DataType (TQDT) always uses 4 bits without shift+scale error correction.
 const TQDT_BITS: TQBits = TQBits::Bits4;
@@ -493,7 +496,43 @@ impl VectorStorage for TurboVectorStorage {
     }
 }
 
-impl DenseTQVectorStorage for TurboVectorStorage {
+pub trait TurboScoring: DenseTQVectorStorageRead {
+    fn preprocess_query(&self, query: DenseVector) -> EncodedQueryTQ;
+
+    fn score_query_bytes(&self, query: &EncodedQueryTQ, bytes: &[u8]) -> ScoreType;
+
+    fn score_internal_encoded(
+        &self,
+        point_a: PointOffsetType,
+        point_b: PointOffsetType,
+    ) -> ScoreType;
+
+    fn get_quantized_vector(&self, key: PointOffsetType) -> Cow<'_, [u8]>;
+}
+
+impl TurboScoring for TurboVectorStorage {
+    fn preprocess_query(&self, query: DenseVector) -> EncodedQueryTQ {
+        TurboVectorStorage::preprocess_query(self, query)
+    }
+
+    fn score_query_bytes(&self, query: &EncodedQueryTQ, bytes: &[u8]) -> ScoreType {
+        TurboVectorStorage::score_query_bytes(self, query, bytes)
+    }
+
+    fn score_internal_encoded(
+        &self,
+        point_a: PointOffsetType,
+        point_b: PointOffsetType,
+    ) -> ScoreType {
+        TurboVectorStorage::score_internal_encoded(self, point_a, point_b)
+    }
+
+    fn get_quantized_vector(&self, key: PointOffsetType) -> Cow<'_, [u8]> {
+        TurboVectorStorage::get_quantized_vector(self, key)
+    }
+}
+
+impl DenseTQVectorStorageRead for TurboVectorStorage {
     fn vector_dim(&self) -> usize {
         self.dim
     }
@@ -527,7 +566,9 @@ impl DenseTQVectorStorage for TurboVectorStorage {
                 callback(user_data[idx], point_offsets[idx], bytes.to_vec());
             })
     }
+}
 
+impl DenseTQVectorStorage for TurboVectorStorage {
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (Cow<'a, [u8]>, bool)>,

--- a/lib/segment/src/vector_storage/turbo/multi.rs
+++ b/lib/segment/src/vector_storage/turbo/multi.rs
@@ -691,6 +691,19 @@ pub trait TurboMultiScoring: MultiTQVectorStorageRead {
         point_b: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> ScoreType;
+
+    /// Score a precomputed multi-query directly against a point's concatenated
+    /// encoded records, without a separate storage fetch.
+    fn score_records_max_similarity(&self, query: &[EncodedQueryTQ], records: &[u8]) -> ScoreType;
+
+    /// Two-pass batched read for records (offsets, then vectors), invoking
+    /// `callback` once per requested point. Lets the query scorers batch the
+    /// underlying reads over either backend.
+    fn for_each_record_range<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, &[u8]),
+    ) -> OperationResult<()>;
 }
 
 impl TurboMultiScoring for TurboMultiVectorStorage {
@@ -714,6 +727,18 @@ impl TurboMultiScoring for TurboMultiVectorStorage {
         hw_counter: &HardwareCounterCell,
     ) -> ScoreType {
         TurboMultiVectorStorage::score_internal_max_similarity(self, point_a, point_b, hw_counter)
+    }
+
+    fn score_records_max_similarity(&self, query: &[EncodedQueryTQ], records: &[u8]) -> ScoreType {
+        TurboMultiVectorStorage::score_records_max_similarity(self, query, records)
+    }
+
+    fn for_each_record_range<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, &[u8]),
+    ) -> OperationResult<()> {
+        TurboMultiVectorStorage::for_each_record_range::<P, _>(self, keys, callback)
     }
 }
 

--- a/lib/segment/src/vector_storage/turbo/multi.rs
+++ b/lib/segment/src/vector_storage/turbo/multi.rs
@@ -40,10 +40,11 @@ use crate::vector_storage::chunked_vectors::ChunkedVectors;
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::MultivectorMmapOffset;
 use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedChunkedStorage;
 use crate::vector_storage::{
-    MultiTQVectorStorage, VectorOffsetType, VectorStorage, VectorStorageRead,
+    MultiTQVectorStorage, MultiTQVectorStorageRead, VectorOffsetType, VectorStorage,
+    VectorStorageRead,
 };
 
-const OFFSETS_PATH: &str = "tq_offsets.dat";
+pub(super) const OFFSETS_PATH: &str = "tq_offsets.dat";
 
 /// Multivector storage for TurboQuant encoded inner vectors.
 pub struct TurboMultiVectorStorage {
@@ -665,7 +666,58 @@ impl VectorStorage for TurboMultiVectorStorage {
     }
 }
 
-impl MultiTQVectorStorage for TurboMultiVectorStorage {
+/// Scoring surface the Turbo multivector query scorers need from a multivector
+/// TurboQuant storage. Multi counterpart of
+/// [`TurboScoring`](super::TurboScoring): implemented by the writable
+/// [`TurboMultiVectorStorage`] and its read-only counterpart, so the shared
+/// `raw_turbo_multi_scorer_impl` works over either.
+pub trait TurboMultiScoring: MultiTQVectorStorageRead {
+    /// Preprocess and precompute each inner query vector of a multi-query once.
+    fn preprocess_query(&self, query: &MultiDenseVectorInternal) -> Vec<EncodedQueryTQ>;
+
+    /// Asymmetric MaxSim score of a precomputed multi-query against stored point
+    /// `key`.
+    fn score_point_max_similarity(
+        &self,
+        query: &[EncodedQueryTQ],
+        key: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> ScoreType;
+
+    /// Symmetric MaxSim score between two stored points.
+    fn score_internal_max_similarity(
+        &self,
+        point_a: PointOffsetType,
+        point_b: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> ScoreType;
+}
+
+impl TurboMultiScoring for TurboMultiVectorStorage {
+    fn preprocess_query(&self, query: &MultiDenseVectorInternal) -> Vec<EncodedQueryTQ> {
+        TurboMultiVectorStorage::preprocess_query(self, query)
+    }
+
+    fn score_point_max_similarity(
+        &self,
+        query: &[EncodedQueryTQ],
+        key: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> ScoreType {
+        TurboMultiVectorStorage::score_point_max_similarity(self, query, key, hw_counter)
+    }
+
+    fn score_internal_max_similarity(
+        &self,
+        point_a: PointOffsetType,
+        point_b: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> ScoreType {
+        TurboMultiVectorStorage::score_internal_max_similarity(self, point_a, point_b, hw_counter)
+    }
+}
+
+impl MultiTQVectorStorageRead for TurboMultiVectorStorage {
     fn vector_dim(&self) -> usize {
         self.dim
     }
@@ -688,7 +740,9 @@ impl MultiTQVectorStorage for TurboMultiVectorStorage {
             // `fresh_range_start` guarantees ranges never straddle a boundary.
             .expect("Multivector not found")
     }
+}
 
+impl MultiTQVectorStorage for TurboMultiVectorStorage {
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (Cow<'a, [u8]>, bool)>,

--- a/lib/segment/src/vector_storage/turbo/read_only.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only.rs
@@ -71,9 +71,10 @@ impl<S: UniversalRead> ReadOnlyTurboEncoded<S> {
         }
     }
 
-    /// Run `f` for each vector in the batch, batching the underlying reads where
-    /// the backend supports it (the single-file backend pipelines io_uring /
-    /// prefetches mmap; the chunked backend reads one record at a time).
+    /// Run `f` for each vector in the batch, batching the underlying reads
+    /// where the backend supports it (the single-file backend pipelines
+    /// io_uring / prefetches mmap; the chunked backend batches through
+    /// [`EncodedStorage::for_each_batch`]).
     fn for_each_in_batch<F: FnMut(usize, &[u8])>(
         &self,
         keys: &[PointOffsetType],
@@ -82,9 +83,7 @@ impl<S: UniversalRead> ReadOnlyTurboEncoded<S> {
         match self {
             Self::Single(s) => s.for_each_in_batch(keys, f),
             Self::Chunked(s) => {
-                for (idx, &key) in keys.iter().enumerate() {
-                    f(idx, &s.get_vector_data(key));
-                }
+                s.for_each_batch(keys, |idx, bytes| f(idx, &bytes));
                 Ok(())
             }
         }

--- a/lib/segment/src/vector_storage/turbo/read_only.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only.rs
@@ -1,0 +1,791 @@
+//! Read-only counterpart of [`TurboVectorStorage`](super::TurboVectorStorage).
+//!
+//! Opens the TurboQuant-encoded blob and deletion flags over an arbitrary
+//! [`UniversalRead`] backend (mmap / cache / remote), so a read-only segment can
+//! retrieve and score a `Turbo4`-typed vector storage. The quantizer is fully
+//! determined by `(dim, distance)` (fixed TQDT constants), so nothing beyond the
+//! encoded bytes and flags is read from disk.
+//!
+//! Scoring is reused verbatim from the writable storage via the shared
+//! [`TurboScoring`](super::TurboScoring) trait — this storage only provides the
+//! read surface it needs.
+
+use std::borrow::Cow;
+use std::path::Path;
+
+use common::bitvec::BitSlice;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::{AccessPattern, Random};
+use common::mmap::AdviceSetting;
+use common::sorted_slice::SortedSlice;
+use common::types::{PointOffsetType, ScoreType};
+use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs, UserData};
+use quantization::EncodedStorage;
+use quantization::turboquant::EncodedQueryTQ;
+use quantization::turboquant::quantization::TurboQuantizer;
+use smallvec::{SmallVec, smallvec};
+
+use super::multi::{OFFSETS_PATH, TurboMultiScoring};
+use super::{DELETED_PATH, TQDT_BITS, TQDT_MODE, TQDT_ROTATION, TurboScoring, VECTORS_PATH};
+use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
+use crate::common::live_reload::LiveReload;
+use crate::common::operation_error::OperationResult;
+use crate::data_types::named_vectors::{CowMultiVector, CowVector};
+use crate::data_types::vectors::{
+    DenseVector, MultiDenseVectorInternal, TypedMultiDenseVector, VectorElementType,
+};
+use crate::spaces::metric::Metric;
+use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
+use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
+use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
+use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::MultivectorMmapOffset;
+use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedChunkedStorageRead;
+use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
+use crate::vector_storage::vector_storage_base::VectorStorageRead;
+use crate::vector_storage::{DenseTQVectorStorageRead, MultiTQVectorStorageRead, VectorOffsetType};
+
+/// Read-only TurboQuant encoded backend over a [`UniversalRead`] `S`.
+///
+/// Read-only counterpart of the writable
+/// [`TurboEncodedVectorStorage`](super::turbo_encoded_vectors::TurboEncodedVectorStorage):
+/// the storage layout is picked at open time from the segment's storage type.
+enum ReadOnlyTurboEncoded<S: UniversalRead> {
+    /// Single-file layout, written by the non-appendable `Mmap` / `InRamMmap`.
+    Single(QuantizedStorage<S>),
+    /// Chunked layout, written by the appendable `ChunkedMmap` / `InRamChunkedMmap`.
+    Chunked(QuantizedChunkedStorageRead<S>),
+}
+
+impl<S: UniversalRead> ReadOnlyTurboEncoded<S> {
+    fn get_quantized_vector(&self, key: PointOffsetType) -> Cow<'_, [u8]> {
+        match self {
+            Self::Single(s) => s.get_vector_data(key),
+            Self::Chunked(s) => s.get_vector_data(key),
+        }
+    }
+
+    fn get_quantized_vector_opt(&self, key: PointOffsetType) -> Option<Cow<'_, [u8]>> {
+        match self {
+            Self::Single(s) => s.get_vector_data_opt(key),
+            Self::Chunked(s) => s.get_vector_data_opt(key),
+        }
+    }
+
+    /// Run `f` for each vector in the batch, batching the underlying reads where
+    /// the backend supports it (the single-file backend pipelines io_uring /
+    /// prefetches mmap; the chunked backend reads one record at a time).
+    fn for_each_in_batch<F: FnMut(usize, &[u8])>(
+        &self,
+        keys: &[PointOffsetType],
+        mut f: F,
+    ) -> OperationResult<()> {
+        match self {
+            Self::Single(s) => s.for_each_in_batch(keys, f),
+            Self::Chunked(s) => {
+                for (idx, &key) in keys.iter().enumerate() {
+                    f(idx, &s.get_vector_data(key));
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn vectors_count(&self) -> usize {
+        match self {
+            Self::Single(s) => s.vectors_count(),
+            Self::Chunked(s) => s.vectors_count(),
+        }
+    }
+
+    fn is_on_disk(&self) -> bool {
+        match self {
+            Self::Single(s) => s.is_on_disk(),
+            Self::Chunked(s) => s.is_on_disk(),
+        }
+    }
+
+    fn populate(&self) -> OperationResult<()> {
+        match self {
+            Self::Single(s) => {
+                s.populate();
+                Ok(())
+            }
+            Self::Chunked(s) => s.populate(),
+        }
+    }
+}
+
+/// Read-only TurboQuant dense vector storage over a [`UniversalRead`] backend.
+pub struct ReadOnlyTurboVectorStorage<S: UniversalRead> {
+    /// Read-only encoded vector blob over one of the two backends.
+    storage: ReadOnlyTurboEncoded<S>,
+    /// Quantizer used to de/quantize and score; rebuilt from `(dim, distance)`.
+    quantizer: TurboQuantizer,
+    /// Persisted soft-deletion flags, materialized in memory.
+    deleted: InMemoryBitvecFlags,
+    /// Distance used for scoring / query preprocessing.
+    distance: Distance,
+    /// Original (un-padded) vector dimensionality.
+    dim: usize,
+}
+
+impl<S: UniversalRead> std::fmt::Debug for ReadOnlyTurboVectorStorage<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReadOnlyTurboVectorStorage")
+            .field("dim", &self.dim)
+            .field("distance", &self.distance)
+            .field("total_vector_count", &self.storage.vectors_count())
+            .field("deleted_count", &self.deleted.count())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S: UniversalRead> ReadOnlyTurboVectorStorage<S> {
+    /// Build the quantizer for a `Turbo4` storage; fully determined by
+    /// `(dim, distance)` and the fixed TQDT constants (matches the writable
+    /// `open_turbo_vector_storage_impl`).
+    fn build_quantizer(dim: usize, distance: Distance) -> TurboQuantizer {
+        TurboQuantizer::new(
+            dim,
+            TQDT_BITS,
+            TQDT_MODE,
+            distance.into(),
+            TQDT_ROTATION,
+            None,
+        )
+    }
+
+    /// Schedule background prefetch of the files [`Self::open`] will read.
+    ///
+    /// Absent files are skipped rather than reported: the subsequent open is
+    /// the one to produce the error.
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        path: &Path,
+        chunked: bool,
+        populate: Populate,
+    ) -> OperationResult<()> {
+        let vectors_path = path.join(VECTORS_PATH);
+        if chunked {
+            QuantizedChunkedStorageRead::<S>::preopen(fs, &vectors_path, populate)?;
+        } else {
+            QuantizedStorage::<S>::preopen(fs, &vectors_path, populate)?;
+        }
+        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_PATH))?;
+        Ok(())
+    }
+
+    /// Open the read-only counterpart of a `Turbo4` dense storage at `path`,
+    /// threading every file open through `fs`; reads the existing layout but
+    /// creates and writes nothing. `chunked` selects the on-disk layout the
+    /// writable storage produced for the segment's storage type.
+    pub fn open(
+        fs: &impl UniversalReadFs<File = S>,
+        path: &Path,
+        dim: usize,
+        distance: Distance,
+        chunked: bool,
+        populate: Populate,
+    ) -> OperationResult<Self> {
+        let quantizer = Self::build_quantizer(dim, distance);
+        let quantized_vector_size = quantizer.quantized_size();
+        let vectors_path = path.join(VECTORS_PATH);
+
+        let storage = if chunked {
+            ReadOnlyTurboEncoded::Chunked(QuantizedChunkedStorageRead::open(
+                fs,
+                &vectors_path,
+                quantized_vector_size,
+            )?)
+        } else {
+            ReadOnlyTurboEncoded::Single(QuantizedStorage::from_file(
+                fs,
+                &vectors_path,
+                quantized_vector_size,
+            )?)
+        };
+
+        // The read-only backends map lazily; warm them when the load profile asks.
+        if !matches!(populate, Populate::No) {
+            storage.populate()?;
+        }
+
+        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_PATH))?;
+
+        Ok(Self {
+            storage,
+            quantizer,
+            deleted,
+            distance,
+            dim,
+        })
+    }
+
+    /// Whether scores must be negated to follow qdrant's "higher = better"
+    /// convention (mirrors `TurboVectorStorage::invert_score`).
+    fn invert_score(&self) -> bool {
+        matches!(self.distance, Distance::Euclid | Distance::Manhattan)
+    }
+
+    /// Dequantize + inverse-rotate a stored encoded vector back to `f32`,
+    /// dropping the padding tail (mirrors `TurboVectorStorage::dequantize_vector`).
+    fn dequantize_vector(&self, quantized: Cow<[u8]>) -> CowVector<'_> {
+        let mut dequantized = self.quantizer.dequantize::<f64>(&quantized);
+        self.quantizer.apply_inverse_rotation(&mut dequantized);
+        CowVector::Dense(Cow::Owned(
+            dequantized[..self.dim]
+                .iter()
+                .map(|i| *i as f32)
+                .collect::<Vec<_>>(),
+        ))
+    }
+}
+
+impl<S: UniversalRead> VectorStorageRead for ReadOnlyTurboVectorStorage<S> {
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        self.available_vector_count() * self.quantized_vector_size()
+    }
+
+    fn distance(&self) -> Distance {
+        self.distance
+    }
+
+    fn datatype(&self) -> VectorStorageDatatype {
+        VectorStorageDatatype::Turbo4
+    }
+
+    fn is_on_disk(&self) -> bool {
+        self.storage.is_on_disk()
+    }
+
+    fn total_vector_count(&self) -> usize {
+        self.storage.vectors_count()
+    }
+
+    fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
+        self.dequantize_vector(self.storage.get_quantized_vector(key))
+    }
+
+    fn read_vectors<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
+    ) {
+        let (user_data, point_offsets): (Vec<U>, Vec<PointOffsetType>) = keys.into_iter().unzip();
+
+        self.storage
+            .for_each_in_batch(&point_offsets, |idx, bytes| {
+                let vector = self.dequantize_vector(Cow::Borrowed(bytes));
+                callback(user_data[idx], point_offsets[idx], vector);
+            })
+            .expect("read TQ vectors");
+    }
+
+    fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
+        Some(self.dequantize_vector(self.storage.get_quantized_vector_opt(key)?))
+    }
+
+    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
+        self.deleted.get(key)
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.deleted.count()
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        self.deleted.as_bitslice()
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        self.read_dense_tq_bytes::<P, U>(keys, callback)
+    }
+}
+
+impl<S: UniversalRead> DenseTQVectorStorageRead for ReadOnlyTurboVectorStorage<S> {
+    fn vector_dim(&self) -> usize {
+        self.dim
+    }
+
+    fn quantized_vector_size(&self) -> usize {
+        self.quantizer.quantized_size()
+    }
+
+    fn get_dense_tq<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [u8]> {
+        self.storage.get_quantized_vector(key)
+    }
+
+    fn for_each_in_dense_tq_batch<F: FnMut(usize, &[u8])>(
+        &self,
+        keys: &[PointOffsetType],
+        f: F,
+    ) -> OperationResult<()> {
+        self.storage.for_each_in_batch(keys, f)
+    }
+
+    fn read_dense_tq_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        // Same parallel-arrays split as `read_vectors`, minus the dequantization.
+        let (user_data, point_offsets): (Vec<U>, Vec<PointOffsetType>) = keys.into_iter().unzip();
+
+        self.storage
+            .for_each_in_batch(&point_offsets, |idx, bytes| {
+                callback(user_data[idx], point_offsets[idx], bytes.to_vec());
+            })
+    }
+}
+
+impl<S: UniversalRead> TurboScoring for ReadOnlyTurboVectorStorage<S> {
+    fn preprocess_query(&self, query: DenseVector) -> EncodedQueryTQ {
+        let preprocessed = match self.distance {
+            Distance::Cosine => <CosineMetric as Metric<VectorElementType>>::preprocess(query),
+            Distance::Euclid => <EuclidMetric as Metric<VectorElementType>>::preprocess(query),
+            Distance::Dot => <DotProductMetric as Metric<VectorElementType>>::preprocess(query),
+            Distance::Manhattan => {
+                <ManhattanMetric as Metric<VectorElementType>>::preprocess(query)
+            }
+        };
+        self.quantizer.precompute_query(&preprocessed)
+    }
+
+    fn score_query_bytes(&self, query: &EncodedQueryTQ, bytes: &[u8]) -> ScoreType {
+        let score = self.quantizer.score_precomputed(query, bytes);
+        if self.invert_score() { -score } else { score }
+    }
+
+    fn score_internal_encoded(
+        &self,
+        point_a: PointOffsetType,
+        point_b: PointOffsetType,
+    ) -> ScoreType {
+        let v1 = self.storage.get_quantized_vector(point_a);
+        let v2 = self.storage.get_quantized_vector(point_b);
+        let score = self.quantizer.score_symmetric(&v1, &v2);
+        if self.invert_score() { -score } else { score }
+    }
+
+    fn get_quantized_vector(&self, key: PointOffsetType) -> Cow<'_, [u8]> {
+        self.storage.get_quantized_vector(key)
+    }
+}
+
+impl<S: UniversalRead> LiveReload for ReadOnlyTurboVectorStorage<S> {
+    type Fs = S::Fs;
+
+    /// Pick up vectors a writer appended (chunked backend only; the single-file
+    /// layout is immutable) and patch the in-memory deletion flags.
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        if let ReadOnlyTurboEncoded::Chunked(storage) = &mut self.storage {
+            storage.live_reload(fs, deleted_points, new_points, hw_counter)?;
+        }
+        self.deleted.insert_all(deleted_points);
+        Ok(())
+    }
+}
+
+/// Read-only TurboQuant multivector vector storage over a [`UniversalRead`]
+/// backend. Read-only counterpart of
+/// [`TurboMultiVectorStorage`](super::multi::TurboMultiVectorStorage).
+///
+/// Multivectors are always stored in the appendable chunked layout, so — unlike
+/// the dense storage — there is a single backend.
+pub struct ReadOnlyTurboMultiVectorStorage<S: UniversalRead> {
+    /// Flat inner-vector space: one fixed-size encoded record per inner vector.
+    storage: QuantizedChunkedStorageRead<S>,
+    /// Maps each point to its record range in the inner space.
+    offsets: ChunkedVectorsRead<MultivectorMmapOffset, S>,
+    /// Quantizer used to de/quantize and score; rebuilt from `(dim, distance)`.
+    quantizer: TurboQuantizer,
+    /// Persisted soft-deletion flags, materialized in memory.
+    deleted: InMemoryBitvecFlags,
+    /// Distance used for scoring / query preprocessing.
+    distance: Distance,
+    /// Original (un-padded) inner vector dimensionality.
+    dim: usize,
+    multi_vector_config: MultiVectorConfig,
+}
+
+impl<S: UniversalRead> std::fmt::Debug for ReadOnlyTurboMultiVectorStorage<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReadOnlyTurboMultiVectorStorage")
+            .field("dim", &self.dim)
+            .field("distance", &self.distance)
+            .field("total_vector_count", &self.offsets.len())
+            .field("deleted_count", &self.deleted.count())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<S: UniversalRead> ReadOnlyTurboMultiVectorStorage<S> {
+    /// Schedule background prefetch of the files [`Self::open`] will read.
+    ///
+    /// Absent files are skipped rather than reported: the subsequent open is
+    /// the one to produce the error.
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        path: &Path,
+        advice: AdviceSetting,
+        populate: Populate,
+    ) -> OperationResult<()> {
+        QuantizedChunkedStorageRead::<S>::preopen(fs, &path.join(VECTORS_PATH), populate)?;
+        ChunkedVectorsRead::<MultivectorMmapOffset, S>::preopen(
+            fs,
+            &path.join(OFFSETS_PATH),
+            advice,
+            populate,
+        )?;
+        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_PATH))?;
+        Ok(())
+    }
+
+    /// Open the read-only counterpart of a `Turbo4` multivector storage at
+    /// `path`, threading every file open through `fs`; reads the existing layout
+    /// but creates and writes nothing.
+    pub fn open(
+        fs: &impl UniversalReadFs<File = S>,
+        path: &Path,
+        dim: usize,
+        distance: Distance,
+        multi_vector_config: MultiVectorConfig,
+        advice: AdviceSetting,
+        populate: Populate,
+    ) -> OperationResult<Self> {
+        let quantizer = ReadOnlyTurboVectorStorage::<S>::build_quantizer(dim, distance);
+
+        let storage = QuantizedChunkedStorageRead::open(
+            fs,
+            &path.join(VECTORS_PATH),
+            quantizer.quantized_size(),
+        )?;
+        // The chunked read backend maps lazily; warm it when the profile asks.
+        if !matches!(populate, Populate::No) {
+            storage.populate()?;
+        }
+
+        let offsets = ChunkedVectorsRead::open(fs, &path.join(OFFSETS_PATH), 1, advice, populate)?;
+
+        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_PATH))?;
+
+        Ok(Self {
+            storage,
+            offsets,
+            quantizer,
+            deleted,
+            distance,
+            dim,
+            multi_vector_config,
+        })
+    }
+
+    /// Offset record for `key`, if the point exists.
+    fn get_offset<P: AccessPattern>(&self, key: PointOffsetType) -> Option<MultivectorMmapOffset> {
+        let record = self.offsets.get::<P>(key as VectorOffsetType)?;
+        let &[offset] = record.as_ref() else {
+            debug_assert!(
+                false,
+                "multi-vector offsets are stored as vectors of length 1"
+            );
+            return None;
+        };
+        Some(offset)
+    }
+
+    fn invert_score(&self) -> bool {
+        matches!(self.distance, Distance::Euclid | Distance::Manhattan)
+    }
+
+    fn signed(&self, score: f32) -> ScoreType {
+        if self.invert_score() { -score } else { score }
+    }
+
+    /// Decode one inner record into `out`: dequantize, rotate back, drop padding.
+    fn dequantize_inner_into(&self, encoded: &[u8], out: &mut Vec<VectorElementType>) {
+        let mut dequantized = self.quantizer.dequantize::<f64>(encoded);
+        self.quantizer.apply_inverse_rotation(&mut dequantized);
+        out.extend(
+            dequantized[..self.dim]
+                .iter()
+                .map(|&x| x as VectorElementType),
+        );
+    }
+
+    /// Decode the full multivector behind an offset record.
+    fn dequantize_multi(&self, offset: MultivectorMmapOffset) -> CowVector<'_> {
+        let records = self
+            .storage
+            .get_many::<Random>(offset.offset, offset.count as usize)
+            .expect("Multivector not found");
+        self.dequantize_records(&records)
+    }
+
+    /// Decode concatenated encoded records into a multivector.
+    fn dequantize_records(&self, records: &[u8]) -> CowVector<'_> {
+        let record_size = self.quantizer.quantized_size();
+        let mut flattened = Vec::with_capacity(records.len() / record_size * self.dim);
+        for encoded in records.chunks_exact(record_size) {
+            self.dequantize_inner_into(encoded, &mut flattened);
+        }
+        CowVector::MultiDense(CowMultiVector::Owned(TypedMultiDenseVector {
+            flattened_vectors: flattened,
+            dim: self.dim,
+        }))
+    }
+
+    /// Two-pass batched read for records: first offsets, then vectors.
+    fn for_each_record_range<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, &[u8]),
+    ) -> OperationResult<()> {
+        let offset_keys = keys
+            .into_iter()
+            .map(|(user_data, key)| ((user_data, key), key, 1));
+
+        let mut ranges = Vec::with_capacity(offset_keys.size_hint().0);
+        self.offsets
+            .for_each_vector::<P, _>(offset_keys, |(user_data, key), record| {
+                let &[offset] = record.as_ref() else {
+                    unreachable!("multi-vector offsets are stored as vectors of length 1");
+                };
+                ranges.push(((user_data, key), offset.offset, offset.count));
+                Ok(())
+            })?;
+
+        self.storage
+            .for_each_many::<P, _>(ranges.into_iter(), |(user_data, key), records| {
+                callback(user_data, key, records.as_ref());
+                Ok(())
+            })
+    }
+}
+
+impl<S: UniversalRead> VectorStorageRead for ReadOnlyTurboMultiVectorStorage<S> {
+    fn distance(&self) -> Distance {
+        self.distance
+    }
+
+    fn datatype(&self) -> VectorStorageDatatype {
+        VectorStorageDatatype::Turbo4
+    }
+
+    fn is_on_disk(&self) -> bool {
+        self.storage.is_on_disk()
+    }
+
+    fn total_vector_count(&self) -> usize {
+        self.offsets.len()
+    }
+
+    fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
+        self.get_vector_opt::<P>(key).expect("vector not found")
+    }
+
+    fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
+        Some(self.dequantize_multi(self.get_offset::<P>(key)?))
+    }
+
+    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
+        self.deleted.get(key)
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.deleted.count()
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        self.deleted.as_bitslice()
+    }
+
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        if self.total_vector_count() > 0 {
+            let total_size = self.storage.vectors_count() * self.quantizer.quantized_size();
+            (total_size as u128 * self.available_vector_count() as u128
+                / self.total_vector_count() as u128) as usize
+        } else {
+            0
+        }
+    }
+
+    fn read_vectors<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
+    ) {
+        self.for_each_record_range::<P, _>(keys, |user_data, key, records| {
+            callback(user_data, key, self.dequantize_records(records));
+        })
+        .expect("read TQ multivectors");
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        self.for_each_record_range::<P, _>(keys, |user_data, key, records| {
+            callback(user_data, key, records.to_vec());
+        })
+    }
+}
+
+impl<S: UniversalRead> MultiTQVectorStorageRead for ReadOnlyTurboMultiVectorStorage<S> {
+    fn vector_dim(&self) -> usize {
+        self.dim
+    }
+
+    fn quantized_vector_size(&self) -> usize {
+        self.quantizer.quantized_size()
+    }
+
+    fn multi_vector_config(&self) -> &MultiVectorConfig {
+        &self.multi_vector_config
+    }
+
+    fn get_multi_tq<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [u8]> {
+        self.get_offset::<P>(key)
+            .and_then(|offset| {
+                self.storage
+                    .get_many::<P>(offset.offset, offset.count as usize)
+            })
+            .expect("Multivector not found")
+    }
+}
+
+impl<S: UniversalRead> TurboMultiScoring for ReadOnlyTurboMultiVectorStorage<S> {
+    fn preprocess_query(&self, query: &MultiDenseVectorInternal) -> Vec<EncodedQueryTQ> {
+        query
+            .multi_vectors()
+            .map(|inner| {
+                let preprocessed = match self.distance {
+                    Distance::Cosine => {
+                        <CosineMetric as Metric<VectorElementType>>::preprocess(inner.to_vec())
+                    }
+                    Distance::Euclid => {
+                        <EuclidMetric as Metric<VectorElementType>>::preprocess(inner.to_vec())
+                    }
+                    Distance::Dot => {
+                        <DotProductMetric as Metric<VectorElementType>>::preprocess(inner.to_vec())
+                    }
+                    Distance::Manhattan => {
+                        <ManhattanMetric as Metric<VectorElementType>>::preprocess(inner.to_vec())
+                    }
+                };
+                self.quantizer.precompute_query(&preprocessed)
+            })
+            .collect()
+    }
+
+    fn score_point_max_similarity(
+        &self,
+        query: &[EncodedQueryTQ],
+        key: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> ScoreType {
+        let Some(offset) = self.get_offset::<Random>(key) else {
+            log::error!("Multivector not found");
+            return ScoreType::NEG_INFINITY;
+        };
+
+        let records = self
+            .storage
+            .get_many::<Random>(offset.offset, offset.count as usize)
+            .expect("Multivector not found");
+
+        hw_counter
+            .cpu_counter()
+            .incr_delta(records.len() * query.len());
+        hw_counter.vector_io_read().incr_delta(records.len());
+
+        let mut max_sim: SmallVec<[_; 8]> = smallvec![ScoreType::NEG_INFINITY; query.len()];
+
+        for bytes in records.chunks_exact(self.quantizer.quantized_size()) {
+            for (qi, inner_query) in query.iter().enumerate() {
+                let sim = self.signed(self.quantizer.score_precomputed(inner_query, bytes));
+                if max_sim[qi] < sim {
+                    max_sim[qi] = sim;
+                }
+            }
+        }
+        max_sim.into_iter().sum()
+    }
+
+    fn score_internal_max_similarity(
+        &self,
+        point_a: PointOffsetType,
+        point_b: PointOffsetType,
+        hw_counter: &HardwareCounterCell,
+    ) -> ScoreType {
+        let (Some(offset_a), Some(offset_b)) = (
+            self.get_offset::<Random>(point_a),
+            self.get_offset::<Random>(point_b),
+        ) else {
+            log::error!("Multivector not found");
+            return ScoreType::NEG_INFINITY;
+        };
+
+        let records_a = self
+            .storage
+            .get_many::<Random>(offset_a.offset, offset_a.count as usize)
+            .expect("Multivector not found");
+
+        let records_b = self
+            .storage
+            .get_many::<Random>(offset_b.offset, offset_b.count as usize)
+            .expect("Multivector not found");
+
+        hw_counter
+            .cpu_counter()
+            .incr_delta(records_a.len() * offset_b.count as usize);
+        hw_counter
+            .vector_io_read()
+            .incr_delta(records_a.len() + records_b.len());
+
+        let quantized_size = self.quantizer.quantized_size();
+        let mut sum = 0.0;
+        for bytes_a in records_a.chunks_exact(quantized_size) {
+            let mut max_sim = ScoreType::NEG_INFINITY;
+            for bytes_b in records_b.chunks_exact(quantized_size) {
+                let sim = self.signed(self.quantizer.score_symmetric(bytes_a, bytes_b));
+                if sim > max_sim {
+                    max_sim = sim;
+                }
+            }
+            sum += max_sim;
+        }
+        sum
+    }
+}
+
+impl<S: UniversalRead> LiveReload for ReadOnlyTurboMultiVectorStorage<S> {
+    type Fs = S::Fs;
+
+    /// Pick up multivectors a writer appended (records + offsets) and patch the
+    /// in-memory deletion flags.
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.storage
+            .live_reload(fs, deleted_points, new_points, hw_counter)?;
+        self.offsets
+            .live_reload(fs, deleted_points, new_points, hw_counter)?;
+        self.deleted.insert_all(deleted_points);
+        Ok(())
+    }
+}

--- a/lib/segment/src/vector_storage/turbo/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/lifecycle.rs
@@ -1,0 +1,160 @@
+use std::path::Path;
+
+use common::mmap::AdviceSetting;
+use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs};
+use quantization::turboquant::quantization::TurboQuantizer;
+
+use super::super::multi::OFFSETS_PATH;
+use super::super::{DELETED_PATH, TQDT_BITS, TQDT_MODE, TQDT_ROTATION, VECTORS_PATH};
+use super::{ReadOnlyTurboEncoded, ReadOnlyTurboMultiVectorStorage, ReadOnlyTurboVectorStorage};
+use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
+use crate::common::operation_error::OperationResult;
+use crate::types::{Distance, MultiVectorConfig};
+use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
+use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::MultivectorMmapOffset;
+use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedChunkedStorageRead;
+use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
+
+impl<S: UniversalRead> ReadOnlyTurboVectorStorage<S> {
+    /// Build the quantizer for a `Turbo4` storage; fully determined by
+    /// `(dim, distance)` and the fixed TQDT constants (matches the writable
+    /// `open_turbo_vector_storage_impl`).
+    pub(super) fn build_quantizer(dim: usize, distance: Distance) -> TurboQuantizer {
+        TurboQuantizer::new(
+            dim,
+            TQDT_BITS,
+            TQDT_MODE,
+            distance.into(),
+            TQDT_ROTATION,
+            None,
+        )
+    }
+
+    /// Schedule background prefetch of the files [`Self::open`] will read.
+    ///
+    /// Absent files are skipped rather than reported: the subsequent open is
+    /// the one to produce the error.
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        path: &Path,
+        chunked: bool,
+        populate: Populate,
+    ) -> OperationResult<()> {
+        let vectors_path = path.join(VECTORS_PATH);
+        if chunked {
+            QuantizedChunkedStorageRead::<S>::preopen(fs, &vectors_path, populate)?;
+        } else {
+            QuantizedStorage::<S>::preopen(fs, &vectors_path, populate)?;
+        }
+        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_PATH))?;
+        Ok(())
+    }
+
+    /// Open the read-only counterpart of a `Turbo4` dense storage at `path`,
+    /// threading every file open through `fs`; reads the existing layout but
+    /// creates and writes nothing. `chunked` selects the on-disk layout the
+    /// writable storage produced for the segment's storage type.
+    pub fn open(
+        fs: &impl UniversalReadFs<File = S>,
+        path: &Path,
+        dim: usize,
+        distance: Distance,
+        chunked: bool,
+        populate: Populate,
+    ) -> OperationResult<Self> {
+        let quantizer = Self::build_quantizer(dim, distance);
+        let quantized_vector_size = quantizer.quantized_size();
+        let vectors_path = path.join(VECTORS_PATH);
+
+        let storage = if chunked {
+            ReadOnlyTurboEncoded::Chunked(QuantizedChunkedStorageRead::open(
+                fs,
+                &vectors_path,
+                quantized_vector_size,
+            )?)
+        } else {
+            ReadOnlyTurboEncoded::Single(QuantizedStorage::from_file(
+                fs,
+                &vectors_path,
+                quantized_vector_size,
+            )?)
+        };
+
+        // The read-only backends map lazily; warm them when the load profile asks.
+        if !matches!(populate, Populate::No) {
+            storage.populate()?;
+        }
+
+        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_PATH))?;
+
+        Ok(Self {
+            storage,
+            quantizer,
+            deleted,
+            distance,
+            dim,
+        })
+    }
+}
+
+impl<S: UniversalRead> ReadOnlyTurboMultiVectorStorage<S> {
+    /// Schedule background prefetch of the files [`Self::open`] will read.
+    ///
+    /// Absent files are skipped rather than reported: the subsequent open is
+    /// the one to produce the error.
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        path: &Path,
+        advice: AdviceSetting,
+        populate: Populate,
+    ) -> OperationResult<()> {
+        QuantizedChunkedStorageRead::<S>::preopen(fs, &path.join(VECTORS_PATH), populate)?;
+        ChunkedVectorsRead::<MultivectorMmapOffset, S>::preopen(
+            fs,
+            &path.join(OFFSETS_PATH),
+            advice,
+            populate,
+        )?;
+        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_PATH))?;
+        Ok(())
+    }
+
+    /// Open the read-only counterpart of a `Turbo4` multivector storage at
+    /// `path`, threading every file open through `fs`; reads the existing layout
+    /// but creates and writes nothing.
+    pub fn open(
+        fs: &impl UniversalReadFs<File = S>,
+        path: &Path,
+        dim: usize,
+        distance: Distance,
+        multi_vector_config: MultiVectorConfig,
+        advice: AdviceSetting,
+        populate: Populate,
+    ) -> OperationResult<Self> {
+        let quantizer = ReadOnlyTurboVectorStorage::<S>::build_quantizer(dim, distance);
+
+        let storage = QuantizedChunkedStorageRead::open(
+            fs,
+            &path.join(VECTORS_PATH),
+            quantizer.quantized_size(),
+        )?;
+        // The chunked read backend maps lazily; warm it when the profile asks.
+        if !matches!(populate, Populate::No) {
+            storage.populate()?;
+        }
+
+        let offsets = ChunkedVectorsRead::open(fs, &path.join(OFFSETS_PATH), 1, advice, populate)?;
+
+        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_PATH))?;
+
+        Ok(Self {
+            storage,
+            offsets,
+            quantizer,
+            deleted,
+            distance,
+            dim,
+            multi_vector_config,
+        })
+    }
+}

--- a/lib/segment/src/vector_storage/turbo/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/lifecycle.rs
@@ -24,7 +24,7 @@ impl<S: UniversalRead> ReadOnlyTurboVectorStorage<S> {
             dim,
             TQDT_BITS,
             TQDT_MODE,
-            distance.into(),
+            quantization::DistanceType::from(distance),
             TQDT_ROTATION,
             None,
         )
@@ -81,8 +81,12 @@ impl<S: UniversalRead> ReadOnlyTurboVectorStorage<S> {
         };
 
         // The read-only backends map lazily; warm them when the load profile asks.
-        if !matches!(populate, Populate::No) {
-            storage.populate()?;
+        match populate {
+            Populate::No => {}
+            Populate::Auto
+            | Populate::Blocking
+            | Populate::PreferBackground
+            | Populate::Partial(_) => storage.populate()?,
         }
 
         let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_PATH))?;
@@ -139,8 +143,12 @@ impl<S: UniversalRead> ReadOnlyTurboMultiVectorStorage<S> {
             quantizer.quantized_size(),
         )?;
         // The chunked read backend maps lazily; warm it when the profile asks.
-        if !matches!(populate, Populate::No) {
-            storage.populate()?;
+        match populate {
+            Populate::No => {}
+            Populate::Auto
+            | Populate::Blocking
+            | Populate::PreferBackground
+            | Populate::Partial(_) => storage.populate()?,
         }
 
         let offsets = ChunkedVectorsRead::open(fs, &path.join(OFFSETS_PATH), 1, advice, populate)?;

--- a/lib/segment/src/vector_storage/turbo/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/live_reload.rs
@@ -1,0 +1,49 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use super::{ReadOnlyTurboEncoded, ReadOnlyTurboMultiVectorStorage, ReadOnlyTurboVectorStorage};
+use crate::common::live_reload::LiveReload;
+use crate::common::operation_error::OperationResult;
+
+impl<S: UniversalRead> LiveReload for ReadOnlyTurboVectorStorage<S> {
+    type Fs = S::Fs;
+
+    /// Pick up vectors a writer appended (chunked backend only; the single-file
+    /// layout is immutable) and patch the in-memory deletion flags.
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        if let ReadOnlyTurboEncoded::Chunked(storage) = &mut self.storage {
+            storage.live_reload(fs, deleted_points, new_points, hw_counter)?;
+        }
+        self.deleted.insert_all(deleted_points);
+        Ok(())
+    }
+}
+
+impl<S: UniversalRead> LiveReload for ReadOnlyTurboMultiVectorStorage<S> {
+    type Fs = S::Fs;
+
+    /// Pick up multivectors a writer appended (records + offsets) and patch the
+    /// in-memory deletion flags.
+    fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        deleted_points: &SortedSlice<'_, PointOffsetType>,
+        new_points: &SortedSlice<'_, PointOffsetType>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.storage
+            .live_reload(fs, deleted_points, new_points, hw_counter)?;
+        self.offsets
+            .live_reload(fs, deleted_points, new_points, hw_counter)?;
+        self.deleted.insert_all(deleted_points);
+        Ok(())
+    }
+}

--- a/lib/segment/src/vector_storage/turbo/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/mod.rs
@@ -1,0 +1,164 @@
+//! Read-only counterpart of [`TurboVectorStorage`](super::TurboVectorStorage).
+//!
+//! Opens the TurboQuant-encoded blob and deletion flags over an arbitrary
+//! [`UniversalRead`] backend (mmap / cache / remote), so a read-only segment can
+//! retrieve and score a `Turbo4`-typed vector storage. The quantizer is fully
+//! determined by `(dim, distance)` (fixed TQDT constants), so nothing beyond the
+//! encoded bytes and flags is read from disk.
+//!
+//! Scoring is reused verbatim from the writable storage via the shared
+//! [`TurboScoring`](super::TurboScoring) trait — this storage only provides the
+//! read surface it needs.
+//!
+//! The implementation is split across submodules the same way the other
+//! read-only vector storages are:
+//! - [`lifecycle`]: `preopen` / `open` construction,
+//! - [`read_ops`]: retrieval and scoring trait impls,
+//! - [`live_reload`]: picking up a writer's appends and deletions.
+
+use std::borrow::Cow;
+
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+use quantization::EncodedStorage;
+use quantization::turboquant::quantization::TurboQuantizer;
+
+use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
+use crate::common::operation_error::OperationResult;
+use crate::types::{Distance, MultiVectorConfig};
+use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
+use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::MultivectorMmapOffset;
+use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedChunkedStorageRead;
+use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
+
+mod lifecycle;
+mod live_reload;
+mod read_ops;
+
+/// Read-only TurboQuant encoded backend over a [`UniversalRead`] `S`.
+///
+/// Read-only counterpart of the writable
+/// [`TurboEncodedVectorStorage`](super::turbo_encoded_vectors::TurboEncodedVectorStorage):
+/// the storage layout is picked at open time from the segment's storage type.
+enum ReadOnlyTurboEncoded<S: UniversalRead> {
+    /// Single-file layout, written by the non-appendable `Mmap` / `InRamMmap`.
+    Single(QuantizedStorage<S>),
+    /// Chunked layout, written by the appendable `ChunkedMmap` / `InRamChunkedMmap`.
+    Chunked(QuantizedChunkedStorageRead<S>),
+}
+
+impl<S: UniversalRead> ReadOnlyTurboEncoded<S> {
+    fn get_quantized_vector(&self, key: PointOffsetType) -> Cow<'_, [u8]> {
+        match self {
+            Self::Single(s) => s.get_vector_data(key),
+            Self::Chunked(s) => s.get_vector_data(key),
+        }
+    }
+
+    fn get_quantized_vector_opt(&self, key: PointOffsetType) -> Option<Cow<'_, [u8]>> {
+        match self {
+            Self::Single(s) => s.get_vector_data_opt(key),
+            Self::Chunked(s) => s.get_vector_data_opt(key),
+        }
+    }
+
+    /// Run `f` for each vector in the batch, batching the underlying reads
+    /// where the backend supports it (the single-file backend pipelines
+    /// io_uring / prefetches mmap; the chunked backend batches through
+    /// [`EncodedStorage::for_each_batch`]).
+    fn for_each_in_batch<F: FnMut(usize, &[u8])>(
+        &self,
+        keys: &[PointOffsetType],
+        mut f: F,
+    ) -> OperationResult<()> {
+        match self {
+            Self::Single(s) => s.for_each_in_batch(keys, f),
+            Self::Chunked(s) => {
+                s.for_each_batch(keys, |idx, bytes| f(idx, &bytes));
+                Ok(())
+            }
+        }
+    }
+
+    fn vectors_count(&self) -> usize {
+        match self {
+            Self::Single(s) => s.vectors_count(),
+            Self::Chunked(s) => s.vectors_count(),
+        }
+    }
+
+    fn is_on_disk(&self) -> bool {
+        match self {
+            Self::Single(s) => s.is_on_disk(),
+            Self::Chunked(s) => s.is_on_disk(),
+        }
+    }
+
+    fn populate(&self) -> OperationResult<()> {
+        match self {
+            Self::Single(s) => {
+                s.populate();
+                Ok(())
+            }
+            Self::Chunked(s) => s.populate(),
+        }
+    }
+}
+
+/// Read-only TurboQuant dense vector storage over a [`UniversalRead`] backend.
+pub struct ReadOnlyTurboVectorStorage<S: UniversalRead> {
+    /// Read-only encoded vector blob over one of the two backends.
+    storage: ReadOnlyTurboEncoded<S>,
+    /// Quantizer used to de/quantize and score; rebuilt from `(dim, distance)`.
+    quantizer: TurboQuantizer,
+    /// Persisted soft-deletion flags, materialized in memory.
+    deleted: InMemoryBitvecFlags,
+    /// Distance used for scoring / query preprocessing.
+    distance: Distance,
+    /// Original (un-padded) vector dimensionality.
+    dim: usize,
+}
+
+impl<S: UniversalRead> std::fmt::Debug for ReadOnlyTurboVectorStorage<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReadOnlyTurboVectorStorage")
+            .field("dim", &self.dim)
+            .field("distance", &self.distance)
+            .field("total_vector_count", &self.storage.vectors_count())
+            .field("deleted_count", &self.deleted.count())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Read-only TurboQuant multivector vector storage over a [`UniversalRead`]
+/// backend. Read-only counterpart of
+/// [`TurboMultiVectorStorage`](super::multi::TurboMultiVectorStorage).
+///
+/// Multivectors are always stored in the appendable chunked layout, so — unlike
+/// the dense storage — there is a single backend.
+pub struct ReadOnlyTurboMultiVectorStorage<S: UniversalRead> {
+    /// Flat inner-vector space: one fixed-size encoded record per inner vector.
+    storage: QuantizedChunkedStorageRead<S>,
+    /// Maps each point to its record range in the inner space.
+    offsets: ChunkedVectorsRead<MultivectorMmapOffset, S>,
+    /// Quantizer used to de/quantize and score; rebuilt from `(dim, distance)`.
+    quantizer: TurboQuantizer,
+    /// Persisted soft-deletion flags, materialized in memory.
+    deleted: InMemoryBitvecFlags,
+    /// Distance used for scoring / query preprocessing.
+    distance: Distance,
+    /// Original (un-padded) inner vector dimensionality.
+    dim: usize,
+    multi_vector_config: MultiVectorConfig,
+}
+
+impl<S: UniversalRead> std::fmt::Debug for ReadOnlyTurboMultiVectorStorage<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReadOnlyTurboMultiVectorStorage")
+            .field("dim", &self.dim)
+            .field("distance", &self.distance)
+            .field("total_vector_count", &self.offsets.len())
+            .field("deleted_count", &self.deleted.count())
+            .finish_non_exhaustive()
+    }
+}

--- a/lib/segment/src/vector_storage/turbo/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/read_ops.rs
@@ -1,34 +1,17 @@
-//! Read-only counterpart of [`TurboVectorStorage`](super::TurboVectorStorage).
-//!
-//! Opens the TurboQuant-encoded blob and deletion flags over an arbitrary
-//! [`UniversalRead`] backend (mmap / cache / remote), so a read-only segment can
-//! retrieve and score a `Turbo4`-typed vector storage. The quantizer is fully
-//! determined by `(dim, distance)` (fixed TQDT constants), so nothing beyond the
-//! encoded bytes and flags is read from disk.
-//!
-//! Scoring is reused verbatim from the writable storage via the shared
-//! [`TurboScoring`](super::TurboScoring) trait — this storage only provides the
-//! read surface it needs.
-
 use std::borrow::Cow;
-use std::path::Path;
 
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random};
-use common::mmap::AdviceSetting;
-use common::sorted_slice::SortedSlice;
 use common::types::{PointOffsetType, ScoreType};
-use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs, UserData};
+use common::universal_io::{UniversalRead, UserData};
 use quantization::EncodedStorage;
 use quantization::turboquant::EncodedQueryTQ;
-use quantization::turboquant::quantization::TurboQuantizer;
 use smallvec::{SmallVec, smallvec};
 
-use super::multi::{OFFSETS_PATH, TurboMultiScoring};
-use super::{DELETED_PATH, TQDT_BITS, TQDT_MODE, TQDT_ROTATION, TurboScoring, VECTORS_PATH};
-use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
-use crate::common::live_reload::LiveReload;
+use super::super::TurboScoring;
+use super::super::multi::TurboMultiScoring;
+use super::{ReadOnlyTurboMultiVectorStorage, ReadOnlyTurboVectorStorage};
 use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::{CowMultiVector, CowVector};
 use crate::data_types::vectors::{
@@ -37,189 +20,11 @@ use crate::data_types::vectors::{
 use crate::spaces::metric::Metric;
 use crate::spaces::simple::{CosineMetric, DotProductMetric, EuclidMetric, ManhattanMetric};
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
-use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::MultivectorMmapOffset;
-use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedChunkedStorageRead;
-use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
 use crate::vector_storage::vector_storage_base::VectorStorageRead;
 use crate::vector_storage::{DenseTQVectorStorageRead, MultiTQVectorStorageRead, VectorOffsetType};
 
-/// Read-only TurboQuant encoded backend over a [`UniversalRead`] `S`.
-///
-/// Read-only counterpart of the writable
-/// [`TurboEncodedVectorStorage`](super::turbo_encoded_vectors::TurboEncodedVectorStorage):
-/// the storage layout is picked at open time from the segment's storage type.
-enum ReadOnlyTurboEncoded<S: UniversalRead> {
-    /// Single-file layout, written by the non-appendable `Mmap` / `InRamMmap`.
-    Single(QuantizedStorage<S>),
-    /// Chunked layout, written by the appendable `ChunkedMmap` / `InRamChunkedMmap`.
-    Chunked(QuantizedChunkedStorageRead<S>),
-}
-
-impl<S: UniversalRead> ReadOnlyTurboEncoded<S> {
-    fn get_quantized_vector(&self, key: PointOffsetType) -> Cow<'_, [u8]> {
-        match self {
-            Self::Single(s) => s.get_vector_data(key),
-            Self::Chunked(s) => s.get_vector_data(key),
-        }
-    }
-
-    fn get_quantized_vector_opt(&self, key: PointOffsetType) -> Option<Cow<'_, [u8]>> {
-        match self {
-            Self::Single(s) => s.get_vector_data_opt(key),
-            Self::Chunked(s) => s.get_vector_data_opt(key),
-        }
-    }
-
-    /// Run `f` for each vector in the batch, batching the underlying reads
-    /// where the backend supports it (the single-file backend pipelines
-    /// io_uring / prefetches mmap; the chunked backend batches through
-    /// [`EncodedStorage::for_each_batch`]).
-    fn for_each_in_batch<F: FnMut(usize, &[u8])>(
-        &self,
-        keys: &[PointOffsetType],
-        mut f: F,
-    ) -> OperationResult<()> {
-        match self {
-            Self::Single(s) => s.for_each_in_batch(keys, f),
-            Self::Chunked(s) => {
-                s.for_each_batch(keys, |idx, bytes| f(idx, &bytes));
-                Ok(())
-            }
-        }
-    }
-
-    fn vectors_count(&self) -> usize {
-        match self {
-            Self::Single(s) => s.vectors_count(),
-            Self::Chunked(s) => s.vectors_count(),
-        }
-    }
-
-    fn is_on_disk(&self) -> bool {
-        match self {
-            Self::Single(s) => s.is_on_disk(),
-            Self::Chunked(s) => s.is_on_disk(),
-        }
-    }
-
-    fn populate(&self) -> OperationResult<()> {
-        match self {
-            Self::Single(s) => {
-                s.populate();
-                Ok(())
-            }
-            Self::Chunked(s) => s.populate(),
-        }
-    }
-}
-
-/// Read-only TurboQuant dense vector storage over a [`UniversalRead`] backend.
-pub struct ReadOnlyTurboVectorStorage<S: UniversalRead> {
-    /// Read-only encoded vector blob over one of the two backends.
-    storage: ReadOnlyTurboEncoded<S>,
-    /// Quantizer used to de/quantize and score; rebuilt from `(dim, distance)`.
-    quantizer: TurboQuantizer,
-    /// Persisted soft-deletion flags, materialized in memory.
-    deleted: InMemoryBitvecFlags,
-    /// Distance used for scoring / query preprocessing.
-    distance: Distance,
-    /// Original (un-padded) vector dimensionality.
-    dim: usize,
-}
-
-impl<S: UniversalRead> std::fmt::Debug for ReadOnlyTurboVectorStorage<S> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ReadOnlyTurboVectorStorage")
-            .field("dim", &self.dim)
-            .field("distance", &self.distance)
-            .field("total_vector_count", &self.storage.vectors_count())
-            .field("deleted_count", &self.deleted.count())
-            .finish_non_exhaustive()
-    }
-}
-
 impl<S: UniversalRead> ReadOnlyTurboVectorStorage<S> {
-    /// Build the quantizer for a `Turbo4` storage; fully determined by
-    /// `(dim, distance)` and the fixed TQDT constants (matches the writable
-    /// `open_turbo_vector_storage_impl`).
-    fn build_quantizer(dim: usize, distance: Distance) -> TurboQuantizer {
-        TurboQuantizer::new(
-            dim,
-            TQDT_BITS,
-            TQDT_MODE,
-            distance.into(),
-            TQDT_ROTATION,
-            None,
-        )
-    }
-
-    /// Schedule background prefetch of the files [`Self::open`] will read.
-    ///
-    /// Absent files are skipped rather than reported: the subsequent open is
-    /// the one to produce the error.
-    pub fn preopen(
-        fs: &impl CachedReadFs<File = S>,
-        path: &Path,
-        chunked: bool,
-        populate: Populate,
-    ) -> OperationResult<()> {
-        let vectors_path = path.join(VECTORS_PATH);
-        if chunked {
-            QuantizedChunkedStorageRead::<S>::preopen(fs, &vectors_path, populate)?;
-        } else {
-            QuantizedStorage::<S>::preopen(fs, &vectors_path, populate)?;
-        }
-        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_PATH))?;
-        Ok(())
-    }
-
-    /// Open the read-only counterpart of a `Turbo4` dense storage at `path`,
-    /// threading every file open through `fs`; reads the existing layout but
-    /// creates and writes nothing. `chunked` selects the on-disk layout the
-    /// writable storage produced for the segment's storage type.
-    pub fn open(
-        fs: &impl UniversalReadFs<File = S>,
-        path: &Path,
-        dim: usize,
-        distance: Distance,
-        chunked: bool,
-        populate: Populate,
-    ) -> OperationResult<Self> {
-        let quantizer = Self::build_quantizer(dim, distance);
-        let quantized_vector_size = quantizer.quantized_size();
-        let vectors_path = path.join(VECTORS_PATH);
-
-        let storage = if chunked {
-            ReadOnlyTurboEncoded::Chunked(QuantizedChunkedStorageRead::open(
-                fs,
-                &vectors_path,
-                quantized_vector_size,
-            )?)
-        } else {
-            ReadOnlyTurboEncoded::Single(QuantizedStorage::from_file(
-                fs,
-                &vectors_path,
-                quantized_vector_size,
-            )?)
-        };
-
-        // The read-only backends map lazily; warm them when the load profile asks.
-        if !matches!(populate, Populate::No) {
-            storage.populate()?;
-        }
-
-        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_PATH))?;
-
-        Ok(Self {
-            storage,
-            quantizer,
-            deleted,
-            distance,
-            dim,
-        })
-    }
-
     /// Whether scores must be negated to follow qdrant's "higher = better"
     /// convention (mirrors `TurboVectorStorage::invert_score`).
     fn invert_score(&self) -> bool {
@@ -375,120 +180,7 @@ impl<S: UniversalRead> TurboScoring for ReadOnlyTurboVectorStorage<S> {
     }
 }
 
-impl<S: UniversalRead> LiveReload for ReadOnlyTurboVectorStorage<S> {
-    type Fs = S::Fs;
-
-    /// Pick up vectors a writer appended (chunked backend only; the single-file
-    /// layout is immutable) and patch the in-memory deletion flags.
-    fn live_reload(
-        &mut self,
-        fs: &S::Fs,
-        deleted_points: &SortedSlice<'_, PointOffsetType>,
-        new_points: &SortedSlice<'_, PointOffsetType>,
-        hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
-        if let ReadOnlyTurboEncoded::Chunked(storage) = &mut self.storage {
-            storage.live_reload(fs, deleted_points, new_points, hw_counter)?;
-        }
-        self.deleted.insert_all(deleted_points);
-        Ok(())
-    }
-}
-
-/// Read-only TurboQuant multivector vector storage over a [`UniversalRead`]
-/// backend. Read-only counterpart of
-/// [`TurboMultiVectorStorage`](super::multi::TurboMultiVectorStorage).
-///
-/// Multivectors are always stored in the appendable chunked layout, so — unlike
-/// the dense storage — there is a single backend.
-pub struct ReadOnlyTurboMultiVectorStorage<S: UniversalRead> {
-    /// Flat inner-vector space: one fixed-size encoded record per inner vector.
-    storage: QuantizedChunkedStorageRead<S>,
-    /// Maps each point to its record range in the inner space.
-    offsets: ChunkedVectorsRead<MultivectorMmapOffset, S>,
-    /// Quantizer used to de/quantize and score; rebuilt from `(dim, distance)`.
-    quantizer: TurboQuantizer,
-    /// Persisted soft-deletion flags, materialized in memory.
-    deleted: InMemoryBitvecFlags,
-    /// Distance used for scoring / query preprocessing.
-    distance: Distance,
-    /// Original (un-padded) inner vector dimensionality.
-    dim: usize,
-    multi_vector_config: MultiVectorConfig,
-}
-
-impl<S: UniversalRead> std::fmt::Debug for ReadOnlyTurboMultiVectorStorage<S> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ReadOnlyTurboMultiVectorStorage")
-            .field("dim", &self.dim)
-            .field("distance", &self.distance)
-            .field("total_vector_count", &self.offsets.len())
-            .field("deleted_count", &self.deleted.count())
-            .finish_non_exhaustive()
-    }
-}
-
 impl<S: UniversalRead> ReadOnlyTurboMultiVectorStorage<S> {
-    /// Schedule background prefetch of the files [`Self::open`] will read.
-    ///
-    /// Absent files are skipped rather than reported: the subsequent open is
-    /// the one to produce the error.
-    pub fn preopen(
-        fs: &impl CachedReadFs<File = S>,
-        path: &Path,
-        advice: AdviceSetting,
-        populate: Populate,
-    ) -> OperationResult<()> {
-        QuantizedChunkedStorageRead::<S>::preopen(fs, &path.join(VECTORS_PATH), populate)?;
-        ChunkedVectorsRead::<MultivectorMmapOffset, S>::preopen(
-            fs,
-            &path.join(OFFSETS_PATH),
-            advice,
-            populate,
-        )?;
-        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_PATH))?;
-        Ok(())
-    }
-
-    /// Open the read-only counterpart of a `Turbo4` multivector storage at
-    /// `path`, threading every file open through `fs`; reads the existing layout
-    /// but creates and writes nothing.
-    pub fn open(
-        fs: &impl UniversalReadFs<File = S>,
-        path: &Path,
-        dim: usize,
-        distance: Distance,
-        multi_vector_config: MultiVectorConfig,
-        advice: AdviceSetting,
-        populate: Populate,
-    ) -> OperationResult<Self> {
-        let quantizer = ReadOnlyTurboVectorStorage::<S>::build_quantizer(dim, distance);
-
-        let storage = QuantizedChunkedStorageRead::open(
-            fs,
-            &path.join(VECTORS_PATH),
-            quantizer.quantized_size(),
-        )?;
-        // The chunked read backend maps lazily; warm it when the profile asks.
-        if !matches!(populate, Populate::No) {
-            storage.populate()?;
-        }
-
-        let offsets = ChunkedVectorsRead::open(fs, &path.join(OFFSETS_PATH), 1, advice, populate)?;
-
-        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_PATH))?;
-
-        Ok(Self {
-            storage,
-            offsets,
-            quantizer,
-            deleted,
-            distance,
-            dim,
-            multi_vector_config,
-        })
-    }
-
     /// Offset record for `key`, if the point exists.
     fn get_offset<P: AccessPattern>(&self, key: PointOffsetType) -> Option<MultivectorMmapOffset> {
         let record = self.offsets.get::<P>(key as VectorOffsetType)?;
@@ -765,26 +457,5 @@ impl<S: UniversalRead> TurboMultiScoring for ReadOnlyTurboMultiVectorStorage<S> 
             sum += max_sim;
         }
         sum
-    }
-}
-
-impl<S: UniversalRead> LiveReload for ReadOnlyTurboMultiVectorStorage<S> {
-    type Fs = S::Fs;
-
-    /// Pick up multivectors a writer appended (records + offsets) and patch the
-    /// in-memory deletion flags.
-    fn live_reload(
-        &mut self,
-        fs: &S::Fs,
-        deleted_points: &SortedSlice<'_, PointOffsetType>,
-        new_points: &SortedSlice<'_, PointOffsetType>,
-        hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
-        self.storage
-            .live_reload(fs, deleted_points, new_points, hw_counter)?;
-        self.offsets
-            .live_reload(fs, deleted_points, new_points, hw_counter)?;
-        self.deleted.insert_all(deleted_points);
-        Ok(())
     }
 }

--- a/lib/segment/src/vector_storage/turbo/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/read_ops.rs
@@ -400,17 +400,7 @@ impl<S: UniversalRead> TurboMultiScoring for ReadOnlyTurboMultiVectorStorage<S> 
             .incr_delta(records.len() * query.len());
         hw_counter.vector_io_read().incr_delta(records.len());
 
-        let mut max_sim: SmallVec<[_; 8]> = smallvec![ScoreType::NEG_INFINITY; query.len()];
-
-        for bytes in records.chunks_exact(self.quantizer.quantized_size()) {
-            for (qi, inner_query) in query.iter().enumerate() {
-                let sim = self.signed(self.quantizer.score_precomputed(inner_query, bytes));
-                if max_sim[qi] < sim {
-                    max_sim[qi] = sim;
-                }
-            }
-        }
-        max_sim.into_iter().sum()
+        self.score_records_max_similarity(query, &records)
     }
 
     fn score_internal_max_similarity(
@@ -457,5 +447,27 @@ impl<S: UniversalRead> TurboMultiScoring for ReadOnlyTurboMultiVectorStorage<S> 
             sum += max_sim;
         }
         sum
+    }
+
+    fn score_records_max_similarity(&self, query: &[EncodedQueryTQ], records: &[u8]) -> ScoreType {
+        let mut max_sim: SmallVec<[_; 8]> = smallvec![ScoreType::NEG_INFINITY; query.len()];
+
+        for bytes in records.chunks_exact(self.quantizer.quantized_size()) {
+            for (qi, inner_query) in query.iter().enumerate() {
+                let sim = self.signed(self.quantizer.score_precomputed(inner_query, bytes));
+                if max_sim[qi] < sim {
+                    max_sim[qi] = sim;
+                }
+            }
+        }
+        max_sim.into_iter().sum()
+    }
+
+    fn for_each_record_range<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, &[u8]),
+    ) -> OperationResult<()> {
+        self.for_each_record_range::<P, _>(keys, callback)
     }
 }

--- a/lib/segment/src/vector_storage/turbo/test.rs
+++ b/lib/segment/src/vector_storage/turbo/test.rs
@@ -15,7 +15,9 @@ use super::*;
 use crate::data_types::named_vectors::CowMultiVector;
 use crate::data_types::vectors::{MultiDenseVectorInternal, TypedMultiDenseVectorRef};
 use crate::types::MultiVectorConfig;
-use crate::vector_storage::MultiTQVectorStorage;
+use crate::vector_storage::{
+    DenseTQVectorStorageRead, MultiTQVectorStorage, MultiTQVectorStorageRead,
+};
 
 /// Random unit vector with a fixed fallback for an all-zero draw.
 fn random_unit_vector(rng: &mut SmallRng, dim: usize) -> DenseVector {
@@ -102,8 +104,8 @@ fn assert_congruent(dense: &TurboVectorStorage, multi: &TurboMultiVectorStorage,
     assert_eq!(dense.is_on_disk(), multi.is_on_disk(), "{ctx}: is_on_disk");
     assert_eq!(dense.vector_dim(), multi.vector_dim(), "{ctx}: vector_dim");
     assert_eq!(
-        DenseTQVectorStorage::quantized_vector_size(dense),
-        MultiTQVectorStorage::quantized_vector_size(multi),
+        DenseTQVectorStorageRead::quantized_vector_size(dense),
+        MultiTQVectorStorageRead::quantized_vector_size(multi),
         "{ctx}: quantized_vector_size",
     );
 

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -439,7 +439,7 @@ pub trait MultiVectorStorage<T: PrimitiveVectorElement>: MultiVectorStorageRead<
     ) -> OperationResult<Range<PointOffsetType>>;
 }
 
-pub trait DenseTQVectorStorage: VectorStorageRead {
+pub trait DenseTQVectorStorageRead: VectorStorageRead {
     /// Original dimension of the vector, without quantization applied.
     fn vector_dim(&self) -> usize;
 
@@ -448,18 +448,6 @@ pub trait DenseTQVectorStorage: VectorStorageRead {
 
     /// Get the quantized vector by the given key
     fn get_dense_tq<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [u8]>;
-
-    /// Add the given dense TQ vectors to the storage.
-    ///
-    /// # Returns
-    /// The range of point offsets that were added to the storage.
-    ///
-    /// If stopped, the operation returns a cancellation error.
-    fn update_from<'a>(
-        &mut self,
-        other_vectors: &mut impl Iterator<Item = (Cow<'a, [u8]>, bool)>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>>;
 
     /// Call `f` with the raw encoded bytes of the vector if it exists.
     fn with_dense_tq_bytes_opt<P: AccessPattern, R>(
@@ -499,9 +487,15 @@ pub trait DenseTQVectorStorage: VectorStorageRead {
     ) -> OperationResult<()>;
 }
 
-/// Read + bulk-ingest access to a multivector storage of TurboQuant encoded
-/// inner vectors. Multi counterpart of [`DenseTQVectorStorage`].
-pub trait MultiTQVectorStorage: VectorStorageRead {
+pub trait DenseTQVectorStorage: DenseTQVectorStorageRead {
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, [u8]>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>>;
+}
+
+pub trait MultiTQVectorStorageRead: VectorStorageRead {
     /// Original dimension of each inner vector, without quantization applied.
     fn vector_dim(&self) -> usize;
 
@@ -515,18 +509,6 @@ pub trait MultiTQVectorStorage: VectorStorageRead {
     /// must read inner records individually to avoid the concatenation.
     fn get_multi_tq<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [u8]>;
 
-    /// Add the given multi TQ vectors to the storage.
-    ///
-    /// # Returns
-    /// The range of point offsets that were added to the storage.
-    ///
-    /// If stopped, the operation returns a cancellation error.
-    fn update_from<'a>(
-        &mut self,
-        other_vectors: &mut impl Iterator<Item = (Cow<'a, [u8]>, bool)>,
-        stopped: &AtomicBool,
-    ) -> OperationResult<Range<PointOffsetType>>;
-
     /// Call `f` with the concatenated encoded inner vectors, if any.
     /// Inner-vector count = `len() / quantized_vector_size()`.
     fn with_multi_tq_bytes_opt<P: AccessPattern, R>(
@@ -539,6 +521,14 @@ pub trait MultiTQVectorStorage: VectorStorageRead {
             f(&multi_tq)
         })
     }
+}
+
+pub trait MultiTQVectorStorage: MultiTQVectorStorageRead {
+    fn update_from<'a>(
+        &mut self,
+        other_vectors: &mut impl Iterator<Item = (Cow<'a, [u8]>, bool)>,
+        stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>>;
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Read-only segments (UniversalRead) could not open a `Turbo4`-typed vector storage — every dispatch arm returned "not yet supported". This adds the missing read-only TurboQuant storages so read-only segments can retrieve and score TQ-typed vectors.