### PR TITLE
Honor applied_seq during WAL replay only under prevent_unoptimized

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -737,7 +737,35 @@ impl LocalShard {
 
         let from = wal.first_index();
         let last_wal_index = from + wal.len(false);
-        let op_num_upper_bound = self.applied_seq_handler.op_num_upper_bound();
+
+        // Honor `applied_seq` only when the collection prevents unoptimized segments, the same
+        // condition that gates the update worker's deferred-points wait.
+        //
+        // The split it drives skips no work: the synchronous pass below still starts at
+        // `first_index` and covers `[from, applied_seq + APPLIED_SEQ_SAVE_INTERVAL + 1)`, which is
+        // the *already applied* prefix. What it hands to the update worker instead is the
+        // genuinely unapplied tail. Routing that tail through the worker is what deferred points
+        // need: the worker signals the optimizer per operation, and optimization is the only thing
+        // that makes deferred points visible.
+        //
+        // Everywhere else that routing buys nothing and costs correctness. The tail is applied in
+        // the background *after* `load` returns, so the shard starts serving reads while
+        // operations that were already acknowledged to a client are still missing, and they
+        // reappear one by one as the worker catches up. Replaying the whole WAL synchronously here
+        // (the pre-`applied_seq` behavior) keeps the shard unavailable until every acknowledged
+        // operation is applied, which is what every read path assumes.
+        let prevent_unoptimized = self
+            .collection_config
+            .read()
+            .await
+            .optimizer_config
+            .prevent_unoptimized
+            .unwrap_or_default();
+        let op_num_upper_bound = if prevent_unoptimized {
+            self.applied_seq_handler.op_num_upper_bound()
+        } else {
+            None
+        };
         let to = op_num_upper_bound.unwrap_or(last_wal_index);
 
         // Cap the number of WAL entries to move to the update queue size,
@@ -926,9 +954,9 @@ impl LocalShard {
             // regress across a restart, and the first post-restart updates would then reuse
             // clock ticks that earlier WAL entries already carry for different operations.
             //
-            // This tail is queued whenever the persisted `applied_seq` lags the WAL end, so it
-            // runs independently of the `prevent_unoptimized` flag's value: the flag only gates
-            // the worker's deferred-points wait, not whether the tail is queued here.
+            // This tail is only ever non-empty under `prevent_unoptimized`: the
+            // `op_num_upper_bound` gate above gives up on `applied_seq` otherwise, which makes
+            // the synchronous replay exhaustive and leaves nothing to queue here.
             //
             // An unreadable entry is logged and skipped (its clock tag is lost, but its op_num is
             // still enqueued below): the worker re-reads it and tolerates the same failure by

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -33,6 +33,18 @@ use crate::shards::shard_trait::{ShardOperation, WaitUntil};
 use crate::tests::fixtures::*;
 use crate::update_workers::applied_seq::{APPLIED_SEQ_SAVE_INTERVAL, AppliedSeqHandler};
 
+/// Collection config with `prevent_unoptimized`.
+///
+/// `load_from_wal` honors the persisted `applied_seq` — and therefore splits the replay, handing
+/// the unapplied WAL tail to the update worker — only under that flag. Any test that needs that
+/// tail to exist must build its config through here, otherwise the replay is exhaustive and the
+/// test silently stops exercising the path it was written for.
+fn create_collection_config_with_prevent_unoptimized() -> CollectionConfigInternal {
+    let mut config = create_collection_config();
+    config.optimizer_config.prevent_unoptimized = Some(true);
+    config
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_delete_from_indexed_payload() {
     //  Init the logger
@@ -443,7 +455,7 @@ async fn test_wal_replay_loads_pending_to_queue() {
     let _ = env_logger::builder().is_test(true).try_init();
     let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
 
-    let config = create_collection_config();
+    let config = create_collection_config_with_prevent_unoptimized();
 
     let collection_name = "test".to_string();
 
@@ -597,6 +609,137 @@ async fn test_wal_replay_loads_pending_to_queue() {
     shard.stop_gracefully().await;
 }
 
+/// Without `prevent_unoptimized`, WAL replay must be exhaustive before `LocalShard::load` returns.
+///
+/// `applied_seq` splits the replay in two: everything past it is handed to the update worker and
+/// applied in the background, *after* `load` returns and the shard starts answering reads. Only
+/// `prevent_unoptimized` needs that routing, and doing it anywhere else is observable as data
+/// loss — an operation already acknowledged to a client is missing from reads until the worker
+/// catches up, then reappears.
+///
+/// Force `applied_seq` far below the WAL end and reload: every point must be visible immediately,
+/// with no plunger, no queue drain and no polling.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_wal_replay_is_synchronous_without_prevent_unoptimized() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+
+    // Plain config: no `prevent_unoptimized`, so `applied_seq` must not be honored.
+    let config = create_collection_config();
+    assert!(
+        !config
+            .optimizer_config
+            .prevent_unoptimized
+            .unwrap_or_default(),
+        "this test requires a collection without prevent_unoptimized",
+    );
+
+    let collection_name = "test".to_string();
+
+    let update_runtime = Handle::current();
+    let current_runtime: AdaptiveSearchHandle = AdaptiveSearchHandle::current_for_tests();
+
+    let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+    let payload_index_schema =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
+    let shared_storage_config = Arc::new(SharedStorageConfig {
+        update_queue_size: 10_000,
+        ..Default::default()
+    });
+
+    // Enough operations that a stale applied_seq would leave a large tail behind.
+    let total_ops = 500u64;
+
+    let shard = LocalShard::build(
+        0,
+        collection_name.clone(),
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        shared_storage_config.clone(),
+        payload_index_schema.clone(),
+        update_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+        config.optimizer_config.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Stop flush worker to prevent automatic WAL truncation.
+    shard.stop_flush_worker().await;
+
+    let hw_acc = HwMeasurementAcc::new();
+
+    // Every one of these is acknowledged with `WaitUntil::Visible`, so a client has been told
+    // they are durable *and* readable.
+    for i in 0..total_ops {
+        let point = PointStructPersisted {
+            id: i.into(),
+            vector: VectorStructInternal::from(vec![1.0, 2.0, 3.0, 4.0]).into(),
+            payload: None,
+        };
+        let op = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+            PointInsertOperationsInternal::PointsList(vec![point]),
+        ));
+        shard
+            .update(op.into(), WaitUntil::Visible, None, hw_acc.clone())
+            .await
+            .unwrap();
+    }
+
+    // Stop the shard without flush to preserve WAL.
+    shard.stop_gracefully().await;
+
+    // Push applied_seq well below the WAL end. Under `prevent_unoptimized` this would send
+    // everything past `applied_seq + APPLIED_SEQ_SAVE_INTERVAL` to the update queue.
+    let applied_seq_handler = AppliedSeqHandler::load_or_init(collection_dir.path(), total_ops);
+    let low_applied_seq = total_ops.saturating_sub(100);
+    if applied_seq_handler.op_num().unwrap_or(0) > low_applied_seq {
+        applied_seq_handler
+            .force_set_and_persist(low_applied_seq)
+            .unwrap();
+    }
+
+    let shard = LocalShard::load(
+        0,
+        collection_name,
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        config.optimizer_config.clone(),
+        shared_storage_config,
+        payload_index_schema,
+        false,
+        update_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+    )
+    .await
+    .unwrap();
+
+    // Read first, exactly as a client would the moment the shard starts serving: no plunger, no
+    // drain, no polling. Both samples are taken before asserting, so the visible count is the
+    // earliest observation possible rather than one taken after the queue check gave the worker
+    // time to catch up.
+    let visible_points = shard.info().await.unwrap().points_count.unwrap_or(0);
+    let pending_updates = shard.local_update_queue_info().await.length;
+
+    // The symptom: every one of these was acknowledged as visible before the restart.
+    assert_eq!(
+        visible_points, total_ops as usize,
+        "all {total_ops} acknowledged points must be visible as soon as load returns",
+    );
+
+    // The cause: nothing may be left for the update worker to apply in the background.
+    assert_eq!(
+        pending_updates, 0,
+        "no WAL entry may be deferred to the update queue without prevent_unoptimized",
+    );
+
+    shard.stop_gracefully().await;
+}
+
 /// A deferred-tail WAL entry that fails deserialization must not fail shard load.
 ///
 /// `load_from_wal` reads the tail past `applied_seq` to advance the newest clocks before
@@ -608,7 +751,7 @@ async fn test_wal_replay_tolerates_corrupt_tail_entry() {
     let _ = env_logger::builder().is_test(true).try_init();
     let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
 
-    let config = create_collection_config();
+    let config = create_collection_config_with_prevent_unoptimized();
 
     let collection_name = "test".to_string();
 
@@ -749,7 +892,7 @@ async fn test_wal_replay_truncated_past_applied_seq() {
     let _ = env_logger::builder().is_test(true).try_init();
     let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
 
-    let config = create_collection_config();
+    let config = create_collection_config_with_prevent_unoptimized();
 
     let collection_name = "test".to_string();
 
@@ -887,7 +1030,7 @@ async fn test_wal_replay_with_smaller_queue_size() {
     let _ = env_logger::builder().is_test(true).try_init();
     let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
 
-    let config = create_collection_config();
+    let config = create_collection_config_with_prevent_unoptimized();
 
     let collection_name = "test".to_string();
 


### PR DESCRIPTION
## Problem

`load_from_wal` splits WAL recovery in two: it replays `[first_index, applied_seq + APPLIED_SEQ_SAVE_INTERVAL + 1)` synchronously, then hands the remaining tail to the update worker, which applies it in the background after `LocalShard::load` has returned and the shard already serves reads.

The split was introduced by #8008 (before it, `load_from_wal` replayed everything synchronously) and applies to every collection. As a result, up to `update_queue_size - 1` operations already acknowledged to a client with `wait=true` can be missing from reads right after a restart, then reappear as the worker catches up.

This affects both normal startup and snapshot restore.

## Fix

The split saves no work: the synchronous pass still starts at `first_index` and covers the already applied prefix, and what it hands to the worker is the genuinely unapplied tail. 

Routing that tail through the worker only matters for deferred points, because the worker signals the optimizer per operation and optimization is what makes deferred points visible.

So `applied_seq` is now consulted only under `prevent_unoptimized`, the same condition that already gates the worker's deferred-points wait (`update_worker.rs`). Everywhere else the replay is fully synchronous again.

## How it was found

The [crasher](https://github.com/qdrant/crasher) reported 72 missing points out of a confirmed 3202 after a crash-restart cycle:

```
15:52:32.165  Loading remaining 167 WAL entries from:258 into update queue   <- shard 0
15:52:35.207  Loading remaining 165 WAL entries from:258 into update queue   <- shard 1
15:52:35.358  Qdrant gRPC listening on 6334
15:52:35.420  Run: previous data consistency check (3930 / 3202 points)
```

3930 acknowledged, 3202 counted, so 728 points were still pending 200ms after the port opened.

## Test plan

New `test_wal_replay_is_synchronous_without_prevent_unoptimized` forces `applied_seq` 100 ops below the WAL end, reloads, and reads immediately without any drain or polling. Without the fix it sees 464 of 500 acknowledged points, reproducibly; with it, 500.

Four existing tests exercise the tail path and would otherwise have become vacuous. They now build their config through a shared `create_collection_config_with_prevent_unoptimized()` helper.

`cargo test -p collection --lib`: 251 passed, 0 failed. Clippy clean.

## Trade-offs and remaining gaps

- Restart for collections without `prevent_unoptimized` returns to the pre-#8008 cost: the whole WAL replays before the shard serves. Bounded by WAL contents, which flush truncates.
- `applied_seq` is still maintained for these collections but no longer consulted at load. It can drift since the synchronous replay never feeds it, but the `update_queue_size` cap bounds any tail a later flip of the flag would produce.
- The gate is looser than the actual deferral predicate (`deferred_internal_id`), which is also `None` for `indexing_threshold = 0`, all-`m: 0` vectors, and sparse-only collections. Those keep the current behaviour, so strictly fewer collections change and there is no regression.
- Collections with `prevent_unoptimized` keep the window, and theirs closes only once an optimization runs, since the tail is queued with `sender: None, wait_for_deferred: false`. Closing it needs a drain plus a deferred-points wait during load, left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
