### PR TITLE
Clean up stale shard transfers when applying consensus snapshot

### DIFF
--- a/lib/collection/src/collection/state_management.rs
+++ b/lib/collection/src/collection/state_management.rs
@@ -76,11 +76,39 @@ impl Collection {
             .shard_transfers
             .read()
             .clone();
-        for transfer in shard_transfers.intersection(&old_transfers) {
-            log::debug!("Aborting shard transfer: {transfer:?}");
-        }
         for transfer in old_transfers.difference(&shard_transfers) {
-            log::debug!("Aborting shard transfer: {transfer:?}");
+            // This transfer finished or was aborted in consensus while this peer was too far
+            // behind to receive the corresponding log entries, so the regular finish/abort
+            // handlers never ran here. Clean up leftover transfer state explicitly. Otherwise, if
+            // this peer is the transfer source, its local shard stays proxified forever and keeps
+            // forwarding updates to a peer that may not have the shard anymore — which fails
+            // snapshot application itself (on payload index updates) and prevents this peer from
+            // ever catching up with consensus.
+            log::debug!("Cleaning up stale shard transfer: {transfer:?}");
+
+            self.transfer_tasks
+                .lock()
+                .await
+                .stop_task(&transfer.key())
+                .await;
+
+            if transfer.from == this_peer_id {
+                let shard_holder = self.shards_holder.read().await;
+                if let Some(replica_set) = shard_holder.get_shard(transfer.shard_id) {
+                    // Discard proxy state instead of flushing it to the remote: replica states in
+                    // the same snapshot already reflect the transfer outcome, and the target may
+                    // not have the shard anymore
+                    replica_set.discard_proxy_local().await;
+                }
+            }
+
+            // Notify any tasks waiting for this transfer to end
+            let _ = self
+                .shards_holder
+                .read()
+                .await
+                .shard_transfer_changes
+                .send(ShardTransferChange::Abort(transfer.key()));
         }
         for transfer in shard_transfers.difference(&old_transfers) {
             if transfer.from == this_peer_id {

--- a/lib/collection/src/shards/replica_set/shard_transfer.rs
+++ b/lib/collection/src/shards/replica_set/shard_transfer.rs
@@ -342,6 +342,47 @@ impl ShardReplicaSet {
         let _ = local.insert(Shard::Local(local_shard));
     }
 
+    /// Revert any proxy wrapper on the local shard back into a plain local shard, discarding
+    /// all proxy state. Nothing is ever sent to a remote shard: queued updates are forgotten
+    /// and update forwarding stops.
+    ///
+    /// Does nothing if there is no local shard, or if the local shard is not a proxy.
+    ///
+    /// This method cannot fail and performs no remote calls.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
+    ///
+    /// If cancelled - the proxy may not be reverted to a local shard.
+    pub async fn discard_proxy_local(&self) {
+        let mut local = self.local.write().await;
+
+        let Some(shard) = local.take() else {
+            return;
+        };
+
+        // Making `await` calls between `local.take()` and `local.insert(...)` is *not* cancel safe!
+        let shard = match shard {
+            shard @ (Shard::Local(_) | Shard::Dummy(_)) => shard,
+            Shard::ForwardProxy(proxy) => {
+                log::debug!("Discarding forward proxy and reverting to local shard");
+                Shard::Local(proxy.wrapped_shard)
+            }
+            Shard::QueueProxy(proxy) => {
+                log::debug!("Forgetting queue proxy updates and reverting to local shard");
+                let (local_shard, _) = proxy.forget_updates_and_finalize();
+                Shard::Local(local_shard)
+            }
+            Shard::Proxy(proxy) => {
+                log::debug!("Discarding proxy and reverting to local shard");
+                Shard::Local(proxy.wrapped_shard)
+            }
+        };
+
+        let _ = local.insert(shard);
+    }
+
     /// Read a transfer batch without sending it yet.
     ///
     /// Returns a [`PreparedTransferBatch`] that holds the update lock. The caller can then drop

--- a/tests/consensus_tests/test_snapshot_aborted_transfer_proxy.py
+++ b/tests/consensus_tests/test_snapshot_aborted_transfer_proxy.py
@@ -1,0 +1,217 @@
+import os
+import pathlib
+import signal
+from time import sleep
+from typing import Any
+
+from .fixtures import create_collection, upsert_random_points
+from .utils import *
+
+N_PEERS = 3
+N_SHARDS = 1
+N_REPLICAS = 1
+COLLECTION_NAME = "test_collection"
+
+# Points in the shard; enough that the streaming transfer is still running when
+# the source peer gets paused shortly after the transfer starts
+N_POINTS = 20_000
+
+
+def test_consensus_snapshot_cleans_up_aborted_transfer_proxy(tmp_path: pathlib.Path):
+    """
+    A transfer source that misses the transfer abort must recover via consensus snapshot.
+
+    Scenario (reproduces a 1.16.3 production incident):
+    1. The source of a `stream_records` shard transfer wraps its local shard into a forward
+       proxy, then gets paused (SIGSTOP) mid-transfer.
+    2. The two other peers are killed and restarted while the source is paused. The fresh
+       leader keeps the unresponsive source in raft probe state (so no log entries are
+       streamed into the source's socket buffers), and aggressive WAL compaction removes
+       the entries the source would need — the source can only ever catch up by consensus
+       snapshot.
+    3. While the source is unresponsive, the transfer is aborted through consensus and the
+       target drops its partial shard. The source never applies the abort, so its local
+       shard stays proxified.
+    4. On resume, the source applies the consensus snapshot. Re-creating payload indexes
+       during snapshot application sends an update operation through the stale forward
+       proxy to the target, which no longer has the shard. The resulting error failed
+       snapshot application and killed the consensus thread, leaving the source unable to
+       ever catch up.
+
+    The fix un-proxifies the local shard when snapshot application drops a transfer that
+    consensus no longer knows about, so the snapshot applies cleanly.
+    """
+    assert_project_root()
+
+    env = {
+        # Aggressively compact consensus WAL, so the paused peer can only catch up by snapshot
+        "QDRANT__CLUSTER__CONSENSUS__COMPACT_WAL_ENTRIES": "1",
+    }
+
+    peer_api_uris, peer_dirs, bootstrap_uri = start_cluster(tmp_path, N_PEERS, extra_env=env)
+
+    create_collection(peer_api_uris[0], shard_number=N_SHARDS, replication_factor=N_REPLICAS)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME,
+        peer_api_uris=peer_api_uris,
+    )
+
+    # Payload index is part of the consensus snapshot; re-creating it during snapshot
+    # application is what sends an update operation through the stale proxy
+    r = requests.put(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/index?wait=true",
+        json={"field_name": "city", "field_schema": "keyword"},
+    )
+    assert_http_ok(r)
+
+    upsert_random_points(peer_api_uris[0], N_POINTS, batch_size=1000)
+
+    # Find the peer holding the only shard (transfer source) and pick a target without it
+    source_idx = None
+    for idx, uri in enumerate(peer_api_uris):
+        info = get_collection_cluster_info(uri, COLLECTION_NAME)
+        if len(info["local_shards"]) > 0:
+            source_idx = idx
+            source_peer_id = info["peer_id"]
+            shard_id = info["local_shards"][0]["shard_id"]
+    assert source_idx is not None, "no peer holds the shard"
+
+    target_idx = (source_idx + 1) % N_PEERS
+    other_idx = (source_idx + 2) % N_PEERS
+    source_uri = peer_api_uris[source_idx]
+    target_uri = peer_api_uris[target_idx]
+    other_uri = peer_api_uris[other_idx]
+    target_peer_id = get_collection_cluster_info(target_uri, COLLECTION_NAME)["peer_id"]
+
+    # Start a streaming move; the source wraps its local shard into a forward proxy
+    r = requests.post(
+        f"{source_uri}/collections/{COLLECTION_NAME}/cluster",
+        json={
+            "move_shard": {
+                "shard_id": shard_id,
+                "from_peer_id": source_peer_id,
+                "to_peer_id": target_peer_id,
+                "method": "stream_records",
+            }
+        },
+    )
+    assert_http_ok(r)
+
+    # As soon as the transfer is registered, give the transfer driver on the source a
+    # moment to proxify the local shard, then pause the source mid-transfer
+    wait_for(
+        lambda: get_shard_transfer_count(source_uri, COLLECTION_NAME) == 1,
+        wait_for_interval=0.05,
+    )
+    sleep(0.3)
+    source_process = processes[source_idx]
+    os.kill(source_process.pid, signal.SIGSTOP)
+
+    try:
+        # The transfer must still be running, otherwise the source was paused too late and
+        # its local shard is no longer proxified
+        assert get_shard_transfer_count(other_uri, COLLECTION_NAME) == 1, \
+            "transfer finished before the source was paused; increase N_POINTS"
+
+        # Restart the two other peers. This drops the raft connections to the paused
+        # source: a SIGSTOPped process still accepts TCP data into its socket buffers, so
+        # a leader that stays up would deliver all missed log entries (including the
+        # transfer abort below) right when the source resumes, and the source would never
+        # need a consensus snapshot. A freshly elected leader instead keeps the
+        # unresponsive source in raft probe state, and its aggressively compacted WAL
+        # cannot bridge the source's log gap — snapshot is the only way to catch up.
+        for idx in (target_idx, other_idx):
+            peer_process = processes[idx]
+            port = peer_process.p2p_port
+            peer_process.kill()
+            peer_api_uris[idx] = start_peer(
+                peer_dirs[idx], f"peer_{idx}_restarted.log", bootstrap_uri, port=port, extra_env=env,
+            )
+        target_uri = peer_api_uris[target_idx]
+        other_uri = peer_api_uris[other_idx]
+        wait_all_peers_up([target_uri, other_uri])
+        wait_for(
+            lambda: get_cluster_info(other_uri)["raft_info"]["leader"] is not None,
+        )
+
+        # Abort the transfer; every live peer applies it, and the target drops its partial
+        # shard. The paused source never learns about the abort. The restarted peers may
+        # have auto-aborted the transfer already (reason: "Source or target peer
+        # restarted"), in which case the explicit abort reports there is no transfer.
+        r = requests.post(
+            f"{other_uri}/collections/{COLLECTION_NAME}/cluster",
+            json={
+                "abort_transfer": {
+                    "shard_id": shard_id,
+                    "from_peer_id": source_peer_id,
+                    "to_peer_id": target_peer_id,
+                }
+            },
+        )
+        if not r.ok:
+            # Depending on how far the auto-abort got, the explicit abort is rejected
+            # either by API validation (400 "There is no transfer ...") or on consensus
+            # application (404 "Shard transfer ... does not exist")
+            error = r.json()["status"]["error"].lower()
+            assert "no transfer" in error or "does not exist" in error, error
+        wait_for_collection_shard_transfers_count(other_uri, COLLECTION_NAME, 0)
+        wait_for(
+            lambda: len(get_collection_cluster_info(target_uri, COLLECTION_NAME)["local_shards"]) == 0,
+        )
+
+        # Accumulate consensus operations; with aggressive WAL compaction the paused peer
+        # falls behind the compacted WAL and can only catch up by consensus snapshot.
+        # Cluster metadata operations are pure consensus operations without shard
+        # placement, so they cannot get stuck on the paused peer.
+        for i in range(5):
+            put_metadata_key(other_uri, f"churn_{i}", f"value_{i}")
+
+        # Marker operation to verify the source catches up with consensus after resuming
+        put_metadata_key(other_uri, "marker", "after-pause")
+    finally:
+        os.kill(source_process.pid, signal.SIGCONT)
+
+    # The source must catch up by applying the consensus snapshot. Without the stale
+    # transfer cleanup, snapshot application fails on the proxified shard and the source
+    # stays behind forever.
+    wait_for(
+        peer_has_metadata_key, source_uri, "marker", "after-pause",
+        wait_for_timeout=60,
+    )
+    wait_for_same_commit(peer_api_uris)
+
+    status = get_cluster_info(source_uri)["consensus_thread_status"]["consensus_thread_status"]
+    assert status == "working"
+
+    # The source keeps its shard, the target must not have gotten it back
+    assert len(get_collection_cluster_info(source_uri, COLLECTION_NAME)["local_shards"]) == 1
+    assert len(get_collection_cluster_info(target_uri, COLLECTION_NAME)["local_shards"]) == 0
+    assert get_shard_transfer_count(source_uri, COLLECTION_NAME) == 0
+
+    wait_for_all_replicas_active(source_uri, COLLECTION_NAME)
+
+    # Updates through the source must work again: its local shard is a regular local shard,
+    # not a proxy forwarding to the removed target replica
+    upsert_random_points(source_uri, 100, offset=N_POINTS)
+
+    r = requests.post(
+        f"{source_uri}/collections/{COLLECTION_NAME}/points/count",
+        json={"exact": True},
+    )
+    assert_http_ok(r)
+    assert r.json()["result"]["count"] == N_POINTS + 100
+
+
+def put_metadata_key(peer_uri: str, key: str, value: Any):
+    resp = requests.put(f"{peer_uri}/cluster/metadata/keys/{key}?wait=true", json=value)
+    assert_http_ok(resp)
+
+
+def peer_has_metadata_key(peer_uri: str, key: str, expected_value: Any) -> bool:
+    try:
+        resp = requests.get(f"{peer_uri}/cluster/metadata/keys/{key}")
+        if not resp.ok:
+            return False
+        return resp.json()["result"] == expected_value
+    except requests.RequestException:
+        return False


### PR DESCRIPTION
## What

Fixes a production failure observed on 1.16.3, where a node's consensus thread stops permanently with:

```
Pre-condition failure: Precondition failed: status: FailedPrecondition,
message: "Pre-condition failure: Precondition failed: No target shard 0 found for update"
```

## Failure mechanism

1. The node is the **source of a shard transfer**, so its local shard is wrapped in a forward proxy (or queue proxy).
2. The node lags behind consensus (partition, pause, overload). Meanwhile the transfer is **aborted** through consensus and the target drops its partial shard. The source never applies the abort, so the stale proxy stays.
3. The node fell behind the compacted Raft WAL, so it can only catch up via **consensus snapshot**.
4. Applying the snapshot, `Collection::apply_state` → `apply_payload_index_schema` re-creates every payload index via `update_all_local`. The stale forward proxy forwards that update to the target, which no longer has the shard → `FailedPrecondition`.
5. The `ForwardProxyError` wrapper is stripped to a bare `PreconditionFailed` in the `StorageError` conversion, and `apply_snapshot`'s error propagates uncontexted out of `process_ready` → consensus thread stops. On 1.16.3 this is permanent. On dev (with the #9662 restart loop) the retried snapshot compares state as equal after the partial first apply and skips `apply_state`, so consensus recovers — but the stale proxy survives forever and every write to that shard keeps failing with the same error until process restart.

The deadlock is self-sustaining: the only way the node could learn that the transfer was aborted is the very snapshot it keeps failing to apply.

## Fix

`apply_shard_transfers` previously logged `"Aborting shard transfer"` for transfers that disappeared from consensus — without doing anything. It now actually cleans them up: stops the local transfer task and reverts the proxy via the new `ShardReplicaSet::discard_proxy_local`.

`discard_proxy_local` is deliberately different from `un_proxify_local`:
- **infallible and never contacts the remote** — queued updates are *forgotten*, not flushed (replica states in the same snapshot already reflect the transfer outcome, and the target may not have the shard), so the cleanup itself can never fail snapshot application;
- **exhaustive match over all `Shard` variants** — adding a future proxy type forces a compile-time decision here instead of being silently skipped.

Out of scope (kept as-is intentionally): a transfer that is *still registered* while its target is broken can still fail snapshot application; combined with the consensus restart loop (#9662) and this fix, that case now converges once the transfer gets aborted.

Side observation: `Shard::Proxy(ProxyShard)` is dead code — `ProxyShard::new` has no callers. Candidate for a separate cleanup.

## Test

`tests/consensus_tests/test_snapshot_aborted_transfer_proxy.py` reproduces the incident end to end: pause the transfer source mid-`stream_records` (SIGSTOP), restart the two other peers, abort the transfer, churn consensus with aggressive WAL compaction, resume, and require the source to fully catch up and accept writes.

Two non-obvious ingredients, documented in the test:
- SIGSTOP alone does **not** partition a peer: a leader in raft `Replicate` state streams all missed entries (including the abort) into the paused peer's TCP socket buffer, and on resume the peer catches up via the log — never via snapshot. Restarting the other peers puts the fresh leader in `Probe` state towards the unresponsive source, and its compacted WAL cannot bridge the gap, making snapshot the only path structurally.
- Restarted peers auto-abort the transfer (`"Source or target peer restarted"`), so the explicit abort tolerates racing with it.

Validation:
- Without the fix, the test fails and the source log shows the exact production error (`Consensus stopped with error: Pre-condition failure: ... No target shard 0 found for update`).
- With the fix, the source log shows `Cleaning up stale shard transfer`, the snapshot applies cleanly, and the test passes (~30 s, stable across repeated runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)