### PR TITLE
Cleanup UniversalRead methods interface

### DIFF
--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -7,7 +7,7 @@ use common::mmap::AdviceSetting;
 #[cfg(target_os = "linux")]
 use common::universal_io::IoUringFs;
 use common::universal_io::{
-    MmapFs, OpenOptions, Populate, ReadRange, UniversalRead, UniversalReadFs,
+    MmapFs, OpenOptions, Populate, ReadRange, UioResult, UniversalRead, UniversalReadFs,
 };
 use criterion::{Criterion, criterion_group, criterion_main};
 use fs_err as fs;
@@ -126,11 +126,11 @@ fn read_benches<T: bytemuck::Pod + Send, Fs: UniversalReadFs>(
                 })
                 .map(|range| ((), range));
             storage
-                .read_batch::<Random, T, ()>(ranges, |(), chunk| {
+                .read_batch::<Random, T, (), _>(ranges, |(), chunk| {
                     for &item in bytemuck::cast_slice::<T, u64>(chunk) {
                         sum = sum.wrapping_add(item);
                     }
-                    Ok(())
+                    UioResult::Ok(())
                 })
                 .unwrap();
             black_box(sum);
@@ -149,11 +149,11 @@ fn read_benches<T: bytemuck::Pod + Send, Fs: UniversalReadFs>(
                 })
                 .map(|range| ((), range));
             storage
-                .read_batch::<Sequential, T, ()>(ranges, |(), chunk| {
+                .read_batch::<Sequential, T, (), _>(ranges, |(), chunk| {
                     for &item in bytemuck::cast_slice::<T, u64>(chunk) {
                         sum = sum.wrapping_add(item);
                     }
-                    Ok(())
+                    UioResult::Ok(())
                 })
                 .unwrap();
             black_box(sum);
@@ -166,11 +166,11 @@ fn read_benches<T: bytemuck::Pod + Send, Fs: UniversalReadFs>(
             b.iter(|| {
                 let mut sum = 0u64;
                 storage
-                    .read_batch::<Sequential, T, ()>(ranges_full_file::<T>(), |(), chunk| {
+                    .read_batch::<Sequential, T, (), _>(ranges_full_file::<T>(), |(), chunk| {
                         for &item in bytemuck::cast_slice::<T, u64>(chunk) {
                             sum = sum.wrapping_add(item);
                         }
-                        Ok(())
+                        UioResult::Ok(())
                     })
                     .unwrap();
                 black_box(sum);

--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -126,7 +126,7 @@ fn read_benches<T: bytemuck::Pod + Send, Fs: UniversalReadFs>(
                 })
                 .map(|range| ((), range));
             storage
-                .read_batch::<Random, T, (), _>(ranges, |(), chunk| {
+                .read_batch(ranges, Random, |(), chunk| {
                     for &item in bytemuck::cast_slice::<T, u64>(chunk) {
                         sum = sum.wrapping_add(item);
                     }
@@ -149,7 +149,7 @@ fn read_benches<T: bytemuck::Pod + Send, Fs: UniversalReadFs>(
                 })
                 .map(|range| ((), range));
             storage
-                .read_batch::<Sequential, T, (), _>(ranges, |(), chunk| {
+                .read_batch(ranges, Sequential, |(), chunk| {
                     for &item in bytemuck::cast_slice::<T, u64>(chunk) {
                         sum = sum.wrapping_add(item);
                     }
@@ -166,7 +166,7 @@ fn read_benches<T: bytemuck::Pod + Send, Fs: UniversalReadFs>(
             b.iter(|| {
                 let mut sum = 0u64;
                 storage
-                    .read_batch::<Sequential, T, (), _>(ranges_full_file::<T>(), |(), chunk| {
+                    .read_batch(ranges_full_file::<T>(), Sequential, |(), chunk| {
                         for &item in bytemuck::cast_slice::<T, u64>(chunk) {
                             sum = sum.wrapping_add(item);
                         }

--- a/lib/common/common/benches/universal_io.rs
+++ b/lib/common/common/benches/universal_io.rs
@@ -102,12 +102,7 @@ fn read_benches<T: bytemuck::Pod + Send, Fs: UniversalReadFs>(
         b.iter(|| {
             let mut sum = 0u64;
             let offset = rng.random_range(0..len) * size_of::<T>() as u64;
-            let data = storage
-                .read::<Random, T>(ReadRange {
-                    byte_offset: offset,
-                    length: 1,
-                })
-                .unwrap();
+            let data = storage.read(ReadRange::one(offset), Random).unwrap();
             for &item in bytemuck::cast_slice::<T, u64>(&data) {
                 sum = sum.wrapping_add(item);
             }

--- a/lib/common/common/src/generic_consts.rs
+++ b/lib/common/common/src/generic_consts.rs
@@ -1,11 +1,11 @@
-pub trait AccessPattern: Copy {
+pub trait AccessPattern: Copy + Default {
     const IS_SEQUENTIAL: bool;
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct Random;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub struct Sequential;
 
 impl AccessPattern for Random {

--- a/lib/common/common/src/persisted_hashmap/uio/mod.rs
+++ b/lib/common/common/src/persisted_hashmap/uio/mod.rs
@@ -154,7 +154,7 @@ where
         };
         let mut iter = OrderingIterator::new(
             self.storage
-                .read_iter::<Sequential, usize>(range.iter_autochunks::<u8>().enumerate())?,
+                .read_iter::<_, usize>(range.iter_autochunks::<u8>().enumerate(), Sequential)?,
         );
 
         while let Some(chunk) = iter.next() {

--- a/lib/common/common/src/persisted_hashmap/uio/mod.rs
+++ b/lib/common/common/src/persisted_hashmap/uio/mod.rs
@@ -69,10 +69,8 @@ where
         let storage = TypedStorage::<S, u8>::open(fs, path, options, extra)?;
 
         // 1. Read header.
-        let header_bytes = storage.read::<Sequential>(ReadRange {
-            byte_offset: 0,
-            length: size_of::<Header>() as u64,
-        })?;
+        let header_bytes =
+            storage.read(ReadRange::new(0, size_of::<Header>() as u64), Sequential)?;
         let (header, _) = Header::read_from_prefix(&header_bytes)
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid header"))?;
 
@@ -93,10 +91,8 @@ where
             .ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidData, "buckets_pos before header end")
             })?;
-        let phf_bytes = storage.read::<Sequential>(ReadRange {
-            byte_offset: phf_region_start,
-            length: phf_region_len,
-        })?;
+        let phf_bytes =
+            storage.read(ReadRange::new(phf_region_start, phf_region_len), Sequential)?;
         let phf = Function::read(&mut Cursor::new(&*phf_bytes))?;
 
         let entries_start =
@@ -196,10 +192,13 @@ where
         if self.average_entry_size < SEQUENTIAL_READ_THRESHOLD {
             self.for_each_entry(|key, _| f(key))
         } else {
-            let buckets = self.storage.read::<Sequential>(ReadRange {
-                byte_offset: self.header.buckets_pos,
-                length: self.header.buckets_count * size_of::<BucketOffset>() as u64,
-            })?;
+            let buckets = self.storage.read(
+                ReadRange::new(
+                    self.header.buckets_pos,
+                    self.header.buckets_count * size_of::<BucketOffset>() as u64,
+                ),
+                Sequential,
+            )?;
             let mut offsets: Vec<BucketOffset> = buckets
                 .as_chunks::<{ size_of::<BucketOffset>() }>()
                 .0

--- a/lib/common/common/src/stored_bitmask/read.rs
+++ b/lib/common/common/src/stored_bitmask/read.rs
@@ -60,10 +60,7 @@ impl<S: UniversalRead> StoredBitmask<S> {
             ));
         }
 
-        let header_bytes = storage.read::<Sequential>(ReadRange {
-            byte_offset: 0,
-            length: HEADER_SIZE as u64,
-        })?;
+        let header_bytes = storage.read(ReadRange::new(0, HEADER_SIZE as u64), Sequential)?;
         let header: BitmaskHeader = bytemuck::pod_read_unaligned(&header_bytes);
 
         if header.magic != MAGIC {
@@ -134,10 +131,10 @@ impl<S: UniversalRead> StoredBitmask<S> {
 
     /// Read and decode the payload, in the stored polarity.
     pub fn read(&self) -> UioResult<BitmaskContent<'_>> {
-        let payload = self.storage.read::<Sequential>(ReadRange {
-            byte_offset: HEADER_SIZE as u64,
-            length: self.payload_len,
-        })?;
+        let payload = self.storage.read(
+            ReadRange::new(HEADER_SIZE as u64, self.payload_len),
+            Sequential,
+        )?;
 
         match self.encoding {
             Encoding::Dense => {

--- a/lib/common/common/src/stored_bitslice.rs
+++ b/lib/common/common/src/stored_bitslice.rs
@@ -143,10 +143,10 @@ impl<S: UniversalRead> StoredBitSlice<S> {
         let elem_end = range.end.div_ceil(u64::from(BITS_PER_ELEMENT));
         let num_elements = elem_end - elem_start;
 
-        let elements = self.storage.read::<Random>(ReadRange {
-            byte_offset: elem_start * size_of::<BitStore>() as u64,
-            length: num_elements,
-        })?;
+        let elements = self.storage.read(
+            ReadRange::new(elem_start * size_of::<BitStore>() as u64, num_elements),
+            Random,
+        )?;
 
         let bit_offset = Self::bit_within_element(range.start) as usize;
         let bit_end = bit_offset + (range.end - range.start) as usize;
@@ -199,9 +199,10 @@ impl<S: UniversalRead> StoredBitSlice<S> {
             return Ok(None);
         }
 
-        let element = self
-            .storage
-            .read::<Random>(ReadRange::one(element_index * size_of::<BitStore>() as u64))?[0];
+        let element = self.storage.read(
+            ReadRange::one(element_index * size_of::<BitStore>() as u64),
+            Random,
+        )?[0];
 
         let bitslice = BitSlice::from_element(&element);
 
@@ -266,10 +267,10 @@ impl<S: UniversalWrite> StoredBitSlice<S> {
 
             let mut buf = self
                 .storage
-                .read::<Random>(ReadRange {
-                    byte_offset: element_start * size_of::<BitStore>() as u64,
-                    length: num_elements,
-                })?
+                .read(
+                    ReadRange::new(element_start * size_of::<BitStore>() as u64, num_elements),
+                    Random,
+                )?
                 .into_owned();
             let bitslice = BitSlice::from_slice_mut(&mut buf);
 
@@ -317,10 +318,9 @@ impl<S: UniversalWrite> StoredBitSlice<S> {
         // Fetch existing, in case the source length is not a multiple of element size
         let element_count = bit_count.div_ceil(u64::from(BITS_PER_ELEMENT));
 
-        let existing = self.storage.read::<Random>(ReadRange {
-            byte_offset: 0,
-            length: element_count,
-        })?;
+        let existing = self
+            .storage
+            .read(ReadRange::new(0, element_count), Random)?;
 
         let mut buf = existing.into_owned();
         let buf_bits = BitSlice::from_slice_mut(&mut buf);
@@ -344,9 +344,10 @@ impl<S: UniversalWrite> StoredBitSlice<S> {
             });
         }
 
-        let mut element = self
-            .storage
-            .read::<Random>(ReadRange::one(element_index * size_of::<BitStore>() as u64))?[0];
+        let mut element = self.storage.read(
+            ReadRange::one(element_index * size_of::<BitStore>() as u64),
+            Random,
+        )?[0];
 
         let element = &mut element;
 

--- a/lib/common/common/src/universal_io/conformance.rs
+++ b/lib/common/common/src/universal_io/conformance.rs
@@ -53,7 +53,7 @@ where
         b"hello world".as_slice(),
     );
     assert_eq!(
-        file.read::<Random, u8>(ReadRange::new(6, 5))
+        file.read::<_, u8>(ReadRange::new(6, 5), Random)
             .unwrap()
             .as_ref(),
         b"world".as_slice(),
@@ -78,7 +78,7 @@ where
     file.append_batch(11, batch).unwrap();
     assert_eq!(file.len::<u8>().unwrap(), 17);
     assert_eq!(
-        file.read::<Random, u8>(ReadRange::new(11, 6))
+        file.read::<_, u8>(ReadRange::new(11, 6), Random)
             .unwrap()
             .as_ref(),
         b"abcdef".as_slice(),
@@ -94,7 +94,7 @@ where
     file.append_batch(17, buffers.iter().map(Vec::as_slice))
         .unwrap();
     assert_eq!(
-        file.read::<Random, u8>(ReadRange::new(17, expected.len() as u64))
+        file.read::<_, u8>(ReadRange::new(17, expected.len() as u64), Random)
             .unwrap()
             .as_ref(),
         expected.as_slice(),
@@ -112,7 +112,7 @@ where
     assert_eq!(reader.len::<u8>().unwrap(), eof + 4);
     assert_eq!(
         reader
-            .read::<Random, u8>(ReadRange::new(eof, 4))
+            .read::<_, u8>(ReadRange::new(eof, 4), Random)
             .unwrap()
             .as_ref(),
         b"tail".as_slice(),

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -161,7 +161,12 @@ impl UniversalRead for CachedSlice {
         Ok(())
     }
 
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> UioResult<ACow<'_>> {
+    fn read_bytes<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        _access_pattern: P,
+        align: usize,
+    ) -> UioResult<ACow<'_>> {
         let start = usize::try_from(range.start).expect("range.start is within usize");
         let end = usize::try_from(range.end).expect("range.end is within usize");
         Ok(self.get_range_bytes(start..end, align)?)

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -164,7 +164,12 @@ impl UniversalRead for IoUringFile {
         Ok(())
     }
 
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> UioResult<ACow<'_>> {
+    fn read_bytes<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        _access_pattern: P,
+        align: usize,
+    ) -> UioResult<ACow<'_>> {
         if self.direct_io {
             // direct_io needs special handling
             let mut pipeline = IoUringPipeline::<()>::new()?;

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -103,7 +103,7 @@ fn test_io_uring_read_batch_read_iter() -> UioResult<()> {
     }
 
     // --- read_iter (iterator API) ---
-    let read_iter = file.read_iter::<Sequential, _>(ranges.into_iter().enumerate())?;
+    let read_iter = file.read_iter(ranges.into_iter().enumerate(), Sequential)?;
 
     let mut iter_results: Vec<_> = read_iter.collect::<UioResult<Vec<_>>>()?;
     iter_results.sort_by_key(|&(idx, _)| idx);
@@ -120,7 +120,7 @@ fn test_io_uring_read_batch_read_iter() -> UioResult<()> {
     let many_ranges = (0..64).map(|i| read_range::<u64>(i, 1)).enumerate();
 
     let mut count = 0;
-    for record in file.read_iter::<Sequential, _>(many_ranges)? {
+    for record in file.read_iter(many_ranges, Sequential)? {
         let (idx, items) = record?;
 
         assert_eq!(
@@ -160,8 +160,8 @@ fn test_io_uring_read_iter_concurrent() -> UioResult<()> {
     let ranges_a = (0..NUM_RANGES).map(|i| read_range::<u64>((i * CHUNK) as usize, CHUNK as usize));
     let ranges_b = (0..NUM_RANGES).map(|i| read_range::<u64>((i * CHUNK) as usize, CHUNK as usize));
 
-    let iter_a = file_a.read_iter::<Sequential, _>(ranges_a.enumerate())?;
-    let iter_b = file_b.read_iter::<Sequential, _>(ranges_b.enumerate())?;
+    let iter_a = file_a.read_iter(ranges_a.enumerate(), Sequential)?;
+    let iter_b = file_b.read_iter(ranges_b.enumerate(), Sequential)?;
 
     // Zip alternates next() calls between the two iterators on the same
     // thread-local io_uring ring. With in-flight operations left across
@@ -267,7 +267,7 @@ fn test_io_uring_eintr_handling() -> UioResult<()> {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut errors = 0u64;
 
-            let Ok(iter) = file.read_iter::<Sequential, _>(ranges) else {
+            let Ok(iter) = file.read_iter(ranges, Sequential) else {
                 return 1;
             };
 

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -87,7 +87,7 @@ fn test_io_uring_read_batch_read_iter() -> UioResult<()> {
     // --- read_batch (callback API) ---
     let mut batch_results = Vec::new();
 
-    file.read_batch::<Sequential, _, _>(ranges.into_iter().enumerate(), |idx, items| {
+    file.read_batch(ranges.into_iter().enumerate(), Sequential, |idx, items| {
         batch_results.push((idx, items.to_vec()));
         UioResult::Ok(())
     })?;

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -7,6 +7,7 @@ use nix::libc;
 use super::super::*;
 use super::*;
 use crate::generic_consts::Sequential;
+use crate::universal_io::UioResult;
 
 /// Create `path`, populate it with the binary representation of `data`,
 /// then open and return it.
@@ -86,9 +87,9 @@ fn test_io_uring_read_batch_read_iter() -> UioResult<()> {
     // --- read_batch (callback API) ---
     let mut batch_results = Vec::new();
 
-    file.read_batch::<Sequential, _>(ranges.into_iter().enumerate(), |idx, items| {
+    file.read_batch::<Sequential, _, _>(ranges.into_iter().enumerate(), |idx, items| {
         batch_results.push((idx, items.to_vec()));
-        Ok(())
+        UioResult::Ok(())
     })?;
 
     batch_results.sort_by_key(|&(idx, _)| idx);

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -333,7 +333,7 @@ fn test_io_uring_direct_io() -> UioResult<()> {
         let end = start + expected.len();
 
         let range = start as u64..end as u64;
-        let bytes = file.read_bytes::<Sequential>(range, KERNEL_PAGE_SIZE)?;
+        let bytes = file.read_bytes(range, Sequential, KERNEL_PAGE_SIZE)?;
 
         assert_eq!(bytes.as_ref(), expected, "O_DIRECT block {idx} mismatch");
     }

--- a/lib/common/common/src/universal_io/io_uring/tests.rs
+++ b/lib/common/common/src/universal_io/io_uring/tests.rs
@@ -47,11 +47,11 @@ fn test_io_uring_read() -> UioResult<()> {
     // 2. Read data back and verify it matches what was written
 
     // Read all elements
-    let full = file.read::<Sequential>(read_range::<u64>(0, data.len()))?;
+    let full = file.read(read_range::<u64>(0, data.len()), Sequential)?;
     assert_eq!(full.as_ref(), &data);
 
     // Read a sub-range (elements 10..30)
-    let sub = file.read::<Sequential>(read_range::<u64>(10, 20))?;
+    let sub = file.read(read_range::<u64>(10, 20), Sequential)?;
     assert_eq!(sub.as_ref(), &data[10..30]);
 
     // Verify len()

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -225,11 +225,11 @@ impl UniversalRead for MmapFile {
     }
 
     /// Override the default pipeline-based for better performance.
-    fn read_batch<P: AccessPattern, T: Item, U: UserData>(
+    fn read_batch<P: AccessPattern, T: Item, U: UserData, E: From<UniversalIoError>>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-        mut callback: impl FnMut(U, &[T]) -> UioResult<()>,
-    ) -> UioResult<()> {
+        mut callback: impl FnMut(U, &[T]) -> Result<(), E>,
+    ) -> Result<(), E> {
         let bytes = self.as_bytes::<P>();
         for (user_data, range) in ranges {
             let items = read_bytemuck::<T>(bytes, range)?;

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -205,6 +205,7 @@ impl UniversalRead for MmapFile {
     fn read_bytes<P: AccessPattern>(
         &self,
         range: Range<u64>,
+        _access_pattern: P,
         _align: usize,
     ) -> UioResult<ACow<'_>> {
         let mmap = self.as_bytes::<P>();

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -216,6 +216,7 @@ impl UniversalRead for MmapFile {
     fn read_iter<P: AccessPattern, T: Item, U: UserData>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
+        _access_pattern: P,
     ) -> UioResult<impl Iterator<Item = UioResult<(U, Cow<'_, [T]>)>>> {
         let bytes = self.as_bytes::<P>();
         Ok(ranges.into_iter().map(move |(user_data, range)| {

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -228,6 +228,7 @@ impl UniversalRead for MmapFile {
     fn read_batch<P: AccessPattern, T: Item, U: UserData, E: From<UniversalIoError>>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
+        _access_pattern: P,
         mut callback: impl FnMut(U, &[T]) -> Result<(), E>,
     ) -> Result<(), E> {
         let bytes = self.as_bytes::<P>();

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -35,7 +35,9 @@ where
 
         // Read one byte per block purely to fault each block into the local
         // cache; the bytes themselves are discarded.
-        self.read_batch::<Sequential, u8, ()>(one_byte_per_block, |(), _bytes| Ok(()))?;
+        self.read_batch::<Sequential, u8, (), _>(one_byte_per_block, |(), _bytes| {
+            UioResult::Ok(())
+        })?;
 
         Ok(())
     }

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -35,7 +35,7 @@ where
 
         // Read one byte per block purely to fault each block into the local
         // cache; the bytes themselves are discarded.
-        self.read_batch::<Sequential, u8, (), _>(one_byte_per_block, |(), _bytes| {
+        self.read_batch(one_byte_per_block, Sequential, |(), _bytes: &[u8]| {
             UioResult::Ok(())
         })?;
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -70,10 +70,7 @@ where
     fn read_whole<T: Item>(&self) -> UioResult<Cow<'_, [T]>> {
         self.prefill_if_uninit()?;
         let length = self.len::<T>()?;
-        self.read::<Sequential, T>(ReadRange {
-            byte_offset: 0,
-            length,
-        })
+        self.read(ReadRange::new(0, length), Sequential)
     }
 
     fn len<T>(&self) -> UioResult<u64> {

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -60,7 +60,12 @@ where
         self.reopen_impl()
     }
 
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> UioResult<ACow<'_>> {
+    fn read_bytes<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        _access_pattern: P,
+        align: usize,
+    ) -> UioResult<ACow<'_>> {
         let mut pipeline = DiskCachePipeline::<R, ()>::new()?;
         pipeline.schedule::<P>((), self, range, align)?;
         let (_, bytes) = pipeline.wait()?.expect("there's exactly one read");

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -173,6 +173,7 @@ mod tests_mod {
     use super::*;
     #[cfg_predicate]
     use crate::universal_io::R;
+    use crate::universal_io::UioResult;
 
     const PREFILL: bool = _PREFILL;
 
@@ -754,12 +755,12 @@ mod tests_mod {
             .collect();
 
         let mut seen = vec![false; ranges.len()];
-        file.read_batch::<Random, u8, usize>(ranges.clone(), |i, bytes| {
+        file.read_batch::<Random, u8, usize, _>(ranges.clone(), |i, bytes| {
             let start = ranges[i].1.byte_offset as usize;
             assert_eq!(bytes, &scn.data[start..start + 100]);
             assert!(!seen[i]);
             seen[i] = true;
-            Ok(())
+            UioResult::Ok(())
         })
         .unwrap();
         assert!(seen.iter().all(|&s| s));

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -184,20 +184,14 @@ mod tests_mod {
 
         // Read inside the first block.
         let bytes = file
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: 10,
-                length: 20,
-            })
+            .read::<_, u8>(ReadRange::new(10, 20), Sequential)
             .unwrap();
         assert_eq!(&*bytes, &scn.data[10..30]);
 
         // Last block includes the 100-byte tail.
         let last = scn.data.len() as u64;
         let bytes = file
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: last - 50,
-                length: 50,
-            })
+            .read::<_, u8>(ReadRange::new(last - 50, 50), Sequential)
             .unwrap();
         assert_eq!(&*bytes, &scn.data[scn.data.len() - 50..]);
     }
@@ -225,10 +219,7 @@ mod tests_mod {
         let start = (BLOCK_SIZE - 50) as u64;
         let len = (BLOCK_SIZE + 100) as u64;
         let bytes = file
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: start,
-                length: len,
-            })
+            .read::<_, u8>(ReadRange::new(start, len), Sequential)
             .unwrap();
         let start = start as usize;
         let end = start + len as usize;
@@ -258,12 +249,7 @@ mod tests_mod {
         );
 
         // Trigger one read. This must bring up the local file.
-        let _ = file
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: 0,
-                length: 1,
-            })
-            .unwrap();
+        let _ = file.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
 
         assert!(
             expected_local.exists(),
@@ -284,10 +270,7 @@ mod tests_mod {
         file.populate().unwrap();
 
         let bytes = file
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: 0,
-                length: scn.data.len() as u64,
-            })
+            .read::<_, u8>(ReadRange::new(0, scn.data.len() as u64), Sequential)
             .unwrap();
         assert_eq!(&*bytes, &scn.data[..]);
     }
@@ -298,10 +281,7 @@ mod tests_mod {
         let file = scn.open::<R>(PREFILL);
 
         let err = file
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: 1000,
-                length: 100,
-            })
+            .read::<_, u8>(ReadRange::new(1000, 100), Sequential)
             .unwrap_err();
         assert_matches!(
             err,
@@ -320,10 +300,7 @@ mod tests_mod {
         let first = scn.open::<R>(PREFILL);
         let read_all = |cache: &DiskCache<R>| {
             cache
-                .read::<Sequential, u8>(ReadRange {
-                    byte_offset: 0,
-                    length: scn.data.len() as u64,
-                })
+                .read::<_, u8>(ReadRange::new(0, scn.data.len() as u64), Sequential)
                 .unwrap()
                 .to_vec()
         };
@@ -344,12 +321,7 @@ mod tests_mod {
         let scn = Scenario::new(BLOCK_SIZE);
         let cache = scn.open::<R>(PREFILL);
 
-        let _ = cache
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: 0,
-                length: 1,
-            })
-            .unwrap();
+        let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
 
         let local_path = cache.local_path.clone();
         assert!(local_path.exists());
@@ -387,12 +359,7 @@ mod tests_mod {
         let scn = Scenario::new(BLOCK_SIZE * 3);
         let mut cache = scn.open::<R>(PREFILL);
 
-        let _ = cache
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: 0,
-                length: 1,
-            })
-            .unwrap();
+        let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
 
         let (len_before, populated_before, fetched_before) = {
             let local = cache.state().expect("local initialized after read").local;
@@ -433,20 +400,12 @@ mod tests_mod {
 
         let original_len = scn.data.len() as u64;
 
-        let _ = cache
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: 0,
-                length: 1,
-            })
-            .unwrap();
+        let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
 
         let new_data = scn.grow_remote(BLOCK_SIZE);
 
         let err = cache
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: original_len,
-                length: BLOCK_SIZE as u64,
-            })
+            .read::<_, u8>(ReadRange::new(original_len, BLOCK_SIZE as u64), Sequential)
             .unwrap_err();
         assert_matches!(
             err,
@@ -456,10 +415,7 @@ mod tests_mod {
         cache.reopen().unwrap();
 
         let bytes = cache
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: original_len,
-                length: BLOCK_SIZE as u64,
-            })
+            .read::<_, u8>(ReadRange::new(original_len, BLOCK_SIZE as u64), Sequential)
             .unwrap();
         assert_eq!(&*bytes, &new_data[original_len as usize..]);
     }
@@ -476,10 +432,7 @@ mod tests_mod {
         // Touch the partial tail so block 1 ends up in the `fetched` bitmap
         // (its fetch is clamped to the old EOF).
         let _ = cache
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: BLOCK_SIZE as u64,
-                length: 1,
-            })
+            .read::<_, u8>(ReadRange::one(BLOCK_SIZE as u64), Sequential)
             .unwrap();
 
         // Grow remote past the old tail block boundary.
@@ -491,10 +444,10 @@ mod tests_mod {
         // and the newly-grown tail [old_len..BLOCK_SIZE*2). Without the
         // invalidation, the second half would be zeros from `set_len`.
         let bytes = cache
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: BLOCK_SIZE as u64,
-                length: BLOCK_SIZE as u64,
-            })
+            .read::<_, u8>(
+                ReadRange::new(BLOCK_SIZE as u64, BLOCK_SIZE as u64),
+                Sequential,
+            )
             .unwrap();
         assert_eq!(&*bytes, &new_data[BLOCK_SIZE..BLOCK_SIZE * 2]);
     }
@@ -515,10 +468,7 @@ mod tests_mod {
 
         // A read within the prefetched range is served from the local mirror.
         let bytes = file
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: 10,
-                length: 20,
-            })
+            .read::<_, u8>(ReadRange::new(10, 20), Sequential)
             .unwrap();
         assert_eq!(&*bytes, &scn.data[10..30]);
 
@@ -536,10 +486,7 @@ mod tests_mod {
         // A read outside the prefetched range faults its block in on demand.
         let start = (BLOCK_SIZE * 2) as u64;
         let bytes = file
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: start,
-                length: 30,
-            })
+            .read::<_, u8>(ReadRange::new(start, 30), Sequential)
             .unwrap();
         assert_eq!(&*bytes, &scn.data[start as usize..start as usize + 30]);
         assert!(file.state().unwrap().local.fetched.lock().contains(2));
@@ -554,10 +501,7 @@ mod tests_mod {
 
         // Nothing prefetched, so the first read must fault its block in.
         let bytes = file
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: 0,
-                length: 16,
-            })
+            .read::<_, u8>(ReadRange::new(0, 16), Sequential)
             .unwrap();
         assert_eq!(&*bytes, &scn.data[0..16]);
         assert_eq!(file.len::<u8>().unwrap(), scn.data.len() as u64);
@@ -571,10 +515,7 @@ mod tests_mod {
         let file = scn.open_partial::<R>(BLOCK_SIZE as u64 * 4..BLOCK_SIZE as u64 * 5);
 
         let bytes = file
-            .read::<Sequential, u8>(ReadRange {
-                byte_offset: 0,
-                length: 100,
-            })
+            .read::<_, u8>(ReadRange::new(0, 100), Sequential)
             .unwrap();
         assert_eq!(&*bytes, &scn.data[..]);
         assert_eq!(file.len::<u8>().unwrap(), 100);

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -755,7 +755,7 @@ mod tests_mod {
             .collect();
 
         let mut seen = vec![false; ranges.len()];
-        file.read_batch::<Random, u8, usize, _>(ranges.clone(), |i, bytes| {
+        file.read_batch(ranges.clone(), Random, |i, bytes: &[u8]| {
             let start = ranges[i].1.byte_offset as usize;
             assert_eq!(bytes, &scn.data[start..start + 100]);
             assert!(!seen[i]);

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -60,7 +60,11 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
 
     /// Prefer [`read_batch`] if you need high performance.
     #[inline]
-    fn read<P: AccessPattern, T: Item>(&self, range: ReadRange) -> UioResult<Cow<'_, [T]>> {
+    fn read<P: AccessPattern, T: Item>(
+        &self,
+        range: ReadRange,
+        _access_pattern: P,
+    ) -> UioResult<Cow<'_, [T]>> {
         let bytes = self.read_bytes::<P>(range.into_byte_range::<T>(), align_of::<T>())?;
         Ok(bytes.try_cast_bytemuck().unwrap())
     }
@@ -78,7 +82,7 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
             length: self.len::<T>()?,
         };
 
-        self.read::<Sequential, T>(range)
+        self.read(range, Sequential)
     }
 
     fn read_batch<P, T, U, E>(

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -63,13 +63,22 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     fn read<P: AccessPattern, T: Item>(
         &self,
         range: ReadRange,
-        _access_pattern: P,
+        access_pattern: P,
     ) -> UioResult<Cow<'_, [T]>> {
-        let bytes = self.read_bytes::<P>(range.into_byte_range::<T>(), align_of::<T>())?;
+        let bytes = self.read_bytes(
+            range.into_byte_range::<T>(),
+            access_pattern,
+            align_of::<T>(),
+        )?;
         Ok(bytes.try_cast_bytemuck().unwrap())
     }
 
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> UioResult<ACow<'_>>;
+    fn read_bytes<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        access_pattern: P,
+        align: usize,
+    ) -> UioResult<ACow<'_>>;
 
     /// Read the entire file in one logical access.
     ///

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -115,15 +115,11 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
 
     /// Like [`read_batch`](Self::read_batch), but returns a fallible iterator
     /// instead of accepting a callback.
-    fn read_iter<P, T, U>(
+    fn read_iter<P: AccessPattern, T: Item, U: UserData>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-    ) -> UioResult<impl Iterator<Item = UioResult<(U, Cow<'_, [T]>)>>>
-    where
-        P: AccessPattern,
-        T: Item,
-        U: UserData,
-    {
+        _access_pattern: P,
+    ) -> UioResult<impl Iterator<Item = UioResult<(U, Cow<'_, [T]>)>>> {
         let mut pipeline = Self::ReadPipeline::<'_, U>::new()?;
         let mut ranges = ranges.into_iter();
 

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -84,6 +84,7 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     fn read_batch<P, T, U, E>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
+        _access_pattern: P,
         mut callback: impl FnMut(U, &[T]) -> Result<(), E>,
     ) -> Result<(), E>
     where

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use super::{Item, ReadPipeline, UniversalReadFs, UserData};
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Sequential};
-use crate::universal_io::{ReadBytesItem, ReadRange, UioResult, UniversalKind};
+use crate::universal_io::{ReadBytesItem, ReadRange, UioResult, UniversalIoError, UniversalKind};
 
 /// Per-file handle for universal read access.
 ///
@@ -81,15 +81,16 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
         self.read::<Sequential, T>(range)
     }
 
-    fn read_batch<P, T, U>(
+    fn read_batch<P, T, U, E>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-        mut callback: impl FnMut(U, &[T]) -> UioResult<()>,
-    ) -> UioResult<()>
+        mut callback: impl FnMut(U, &[T]) -> Result<(), E>,
+    ) -> Result<(), E>
     where
         P: AccessPattern,
         T: Item,
         U: UserData,
+        E: From<UniversalIoError>,
     {
         let mut pipeline = Self::ReadPipeline::<'_, U>::new()?;
         let mut ranges = ranges.into_iter();

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -141,14 +141,11 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
         }))
     }
 
-    fn read_bytes_iter<P, U>(
+    fn read_bytes_iter<P: AccessPattern, U: UserData>(
         &self,
         ranges: impl IntoIterator<Item = ReadBytesItem<U>>,
-    ) -> UioResult<impl Iterator<Item = UioResult<(U, ACow<'_>)>>>
-    where
-        P: AccessPattern,
-        U: UserData,
-    {
+        _access_pattern: P,
+    ) -> UioResult<impl Iterator<Item = UioResult<(U, ACow<'_>)>>> {
         let mut pipeline = Self::ReadPipeline::<'_, U>::new()?;
         let mut ranges = ranges.into_iter();
 

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -147,16 +147,12 @@ where
     }
 
     #[inline]
-    fn read_iter<P, T, U>(
+    fn read_iter<P: AccessPattern, T: Item, U: UserData>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-    ) -> UioResult<impl Iterator<Item = UioResult<(U, Cow<'_, [T]>)>>>
-    where
-        P: AccessPattern,
-        T: Item,
-        U: UserData,
-    {
-        self.0.read_iter::<P, T, U>(ranges)
+        access_pattern: P,
+    ) -> UioResult<impl Iterator<Item = UioResult<(U, Cow<'_, [T]>)>>> {
+        self.0.read_iter(ranges, access_pattern)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -125,8 +125,13 @@ where
     }
 
     #[inline]
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> UioResult<ACow<'_>> {
-        self.0.read_bytes::<P>(range, align)
+    fn read_bytes<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        access_pattern: P,
+        align: usize,
+    ) -> UioResult<ACow<'_>> {
+        self.0.read_bytes(range, access_pattern, align)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -134,6 +134,7 @@ where
     fn read_batch<P, T, U, E>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
+        access_pattern: P,
         callback: impl FnMut(U, &[T]) -> Result<(), E>,
     ) -> Result<(), E>
     where
@@ -142,7 +143,7 @@ where
         U: UserData,
         E: From<UniversalIoError>,
     {
-        self.0.read_batch::<P, T, U, E>(ranges, callback)
+        self.0.read_batch(ranges, access_pattern, callback)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -10,8 +10,8 @@ use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::traits::UniversalReadFileOps;
 use crate::universal_io::{
-    Item, ListedFile, OpenOptions, ReadBytesItem, ReadRange, UioResult, UniversalKind,
-    UniversalRead, UniversalReadFs, UserData,
+    Item, ListedFile, OpenOptions, ReadBytesItem, ReadRange, UioResult, UniversalIoError,
+    UniversalKind, UniversalRead, UniversalReadFs, UserData,
 };
 
 #[derive(Debug, TransparentWrapper)]
@@ -131,17 +131,18 @@ where
     }
 
     #[inline]
-    fn read_batch<P, T, U>(
+    fn read_batch<P, T, U, E>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-        callback: impl FnMut(U, &[T]) -> UioResult<()>,
-    ) -> UioResult<()>
+        callback: impl FnMut(U, &[T]) -> Result<(), E>,
+    ) -> Result<(), E>
     where
         P: AccessPattern,
         T: Item,
         U: UserData,
+        E: From<UniversalIoError>,
     {
-        self.0.read_batch::<P, T, U>(ranges, callback)
+        self.0.read_batch::<P, T, U, E>(ranges, callback)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -160,15 +160,12 @@ where
     }
 
     #[inline]
-    fn read_bytes_iter<P, U>(
+    fn read_bytes_iter<P: AccessPattern, U: UserData>(
         &self,
         ranges: impl IntoIterator<Item = ReadBytesItem<U>>,
-    ) -> UioResult<impl Iterator<Item = UioResult<(U, ACow<'_>)>>>
-    where
-        P: AccessPattern,
-        U: UserData,
-    {
-        self.0.read_bytes_iter::<P, U>(ranges)
+        access_pattern: P,
+    ) -> UioResult<impl Iterator<Item = UioResult<(U, ACow<'_>)>>> {
+        self.0.read_bytes_iter(ranges, access_pattern)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -116,8 +116,12 @@ where
     }
 
     #[inline]
-    fn read<P: AccessPattern, T: Item>(&self, range: ReadRange) -> UioResult<Cow<'_, [T]>> {
-        self.0.read::<P, T>(range)
+    fn read<P: AccessPattern, T: Item>(
+        &self,
+        range: ReadRange,
+        access_pattern: P,
+    ) -> UioResult<Cow<'_, [T]>> {
+        self.0.read(range, access_pattern)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -72,8 +72,12 @@ where
     }
 
     #[inline]
-    pub fn read<P: AccessPattern>(&self, range: ReadRange) -> UioResult<Cow<'_, [T]>> {
-        self.inner.read::<P, T>(range)
+    pub fn read<P: AccessPattern>(
+        &self,
+        range: ReadRange,
+        access_pattern: P,
+    ) -> UioResult<Cow<'_, [T]>> {
+        self.inner.read(range, access_pattern)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -8,7 +8,8 @@ use bytemuck::TransparentWrapper;
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
     ByteOffset, FileIndex, Flusher, Item, OpenOptions, ReadRange, UioResult, UniversalAppend,
-    UniversalFlush, UniversalKind, UniversalRead, UniversalReadFs, UniversalWrite, UserData,
+    UniversalFlush, UniversalIoError, UniversalKind, UniversalRead, UniversalReadFs,
+    UniversalWrite, UserData,
 };
 
 /// A wrapper around [`UniversalRead`]/[`UniversalWrite`] that binds the element
@@ -81,16 +82,17 @@ where
     }
 
     #[inline]
-    pub fn read_batch<P, U>(
+    pub fn read_batch<P, U, E>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
-        callback: impl FnMut(U, &[T]) -> UioResult<()>,
-    ) -> UioResult<()>
+        callback: impl FnMut(U, &[T]) -> Result<(), E>,
+    ) -> Result<(), E>
     where
         P: AccessPattern,
         U: UserData,
+        E: From<UniversalIoError>,
     {
-        self.inner.read_batch::<P, T, U>(ranges, callback)
+        self.inner.read_batch::<P, T, U, E>(ranges, callback)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -82,17 +82,13 @@ where
     }
 
     #[inline]
-    pub fn read_batch<P, U, E>(
+    pub fn read_batch<P: AccessPattern, U: UserData, E: From<UniversalIoError>>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
+        access_pattern: P,
         callback: impl FnMut(U, &[T]) -> Result<(), E>,
-    ) -> Result<(), E>
-    where
-        P: AccessPattern,
-        U: UserData,
-        E: From<UniversalIoError>,
-    {
-        self.inner.read_batch::<P, T, U, E>(ranges, callback)
+    ) -> Result<(), E> {
+        self.inner.read_batch(ranges, access_pattern, callback)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -95,12 +95,13 @@ where
     pub fn read_iter<P, U>(
         &self,
         ranges: impl IntoIterator<Item = (U, ReadRange)>,
+        access_pattern: P,
     ) -> UioResult<impl Iterator<Item = UioResult<(U, Cow<'_, [T]>)>>>
     where
         P: AccessPattern,
         U: UserData,
     {
-        self.inner.read_iter::<P, T, U>(ranges)
+        self.inner.read_iter(ranges, access_pattern)
     }
 
     #[inline]

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -314,7 +314,7 @@ mod tests {
             .open("obj", OpenOptions::new_for_test(), ())
             .expect("open");
         let cow = file
-            .read::<Sequential, u8>(ReadRange::new(0, 11))
+            .read::<_, u8>(ReadRange::new(0, 11), Sequential)
             .expect("read");
         assert_eq!(&cow[..], b"hello world");
     }
@@ -327,7 +327,7 @@ mod tests {
             "obj",
         );
         let cow = file
-            .read::<Sequential, u8>(ReadRange::new(0, 11))
+            .read::<_, u8>(ReadRange::new(0, 11), Sequential)
             .expect("read");
         assert_eq!(&cow[..], b"hello world");
     }
@@ -339,7 +339,9 @@ mod tests {
             BridgeRuntime::global(),
             "obj",
         );
-        let cow = file.read::<Random, u8>(ReadRange::new(6, 5)).expect("read");
+        let cow = file
+            .read::<_, u8>(ReadRange::new(6, 5), Random)
+            .expect("read");
         assert_eq!(&cow[..], b"world");
     }
 

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -230,6 +230,7 @@ mod tests {
     use std::sync::Arc;
 
     use bytes::Bytes;
+    use common::generic_consts::{Random, Sequential};
     use common::universal_io::{
         ListedFile, OpenOptions, ReadRange, UniversalIoError, UniversalReadFs,
     };
@@ -313,7 +314,7 @@ mod tests {
             .open("obj", OpenOptions::new_for_test(), ())
             .expect("open");
         let cow = file
-            .read::<common::generic_consts::Sequential, u8>(ReadRange::new(0, 11))
+            .read::<Sequential, u8>(ReadRange::new(0, 11))
             .expect("read");
         assert_eq!(&cow[..], b"hello world");
     }
@@ -326,7 +327,7 @@ mod tests {
             "obj",
         );
         let cow = file
-            .read::<common::generic_consts::Sequential, u8>(ReadRange::new(0, 11))
+            .read::<Sequential, u8>(ReadRange::new(0, 11))
             .expect("read");
         assert_eq!(&cow[..], b"hello world");
     }
@@ -338,9 +339,7 @@ mod tests {
             BridgeRuntime::global(),
             "obj",
         );
-        let cow = file
-            .read::<common::generic_consts::Random, u8>(ReadRange::new(6, 5))
-            .expect("read");
+        let cow = file.read::<Random, u8>(ReadRange::new(6, 5)).expect("read");
         assert_eq!(&cow[..], b"world");
     }
 
@@ -368,7 +367,7 @@ mod tests {
             (3u32, ReadRange::new(10, 3)),
         ];
         let mut got: std::collections::HashMap<u32, Vec<u8>> = std::collections::HashMap::new();
-        file.read_batch::<common::generic_consts::Random, u8, _>(inputs, |u, s| {
+        file.read_batch::<Random, u8, _>(inputs, |u, s| {
             got.insert(u, s.to_vec());
             Ok(())
         })

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -367,7 +367,7 @@ mod tests {
             (3u32, ReadRange::new(10, 3)),
         ];
         let mut got: std::collections::HashMap<u32, Vec<u8>> = std::collections::HashMap::new();
-        file.read_batch::<Random, u8, _, _>(inputs, |u, s| {
+        file.read_batch(inputs, Random, |u, s| {
             got.insert(u, s.to_vec());
             UioResult::Ok(())
         })

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -102,7 +102,12 @@ impl<A: AsyncRead + Clone> UniversalRead for BlobFile<A> {
         Ok(())
     }
 
-    fn read_bytes<P: AccessPattern>(&self, range: Range<u64>, align: usize) -> UioResult<ACow<'_>> {
+    fn read_bytes<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        _access_pattern: P,
+        align: usize,
+    ) -> UioResult<ACow<'_>> {
         let enabled = log::log_enabled!(target: crate::LATENCY_LOG_TARGET, log::Level::Trace);
         let start_time = enabled.then(std::time::Instant::now);
         let buf = self

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -367,9 +367,9 @@ mod tests {
             (3u32, ReadRange::new(10, 3)),
         ];
         let mut got: std::collections::HashMap<u32, Vec<u8>> = std::collections::HashMap::new();
-        file.read_batch::<Random, u8, _>(inputs, |u, s| {
+        file.read_batch::<Random, u8, _, _>(inputs, |u, s| {
             got.insert(u, s.to_vec());
-            Ok(())
+            UioResult::Ok(())
         })
         .expect("read_batch");
         assert_eq!(got[&1], b"hello");

--- a/lib/common/io_bridge/src/tests/whole_read.rs
+++ b/lib/common/io_bridge/src/tests/whole_read.rs
@@ -249,7 +249,7 @@ fn disk_cache_read_whole_skips_remote_len() {
     );
 
     let again = file
-        .read::<Sequential, u8>(ReadRange::new(0, DATA.len() as u64))
+        .read::<_, u8>(ReadRange::new(0, DATA.len() as u64), Sequential)
         .expect("local read");
     assert_eq!(&again[..], DATA);
     assert_eq!(counters.whole.load(Ordering::Relaxed), 1);

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -502,7 +502,7 @@ mod tests {
         let store = inmemory_with(&runtime, &[("obj", b"hello world")]);
         let file = make_file(runtime, store, "obj");
         let cow = file
-            .read::<Sequential, u8>(ReadRange::new(0, 11))
+            .read::<_, u8>(ReadRange::new(0, 11), Sequential)
             .expect("read");
         assert_eq!(&cow[..], b"hello world");
     }
@@ -512,7 +512,9 @@ mod tests {
         let runtime = BridgeRuntime::global();
         let store = inmemory_with(&runtime, &[("obj", b"hello world")]);
         let file = make_file(runtime, store, "obj");
-        let cow = file.read::<Random, u8>(ReadRange::new(6, 5)).expect("read");
+        let cow = file
+            .read::<_, u8>(ReadRange::new(6, 5), Random)
+            .expect("read");
         assert_eq!(&cow[..], b"world");
     }
 

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -372,6 +372,7 @@ fn build_dir_prefix(path: &Path) -> object_store::path::Path {
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
+    use common::generic_consts::{Random, Sequential};
     use common::universal_io::{ListedFile, ReadRange, UniversalAppend, UniversalRead};
     use io_bridge::{BlobFile, BridgeRuntime};
     use object_store::memory::InMemory;
@@ -501,7 +502,7 @@ mod tests {
         let store = inmemory_with(&runtime, &[("obj", b"hello world")]);
         let file = make_file(runtime, store, "obj");
         let cow = file
-            .read::<common::generic_consts::Sequential, u8>(ReadRange::new(0, 11))
+            .read::<Sequential, u8>(ReadRange::new(0, 11))
             .expect("read");
         assert_eq!(&cow[..], b"hello world");
     }
@@ -511,9 +512,7 @@ mod tests {
         let runtime = BridgeRuntime::global();
         let store = inmemory_with(&runtime, &[("obj", b"hello world")]);
         let file = make_file(runtime, store, "obj");
-        let cow = file
-            .read::<common::generic_consts::Random, u8>(ReadRange::new(6, 5))
-            .expect("read");
+        let cow = file.read::<Random, u8>(ReadRange::new(6, 5)).expect("read");
         assert_eq!(&cow[..], b"world");
     }
 
@@ -529,7 +528,7 @@ mod tests {
             (3u32, ReadRange::new(10, 3)),
         ];
         let mut got: std::collections::HashMap<u32, Vec<u8>> = std::collections::HashMap::new();
-        file.read_batch::<common::generic_consts::Random, u8, _>(inputs, |u, s| {
+        file.read_batch::<Random, u8, _>(inputs, |u, s| {
             got.insert(u, s.to_vec());
             Ok(())
         })

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -373,7 +373,7 @@ fn build_dir_prefix(path: &Path) -> object_store::path::Path {
 mod tests {
     use bytes::Bytes;
     use common::generic_consts::{Random, Sequential};
-    use common::universal_io::{ListedFile, ReadRange, UniversalAppend, UniversalRead};
+    use common::universal_io::{ListedFile, ReadRange, UioResult, UniversalAppend, UniversalRead};
     use io_bridge::{BlobFile, BridgeRuntime};
     use object_store::memory::InMemory;
     use object_store::{PutMode, UpdateVersion};
@@ -528,9 +528,9 @@ mod tests {
             (3u32, ReadRange::new(10, 3)),
         ];
         let mut got: std::collections::HashMap<u32, Vec<u8>> = std::collections::HashMap::new();
-        file.read_batch::<Random, u8, _>(inputs, |u, s| {
+        file.read_batch::<Random, u8, _, _>(inputs, |u, s| {
             got.insert(u, s.to_vec());
-            Ok(())
+            UioResult::Ok(())
         })
         .expect("read_batch");
         assert_eq!(got[&1], b"hello");

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -528,7 +528,7 @@ mod tests {
             (3u32, ReadRange::new(10, 3)),
         ];
         let mut got: std::collections::HashMap<u32, Vec<u8>> = std::collections::HashMap::new();
-        file.read_batch::<Random, u8, _, _>(inputs, |u, s| {
+        file.read_batch(inputs, Random, |u, s| {
             got.insert(u, s.to_vec());
             UioResult::Ok(())
         })

--- a/lib/common/io_bridge_object_store/src/tests/integration.rs
+++ b/lib/common/io_bridge_object_store/src/tests/integration.rs
@@ -3,6 +3,7 @@
 use std::assert_matches;
 use std::path::Path;
 
+use common::generic_consts::Random;
 use common::universal_io::{
     ListedFile, ReadRange, UniversalAppend, UniversalIoError, UniversalRead,
 };
@@ -68,7 +69,7 @@ fn test_read_range() {
         BlobFile::<ObjectStoreSource<AmazonS3>>::open(&rustfs_aws_config(), runtime, "ranged.bin")
             .expect("open");
     let bytes = file
-        .read::<common::generic_consts::Random, u8>(ReadRange::new(16, 16))
+        .read::<Random, u8>(ReadRange::new(16, 16))
         .expect("read");
     assert_eq!(bytes.len(), 16);
     assert_eq!(bytes[0], 16);
@@ -90,7 +91,7 @@ fn test_read_batch_parallel() {
         .map(|i| (i, ReadRange::new(u64::from(i) * 16, 16)))
         .collect();
     let mut got: std::collections::HashMap<u32, Vec<u8>> = Default::default();
-    file.read_batch::<common::generic_consts::Random, u8, _>(inputs, |user_data, slice| {
+    file.read_batch::<Random, u8, _>(inputs, |user_data, slice| {
         got.insert(user_data, slice.to_vec());
         Ok(())
     })

--- a/lib/common/io_bridge_object_store/src/tests/integration.rs
+++ b/lib/common/io_bridge_object_store/src/tests/integration.rs
@@ -69,7 +69,7 @@ fn test_read_range() {
         BlobFile::<ObjectStoreSource<AmazonS3>>::open(&rustfs_aws_config(), runtime, "ranged.bin")
             .expect("open");
     let bytes = file
-        .read::<Random, u8>(ReadRange::new(16, 16))
+        .read::<_, u8>(ReadRange::new(16, 16), Random)
         .expect("read");
     assert_eq!(bytes.len(), 16);
     assert_eq!(bytes[0], 16);

--- a/lib/common/io_bridge_object_store/src/tests/integration.rs
+++ b/lib/common/io_bridge_object_store/src/tests/integration.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use common::generic_consts::Random;
 use common::universal_io::{
-    ListedFile, ReadRange, UniversalAppend, UniversalIoError, UniversalRead,
+    ListedFile, ReadRange, UioResult, UniversalAppend, UniversalIoError, UniversalRead,
 };
 use io_bridge::{AsyncRead, BridgeRuntime};
 use object_store::aws::AmazonS3;
@@ -91,9 +91,9 @@ fn test_read_batch_parallel() {
         .map(|i| (i, ReadRange::new(u64::from(i) * 16, 16)))
         .collect();
     let mut got: std::collections::HashMap<u32, Vec<u8>> = Default::default();
-    file.read_batch::<Random, u8, _>(inputs, |user_data, slice| {
+    file.read_batch::<Random, u8, _, _>(inputs, |user_data, slice| {
         got.insert(user_data, slice.to_vec());
-        Ok(())
+        UioResult::Ok(())
     })
     .expect("read_batch");
     assert_eq!(got.len(), 16);

--- a/lib/common/io_bridge_object_store/src/tests/integration.rs
+++ b/lib/common/io_bridge_object_store/src/tests/integration.rs
@@ -91,7 +91,7 @@ fn test_read_batch_parallel() {
         .map(|i| (i, ReadRange::new(u64::from(i) * 16, 16)))
         .collect();
     let mut got: std::collections::HashMap<u32, Vec<u8>> = Default::default();
-    file.read_batch::<Random, u8, _, _>(inputs, |user_data, slice| {
+    file.read_batch(inputs, Random, |user_data, slice| {
         got.insert(user_data, slice.to_vec());
         UioResult::Ok(())
     })

--- a/lib/gridstore/src/tracker/mod.rs
+++ b/lib/gridstore/src/tracker/mod.rs
@@ -150,7 +150,7 @@ fn read_slot<S: UniversalRead>(
     if end_offset as u64 > storage_len {
         return Ok(None);
     }
-    let opt = storage.read::<Random, OptionalPointer>(ReadRange::one(start_offset as u64))?[0];
+    let opt = storage.read::<_, OptionalPointer>(ReadRange::one(start_offset as u64), Random)?[0];
     Ok(opt.to_option())
 }
 
@@ -355,7 +355,7 @@ impl<S: UniversalRead> Tracker<S> {
     }
 
     fn read_header(storage: &S) -> Result<TrackerHeader> {
-        let header = storage.read::<Random, TrackerHeader>(ReadRange::one(0))?[0];
+        let header = storage.read(ReadRange::one(0), Random)?[0];
         Ok(header)
     }
 

--- a/lib/segment/src/id_tracker/disk_id_tracker/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/id_tracker_read.rs
@@ -46,6 +46,7 @@ impl<S: UniversalWrite + Send + Sync + 'static> DiskMappingsSource for DiskIdTra
             if !self.point_deleted(offset) {
                 on_live(id, offset);
             }
+            Ok(())
         })
     }
 }

--- a/lib/segment/src/id_tracker/disk_id_tracker/read_only/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/read_only/id_tracker_read.rs
@@ -121,7 +121,7 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyDiskIdTracker<S> {
                 (internal_id, range)
             });
         self.versions
-            .read_batch::<Random, PointOffsetType, _>(ranges, |internal_id, values| {
+            .read_batch(ranges, Random, |internal_id, values| {
                 if let Some(&version) = values.first() {
                     callback(internal_id, version);
                 }

--- a/lib/segment/src/id_tracker/disk_id_tracker/read_only/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/read_only/id_tracker_read.rs
@@ -60,10 +60,10 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyDiskIdTracker<S> {
         if u64::from(internal_id) >= self.versions_len {
             return None;
         }
-        match self.versions.read::<Random>(ReadRange {
-            byte_offset: u64::from(internal_id) * size_of::<SeqNumberType>() as u64,
-            length: 1,
-        }) {
+        match self.versions.read(
+            ReadRange::one(u64::from(internal_id) * size_of::<SeqNumberType>() as u64),
+            Random,
+        ) {
             Ok(values) => values.first().copied(),
             Err(err) => {
                 log::error!("disk id tracker version read failed: {err}");
@@ -173,10 +173,7 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyDiskIdTracker<S> {
     ) -> OperationResult<Box<dyn Iterator<Item = (PointOffsetType, SeqNumberType)> + '_>> {
         let versions = self
             .versions
-            .read::<Sequential>(ReadRange {
-                byte_offset: 0,
-                length: self.versions_len,
-            })?
+            .read(ReadRange::new(0, self.versions_len), Sequential)?
             .into_owned();
         Ok(Box::new(versions.into_iter().enumerate().map(
             |(offset, version)| (offset as PointOffsetType, version),

--- a/lib/segment/src/id_tracker/disk_id_tracker/read_only/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/read_only/id_tracker_read.rs
@@ -4,7 +4,7 @@ use common::bitvec::BitSlice;
 use common::generic_consts::{Random, Sequential};
 use common::iterator_ext::IteratorExt as _;
 use common::types::{DeferredBehavior, PointOffsetType};
-use common::universal_io::{ReadRange, UniversalRead};
+use common::universal_io::{ReadRange, UioResult, UniversalRead};
 use itertools::Itertools as _;
 
 use super::ReadOnlyDiskIdTracker;
@@ -40,21 +40,12 @@ impl<S: UniversalRead> DiskMappingsSource for ReadOnlyDiskIdTracker<S> {
         external_ids: impl IntoIterator<Item = PointIdType>,
         mut on_live: impl FnMut(PointIdType, PointOffsetType),
     ) -> OperationResult<()> {
-        // Use `first_err` instead of `?` to avoid UniversalIoError vs OperationResult problems
-        let mut first_err = None;
         self.reader.lookup_batch(external_ids, |id, offset| {
-            match self.point_deleted(offset) {
-                Ok(false) => on_live(id, offset),
-                Ok(true) => {}
-                Err(err) => {
-                    first_err.get_or_insert(err);
-                }
+            if !self.point_deleted(offset)? {
+                on_live(id, offset);
             }
-        })?;
-        match first_err {
-            Some(err) => Err(err),
-            None => Ok(()),
-        }
+            Ok(())
+        })
     }
 }
 
@@ -130,11 +121,11 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyDiskIdTracker<S> {
                 (internal_id, range)
             });
         self.versions
-            .read_batch::<Random, PointOffsetType>(ranges, |internal_id, values| {
+            .read_batch::<Random, PointOffsetType, _>(ranges, |internal_id, values| {
                 if let Some(&version) = values.first() {
                     callback(internal_id, version);
                 }
-                Ok(())
+                UioResult::Ok(())
             })?;
 
         Ok(())

--- a/lib/segment/src/id_tracker/disk_id_tracker/reader/lifecycle.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/reader/lifecycle.rs
@@ -4,6 +4,7 @@ use std::io::Cursor;
 use std::path::Path;
 
 use byteorder::{LittleEndian, ReadBytesExt};
+use common::generic_consts::Random;
 use common::mmap::AdviceSetting;
 use common::stored_bitmask::StoredBitmask;
 use common::universal_io::{
@@ -103,21 +104,21 @@ impl<S: UniversalRead> DiskMappingReader<S> {
         else {
             return Ok(None);
         };
-        let i2e_header_bytes = i2e.read::<common::generic_consts::Random, u8>(ReadRange {
+        let i2e_header_bytes = i2e.read::<Random, u8>(ReadRange {
             byte_offset: 0,
             length: I2E_HEADER_SIZE,
         })?;
         let i2e_header = I2eHeader::parse(i2e_header_bytes.as_ref())?;
 
         let e2i = fs.open(e2i_path(segment_path), options, Default::default())?;
-        let e2i_header_bytes = e2i.read::<common::generic_consts::Random, u8>(ReadRange {
+        let e2i_header_bytes = e2i.read::<Random, u8>(ReadRange {
             byte_offset: 0,
             length: E2I_HEADER_SIZE,
         })?;
         let e2i_header = E2iHeader::parse(e2i_header_bytes.as_ref())?;
 
         // Read the whole sparse index (numeric then UUID) in a single range.
-        let index_bytes = e2i.read::<common::generic_consts::Random, u8>(ReadRange {
+        let index_bytes = e2i.read::<Random, u8>(ReadRange {
             byte_offset: E2I_HEADER_SIZE,
             length: e2i_header.index_end() - E2I_HEADER_SIZE,
         })?;

--- a/lib/segment/src/id_tracker/disk_id_tracker/reader/lifecycle.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/reader/lifecycle.rs
@@ -104,24 +104,18 @@ impl<S: UniversalRead> DiskMappingReader<S> {
         else {
             return Ok(None);
         };
-        let i2e_header_bytes = i2e.read::<Random, u8>(ReadRange {
-            byte_offset: 0,
-            length: I2E_HEADER_SIZE,
-        })?;
+        let i2e_header_bytes = i2e.read::<_, u8>(ReadRange::new(0, I2E_HEADER_SIZE), Random)?;
         let i2e_header = I2eHeader::parse(i2e_header_bytes.as_ref())?;
 
         let e2i = fs.open(e2i_path(segment_path), options, Default::default())?;
-        let e2i_header_bytes = e2i.read::<Random, u8>(ReadRange {
-            byte_offset: 0,
-            length: E2I_HEADER_SIZE,
-        })?;
+        let e2i_header_bytes = e2i.read::<_, u8>(ReadRange::new(0, E2I_HEADER_SIZE), Random)?;
         let e2i_header = E2iHeader::parse(e2i_header_bytes.as_ref())?;
 
         // Read the whole sparse index (numeric then UUID) in a single range.
-        let index_bytes = e2i.read::<Random, u8>(ReadRange {
-            byte_offset: E2I_HEADER_SIZE,
-            length: e2i_header.index_end() - E2I_HEADER_SIZE,
-        })?;
+        let index_bytes = e2i.read::<_, u8>(
+            ReadRange::new(E2I_HEADER_SIZE, e2i_header.index_end() - E2I_HEADER_SIZE),
+            Random,
+        )?;
         let mut cursor = Cursor::new(index_bytes.as_ref());
         let mut num_sparse = Vec::with_capacity(e2i_header.num_blocks() as usize);
         for _ in 0..e2i_header.num_blocks() {

--- a/lib/segment/src/id_tracker/disk_id_tracker/reader/lookup.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/reader/lookup.rs
@@ -116,7 +116,8 @@ impl<S: UniversalRead> DiskMappingReader<S> {
     /// completes; absent ids are dropped. Delivery is in read-completion order,
     /// not input order — the id is rebuilt from `is_uuid` + key, so callers
     /// never need the input position. Deletion is NOT applied (same contract as
-    /// `lookup`); storage errors propagate.
+    /// `lookup`); storage errors and `on_found` errors propagate, aborting the
+    /// pass.
     ///
     /// Ids are not grouped by block up front: a block is one ~16 KiB DiskCache
     /// block, so reads landing in the same block are deduplicated by the cache
@@ -125,7 +126,7 @@ impl<S: UniversalRead> DiskMappingReader<S> {
     pub fn lookup_batch(
         &self,
         external_ids: impl IntoIterator<Item = PointIdType>,
-        mut on_found: impl FnMut(PointIdType, PointOffsetType),
+        mut on_found: impl FnMut(PointIdType, PointOffsetType) -> OperationResult<()>,
     ) -> OperationResult<()> {
         // Each read is tagged with `(is_uuid, key)` so the callback can pick the
         // decoder, binary-search, and rebuild the id. Ids outside every block
@@ -145,7 +146,7 @@ impl<S: UniversalRead> DiskMappingReader<S> {
             });
 
         self.e2i
-            .read_batch::<Random, u8, (bool, u128)>(ranges, |(is_uuid, key), bytes| {
+            .read_batch::<Random, u8, (bool, u128), _>(ranges, |(is_uuid, key), bytes| {
                 let entries = if is_uuid {
                     decode_uuid_block(bytes)
                 } else {
@@ -157,12 +158,10 @@ impl<S: UniversalRead> DiskMappingReader<S> {
                     } else {
                         PointIdType::NumId(key as u64)
                     };
-                    on_found(id, entries[pos].1);
+                    on_found(id, entries[pos].1)?;
                 }
                 Ok(())
-            })?;
-
-        Ok(())
+            })
     }
 
     /// Internal→external lookup ignoring deletion. `Ok(None)` for out-of-range
@@ -202,16 +201,14 @@ impl<S: UniversalRead> DiskMappingReader<S> {
             });
 
         self.i2e
-            .read_batch::<Random, u8, PointOffsetType>(ranges, |offset, bytes| {
+            .read_batch::<Random, u8, PointOffsetType, _>(ranges, |offset, bytes| {
                 let value = u128::from_le_bytes(bytes.try_into().expect("16 data bytes"));
                 on_found(
                     offset,
                     decode_external(value, self.is_uuid.contains(offset)),
                 );
                 Ok(())
-            })?;
-
-        Ok(())
+            })
     }
 
     /// One 16-byte i2e read; the `is_uuid` flag comes from the RAM-resident

--- a/lib/segment/src/id_tracker/disk_id_tracker/reader/lookup.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/reader/lookup.rs
@@ -39,7 +39,9 @@ impl<S: UniversalRead> DiskMappingReader<S> {
         &self,
         block: u64,
     ) -> OperationResult<Vec<(u128, PointOffsetType)>> {
-        let bytes = self.e2i.read::<Random, u8>(self.num_block_range(block))?;
+        let bytes = self
+            .e2i
+            .read::<_, u8>(self.num_block_range(block), Random)?;
         Ok(decode_num_block(bytes.as_ref()))
     }
 
@@ -47,7 +49,9 @@ impl<S: UniversalRead> DiskMappingReader<S> {
         &self,
         block: u64,
     ) -> OperationResult<Vec<(u128, PointOffsetType)>> {
-        let bytes = self.e2i.read::<Random, u8>(self.uuid_block_range(block))?;
+        let bytes = self
+            .e2i
+            .read::<_, u8>(self.uuid_block_range(block), Random)?;
         Ok(decode_uuid_block(bytes.as_ref()))
     }
 
@@ -214,10 +218,9 @@ impl<S: UniversalRead> DiskMappingReader<S> {
     /// bitmap.
     fn read_external_id(&self, offset: PointOffsetType) -> OperationResult<PointIdType> {
         let data_offset = self.i2e_header.data_offset + u64::from(offset) * 16;
-        let data = self.i2e.read::<Random, u8>(ReadRange {
-            byte_offset: data_offset,
-            length: 16,
-        })?;
+        let data = self
+            .i2e
+            .read::<_, u8>(ReadRange::new(data_offset, 16), Random)?;
         let value = u128::from_le_bytes(data.as_ref().try_into().expect("16 data bytes"));
         Ok(decode_external(value, self.is_uuid.contains(offset)))
     }

--- a/lib/segment/src/id_tracker/disk_id_tracker/reader/lookup.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/reader/lookup.rs
@@ -146,7 +146,7 @@ impl<S: UniversalRead> DiskMappingReader<S> {
             });
 
         self.e2i
-            .read_batch::<Random, u8, (bool, u128), _>(ranges, |(is_uuid, key), bytes| {
+            .read_batch(ranges, Random, |(is_uuid, key), bytes| {
                 let entries = if is_uuid {
                     decode_uuid_block(bytes)
                 } else {
@@ -200,15 +200,14 @@ impl<S: UniversalRead> DiskMappingReader<S> {
                 (offset, range)
             });
 
-        self.i2e
-            .read_batch::<Random, u8, PointOffsetType, _>(ranges, |offset, bytes| {
-                let value = u128::from_le_bytes(bytes.try_into().expect("16 data bytes"));
-                on_found(
-                    offset,
-                    decode_external(value, self.is_uuid.contains(offset)),
-                );
-                Ok(())
-            })
+        self.i2e.read_batch(ranges, Random, |offset, bytes| {
+            let value = u128::from_le_bytes(bytes.try_into().expect("16 data bytes"));
+            on_found(
+                offset,
+                decode_external(value, self.is_uuid.contains(offset)),
+            );
+            Ok(())
+        })
     }
 
     /// One 16-byte i2e read; the `is_uuid` flag comes from the RAM-resident

--- a/lib/segment/src/id_tracker/disk_id_tracker/reader/lookup.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/reader/lookup.rs
@@ -1,5 +1,6 @@
 //! Point lookups: sparse-index binary search plus one data-block read.
 
+use common::generic_consts::Random;
 use common::types::PointOffsetType;
 use common::universal_io::{ReadRange, UniversalRead};
 use uuid::Uuid;
@@ -38,9 +39,7 @@ impl<S: UniversalRead> DiskMappingReader<S> {
         &self,
         block: u64,
     ) -> OperationResult<Vec<(u128, PointOffsetType)>> {
-        let bytes = self
-            .e2i
-            .read::<common::generic_consts::Random, u8>(self.num_block_range(block))?;
+        let bytes = self.e2i.read::<Random, u8>(self.num_block_range(block))?;
         Ok(decode_num_block(bytes.as_ref()))
     }
 
@@ -48,9 +47,7 @@ impl<S: UniversalRead> DiskMappingReader<S> {
         &self,
         block: u64,
     ) -> OperationResult<Vec<(u128, PointOffsetType)>> {
-        let bytes = self
-            .e2i
-            .read::<common::generic_consts::Random, u8>(self.uuid_block_range(block))?;
+        let bytes = self.e2i.read::<Random, u8>(self.uuid_block_range(block))?;
         Ok(decode_uuid_block(bytes.as_ref()))
     }
 
@@ -148,25 +145,22 @@ impl<S: UniversalRead> DiskMappingReader<S> {
             });
 
         self.e2i
-            .read_batch::<common::generic_consts::Random, u8, (bool, u128)>(
-                ranges,
-                |(is_uuid, key), bytes| {
-                    let entries = if is_uuid {
-                        decode_uuid_block(bytes)
+            .read_batch::<Random, u8, (bool, u128)>(ranges, |(is_uuid, key), bytes| {
+                let entries = if is_uuid {
+                    decode_uuid_block(bytes)
+                } else {
+                    decode_num_block(bytes)
+                };
+                if let Ok(pos) = entries.binary_search_by_key(&key, |(k, _)| *k) {
+                    let id = if is_uuid {
+                        PointIdType::Uuid(Uuid::from_u128(key))
                     } else {
-                        decode_num_block(bytes)
+                        PointIdType::NumId(key as u64)
                     };
-                    if let Ok(pos) = entries.binary_search_by_key(&key, |(k, _)| *k) {
-                        let id = if is_uuid {
-                            PointIdType::Uuid(Uuid::from_u128(key))
-                        } else {
-                            PointIdType::NumId(key as u64)
-                        };
-                        on_found(id, entries[pos].1);
-                    }
-                    Ok(())
-                },
-            )?;
+                    on_found(id, entries[pos].1);
+                }
+                Ok(())
+            })?;
 
         Ok(())
     }
@@ -208,17 +202,14 @@ impl<S: UniversalRead> DiskMappingReader<S> {
             });
 
         self.i2e
-            .read_batch::<common::generic_consts::Random, u8, PointOffsetType>(
-                ranges,
-                |offset, bytes| {
-                    let value = u128::from_le_bytes(bytes.try_into().expect("16 data bytes"));
-                    on_found(
-                        offset,
-                        decode_external(value, self.is_uuid.contains(offset)),
-                    );
-                    Ok(())
-                },
-            )?;
+            .read_batch::<Random, u8, PointOffsetType>(ranges, |offset, bytes| {
+                let value = u128::from_le_bytes(bytes.try_into().expect("16 data bytes"));
+                on_found(
+                    offset,
+                    decode_external(value, self.is_uuid.contains(offset)),
+                );
+                Ok(())
+            })?;
 
         Ok(())
     }
@@ -227,12 +218,10 @@ impl<S: UniversalRead> DiskMappingReader<S> {
     /// bitmap.
     fn read_external_id(&self, offset: PointOffsetType) -> OperationResult<PointIdType> {
         let data_offset = self.i2e_header.data_offset + u64::from(offset) * 16;
-        let data = self
-            .i2e
-            .read::<common::generic_consts::Random, u8>(ReadRange {
-                byte_offset: data_offset,
-                length: 16,
-            })?;
+        let data = self.i2e.read::<Random, u8>(ReadRange {
+            byte_offset: data_offset,
+            length: 16,
+        })?;
         let value = u128::from_le_bytes(data.as_ref().try_into().expect("16 data bytes"));
         Ok(decode_external(value, self.is_uuid.contains(offset)))
     }

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/lifecycle.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/lifecycle.rs
@@ -90,10 +90,8 @@ impl<S: UniversalRead> ReadOnlyImmutableIdTracker<S> {
             CompressedVersions::from_slice(&internal_to_version_file.read_whole()?);
 
         let mappings_file = fs.open(mappings_path(segment_path), options, Default::default())?;
-        let mappings_bytes = mappings_file.read::<Sequential, u8>(ReadRange {
-            byte_offset: 0,
-            length: mappings_file.len::<u8>()?,
-        })?;
+        let mappings_bytes = mappings_file
+            .read::<_, u8>(ReadRange::new(0, mappings_file.len::<u8>()?), Sequential)?;
         let mappings = load_mapping(Cursor::new(mappings_bytes.as_ref()), Some(deleted_bitvec))?;
 
         Ok(Self {

--- a/lib/segment/src/id_tracker/mutable_id_tracker/read_only/live_reload.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/read_only/live_reload.rs
@@ -162,10 +162,7 @@ impl<S: UniversalRead> ReadOnlyAppendableIdTracker<S> {
             return Ok(Vec::new());
         }
 
-        let bytes = file.read::<Sequential, u8>(ReadRange {
-            byte_offset: start,
-            length: file_len - start,
-        })?;
+        let bytes = file.read::<_, u8>(ReadRange::new(start, file_len - start), Sequential)?;
         let mut reader = Cursor::new(bytes.as_ref());
 
         let mut changes = Vec::new();
@@ -218,10 +215,10 @@ impl<S: UniversalRead> ReadOnlyAppendableIdTracker<S> {
         // Append the newly flushed tail. Anything beyond `versions_len` is not flushed yet and
         // stays absent until a later reload (the mapped-but-versionless case).
         if versions_len > loaded_len {
-            let tail = versions_file.read::<Sequential, SeqNumberType>(ReadRange {
-                byte_offset: loaded_len * VERSION_ELEMENT_SIZE,
-                length: versions_len - loaded_len,
-            })?;
+            let tail = versions_file.read::<_, SeqNumberType>(
+                ReadRange::new(loaded_len * VERSION_ELEMENT_SIZE, versions_len - loaded_len),
+                Sequential,
+            )?;
             internal_to_version.extend_from_slice(&tail);
         }
 

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
@@ -824,6 +824,6 @@ fn read_point_to_tokens_count<S: UniversalRead>(
     point_id: PointOffsetType,
 ) -> Option<usize> {
     let byte_offset = u64::from(point_id).checked_mul(size_of::<usize>() as u64)?;
-    let cow = storage.read::<Random>(ReadRange::one(byte_offset)).ok()?;
+    let cow = storage.read(ReadRange::one(byte_offset), Random).ok()?;
     cow.first().copied()
 }

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
@@ -4,7 +4,8 @@ use std::path::PathBuf;
 
 use common::generic_consts::{Random, Sequential};
 use common::universal_io::{
-    OkNotFound, OpenOptions, ReadRange, UniversalIoError, UniversalRead, UniversalReadFs,
+    OkNotFound, OpenOptions, ReadRange, UniversalIoError, UioResult, UniversalRead,
+    UniversalReadFs,
 };
 use posting_list::{PostingList, PostingListView};
 use zerocopy::FromBytes;
@@ -115,13 +116,13 @@ impl<V: ZerocopyPostingValue, S: UniversalRead> OnDiskPostings<V, S> {
         // the read — `read_batch` is sufficient here, no pipeline needed.
         let mut headers: Vec<HeaderResult> = Vec::with_capacity(valid_ranges.len());
         self.storage
-            .read_batch::<Random, u8, _>(valid_ranges, |token_id, bytes| {
+            .read_batch::<Random, u8, _, _>(valid_ranges, |token_id, bytes| {
                 headers.push(
                     PostingListHeader::read_from_prefix(bytes)
                         .map(|(header, _)| (token_id, header))
                         .map_err(UniversalIoError::from),
                 );
-                Ok(())
+                UioResult::Ok(())
             })?;
 
         Ok(HeadersBatch {

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
@@ -116,7 +116,7 @@ impl<V: ZerocopyPostingValue, S: UniversalRead> OnDiskPostings<V, S> {
         // the read — `read_batch` is sufficient here, no pipeline needed.
         let mut headers: Vec<HeaderResult> = Vec::with_capacity(valid_ranges.len());
         self.storage
-            .read_batch::<Random, u8, _, _>(valid_ranges, |token_id, bytes| {
+            .read_batch(valid_ranges, Random, |token_id, bytes| {
                 headers.push(
                     PostingListHeader::read_from_prefix(bytes)
                         .map(|(header, _)| (token_id, header))

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
@@ -57,7 +57,7 @@ impl<V: ZerocopyPostingValue, S: UniversalRead> OnDiskPostings<V, S> {
             return Ok(None);
         };
 
-        let header = storage.read::<Sequential, PostingsHeader>(ReadRange::one(0))?[0];
+        let header = storage.read::<_, PostingsHeader>(ReadRange::one(0), Sequential)?[0];
 
         Ok(Some(Self {
             _path: path,
@@ -161,7 +161,7 @@ impl<V: ZerocopyPostingValue, S: UniversalRead> OnDiskPostings<V, S> {
             byte_offset: header.offset,
             length: header.posting_size::<V>() as u64,
         };
-        let bytes = self.storage.read::<Sequential, u8>(read_range)?;
+        let bytes = self.storage.read::<_, u8>(read_range, Sequential)?;
         let result = RawPostingList::new(bytes, header);
         Ok(result)
     }

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
@@ -211,7 +211,7 @@ impl<V: ZerocopyPostingValue, S: UniversalRead> OnDiskPostings<V, S> {
         let mut raw_postings: Vec<(TokenId, RawPostingList<'_>)> =
             Vec::with_capacity(expected_capacity);
 
-        for entry in self.storage.read_iter::<Sequential, u8, _>(range_iter)? {
+        for entry in self.storage.read_iter(range_iter, Sequential)? {
             let ((token_id, header), bytes) = entry?;
             raw_postings.push((token_id, RawPostingList::new(bytes, header)));
         }

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index/lifecycle.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use ahash::AHashSet;
 use common::generic_consts::Random;
 use common::types::PointOffsetType;
-use common::universal_io::{ReadRange, UniversalRead};
+use common::universal_io::{ReadRange, UioResult, UniversalRead};
 
 use super::super::on_disk_geo_index::OnDiskGeoIndex;
 use super::{Counts, DELETED_SENTINEL, ImmutableGeoIndex};
@@ -34,7 +34,7 @@ impl<S: UniversalRead> ImmutableGeoIndex<S> {
         let mut points_map_offsets = Vec::with_capacity(num_entries + 1);
         let mut points_map_ids = Vec::new();
 
-        index.storage.points_map_ids.read_batch::<Random, _>(
+        index.storage.points_map_ids.read_batch::<Random, _, _>(
             points_map_entries
                 .iter()
                 .map(|item| ReadRange {
@@ -50,7 +50,7 @@ impl<S: UniversalRead> ImmutableGeoIndex<S> {
                         points_map_ids.push(id);
                     }
                 }
-                Ok(())
+                UioResult::Ok(())
             },
         )?;
         points_map_offsets.push(points_map_ids.len() as u32);

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index/lifecycle.rs
@@ -34,7 +34,7 @@ impl<S: UniversalRead> ImmutableGeoIndex<S> {
         let mut points_map_offsets = Vec::with_capacity(num_entries + 1);
         let mut points_map_ids = Vec::new();
 
-        index.storage.points_map_ids.read_batch::<Random, _, _>(
+        index.storage.points_map_ids.read_batch(
             points_map_entries
                 .iter()
                 .map(|item| ReadRange {
@@ -42,6 +42,7 @@ impl<S: UniversalRead> ImmutableGeoIndex<S> {
                     length: u64::from(item.ids_end.saturating_sub(item.ids_start)),
                 })
                 .enumerate(),
+            Random,
             |i, ids| {
                 points_map_hashes.push(points_map_entries[i].hash.normalize());
                 points_map_offsets.push(points_map_ids.len() as u32);

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
@@ -600,8 +600,9 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         // non-deleted point ids.
         let mut points = AHashSet::new();
         let deleted = &self.storage.deleted;
-        self.storage.points_map_ids.read_batch::<Random, _, _>(
+        self.storage.points_map_ids.read_batch(
             point_map_ranges.into_iter().enumerate(),
+            Random,
             |_idx, values| {
                 points.extend(values.iter().copied().filter(|&id| deleted.is_active(id)));
                 UioResult::Ok(())

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
@@ -13,7 +13,7 @@ use common::mmap::{AdviceSetting, MmapSlice, create_and_ensure_length};
 use common::types::PointOffsetType;
 use common::universal_io::{
     CachedReadFs, MmapFile, OkNotFound, OpenOptions, Populate, ReadRange, SortedBlockIndex,
-    TypedStorage, UniversalRead, UniversalReadFs, UserData, read_json_via,
+    TypedStorage, UioResult, UniversalRead, UniversalReadFs, UserData, read_json_via,
 };
 use fs_err as fs;
 use memmap2::MmapMut;
@@ -600,11 +600,11 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         // non-deleted point ids.
         let mut points = AHashSet::new();
         let deleted = &self.storage.deleted;
-        self.storage.points_map_ids.read_batch::<Random, _>(
+        self.storage.points_map_ids.read_batch::<Random, _, _>(
             point_map_ranges.into_iter().enumerate(),
             |_idx, values| {
                 points.extend(values.iter().copied().filter(|&id| deleted.is_active(id)));
-                Ok(())
+                UioResult::Ok(())
             },
         )?;
 

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
@@ -337,10 +337,10 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         &self,
         filter: impl Fn(&(GeoHash, usize)) -> bool,
     ) -> OperationResult<Vec<(GeoHash, usize)>> {
-        let counts = self.storage.counts_per_hash.read::<Sequential>(ReadRange {
-            byte_offset: 0,
-            length: self.storage.counts_per_hash.len()?,
-        })?;
+        let counts = self.storage.counts_per_hash.read(
+            ReadRange::new(0, self.storage.counts_per_hash.len()?),
+            Sequential,
+        )?;
         let mut results = Vec::with_capacity(counts.len());
         for count in counts.iter() {
             let pair = (count.hash.normalize(), count.points as usize);
@@ -391,10 +391,11 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
                 .payload_index_io_read_counter()
                 .incr_delta(block.len() * size_of::<Counts>());
 
-            let counts = self.storage.counts_per_hash.read::<Random>(ReadRange {
-                byte_offset: (block.start * size_of::<Counts>()) as u64,
-                length: block.len() as u64,
-            })?;
+            let range = ReadRange::new(
+                (block.start * size_of::<Counts>()) as u64,
+                block.len() as u64,
+            );
+            let counts = self.storage.counts_per_hash.read(range, Random)?;
             return Ok(counts
                 .binary_search_by(|counts| counts.hash.normalize().cmp(&hash))
                 .ok()
@@ -408,7 +409,7 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
 
         let read_one = |idx| -> OperationResult<Counts> {
             let range = ReadRange::one((idx * size_of::<Counts>()) as u64);
-            let value = self.storage.counts_per_hash.read::<Random>(range)?;
+            let value = self.storage.counts_per_hash.read(range, Random)?;
             Ok(value[0])
         };
 
@@ -529,10 +530,13 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         // block instead of `O(log n)` random reads.
         let start_idx = if let Some(block_index) = &self.storage.points_map_block_index {
             let block = block_index.find_block(|entry| entry.hash.normalize().cmp(&smallest_hash));
-            let entries = self.storage.points_map.read::<Random>(ReadRange {
-                byte_offset: (block.start * size_of::<PointKeyValue>()) as u64,
-                length: block.len() as u64,
-            })?;
+            let entries = self.storage.points_map.read(
+                ReadRange {
+                    byte_offset: (block.start * size_of::<PointKeyValue>()) as u64,
+                    length: block.len() as u64,
+                },
+                Random,
+            )?;
             let idx = entries
                 .binary_search_by(|entry| entry.hash.normalize().cmp(&smallest_hash))
                 .unwrap_or_else(|idx| idx);
@@ -540,7 +544,7 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         } else {
             binary_search_by(0..len, |idx| {
                 let range = ReadRange::one(idx * size_of::<PointKeyValue>() as u64);
-                let value = self.storage.points_map.read::<Random>(range)?;
+                let value = self.storage.points_map.read(range, Random)?;
                 OperationResult::Ok(value[0].hash.normalize().cmp(&smallest_hash))
             })?
             .unwrap_or_else(|index| index)

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/lifecycle.rs
@@ -550,13 +550,14 @@ impl<S: UniversalRead> OnDiskGeoIndex<S> {
         // arrive out of order from the underlying IO, so we reorder them with
         // `OrderingIterator` before inspecting their contents; this lets us
         // stop reading as soon as we walk past the last prefix.
-        let chunks = self.storage.points_map.read_iter::<Sequential, _>(
+        let chunks = self.storage.points_map.read_iter(
             ReadRange {
                 byte_offset: start_idx * size_of::<PointKeyValue>() as u64,
                 length: len - start_idx,
             }
             .iter_autochunks::<PointKeyValue>()
             .enumerate(),
+            Sequential,
         )?;
 
         let ordered_chunks = OrderingIterator::new(chunks);

--- a/lib/segment/src/index/field_index/map_index/prefix_index/reader.rs
+++ b/lib/segment/src/index/field_index/map_index/prefix_index/reader.rs
@@ -102,7 +102,7 @@ impl<S: UniversalRead> PrefixIndex<S> {
         )?;
 
         let header_size = size_of::<Header>() as u64;
-        let header_bytes = storage.read_bytes::<Random>(0..header_size, align_of::<Header>())?;
+        let header_bytes = storage.read_bytes(0..header_size, Random, align_of::<Header>())?;
         let header: Header = bytemuck::try_pod_read_unaligned(header_bytes.as_ref())
             .map_err(|_| OperationError::service_error("Failed to read prefix index header"))?;
 
@@ -118,8 +118,11 @@ impl<S: UniversalRead> PrefixIndex<S> {
             )));
         }
 
-        let index_bytes =
-            storage.read_bytes::<Random>(header_size..header_size + header.block_index_size, 1)?;
+        let index_bytes = storage.read_bytes(
+            header_size..header_size + header.block_index_size,
+            Random,
+            1,
+        )?;
         let blocks = Self::parse_block_index(
             index_bytes.as_ref(),
             header.block_count,

--- a/lib/segment/src/index/field_index/map_index/prefix_index/reader.rs
+++ b/lib/segment/src/index/field_index/map_index/prefix_index/reader.rs
@@ -230,10 +230,10 @@ impl<S: UniversalRead> PrefixIndex<S> {
             .payload_index_io_read_counter()
             .incr_delta((last_block.bytes.end - bytes_start) as usize);
 
-        let bytes = self.storage.read::<Random, u8>(ReadRange::new(
-            bytes_start,
-            last_block.bytes.end - bytes_start,
-        ))?;
+        let bytes = self.storage.read::<_, u8>(
+            ReadRange::new(bytes_start, last_block.bytes.end - bytes_start),
+            Random,
+        )?;
 
         for block in &self.blocks[range] {
             let block_bytes = bytes
@@ -339,10 +339,10 @@ impl<S: UniversalRead> PrefixIndex<S> {
             .payload_index_io_read_counter()
             .incr_delta((block.bytes.end - block.bytes.start) as usize);
 
-        let bytes = self.storage.read::<Random, u8>(ReadRange::new(
-            block.bytes.start,
-            block.bytes.end - block.bytes.start,
-        ))?;
+        let bytes = self.storage.read::<_, u8>(
+            ReadRange::new(block.bytes.start, block.bytes.end - block.bytes.start),
+            Random,
+        )?;
         decode_block(bytes.as_ref(), block.key_count, f)
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/read_ops.rs
@@ -184,10 +184,13 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
                 // saturates to the boundary the block lies beyond.
                 return Ok(Err(if block.end <= lo { lo } else { hi }));
             }
-            let elems = self.storage.pairs.read::<Random>(ReadRange {
-                byte_offset: (block_lo * size_of::<Point<T>>()) as u64,
-                length: (block_hi - block_lo) as u64,
-            })?;
+            let elems = self.storage.pairs.read(
+                ReadRange::new(
+                    (block_lo * size_of::<Point<T>>()) as u64,
+                    (block_hi - block_lo) as u64,
+                ),
+                Random,
+            )?;
             return Ok(elems
                 .binary_search(bound)
                 .map(|idx| idx + block_lo)
@@ -198,11 +201,10 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
         let mut right = hi;
         while left < right {
             let mid = left + (right - left) / 2;
-            // TODO(luis): use read_one
-            let elem = self.storage.pairs.read::<Random>(ReadRange {
-                byte_offset: (mid * size_of::<Point<T>>()) as u64,
-                length: 1,
-            })?;
+            let elem = self
+                .storage
+                .pairs
+                .read(ReadRange::one((mid * size_of::<Point<T>>()) as u64), Random)?;
             match elem[0].cmp(bound) {
                 std::cmp::Ordering::Less => left = mid + 1,
                 std::cmp::Ordering::Equal => return Ok(Ok(mid)),
@@ -261,10 +263,10 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
         let count = end_pos - start_pos;
 
         let iter = if count > 0 {
-            match self.storage.pairs.read::<Random>(ReadRange {
-                byte_offset: (start_pos * size_of::<Point<T>>()) as u64,
-                length: count as u64,
-            })? {
+            match self.storage.pairs.read(
+                ReadRange::new((start_pos * size_of::<Point<T>>()) as u64, count as u64),
+                Random,
+            )? {
                 Cow::Borrowed(slice) => Either::Left(slice.iter().copied()),
                 Cow::Owned(vec) => Either::Right(vec.into_iter()),
             }

--- a/lib/segment/src/index/field_index/on_disk_point_to_values.rs
+++ b/lib/segment/src/index/field_index/on_disk_point_to_values.rs
@@ -304,7 +304,7 @@ where
             Some((user_data, ReadRange::new(byte_offset, length)))
         });
         self.store
-            .read_batch::<Random, MmapRange, _, _>(range_reads, |user_data, ranges| {
+            .read_batch(range_reads, Random, |user_data, ranges| {
                 let MmapRange { start, count } = ranges[0];
 
                 // Use next point's start as end offset for this one.
@@ -330,7 +330,7 @@ where
             .into_iter()
             .map(|(user_data, count, range)| ((user_data, count), range));
         self.store
-            .read_batch::<Random, u8, _, _>(value_reads, |(user_data, count), bytes| {
+            .read_batch(value_reads, Random, |(user_data, count), bytes| {
                 f(user_data, ValuesIter::new(Cow::Borrowed(bytes), count));
                 UioResult::Ok(())
             })?;

--- a/lib/segment/src/index/field_index/on_disk_point_to_values.rs
+++ b/lib/segment/src/index/field_index/on_disk_point_to_values.rs
@@ -10,8 +10,8 @@ use common::generic_consts::Random;
 use common::mmap::{AdviceSetting, create_and_ensure_length, open_write_mmap};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    self, CachedReadFs, OpenOptions, Populate, ReadOnly, ReadRange, UniversalRead, UniversalReadFs,
-    UserData,
+    self, CachedReadFs, OpenOptions, Populate, ReadOnly, ReadRange, UioResult, UniversalRead,
+    UniversalReadFs, UserData,
 };
 use zerocopy::IntoBytes;
 
@@ -304,7 +304,7 @@ where
             Some((user_data, ReadRange::new(byte_offset, length)))
         });
         self.store
-            .read_batch::<Random, MmapRange, _>(range_reads, |user_data, ranges| {
+            .read_batch::<Random, MmapRange, _, _>(range_reads, |user_data, ranges| {
                 let MmapRange { start, count } = ranges[0];
 
                 // Use next point's start as end offset for this one.
@@ -322,7 +322,7 @@ where
                 // usually marked in `deleted`.
                 value_reads.push((user_data, count as usize, ReadRange::new(start, length)));
 
-                Ok(())
+                UioResult::Ok(())
             })?;
 
         // Batch 2: Read and pass the values to the callback as `ValuesIter`s.
@@ -330,9 +330,9 @@ where
             .into_iter()
             .map(|(user_data, count, range)| ((user_data, count), range));
         self.store
-            .read_batch::<Random, u8, _>(value_reads, |(user_data, count), bytes| {
+            .read_batch::<Random, u8, _, _>(value_reads, |(user_data, count), bytes| {
                 f(user_data, ValuesIter::new(Cow::Borrowed(bytes), count));
-                Ok(())
+                UioResult::Ok(())
             })?;
 
         Ok(())

--- a/lib/segment/src/index/field_index/on_disk_point_to_values.rs
+++ b/lib/segment/src/index/field_index/on_disk_point_to_values.rs
@@ -205,7 +205,7 @@ where
 
         let store = ReadOnly::open(fs, &file_name, open_options, Default::default())?;
 
-        let header = store.read::<Random, Header>(ReadRange::one(0))?[0];
+        let header = store.read(ReadRange::one(0), Random)?[0];
 
         Ok(Self {
             file_name,
@@ -264,7 +264,7 @@ where
             return Ok(None);
         };
 
-        let bytes = self.store.read::<Random, u8>(bytes_range)?;
+        let bytes = self.store.read(bytes_range, Random)?;
         let count = self.get_values_count(point_id)?.unwrap_or(0);
 
         let iter = ValuesIter::new(bytes, count);
@@ -366,7 +366,7 @@ where
 
             let range = self
                 .store
-                .read::<Random, MmapRange>(ReadRange::one(range_offset as u64))?[0];
+                .read(ReadRange::one(range_offset as u64), Random)?[0];
             Ok(Some(range))
         } else {
             Ok(None)

--- a/lib/segment/src/vector_storage/chunked_vectors/read.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read.rs
@@ -195,9 +195,9 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> ChunkedVectorsRead<T, S> {
             force_sequential || range.length as usize * size_of::<T>() > PAGE_SIZE_BYTES * 4;
 
         if use_sequential {
-            chunk.read::<Sequential>(range).ok()
+            chunk.read(range, Sequential).ok()
         } else {
-            chunk.read::<Random>(range).ok()
+            chunk.read(range, Random).ok()
         }
     }
 

--- a/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
@@ -199,6 +199,8 @@ impl VectorStorage for EmptyDenseVectorStorage {
 
 #[cfg(test)]
 mod tests {
+    use common::generic_consts::Random;
+
     use super::*;
 
     #[test]
@@ -226,16 +228,8 @@ mod tests {
         assert!(storage.multi_vector_config().is_none());
 
         // get_vector_opt always returns None
-        assert!(
-            storage
-                .get_vector_opt::<common::generic_consts::Random>(0)
-                .is_none()
-        );
-        assert!(
-            storage
-                .get_vector_opt::<common::generic_consts::Random>(500)
-                .is_none()
-        );
+        assert!(storage.get_vector_opt::<Random>(0).is_none());
+        assert!(storage.get_vector_opt::<Random>(500).is_none());
     }
 
     #[test]

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -200,7 +200,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectorData<T, S>
         };
 
         // access pattern does not matter for io_uring
-        self.storage.read_batch::<Random, _, _>(ranges, callback)?;
+        self.storage.read_batch(ranges, Random, callback)?;
         Ok(())
     }
 

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -122,7 +122,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectorData<T, S>
         };
 
         self.storage
-            .read::<P>(range)
+            .read(range, P::default())
             .expect("vector read from storage failed")
     }
 

--- a/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/immutable_dense_vectors.rs
@@ -12,7 +12,7 @@ use common::mmap::{AdviceSetting, MmapBitSlice, MmapFlusher};
 use common::types::PointOffsetType;
 use common::universal_io::{
     CachedReadFs, MmapFile, OpenOptions as UniversalOpenOptions, Populate, ReadOnly, ReadRange,
-    TypedStorage, UniversalRead, UniversalReadFs,
+    TypedStorage, UioResult, UniversalRead, UniversalReadFs,
 };
 use fs_err::{File, OpenOptions};
 
@@ -196,11 +196,11 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> ImmutableDenseVectorData<T, S>
 
         let callback = move |idx, vector: &[T]| {
             callback(idx, vector);
-            Ok(())
+            UioResult::Ok(())
         };
 
         // access pattern does not matter for io_uring
-        self.storage.read_batch::<Random, _>(ranges, callback)?;
+        self.storage.read_batch::<Random, _, _>(ranges, callback)?;
         Ok(())
     }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
@@ -213,9 +213,10 @@ impl<S: UniversalRead> MultivectorOffsetsStorage for MultivectorOffsetsStorageMm
     fn get_offset(&self, idx: PointOffsetType) -> MultivectorOffset {
         let offset = self
             .offsets
-            .read::<Random>(ReadRange::one(
-                u64::from(idx) * size_of::<MultivectorOffset>() as u64,
-            ))
+            .read(
+                ReadRange::one(u64::from(idx) * size_of::<MultivectorOffset>() as u64),
+                Random,
+            )
             .expect("multi-vector offset read");
 
         let [offset] = offset.as_ref() else {

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
@@ -6,8 +6,8 @@ use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting, MmapFlusher, MmapSlice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFile, MmapFs, OpenOptions, Populate, ReadRange, TypedStorage, UniversalRead,
-    UniversalReadFs, UniversalWrite,
+    CachedReadFs, MmapFile, MmapFs, OpenOptions, Populate, ReadRange, TypedStorage, UioResult,
+    UniversalRead, UniversalReadFs, UniversalWrite,
 };
 use fs_err as fs;
 use memmap2::MmapMut;
@@ -236,12 +236,12 @@ impl<S: UniversalRead> MultivectorOffsetsStorage for MultivectorOffsetsStorageMm
         });
 
         self.offsets
-            .read_batch::<Random, _>(ranges, |idx, offset| {
+            .read_batch::<Random, _, _>(ranges, |idx, offset| {
                 let [offset] = offset else {
                     unreachable!("multi-vector offsets are stored as a single-element slice");
                 };
                 callback(idx, *offset);
-                Ok(())
+                UioResult::Ok(())
             })?;
         Ok(())
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/offsets.rs
@@ -235,14 +235,13 @@ impl<S: UniversalRead> MultivectorOffsetsStorage for MultivectorOffsetsStorageMm
             (idx, ReadRange::one(offset))
         });
 
-        self.offsets
-            .read_batch::<Random, _, _>(ranges, |idx, offset| {
-                let [offset] = offset else {
-                    unreachable!("multi-vector offsets are stored as a single-element slice");
-                };
-                callback(idx, *offset);
-                UioResult::Ok(())
-            })?;
+        self.offsets.read_batch(ranges, Random, |idx, offset| {
+            let [offset] = offset else {
+                unreachable!("multi-vector offsets are stored as a single-element slice");
+            };
+            callback(idx, *offset);
+            UioResult::Ok(())
+        })?;
         Ok(())
     }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -11,8 +11,8 @@ use common::maybe_uninit::maybe_uninit_fill_from;
 use common::mmap::{AdviceSetting, MmapFlusher, advice};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFile, MmapFs, OpenOptions, Populate, ReadOnly, ReadRange, UniversalRead,
-    UniversalReadFs,
+    CachedReadFs, MmapFile, MmapFs, OpenOptions, Populate, ReadOnly, ReadRange, UioResult,
+    UniversalRead, UniversalReadFs,
 };
 use fs_err as fs;
 use memmap2::MmapMut;
@@ -93,11 +93,12 @@ impl<S: UniversalRead> QuantizedStorage<S> {
 
             let callback = |idx, bytes: &[u8]| {
                 f(idx, bytes);
-                Ok(())
+                UioResult::Ok(())
             };
 
             // Access pattern does not matter for io_uring.
-            self.storage.read_batch::<Random, u8, _>(ranges, callback)?;
+            self.storage
+                .read_batch::<Random, u8, _, _>(ranges, callback)?;
             return Ok(());
         }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -97,8 +97,7 @@ impl<S: UniversalRead> QuantizedStorage<S> {
             };
 
             // Access pattern does not matter for io_uring.
-            self.storage
-                .read_batch::<Random, u8, _, _>(ranges, callback)?;
+            self.storage.read_batch(ranges, Random, callback)?;
             return Ok(());
         }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -64,10 +64,7 @@ impl<S: UniversalRead> QuantizedStorage<S> {
     fn read_vector<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [u8]> {
         let size = self.quantized_vector_size.get() as u64;
         self.storage
-            .read::<P, u8>(ReadRange {
-                byte_offset: size * u64::from(key),
-                length: size,
-            })
+            .read(ReadRange::new(size * u64::from(key), size), P::default())
             .expect("vector read from quantized storage failed")
     }
 
@@ -228,10 +225,7 @@ impl<S: UniversalRead> quantization::EncodedStorage for QuantizedStorage<S> {
         let start = (self.quantized_vector_size.get() * index as usize) as u64;
         let length = self.quantized_vector_size.get() as u64;
         self.storage
-            .read::<Random, u8>(ReadRange {
-                byte_offset: start,
-                length,
-            })
+            .read(ReadRange::new(start, length), Random)
             .ok()
     }
 

--- a/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
+++ b/lib/segment/src/vector_storage/sparse/empty_sparse_vector_storage.rs
@@ -167,6 +167,8 @@ impl VectorStorage for EmptySparseVectorStorage {
 
 #[cfg(test)]
 mod tests {
+    use common::generic_consts::Random;
+
     use super::*;
 
     #[test]
@@ -184,17 +186,8 @@ mod tests {
         assert!(storage.is_deleted_vector(499));
         assert!(storage.files().is_empty());
 
-        assert!(
-            storage
-                .get_vector_opt::<common::generic_consts::Random>(0)
-                .is_none()
-        );
-        assert!(
-            storage
-                .get_sparse_opt::<common::generic_consts::Random>(0)
-                .unwrap()
-                .is_none()
-        );
+        assert!(storage.get_vector_opt::<Random>(0).is_none());
+        assert!(storage.get_sparse_opt::<Random>(0).unwrap().is_none());
     }
 
     #[test]

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -349,8 +349,9 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
     ) -> UioResult<()> {
         // Phase 1: read all headers as one contiguous range.
         let storage_len = self.storage.len::<u8>()?;
-        let headers = self.storage.read_bytes::<Sequential>(
+        let headers = self.storage.read_bytes(
             0..(self.file_header.posting_count * Self::HEADER_SIZE) as u64,
+            Sequential,
             align_of::<PostingListFileHeader<W>>(),
         )?;
         hw_counter.vector_io_read().incr_delta(headers.len());

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -369,7 +369,7 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
         });
 
         // Phase 2: read each posting's data via batched reads.
-        for record in self.storage.read_bytes_iter::<Random, _>(ranges)? {
+        for record in self.storage.read_bytes_iter(ranges, Random)? {
             let ((id, header), data) = record?;
             let view = CompressedPostingListView::new(header, &data, hw_counter)
                 .ok_or_else(corrupted_index)?;
@@ -403,7 +403,7 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
         // Phase 2: read each posting's data via batched reads.
         let views = self
             .storage
-            .read_bytes_iter::<Random, _>(ranges)?
+            .read_bytes_iter(ranges, Random)?
             .map(move |record| {
                 let ((user_data, header), data) = record?;
                 let data = match data {
@@ -448,7 +448,7 @@ impl<W: Weight, S: UniversalRead + Debug + 'static> InvertedIndexCompressedMmap<
             })
         });
 
-        for record in self.storage.read_bytes_iter::<Random, _>(ranges)? {
+        for record in self.storage.read_bytes_iter(ranges, Random)? {
             let ((user_data, has_next), header_bytes) = record?;
             hw_counter.vector_io_read().incr_delta(header_bytes.len());
             let (&header, rest) = PostingListFileHeader::<W>::ref_from_prefix(&header_bytes)

--- a/src/tonic/api/storage_read_api/mod.rs
+++ b/src/tonic/api/storage_read_api/mod.rs
@@ -189,7 +189,7 @@ where
                 .open(&path, open_options, Default::default())
                 .map_err(io_error_to_status)?;
             let cow = storage
-                .read::<Random, u8>(ReadRange::new(byte_offset, length))
+                .read(ReadRange::new(byte_offset, length), Random)
                 .map_err(io_error_to_status)?;
             Ok::<_, Status>(cow.into_owned())
         })
@@ -255,7 +255,7 @@ where
 
                 let data = tokio::task::spawn_blocking(move || {
                     storage_for_read
-                        .read::<Random, u8>(ReadRange::new(current_offset, chunk_size))
+                        .read(ReadRange::new(current_offset, chunk_size), Random)
                         .map(|cow| cow.into_owned())
                         .map_err(io_error_to_status)
                 })

--- a/src/tonic/api/storage_read_api/mod.rs
+++ b/src/tonic/api/storage_read_api/mod.rs
@@ -345,7 +345,7 @@ where
                 .map_err(io_error_to_status)?;
             let mut results = ranges.iter().map(|_| Vec::new()).collect::<Vec<_>>();
             storage
-                .read_batch::<Random, u8, _>(ranges.into_iter().enumerate(), |idx, chunk| {
+                .read_batch::<Random, u8, _, _>(ranges.into_iter().enumerate(), |idx, chunk| {
                     results[idx].extend_from_slice(chunk);
                     Ok(())
                 })

--- a/src/tonic/api/storage_read_api/mod.rs
+++ b/src/tonic/api/storage_read_api/mod.rs
@@ -345,7 +345,7 @@ where
                 .map_err(io_error_to_status)?;
             let mut results = ranges.iter().map(|_| Vec::new()).collect::<Vec<_>>();
             storage
-                .read_batch::<Random, u8, _, _>(ranges.into_iter().enumerate(), |idx, chunk| {
+                .read_batch(ranges.into_iter().enumerate(), Random, |idx, chunk| {
                     results[idx].extend_from_slice(chunk);
                     Ok(())
                 })


### PR DESCRIPTION
Depends on #9933.

Supersedes #9924; see https://github.com/qdrant/qdrant/pull/9809#discussion_r3616030931.

This PR updates `UniversalRead::{read_batch, read_bytes_iter, read_iter, read, read_bytes}` interface in the following way:

- Make `UniversalRead::read_batch()` to be generic over `E`.
  So, no more `let mut first_err = None;` dance in [lib/segment/src/id_tracker/disk_id_tracker/mappings.rs](https://github.com/xzfc/qdrant/compare/23321085e8814cd761dcf6e50846d5660a4c9f9e...23d845e3d0d0#diff-766e79aa9bfb2d06a4e4a6709b26a3dccbc209f01d3ac0bb402b31510fb757ca).

- Make `AccessPattern` to be regular parameter, not generic-only parameter. Since it's ZST, it's still expected to be compiled away.
  ```diff
  -storage.read::<Random, _>(range);
  +storage.read(range, Random);
  ```
  So, 82 less usages of turbofish.

- Misc: use `ReadRange::one(…)`/`ReadRange::new(…)` instead of `ReadRange { … }`.
  Why: shorter code. Only inside updated methods calls.
