### PR TITLE
UioResult

### DIFF
--- a/lib/common/common/src/persisted_hashmap/tests.rs
+++ b/lib/common/common/src/persisted_hashmap/tests.rs
@@ -7,9 +7,9 @@ use rand::{RngExt, SeedableRng};
 
 use super::fixtures::{Group, TestKey, TestReport, TestValue};
 use super::{Key, MmapHashMap, UniversalHashMap, serialize_hashmap};
-use crate::universal_io::{self, MmapFile, MmapFs, OpenOptions, UniversalRead};
 #[cfg(target_os = "linux")]
 use crate::universal_io::{IoUringFile, IoUringFs, IoUringOpenExtra};
+use crate::universal_io::{MmapFile, MmapFs, OpenOptions, UioResult, UniversalRead};
 
 #[rustfmt::skip] #[test] fn test_k_str_v_i64()   { run_checks::<str,  i64 >(); }
 #[rustfmt::skip] #[test] fn test_k_str_v_u128()  { run_checks::<str,  u128>(); }
@@ -239,7 +239,7 @@ fn run_uio_checks<K: ?Sized + TestKey, V: TestValue, S: UniversalRead>(
 }
 
 #[expect(clippy::unnecessary_wraps, reason = "reduce boilerplate in checks")]
-fn push_val<T>(v: &mut Vec<T>, val: T) -> universal_io::Result<()> {
+fn push_val<T>(v: &mut Vec<T>, val: T) -> UioResult<()> {
     v.push(val);
     Ok(())
 }

--- a/lib/common/common/src/persisted_hashmap/uio/mod.rs
+++ b/lib/common/common/src/persisted_hashmap/uio/mod.rs
@@ -11,7 +11,7 @@ use crate::aligned_buf::AlignedBuf;
 use crate::generic_consts::Sequential;
 use crate::iterator_ext::ordering_iterator::OrderingIterator;
 use crate::universal_io::{
-    CachedReadFs, OpenOptions, ReadRange, Result, TypedStorage, UniversalIoError, UniversalRead,
+    CachedReadFs, OpenOptions, ReadRange, TypedStorage, UioResult, UniversalIoError, UniversalRead,
     UniversalReadFs, UserData,
 };
 
@@ -51,7 +51,7 @@ where
         fs: &Fs,
         path: impl AsRef<Path>,
         mut options: OpenOptions,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         // Default a lazy open to partially populating the header + a slice of
         // the perfect-hash table, so the map can be opened without a full read.
         options.populate = options.populate.or_partial(0..HEADER_AND_BASIC_PHF_SIZE);
@@ -65,7 +65,7 @@ where
         path: impl AsRef<Path>,
         options: OpenOptions,
         extra: Fs::OpenExtra,
-    ) -> Result<Self> {
+    ) -> UioResult<Self> {
         let storage = TypedStorage::<S, u8>::open(fs, path, options, extra)?;
 
         // 1. Read header.
@@ -122,12 +122,12 @@ where
     }
 
     /// Populate the RAM cache for the backing file.
