### PR TITLE
[TQDT] Make error for invalid vector bytes more generic.

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1124,7 +1124,7 @@ impl From<OperationError> for CollectionError {
             OperationError::WrongVectorDimension { .. } => Self::BadInput {
                 description: err.to_string(),
             },
-            OperationError::WrongVectorBytesSize { .. } => Self::BadInput {
+            OperationError::MalformedVectorBlob { .. } => Self::BadInput {
                 description: err.to_string(),
             },
             OperationError::VectorNameNotExists { .. } => Self::BadInput {

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -25,12 +25,13 @@ pub enum OperationError {
         expected_dim: usize,
         received_dim: usize,
     },
-    /// A storage-native (raw byte) vector blob whose length is incompatible with
-    /// the target storage. Classified as user error (maps to `BadInput`), not
-    /// `ServiceError`, so a malformed blob that reached the WAL is skipped on
-    /// replay instead of crash-looping recovery.
+    /// A storage-native (raw byte) vector blob that is incompatible with the
+    /// target storage (wrong length, undecodable, or out-of-range contents).
+    /// Classified as user error (maps to `BadInput`), not `ServiceError`, so a
+    /// malformed blob that reached the WAL is skipped on replay instead of
+    /// crash-looping recovery.
     #[error("{description}")]
-    WrongVectorBytesSize { description: String },
+    MalformedVectorBlob { description: String },
     #[error("Not existing vector name error: {received_name}")]
     VectorNameNotExists { received_name: VectorNameBuf },
     #[error("No point with id {missed_point_id}")]
@@ -139,8 +140,8 @@ impl OperationError {
         }
     }
 
-    pub fn wrong_vector_bytes_size(description: impl Into<String>) -> Self {
-        Self::WrongVectorBytesSize {
+    pub fn malformed_vector_blob(description: impl Into<String>) -> Self {
+        Self::MalformedVectorBlob {
             description: description.into(),
         }
     }
@@ -151,7 +152,7 @@ impl OperationError {
         match self {
             Self::OutOfAppendableCapacity { .. } => true,
             Self::WrongVectorDimension { .. }
-            | Self::WrongVectorBytesSize { .. }
+            | Self::MalformedVectorBlob { .. }
             | Self::VectorNameNotExists { .. }
             | Self::PointIdError { .. }
             | Self::TypeError { .. }
@@ -191,7 +192,7 @@ impl IsNotFound for OperationError {
         match self {
             Self::FileNotFound { .. } => true,
             Self::WrongVectorDimension { .. }
-            | Self::WrongVectorBytesSize { .. }
+            | Self::MalformedVectorBlob { .. }
             | Self::VectorNameNotExists { .. }
             | Self::PointIdError { .. }
             | Self::TypeError { .. }

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -1393,15 +1393,15 @@ fn test_upsert_raw_malformed_blob_rejected() {
         &[(DEFAULT_VECTOR_NAME.to_owned(), vec![0_u8, 1, 2])],
         &hw_counter,
     );
-    // Must be a user error (`WrongVectorBytesSize`), not a `ServiceError`: a
+    // Must be a user error (`MalformedVectorBlob`), not a `ServiceError`: a
     // malformed blob that reached the WAL is skipped on replay instead of
     // crash-looping recovery.
     assert!(
         matches!(
             result,
-            Err(crate::common::operation_error::OperationError::WrongVectorBytesSize { .. })
+            Err(crate::common::operation_error::OperationError::MalformedVectorBlob { .. })
         ),
-        "malformed blob must be rejected as WrongVectorBytesSize, got {result:?}",
+        "malformed blob must be rejected as MalformedVectorBlob, got {result:?}",
     );
 }
 

--- a/lib/segment/src/vector_storage/sparse/stored_sparse_vectors.rs
+++ b/lib/segment/src/vector_storage/sparse/stored_sparse_vectors.rs
@@ -18,17 +18,17 @@ impl StoredSparseVector {
     /// Fallible counterpart of [`Blob::from_bytes`], for decoding bytes that
     /// arrive from outside this storage (e.g. raw point relocation).
     ///
-    /// Any failure is a user error (`WrongVectorBytesSize`), not a
+    /// Any failure is a user error (`MalformedVectorBlob`), not a
     /// `ServiceError`: the blob is untrusted input, and a malformed blob that
     /// reached the WAL is skipped on replay instead of crash-looping recovery.
     /// Reads of already-stored data use `TryFrom` instead, where a failure is
     /// genuine corruption (service error).
     pub(crate) fn decode_untrusted_bytes(data: &[u8]) -> Result<SparseVector, OperationError> {
         let stored: StoredSparseVector = bincode::deserialize(data).map_err(|err| {
-            OperationError::wrong_vector_bytes_size(format!("Malformed sparse vector blob: {err}"))
+            OperationError::malformed_vector_blob(format!("Malformed sparse vector blob: {err}"))
         })?;
         SparseVector::try_from(stored).map_err(|_| {
-            OperationError::wrong_vector_bytes_size(
+            OperationError::malformed_vector_blob(
                 "Malformed sparse vector blob: index out of u32 range",
             )
         })

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -100,7 +100,7 @@ impl TurboVectorStorage {
     ) -> OperationResult<()> {
         let expected_size = self.quantizer.quantized_size();
         if bytes.len() != expected_size {
-            return Err(OperationError::wrong_vector_bytes_size(format!(
+            return Err(OperationError::malformed_vector_blob(format!(
                 "Malformed dense TQ blob of {} bytes, expected {expected_size}",
                 bytes.len(),
             )));

--- a/lib/segment/src/vector_storage/turbo/multi.rs
+++ b/lib/segment/src/vector_storage/turbo/multi.rs
@@ -322,7 +322,7 @@ impl TurboMultiVectorStorage {
             // User error so WAL replay skips the op instead of crash-looping.
             // Reachable only internally (no `MAX_MULTIVECTOR_FLATTENED_LEN` check).
             let fresh_start = self.fresh_range_start(count).ok_or_else(|| {
-                OperationError::wrong_vector_bytes_size(exceeds_chunk_capacity_message(count))
+                OperationError::malformed_vector_blob(exceeds_chunk_capacity_message(count))
             })?;
             offset = MultivectorMmapOffset {
                 offset: fresh_start,
@@ -380,7 +380,7 @@ impl TurboMultiVectorStorage {
     ) -> OperationResult<()> {
         let record_size = self.quantizer.quantized_size();
         if bytes.is_empty() || !bytes.len().is_multiple_of(record_size) {
-            return Err(OperationError::wrong_vector_bytes_size(format!(
+            return Err(OperationError::malformed_vector_blob(format!(
                 "Malformed multi TQ blob of {} bytes, expected a positive multiple of {record_size}",
                 bytes.len(),
             )));

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -905,9 +905,9 @@ fn insert_dense_bytes<T: PrimitiveVectorElement, S: DenseVectorStorageRead<T> + 
 ) -> OperationResult<()> {
     let expected_size = storage.vector_dim() * size_of::<T>();
     if bytes.len() != expected_size {
-        // `WrongVectorBytesSize` (not `service_error`) so a malformed blob that
+        // `MalformedVectorBlob` (not `service_error`) so a malformed blob that
         // reached the WAL is skipped on replay instead of crash-looping recovery.
-        return Err(OperationError::wrong_vector_bytes_size(format!(
+        return Err(OperationError::malformed_vector_blob(format!(
             "Malformed dense vector blob of {} bytes, expected {expected_size}",
             bytes.len(),
         )));
@@ -935,7 +935,7 @@ fn insert_multi_bytes<T: PrimitiveVectorElement, S: MultiVectorStorageRead<T> + 
 ) -> OperationResult<()> {
     let inner_size = storage.vector_dim() * size_of::<T>();
     if bytes.is_empty() || !bytes.len().is_multiple_of(inner_size) {
-        return Err(OperationError::wrong_vector_bytes_size(format!(
+        return Err(OperationError::malformed_vector_blob(format!(
             "Malformed multi vector blob of {} bytes, expected a positive multiple of {inner_size}",
             bytes.len(),
         )));


### PR DESCRIPTION
This PR renames the `WrongVectorBytesSize` error introduced in #9886 to `MalformedVectorBlob` as discussed here https://github.com/qdrant/qdrant/pull/9904#discussion_r3620807595.