-    pub fn populate(&self) -> Result<()> {
+    pub fn populate(&self) -> UioResult<()> {
         self.storage.populate()
     }
 
     /// Evict the backing file data from RAM cache.
-    pub fn clear_ram_cache(&self) -> Result<()> {
+    pub fn clear_ram_cache(&self) -> UioResult<()> {
         self.storage.clear_ram_cache()
     }
 
@@ -243,36 +243,36 @@ where
     /// Get the values associated with the `key`.
     ///
     /// Prefer to use [`Self::for_each_entry_in_iter`] instead.
-    pub fn unbatched_get(&self, key: &K) -> Result<Option<Vec<V>>> {
+    pub fn unbatched_get(&self, key: &K) -> UioResult<Option<Vec<V>>> {
         let mut result: Option<Vec<V>> = None;
-        self.for_each_entry_in_iter(std::iter::once(((), key)), |(), values| -> Result<()> {
+        self.for_each_entry_in_iter(std::iter::once(((), key)), |(), values| {
             result = values.map(|v| v.to_vec());
-            Ok(())
+            UioResult::Ok(())
         })?;
         Ok(result)
     }
 
     /// Return the number of values for `key` without reading the values themselves.
-    pub fn unbatched_get_values_count(&self, key: &K) -> Result<Option<usize>> {
+    pub fn unbatched_get_values_count(&self, key: &K) -> UioResult<Option<usize>> {
         let mut result: Option<usize> = None;
         self.for_each_sparse(
             MaybeIncompleteEntryKind::KeyAndValuesLen,
             std::iter::once(((), Request::Key(key))),
-            |(), entry| -> Result<()> {
+            |(), entry| {
                 if let Some(e) = entry {
                     let values_len = e
                         .values_len()
                         .expect("KeyAndValuesLen entry should have values len");
                     result = Some(values_len as usize);
                 }
-                Ok(())
+                UioResult::Ok(())
             },
         )?;
         Ok(result)
     }
 }
 
-fn parse_bucket_offset(data: &[u8]) -> Result<BucketOffset> {
+fn parse_bucket_offset(data: &[u8]) -> UioResult<BucketOffset> {
     match <[u8; size_of::<BucketOffset>()]>::try_from(data) {
         Ok(bytes) => Ok(BucketOffset::from_ne_bytes(bytes)),
         Err(_) => Err(UniversalIoError::Io(read_err("Can't read bucket offset"))),

--- a/lib/common/common/src/persisted_hashmap/uio/random_reader.rs
+++ b/lib/common/common/src/persisted_hashmap/uio/random_reader.rs
@@ -7,7 +7,7 @@ use super::{BucketOffset, Key, MaybeIncompleteEntry, MaybeIncompleteEntryKind, U
 use crate::aligned_buf::AlignedBuf;
 use crate::generic_consts::Random;
 use crate::persisted_hashmap::uio::parse_bucket_offset;
-use crate::universal_io::{ReadPipeline, Result, UniversalIoError, UniversalRead, UserData};
+use crate::universal_io::{ReadPipeline, UioResult, UniversalIoError, UniversalRead, UserData};
 
 pub(super) enum Request<'a, K: Key + ?Sized> {
     /// Request an entry by the given offset with unknown key.
@@ -130,7 +130,7 @@ where
     fn new(
         map: &'map UniversalHashMap<K, V, S>,
         entry_kind: MaybeIncompleteEntryKind,
-    ) -> Result<Self> {
+    ) -> UioResult<Self> {
         Ok(Self {
             map,
             entry_kind,

--- a/lib/common/common/src/storage_version.rs
+++ b/lib/common/common/src/storage_version.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use atomicwrites::{AllowOverwrite, AtomicFile};
 use semver::Version;
 
-use crate::universal_io::{self, OkNotFound as _, UniversalReadFs, read_whole_via};
+use crate::universal_io::{OkNotFound as _, UioResult, UniversalReadFs, read_whole_via};
 
 pub const VERSION_FILE: &str = "version.info";
 
@@ -21,10 +21,7 @@ pub trait StorageVersion {
 
     /// Loads and parses the version from the given directory.
     /// Returns `None` if the version file is not found.
-    fn load_universal<Fs: UniversalReadFs>(
-        fs: &Fs,
-        dir_path: &Path,
-    ) -> universal_io::Result<Option<Version>> {
+    fn load_universal<Fs: UniversalReadFs>(fs: &Fs, dir_path: &Path) -> UioResult<Option<Version>> {
         let version_file = dir_path.join(VERSION_FILE);
         read_whole_via(fs, &version_file, |bytes| {
             std::str::from_utf8(&bytes)

--- a/lib/common/common/src/stored_bitmask/read.rs
+++ b/lib/common/common/src/stored_bitmask/read.rs
@@ -8,7 +8,8 @@ use super::format::{BitmaskContent, BitmaskHeader, Encoding, HEADER_SIZE, MAGIC,
 use crate::bitvec::{BitSlice, BitVec};
 use crate::generic_consts::Sequential;
 use crate::universal_io::{
-    OpenOptions, ReadRange, Result, TypedStorage, UniversalIoError, UniversalRead, UniversalReadFs,
+    OpenOptions, ReadRange, TypedStorage, UioResult, UniversalIoError, UniversalRead,
+    UniversalReadFs,
 };
 
 /// Read handle over a bitmask persisted by [`save_bitmask`].
@@ -47,7 +48,7 @@ impl<S: UniversalRead> StoredBitmask<S> {
         path: impl AsRef<Path>,
         options: OpenOptions,
         extra: Fs::OpenExtra,
-    ) -> Result<Self> {
+    ) -> UioResult<Self> {
         let path = path.as_ref();
         let storage = TypedStorage::open(fs, path, options, extra)?;
 
@@ -132,7 +133,7 @@ impl<S: UniversalRead> StoredBitmask<S> {
     }
 
     /// Read and decode the payload, in the stored polarity.
-    pub fn read(&self) -> Result<BitmaskContent<'_>> {
+    pub fn read(&self) -> UioResult<BitmaskContent<'_>> {
         let payload = self.storage.read::<Sequential>(ReadRange {
             byte_offset: HEADER_SIZE as u64,
             length: self.payload_len,
@@ -160,7 +161,7 @@ impl<S: UniversalRead> StoredBitmask<S> {
 
     /// Read and decode the payload into a bitmap of the set positions,
     /// normalizing away the stored encoding/polarity.
-    pub fn read_ones(&self) -> Result<RoaringBitmap> {
+    pub fn read_ones(&self) -> UioResult<RoaringBitmap> {
         match self.read()? {
             BitmaskContent::Dense(bits) => Ok(bits
                 .iter_ones()
@@ -182,7 +183,7 @@ impl<S: UniversalRead> StoredBitmask<S> {
     /// Deserialize a roaring payload, rejecting positions outside
     /// `0..logical_len` so [`BitmaskContent`]'s range contract holds even for
     /// corrupted files.
-    fn decode_roaring(&self, payload: &[u8]) -> Result<RoaringBitmap> {
+    fn decode_roaring(&self, payload: &[u8]) -> UioResult<RoaringBitmap> {
         let bitmap = RoaringBitmap::deserialize_from(payload)?;
         if let Some(max) = bitmap.max()
             && u64::from(max) >= self.logical_len

--- a/lib/common/common/src/stored_bitmask/write.rs
+++ b/lib/common/common/src/stored_bitmask/write.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use roaring::RoaringBitmap;
 
 use super::format::{BitmaskHeader, Encoding, HEADER_SIZE};
-use crate::universal_io::{Result, UniversalIoError, UniversalWriteFileOps};
+use crate::universal_io::{UioResult, UniversalIoError, UniversalWriteFileOps};
 
 /// Atomically persist a bitmask of `logical_len` bits whose set positions are
 /// `ones`.
@@ -16,7 +16,7 @@ pub fn save_bitmask(
     path: &Path,
     logical_len: u64,
     ones: RoaringBitmap,
-) -> Result<()> {
+) -> UioResult<()> {
     validate(logical_len, &ones)?;
 
     let (polarity, mut minority) = minority_polarity(logical_len, ones);
@@ -34,7 +34,7 @@ pub fn save_bitmask(
     fs.atomic_save(path, &bytes)
 }
 
-fn validate(logical_len: u64, ones: &RoaringBitmap) -> Result<()> {
+fn validate(logical_len: u64, ones: &RoaringBitmap) -> UioResult<()> {
     let invalid = |message: String| {
         UniversalIoError::Io(io::Error::new(io::ErrorKind::InvalidInput, message))
     };
@@ -74,7 +74,7 @@ fn roaring_file_bytes(
     logical_len: u64,
     polarity: Encoding,
     minority: &RoaringBitmap,
-) -> Result<Vec<u8>> {
+) -> UioResult<Vec<u8>> {
     let payload_len = minority.serialized_size();
     let header = BitmaskHeader::new(logical_len, polarity, payload_len as u64);
 

--- a/lib/common/common/src/stored_bitslice.rs
+++ b/lib/common/common/src/stored_bitslice.rs
@@ -15,7 +15,7 @@ use itertools::{Either, Itertools};
 use crate::bitvec::BitVec;
 use crate::generic_consts::Random;
 use crate::universal_io::{
-    Flusher, OpenOptions, ReadRange, Result, TypedStorage, UniversalIoError, UniversalRead,
+    Flusher, OpenOptions, ReadRange, TypedStorage, UioResult, UniversalIoError, UniversalRead,
     UniversalReadFs, UniversalWrite,
 };
 
@@ -70,7 +70,7 @@ impl<S: UniversalRead> StoredBitSlice<S> {
         path: impl AsRef<Path>,
         options: OpenOptions,
         extra: Fs::OpenExtra,
-    ) -> Result<Self> {
+    ) -> UioResult<Self> {
         let storage = TypedStorage::open(fs, path, options, extra)?;
         let element_len = storage.len()?;
         Ok(Self {
@@ -79,7 +79,7 @@ impl<S: UniversalRead> StoredBitSlice<S> {
         })
     }
 
-    pub fn reopen(&mut self) -> Result<()> {
+    pub fn reopen(&mut self) -> UioResult<()> {
         self.storage.reopen()?;
         self.element_len = self.storage.len()?;
         Ok(())
@@ -121,7 +121,7 @@ impl<S: UniversalRead> StoredBitSlice<S> {
     ///
     /// Returns `Cow::Borrowed` when the backend supports zero-copy reads
     /// (e.g., mmap), otherwise returns `Cow::Owned`.
-    pub fn read_all(&self) -> Result<Cow<'_, BitSlice>> {
+    pub fn read_all(&self) -> UioResult<Cow<'_, BitSlice>> {
         let elements = self.storage.read_whole()?;
         match elements {
             Cow::Borrowed(slice) => Ok(Cow::Borrowed(BitSlice::from_slice(slice))),
@@ -134,7 +134,7 @@ impl<S: UniversalRead> StoredBitSlice<S> {
     /// The range is specified in bit indices. The underlying element reads are
     /// widened to cover full `u64` boundaries, and the returned slice is trimmed
     /// to the exact requested bit range.
-    pub fn read_bit_range(&self, range: std::ops::Range<u64>) -> Result<Cow<'_, BitSlice>> {
+    pub fn read_bit_range(&self, range: std::ops::Range<u64>) -> UioResult<Cow<'_, BitSlice>> {
         if range.is_empty() {
             return Ok(Cow::Borrowed(BitSlice::empty()));
         }
@@ -164,7 +164,7 @@ impl<S: UniversalRead> StoredBitSlice<S> {
     }
 
     /// Count the number of set bits in the entire storage.
-    pub fn count_ones(&self) -> Result<usize> {
+    pub fn count_ones(&self) -> UioResult<usize> {
         Ok(self.read_all()?.count_ones())
     }
 
@@ -176,7 +176,7 @@ impl<S: UniversalRead> StoredBitSlice<S> {
     /// intermediate `Vec` of set positions is allocated. Reads the whole storage
     /// including any trailing capacity, so callers that keep unused capacity
     /// cleared get back exactly their set positions.
-    pub fn iter_ones(&self) -> Result<impl Iterator<Item = u64> + '_> {
+    pub fn iter_ones(&self) -> UioResult<impl Iterator<Item = u64> + '_> {
         let cow_bitslice = self.read_all()?;
         let iter = match cow_bitslice {
             Cow::Borrowed(bitslice) => Either::Left(bitslice.iter_ones().map(|i| i as u64)),
@@ -191,7 +191,7 @@ impl<S: UniversalRead> StoredBitSlice<S> {
     /// target bit.
     ///
     /// Returns `None` if `bit_index` is out of bounds.
-    pub fn get_bit(&self, bit_index: u64) -> Result<Option<bool>> {
+    pub fn get_bit(&self, bit_index: u64) -> UioResult<Option<bool>> {
         let element_index = Self::element_idx(bit_index);
         let bit_within_element = Self::bit_within_element(bit_index);
 
@@ -212,12 +212,12 @@ impl<S: UniversalRead> StoredBitSlice<S> {
     }
 
     /// Populate the underlying storage's RAM cache.
-    pub fn populate(&self) -> Result<()> {
+    pub fn populate(&self) -> UioResult<()> {
         self.storage.populate()
     }
 
     /// Evict the underlying storage's data from RAM cache.
-    pub fn clear_ram_cache(&self) -> Result<()> {
+    pub fn clear_ram_cache(&self) -> UioResult<()> {
         self.storage.clear_ram_cache()
     }
 }
@@ -234,7 +234,7 @@ impl<S: UniversalWrite> StoredBitSlice<S> {
     pub fn set_ascending_bits_batch(
         &mut self,
         updates: impl IntoIterator<Item = (u64, bool)>,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         // Group updates into runs of consecutive elements. A new run starts
         // whenever the element index jumps by more than 1.
         let mut prev_element: Option<u64> = None;
@@ -292,7 +292,10 @@ impl<S: UniversalWrite> StoredBitSlice<S> {
     /// `source.len()` must not exceed the storage's bit length.
     /// If length of source is less than self's bit length,
     /// only the prefix of the storage will be modified
-    pub fn write_bitslice<T2, O2>(&mut self, source: &bitvec::slice::BitSlice<T2, O2>) -> Result<()>
+    pub fn write_bitslice<T2, O2>(
+        &mut self,
+        source: &bitvec::slice::BitSlice<T2, O2>,
+    ) -> UioResult<()>
     where
         T2: bitvec::store::BitStore,
         O2: bitvec::order::BitOrder,
@@ -329,7 +332,7 @@ impl<S: UniversalWrite> StoredBitSlice<S> {
     /// Read-modify-write a single bit. Returns the previous value.
     ///
     /// Only writes to the backend if the element actually changed.
-    pub fn replace_bit(&mut self, bit_index: u64, value: bool) -> Result<bool> {
+    pub fn replace_bit(&mut self, bit_index: u64, value: bool) -> UioResult<bool> {
         let element_index = Self::element_idx(bit_index);
         let bit_within_element = Self::bit_within_element(bit_index);
 

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -8,8 +8,8 @@ use parking_lot::Mutex;
 use crate::mmap::AdviceSetting;
 use crate::universal_io::traits::CachedReadFs;
 use crate::universal_io::{
-    ListedFile, OpenExtra, OpenOptions, Populate, Result, UniversalIoError, UniversalReadFileOps,
-    UniversalReadFs,
+    ListedFile, OpenExtra, OpenOptions, Populate, UioResult, UniversalIoError,
+    UniversalReadFileOps, UniversalReadFs,
 };
 
 #[derive(Clone, Debug)]
@@ -74,7 +74,7 @@ impl<Fs: UniversalReadFs> Clone for CachedFs<Fs> {
 }
 
 impl<Fs: UniversalReadFs> CachedFs<Fs> {
-    pub fn new(fs: Fs, prefix_path: &Path) -> Result<Self> {
+    pub fn new(fs: Fs, prefix_path: &Path) -> UioResult<Self> {
         Ok(Self {
             fs,
             prefix_path: prefix_path.to_path_buf(),
@@ -137,7 +137,7 @@ impl<Fs: UniversalReadFs> CachedFs<Fs> {
 }
 
 impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
-    fn cache_file_info(&mut self) -> Result<()> {
+    fn cache_file_info(&mut self) -> UioResult<()> {
         // List all files
         let list = self.fs.list_files(&self.prefix_path)?;
 
@@ -168,7 +168,7 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
         path: &Path,
         open_arguments: Option<OpenOptions>,
         open_extra: Option<Fs::OpenExtra>,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         let mut files_prefetched = self.files_prefetched.lock();
 
         if files_prefetched.contains_key(path) {
@@ -205,19 +205,19 @@ pub struct CachedReadFsContext<C> {
 impl<Fs: UniversalReadFs> UniversalReadFileOps for CachedFs<Fs> {
     type ContextConfig = CachedReadFsContext<Fs::ContextConfig>;
 
-    fn from_context(context: Self::ContextConfig) -> Result<Self> {
+    fn from_context(context: Self::ContextConfig) -> UioResult<Self> {
         let CachedReadFsContext { inner, prefix_path } = context;
         Self::new(Fs::from_context(inner)?, &prefix_path)
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
+    fn list_files(&self, prefix_path: &Path) -> UioResult<Vec<ListedFile>> {
         match &self.files_info {
             Some(_) => Ok(self.cached_list_files(prefix_path)),
             None => self.fs.list_files(prefix_path),
         }
     }
 
-    fn exists(&self, path: &Path) -> Result<bool> {
+    fn exists(&self, path: &Path) -> UioResult<bool> {
         match &self.files_info {
             Some(files_info) => Ok(files_info.contains_key(path)),
             None => self.fs.exists(path),
@@ -254,7 +254,7 @@ impl<Fs: UniversalReadFs> UniversalReadFs for CachedFs<Fs> {
         path: impl AsRef<Path>,
         options: OpenOptions,
         extra: Self::OpenExtra,
-    ) -> Result<Fs::File> {
+    ) -> UioResult<Fs::File> {
         let path = path.as_ref();
 
         if options.writeable {

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -7,7 +7,7 @@ use fs_err as fs;
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
-    ListedFile, OpenOptions, Result, UniversalIoError, UniversalRead, UniversalReadFileOps,
+    ListedFile, OpenOptions, UioResult, UniversalIoError, UniversalRead, UniversalReadFileOps,
     UniversalReadFs, UniversalWriteFileOps, UserData, local_file_ops,
 };
 
@@ -85,39 +85,39 @@ pub struct BlockCacheFs {
 impl UniversalReadFileOps for BlockCacheFs {
     type ContextConfig = BlockCacheConfigContext;
 
-    fn from_context(ctx: BlockCacheConfigContext) -> Result<Self> {
+    fn from_context(ctx: BlockCacheConfigContext) -> UioResult<Self> {
         Ok(Self {
             controller: ctx.controller,
         })
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
+    fn list_files(&self, prefix_path: &Path) -> UioResult<Vec<ListedFile>> {
         local_file_ops::local_list_files(prefix_path)
     }
 
-    fn exists(&self, path: &Path) -> Result<bool> {
+    fn exists(&self, path: &Path) -> UioResult<bool> {
         fs::exists(path).map_err(UniversalIoError::from)
     }
 }
 
 impl UniversalWriteFileOps for BlockCacheFs {
-    fn create(&self, path: &Path, expected_length: usize) -> Result<()> {
+    fn create(&self, path: &Path, expected_length: usize) -> UioResult<()> {
         local_file_ops::local_create(path, expected_length)
     }
 
-    fn create_dir(&self, path: &Path) -> Result<()> {
+    fn create_dir(&self, path: &Path) -> UioResult<()> {
         local_file_ops::local_create_dir(path)
     }
 
-    fn remove(&self, path: &Path) -> Result<()> {
+    fn remove(&self, path: &Path) -> UioResult<()> {
         local_file_ops::local_remove(path)
     }
 
-    fn remove_dir(&self, path: &Path) -> Result<()> {
+    fn remove_dir(&self, path: &Path) -> UioResult<()> {
         local_file_ops::local_remove_dir(path)
     }
 
-    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> Result<()> {
+    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> UioResult<()> {
         local_file_ops::local_atomic_save(path, bytes)
     }
 }
@@ -131,7 +131,7 @@ impl UniversalReadFs for BlockCacheFs {
         path: impl AsRef<Path>,
         options: OpenOptions,
         _extra: (),
-    ) -> Result<CachedSlice> {
+    ) -> UioResult<CachedSlice> {
         let OpenOptions {
             writeable,
             need_sequential: _,
@@ -154,24 +154,24 @@ impl UniversalRead for CachedSlice {
         Self: 'a,
         U: UserData;
 
-    fn reopen(&mut self) -> Result<()> {
+    fn reopen(&mut self) -> UioResult<()> {
         // TODO: revise if this is the best way to reopen
         *self = CachedSlice::open(&self.controller, &self.path)
             .map_err(|err| UniversalIoError::extract_not_found(err, &self.path))?;
         Ok(())
     }
 
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> Result<ACow<'_>> {
+    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> UioResult<ACow<'_>> {
         let start = usize::try_from(range.start).expect("range.start is within usize");
         let end = usize::try_from(range.end).expect("range.end is within usize");
         Ok(self.get_range_bytes(start..end, align)?)
     }
 
-    fn len<T>(&self) -> Result<u64> {
+    fn len<T>(&self) -> UioResult<u64> {
         Ok(Self::len::<T>(self) as u64)
     }
 
-    fn populate(&self) -> Result<()> {
+    fn populate(&self) -> UioResult<()> {
         Ok(self.populate()?)
     }
 
@@ -179,7 +179,7 @@ impl UniversalRead for CachedSlice {
         false
     }
 
-    fn clear_ram_cache(&self) -> Result<()> {
+    fn clear_ram_cache(&self) -> UioResult<()> {
         // TODO: issue fadvise DONTNEED on the cache file's backing mmap region.
         Ok(())
     }

--- a/lib/common/common/src/universal_io/disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/disk_cache/pipeline.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use super::CachedSlice;
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Sequential};
-use crate::universal_io::{ReadPipeline, Result, UniversalIoError, UserData};
+use crate::universal_io::{ReadPipeline, UioResult, UniversalIoError, UserData};
 
 pub struct DiskCacheReadPipeline<'file, U> {
     result: Option<(U, ACow<'file>)>,
@@ -15,7 +15,7 @@ where
 {
     type File = CachedSlice;
 
-    fn new() -> Result<Self> {
+    fn new() -> UioResult<Self> {
         Ok(Self { result: None })
     }
 
@@ -29,7 +29,7 @@ where
         file: &'file CachedSlice,
         range: Range<u64>,
         align: usize,
-    ) -> Result<()>
+    ) -> UioResult<()>
     where
         P: AccessPattern,
     {
@@ -42,12 +42,17 @@ where
         Ok(())
     }
 
-    fn schedule_whole(&mut self, user_data: U, file: &'file Self::File, from: u64) -> Result<()> {
+    fn schedule_whole(
+        &mut self,
+        user_data: U,
+        file: &'file Self::File,
+        from: u64,
+    ) -> UioResult<()> {
         let eof = file.len::<u8>() as u64;
         self.schedule::<Sequential>(user_data, file, from..eof, 1)
     }
 
-    fn wait(&mut self) -> Result<Option<(U, ACow<'file>)>> {
+    fn wait(&mut self) -> UioResult<Option<(U, ACow<'file>)>> {
         Ok(self.result.take())
     }
 }

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -58,37 +58,37 @@ pub struct IoUringContextConfig;
 impl UniversalReadFileOps for IoUringFs {
     type ContextConfig = IoUringContextConfig;
 
-    fn from_context(_ctx: Self::ContextConfig) -> Result<Self> {
+    fn from_context(_ctx: Self::ContextConfig) -> UioResult<Self> {
         Ok(Self)
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
+    fn list_files(&self, prefix_path: &Path) -> UioResult<Vec<ListedFile>> {
         local_file_ops::local_list_files(prefix_path)
     }
 
-    fn exists(&self, path: &Path) -> Result<bool> {
+    fn exists(&self, path: &Path) -> UioResult<bool> {
         fs::exists(path).map_err(UniversalIoError::from)
     }
 }
 
 impl UniversalWriteFileOps for IoUringFs {
-    fn create(&self, path: &Path, expected_length: usize) -> Result<()> {
+    fn create(&self, path: &Path, expected_length: usize) -> UioResult<()> {
         local_file_ops::local_create(path, expected_length)
     }
 
-    fn create_dir(&self, path: &Path) -> Result<()> {
+    fn create_dir(&self, path: &Path) -> UioResult<()> {
         local_file_ops::local_create_dir(path)
     }
 
-    fn remove(&self, path: &Path) -> Result<()> {
+    fn remove(&self, path: &Path) -> UioResult<()> {
         local_file_ops::local_remove(path)
     }
 
-    fn remove_dir(&self, path: &Path) -> Result<()> {
+    fn remove_dir(&self, path: &Path) -> UioResult<()> {
         local_file_ops::local_remove_dir(path)
     }
 
-    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> Result<()> {
+    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> UioResult<()> {
         local_file_ops::local_atomic_save(path, bytes)
     }
 }
@@ -121,7 +121,7 @@ impl UniversalReadFs for IoUringFs {
         path: impl AsRef<Path>,
         options: OpenOptions,
         extra: IoUringOpenExtra,
-    ) -> Result<IoUringFile> {
+    ) -> UioResult<IoUringFile> {
         // Check that io_uring is supported on this system.
         pool::check_io_uring_support()?;
 
@@ -160,11 +160,11 @@ impl UniversalRead for IoUringFile {
         Self: 'a,
         U: UserData;
 
-    fn reopen(&mut self) -> Result<()> {
+    fn reopen(&mut self) -> UioResult<()> {
         Ok(())
     }
 
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> Result<ACow<'_>> {
+    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> UioResult<ACow<'_>> {
         if self.direct_io {
             // direct_io needs special handling
             let mut pipeline = IoUringPipeline::<()>::new()?;
@@ -179,7 +179,7 @@ impl UniversalRead for IoUringFile {
         Ok(ACow::Owned(bytes))
     }
 
-    fn len<T>(&self) -> Result<u64> {
+    fn len<T>(&self) -> UioResult<u64> {
         let byte_len = self.file.metadata()?.len();
 
         let items_len = byte_len / size_of::<T>() as u64;
@@ -188,7 +188,7 @@ impl UniversalRead for IoUringFile {
         Ok(items_len)
     }
 
-    fn populate(&self) -> Result<()> {
+    fn populate(&self) -> UioResult<()> {
         if crate::low_memory::low_memory_mode().skip_populate() {
             return Ok(());
         }
@@ -212,7 +212,7 @@ impl UniversalRead for IoUringFile {
         false
     }
 
-    fn clear_ram_cache(&self) -> Result<()> {
+    fn clear_ram_cache(&self) -> UioResult<()> {
         crate::fs::clear_disk_cache(self.file.path())?;
         Ok(())
     }
@@ -224,7 +224,7 @@ impl UniversalRead for IoUringFile {
 /// Reject positioned writes reaching beyond `file_len`: growth is reserved
 /// for [`UniversalAppend`] on every backend — without this check, `pwrite`
 /// would silently extend the file with a zero-filled hole.
-fn check_write_bounds<T>(file_len: u64, byte_offset: ByteOffset, bytes: &[u8]) -> Result<()> {
+fn check_write_bounds<T>(file_len: u64, byte_offset: ByteOffset, bytes: &[u8]) -> UioResult<()> {
     let end = byte_offset.checked_add(bytes.len() as u64);
     if end.is_none_or(|end| end > file_len) {
         return Err(UniversalIoError::OutOfBounds {
@@ -237,7 +237,7 @@ fn check_write_bounds<T>(file_len: u64, byte_offset: ByteOffset, bytes: &[u8]) -
 }
 
 impl UniversalWrite for IoUringFile {
-    fn write<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, items: &[T]) -> Result<()> {
+    fn write<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, items: &[T]) -> UioResult<()> {
         let bytes = bytemuck::cast_slice(items);
         check_write_bounds::<T>(self.file.metadata()?.len(), byte_offset, bytes)?;
         self.file.write_all_at(bytes, byte_offset)?;
@@ -247,7 +247,7 @@ impl UniversalWrite for IoUringFile {
     fn write_batch<'a, T: bytemuck::Pod>(
         &mut self,
         items: impl IntoIterator<Item = (ByteOffset, &'a [T])>,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         let file_len = self.file.metadata()?.len();
 
         let mut rt = IoUringWriteRuntime::new()?;
@@ -279,11 +279,11 @@ impl UniversalWrite for IoUringFile {
     fn write_multi<'a, T: bytemuck::Pod>(
         files: &mut [Self],
         writes: impl IntoIterator<Item = (FileIndex, ByteOffset, &'a [T])>,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         let file_lens = files
             .iter()
             .map(|file| Ok(file.file.metadata()?.len()))
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<UioResult<Vec<_>>>()?;
 
         let mut rt = IoUringWriteRuntime::new()?;
         let mut writes = writes.into_iter().peekable();
@@ -327,7 +327,7 @@ impl UniversalFlush for IoUringFile {
 }
 
 impl UniversalAppend for IoUringFile {
-    fn append<T: bytemuck::Pod>(&mut self, offset: ByteOffset, data: &[T]) -> Result<()> {
+    fn append<T: bytemuck::Pod>(&mut self, offset: ByteOffset, data: &[T]) -> UioResult<()> {
         let bytes: &[u8] = bytemuck::cast_slice(data);
         let mut slices = [io::IoSlice::new(bytes)];
         self.append_slices(offset, &mut slices, bytes.len())
@@ -337,7 +337,7 @@ impl UniversalAppend for IoUringFile {
         &mut self,
         offset: ByteOffset,
         items: impl IntoIterator<Item = &'a [T]>,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         let (mut slices, total) = local_file_ops::collect_append_slices(items);
         self.append_slices(offset, &mut slices, total)
     }
@@ -400,7 +400,7 @@ impl IoUringFile {
         offset: ByteOffset,
         slices: &mut [io::IoSlice<'_>],
         total: usize,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         if total == 0 {
             return Ok(());
         }

--- a/lib/common/common/src/universal_io/io_uring/pipeline.rs
+++ b/lib/common/common/src/universal_io/io_uring/pipeline.rs
@@ -4,7 +4,9 @@ use std::ops::Range;
 use super::{IoUringFile, IoUringReadRuntime, KERNEL_PAGE_SIZE};
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Sequential};
-use crate::universal_io::{ReadPipeline, Result, UniversalIoError, UniversalRead as _, UserData};
+use crate::universal_io::{
+    ReadPipeline, UioResult, UniversalIoError, UniversalRead as _, UserData,
+};
 
 pub struct IoUringPipeline<'file, U>
 where
@@ -17,7 +19,7 @@ where
 impl<'file, U: UserData> ReadPipeline<'file, U> for IoUringPipeline<'file, U> {
     type File = IoUringFile;
 
-    fn new() -> Result<Self> {
+    fn new() -> UioResult<Self> {
         let pipeline = Self {
             runtime: IoUringReadRuntime::new()?,
             _phantom: PhantomData,
@@ -36,7 +38,7 @@ impl<'file, U: UserData> ReadPipeline<'file, U> for IoUringPipeline<'file, U> {
         file: &'file IoUringFile,
         range: Range<u64>,
         align: usize,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         // IoUringPipeline is bound by 'file lifetime, so it can never outlive file
         // or hold fd longer than file is valid
 
@@ -54,7 +56,12 @@ impl<'file, U: UserData> ReadPipeline<'file, U> for IoUringPipeline<'file, U> {
         Ok(())
     }
 
-    fn schedule_whole(&mut self, user_data: U, file: &'file Self::File, from: u64) -> Result<()> {
+    fn schedule_whole(
+        &mut self,
+        user_data: U,
+        file: &'file Self::File,
+        from: u64,
+    ) -> UioResult<()> {
         let eof = file.len::<u8>()?;
 
         if from >= eof {
@@ -65,7 +72,7 @@ impl<'file, U: UserData> ReadPipeline<'file, U> for IoUringPipeline<'file, U> {
         self.schedule::<Sequential>(user_data, file, from..eof, align)
     }
 
-    fn wait(&mut self) -> Result<Option<(U, ACow<'file>)>> {
+    fn wait(&mut self) -> UioResult<Option<(U, ACow<'file>)>> {
         let next = self.runtime.completed().next();
 
         let enqueued = self.runtime.enqueued();

--- a/lib/common/common/src/universal_io/io_uring/pool.rs
+++ b/lib/common/common/src/universal_io/io_uring/pool.rs
@@ -9,7 +9,7 @@ use super::*;
 pub const IO_URING_QUEUE_LENGTH: u32 = 16;
 
 /// Check that io_uring is supported.
-pub fn check_io_uring_support() -> Result<()> {
+pub fn check_io_uring_support() -> UioResult<()> {
     IO_URING_POOL
         .with_borrow_mut(IoUringPool::check_support)
         .map_err(UniversalIoError::IoUringNotSupported)
@@ -19,7 +19,7 @@ pub fn check_io_uring_support() -> Result<()> {
 ///
 /// The instance is automatically returned to the pool when the guard is dropped.
 /// Returns an error if io_uring is not supported on this system.
-pub fn get_io_uring() -> Result<IoUringGuard> {
+pub fn get_io_uring() -> UioResult<IoUringGuard> {
     IO_URING_POOL
         .with_borrow_mut(IoUringPool::get)
         .map_err(UniversalIoError::IoUringNotSupported)

--- a/lib/common/common/src/universal_io/io_uring/runtime.rs
+++ b/lib/common/common/src/universal_io/io_uring/runtime.rs
@@ -18,7 +18,7 @@ pub struct IoUringRuntime<Req, U> {
 }
 
 impl<Req, U> IoUringRuntime<Req, U> {
-    pub fn new() -> Result<Self> {
+    pub fn new() -> UioResult<Self> {
         let mut io_uring = pool::get_io_uring()?;
         let capacity = io_uring.submission().capacity();
 
@@ -47,7 +47,7 @@ impl<Req, U> IoUringRuntime<Req, U> {
         &mut self.state
     }
 
-    pub fn enqueue(&mut self, entry: squeue::Entry) -> Result<()> {
+    pub fn enqueue(&mut self, entry: squeue::Entry) -> UioResult<()> {
         unsafe {
             self.io_uring
                 .submission()
@@ -58,9 +58,9 @@ impl<Req, U> IoUringRuntime<Req, U> {
 
     /// Push entries into Submission Queue while `entries` returns `Ok(Something)`
     /// or the queue is full.
-    pub fn enqueue_while<F>(&mut self, mut entries: F) -> Result<()>
+    pub fn enqueue_while<F>(&mut self, mut entries: F) -> UioResult<()>
     where
-        F: FnMut(&mut IoUringState<Req, U>) -> Result<Option<squeue::Entry>>,
+        F: FnMut(&mut IoUringState<Req, U>) -> UioResult<Option<squeue::Entry>>,
     {
         let mut squeue = self.io_uring.submission();
 

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -10,7 +10,7 @@ use crate::generic_consts::Sequential;
 
 /// Create `path`, populate it with the binary representation of `data`,
 /// then open and return it.
-fn test_file<T: bytemuck::Pod>(path: &Path, data: &[T], direct_io: bool) -> Result<IoUringFile> {
+fn test_file<T: bytemuck::Pod>(path: &Path, data: &[T], direct_io: bool) -> UioResult<IoUringFile> {
     fs_err::write(path, bytemuck::cast_slice(data))?;
 
     let fs = IoUringFs::from_context(Default::default())?;
@@ -35,7 +35,7 @@ fn read_range<T>(offset: usize, length: usize) -> ReadRange {
 }
 
 #[test]
-fn test_io_uring_read() -> Result<()> {
+fn test_io_uring_read() -> UioResult<()> {
     // 1. Populate test file with u64 binary data
     let dir = tempfile::tempdir().unwrap();
 
@@ -61,7 +61,7 @@ fn test_io_uring_read() -> Result<()> {
 }
 
 #[test]
-fn test_io_uring_read_batch_read_iter() -> Result<()> {
+fn test_io_uring_read_batch_read_iter() -> UioResult<()> {
     let dir = tempfile::tempdir().unwrap();
 
     let data: Vec<u64> = (0..256).collect();
@@ -104,7 +104,7 @@ fn test_io_uring_read_batch_read_iter() -> Result<()> {
     // --- read_iter (iterator API) ---
     let read_iter = file.read_iter::<Sequential, _>(ranges.into_iter().enumerate())?;
 
-    let mut iter_results: Vec<_> = read_iter.collect::<Result<Vec<_>>>()?;
+    let mut iter_results: Vec<_> = read_iter.collect::<UioResult<Vec<_>>>()?;
     iter_results.sort_by_key(|&(idx, _)| idx);
 
     for (idx, items) in iter_results {
@@ -137,7 +137,7 @@ fn test_io_uring_read_batch_read_iter() -> Result<()> {
 }
 
 #[test]
-fn test_io_uring_read_iter_concurrent() -> Result<()> {
+fn test_io_uring_read_iter_concurrent() -> UioResult<()> {
     let dir = tempfile::tempdir().unwrap();
 
     // Large enough to span many io_uring batches (64 ranges, queue depth 16).
@@ -203,7 +203,7 @@ extern "C" fn noop_signal_handler(_sig: libc::c_int) {}
 /// `submit_and_wait`. Under signal bombardment with cold page cache,
 /// no errors or panics should surface to the caller.
 #[test]
-fn test_io_uring_eintr_handling() -> Result<()> {
+fn test_io_uring_eintr_handling() -> UioResult<()> {
     // Install a no-op SIGUSR1 handler *without* SA_RESTART so that
     // io_uring_enter() receives EINTR instead of auto-restarting.
     unsafe {
@@ -311,7 +311,7 @@ fn test_io_uring_eintr_handling() -> Result<()> {
 /// Every read is `KERNEL_PAGE_SIZE` aligned on both ends, with `align` set to `KERNEL_PAGE_SIZE`.
 /// The last block extends past EOF, so its read returns a truncated tail of valid bytes.
 #[test]
-fn test_io_uring_direct_io() -> Result<()> {
+fn test_io_uring_direct_io() -> UioResult<()> {
     use super::pipeline::IoUringPipeline;
 
     let dir = tempfile::tempdir().unwrap();

--- a/lib/common/common/src/universal_io/local_file_ops.rs
+++ b/lib/common/common/src/universal_io/local_file_ops.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use crate::fs::atomic_save;
 use crate::mmap::create_and_ensure_length;
-use crate::universal_io::{ListedFile, UniversalIoError};
+use crate::universal_io::{ListedFile, UioResult, UniversalIoError};
 
 /// `writev(2)`-family syscalls accept at most this many iovecs per call
 /// (`IOV_MAX`, 1024 on Linux).
@@ -58,25 +58,25 @@ pub(super) fn write_all_vectored(
     Ok(())
 }
 
-pub fn local_create(path: &Path, expected_length: usize) -> crate::universal_io::Result<()> {
+pub fn local_create(path: &Path, expected_length: usize) -> UioResult<()> {
     create_and_ensure_length(path, expected_length)
         .map(drop)
         .map_err(|err| UniversalIoError::extract_not_found(err, path))
 }
 
-pub fn local_create_dir(path: &Path) -> crate::universal_io::Result<()> {
+pub fn local_create_dir(path: &Path) -> UioResult<()> {
     fs_err::create_dir_all(path).map_err(|err| UniversalIoError::extract_not_found(err, path))
 }
 
-pub fn local_remove(path: &Path) -> crate::universal_io::Result<()> {
+pub fn local_remove(path: &Path) -> UioResult<()> {
     fs_err::remove_file(path).map_err(|err| UniversalIoError::extract_not_found(err, path))
 }
 
-pub fn local_remove_dir(path: &Path) -> crate::universal_io::Result<()> {
+pub fn local_remove_dir(path: &Path) -> UioResult<()> {
     fs_err::remove_dir_all(path).map_err(|err| UniversalIoError::extract_not_found(err, path))
 }
 
-pub fn local_atomic_save(path: &Path, bytes: &[u8]) -> crate::universal_io::Result<()> {
+pub fn local_atomic_save(path: &Path, bytes: &[u8]) -> UioResult<()> {
     atomic_save(path, |writer| {
         writer.write_all(bytes).map_err(UniversalIoError::from)
     })
@@ -91,7 +91,7 @@ pub fn local_atomic_save(path: &Path, bytes: &[u8]) -> crate::universal_io::Resu
 /// everything under `dir/chunk_extra/`. Matching is name-based, never a
 /// whole-path string comparison — a joined prefix may mix `/` and `\` on
 /// Windows, where entry paths use `\` throughout.
-pub fn local_list_files(prefix_path: &Path) -> crate::universal_io::Result<Vec<ListedFile>> {
+pub fn local_list_files(prefix_path: &Path) -> UioResult<Vec<ListedFile>> {
     let dir = prefix_path.parent().unwrap_or(Path::new("."));
     let name_prefix = prefix_path
         .file_name()

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -24,37 +24,37 @@ pub struct MmapFs;
 impl UniversalReadFileOps for MmapFs {
     type ContextConfig = ();
 
-    fn from_context(_: ()) -> Result<Self> {
+    fn from_context(_: ()) -> UioResult<Self> {
         Ok(MmapFs)
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
+    fn list_files(&self, prefix_path: &Path) -> UioResult<Vec<ListedFile>> {
         local_file_ops::local_list_files(prefix_path)
     }
 
-    fn exists(&self, path: &Path) -> Result<bool> {
+    fn exists(&self, path: &Path) -> UioResult<bool> {
         fs_err::exists(path).map_err(UniversalIoError::from)
     }
 }
 
 impl UniversalWriteFileOps for MmapFs {
-    fn create(&self, path: &Path, expected_length: usize) -> Result<()> {
+    fn create(&self, path: &Path, expected_length: usize) -> UioResult<()> {
         local_file_ops::local_create(path, expected_length)
     }
 
-    fn create_dir(&self, path: &Path) -> Result<()> {
+    fn create_dir(&self, path: &Path) -> UioResult<()> {
         local_file_ops::local_create_dir(path)
     }
 
-    fn remove(&self, path: &Path) -> Result<()> {
+    fn remove(&self, path: &Path) -> UioResult<()> {
         local_file_ops::local_remove(path)
     }
 
-    fn remove_dir(&self, path: &Path) -> Result<()> {
+    fn remove_dir(&self, path: &Path) -> UioResult<()> {
         local_file_ops::local_remove_dir(path)
     }
 
-    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> Result<()> {
+    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> UioResult<()> {
         local_file_ops::local_atomic_save(path, bytes)
     }
 }
@@ -63,7 +63,12 @@ impl UniversalReadFs for MmapFs {
     type File = MmapFile;
     type OpenExtra = ();
 
-    fn open(&self, path: impl AsRef<Path>, options: OpenOptions, _extra: ()) -> Result<MmapFile> {
+    fn open(
+        &self,
+        path: impl AsRef<Path>,
+        options: OpenOptions,
+        _extra: (),
+    ) -> UioResult<MmapFile> {
         MmapFile::open_inner(path, options)
     }
 }
@@ -116,7 +121,7 @@ unsafe impl Sync for SendSyncPtr {}
 
 impl MmapFile {
     /// Internal open helper, used by `MmapFs::open`.
-    pub(super) fn open_inner(path: impl AsRef<Path>, options: OpenOptions) -> Result<Self> {
+    pub(super) fn open_inner(path: impl AsRef<Path>, options: OpenOptions) -> UioResult<Self> {
         let OpenOptions {
             writeable,
             need_sequential,
@@ -176,7 +181,7 @@ impl UniversalRead for MmapFile {
         Self: 'a,
         U: UserData;
 
-    fn reopen(&mut self) -> Result<()> {
+    fn reopen(&mut self) -> UioResult<()> {
         let old_len = self.len as u64;
         let new_len = fs_err::File::open(self.path())
             .map_err(|err| UniversalIoError::extract_not_found(err, self.path()))?
@@ -197,7 +202,11 @@ impl UniversalRead for MmapFile {
         self.remap_to(new_len as usize, self.populate)
     }
 
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, _align: usize) -> Result<ACow<'_>> {
+    fn read_bytes<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        _align: usize,
+    ) -> UioResult<ACow<'_>> {
         let mmap = self.as_bytes::<P>();
         let bytes = read_bytes(mmap, range)?;
         Ok(ACow::Borrowed(bytes))
@@ -207,7 +216,7 @@ impl UniversalRead for MmapFile {
     fn read_iter<P: AccessPattern, T: Item, U: UserData>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-    ) -> Result<impl Iterator<Item = Result<(U, Cow<'_, [T]>)>>> {
+    ) -> UioResult<impl Iterator<Item = UioResult<(U, Cow<'_, [T]>)>>> {
         let bytes = self.as_bytes::<P>();
         Ok(ranges.into_iter().map(move |(user_data, range)| {
             let items = read_bytemuck::<T>(bytes, range)?;
@@ -219,8 +228,8 @@ impl UniversalRead for MmapFile {
     fn read_batch<P: AccessPattern, T: Item, U: UserData>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-        mut callback: impl FnMut(U, &[T]) -> Result<()>,
-    ) -> Result<()> {
+        mut callback: impl FnMut(U, &[T]) -> UioResult<()>,
+    ) -> UioResult<()> {
         let bytes = self.as_bytes::<P>();
         for (user_data, range) in ranges {
             let items = read_bytemuck::<T>(bytes, range)?;
@@ -229,12 +238,12 @@ impl UniversalRead for MmapFile {
         Ok(())
     }
 
-    fn len<T>(&self) -> Result<u64> {
+    fn len<T>(&self) -> UioResult<u64> {
         let len = self.len / size_of::<T>();
         Ok(len as u64)
     }
 
-    fn populate(&self) -> Result<()> {
+    fn populate(&self) -> UioResult<()> {
         self.mmap.lock().populate();
         Ok(())
     }
@@ -243,7 +252,7 @@ impl UniversalRead for MmapFile {
         false
     }
 
-    fn clear_ram_cache(&self) -> Result<()> {
+    fn clear_ram_cache(&self) -> UioResult<()> {
         self.mmap.lock().clear_cache();
         if let Some(mmap_seq) = &self.mmap_seq {
             mmap_seq.lock().clear_cache();
@@ -256,7 +265,7 @@ impl UniversalRead for MmapFile {
     }
 }
 impl UniversalWrite for MmapFile {
-    fn write<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, items: &[T]) -> Result<()> {
+    fn write<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, items: &[T]) -> UioResult<()> {
         let mmap = self.as_bytes_mut();
         write(mmap, byte_offset, items)?;
         Ok(())
@@ -265,7 +274,7 @@ impl UniversalWrite for MmapFile {
     fn write_batch<'a, T: bytemuck::Pod>(
         &mut self,
         offset_data: impl IntoIterator<Item = (ByteOffset, &'a [T])>,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         let mmap = self.as_bytes_mut();
 
         for (byte_offset, items) in offset_data {
@@ -306,7 +315,7 @@ impl UniversalFlush for MmapFile {
 }
 
 impl UniversalAppend for MmapFile {
-    fn append<T: bytemuck::Pod>(&mut self, offset: ByteOffset, data: &[T]) -> Result<()> {
+    fn append<T: bytemuck::Pod>(&mut self, offset: ByteOffset, data: &[T]) -> UioResult<()> {
         let bytes: &[u8] = bytemuck::cast_slice(data);
         if bytes.is_empty() {
             return Ok(());
@@ -328,7 +337,7 @@ impl UniversalAppend for MmapFile {
         &mut self,
         offset: ByteOffset,
         items: impl IntoIterator<Item = &'a [T]>,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         let (mut slices, total) = local_file_ops::collect_append_slices(items);
         if total == 0 {
             return Ok(());
@@ -354,7 +363,7 @@ impl MmapFile {
     /// the non-Linux re-mmap never re-populates: growth is mapping
     /// maintenance, and re-faulting the whole file would make each append
     /// O(file size) for handles opened with [`Populate::Blocking`].
-    pub(crate) fn grow_mapping(&mut self, new_len: u64) -> Result<()> {
+    pub(crate) fn grow_mapping(&mut self, new_len: u64) -> UioResult<()> {
         debug_assert!(new_len as usize >= self.len, "grow_mapping cannot shrink");
         if new_len as usize == self.len {
             return Ok(());
@@ -367,7 +376,7 @@ impl MmapFile {
     ///
     /// `populate` only applies to the non-Linux path, which rebuilds the
     /// mapping from scratch; the Linux `mremap` keeps residency as is.
-    fn remap_to(&mut self, new_len: usize, populate: bool) -> Result<()> {
+    fn remap_to(&mut self, new_len: usize, populate: bool) -> UioResult<()> {
         let mut mmap = self.mmap.lock();
         let mut mmap_seq = self.mmap_seq.as_ref().map(|m| m.lock());
         cfg_select! {
@@ -434,7 +443,7 @@ impl MmapFile {
     /// The append precondition: the file must currently end at `offset`.
     /// The fd is statted — not the mapping length, which can be stale when
     /// the file grew externally — so a stale handle gets a clean conflict.
-    fn check_append_offset(&self, fd: &fs_err::File, offset: ByteOffset) -> Result<()> {
+    fn check_append_offset(&self, fd: &fs_err::File, offset: ByteOffset) -> UioResult<()> {
         let file_len = fd.metadata()?.len();
         if file_len != offset {
             return Err(UniversalIoError::AppendOffsetConflict {
@@ -450,7 +459,7 @@ impl MmapFile {
     /// appends. Every `write(2)`/`writev(2)` through it is an atomic
     /// grow+write at the file's current end, so growth cannot leave a
     /// zero-filled window behind.
-    fn append_fd(&self) -> Result<&fs_err::File> {
+    fn append_fd(&self) -> UioResult<&fs_err::File> {
         if !self.writeable {
             return Err(UniversalIoError::Io(io::Error::new(
                 ErrorKind::PermissionDenied,
@@ -474,7 +483,12 @@ impl MmapFile {
     }
 }
 
-fn open_mmap(path: &Path, write: bool, populate: bool, advice: AdviceSetting) -> Result<MmapRaw> {
+fn open_mmap(
+    path: &Path,
+    write: bool,
+    populate: bool,
+    advice: AdviceSetting,
+) -> UioResult<MmapRaw> {
     // TODO: `fs_err` can cause panic when run on a single-threaded Tokio runtime
     #[expect(clippy::disallowed_types)]
     let file = fs::OpenOptions::new()
@@ -583,7 +597,7 @@ impl MmapFile {
 }
 
 #[inline]
-pub(crate) fn read_bytes(bytes: &[u8], range: Range<u64>) -> Result<&[u8]> {
+pub(crate) fn read_bytes(bytes: &[u8], range: Range<u64>) -> UioResult<&[u8]> {
     bytes
         .get(range.start as usize..range.end as usize)
         .ok_or_else(|| UniversalIoError::OutOfBounds {
@@ -594,7 +608,7 @@ pub(crate) fn read_bytes(bytes: &[u8], range: Range<u64>) -> Result<&[u8]> {
 }
 
 #[inline]
-pub(crate) fn read_bytemuck<T: Item>(bytes: &[u8], range: ReadRange) -> Result<&[T]> {
+pub(crate) fn read_bytemuck<T: Item>(bytes: &[u8], range: ReadRange) -> UioResult<&[T]> {
     let ReadRange {
         byte_offset,
         length: items,
@@ -617,7 +631,7 @@ pub(crate) fn read_bytemuck<T: Item>(bytes: &[u8], range: ReadRange) -> Result<&
 }
 
 #[inline]
-fn write<T>(mmap: &mut [u8], byte_offset: ByteOffset, items: &[T]) -> Result<()>
+fn write<T>(mmap: &mut [u8], byte_offset: ByteOffset, items: &[T]) -> UioResult<()>
 where
     T: bytemuck::Pod,
 {

--- a/lib/common/common/src/universal_io/mmap/pipeline.rs
+++ b/lib/common/common/src/universal_io/mmap/pipeline.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use super::{MmapFile, read_bytes};
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Sequential};
-use crate::universal_io::{ReadPipeline, Result, UniversalIoError, UserData};
+use crate::universal_io::{ReadPipeline, UioResult, UniversalIoError, UserData};
 
 pub struct MmapReadPipeline<'file, U> {
     result: Option<(U, &'file [u8])>,
@@ -15,7 +15,7 @@ where
 {
     type File = MmapFile;
 
-    fn new() -> Result<Self> {
+    fn new() -> UioResult<Self> {
         Ok(Self { result: None })
     }
 
@@ -29,7 +29,7 @@ where
         file: &'file MmapFile,
         range: Range<u64>,
         _align: usize,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         if self.result.is_some() {
             return Err(UniversalIoError::QueueIsFull);
         }
@@ -38,12 +38,17 @@ where
         Ok(())
     }
 
-    fn schedule_whole(&mut self, user_data: U, file: &'file Self::File, from: u64) -> Result<()> {
+    fn schedule_whole(
+        &mut self,
+        user_data: U,
+        file: &'file Self::File,
+        from: u64,
+    ) -> UioResult<()> {
         let eof = file.len as u64;
         self.schedule::<Sequential>(user_data, file, from..eof, 1)
     }
 
-    fn wait(&mut self) -> Result<Option<(U, ACow<'file>)>> {
+    fn wait(&mut self) -> UioResult<Option<(U, ACow<'file>)>> {
         let result = self.result.take();
         Ok(result.map(|(user_data, bytes)| (user_data, ACow::Borrowed(bytes))))
     }

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -36,6 +36,6 @@ pub use self::traits::{
 };
 pub use self::types::{
     ByteOffset, FileIndex, Flusher, ListedFile, OpenOptions, Populate, ReadBytesItem, ReadRange,
-    Result, UniversalKind, read_bin_via, read_json_via, read_whole_via,
+    UioResult, UniversalKind, read_bin_via, read_json_via, read_whole_via,
 };
 pub use self::wrappers::{ReadOnly, SliceBufferedUpdateWrapper, StoredStruct, TypedStorage};

--- a/lib/common/common/src/universal_io/oneshot.rs
+++ b/lib/common/common/src/universal_io/oneshot.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use crate::mmap::{Advice, AdviceSetting};
 use crate::universal_io::{
-    CachedReadFs, OpenOptions, Populate, Result, UniversalRead, UniversalReadFs,
+    CachedReadFs, OpenOptions, Populate, UioResult, UniversalRead, UniversalReadFs,
 };
 
 /// Thin RAII wrapper around a [`UniversalRead`] handle for a one-shot read.
@@ -35,7 +35,7 @@ impl<S: UniversalRead> OneshotFile<S> {
     ///
     /// A one-shot file is always read in full, so the prefetch populates it —
     /// the fetch overlaps whatever runs between the schedule and the open.
-    pub fn preopen<Fs: CachedReadFs<File = S>>(fs: &Fs, path: impl AsRef<Path>) -> Result<()> {
+    pub fn preopen<Fs: CachedReadFs<File = S>>(fs: &Fs, path: impl AsRef<Path>) -> UioResult<()> {
         fs.schedule_prefetch(
             path.as_ref(),
             Some(Self::open_options(Populate::PreferBackground)),
@@ -44,7 +44,7 @@ impl<S: UniversalRead> OneshotFile<S> {
     }
 
     /// Open `path` read-only through `fs` for a single sequential read.
-    pub fn open<Fs: UniversalReadFs<File = S>>(fs: &Fs, path: impl AsRef<Path>) -> Result<Self> {
+    pub fn open<Fs: UniversalReadFs<File = S>>(fs: &Fs, path: impl AsRef<Path>) -> UioResult<Self> {
         let inner = fs.open(path, Self::open_options(Populate::No), Default::default())?;
         Ok(Self { inner })
     }

--- a/lib/common/common/src/universal_io/simple_disk_cache/config.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/config.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use fs_err as fs;
 
-use crate::universal_io::{Result, UniversalIoError};
+use crate::universal_io::{UioResult, UniversalIoError};
 
 /// Suffix appended to every local cache file so local mirrors can't be
 /// mistaken for the "real" (remote) copy.
@@ -22,7 +22,7 @@ impl DiskCacheConfig {
     /// Initialize the config for [`DiskCacheConfig`]
     ///
     /// The `remote_dir` may be a network store, but `local_dir` must be a local path.
-    pub fn new(remote_dir: PathBuf, local_dir: PathBuf) -> Result<Self> {
+    pub fn new(remote_dir: PathBuf, local_dir: PathBuf) -> UioResult<Self> {
         let local_dir = fs::canonicalize(&local_dir)
             .map_err(|err| UniversalIoError::extract_not_found(err, &local_dir))?;
         Ok(Self {
@@ -37,7 +37,7 @@ impl DiskCacheConfig {
 
     /// Maps a remote path to its local mirror (`<local_dir>/<rel>` + `.partial`);
     /// `NotFound` if `remote_path` isn't under `remote_dir`.
-    pub fn local_path_for(&self, remote_path: &Path) -> Result<PathBuf> {
+    pub fn local_path_for(&self, remote_path: &Path) -> UioResult<PathBuf> {
         let resolved = canonicalize_remote(remote_path);
         let rel =
             resolved

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::Ordering;
 use super::{DiskCache, State};
 use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::simple_disk_cache::{DiskCacheRemote, to_block_range};
-use crate::universal_io::{OwnedPipeline, Result};
+use crate::universal_io::{OwnedPipeline, UioResult};
 
 /// A borrowed view of a materialized [`State::Ready`]: the live `remote` handle
 /// paired with its local mmap mirror.
@@ -24,7 +24,7 @@ where
     R: DiskCacheRemote,
 {
     /// Return the materialized [`State::Ready`], initializing it on first call.
-    pub(crate) fn state(&self) -> Result<ReadyRef<'_, R>> {
+    pub(crate) fn state(&self) -> UioResult<ReadyRef<'_, R>> {
         if !self.is_ready() {
             self.init_state()?;
         }
@@ -44,7 +44,7 @@ where
 
     /// Drive `state` to [`State::Ready`] under the lock, consuming whichever
     /// pre-init variant is staged. Idempotent: a no-op once `ready` is set.
-    pub(super) fn init_state(&self) -> Result<()> {
+    pub(super) fn init_state(&self) -> UioResult<()> {
         let mut state = self.state.lock();
 
         // Another thread may have materialized while we waited for the lock.
@@ -75,7 +75,7 @@ where
 
     /// Build an empty local mmap sized from the remote length; reads fault blocks
     /// in on demand. The lazy cold-start path ([`State::Uninit`]).
-    fn init_from_scratch(&self, remote: R) -> Result<(R, LocalState)> {
+    fn init_from_scratch(&self, remote: R) -> UioResult<(R, LocalState)> {
         let len = remote.len::<u8>()?;
         let local = LocalState::new(&self.local_path, len, self.open_options)?;
         Ok((remote, local))
@@ -86,7 +86,7 @@ where
     pub(super) fn init_from_open_prefill(
         &self,
         mut pipeline: OwnedPipeline<R, ()>,
-    ) -> Result<(R, LocalState)> {
+    ) -> UioResult<(R, LocalState)> {
         match pipeline.wait()? {
             Some((_, bytes)) => {
                 // `bytes` covers the whole file, so its length is the remote length.
@@ -111,7 +111,7 @@ where
         &self,
         mut pipeline: OwnedPipeline<R, u64>,
         mut local: LocalState,
-    ) -> Result<(R, LocalState)> {
+    ) -> UioResult<(R, LocalState)> {
         match pipeline.wait()? {
             Some((start, bytes)) if !bytes.is_empty() => {
                 let end = start + bytes.len() as u64;
@@ -138,7 +138,7 @@ where
         &self,
         mut pipeline: OwnedPipeline<R, Range<u32>>,
         len: u64,
-    ) -> Result<(R, LocalState)> {
+    ) -> UioResult<(R, LocalState)> {
         let local = LocalState::new(&self.local_path, len, self.open_options)?;
 
         match pipeline.wait()? {
@@ -161,7 +161,7 @@ where
     /// instead of a separate `len` call followed by lazy faulting.
     ///
     /// [`read_whole`]: crate::universal_io::UniversalRead::read_whole
-    pub(super) fn prefill_if_uninit(&self) -> Result<()> {
+    pub(super) fn prefill_if_uninit(&self) -> UioResult<()> {
         if self.is_ready() {
             return Ok(());
         }

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
@@ -11,7 +11,7 @@ use super::DiskCacheRemote;
 use super::local_state::LocalState;
 use crate::mmap::AdviceSetting;
 use crate::universal_io::{
-    OpenOptions, OwnedPipeline, Populate, Result, UniversalRead, UniversalReadFs,
+    OpenOptions, OwnedPipeline, Populate, UioResult, UniversalRead, UniversalReadFs,
 };
 
 mod init;
@@ -132,7 +132,7 @@ where
         }
     }
 
-    pub(super) fn open_remote(&self) -> Result<R> {
+    pub(super) fn open_remote(&self) -> UioResult<R> {
         let remote_options = OpenOptions {
             writeable: false,
             populate: Populate::No,

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -11,7 +11,7 @@ use crate::universal_io::simple_disk_cache::fs::DiskCacheFs;
 use crate::universal_io::simple_disk_cache::pipeline::DiskCachePipeline;
 use crate::universal_io::simple_disk_cache::{BLOCK_SIZE, DiskCacheRemote};
 use crate::universal_io::{
-    Item, ReadPipeline, ReadRange, Result, UniversalIoError, UniversalKind, UniversalRead, UserData,
+    Item, ReadPipeline, ReadRange, UioResult, UniversalKind, UniversalRead, UserData,
 };
 
 impl<R> DiskCache<R>
@@ -19,7 +19,7 @@ where
     R: DiskCacheRemote,
 {
     /// Make sure every byte in the range `byte_start..remote_len` is present on the local file
-    fn populate_from(&self, byte_start: u64) -> std::result::Result<(), UniversalIoError> {
+    fn populate_from(&self, byte_start: u64) -> UioResult<()> {
         if crate::low_memory::low_memory_mode().skip_populate() {
             return Ok(());
         }
@@ -54,18 +54,18 @@ where
         R: 'a,
         U: UserData;
 
-    fn reopen(&mut self) -> Result<()> {
+    fn reopen(&mut self) -> UioResult<()> {
         self.reopen_impl()
     }
 
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> Result<ACow<'_>> {
+    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> UioResult<ACow<'_>> {
         let mut pipeline = DiskCachePipeline::<R, ()>::new()?;
         pipeline.schedule::<P>((), self, range, align)?;
         let (_, bytes) = pipeline.wait()?.expect("there's exactly one read");
         Ok(bytes)
     }
 
-    fn read_whole<T: Item>(&self) -> Result<Cow<'_, [T]>> {
+    fn read_whole<T: Item>(&self) -> UioResult<Cow<'_, [T]>> {
         self.prefill_if_uninit()?;
         let length = self.len::<T>()?;
         self.read::<Sequential, T>(ReadRange {
@@ -74,11 +74,11 @@ where
         })
     }
 
-    fn len<T>(&self) -> Result<u64> {
+    fn len<T>(&self) -> UioResult<u64> {
         self.state()?.local.mmap().len::<T>()
     }
 
-    fn populate(&self) -> Result<()> {
+    fn populate(&self) -> UioResult<()> {
         self.populate_from(0)
     }
 
@@ -86,7 +86,7 @@ where
         false
     }
 
-    fn clear_ram_cache(&self) -> Result<()> {
+    fn clear_ram_cache(&self) -> UioResult<()> {
         // Only touch an already-live mirror; don't force initialization just to
         // clear a cache that may not exist yet.
         if self.is_ready() {

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -6,14 +6,14 @@ use std::io::{self, ErrorKind};
 
 use super::{DiskCache, State};
 use crate::universal_io::simple_disk_cache::{BLOCK_SIZE, DiskCacheRemote};
-use crate::universal_io::{OwnedPipeline, Populate, Result, UniversalIoError, UniversalRead};
+use crate::universal_io::{OwnedPipeline, Populate, UioResult, UniversalIoError, UniversalRead};
 
 impl<R> DiskCache<R>
 where
     R: DiskCacheRemote,
 {
     /// Body of [`UniversalRead::reopen`](crate::universal_io::UniversalRead::reopen).
-    pub(super) fn reopen_impl(&mut self) -> Result<()> {
+    pub(super) fn reopen_impl(&mut self) -> UioResult<()> {
         // `&mut self` gives exclusive access, so we can transition `state`
         // directly without locking or touching the `ready` gate concurrently.
         //

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -11,7 +11,7 @@ use crate::generic_consts::Sequential;
 use crate::mmap::AdviceSetting;
 use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::{
-    ListedFile, OpenExtra, OpenOptions, OwnedPipeline, Populate, Result, UniversalIoError,
+    ListedFile, OpenExtra, OpenOptions, OwnedPipeline, Populate, UioResult, UniversalIoError,
     UniversalRead, UniversalReadFileOps, UniversalReadFs, UniversalWriteFileOps,
 };
 
@@ -94,7 +94,7 @@ impl<R: UniversalRead> DiskCacheFs<R> {
         &self,
         path: impl AsRef<Path>,
         extra: <R::Fs as UniversalReadFs>::OpenExtra,
-    ) -> Result<R> {
+    ) -> UioResult<R> {
         self.remote_fs.open(
             path.as_ref(),
             OpenOptions {
@@ -114,7 +114,7 @@ where
 {
     type ContextConfig = DiskCacheFsContext<<R::Fs as UniversalReadFileOps>::ContextConfig>;
 
-    fn from_context(ctx: Self::ContextConfig) -> Result<Self> {
+    fn from_context(ctx: Self::ContextConfig) -> UioResult<Self> {
         let DiskCacheFsContext { config, remote } = ctx;
         Ok(Self {
             config,
@@ -122,11 +122,11 @@ where
         })
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
+    fn list_files(&self, prefix_path: &Path) -> UioResult<Vec<ListedFile>> {
         self.remote_fs.list_files(prefix_path)
     }
 
-    fn exists(&self, path: &Path) -> Result<bool> {
+    fn exists(&self, path: &Path) -> UioResult<bool> {
         self.remote_fs.exists(path)
     }
 }
@@ -136,23 +136,23 @@ where
     R: UniversalRead,
     R::Fs: UniversalWriteFileOps,
 {
-    fn create(&self, path: &Path, expected_length: usize) -> Result<()> {
+    fn create(&self, path: &Path, expected_length: usize) -> UioResult<()> {
         self.remote_fs.create(path, expected_length)
     }
 
-    fn create_dir(&self, path: &Path) -> Result<()> {
+    fn create_dir(&self, path: &Path) -> UioResult<()> {
         self.remote_fs.create_dir(path)
     }
 
-    fn remove(&self, path: &Path) -> Result<()> {
+    fn remove(&self, path: &Path) -> UioResult<()> {
         self.remote_fs.remove(path)
     }
 
-    fn remove_dir(&self, path: &Path) -> Result<()> {
+    fn remove_dir(&self, path: &Path) -> UioResult<()> {
         self.remote_fs.remove_dir(path)
     }
 
-    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> Result<()> {
+    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> UioResult<()> {
         self.remote_fs.atomic_save(path, bytes)
     }
 }
@@ -185,7 +185,7 @@ where
         path: impl AsRef<Path>,
         options: OpenOptions,
         extra: Self::OpenExtra,
-    ) -> Result<DiskCache<R>> {
+    ) -> UioResult<DiskCache<R>> {
         // The cache is strictly read-only: appends (and any other writes)
         // must go directly to the backing storage, not through the cache.
         if options.writeable {

--- a/lib/common/common/src/universal_io/simple_disk_cache/local_state.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/local_state.rs
@@ -11,7 +11,7 @@ use roaring::RoaringBitmap;
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::simple_disk_cache::BLOCK_SIZE;
 use crate::universal_io::{
-    MmapFile, MmapFs, OpenOptions, Populate, Result, UniversalIoError, UniversalRead,
+    MmapFile, MmapFs, OpenOptions, Populate, UioResult, UniversalIoError, UniversalRead,
     UniversalReadFs, UniversalWrite, mmap as mmap_file,
 };
 
@@ -34,7 +34,7 @@ impl LocalState {
         local_path: impl AsRef<Path>,
         len: u64,
         options: OpenOptions,
-    ) -> Result<Self> {
+    ) -> UioResult<Self> {
         if let Some(parent) = local_path.as_ref().parent() {
             fs::create_dir_all(parent)?;
         }
@@ -72,7 +72,7 @@ impl LocalState {
         })
     }
 
-    pub(super) fn resize(&mut self, local_path: impl AsRef<Path>, new_len: u64) -> Result<()> {
+    pub(super) fn resize(&mut self, local_path: impl AsRef<Path>, new_len: u64) -> UioResult<()> {
         let mmap = self.mmap.get_mut();
         let current_len = mmap.len::<u8>()?;
         if current_len == new_len {
@@ -133,7 +133,7 @@ impl LocalState {
     pub(super) unsafe fn read_mmap_bytes<P: AccessPattern>(
         &self,
         range: Range<u64>,
-    ) -> Result<&[u8]> {
+    ) -> UioResult<&[u8]> {
         let mmap_bytes = self.mmap().as_bytes::<P>();
         mmap_file::read_bytes(mmap_bytes, range)
     }

--- a/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/pipeline.rs
@@ -10,11 +10,11 @@ use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::simple_disk_cache::{
     DiskCache, DiskCacheRemote, block_aligned_fetch, to_block_range,
 };
-use crate::universal_io::{self, ReadPipeline, Result, UniversalIoError, UniversalRead, UserData};
+use crate::universal_io::{ReadPipeline, UioResult, UniversalIoError, UniversalRead, UserData};
 
 #[cfg(target_os = "linux")]
 /// Required alignment when using io_uring with `O_DIRECT` on Linux
-pub(super) const REMOTE_READ_ALIGNMENT: usize = universal_io::io_uring::KERNEL_PAGE_SIZE;
+pub(super) const REMOTE_READ_ALIGNMENT: usize = crate::universal_io::io_uring::KERNEL_PAGE_SIZE;
 
 #[cfg(not(target_os = "linux"))]
 /// Default alignment on non-Linux platforms
@@ -60,7 +60,7 @@ enum Source {
 /// Decide whether `range` can be answered from local mmap or needs a remote fetch.
 ///
 /// Avoids materializing the local file for empty reads.
-fn pick_source<P>(local: &LocalState, range: Range<u64>) -> Result<Source>
+fn pick_source<P>(local: &LocalState, range: Range<u64>) -> UioResult<Source>
 where
     P: AccessPattern,
 {
@@ -112,7 +112,7 @@ unsafe fn read_local<R>(
     file: &DiskCache<R>,
     range: Range<u64>,
     is_sequential: bool,
-) -> universal_io::Result<&[u8]>
+) -> UioResult<&[u8]>
 where
     R: DiskCacheRemote,
 {
@@ -137,7 +137,7 @@ unsafe fn commit_and_read<'file, R, U>(
     fetch: InFlightFetch<'file, R, U>,
     bytes: &[u8],
     results: &mut VecDeque<(U, &'file [u8])>,
-) -> universal_io::Result<()>
+) -> UioResult<()>
 where
     R: DiskCacheRemote,
     U: UserData,
@@ -189,7 +189,7 @@ where
     /// borrows of other fields (see the `vacant_entry` in `schedule`).
     fn get_or_init_remote_pipeline<'a>(
         remote_pipeline: &'a mut OnceCell<RemotePipeline<'file, R>>,
-    ) -> universal_io::Result<&'a mut RemotePipeline<'file, R>> {
+    ) -> UioResult<&'a mut RemotePipeline<'file, R>> {
         if remote_pipeline.get().is_none() {
             let remote = R::ReadPipeline::new()?;
             // We just observed the cell as empty and hold `&mut`, so set cannot fail.
@@ -212,7 +212,7 @@ where
 {
     type File = DiskCache<R>;
 
-    fn new() -> universal_io::Result<Self> {
+    fn new() -> UioResult<Self> {
         Ok(Self {
             remote_pipeline: OnceCell::new(),
             in_flight: Slab::new(),
@@ -234,7 +234,7 @@ where
         file: &'file DiskCache<R>,
         range: Range<u64>,
         _align: usize,
-    ) -> universal_io::Result<()> {
+    ) -> UioResult<()> {
         let state = file.state()?;
         match pick_source::<P>(state.local, range.clone())? {
             Source::Local {
@@ -283,7 +283,12 @@ where
         Ok(())
     }
 
-    fn schedule_whole(&mut self, user_data: U, file: &'file DiskCache<R>, from: u64) -> Result<()>
+    fn schedule_whole(
+        &mut self,
+        user_data: U,
+        file: &'file DiskCache<R>,
+        from: u64,
+    ) -> UioResult<()>
     where
         Self::File: UniversalRead,
     {
@@ -297,7 +302,7 @@ where
         self.schedule::<Sequential>(user_data, file, from..eof, 1)
     }
 
-    fn wait(&mut self) -> universal_io::Result<Option<(U, ACow<'file>)>> {
+    fn wait(&mut self) -> UioResult<Option<(U, ACow<'file>)>> {
         if let Some((user_data, slice)) = self.results.pop_front() {
             return Ok(Some((user_data, ACow::Borrowed(slice))));
         }

--- a/lib/common/common/src/universal_io/sorted_block_index.rs
+++ b/lib/common/common/src/universal_io/sorted_block_index.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::traits::UniversalReadFs;
 use super::types::read_whole_via;
-use super::{OkNotFound, Result};
+use super::{OkNotFound, UioResult};
 
 /// Target size of one logical block of the indexed array, in bytes.
 ///
@@ -106,7 +106,7 @@ impl<T: bytemuck::Pod> SortedBlockIndex<T> {
         fs: &Fs,
         path: &Path,
         expected_len: usize,
-    ) -> Result<Option<Self>> {
+    ) -> UioResult<Option<Self>> {
         let parsed =
             read_whole_via(fs, path, |bytes| Ok(Self::parse(&bytes, path))).ok_not_found()?;
         let Some(index) = parsed.flatten() else {

--- a/lib/common/common/src/universal_io/traits/append.rs
+++ b/lib/common/common/src/universal_io/traits/append.rs
@@ -1,5 +1,5 @@
 use super::{UniversalFlush, UniversalRead, UniversalWriteFileOps};
-use crate::universal_io::{ByteOffset, Result};
+use crate::universal_io::{ByteOffset, UioResult};
 
 /// A file handle that supports atomic appends at a caller-provided offset.
 ///
@@ -60,7 +60,7 @@ pub trait UniversalAppend: UniversalRead<Fs: UniversalWriteFileOps> + UniversalF
     /// [`AppendOffsetConflict`] otherwise.
     ///
     /// [`AppendOffsetConflict`]: crate::universal_io::UniversalIoError::AppendOffsetConflict
-    fn append<T: bytemuck::Pod>(&mut self, offset: ByteOffset, data: &[T]) -> Result<()>;
+    fn append<T: bytemuck::Pod>(&mut self, offset: ByteOffset, data: &[T]) -> UioResult<()>;
 
     /// Append several buffers contiguously, in order, starting at exactly
     /// `offset`, using as few operations as the backend allows (a single
@@ -69,7 +69,7 @@ pub trait UniversalAppend: UniversalRead<Fs: UniversalWriteFileOps> + UniversalF
         &mut self,
         offset: ByteOffset,
         items: impl IntoIterator<Item = &'a [T]>,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         let mut offset = offset;
 
         for item in items {

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use crate::universal_io::traits::open_extra::OpenExtra;
 use crate::universal_io::traits::read::UniversalRead;
-use crate::universal_io::{ListedFile, OpenOptions, Result};
+use crate::universal_io::{ListedFile, OpenOptions, UioResult};
 
 /// Filesystem-level handle for read-only operations.
 ///
@@ -27,7 +27,7 @@ pub trait UniversalReadFileOps: Clone + Debug + Sized {
     type ContextConfig;
 
     /// Build a filesystem handle from its context.
-    fn from_context(context: Self::ContextConfig) -> Result<Self>;
+    fn from_context(context: Self::ContextConfig) -> UioResult<Self>;
 
     /// List files in the filesystem matching the given prefix, alongside
     /// their sizes in bytes.
@@ -36,10 +36,10 @@ pub trait UniversalReadFileOps: Clone + Debug + Sized {
     /// - `./gridstore/page_1.dat` (size in bytes)
     /// - `./gridstore/page_2.dat` (size in bytes)
     /// - `./gridstore/page_3.dat` (size in bytes)
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>>;
+    fn list_files(&self, prefix_path: &Path) -> UioResult<Vec<ListedFile>>;
 
     /// Check whether a file exists at the given path.
-    fn exists(&self, path: &Path) -> Result<bool>;
+    fn exists(&self, path: &Path) -> UioResult<bool>;
 
     // When adding provided methods, don't forget to update impls in
     // `crate::universal_io::wrappers::*`.
@@ -56,26 +56,26 @@ pub trait UniversalWriteFileOps: UniversalReadFileOps {
     ///
     /// Local backends use `expected_length` to pre-size the file. Backends
     /// without fixed-size file objects may ignore it.
-    fn create(&self, path: &Path, expected_length: usize) -> Result<()>;
+    fn create(&self, path: &Path, expected_length: usize) -> UioResult<()>;
 
     /// Create a directory at the given path.
     ///
     /// Backends without materialized directories may treat this as a no-op.
-    fn create_dir(&self, path: &Path) -> Result<()>;
+    fn create_dir(&self, path: &Path) -> UioResult<()>;
 
     /// Remove a file at the given path.
-    fn remove(&self, path: &Path) -> Result<()>;
+    fn remove(&self, path: &Path) -> UioResult<()>;
 
     /// Remove a directory at the given path.
     ///
     /// Backends without materialized directories may treat this as a no-op.
-    fn remove_dir(&self, path: &Path) -> Result<()>;
+    fn remove_dir(&self, path: &Path) -> UioResult<()>;
 
     /// Atomically save bytes at the given path.
     ///
     /// Local backends should use an atomic file replacement. Object-store
     /// backends may overwrite the full object.
-    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> Result<()>;
+    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> UioResult<()>;
 
     // When adding provided methods, don't forget to update impls in
     // `crate::universal_io::wrappers::*`.
@@ -116,7 +116,7 @@ pub trait UniversalReadFs: UniversalReadFileOps {
         path: impl AsRef<Path>,
         options: OpenOptions,
         extra: Self::OpenExtra,
-    ) -> Result<Self::File>;
+    ) -> UioResult<Self::File>;
 }
 
 /// Capability extension over [`UniversalReadFs`]: a filesystem that snapshots
@@ -129,7 +129,7 @@ pub trait CachedReadFs: UniversalReadFs {
     /// Take the file listing snapshot. From this point on, listing and
     /// existence checks are answered locally and opens of unlisted paths
     /// fail with `NotFound` without touching the underlying filesystem.
-    fn cache_file_info(&mut self) -> Result<()>;
+    fn cache_file_info(&mut self) -> UioResult<()>;
 
     /// Open `path` in the background and park the handle in the prefetch
     /// pool, to be consumed by a later [`UniversalReadFs::open`] of the same
@@ -139,5 +139,5 @@ pub trait CachedReadFs: UniversalReadFs {
         path: &Path,
         open_arguments: Option<OpenOptions>,
         open_extra: Option<Self::OpenExtra>,
-    ) -> Result<()>;
+    ) -> UioResult<()>;
 }

--- a/lib/common/common/src/universal_io/traits/pipeline.rs
+++ b/lib/common/common/src/universal_io/traits/pipeline.rs
@@ -30,7 +30,7 @@ use std::ops::Range;
 use super::{Item, UniversalRead};
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
-use crate::universal_io::{Result, UserData};
+use crate::universal_io::{UioResult, UserData};
 
 /// File-borrowing read pipeline.
 ///
@@ -47,7 +47,7 @@ where
 {
     type File: 'file;
 
-    fn new() -> Result<Self>;
+    fn new() -> UioResult<Self>;
 
     fn can_schedule(&mut self) -> bool;
 
@@ -68,17 +68,18 @@ where
         file: &'file Self::File,
         range: Range<u64>,
         align: usize,
-    ) -> Result<()>;
+    ) -> UioResult<()>;
 
     /// Like `Self::schedule`, but doesn't need to know file length upfront.
     /// Reads starting at `from` offset until the end of file.
-    fn schedule_whole(&mut self, user_data: U, file: &'file Self::File, from: u64) -> Result<()>;
+    fn schedule_whole(&mut self, user_data: U, file: &'file Self::File, from: u64)
+    -> UioResult<()>;
 
     /// Block until any scheduled operation completes and consume its result.
-    fn wait(&mut self) -> Result<Option<(U, ACow<'file>)>>;
+    fn wait(&mut self) -> UioResult<Option<(U, ACow<'file>)>>;
 
     #[inline]
-    fn wait_bytemuck<T: Item>(&mut self) -> Result<Option<(U, Cow<'file, [T]>)>> {
+    fn wait_bytemuck<T: Item>(&mut self) -> UioResult<Option<(U, Cow<'file, [T]>)>> {
         let Some((user_data, bytes)) = self.wait()? else {
             return Ok(None);
         };
@@ -129,7 +130,7 @@ where
     R: UniversalRead + 'static,
     U: UserData,
 {
-    pub fn new(file: R) -> Result<Self> {
+    pub fn new(file: R) -> UioResult<Self> {
         let pipeline = R::ReadPipeline::new()?;
 
         let pipeline = Self {
@@ -150,7 +151,7 @@ where
         user_data: U,
         range: Range<u64>,
         align: usize,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         // SAFETY:
         //
         // Safe, because neither inner pipeline, nor returned data can ever outlive file.
@@ -165,7 +166,7 @@ where
     }
 
     /// Like [`schedule`](Self::schedule), but reads the entire file
-    pub fn schedule_whole(&mut self, user_data: U, from: u64) -> Result<()> {
+    pub fn schedule_whole(&mut self, user_data: U, from: u64) -> UioResult<()> {
         // SAFETY:
         //
         // Same as schedule
@@ -177,7 +178,7 @@ where
     }
 
     #[inline]
-    pub fn wait(&mut self) -> Result<Option<(U, ACow<'_>)>> {
+    pub fn wait(&mut self) -> UioResult<Option<(U, ACow<'_>)>> {
         // pipeline returns ACow<'static>, but we shorten its lifetime to ACow<'_>,
         // which mutably borrows self, so pipeline can only be dropped after all returned
         // ACow-s are dropped
@@ -186,7 +187,7 @@ where
     }
 
     #[inline]
-    pub fn wait_bytemuck<T: Item>(&mut self) -> Result<Option<(U, Cow<'_, [T]>)>> {
+    pub fn wait_bytemuck<T: Item>(&mut self) -> UioResult<Option<(U, Cow<'_, [T]>)>> {
         let Some((user_data, bytes)) = self.wait()? else {
             return Ok(None);
         };

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use super::{Item, ReadPipeline, UniversalReadFs, UserData};
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Sequential};
-use crate::universal_io::{ReadBytesItem, ReadRange, Result, UniversalKind};
+use crate::universal_io::{ReadBytesItem, ReadRange, UioResult, UniversalKind};
 
 /// Per-file handle for universal read access.
 ///
@@ -56,23 +56,23 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     /// underlying file larger, so reopening can account for this growth.
     ///
     /// This may be a no-op in some implementations.
-    fn reopen(&mut self) -> Result<()>;
+    fn reopen(&mut self) -> UioResult<()>;
 
     /// Prefer [`read_batch`] if you need high performance.
     #[inline]
-    fn read<P: AccessPattern, T: Item>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
+    fn read<P: AccessPattern, T: Item>(&self, range: ReadRange) -> UioResult<Cow<'_, [T]>> {
         let bytes = self.read_bytes::<P>(range.into_byte_range::<T>(), align_of::<T>())?;
         Ok(bytes.try_cast_bytemuck().unwrap())
     }
 
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> Result<ACow<'_>>;
+    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> UioResult<ACow<'_>>;
 
     /// Read the entire file in one logical access.
     ///
     /// Implementations may override this to avoid the two accesses that would
     /// result from `len()` followed by `read(0..len())`. Default implementation
     /// does exactly that.
-    fn read_whole<T: Item>(&self) -> Result<Cow<'_, [T]>> {
+    fn read_whole<T: Item>(&self) -> UioResult<Cow<'_, [T]>> {
         let range = ReadRange {
             byte_offset: 0,
             length: self.len::<T>()?,
@@ -84,8 +84,8 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     fn read_batch<P, T, U>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-        mut callback: impl FnMut(U, &[T]) -> Result<()>,
-    ) -> Result<()>
+        mut callback: impl FnMut(U, &[T]) -> UioResult<()>,
+    ) -> UioResult<()>
     where
         P: AccessPattern,
         T: Item,
@@ -116,7 +116,7 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     fn read_iter<P, T, U>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-    ) -> Result<impl Iterator<Item = Result<(U, Cow<'_, [T]>)>>>
+    ) -> UioResult<impl Iterator<Item = UioResult<(U, Cow<'_, [T]>)>>>
     where
         P: AccessPattern,
         T: Item,
@@ -142,7 +142,7 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     fn read_bytes_iter<P, U>(
         &self,
         ranges: impl IntoIterator<Item = ReadBytesItem<U>>,
-    ) -> Result<impl Iterator<Item = Result<(U, ACow<'_>)>>>
+    ) -> UioResult<impl Iterator<Item = UioResult<(U, ACow<'_>)>>>
     where
         P: AccessPattern,
         U: UserData,
@@ -168,12 +168,12 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
         }))
     }
 
-    fn len<T>(&self) -> Result<u64>;
+    fn len<T>(&self) -> UioResult<u64>;
 
     /// Fill RAM cache with related data, if applicable for this implementation.
     ///
     /// For example in MMAP-based files we do `madvise` with `MADV_POPULATE_READ`.
-    fn populate(&self) -> Result<()>;
+    fn populate(&self) -> UioResult<()>;
 
     /// Whether the backend chooses to populate when using `Populate::Auto`
     fn populate_auto() -> bool;
@@ -181,7 +181,7 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     /// Ask to evict related data from RAM cache, if applicable for this implementation.
     ///
     /// For example in MMAP-based files we do `madvise` with `MADV_PAGEOUT`.
-    fn clear_ram_cache(&self) -> Result<()>;
+    fn clear_ram_cache(&self) -> UioResult<()>;
 
     fn kind() -> UniversalKind;
 

--- a/lib/common/common/src/universal_io/traits/write.rs
+++ b/lib/common/common/src/universal_io/traits/write.rs
@@ -1,5 +1,5 @@
 use super::{UniversalRead, UniversalWriteFileOps};
-use crate::universal_io::{ByteOffset, FileIndex, Flusher, Result, UniversalIoError};
+use crate::universal_io::{ByteOffset, FileIndex, Flusher, UioResult, UniversalIoError};
 
 /// Durability control for mutating file handles.
 ///
@@ -20,18 +20,18 @@ pub trait UniversalFlush {
 /// ([`UniversalWriteFileOps`]): a backend that can open files for writing
 /// must also be able to create and remove them.
 pub trait UniversalWrite: UniversalRead<Fs: UniversalWriteFileOps> + UniversalFlush {
-    fn write<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, data: &[T]) -> Result<()>;
+    fn write<T: bytemuck::Pod>(&mut self, byte_offset: ByteOffset, data: &[T]) -> UioResult<()>;
 
     fn write_batch<'a, T: bytemuck::Pod>(
         &mut self,
         offset_data: impl IntoIterator<Item = (ByteOffset, &'a [T])>,
-    ) -> Result<()>;
+    ) -> UioResult<()>;
 
     /// Write to multiple files in a single operation.
     fn write_multi<'a, T: bytemuck::Pod>(
         files: &mut [Self],
         writes: impl IntoIterator<Item = (FileIndex, ByteOffset, &'a [T])>,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         let files_len = files.len();
 
         for (file_index, offset, data) in writes {

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -223,15 +223,15 @@ pub type ByteOffset = u64;
 
 pub type FileIndex = usize;
 
-pub type Flusher = Box<dyn FnOnce() -> Result<()> + Send>;
+pub type Flusher = Box<dyn FnOnce() -> UioResult<()> + Send>;
 
-pub type Result<T, E = UniversalIoError> = std::result::Result<T, E>;
+pub type UioResult<T> = Result<T, UniversalIoError>;
 
 pub fn read_whole_via<Fs, T>(
     fs: &Fs,
     path: impl AsRef<Path>,
-    callback: impl FnOnce(Cow<'_, [u8]>) -> Result<T, UniversalIoError>,
-) -> Result<T, UniversalIoError>
+    callback: impl FnOnce(Cow<'_, [u8]>) -> UioResult<T>,
+) -> UioResult<T>
 where
     Fs: UniversalReadFs,
 {
@@ -256,7 +256,7 @@ where
 ///
 /// Uses a single logical read when the backend overrides
 /// [`UniversalRead::read_whole`](super::UniversalRead::read_whole).
-pub fn read_json_via<Fs, T>(fs: &Fs, path: impl AsRef<Path>) -> Result<T>
+pub fn read_json_via<Fs, T>(fs: &Fs, path: impl AsRef<Path>) -> UioResult<T>
 where
     Fs: UniversalReadFs,
     T: DeserializeOwned,
@@ -270,7 +270,7 @@ where
 ///
 /// Uses a single logical read when the backend overrides
 /// [`UniversalRead::read_whole`](super::UniversalRead::read_whole).
-pub fn read_bin_via<Fs, T>(fs: &Fs, path: impl AsRef<Path>) -> Result<T>
+pub fn read_bin_via<Fs, T>(fs: &Fs, path: impl AsRef<Path>) -> UioResult<T>
 where
     Fs: UniversalReadFs,
     T: DeserializeOwned,

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -10,8 +10,8 @@ use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::traits::UniversalReadFileOps;
 use crate::universal_io::{
-    Item, ListedFile, OpenOptions, ReadBytesItem, ReadRange, Result, UniversalKind, UniversalRead,
-    UniversalReadFs, UserData,
+    Item, ListedFile, OpenOptions, ReadBytesItem, ReadRange, UioResult, UniversalKind,
+    UniversalRead, UniversalReadFs, UserData,
 };
 
 #[derive(Debug, TransparentWrapper)]
@@ -38,15 +38,15 @@ impl<F: fmt::Debug> fmt::Debug for ReadOnlyFs<F> {
 impl<F: UniversalReadFileOps> UniversalReadFileOps for ReadOnlyFs<F> {
     type ContextConfig = ReadOnlyConfigContext<F::ContextConfig>;
 
-    fn from_context(ctx: Self::ContextConfig) -> Result<Self> {
+    fn from_context(ctx: Self::ContextConfig) -> UioResult<Self> {
         Ok(ReadOnlyFs(F::from_context(ctx.0)?))
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
+    fn list_files(&self, prefix_path: &Path) -> UioResult<Vec<ListedFile>> {
         self.0.list_files(prefix_path)
     }
 
-    fn exists(&self, path: &Path) -> Result<bool> {
+    fn exists(&self, path: &Path) -> UioResult<bool> {
         self.0.exists(path)
     }
 
@@ -63,7 +63,7 @@ impl<F: UniversalReadFs> UniversalReadFs for ReadOnlyFs<F> {
         path: impl AsRef<Path>,
         options: OpenOptions,
         extra: F::OpenExtra,
-    ) -> Result<Self::File> {
+    ) -> UioResult<Self::File> {
         debug_assert!(!options.writeable);
         Ok(ReadOnly(self.0.open(path, options, extra)?))
     }
@@ -91,7 +91,7 @@ where
         path: impl AsRef<Path>,
         options: OpenOptions,
         extra: Fs::OpenExtra,
-    ) -> Result<Self> {
+    ) -> UioResult<Self> {
         debug_assert!(!options.writeable);
         let io = fs.open(path, options, extra)?;
         Ok(Self(io))
@@ -111,22 +111,22 @@ where
         U: UserData;
 
     #[inline]
-    fn reopen(&mut self) -> Result<()> {
+    fn reopen(&mut self) -> UioResult<()> {
         self.0.reopen()
     }
 
     #[inline]
-    fn read<P: AccessPattern, T: Item>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
+    fn read<P: AccessPattern, T: Item>(&self, range: ReadRange) -> UioResult<Cow<'_, [T]>> {
         self.0.read::<P, T>(range)
     }
 
     #[inline]
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> Result<ACow<'_>> {
+    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> UioResult<ACow<'_>> {
         self.0.read_bytes::<P>(range, align)
     }
 
     #[inline]
-    fn read_whole<T: Item>(&self) -> Result<Cow<'_, [T]>> {
+    fn read_whole<T: Item>(&self) -> UioResult<Cow<'_, [T]>> {
         self.0.read_whole()
     }
 
@@ -134,8 +134,8 @@ where
     fn read_batch<P, T, U>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-        callback: impl FnMut(U, &[T]) -> Result<()>,
-    ) -> Result<()>
+        callback: impl FnMut(U, &[T]) -> UioResult<()>,
+    ) -> UioResult<()>
     where
         P: AccessPattern,
         T: Item,
@@ -148,7 +148,7 @@ where
     fn read_iter<P, T, U>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-    ) -> Result<impl Iterator<Item = Result<(U, Cow<'_, [T]>)>>>
+    ) -> UioResult<impl Iterator<Item = UioResult<(U, Cow<'_, [T]>)>>>
     where
         P: AccessPattern,
         T: Item,
@@ -161,7 +161,7 @@ where
     fn read_bytes_iter<P, U>(
         &self,
         ranges: impl IntoIterator<Item = ReadBytesItem<U>>,
-    ) -> Result<impl Iterator<Item = Result<(U, ACow<'_>)>>>
+    ) -> UioResult<impl Iterator<Item = UioResult<(U, ACow<'_>)>>>
     where
         P: AccessPattern,
         U: UserData,
@@ -170,12 +170,12 @@ where
     }
 
     #[inline]
-    fn len<T>(&self) -> Result<u64> {
+    fn len<T>(&self) -> UioResult<u64> {
         self.0.len::<T>()
     }
 
     #[inline]
-    fn populate(&self) -> Result<()> {
+    fn populate(&self) -> UioResult<()> {
         self.0.populate()
     }
 
@@ -185,7 +185,7 @@ where
     }
 
     #[inline]
-    fn clear_ram_cache(&self) -> Result<()> {
+    fn clear_ram_cache(&self) -> UioResult<()> {
         self.0.clear_ram_cache()
     }
 

--- a/lib/common/common/src/universal_io/wrappers/stored_struct.rs
+++ b/lib/common/common/src/universal_io/wrappers/stored_struct.rs
@@ -5,7 +5,7 @@ use parking_lot::Mutex;
 
 use crate::is_alive_lock::IsAliveLock;
 use crate::universal_io::{
-    self, Flusher, OpenOptions, TypedStorage, UniversalReadFs, UniversalWrite,
+    Flusher, OpenOptions, TypedStorage, UioResult, UniversalReadFs, UniversalWrite,
 };
 
 /// A generic-storage wrapper for a type that should be possible to `read_whole` fairly cheaply.
@@ -29,7 +29,7 @@ where
         path: impl AsRef<Path>,
         options: OpenOptions,
         extra: Fs::OpenExtra,
-    ) -> universal_io::Result<Self> {
+    ) -> UioResult<Self> {
         let storage = TypedStorage::<S, T>::open(fs, path, options, extra)?;
         let inner = storage.read_whole()?[0];
         Ok(Self {

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -7,7 +7,7 @@ use bytemuck::TransparentWrapper;
 
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
-    ByteOffset, FileIndex, Flusher, Item, OpenOptions, ReadRange, Result, UniversalAppend,
+    ByteOffset, FileIndex, Flusher, Item, OpenOptions, ReadRange, UioResult, UniversalAppend,
     UniversalFlush, UniversalKind, UniversalRead, UniversalReadFs, UniversalWrite, UserData,
 };
 
@@ -62,21 +62,21 @@ where
         path: impl AsRef<Path>,
         options: OpenOptions,
         extra: Fs::OpenExtra,
-    ) -> Result<Self> {
+    ) -> UioResult<Self> {
         fs.open(path, options, extra).map(Self::new)
     }
 
-    pub fn reopen(&mut self) -> Result<()> {
+    pub fn reopen(&mut self) -> UioResult<()> {
         self.inner.reopen()
     }
 
     #[inline]
-    pub fn read<P: AccessPattern>(&self, range: ReadRange) -> Result<Cow<'_, [T]>> {
+    pub fn read<P: AccessPattern>(&self, range: ReadRange) -> UioResult<Cow<'_, [T]>> {
         self.inner.read::<P, T>(range)
     }
 
     #[inline]
-    pub fn read_whole(&self) -> Result<Cow<'_, [T]>> {
+    pub fn read_whole(&self) -> UioResult<Cow<'_, [T]>> {
         self.inner.read_whole::<T>()
     }
 
@@ -84,8 +84,8 @@ where
     pub fn read_batch<P, U>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-        callback: impl FnMut(U, &[T]) -> Result<()>,
-    ) -> Result<()>
+        callback: impl FnMut(U, &[T]) -> UioResult<()>,
+    ) -> UioResult<()>
     where
         P: AccessPattern,
         U: UserData,
@@ -97,7 +97,7 @@ where
     pub fn read_iter<P, U>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-    ) -> Result<impl Iterator<Item = Result<(U, Cow<'_, [T]>)>>>
+    ) -> UioResult<impl Iterator<Item = UioResult<(U, Cow<'_, [T]>)>>>
     where
         P: AccessPattern,
         U: UserData,
@@ -106,17 +106,17 @@ where
     }
 
     #[inline]
-    pub fn len(&self) -> Result<u64> {
+    pub fn len(&self) -> UioResult<u64> {
         self.inner.len::<T>()
     }
 
     #[inline]
-    pub fn populate(&self) -> Result<()> {
+    pub fn populate(&self) -> UioResult<()> {
         self.inner.populate()
     }
 
     #[inline]
-    pub fn clear_ram_cache(&self) -> Result<()> {
+    pub fn clear_ram_cache(&self) -> UioResult<()> {
         self.inner.clear_ram_cache()
     }
 
@@ -131,7 +131,7 @@ where
     T: bytemuck::Pod,
 {
     #[inline]
-    pub fn write(&mut self, byte_offset: ByteOffset, data: &[T]) -> Result<()> {
+    pub fn write(&mut self, byte_offset: ByteOffset, data: &[T]) -> UioResult<()> {
         self.inner.write::<T>(byte_offset, data)
     }
 
@@ -139,7 +139,7 @@ where
     pub fn write_batch<'a>(
         &mut self,
         offset_data: impl IntoIterator<Item = (ByteOffset, &'a [T])>,
-    ) -> Result<()>
+    ) -> UioResult<()>
     where
         T: 'a,
     {
@@ -150,7 +150,7 @@ where
     pub fn write_multi<'a>(
         files: &mut [Self],
         writes: impl IntoIterator<Item = (FileIndex, ByteOffset, &'a [T])>,
-    ) -> Result<()>
+    ) -> UioResult<()>
     where
         T: 'a,
     {
@@ -178,7 +178,7 @@ where
     /// Append `data` at exactly byte offset `offset`, which must equal the
     /// current end of file.
     #[inline]
-    pub fn append(&mut self, offset: ByteOffset, data: &[T]) -> Result<()> {
+    pub fn append(&mut self, offset: ByteOffset, data: &[T]) -> UioResult<()> {
         self.inner.append::<T>(offset, data)
     }
 
@@ -189,7 +189,7 @@ where
         &mut self,
         offset: ByteOffset,
         items: impl IntoIterator<Item = &'a [T]>,
-    ) -> Result<()>
+    ) -> UioResult<()>
     where
         T: 'a,
     {

--- a/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
+++ b/lib/common/common/src/universal_io/wrappers/wrapped_pipeline.rs
@@ -5,7 +5,7 @@ use bytemuck::TransparentWrapper;
 
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
-use crate::universal_io::{ReadPipeline, Result, UserData};
+use crate::universal_io::{ReadPipeline, UioResult, UserData};
 
 /// Default [`ReadPipeline`] implementation for transparent wrappers
 pub struct WrappedReadPipeline<File, Inner> {
@@ -22,7 +22,7 @@ where
     type File = File;
 
     #[inline]
-    fn new() -> Result<Self> {
+    fn new() -> UioResult<Self> {
         let wrapper = Self {
             inner: Inner::new()?,
             _phantom: PhantomData,
@@ -43,18 +43,23 @@ where
         file: &'file File,
         range: Range<u64>,
         align: usize,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         self.inner
             .schedule::<P>(user_data, File::peel_ref(file), range, align)
     }
 
-    fn schedule_whole(&mut self, user_data: U, file: &'file Self::File, from: u64) -> Result<()> {
+    fn schedule_whole(
+        &mut self,
+        user_data: U,
+        file: &'file Self::File,
+        from: u64,
+    ) -> UioResult<()> {
         self.inner
             .schedule_whole(user_data, File::peel_ref(file), from)
     }
 
     #[inline]
-    fn wait(&mut self) -> Result<Option<(U, ACow<'file>)>> {
+    fn wait(&mut self) -> UioResult<Option<(U, ACow<'file>)>> {
         self.inner.wait()
     }
 }

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use common::ext::aligned_vec::ACow;
 use common::generic_consts::AccessPattern;
 use common::universal_io::{
-    ByteOffset, Flusher, Item, Result, UniversalAppend, UniversalFlush, UniversalIoError,
+    ByteOffset, Flusher, Item, UioResult, UniversalAppend, UniversalFlush, UniversalIoError,
     UniversalKind, UniversalRead, UserData,
 };
 
@@ -71,7 +71,7 @@ impl<A: AsyncRead> BlobFile<A> {
         config: &A::Config,
         runtime: BridgeRuntime,
         path: impl Into<PathBuf>,
-    ) -> Result<Self> {
+    ) -> UioResult<Self> {
         let inner = A::open(config)?;
         Ok(Self::new(inner, runtime, path))
     }
@@ -98,11 +98,11 @@ impl<A: AsyncRead + Clone> UniversalRead for BlobFile<A> {
         Self: 'a,
         U: UserData;
 
-    fn reopen(&mut self) -> Result<()> {
+    fn reopen(&mut self) -> UioResult<()> {
         Ok(())
     }
 
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> Result<ACow<'_>> {
+    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> UioResult<ACow<'_>> {
         let enabled = log::log_enabled!(target: crate::LATENCY_LOG_TARGET, log::Level::Trace);
         let start_time = enabled.then(std::time::Instant::now);
         let buf = self
@@ -122,7 +122,7 @@ impl<A: AsyncRead + Clone> UniversalRead for BlobFile<A> {
         Ok(ACow::Owned(buf))
     }
 
-    fn read_whole<T: Item>(&self) -> Result<Cow<'_, [T]>> {
+    fn read_whole<T: Item>(&self) -> UioResult<Cow<'_, [T]>> {
         let buf = self
             .runtime
             .block_on(read_whole_into_byte_buffer::<A>(self, align_of::<T>()))?;
@@ -131,7 +131,7 @@ impl<A: AsyncRead + Clone> UniversalRead for BlobFile<A> {
             .expect("buffer has compatible layout"))
     }
 
-    fn len<T>(&self) -> Result<u64> {
+    fn len<T>(&self) -> UioResult<u64> {
         let enabled = log::log_enabled!(target: crate::LATENCY_LOG_TARGET, log::Level::Trace);
         let start_time = enabled.then(std::time::Instant::now);
         let item_size = size_of::<T>() as u64;
@@ -151,7 +151,7 @@ impl<A: AsyncRead + Clone> UniversalRead for BlobFile<A> {
         Ok(len / item_size)
     }
 
-    fn populate(&self) -> Result<()> {
+    fn populate(&self) -> UioResult<()> {
         Ok(())
     }
 
@@ -159,7 +159,7 @@ impl<A: AsyncRead + Clone> UniversalRead for BlobFile<A> {
         false
     }
 
-    fn clear_ram_cache(&self) -> Result<()> {
+    fn clear_ram_cache(&self) -> UioResult<()> {
         Ok(())
     }
 
@@ -179,7 +179,7 @@ impl<A: AsyncAppend + Clone> BlobFile<A> {
     /// One append RPC at exactly `offset`; the backend itself validates the
     /// offset against the current object size (the compare-and-swap), so no
     /// local length tracking is needed.
-    fn append_bytes(&self, offset: ByteOffset, data: Bytes) -> Result<()> {
+    fn append_bytes(&self, offset: ByteOffset, data: Bytes) -> UioResult<()> {
         if data.is_empty() {
             return Ok(());
         }
@@ -198,7 +198,7 @@ impl<A: AsyncAppend + Clone> BlobFile<A> {
 }
 
 impl<A: AsyncAppend + Clone> UniversalAppend for BlobFile<A> {
-    fn append<T: bytemuck::Pod>(&mut self, offset: ByteOffset, data: &[T]) -> Result<()> {
+    fn append<T: bytemuck::Pod>(&mut self, offset: ByteOffset, data: &[T]) -> UioResult<()> {
         self.append_bytes(offset, Bytes::copy_from_slice(bytemuck::cast_slice(data)))
     }
 
@@ -206,7 +206,7 @@ impl<A: AsyncAppend + Clone> UniversalAppend for BlobFile<A> {
         &mut self,
         offset: ByteOffset,
         items: impl IntoIterator<Item = &'a [T]>,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         // Concatenate into a single buffer so the whole batch lands in one
         // request.
         let slices: Vec<&[u8]> = items
@@ -254,7 +254,7 @@ mod tests {
     impl AsyncRead for MockSource {
         type Config = ();
 
-        fn open(_config: &()) -> Result<Self> {
+        fn open(_config: &()) -> UioResult<Self> {
             Err(UniversalIoError::S3Config {
                 description: "MockSource has no real open path; construct directly in tests".into(),
             })
@@ -263,11 +263,11 @@ mod tests {
         fn list_files(
             &self,
             _prefix: &Path,
-        ) -> impl Future<Output = Result<Vec<ListedFile>>> + Send + 'static {
+        ) -> impl Future<Output = UioResult<Vec<ListedFile>>> + Send + 'static {
             std::future::ready(Ok(vec![]))
         }
 
-        fn exists(&self, _path: &Path) -> impl Future<Output = Result<bool>> + Send + 'static {
+        fn exists(&self, _path: &Path) -> impl Future<Output = UioResult<bool>> + Send + 'static {
             std::future::ready(Ok(true))
         }
 
@@ -275,7 +275,7 @@ mod tests {
             &self,
             _path: &Path,
             range: Range<u64>,
-        ) -> impl Future<Output = Result<BoxStream<'static, Result<Bytes>>>> + Send + 'static
+        ) -> impl Future<Output = UioResult<BoxStream<'static, UioResult<Bytes>>>> + Send + 'static
         {
             let bytes = self.data.slice(range.start as usize..range.end as usize);
             async move { Ok(futures::stream::once(async move { Ok(bytes) }).boxed()) }
@@ -285,7 +285,7 @@ mod tests {
             &self,
             _path: &Path,
             from: u64,
-        ) -> impl Future<Output = Result<(u64, OffsetByteStream)>> + Send + 'static {
+        ) -> impl Future<Output = UioResult<(u64, OffsetByteStream)>> + Send + 'static {
             let size = self.data.len() as u64;
             let tail = self.data.slice(from as usize..);
             async move {
@@ -296,7 +296,7 @@ mod tests {
             }
         }
 
-        fn len(&self, _path: &Path) -> impl Future<Output = Result<u64>> + Send + 'static {
+        fn len(&self, _path: &Path) -> impl Future<Output = UioResult<u64>> + Send + 'static {
             let len = self.data.len() as u64;
             async move { Ok(len) }
         }
@@ -396,18 +396,18 @@ mod tests {
     impl AsyncRead for MutableMockSource {
         type Config = ();
 
-        fn open(_config: &()) -> Result<Self> {
+        fn open(_config: &()) -> UioResult<Self> {
             Ok(Self::default())
         }
 
         fn list_files(
             &self,
             _prefix: &Path,
-        ) -> impl Future<Output = Result<Vec<ListedFile>>> + Send + 'static {
+        ) -> impl Future<Output = UioResult<Vec<ListedFile>>> + Send + 'static {
             std::future::ready(Ok(vec![]))
         }
 
-        fn exists(&self, _path: &Path) -> impl Future<Output = Result<bool>> + Send + 'static {
+        fn exists(&self, _path: &Path) -> impl Future<Output = UioResult<bool>> + Send + 'static {
             std::future::ready(Ok(self.store.lock().unwrap().is_some()))
         }
 
@@ -415,7 +415,7 @@ mod tests {
             &self,
             path: &Path,
             range: Range<u64>,
-        ) -> impl Future<Output = Result<BoxStream<'static, Result<Bytes>>>> + Send + 'static
+        ) -> impl Future<Output = UioResult<BoxStream<'static, UioResult<Bytes>>>> + Send + 'static
         {
             let result = match &*self.store.lock().unwrap() {
                 Some(data) => Ok(Bytes::copy_from_slice(
@@ -433,7 +433,7 @@ mod tests {
             &self,
             path: &Path,
             from: u64,
-        ) -> impl Future<Output = Result<(u64, OffsetByteStream)>> + Send + 'static {
+        ) -> impl Future<Output = UioResult<(u64, OffsetByteStream)>> + Send + 'static {
             let result = match &*self.store.lock().unwrap() {
                 Some(data) => Ok((
                     data.len() as u64,
@@ -450,7 +450,7 @@ mod tests {
             }
         }
 
-        fn len(&self, path: &Path) -> impl Future<Output = Result<u64>> + Send + 'static {
+        fn len(&self, path: &Path) -> impl Future<Output = UioResult<u64>> + Send + 'static {
             self.len_calls
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let result = match &*self.store.lock().unwrap() {
@@ -466,12 +466,12 @@ mod tests {
     }
 
     impl AsyncWrite for MutableMockSource {
-        fn create(&self, _path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
+        fn create(&self, _path: &Path) -> impl Future<Output = UioResult<()>> + Send + 'static {
             *self.store.lock().unwrap() = Some(Vec::new());
             std::future::ready(Ok(()))
         }
 
-        fn remove(&self, path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
+        fn remove(&self, path: &Path) -> impl Future<Output = UioResult<()>> + Send + 'static {
             let result = match self.store.lock().unwrap().take() {
                 Some(_) => Ok(()),
                 None => Err(UniversalIoError::NotFound { path: path.into() }),
@@ -483,7 +483,7 @@ mod tests {
             &self,
             _path: &Path,
             bytes: Bytes,
-        ) -> impl Future<Output = Result<()>> + Send + 'static {
+        ) -> impl Future<Output = UioResult<()>> + Send + 'static {
             *self.store.lock().unwrap() = Some(bytes.to_vec());
             std::future::ready(Ok(()))
         }
@@ -495,7 +495,7 @@ mod tests {
             path: &Path,
             offset: u64,
             data: Bytes,
-        ) -> impl Future<Output = Result<u64>> + Send + 'static {
+        ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
             self.append_calls
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let mut guard = self.store.lock().unwrap();

--- a/lib/common/io_bridge/src/fs.rs
+++ b/lib/common/io_bridge/src/fs.rs
@@ -2,7 +2,8 @@ use std::path::Path;
 
 use bytes::Bytes;
 use common::universal_io::{
-    ListedFile, OpenOptions, Result, UniversalReadFileOps, UniversalReadFs, UniversalWriteFileOps,
+    ListedFile, OpenOptions, UioResult, UniversalReadFileOps, UniversalReadFs,
+    UniversalWriteFileOps,
 };
 
 use crate::{AsyncRead, AsyncWrite, BlobFile, BridgeRuntime};
@@ -35,13 +36,13 @@ impl<A: AsyncRead> BlobFs<A> {
 impl<A: AsyncRead + Clone> UniversalReadFileOps for BlobFs<A> {
     type ContextConfig = A::Config;
 
-    fn from_context(config: Self::ContextConfig) -> Result<Self> {
+    fn from_context(config: Self::ContextConfig) -> UioResult<Self> {
         // The context carries no runtime, so use the process-wide BridgeRuntime;
         // callers needing an isolated runtime construct via `BlobFs::new`.
         Ok(Self::new(A::open(&config)?, BridgeRuntime::global()))
     }
 
-    fn list_files(&self, prefix_path: &Path) -> Result<Vec<ListedFile>> {
+    fn list_files(&self, prefix_path: &Path) -> UioResult<Vec<ListedFile>> {
         let enabled = log::log_enabled!(target: crate::LATENCY_LOG_TARGET, log::Level::Trace);
         let start_time = enabled.then(std::time::Instant::now);
         let result = self.runtime.block_on(self.inner.list_files(prefix_path));
@@ -57,7 +58,7 @@ impl<A: AsyncRead + Clone> UniversalReadFileOps for BlobFs<A> {
         result
     }
 
-    fn exists(&self, path: &Path) -> Result<bool> {
+    fn exists(&self, path: &Path) -> UioResult<bool> {
         let enabled = log::log_enabled!(target: crate::LATENCY_LOG_TARGET, log::Level::Trace);
         let start_time = enabled.then(std::time::Instant::now);
         let result = self.runtime.block_on(self.inner.exists(path));
@@ -74,27 +75,27 @@ impl<A: AsyncRead + Clone> UniversalReadFileOps for BlobFs<A> {
 }
 
 impl<A: AsyncWrite + Clone> UniversalWriteFileOps for BlobFs<A> {
-    fn create(&self, path: &Path, _expected_length: usize) -> Result<()> {
+    fn create(&self, path: &Path, _expected_length: usize) -> UioResult<()> {
         // Object stores have no fixed-size preallocation; the expected
         // length is ignored, as the trait allows.
         self.runtime.block_on(self.inner.create(path))
     }
 
-    fn create_dir(&self, _path: &Path) -> Result<()> {
+    fn create_dir(&self, _path: &Path) -> UioResult<()> {
         // No materialized directories.
         Ok(())
     }
 
-    fn remove(&self, path: &Path) -> Result<()> {
+    fn remove(&self, path: &Path) -> UioResult<()> {
         self.runtime.block_on(self.inner.remove(path))
     }
 
-    fn remove_dir(&self, _path: &Path) -> Result<()> {
+    fn remove_dir(&self, _path: &Path) -> UioResult<()> {
         // No materialized directories.
         Ok(())
     }
 
-    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> Result<()> {
+    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> UioResult<()> {
         // A whole-object put is atomic on object stores.
         self.runtime
             .block_on(self.inner.save(path, Bytes::copy_from_slice(bytes)))
@@ -112,7 +113,7 @@ impl<A: AsyncRead + Clone> UniversalReadFs for BlobFs<A> {
         path: impl AsRef<Path>,
         options: OpenOptions,
         _extra: (),
-    ) -> Result<BlobFile<A>> {
+    ) -> UioResult<BlobFile<A>> {
         Ok(
             BlobFile::new(self.inner.clone(), self.runtime.clone(), path.as_ref())
                 .with_writeable(options.writeable),

--- a/lib/common/io_bridge/src/pipeline/buffer.rs
+++ b/lib/common/io_bridge/src/pipeline/buffer.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::ops::Range;
 
 use aligned_vec::{AVec, RuntimeAlign};
-use common::universal_io::{Result, UniversalIoError};
+use common::universal_io::{UioResult, UniversalIoError};
 use futures::StreamExt as _;
 
 use crate::file::BlobFile;
@@ -21,7 +21,7 @@ pub fn read_into_byte_buffer<A: AsyncRead>(
     file: &BlobFile<A>,
     range: Range<u64>,
     align: usize,
-) -> impl Future<Output = Result<AVec<u8, RuntimeAlign>>> + Send + 'static {
+) -> impl Future<Output = UioResult<AVec<u8, RuntimeAlign>>> + Send + 'static {
     let len = (range.end - range.start) as usize;
     let stream_fut = file.inner.read_range(&file.path, range);
     async move {
@@ -35,7 +35,7 @@ pub fn read_into_byte_buffer<A: AsyncRead>(
 pub fn read_whole_into_byte_buffer<A: AsyncRead + Clone>(
     file: &BlobFile<A>,
     align: usize,
-) -> impl Future<Output = Result<AVec<u8, RuntimeAlign>>> + Send + 'static {
+) -> impl Future<Output = UioResult<AVec<u8, RuntimeAlign>>> + Send + 'static {
     read_from_into_byte_buffer(file, 0, align)
 }
 
@@ -52,7 +52,7 @@ pub fn read_from_into_byte_buffer<A: AsyncRead + Clone>(
     file: &BlobFile<A>,
     from: u64,
     align: usize,
-) -> impl Future<Output = Result<AVec<u8, RuntimeAlign>>> + Send + 'static {
+) -> impl Future<Output = UioResult<AVec<u8, RuntimeAlign>>> + Send + 'static {
     let read_fut = file.inner.read_from(&file.path, from);
     // Cloned for the cold disambiguation path only; building the `len` future is
     // deferred until a read error actually occurs.
@@ -88,7 +88,7 @@ async fn scatter_stream_into_buffer(
     mut stream: OffsetByteStream,
     expected_len: usize,
     align: usize,
-) -> Result<AVec<u8, RuntimeAlign>> {
+) -> UioResult<AVec<u8, RuntimeAlign>> {
     let mut buf = AVec::<u8, RuntimeAlign>::with_capacity(align, expected_len);
     // Disjoint runs of already-written bytes, grown/merged as chunks land.
     // There are few in practice — an in-order stream is a single run, an
@@ -158,7 +158,7 @@ mod tests {
     fn scatter(
         chunks: Vec<(u64, &'static [u8])>,
         expected_len: usize,
-    ) -> Result<AVec<u8, RuntimeAlign>> {
+    ) -> UioResult<AVec<u8, RuntimeAlign>> {
         let stream = futures::stream::iter(
             chunks
                 .into_iter()

--- a/lib/common/io_bridge/src/pipeline/inner.rs
+++ b/lib/common/io_bridge/src/pipeline/inner.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::panic::AssertUnwindSafe;
 
 use aligned_vec::{AVec, RuntimeAlign};
-use common::universal_io::{Result, UniversalIoError, UserData};
+use common::universal_io::{UioResult, UniversalIoError, UserData};
 use futures::FutureExt as _;
 use slab::Slab;
 use tokio::sync::mpsc;
@@ -105,9 +105,9 @@ where
         runtime: &BridgeRuntime,
         user_data: U,
         future: F,
-    ) -> Result<()>
+    ) -> UioResult<()>
     where
-        F: Future<Output = Result<AVec<u8, RuntimeAlign>>> + Send + 'static,
+        F: Future<Output = UioResult<AVec<u8, RuntimeAlign>>> + Send + 'static,
     {
         if !self.can_schedule() {
             return Err(UniversalIoError::QueueIsFull);
@@ -149,7 +149,7 @@ where
 
     /// Block until any in-flight read completes, returning its caller
     /// `user_data`, destination buffer, and the time the read itself took.
-    pub(crate) fn wait(&mut self) -> Result<Option<CompletedRead<U>>> {
+    pub(crate) fn wait(&mut self) -> UioResult<Option<CompletedRead<U>>> {
         if self.slots.is_empty() {
             return Ok(None);
         }

--- a/lib/common/io_bridge/src/pipeline/mod.rs
+++ b/lib/common/io_bridge/src/pipeline/mod.rs
@@ -16,7 +16,7 @@ use std::ops::Range;
 
 use common::ext::aligned_vec::ACow;
 use common::generic_consts::AccessPattern;
-use common::universal_io::{ReadPipeline, Result, UserData};
+use common::universal_io::{ReadPipeline, UioResult, UserData};
 
 pub(crate) use self::buffer::{
     read_from_into_byte_buffer, read_into_byte_buffer, read_whole_into_byte_buffer,
@@ -45,7 +45,7 @@ where
 {
     type File = BlobFile<A>;
 
-    fn new() -> Result<Self> {
+    fn new() -> UioResult<Self> {
         Ok(Self {
             inner: None,
             _phantom: PhantomData,
@@ -62,7 +62,7 @@ where
         file: &'file BlobFile<A>,
         range: Range<u64>,
         align: usize,
-    ) -> Result<()> {
+    ) -> UioResult<()> {
         let inner = self.inner.get_or_insert_with(|| {
             let (tx, rx) = PipelineInner::<U>::default_channel();
             PipelineInner::new(tx, rx)
@@ -77,7 +77,12 @@ where
         inner.schedule(&file.runtime, user_data, future)
     }
 
-    fn schedule_whole(&mut self, user_data: U, file: &'file BlobFile<A>, from: u64) -> Result<()> {
+    fn schedule_whole(
+        &mut self,
+        user_data: U,
+        file: &'file BlobFile<A>,
+        from: u64,
+    ) -> UioResult<()> {
         // One open-ended GET from `from` to EOF, byte-aligned, sized from the
         // response — no separate `len`/HEAD round-trip. `from == 0` reads the
         // whole object; an offset at or past EOF resolves to an empty read
@@ -98,7 +103,7 @@ where
         inner.schedule(&file.runtime, user_data, future)
     }
 
-    fn wait(&mut self) -> Result<Option<(U, ACow<'file>)>> {
+    fn wait(&mut self) -> UioResult<Option<(U, ACow<'file>)>> {
         let Some(inner) = self.inner.as_mut() else {
             return Ok(None);
         };

--- a/lib/common/io_bridge/src/read.rs
+++ b/lib/common/io_bridge/src/read.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use std::path::Path;
 
 use bytes::Bytes;
-use common::universal_io::{ListedFile, Result, UniversalKind};
+use common::universal_io::{ListedFile, UioResult, UniversalKind};
 use futures::stream::BoxStream;
 
 /// Read-capable blob backend (S3, GCS, …). One impl per backend.
@@ -31,14 +31,14 @@ use futures::stream::BoxStream;
 pub trait AsyncRead: Send + Sync + Sized + 'static {
     type Config;
 
-    fn open(config: &Self::Config) -> Result<Self>;
+    fn open(config: &Self::Config) -> UioResult<Self>;
 
     fn list_files(
         &self,
         prefix: &Path,
-    ) -> impl Future<Output = Result<Vec<ListedFile>>> + Send + 'static;
+    ) -> impl Future<Output = UioResult<Vec<ListedFile>>> + Send + 'static;
 
-    fn exists(&self, path: &Path) -> impl Future<Output = Result<bool>> + Send + 'static;
+    fn exists(&self, path: &Path) -> impl Future<Output = UioResult<bool>> + Send + 'static;
 
     /// Fetch `range` from `path` as a stream of byte chunks.
     ///
@@ -51,7 +51,7 @@ pub trait AsyncRead: Send + Sync + Sized + 'static {
         &self,
         path: &Path,
         range: Range<u64>,
-    ) -> impl Future<Output = Result<BoxStream<'static, Result<Bytes>>>> + Send + 'static;
+    ) -> impl Future<Output = UioResult<BoxStream<'static, UioResult<Bytes>>>> + Send + 'static;
 
     /// Fetch the object at `path` from byte offset `from` to its end — no
     /// separate `len`/HEAD round-trip. `from == 0` reads the whole object.
@@ -81,20 +81,20 @@ pub trait AsyncRead: Send + Sync + Sized + 'static {
         &self,
         path: &Path,
         from: u64,
-    ) -> impl Future<Output = Result<(u64, OffsetByteStream)>> + Send + 'static;
+    ) -> impl Future<Output = UioResult<(u64, OffsetByteStream)>> + Send + 'static;
 
     /// Fetch the whole object at `path`. Convenience for
     /// [`read_from(path, 0)`](Self::read_from).
     fn read_whole(
         &self,
         path: &Path,
-    ) -> impl Future<Output = Result<(u64, OffsetByteStream)>> + Send + 'static {
+    ) -> impl Future<Output = UioResult<(u64, OffsetByteStream)>> + Send + 'static {
         self.read_from(path, 0)
     }
 
-    fn len(&self, path: &Path) -> impl Future<Output = Result<u64>> + Send + 'static;
+    fn len(&self, path: &Path) -> impl Future<Output = UioResult<u64>> + Send + 'static;
 
-    fn is_empty(&self, path: &Path) -> impl Future<Output = Result<bool>> + Send + 'static {
+    fn is_empty(&self, path: &Path) -> impl Future<Output = UioResult<bool>> + Send + 'static {
         let len = self.len(path);
         async move { Ok(len.await? == 0) }
     }
@@ -106,13 +106,13 @@ pub trait AsyncRead: Send + Sync + Sized + 'static {
 /// each chunk's position relative to the requested start, plus its bytes.
 /// Chunks may arrive out of order; they must be disjoint and tile the tail
 /// exactly.
-pub type OffsetByteStream = BoxStream<'static, Result<(u64, Bytes)>>;
+pub type OffsetByteStream = BoxStream<'static, UioResult<(u64, Bytes)>>;
 
 /// Tag an in-order byte stream with running offsets, producing the
 /// `(offset, bytes)` item shape [`AsyncRead::read_from`] requires. For
 /// backends that deliver the tail as one sequential stream.
 pub fn with_running_offsets(
-    stream: impl futures::Stream<Item = Result<Bytes>> + Send + 'static,
+    stream: impl futures::Stream<Item = UioResult<Bytes>> + Send + 'static,
 ) -> OffsetByteStream {
     use futures::StreamExt as _;
     stream

--- a/lib/common/io_bridge/src/tests/whole_read.rs
+++ b/lib/common/io_bridge/src/tests/whole_read.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use common::generic_consts::Sequential;
 use common::universal_io::{
     DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, ListedFile, OpenOptions, OwnedPipeline,
-    Populate, ReadRange, Result, UniversalIoError, UniversalKind, UniversalRead,
+    Populate, ReadRange, UioResult, UniversalIoError, UniversalKind, UniversalRead,
     UniversalReadFileOps, UniversalReadFs,
 };
 use futures::stream::{BoxStream, StreamExt};
@@ -63,7 +63,7 @@ impl CountingSource {
 impl AsyncRead for CountingSource {
     type Config = CountingConfig;
 
-    fn open(config: &Self::Config) -> Result<Self> {
+    fn open(config: &Self::Config) -> UioResult<Self> {
         Ok(Self {
             data: config.data.clone(),
             counters: config.counters.clone(),
@@ -73,11 +73,11 @@ impl AsyncRead for CountingSource {
     fn list_files(
         &self,
         _prefix: &Path,
-    ) -> impl Future<Output = Result<Vec<ListedFile>>> + Send + 'static {
+    ) -> impl Future<Output = UioResult<Vec<ListedFile>>> + Send + 'static {
         std::future::ready(Ok(vec![]))
     }
 
-    fn exists(&self, _path: &Path) -> impl Future<Output = Result<bool>> + Send + 'static {
+    fn exists(&self, _path: &Path) -> impl Future<Output = UioResult<bool>> + Send + 'static {
         std::future::ready(Ok(true))
     }
 
@@ -85,7 +85,8 @@ impl AsyncRead for CountingSource {
         &self,
         _path: &Path,
         range: Range<u64>,
-    ) -> impl Future<Output = Result<BoxStream<'static, Result<Bytes>>>> + Send + 'static {
+    ) -> impl Future<Output = UioResult<BoxStream<'static, UioResult<Bytes>>>> + Send + 'static
+    {
         self.counters.range.fetch_add(1, Ordering::Relaxed);
         let bytes = self.data.slice(range.start as usize..range.end as usize);
         async move { Ok(futures::stream::once(async move { Ok(bytes) }).boxed()) }
@@ -95,7 +96,7 @@ impl AsyncRead for CountingSource {
         &self,
         _path: &Path,
         from: u64,
-    ) -> impl Future<Output = Result<(u64, OffsetByteStream)>> + Send + 'static {
+    ) -> impl Future<Output = UioResult<(u64, OffsetByteStream)>> + Send + 'static {
         if from == 0 {
             self.counters.whole.fetch_add(1, Ordering::Relaxed);
         } else {
@@ -120,7 +121,7 @@ impl AsyncRead for CountingSource {
         }
     }
 
-    fn len(&self, _path: &Path) -> impl Future<Output = Result<u64>> + Send + 'static {
+    fn len(&self, _path: &Path) -> impl Future<Output = UioResult<u64>> + Send + 'static {
         self.counters.len.fetch_add(1, Ordering::Relaxed);
         let len = self.data.len() as u64;
         async move { Ok(len) }

--- a/lib/common/io_bridge/src/write.rs
+++ b/lib/common/io_bridge/src/write.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::path::Path;
 
 use bytes::Bytes;
-use common::universal_io::Result;
+use common::universal_io::UioResult;
 
 use crate::read::AsyncRead;
 
@@ -17,13 +17,17 @@ use crate::read::AsyncRead;
 /// [`UniversalWriteFileOps`]: common::universal_io::UniversalWriteFileOps
 pub trait AsyncWrite: AsyncRead {
     /// Create (or truncate to empty) the object at `path`.
-    fn create(&self, path: &Path) -> impl Future<Output = Result<()>> + Send + 'static;
+    fn create(&self, path: &Path) -> impl Future<Output = UioResult<()>> + Send + 'static;
 
     /// Delete the object at `path`.
-    fn remove(&self, path: &Path) -> impl Future<Output = Result<()>> + Send + 'static;
+    fn remove(&self, path: &Path) -> impl Future<Output = UioResult<()>> + Send + 'static;
 
     /// Atomically replace the object at `path` with `bytes` in a single put.
-    fn save(&self, path: &Path, bytes: Bytes) -> impl Future<Output = Result<()>> + Send + 'static;
+    fn save(
+        &self,
+        path: &Path,
+        bytes: Bytes,
+    ) -> impl Future<Output = UioResult<()>> + Send + 'static;
 }
 
 /// Blob backends supporting native single-request appends.
@@ -47,5 +51,5 @@ pub trait AsyncAppend: AsyncWrite {
         path: &Path,
         offset: u64,
         data: Bytes,
-    ) -> impl Future<Output = Result<u64>> + Send + 'static;
+    ) -> impl Future<Output = UioResult<u64>> + Send + 'static;
 }

--- a/lib/common/io_bridge_object_store/src/append.rs
+++ b/lib/common/io_bridge_object_store/src/append.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use bytes::Bytes;
-use common::universal_io::{Result, UniversalIoError};
+use common::universal_io::{UioResult, UniversalIoError};
 use io_bridge::AsyncAppend;
 use object_store::aws::{AmazonS3, AwsAuthorizer};
 use object_store::client::{HttpClient, HttpConnector as _, HttpRequestBody, ReqwestConnector};
@@ -72,7 +72,7 @@ impl AppendContext {
 
     /// The shared HTTP client, built on first call. Concurrent first calls
     /// may build a transient extra client; exactly one is kept.
-    fn client(&self) -> Result<HttpClient> {
+    fn client(&self) -> UioResult<HttpClient> {
         if let Some(client) = self.client.get() {
             return Ok(client.clone());
         }
@@ -97,7 +97,7 @@ impl AsyncAppend for ObjectStoreSource<AmazonS3> {
         path: &std::path::Path,
         offset: u64,
         data: Bytes,
-    ) -> impl Future<Output = Result<u64>> + Send + 'static {
+    ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
         let store = self.store().clone();
         let context = self.append_context().cloned();
         let key = crate::source::build_key(path);
@@ -134,7 +134,7 @@ async fn append_request(
     key: &object_store::path::Path,
     offset: u64,
     data: Bytes,
-) -> Result<u64> {
+) -> UioResult<u64> {
     let credential = store
         .credentials()
         .get_credential()
@@ -468,7 +468,7 @@ mod tests {
 
     /// Append `b"data"` at `offset` to `dir/append.dat` via the stub, so a
     /// consistent store would report a new object size of `offset + 4`.
-    fn append_data_at(endpoint: &str, offset: u64) -> Result<u64> {
+    fn append_data_at(endpoint: &str, offset: u64) -> UioResult<u64> {
         let store = Arc::new(
             AmazonS3Builder::new()
                 .with_bucket_name("bucket")

--- a/lib/common/io_bridge_object_store/src/backend.rs
+++ b/lib/common/io_bridge_object_store/src/backend.rs
@@ -2,7 +2,7 @@
 //! produce it. Implemented for AWS S3, GCS, and Azure (see [`crate::backends`])
 //! so the [`AsyncRead`](crate::AsyncRead) impl on `Arc<S>` stays free of `dyn`.
 
-use common::universal_io::{Result, UniversalKind};
+use common::universal_io::{UioResult, UniversalKind};
 use object_store::ObjectStore;
 
 use crate::append::AppendContext;
@@ -19,7 +19,7 @@ use crate::append::AppendContext;
 pub trait BlobBackend: ObjectStore + Send + Sync + Sized + 'static {
     type Config: Clone + Send + Sync + 'static;
 
-    fn build_store(config: &Self::Config) -> Result<Self>;
+    fn build_store(config: &Self::Config) -> UioResult<Self>;
 
     fn kind() -> UniversalKind;
 
@@ -27,7 +27,7 @@ pub trait BlobBackend: ObjectStore + Send + Sync + Sized + 'static {
     /// support it (see [`crate::append`]). The default — no append support —
     /// leaves [`ObjectStoreSource`](crate::ObjectStoreSource) without its
     /// `AsyncAppend` prerequisites for this backend.
-    fn append_context(_config: &Self::Config) -> Result<Option<AppendContext>> {
+    fn append_context(_config: &Self::Config) -> UioResult<Option<AppendContext>> {
         Ok(None)
     }
 }

--- a/lib/common/io_bridge_object_store/src/backends/aws.rs
+++ b/lib/common/io_bridge_object_store/src/backends/aws.rs
@@ -1,6 +1,6 @@
 //! AWS S3 backend.
 
-use common::universal_io::{Result, UniversalIoError, UniversalKind};
+use common::universal_io::{UioResult, UniversalIoError, UniversalKind};
 use object_store::aws::{AmazonS3, AmazonS3Builder};
 use url::Url;
 
@@ -45,7 +45,7 @@ pub enum AwsCredentials {
 impl BlobBackend for AmazonS3 {
     type Config = AwsConfig;
 
-    fn build_store(config: &Self::Config) -> Result<Self> {
+    fn build_store(config: &Self::Config) -> UioResult<Self> {
         let mut builder = match &config.credentials {
             AwsCredentials::Default => AmazonS3Builder::from_env(),
             AwsCredentials::Static {
@@ -80,7 +80,7 @@ impl BlobBackend for AmazonS3 {
         UniversalKind::S3
     }
 
-    fn append_context(config: &Self::Config) -> Result<Option<AppendContext>> {
+    fn append_context(config: &Self::Config) -> UioResult<Option<AppendContext>> {
         let s3_config_error = |description: String| UniversalIoError::S3Config { description };
 
         let (endpoint, region) =

--- a/lib/common/io_bridge_object_store/src/backends/azure.rs
+++ b/lib/common/io_bridge_object_store/src/backends/azure.rs
@@ -1,6 +1,6 @@
 //! Microsoft Azure Blob Storage backend.
 
-use common::universal_io::{Result, UniversalIoError, UniversalKind};
+use common::universal_io::{UioResult, UniversalIoError, UniversalKind};
 use object_store::azure::{MicrosoftAzure, MicrosoftAzureBuilder};
 
 use crate::backend::BlobBackend;
@@ -42,7 +42,7 @@ pub enum AzureCredentials {
 impl BlobBackend for MicrosoftAzure {
     type Config = AzureConfig;
 
-    fn build_store(config: &Self::Config) -> Result<Self> {
+    fn build_store(config: &Self::Config) -> UioResult<Self> {
         let mut builder = MicrosoftAzureBuilder::new()
             .with_account(&config.account)
             .with_container_name(&config.container);

--- a/lib/common/io_bridge_object_store/src/backends/gcp.rs
+++ b/lib/common/io_bridge_object_store/src/backends/gcp.rs
@@ -1,6 +1,6 @@
 //! Google Cloud Storage backend.
 
-use common::universal_io::{Result, UniversalIoError, UniversalKind};
+use common::universal_io::{UioResult, UniversalIoError, UniversalKind};
 use object_store::gcp::{GoogleCloudStorage, GoogleCloudStorageBuilder};
 
 use crate::backend::BlobBackend;
@@ -35,7 +35,7 @@ pub enum GcsCredentials {
 impl BlobBackend for GoogleCloudStorage {
     type Config = GcsConfig;
 
-    fn build_store(config: &Self::Config) -> Result<Self> {
+    fn build_store(config: &Self::Config) -> UioResult<Self> {
         let mut builder = GoogleCloudStorageBuilder::new().with_bucket_name(&config.bucket);
         builder = match &config.credentials {
             GcsCredentials::Default => builder,

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use bytes::Bytes;
-use common::universal_io::{ListedFile, Result, UniversalIoError, UniversalKind};
+use common::universal_io::{ListedFile, UioResult, UniversalIoError, UniversalKind};
 use futures::stream::{BoxStream, StreamExt, TryStreamExt};
 use io_bridge::{AsyncRead, AsyncWrite, OffsetByteStream};
 use object_store::{GetOptions, GetRange, ObjectStore, ObjectStoreExt, PutPayload};
@@ -110,7 +110,7 @@ impl<S> ObjectStoreSource<S> {
 impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
     type Config = S::Config;
 
-    fn open(config: &Self::Config) -> Result<Self> {
+    fn open(config: &Self::Config) -> UioResult<Self> {
         Ok(Self {
             store: Arc::new(S::build_store(config)?),
             append: S::append_context(config)?,
@@ -121,7 +121,7 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
     fn list_files(
         &self,
         prefix: &Path,
-    ) -> impl Future<Output = Result<Vec<ListedFile>>> + Send + 'static {
+    ) -> impl Future<Output = UioResult<Vec<ListedFile>>> + Send + 'static {
         let store = self.store.clone();
         let prefix_path = prefix.to_path_buf();
         // object_store lists by whole path segment; emulate the byte-prefix
@@ -159,7 +159,7 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
         }
     }
 
-    fn exists(&self, path: &Path) -> impl Future<Output = Result<bool>> + Send + 'static {
+    fn exists(&self, path: &Path) -> impl Future<Output = UioResult<bool>> + Send + 'static {
         let store = self.store.clone();
         let key = build_key(path);
 
@@ -176,7 +176,8 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
         &self,
         path: &Path,
         range: Range<u64>,
-    ) -> impl Future<Output = Result<BoxStream<'static, Result<Bytes>>>> + Send + 'static {
+    ) -> impl Future<Output = UioResult<BoxStream<'static, UioResult<Bytes>>>> + Send + 'static
+    {
         let store = self.store.clone();
         let key = build_key(path);
         async move {
@@ -196,7 +197,7 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
         &self,
         path: &Path,
         from: u64,
-    ) -> impl Future<Output = Result<(u64, OffsetByteStream)>> + Send + 'static {
+    ) -> impl Future<Output = UioResult<(u64, OffsetByteStream)>> + Send + 'static {
         let store = self.store.clone();
         let key = build_key(path);
         let chunk_size = self.chunk_size;
@@ -283,7 +284,7 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
         }
     }
 
-    fn len(&self, path: &Path) -> impl Future<Output = Result<u64>> + Send + 'static {
+    fn len(&self, path: &Path) -> impl Future<Output = UioResult<u64>> + Send + 'static {
         let store = self.store.clone();
         let key = build_key(path);
         async move {
@@ -301,7 +302,7 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
 }
 
 impl<S: BlobBackend> AsyncWrite for ObjectStoreSource<S> {
-    fn create(&self, path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
+    fn create(&self, path: &Path) -> impl Future<Output = UioResult<()>> + Send + 'static {
         let store = self.store.clone();
         let key = build_key(path);
         async move {
@@ -314,7 +315,7 @@ impl<S: BlobBackend> AsyncWrite for ObjectStoreSource<S> {
         }
     }
 
-    fn remove(&self, path: &Path) -> impl Future<Output = Result<()>> + Send + 'static {
+    fn remove(&self, path: &Path) -> impl Future<Output = UioResult<()>> + Send + 'static {
         let store = self.store.clone();
         let key = build_key(path);
         async move {
@@ -325,7 +326,11 @@ impl<S: BlobBackend> AsyncWrite for ObjectStoreSource<S> {
         }
     }
 
-    fn save(&self, path: &Path, bytes: Bytes) -> impl Future<Output = Result<()>> + Send + 'static {
+    fn save(
+        &self,
+        path: &Path,
+        bytes: Bytes,
+    ) -> impl Future<Output = UioResult<()>> + Send + 'static {
         let store = self.store.clone();
         let key = build_key(path);
         async move {
@@ -383,7 +388,7 @@ mod tests {
     impl BlobBackend for InMemory {
         type Config = InMemoryConfig;
 
-        fn build_store(_config: &Self::Config) -> Result<Self> {
+        fn build_store(_config: &Self::Config) -> UioResult<Self> {
             Ok(InMemory::new())
         }
 
@@ -402,7 +407,7 @@ mod tests {
             path: &Path,
             offset: u64,
             data: Bytes,
-        ) -> impl Future<Output = Result<u64>> + Send + 'static {
+        ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
             let store = self.store().clone();
             let key = build_key(path);
 

--- a/lib/common/io_bridge_uio_grpc/src/lib.rs
+++ b/lib/common/io_bridge_uio_grpc/src/lib.rs
@@ -40,7 +40,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use common::universal_io::{ListedFile, Result, UniversalKind};
+use common::universal_io::{ListedFile, UioResult, UniversalKind};
 use futures::stream::{self, BoxStream, StreamExt as _};
 use io_bridge::{AsyncRead, BlobFile, BlobFs, OffsetByteStream};
 use tokio::sync::OnceCell;
@@ -77,7 +77,7 @@ impl Inner {
     /// The shared gRPC client, building it on first use. Must be awaited from
     /// within the runtime that drives the reads (the tonic channel captures the
     /// current reactor on construction).
-    async fn client(&self) -> Result<&Client> {
+    async fn client(&self) -> UioResult<&Client> {
         self.client
             .get_or_try_init(|| async {
                 Client::connect_lazy(self.endpoint.clone(), self.api_key.clone())
@@ -123,7 +123,7 @@ fn path_to_string(path: &Path) -> String {
 impl AsyncRead for UioGrpcSource {
     type Config = UioGrpcConfig;
 
-    fn open(config: &Self::Config) -> Result<Self> {
+    fn open(config: &Self::Config) -> UioResult<Self> {
         Ok(Self::new(
             config.endpoint.clone(),
             config.collection.as_str(),
@@ -135,7 +135,7 @@ impl AsyncRead for UioGrpcSource {
     fn list_files(
         &self,
         prefix: &Path,
-    ) -> impl Future<Output = Result<Vec<ListedFile>>> + Send + 'static {
+    ) -> impl Future<Output = UioResult<Vec<ListedFile>>> + Send + 'static {
         let inner = self.inner.clone();
         let prefix = path_to_string(prefix);
         async move {
@@ -146,7 +146,7 @@ impl AsyncRead for UioGrpcSource {
         }
     }
 
-    fn exists(&self, path: &Path) -> impl Future<Output = Result<bool>> + Send + 'static {
+    fn exists(&self, path: &Path) -> impl Future<Output = UioResult<bool>> + Send + 'static {
         let inner = self.inner.clone();
         let path = path_to_string(path);
         async move {
@@ -161,7 +161,8 @@ impl AsyncRead for UioGrpcSource {
         &self,
         path: &Path,
         range: Range<u64>,
-    ) -> impl Future<Output = Result<BoxStream<'static, Result<Bytes>>>> + Send + 'static {
+    ) -> impl Future<Output = UioResult<BoxStream<'static, UioResult<Bytes>>>> + Send + 'static
+    {
         let inner = self.inner.clone();
         let path = path_to_string(path);
         let length = range.end - range.start;
@@ -183,7 +184,7 @@ impl AsyncRead for UioGrpcSource {
         &self,
         path: &Path,
         from: u64,
-    ) -> impl Future<Output = Result<(u64, OffsetByteStream)>> + Send + 'static {
+    ) -> impl Future<Output = UioResult<(u64, OffsetByteStream)>> + Send + 'static {
         let inner = self.inner.clone();
         let path = path_to_string(path);
         async move {
@@ -208,7 +209,7 @@ impl AsyncRead for UioGrpcSource {
         }
     }
 
-    fn len(&self, path: &Path) -> impl Future<Output = Result<u64>> + Send + 'static {
+    fn len(&self, path: &Path) -> impl Future<Output = UioResult<u64>> + Send + 'static {
         let inner = self.inner.clone();
         let path = path_to_string(path);
         async move {

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -11,7 +11,7 @@ use common::mmap::MmapFlusher;
 use common::mmap::{transmute_from_u8_to_slice, transmute_to_u8_slice};
 use common::typelevel::True;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalReadFs, read_json_via};
+use common::universal_io::{UioResult, UniversalReadFs, read_json_via};
 use fs_err as fs;
 use serde::{Deserialize, Serialize};
 use strum::EnumIter;
@@ -515,7 +515,7 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
         fs: &Fs,
         encoded_vectors: TStorage,
         meta_path: &Path,
-    ) -> common::universal_io::Result<Self> {
+    ) -> UioResult<Self> {
         let metadata: Metadata = read_json_via(fs, meta_path)?;
         let result = Self {
             metadata,

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -15,7 +15,7 @@ use common::fs::atomic_save_json;
 use common::mmap::MmapFlusher;
 use common::typelevel::True;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalReadFs, read_json_via};
+use common::universal_io::{UioResult, UniversalReadFs, read_json_via};
 use fs_err as fs;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
@@ -145,7 +145,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
         fs: &Fs,
         encoded_vectors: TStorage,
         meta_path: &Path,
-    ) -> common::universal_io::Result<Self> {
+    ) -> UioResult<Self> {
         let metadata: Metadata = read_json_via(fs, meta_path)?;
         let result = Self {
             encoded_vectors,

--- a/lib/quantization/src/encoded_vectors_tq.rs
+++ b/lib/quantization/src/encoded_vectors_tq.rs
@@ -8,7 +8,7 @@ use common::fs::atomic_save_json;
 use common::mmap::MmapFlusher;
 use common::typelevel::True;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalReadFs, read_json_via};
+use common::universal_io::{UioResult, UniversalReadFs, read_json_via};
 use fs_err as fs;
 use serde::{Deserialize, Serialize};
 
@@ -307,7 +307,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
         fs: &Fs,
         encoded_vectors: TStorage,
         meta_path: &Path,
-    ) -> common::universal_io::Result<Self> {
+    ) -> UioResult<Self> {
         let metadata: Metadata = read_json_via(fs, meta_path)?;
 
         let quantizer = new_turbo_quantizer_from_metadata(&metadata)?;

--- a/lib/quantization/src/encoded_vectors_u8.rs
+++ b/lib/quantization/src/encoded_vectors_u8.rs
@@ -8,7 +8,7 @@ use common::fs::atomic_save_json;
 use common::mmap::MmapFlusher;
 use common::typelevel::True;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalReadFs, read_json_via};
+use common::universal_io::{UioResult, UniversalReadFs, read_json_via};
 use fs_err as fs;
 use serde::{Deserialize, Serialize};
 
@@ -319,7 +319,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsU8<TStorage> {
         fs: &Fs,
         encoded_vectors: TStorage,
         meta_path: &Path,
-    ) -> common::universal_io::Result<Self> {
+    ) -> UioResult<Self> {
         let metadata: Metadata = read_json_via(fs, meta_path)?;
         let result = Self {
             encoded_vectors,

--- a/lib/segment/src/index/sparse_index/indices_tracker.rs
+++ b/lib/segment/src/index/sparse_index/indices_tracker.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use ahash::AHashMap;
 use common::fs::{atomic_save_json, read_json};
-use common::universal_io::{self, UniversalReadFs, read_json_via};
+use common::universal_io::{UioResult, UniversalReadFs, read_json_via};
 use serde::{Deserialize, Serialize};
 use sparse::common::sparse_vector::{RemappedSparseVector, SparseVector};
 use sparse::common::types::{DimId, DimOffset};
@@ -23,7 +23,7 @@ impl IndicesTracker {
     }
 
     /// Universal-IO variant of [`Self::open`].
-    pub fn open_universal<Fs: UniversalReadFs>(fs: &Fs, path: &Path) -> universal_io::Result<Self> {
+    pub fn open_universal<Fs: UniversalReadFs>(fs: &Fs, path: &Path) -> UioResult<Self> {
         read_json_via(fs, Self::file_path(path))
     }
 

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_immutable_ram.rs
@@ -6,7 +6,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::ext::VecExt;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    MmapFs, Result, UniversalRead, UniversalReadFs, UniversalWrite, UserData,
+    MmapFs, UioResult, UniversalRead, UniversalReadFs, UniversalWrite, UserData,
 };
 
 use super::inverted_index_compressed_mmap::InvertedIndexCompressedMmap;
@@ -33,7 +33,7 @@ type Storage = common::universal_io::MmapFile;
 impl<W: Weight, S: UniversalRead + 'static> InvertedIndexReadOnly<S>
     for InvertedIndexCompressedImmutableRam<W>
 {
-    fn open_ro_impl<Fs: UniversalReadFs<File = S>>(fs: &Fs, path: &Path) -> Result<Self> {
+    fn open_ro_impl<Fs: UniversalReadFs<File = S>>(fs: &Fs, path: &Path) -> UioResult<Self> {
         let mmap_inverted_index = InvertedIndexCompressedMmap::<W, S>::open_ro(fs, path)?;
         Self::from_mmap_index(mmap_inverted_index)
     }
@@ -42,7 +42,7 @@ impl<W: Weight, S: UniversalRead + 'static> InvertedIndexReadOnly<S>
 impl<W: Weight, S: UniversalWrite + 'static> InvertedIndexReadWrite<S>
     for InvertedIndexCompressedImmutableRam<W>
 {
-    fn open_rw_impl(fs: &<S as UniversalRead>::Fs, path: &Path) -> Result<Self> {
+    fn open_rw_impl(fs: &<S as UniversalRead>::Fs, path: &Path) -> UioResult<Self> {
         let mmap_inverted_index = InvertedIndexCompressedMmap::<W, S>::open_rw(fs, path)?;
         Self::from_mmap_index(mmap_inverted_index)
     }
@@ -51,7 +51,7 @@ impl<W: Weight, S: UniversalWrite + 'static> InvertedIndexReadWrite<S>
         _fs: &S::Fs,
         ram_index: Cow<InvertedIndexRam>,
         _path: P,
-    ) -> Result<Self> {
+    ) -> UioResult<Self> {
         let mut postings = Vec::with_capacity(ram_index.postings.len());
         for old_posting_list in &ram_index.postings {
             let mut new_posting_list = CompressedPostingBuilder::new();
@@ -85,7 +85,7 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedImmutableRam<W> {
         false
     }
 
-    fn save(&self, path: &Path) -> Result<()> {
+    fn save(&self, path: &Path) -> UioResult<()> {
         InvertedIndexCompressedMmap::<W, Storage>::convert_and_save(&MmapFs, self, path)?;
         Ok(())
     }
@@ -95,8 +95,8 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedImmutableRam<W> {
         ids: impl Iterator<Item = (U, DimOffset)>,
         _arena: &'a Blink,
         hw_counter: &'a HardwareCounterCell, // Ignored for in-ram index
-        mut callback: impl FnMut(U, Self::Iter<'a>) -> Result<()>,
-    ) -> Result<()> {
+        mut callback: impl FnMut(U, Self::Iter<'a>) -> UioResult<()>,
+    ) -> UioResult<()> {
         for (user_data, id) in ids {
             callback(user_data, self.get(id, hw_counter)?.iter())?;
         }
@@ -111,8 +111,8 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedImmutableRam<W> {
         &self,
         ids: impl Iterator<Item = (U, DimOffset)>,
         hw_counter: &HardwareCounterCell,
-        mut callback: impl FnMut(U, usize) -> Result<()>,
-    ) -> Result<()> {
+        mut callback: impl FnMut(U, usize) -> UioResult<()>,
+    ) -> UioResult<()> {
         for (user_data, id) in ids {
             callback(user_data, self.get(id, hw_counter)?.len())?;
         }
@@ -159,7 +159,7 @@ impl<W: Weight> InvertedIndex for InvertedIndexCompressedImmutableRam<W> {
 
 impl<W: Weight> InvertedIndexCompressedImmutableRam<W> {
     /// Materialize an mmap-layout index into owned in-RAM postings.
-    fn from_mmap_index<S>(mmap_inverted_index: InvertedIndexCompressedMmap<W, S>) -> Result<Self>
+    fn from_mmap_index<S>(mmap_inverted_index: InvertedIndexCompressedMmap<W, S>) -> UioResult<Self>
     where
         S: UniversalRead + 'static,
     {
@@ -188,7 +188,7 @@ impl<W: Weight> InvertedIndexCompressedImmutableRam<W> {
         &'a self,
         id: DimOffset,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Result<CompressedPostingListView<'a, W>> {
+    ) -> UioResult<CompressedPostingListView<'a, W>> {
         let Some(posting) = self.postings.get(id as usize) else {
             return Err(out_of_bounds(id, self.len()));
         };

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -16,7 +16,7 @@ use common::mmap::{transmute_to_u8, transmute_to_u8_slice};
 use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFs, OpenOptions, Populate, ReadBytesItem, Result, UniversalRead,
+    CachedReadFs, MmapFs, OpenOptions, Populate, ReadBytesItem, UioResult, UniversalRead,
     UniversalReadFs, UniversalWrite, UserData, read_json_via,
 };
 use serde::{Deserialize, Serialize};
@@ -59,7 +59,7 @@ fn index_open_options(populate: Populate) -> OpenOptions {
 /// `populate` warms the index data: pass a populating mode when the open
 /// reads it in full (immutable-RAM), [`Populate::No`] when it reads lazily
 /// (mmap).
-pub fn preopen(fs: &impl CachedReadFs, path: &Path, populate: Populate) -> Result<()> {
+pub fn preopen(fs: &impl CachedReadFs, path: &Path, populate: Populate) -> UioResult<()> {
     // Config
     fs.schedule_prefetch(&index_config_file_path(path), None, None)?;
 
@@ -85,7 +85,7 @@ pub fn index_config_file_path(path: &Path) -> PathBuf {
 impl<W: Weight, S: UniversalRead + 'static> InvertedIndexReadOnly<S>
     for InvertedIndexCompressedMmap<W, S>
 {
-    fn open_ro_impl<Fs: UniversalReadFs<File = S>>(fs: &Fs, path: &Path) -> Result<Self> {
+    fn open_ro_impl<Fs: UniversalReadFs<File = S>>(fs: &Fs, path: &Path) -> UioResult<Self> {
         let file_header: InvertedIndexFileHeader =
             read_json_via(fs, Self::index_config_file_path(path))?;
 
@@ -116,7 +116,7 @@ impl<W: Weight, S: UniversalRead + 'static> InvertedIndexReadOnly<S>
 impl<W: Weight, S: UniversalWrite + 'static> InvertedIndexReadWrite<S>
     for InvertedIndexCompressedMmap<W, S>
 {
-    fn open_rw_impl(fs: &S::Fs, path: &Path) -> Result<Self> {
+    fn open_rw_impl(fs: &S::Fs, path: &Path) -> UioResult<Self> {
         // read index config file
         let config_file_path = Self::index_config_file_path(path);
         // if the file header does not exist, the index is malformed
@@ -156,7 +156,7 @@ impl<W: Weight, S: UniversalWrite + 'static> InvertedIndexReadWrite<S>
         fs: &<S as UniversalRead>::Fs,
         ram_index: Cow<InvertedIndexRam>,
         path: P,
-    ) -> Result<Self> {
+    ) -> UioResult<Self> {
         // The intermediate RAM index is built in memory; its no-op `MmapFs` is
         // irrelevant. The conversion writes through the real `fs`.
         let index =
@@ -223,7 +223,7 @@ impl<W: Weight, S: UniversalRead + 'static> InvertedIndex for InvertedIndexCompr
         true
     }
 
-    fn save(&self, path: &Path) -> Result<()> {
+    fn save(&self, path: &Path) -> UioResult<()> {
         debug_assert_eq!(path, self.path);
 
         // If Self instance exists, it's either constructed by using `open()` (which reads index
@@ -241,8 +241,8 @@ impl<W: Weight, S: UniversalRead + 'static> InvertedIndex for InvertedIndexCompr
         ids: impl Iterator<Item = (U, DimOffset)>,
         arena: &'a Blink,
         hw_counter: &'a HardwareCounterCell,
-        mut callback: impl FnMut(U, Self::Iter<'a>) -> Result<()>,
-    ) -> Result<()> {
+        mut callback: impl FnMut(U, Self::Iter<'a>) -> UioResult<()>,
+    ) -> UioResult<()> {
         for record in self.views_iter(ids, arena, hw_counter)? {
             let (user_data, view) = record?;
             callback(user_data, view.iter())?;
@@ -258,8 +258,8 @@ impl<W: Weight, S: UniversalRead + 'static> InvertedIndex for InvertedIndexCompr
         &self,
         ids: impl Iterator<Item = (U, DimOffset)>,
         hw_counter: &HardwareCounterCell,
-        mut callback: impl FnMut(U, usize) -> Result<()>,
-    ) -> Result<()> {
+        mut callback: impl FnMut(U, usize) -> UioResult<()>,
+    ) -> UioResult<()> {
         self.for_each_header(ids, hw_counter, |user_data, header, remainders_end| {
             let count = header
                 .postings_count(remainders_end)
@@ -330,7 +330,7 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
         id: DimId,
         arena: &'a Blink,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Result<CompressedPostingListView<'a, W>> {
+    ) -> UioResult<CompressedPostingListView<'a, W>> {
         let ((), view) = self
             .views_iter(std::iter::once(((), id)), arena, hw_counter)?
             .next()
@@ -345,8 +345,8 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
     pub fn for_each_view(
         &self,
         hw_counter: &HardwareCounterCell,
-        mut callback: impl FnMut(DimOffset, CompressedPostingListView<'_, W>) -> Result<()>,
-    ) -> Result<()> {
+        mut callback: impl FnMut(DimOffset, CompressedPostingListView<'_, W>) -> UioResult<()>,
+    ) -> UioResult<()> {
         // Phase 1: read all headers as one contiguous range.
         let storage_len = self.storage.len::<u8>()?;
         let headers = self.storage.read_bytes::<Sequential>(
@@ -388,7 +388,7 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
         ids: impl Iterator<Item = (U, DimOffset)>,
         arena: &'a Blink,
         hw_counter: &'a HardwareCounterCell,
-    ) -> Result<impl Iterator<Item = Result<(U, CompressedPostingListView<'a, W>)>>> {
+    ) -> UioResult<impl Iterator<Item = UioResult<(U, CompressedPostingListView<'a, W>)>>> {
         // Phase 1: read headers via batched reads.
         let mut ranges = Vec::with_capacity(ids.size_hint().0);
         self.for_each_header(ids, hw_counter, |user_data, header, remainders_end| {
@@ -423,8 +423,8 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
         &self,
         ids: impl Iterator<Item = (U, DimOffset)>,
         hw_counter: &HardwareCounterCell,
-        mut callback: impl FnMut(U, PostingListFileHeader<W>, u64) -> Result<()>,
-    ) -> Result<()> {
+        mut callback: impl FnMut(U, PostingListFileHeader<W>, u64) -> UioResult<()>,
+    ) -> UioResult<()> {
         let storage_len = self.storage.len::<u8>()?;
         let posting_count = self.file_header.posting_count as DimOffset;
 
@@ -468,7 +468,7 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
         fs: &S::Fs,
         index: &InvertedIndexCompressedImmutableRam<W>,
         path: P,
-    ) -> Result<Self> {
+    ) -> UioResult<Self> {
         let total_posting_headers_size =
             index.postings.as_slice().len() * size_of::<PostingListFileHeader<W>>();
 
@@ -551,7 +551,7 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
         })
     }
 
-    fn calculate_total_sparse_size(&self, hw_counter: &HardwareCounterCell) -> Result<usize> {
+    fn calculate_total_sparse_size(&self, hw_counter: &HardwareCounterCell) -> UioResult<usize> {
         let mut total = 0;
         self.for_each_view(hw_counter, |_id, view| {
             total += view.store_size().total;
@@ -561,12 +561,12 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
     }
 
     /// Populate the underlying storage in RAM cache. Block until completed.
-    pub fn populate(&self) -> Result<()> {
+    pub fn populate(&self) -> UioResult<()> {
         self.storage.populate()
     }
 
     /// Drop disk cache.
-    pub fn clear_cache(&self) -> Result<()> {
+    pub fn clear_cache(&self) -> UioResult<()> {
         self.storage.clear_ram_cache()
     }
 }

--- a/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_ram.rs
@@ -7,7 +7,7 @@ use blink_alloc::Blink;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
-use common::universal_io::{Result, UniversalRead, UniversalWrite, UserData};
+use common::universal_io::{UioResult, UniversalRead, UniversalWrite, UserData};
 #[cfg(feature = "testing")]
 use fs_err as fs;
 #[cfg(feature = "testing")]
@@ -41,7 +41,7 @@ pub struct InvertedIndexRam {
 }
 
 impl<S: UniversalWrite> InvertedIndexReadWrite<S> for InvertedIndexRam {
-    fn open_rw_impl(_fs: &<S as UniversalRead>::Fs, _path: &Path) -> Result<Self> {
+    fn open_rw_impl(_fs: &<S as UniversalRead>::Fs, _path: &Path) -> UioResult<Self> {
         panic!("InvertedIndexRam is never persisted, so can't to be loaded");
     }
 
@@ -49,7 +49,7 @@ impl<S: UniversalWrite> InvertedIndexReadWrite<S> for InvertedIndexRam {
         _fs: &<S as UniversalRead>::Fs,
         ram_index: Cow<InvertedIndexRam>,
         _path: P,
-    ) -> Result<Self> {
+    ) -> UioResult<Self> {
         Ok(ram_index.into_owned())
     }
 }
@@ -63,7 +63,7 @@ impl InvertedIndex for InvertedIndexRam {
         false
     }
 
-    fn save(&self, _path: &Path) -> Result<()> {
+    fn save(&self, _path: &Path) -> UioResult<()> {
         panic!("InvertedIndexRam is not supposed to be saved");
     }
 
@@ -72,8 +72,8 @@ impl InvertedIndex for InvertedIndexRam {
         ids: impl Iterator<Item = (U, DimOffset)>,
         _arena: &'a Blink,
         _hw_counter: &'a HardwareCounterCell,
-        mut callback: impl FnMut(U, PostingListIterator<'a>) -> Result<()>,
-    ) -> Result<()> {
+        mut callback: impl FnMut(U, PostingListIterator<'a>) -> UioResult<()>,
+    ) -> UioResult<()> {
         for (user_data, id) in ids {
             callback(user_data, self.get(id)?.iter())?;
         }
@@ -88,8 +88,8 @@ impl InvertedIndex for InvertedIndexRam {
         &self,
         ids: impl Iterator<Item = (U, DimOffset)>,
         _hw_counter: &HardwareCounterCell,
-        mut callback: impl FnMut(U, usize) -> Result<()>,
-    ) -> Result<()> {
+        mut callback: impl FnMut(U, usize) -> UioResult<()>,
+    ) -> UioResult<()> {
         for (user_data, id) in ids {
             callback(user_data, self.get(id)?.elements.len())?;
         }
@@ -154,7 +154,7 @@ impl InvertedIndexRam {
         }
     }
 
-    pub fn get(&self, id: DimOffset) -> Result<&PostingList> {
+    pub fn get(&self, id: DimOffset) -> UioResult<&PostingList> {
         self.postings
             .get(id as usize)
             .ok_or_else(|| out_of_bounds(id, self.len()))

--- a/lib/sparse/src/index/inverted_index/mod.rs
+++ b/lib/sparse/src/index/inverted_index/mod.rs
@@ -7,7 +7,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::storage_version::StorageVersion;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    Result, UniversalIoError, UniversalRead, UniversalReadFs, UniversalWrite, UserData,
+    UioResult, UniversalIoError, UniversalRead, UniversalReadFs, UniversalWrite, UserData,
 };
 
 use super::posting_list_common::PostingListIter;
@@ -28,19 +28,19 @@ pub const INDEX_FILE_NAME: &str = "inverted_index.dat";
 
 pub trait InvertedIndexReadOnly<S: UniversalRead>: InvertedIndex {
     /// See [`InvertedIndex::open_ro`].
-    fn open_ro_impl<Fs: UniversalReadFs<File = S>>(fs: &Fs, path: &Path) -> Result<Self>;
+    fn open_ro_impl<Fs: UniversalReadFs<File = S>>(fs: &Fs, path: &Path) -> UioResult<Self>;
 }
 
 pub trait InvertedIndexReadWrite<S: UniversalWrite>: InvertedIndex {
     /// See [`InvertedIndex::open_rw`].
-    fn open_rw_impl(fs: &S::Fs, path: &Path) -> Result<Self>;
+    fn open_rw_impl(fs: &S::Fs, path: &Path) -> UioResult<Self>;
 
     /// See [`InvertedIndex::from_ram_index`].
     fn from_ram_index_impl<P: AsRef<Path>>(
         fs: &S::Fs,
         ram_index: Cow<InvertedIndexRam>,
         path: P,
-    ) -> Result<Self>;
+    ) -> UioResult<Self>;
 }
 
 pub trait InvertedIndex: Sized + Debug + 'static {
@@ -53,7 +53,7 @@ pub trait InvertedIndex: Sized + Debug + 'static {
     fn is_on_disk(&self) -> bool;
 
     /// Open existing index based on path.
-    fn open_ro<Fs: UniversalReadFs>(fs: &Fs, path: &Path) -> Result<Self>
+    fn open_ro<Fs: UniversalReadFs>(fs: &Fs, path: &Path) -> UioResult<Self>
     where
         Self: InvertedIndexReadOnly<Fs::File>,
     {
@@ -67,7 +67,7 @@ pub trait InvertedIndex: Sized + Debug + 'static {
     /// TODO(uio): probably, this can be refactored into a single `open` with
     /// boolean parameter, if we add something like
     /// `UniversalReadFs::try_write(&self) -> Option<&impl UniversalWriteFs>`.
-    fn open_rw<Fs: UniversalReadFs>(fs: &Fs, path: &Path) -> Result<Self>
+    fn open_rw<Fs: UniversalReadFs>(fs: &Fs, path: &Path) -> UioResult<Self>
     where
         Self: InvertedIndexReadWrite<Fs::File>,
         Fs::File: UniversalWrite<Fs = Fs>,
@@ -76,7 +76,7 @@ pub trait InvertedIndex: Sized + Debug + 'static {
     }
 
     /// Save index
-    fn save(&self, path: &Path) -> Result<()>;
+    fn save(&self, path: &Path) -> UioResult<()>;
 
     /// Get the posting lists for the given dimension ids.
     fn get_batch<'a, U: UserData>(
@@ -84,8 +84,8 @@ pub trait InvertedIndex: Sized + Debug + 'static {
         ids: impl Iterator<Item = (U, DimOffset)>,
         arena: &'a Blink,
         hw_counter: &'a HardwareCounterCell,
-        callback: impl FnMut(U, Self::Iter<'a>) -> Result<()>,
-    ) -> Result<()>;
+        callback: impl FnMut(U, Self::Iter<'a>) -> UioResult<()>,
+    ) -> UioResult<()>;
 
     /// Get number of posting lists
     fn len(&self) -> usize;
@@ -100,8 +100,8 @@ pub trait InvertedIndex: Sized + Debug + 'static {
         &self,
         ids: impl Iterator<Item = (U, DimOffset)>,
         hw_counter: &HardwareCounterCell,
-        callback: impl FnMut(U, usize) -> Result<()>,
-    ) -> Result<()>;
+        callback: impl FnMut(U, usize) -> UioResult<()>,
+    ) -> UioResult<()>;
 
     /// Files used by this index
     fn files(path: &Path) -> Vec<PathBuf>;
@@ -123,7 +123,7 @@ pub trait InvertedIndex: Sized + Debug + 'static {
         fs: &Fs,
         ram_index: Cow<InvertedIndexRam>,
         path: P,
-    ) -> Result<Self>
+    ) -> UioResult<Self>
     where
         Self: InvertedIndexReadWrite<Fs::File>,
         Fs::File: UniversalWrite<Fs = Fs>,

--- a/lib/sparse/src/index/search_context.rs
+++ b/lib/sparse/src/index/search_context.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::Ordering::Relaxed;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::top_k::TopK;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
-use common::universal_io::Result;
+use common::universal_io::UioResult;
 
 use super::posting_list_common::PostingListIter;
 use crate::SearchScratch;
@@ -46,7 +46,7 @@ impl<'a, T: PostingListIter> SearchContext<'a, T> {
         scratch: &'a mut SearchScratch<'_>,
         is_stopped: &'a AtomicBool,
         hardware_counter: &'a HardwareCounterCell,
-    ) -> Result<SearchContext<'a, T>> {
+    ) -> UioResult<SearchContext<'a, T>> {
         let mut postings_iterators = Vec::new();
         // track min and max record ids across all posting lists
         let mut max_record_id = 0;

--- a/lib/uio-grpc-client/src/read.rs
+++ b/lib/uio-grpc-client/src/read.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use bytes::Bytes;
-use common::universal_io::{ListedFile, ReadRange, Result, UniversalIoError};
+use common::universal_io::{ListedFile, ReadRange, UioResult, UniversalIoError};
 use futures::StreamExt as _;
 use futures::stream::BoxStream;
 use tonic::codegen::InterceptedService;
@@ -29,7 +29,7 @@ pub struct AuthInterceptor {
 impl AuthInterceptor {
     /// Parse the optional API key into a (sensitive) metadata value up front, so
     /// an invalid key is reported at connect time rather than on every request.
-    fn new(api_key: Option<String>) -> Result<Self> {
+    fn new(api_key: Option<String>) -> UioResult<Self> {
         let api_key = api_key
             .map(|key| {
                 let mut value: MetadataValue<Ascii> = key.parse().map_err(|err| {
@@ -90,7 +90,7 @@ pub struct Client {
 impl Client {
     /// Connect to a remote StorageRead gRPC service, authenticating with the
     /// optional Qdrant API key.
-    pub async fn connect(endpoint: impl Into<String>, api_key: Option<String>) -> Result<Self> {
+    pub async fn connect(endpoint: impl Into<String>, api_key: Option<String>) -> UioResult<Self> {
         let interceptor = AuthInterceptor::new(api_key)?;
         let channel = Channel::from_shared(endpoint.into())
             .map_err(|e| UniversalIoError::Io(std::io::Error::other(e)))?
@@ -111,7 +111,7 @@ impl Client {
     /// first request (driven by whatever runtime executes that request). This is
     /// what lets the `io_bridge_uio_grpc` backend satisfy the synchronous,
     /// runtime-free `AsyncRead::open` contract.
-    pub fn connect_lazy(endpoint: impl Into<String>, api_key: Option<String>) -> Result<Self> {
+    pub fn connect_lazy(endpoint: impl Into<String>, api_key: Option<String>) -> UioResult<Self> {
         let interceptor = AuthInterceptor::new(api_key)?;
         let channel = Channel::from_shared(endpoint.into())
             .map_err(|e| UniversalIoError::Io(std::io::Error::other(e)))?
@@ -128,7 +128,7 @@ impl Client {
         collection_name: &str,
         shard_id: u32,
         prefix_path: &str,
-    ) -> Result<Vec<ListedFile>> {
+    ) -> UioResult<Vec<ListedFile>> {
         let response = self
             .inner
             .clone()
@@ -160,7 +160,7 @@ impl Client {
         collection_name: &str,
         shard_id: u32,
         path: &str,
-    ) -> Result<bool> {
+    ) -> UioResult<bool> {
         let response = self
             .inner
             .clone()
@@ -181,7 +181,7 @@ impl Client {
         collection_name: &str,
         shard_id: u32,
         path: &str,
-    ) -> Result<u64> {
+    ) -> UioResult<u64> {
         let response = self
             .inner
             .clone()
@@ -204,7 +204,7 @@ impl Client {
         path: &str,
         byte_offset: u64,
         length: u64,
-    ) -> Result<Vec<u8>> {
+    ) -> UioResult<Vec<u8>> {
         let response = self
             .inner
             .clone()
@@ -229,7 +229,7 @@ impl Client {
         path: &str,
         byte_offset: u64,
         length: u64,
-    ) -> Result<Vec<u8>> {
+    ) -> UioResult<Vec<u8>> {
         let mut stream = self
             .inner
             .clone()
@@ -266,7 +266,7 @@ impl Client {
         path: &str,
         byte_offset: u64,
         length: u64,
-    ) -> Result<BoxStream<'static, Result<Bytes>>> {
+    ) -> UioResult<BoxStream<'static, UioResult<Bytes>>> {
         let path = path.to_string();
         let stream = self
             .inner
@@ -296,7 +296,7 @@ impl Client {
         collection_name: &str,
         shard_id: u32,
         path: &str,
-    ) -> Result<Vec<u8>> {
+    ) -> UioResult<Vec<u8>> {
         let response = self
             .inner
             .clone()
@@ -318,7 +318,7 @@ impl Client {
         shard_id: u32,
         path: &str,
         ranges: &[ReadRange],
-    ) -> Result<Vec<Vec<u8>>> {
+    ) -> UioResult<Vec<Vec<u8>>> {
         let proto_ranges: Vec<_> = ranges
             .iter()
             .map(|r| qdrant::ReadBatchRange {

--- a/src/tonic/api/storage_read_api/helpers.rs
+++ b/src/tonic/api/storage_read_api/helpers.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 
 use collection::operations::verification::new_unchecked_verification_pass;
 use collection::shards::shard::ShardId;
-use common::universal_io::{ReadRange, UniversalIoError, UniversalRead, UniversalReadFileOps};
+use common::universal_io::{
+    ReadRange, UioResult, UniversalIoError, UniversalRead, UniversalReadFileOps,
+};
 use storage::content_manager::toc::COLLECTIONS_DIR;
 use storage::dispatcher::Dispatcher;
 use storage::rbac::AccessRequirements;
@@ -205,7 +207,7 @@ fn canonicalize_existing_ancestor(path: &Path) -> std::io::Result<Option<PathBuf
 
 /// Validate a requested range against the file size using the same
 /// out-of-bounds semantics as `UniversalRead::read()`.
-pub fn validate_range(range: ReadRange, data_length: u64) -> common::universal_io::Result<()> {
+pub fn validate_range(range: ReadRange, data_length: u64) -> UioResult<()> {
     let end = range
         .byte_offset
         .checked_add(range.length)


### PR DESCRIPTION
Update UIO `Result` alias:

```rust
// Before this pr:
pub type Result<T, E = UniversalIoError> = std::result::Result<T, E>;


// In this PR:
pub type UioResult<T> = Result<T, UniversalIoError>;


// (rejected) The idiomatic way:
pub type Result<T> = std::result::Result<T, E>;
// … and in user code:
use common::unversal_io::Result as UioResult;
```

- Why remove generic arg `E`: for better type inference (otherwise sometimes wants more annotations). And it's more idiomatic Rust.
- Why rename `Result` -> `UioResult`:
    Not idiomatic, but it follows our pattern `OperationResult`/`StorageResult`/`CollectionResult`.
    And the idiomatic approach requires discipline: need import-rename (as opposed to auto-import via IDE/rust-analyzer).

This is a preparation for #9934 (otherwise it will require more type annotations).