### PR TITLE
Mandatory batch impls

### DIFF
--- a/lib/quantization/src/encoded_storage.rs
+++ b/lib/quantization/src/encoded_storage.rs
@@ -25,12 +25,8 @@ pub trait EncodedStorage {
     fn for_each_batch(
         &self,
         offsets: &[PointOffsetType],
-        mut callback: impl FnMut(usize, Cow<'_, [u8]>),
-    ) {
-        for (index, &offset) in offsets.iter().enumerate() {
-            callback(index, self.get_vector_data(offset));
-        }
-    }
+        callback: impl FnMut(usize, Cow<'_, [u8]>),
+    );
 
     fn is_in_ram_or_mmap() -> bool;
     fn is_on_disk(&self) -> bool;
@@ -53,6 +49,16 @@ pub trait EncodedStorage {
     /// Additional heap memory used by this storage beyond what's tracked in files.
     /// RAM-based storages should report their in-memory data size here.
     fn heap_size_bytes(&self) -> usize;
+}
+
+pub fn default_for_each_batch<E: EncodedStorage + ?Sized>(
+    this: &E,
+    offsets: &[u32],
+    mut callback: impl FnMut(usize, Cow<'_, [u8]>),
+) {
+    for (index, &offset) in offsets.iter().enumerate() {
+        callback(index, this.get_vector_data(offset));
+    }
 }
 
 pub trait EncodedStorageBuilder {
@@ -153,6 +159,14 @@ impl EncodedStorage for TestEncodedStorage {
             .saturating_mul(index as usize + 1);
 
         Some(Cow::Borrowed(self.data.get(start..end)?))
+    }
+
+    fn for_each_batch(
+        &self,
+        offsets: &[PointOffsetType],
+        callback: impl FnMut(usize, Cow<'_, [u8]>),
+    ) {
+        default_for_each_batch(self, offsets, callback);
     }
 
     fn upsert_vector(

--- a/lib/quantization/tests/integration/test_owned_storage.rs
+++ b/lib/quantization/tests/integration/test_owned_storage.rs
@@ -18,6 +18,7 @@ mod tests {
     use common::types::PointOffsetType;
     use quantization::encoded_storage::{
         EncodedStorage, EncodedStorageBuilder, TestEncodedStorage, TestEncodedStorageBuilder,
+        default_for_each_batch,
     };
     use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
     use quantization::encoded_vectors_u8;
@@ -36,6 +37,14 @@ mod tests {
         fn get_vector_data_opt(&self, index: PointOffsetType) -> Option<Cow<'_, [u8]>> {
             let Self(inner) = self;
             Some(Cow::Owned(inner.get_vector_data_opt(index)?.into_owned()))
+        }
+
+        fn for_each_batch(
+            &self,
+            offsets: &[PointOffsetType],
+            callback: impl FnMut(usize, Cow<'_, [u8]>),
+        ) {
+            default_for_each_batch(self, offsets, callback);
         }
 
         fn is_in_ram_or_mmap() -> bool {

--- a/lib/segment/src/id_tracker/disk_id_tracker/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/id_tracker_read.rs
@@ -8,7 +8,7 @@ use super::DiskIdTracker;
 use super::mappings::{DiskMappingsSource, log_lookup_err};
 use super::reader::DiskMappingReader;
 use crate::common::operation_error::OperationResult;
-use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
+use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum, default_internal_versions_batch};
 use crate::types::{PointIdType, SeqNumberType};
 
 impl<S: UniversalWrite> DiskIdTracker<S> {
@@ -45,11 +45,19 @@ impl<S: UniversalWrite + Send + Sync + 'static> IdTrackerRead for DiskIdTracker<
     }
 
     fn internal_version(&self, internal_id: PointOffsetType) -> Option<SeqNumberType> {
-        // Resident versions, mutated in place. `internal_versions_batch` is
-        // deliberately NOT overridden: its default loop hits this resident
-        // store, so there is no IO to pipeline. Only the read-only tracker,
-        // whose versions file stays on disk, batches it.
+        // Resident versions, mutated in place.
         self.internal_to_version.get(internal_id)
+    }
+
+    /// The default single-lookup loop hits the resident version store, so
+    /// there is no IO to pipeline. Only the read-only tracker, whose versions
+    /// file stays on disk, batches the reads.
+    fn internal_versions_batch(
+        &self,
+        internal_ids: impl IntoIterator<Item = PointOffsetType>,
+        callback: impl FnMut(PointOffsetType, SeqNumberType),
+    ) -> OperationResult<()> {
+        default_internal_versions_batch(self, internal_ids, callback)
     }
 
     fn internal_id_with_behavior(

--- a/lib/segment/src/id_tracker/disk_id_tracker/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/id_tracker_read.rs
@@ -35,6 +35,19 @@ impl<S: UniversalWrite + Send + Sync + 'static> DiskMappingsSource for DiskIdTra
         // Resident bitvec, so this never fails.
         Ok(&self.deleted)
     }
+
+    fn resolve_internal_batch(
+        &self,
+        external_ids: impl IntoIterator<Item = PointIdType>,
+        mut on_live: impl FnMut(PointIdType, PointOffsetType),
+    ) -> OperationResult<()> {
+        // The deleted bitvec is resident, so the per-point check is infallible.
+        self.reader.lookup_batch(external_ids, |id, offset| {
+            if !self.point_deleted(offset) {
+                on_live(id, offset);
+            }
+        })
+    }
 }
 
 impl<S: UniversalWrite + Send + Sync + 'static> IdTrackerRead for DiskIdTracker<S> {

--- a/lib/segment/src/id_tracker/disk_id_tracker/mappings.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/mappings.rs
@@ -80,25 +80,8 @@ pub trait DiskMappingsSource {
     fn resolve_internal_batch(
         &self,
         external_ids: impl IntoIterator<Item = PointIdType>,
-        mut on_live: impl FnMut(PointIdType, PointOffsetType),
-    ) -> OperationResult<()> {
-        // Use `first_err` instead of `?` to avoid UniversalIoError vs OperationResult problems
-        let mut first_err = None;
-        self.mapping_reader()
-            .lookup_batch(external_ids, |id, offset| {
-                match self.point_deleted(offset) {
-                    Ok(false) => on_live(id, offset),
-                    Ok(true) => {}
-                    Err(err) => {
-                        first_err.get_or_insert(err);
-                    }
-                }
-            })?;
-        match first_err {
-            Some(err) => Err(err),
-            None => Ok(()),
-        }
-    }
+        on_live: impl FnMut(PointIdType, PointOffsetType),
+    ) -> OperationResult<()>;
 }
 
 /// A borrowed `(reader, deleted)` view; a `Copy` pair of references whose

--- a/lib/segment/src/id_tracker/disk_id_tracker/read_only/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/read_only/id_tracker_read.rs
@@ -34,6 +34,28 @@ impl<S: UniversalRead> DiskMappingsSource for ReadOnlyDiskIdTracker<S> {
     fn deleted_bitslice(&self) -> OperationResult<&BitSlice> {
         Ok(self.deleted_full()?.as_bitslice())
     }
+
+    fn resolve_internal_batch(
+        &self,
+        external_ids: impl IntoIterator<Item = PointIdType>,
+        mut on_live: impl FnMut(PointIdType, PointOffsetType),
+    ) -> OperationResult<()> {
+        // Use `first_err` instead of `?` to avoid UniversalIoError vs OperationResult problems
+        let mut first_err = None;
+        self.reader.lookup_batch(external_ids, |id, offset| {
+            match self.point_deleted(offset) {
+                Ok(false) => on_live(id, offset),
+                Ok(true) => {}
+                Err(err) => {
+                    first_err.get_or_insert(err);
+                }
+            }
+        })?;
+        match first_err {
+            Some(err) => Err(err),
+            None => Ok(()),
+        }
+    }
 }
 
 impl<S: UniversalRead> IdTrackerRead for ReadOnlyDiskIdTracker<S> {

--- a/lib/segment/src/id_tracker/id_tracker_base/mod.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/mod.rs
@@ -8,5 +8,6 @@ pub mod read_only_tracker_enum;
 pub use point_mappings_ref::{PointMappingsGuard, PointMappingsRefEnum};
 pub use tracker_enum::IdTrackerEnum;
 pub use trait_def::{
-    DELETED_POINT_VERSION, IdTracker, IdTrackerRead, default_internal_versions_batch,
+    DELETED_POINT_VERSION, IdTracker, IdTrackerRead, default_external_ids_batch,
+    default_internal_versions_batch,
 };

--- a/lib/segment/src/id_tracker/id_tracker_base/mod.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/mod.rs
@@ -7,4 +7,6 @@ pub mod read_only_tracker_enum;
 
 pub use point_mappings_ref::{PointMappingsGuard, PointMappingsRefEnum};
 pub use tracker_enum::IdTrackerEnum;
-pub use trait_def::{DELETED_POINT_VERSION, IdTracker, IdTrackerRead};
+pub use trait_def::{
+    DELETED_POINT_VERSION, IdTracker, IdTrackerRead, default_internal_versions_batch,
+};

--- a/lib/segment/src/id_tracker/id_tracker_base/trait_def.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/trait_def.rs
@@ -171,21 +171,14 @@ pub trait IdTrackerRead {
     /// unknown points are skipped, and delivery order is unspecified — callers
     /// pair results by internal id, not input position.
     ///
-    /// The default streams the iterator through the single lookup, which is
-    /// what in-RAM trackers want; disk-resident trackers override it to
-    /// pipeline the reads, propagating storage errors.
+    /// In-RAM trackers stream the iterator through the single lookup
+    /// ([`default_external_ids_batch`]); disk-resident trackers pipeline the
+    /// reads, propagating storage errors.
     fn external_ids_batch(
         &self,
         internal_ids: impl IntoIterator<Item = PointOffsetType>,
-        mut callback: impl FnMut(PointOffsetType, PointIdType),
-    ) -> OperationResult<()> {
-        for internal_id in internal_ids {
-            if let Some(external_id) = self.external_id(internal_id) {
-                callback(internal_id, external_id);
-            }
-        }
-        Ok(())
-    }
+        callback: impl FnMut(PointOffsetType, PointIdType),
+    ) -> OperationResult<()>;
 
     /// Number of total points
     ///
@@ -295,6 +288,22 @@ pub trait IdTrackerRead {
         }
         Ok(())
     }
+}
+
+/// Default [`external_ids_batch`](IdTrackerRead::external_ids_batch) for
+/// in-RAM trackers: streams the iterator through the single lookup, no IO to
+/// pipeline.
+pub fn default_external_ids_batch<T: IdTrackerRead + ?Sized>(
+    this: &T,
+    internal_ids: impl IntoIterator<Item = PointOffsetType>,
+    mut callback: impl FnMut(PointOffsetType, PointIdType),
+) -> OperationResult<()> {
+    for internal_id in internal_ids {
+        if let Some(external_id) = this.external_id(internal_id) {
+            callback(internal_id, external_id);
+        }
+    }
+    Ok(())
 }
 
 /// Default [`internal_versions_batch`](IdTrackerRead::internal_versions_batch)

--- a/lib/segment/src/id_tracker/id_tracker_base/trait_def.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/trait_def.rs
@@ -140,21 +140,15 @@ pub trait IdTrackerRead {
     /// `callback` receives each `(internal_id, version)` as it resolves; ids
     /// without a version (e.g. out of range) are skipped.
     ///
-    /// The in-RAM default streams the single lookup; disk-resident trackers
+    /// Trackers with resident versions stream the single lookup
+    /// ([`default_internal_versions_batch`]); disk-resident trackers
     /// pipeline the reads and propagate any storage error. Neither buffers —
     /// the input is walked once and the pairs go straight to `callback`.
     fn internal_versions_batch(
         &self,
         internal_ids: impl IntoIterator<Item = PointOffsetType>,
-        mut callback: impl FnMut(PointOffsetType, SeqNumberType),
-    ) -> OperationResult<()> {
-        for internal_id in internal_ids {
-            if let Some(version) = self.internal_version(internal_id) {
-                callback(internal_id, version);
-            }
-        }
-        Ok(())
-    }
+        callback: impl FnMut(PointOffsetType, SeqNumberType),
+    ) -> OperationResult<()>;
 
     /// Returns the internal ID of the point under explicit deferred
     /// semantics — see [`PointMappings::internal_id_with_behavior`].
@@ -301,4 +295,20 @@ pub trait IdTrackerRead {
         }
         Ok(())
     }
+}
+
+/// Default [`internal_versions_batch`](IdTrackerRead::internal_versions_batch)
+/// for trackers with resident versions: streams the single lookup, no IO to
+/// pipeline.
+pub fn default_internal_versions_batch<T: IdTrackerRead + ?Sized>(
+    this: &T,
+    internal_ids: impl IntoIterator<Item = PointOffsetType>,
+    mut callback: impl FnMut(PointOffsetType, SeqNumberType),
+) -> OperationResult<()> {
+    for internal_id in internal_ids {
+        if let Some(version) = this.internal_version(internal_id) {
+            callback(internal_id, version);
+        }
+    }
+    Ok(())
 }

--- a/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
@@ -38,7 +38,7 @@ use crate::id_tracker::compressed::versions_store::CompressedVersions;
 use crate::id_tracker::in_memory_id_tracker::InMemoryIdTracker;
 use crate::id_tracker::{
     DELETED_POINT_VERSION, IdTracker, IdTrackerRead, PointMappingsRefEnum,
-    default_internal_versions_batch,
+    default_external_ids_batch, default_internal_versions_batch,
 };
 use crate::types::{PointIdType, SeqNumberType};
 
@@ -261,6 +261,14 @@ impl<S: UniversalWrite + Send + Sync + 'static> IdTrackerRead for ImmutableIdTra
 
     fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
         self.mappings.external_id(internal_id)
+    }
+
+    fn external_ids_batch(
+        &self,
+        internal_ids: impl IntoIterator<Item = PointOffsetType>,
+        callback: impl FnMut(PointOffsetType, PointIdType),
+    ) -> OperationResult<()> {
+        default_external_ids_batch(self, internal_ids, callback)
     }
 
     type Backend = S;

--- a/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/mod.rs
@@ -36,7 +36,10 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::compressed::compressed_point_mappings::CompressedPointMappings;
 use crate::id_tracker::compressed::versions_store::CompressedVersions;
 use crate::id_tracker::in_memory_id_tracker::InMemoryIdTracker;
-use crate::id_tracker::{DELETED_POINT_VERSION, IdTracker, IdTrackerRead, PointMappingsRefEnum};
+use crate::id_tracker::{
+    DELETED_POINT_VERSION, IdTracker, IdTrackerRead, PointMappingsRefEnum,
+    default_internal_versions_batch,
+};
 use crate::types::{PointIdType, SeqNumberType};
 
 #[derive(Debug)]
@@ -237,6 +240,14 @@ where
 impl<S: UniversalWrite + Send + Sync + 'static> IdTrackerRead for ImmutableIdTracker<S> {
     fn internal_version(&self, internal_id: PointOffsetType) -> Option<SeqNumberType> {
         self.internal_to_version.get(internal_id)
+    }
+
+    fn internal_versions_batch(
+        &self,
+        internal_ids: impl IntoIterator<Item = PointOffsetType>,
+        callback: impl FnMut(PointOffsetType, SeqNumberType),
+    ) -> OperationResult<()> {
+        default_internal_versions_batch(self, internal_ids, callback)
     }
 
     fn internal_id_with_behavior(

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/id_tracker_read.rs
@@ -4,7 +4,10 @@ use common::universal_io::UniversalRead;
 
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::immutable_id_tracker::read_only::ReadOnlyImmutableIdTracker;
-use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum, default_internal_versions_batch};
+use crate::id_tracker::{
+    IdTrackerRead, PointMappingsRefEnum, default_external_ids_batch,
+    default_internal_versions_batch,
+};
 use crate::types::{PointIdType, SeqNumberType};
 
 impl<S: UniversalRead> IdTrackerRead for ReadOnlyImmutableIdTracker<S> {
@@ -37,6 +40,14 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyImmutableIdTracker<S> {
 
     fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
         self.mappings.external_id(internal_id)
+    }
+
+    fn external_ids_batch(
+        &self,
+        internal_ids: impl IntoIterator<Item = PointOffsetType>,
+        callback: impl FnMut(PointOffsetType, PointIdType),
+    ) -> OperationResult<()> {
+        default_external_ids_batch(self, internal_ids, callback)
     }
 
     fn total_point_count(&self) -> usize {

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/id_tracker_read.rs
@@ -4,7 +4,7 @@ use common::universal_io::UniversalRead;
 
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::immutable_id_tracker::read_only::ReadOnlyImmutableIdTracker;
-use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
+use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum, default_internal_versions_batch};
 use crate::types::{PointIdType, SeqNumberType};
 
 impl<S: UniversalRead> IdTrackerRead for ReadOnlyImmutableIdTracker<S> {
@@ -16,6 +16,14 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyImmutableIdTracker<S> {
 
     fn internal_version(&self, internal_id: PointOffsetType) -> Option<SeqNumberType> {
         self.internal_to_version.get(internal_id)
+    }
+
+    fn internal_versions_batch(
+        &self,
+        internal_ids: impl IntoIterator<Item = PointOffsetType>,
+        callback: impl FnMut(PointOffsetType, SeqNumberType),
+    ) -> OperationResult<()> {
+        default_internal_versions_batch(self, internal_ids, callback)
     }
 
     fn internal_id_with_behavior(

--- a/lib/segment/src/id_tracker/in_memory_id_tracker.rs
+++ b/lib/segment/src/id_tracker/in_memory_id_tracker.rs
@@ -10,7 +10,10 @@ use rand::rngs::StdRng;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::point_mappings::PointMappings;
-use crate::id_tracker::{DELETED_POINT_VERSION, IdTracker, IdTrackerRead, PointMappingsRefEnum};
+use crate::id_tracker::{
+    DELETED_POINT_VERSION, IdTracker, IdTrackerRead, PointMappingsRefEnum,
+    default_internal_versions_batch,
+};
 use crate::types::{PointIdType, SeqNumberType};
 
 /// A non-persistent ID tracker for faster and more efficient building of `ImmutableIdTracker`.
@@ -62,6 +65,14 @@ impl InMemoryIdTracker {
 impl IdTrackerRead for InMemoryIdTracker {
     fn internal_version(&self, internal_id: PointOffsetType) -> Option<SeqNumberType> {
         self.internal_to_version.get(internal_id as usize).copied()
+    }
+
+    fn internal_versions_batch(
+        &self,
+        internal_ids: impl IntoIterator<Item = PointOffsetType>,
+        callback: impl FnMut(PointOffsetType, SeqNumberType),
+    ) -> OperationResult<()> {
+        default_internal_versions_batch(self, internal_ids, callback)
     }
 
     fn internal_id_with_behavior(

--- a/lib/segment/src/id_tracker/in_memory_id_tracker.rs
+++ b/lib/segment/src/id_tracker/in_memory_id_tracker.rs
@@ -12,7 +12,7 @@ use crate::common::operation_error::OperationResult;
 use crate::id_tracker::point_mappings::PointMappings;
 use crate::id_tracker::{
     DELETED_POINT_VERSION, IdTracker, IdTrackerRead, PointMappingsRefEnum,
-    default_internal_versions_batch,
+    default_external_ids_batch, default_internal_versions_batch,
 };
 use crate::types::{PointIdType, SeqNumberType};
 
@@ -86,6 +86,14 @@ impl IdTrackerRead for InMemoryIdTracker {
 
     fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
         self.mappings.external_id(internal_id)
+    }
+
+    fn external_ids_batch(
+        &self,
+        internal_ids: impl IntoIterator<Item = PointOffsetType>,
+        callback: impl FnMut(PointOffsetType, PointIdType),
+    ) -> OperationResult<()> {
+        default_external_ids_batch(self, internal_ids, callback)
     }
 
     type Backend = common::universal_io::MmapFile;

--- a/lib/segment/src/id_tracker/mutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/mod.rs
@@ -30,7 +30,10 @@ use self::versions_storage::{
 use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::point_mappings::PointMappings;
-use crate::id_tracker::{DELETED_POINT_VERSION, IdTracker, IdTrackerRead, PointMappingsRefEnum};
+use crate::id_tracker::{
+    DELETED_POINT_VERSION, IdTracker, IdTrackerRead, PointMappingsRefEnum,
+    default_internal_versions_batch,
+};
 use crate::types::{PointIdType, SeqNumberType};
 
 /// Mutable in-memory ID tracker with simple file based backing storage
@@ -173,6 +176,14 @@ impl MutableIdTracker {
 impl IdTrackerRead for MutableIdTracker {
     fn internal_version(&self, internal_id: PointOffsetType) -> Option<SeqNumberType> {
         self.internal_to_version.get(internal_id as usize).copied()
+    }
+
+    fn internal_versions_batch(
+        &self,
+        internal_ids: impl IntoIterator<Item = PointOffsetType>,
+        callback: impl FnMut(PointOffsetType, SeqNumberType),
+    ) -> OperationResult<()> {
+        default_internal_versions_batch(self, internal_ids, callback)
     }
 
     fn internal_id_with_behavior(

--- a/lib/segment/src/id_tracker/mutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/mod.rs
@@ -32,7 +32,7 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::point_mappings::PointMappings;
 use crate::id_tracker::{
     DELETED_POINT_VERSION, IdTracker, IdTrackerRead, PointMappingsRefEnum,
-    default_internal_versions_batch,
+    default_external_ids_batch, default_internal_versions_batch,
 };
 use crate::types::{PointIdType, SeqNumberType};
 
@@ -197,6 +197,14 @@ impl IdTrackerRead for MutableIdTracker {
 
     fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
         self.mappings.external_id(internal_id)
+    }
+
+    fn external_ids_batch(
+        &self,
+        internal_ids: impl IntoIterator<Item = PointOffsetType>,
+        callback: impl FnMut(PointOffsetType, PointIdType),
+    ) -> OperationResult<()> {
+        default_external_ids_batch(self, internal_ids, callback)
     }
 
     type Backend = common::universal_io::MmapFile;

--- a/lib/segment/src/id_tracker/mutable_id_tracker/read_only/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/read_only/id_tracker_read.rs
@@ -4,7 +4,7 @@ use common::universal_io::UniversalRead;
 
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::mutable_id_tracker::read_only::ReadOnlyAppendableIdTracker;
-use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum};
+use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum, default_internal_versions_batch};
 use crate::types::{PointIdType, SeqNumberType};
 
 impl<S: UniversalRead> IdTrackerRead for ReadOnlyAppendableIdTracker<S> {
@@ -16,6 +16,14 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyAppendableIdTracker<S> {
 
     fn internal_version(&self, internal_id: PointOffsetType) -> Option<SeqNumberType> {
         self.internal_to_version.get(internal_id as usize).copied()
+    }
+
+    fn internal_versions_batch(
+        &self,
+        internal_ids: impl IntoIterator<Item = PointOffsetType>,
+        callback: impl FnMut(PointOffsetType, SeqNumberType),
+    ) -> OperationResult<()> {
+        default_internal_versions_batch(self, internal_ids, callback)
     }
 
     fn internal_id_with_behavior(

--- a/lib/segment/src/id_tracker/mutable_id_tracker/read_only/id_tracker_read.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/read_only/id_tracker_read.rs
@@ -4,7 +4,10 @@ use common::universal_io::UniversalRead;
 
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::mutable_id_tracker::read_only::ReadOnlyAppendableIdTracker;
-use crate::id_tracker::{IdTrackerRead, PointMappingsRefEnum, default_internal_versions_batch};
+use crate::id_tracker::{
+    IdTrackerRead, PointMappingsRefEnum, default_external_ids_batch,
+    default_internal_versions_batch,
+};
 use crate::types::{PointIdType, SeqNumberType};
 
 impl<S: UniversalRead> IdTrackerRead for ReadOnlyAppendableIdTracker<S> {
@@ -37,6 +40,14 @@ impl<S: UniversalRead> IdTrackerRead for ReadOnlyAppendableIdTracker<S> {
 
     fn external_id(&self, internal_id: PointOffsetType) -> Option<PointIdType> {
         self.mappings.external_id(internal_id)
+    }
+
+    fn external_ids_batch(
+        &self,
+        internal_ids: impl IntoIterator<Item = PointOffsetType>,
+        callback: impl FnMut(PointOffsetType, PointIdType),
+    ) -> OperationResult<()> {
+        default_external_ids_batch(self, internal_ids, callback)
     }
 
     fn total_point_count(&self) -> usize {

--- a/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/empty_dense_vector_storage.rs
@@ -16,7 +16,7 @@ use crate::data_types::vectors::{VectorElementType, VectorRef};
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::{
     DenseVectorStorage, DenseVectorStorageRead, VectorStorage, VectorStorageEnum,
-    VectorStorageRead, default_read_vector_bytes_impl,
+    VectorStorageRead, default_for_each_in_dense_batch, default_read_vector_bytes_impl,
 };
 
 /// Placeholder vector storage that contains no data.
@@ -97,6 +97,14 @@ impl DenseVectorStorageRead<VectorElementType> for EmptyDenseVectorStorage {
         // the destination's index→offset layout stays aligned. The deletion
         // flag from `is_deleted_vector` keeps the placeholder from being read.
         Cow::Owned(vec![0.0; self.dim])
+    }
+
+    fn for_each_in_dense_batch<F: FnMut(usize, &[VectorElementType])>(
+        &self,
+        keys: &[PointOffsetType],
+        f: F,
+    ) -> OperationResult<()> {
+        default_for_each_in_dense_batch(self, keys, f)
     }
 }
 

--- a/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/volatile_dense_vector_storage.rs
@@ -17,7 +17,7 @@ use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::volatile_chunked_vectors::VolatileChunkedVectors;
 use crate::vector_storage::{
     DenseVectorStorage, DenseVectorStorageRead, VectorOffsetType, VectorStorage, VectorStorageEnum,
-    VectorStorageRead, default_read_vector_bytes_impl,
+    VectorStorageRead, default_for_each_in_dense_batch, default_read_vector_bytes_impl,
 };
 
 /// In-memory vector storage that is volatile
@@ -84,6 +84,14 @@ impl<T: PrimitiveVectorElement> DenseVectorStorageRead<T> for VolatileDenseVecto
 
     fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]> {
         Cow::Borrowed(self.vectors.get(key as VectorOffsetType))
+    }
+
+    fn for_each_in_dense_batch<F: FnMut(usize, &[T])>(
+        &self,
+        keys: &[PointOffsetType],
+        f: F,
+    ) -> OperationResult<()> {
+        default_for_each_in_dense_batch(self, keys, f)
     }
 }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -8,6 +8,7 @@ use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, OneshotFile, UniversalRead, UniversalReadFs};
 use fs_err as fs;
 use fs_err::File;
+use quantization::encoded_storage::default_for_each_batch;
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::vector_utils::TrySetCapacityExact;
@@ -86,6 +87,14 @@ impl quantization::EncodedStorage for QuantizedRamStorage {
         Some(Cow::Borrowed(
             self.vectors.get_opt(index as VectorOffsetType)?,
         ))
+    }
+
+    fn for_each_batch(
+        &self,
+        offsets: &[PointOffsetType],
+        callback: impl FnMut(usize, Cow<'_, [u8]>),
+    ) {
+        default_for_each_batch(self, offsets, callback);
     }
 
     fn upsert_vector(

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -235,6 +235,15 @@ impl<S: UniversalRead> quantization::EncodedStorage for QuantizedStorage<S> {
             .ok()
     }
 
+    fn for_each_batch(
+        &self,
+        offsets: &[PointOffsetType],
+        mut callback: impl FnMut(usize, Cow<'_, [u8]>),
+    ) {
+        self.for_each_in_batch(offsets, |idx, data| callback(idx, Cow::Borrowed(data)))
+            .expect("vectors exist and are read correctly");
+    }
+
     fn upsert_vector(
         &mut self,
         _id: PointOffsetType,

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -25,18 +25,24 @@ pub trait QueryScorer {
     /// Score a batch of points
     ///
     /// Enables underlying storage to optimize pre-fetching of data
-    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
-        debug_assert_eq!(ids.len(), scores.len());
-
-        for (idx, id) in ids.iter().enumerate() {
-            scores[idx] = self.score_stored(*id);
-        }
-    }
+    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]);
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType;
 
     type SupportsBytes: TBool;
     fn score_bytes(&self, _: Self::SupportsBytes, bytes: &[u8]) -> ScoreType;
+}
+
+pub fn default_score_stored_batch<Q: QueryScorer + ?Sized>(
+    this: &Q,
+    ids: &[u32],
+    scores: &mut [f32],
+) {
+    debug_assert_eq!(ids.len(), scores.len());
+
+    for (idx, id) in ids.iter().enumerate() {
+        scores[idx] = this.score_stored(*id);
+    }
 }
 
 pub trait QueryScorerBytes {

--- a/lib/segment/src/vector_storage/query_scorer/turbo_multi_custom_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/turbo_multi_custom_query_scorer.rs
@@ -1,4 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::Random;
 use common::typelevel::False;
 use common::types::{PointOffsetType, ScoreType};
 use quantization::turboquant::EncodedQueryTQ;
@@ -61,6 +62,26 @@ where
             self.storage
                 .score_point_max_similarity(query, idx, &self.hardware_counter)
         })
+    }
+
+    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
+        let keys = ids.iter().copied().enumerate();
+
+        let hw_counter = &self.hardware_counter;
+
+        self.storage
+            .for_each_record_range::<Random, _>(keys, |idx, _id, records| {
+                hw_counter.vector_io_read().incr_delta(records.len());
+
+                scores[idx] = self.query.score_by(|query| {
+                    hw_counter
+                        .cpu_counter()
+                        .incr_delta(records.len() * query.len());
+
+                    self.storage.score_records_max_similarity(query, records)
+                });
+            })
+            .expect("Failed to score stored batch");
     }
 
     fn score_internal(&self, _point_a: PointOffsetType, _point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/query_scorer/turbo_multi_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/turbo_multi_query_scorer.rs
@@ -1,4 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::Random;
 use common::typelevel::False;
 use common::types::{PointOffsetType, ScoreType};
 use quantization::turboquant::EncodedQueryTQ;
@@ -42,6 +43,26 @@ impl QueryScorer for TurboMultiQueryScorer<'_> {
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {
         self.storage
             .score_point_max_similarity(&self.query, idx, &self.hardware_counter)
+    }
+
+    fn score_stored_batch(&self, ids: &[PointOffsetType], scores: &mut [ScoreType]) {
+        let keys = ids.iter().copied().enumerate();
+
+        let hw_counter = &self.hardware_counter;
+
+        self.storage
+            .for_each_record_range::<Random, _>(keys, |idx, _id, records| {
+                hw_counter.vector_io_read().incr_delta(records.len());
+
+                hw_counter
+                    .cpu_counter()
+                    .incr_delta(records.len() * self.query.len());
+
+                scores[idx] = self
+                    .storage
+                    .score_records_max_similarity(&self.query, records);
+            })
+            .expect("Failed to score stored batch");
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/turbo/multi.rs
+++ b/lib/segment/src/vector_storage/turbo/multi.rs
@@ -260,7 +260,7 @@ impl TurboMultiVectorStorage {
     }
 
     /// Two-pass batched read for records. First offsets, then vectors.
-    fn for_each_record_range<P: AccessPattern, U: Copy + UserData>(
+    pub fn for_each_record_range<P: AccessPattern, U: Copy + UserData>(
         &self,
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
         mut callback: impl FnMut(U, PointOffsetType, &[u8]),
@@ -457,6 +457,25 @@ impl TurboMultiVectorStorage {
             .collect()
     }
 
+    /// Score query directly against records directly, without fetching from storage.
+    pub fn score_records_max_similarity(
+        &self,
+        query: &[EncodedQueryTQ],
+        records: &[u8],
+    ) -> ScoreType {
+        let mut max_sim: SmallVec<[_; 8]> = smallvec![ScoreType::NEG_INFINITY; query.len()];
+
+        for bytes in records.chunks_exact(self.quantizer.quantized_size()) {
+            for (qi, inner_query) in query.iter().enumerate() {
+                let sim = self.signed(self.quantizer.score_precomputed(inner_query, bytes));
+                if max_sim[qi] < sim {
+                    max_sim[qi] = sim;
+                }
+            }
+        }
+        max_sim.into_iter().sum()
+    }
+
     /// Asymmetric MaxSim score of a precomputed multi-query against stored point
     /// `key`: each inner query vector takes its best similarity to any of the
     /// point's inner records, summed.
@@ -482,17 +501,7 @@ impl TurboMultiVectorStorage {
 
         hw_counter.vector_io_read().incr_delta(records.len());
 
-        let mut max_sim: SmallVec<[_; 8]> = smallvec![ScoreType::NEG_INFINITY; query.len()];
-
-        for bytes in records.chunks_exact(self.quantizer.quantized_size()) {
-            for (qi, inner_query) in query.iter().enumerate() {
-                let sim = self.signed(self.quantizer.score_precomputed(inner_query, bytes));
-                if max_sim[qi] < sim {
-                    max_sim[qi] = sim;
-                }
-            }
-        }
-        max_sim.into_iter().sum()
+        self.score_records_max_similarity(query, &records)
     }
 
     /// Symmetric MaxSim score between two stored points. Reads both points'

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -295,13 +295,24 @@ pub trait DenseVectorStorageRead<T: PrimitiveVectorElement>: VectorStorageRead {
     fn for_each_in_dense_batch<F: FnMut(usize, &[T])>(
         &self,
         keys: &[PointOffsetType],
-        mut f: F,
-    ) -> OperationResult<()> {
-        for (idx, &key) in keys.iter().enumerate() {
-            f(idx, &self.get_dense::<Random>(key));
-        }
-        Ok(())
+        f: F,
+    ) -> OperationResult<()>;
+}
+
+pub fn default_for_each_in_dense_batch<T, F, D>(
+    this: &D,
+    keys: &[u32],
+    mut callback: F,
+) -> Result<(), OperationError>
+where
+    T: PrimitiveVectorElement,
+    F: FnMut(usize, &[T]),
+    D: DenseVectorStorageRead<T> + ?Sized,
+{
+    for (idx, &key) in keys.iter().enumerate() {
+        callback(idx, &this.get_dense::<Random>(key));
     }
+    Ok(())
 }
 
 pub trait DenseVectorStorage<T: PrimitiveVectorElement>: DenseVectorStorageRead<T> {

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -483,21 +483,11 @@ pub trait DenseTQVectorStorage: VectorStorageRead {
     /// `callback` with the raw encoded bytes of each vector. TQ counterpart of
     /// [`DenseVectorStorageRead::read_dense_bytes`], with the same valid-keys
     /// precondition.
-    ///
-    /// The default reads one vector at a time; storages with batched readers
-    /// override this so bulk byte reads keep the same read pipelining as
-    /// `read_vectors` (io_uring submission batching for on-disk storages).
     fn read_dense_tq_bytes<P: AccessPattern, U: Copy + UserData>(
         &self,
         keys: impl IntoIterator<Item = (U, PointOffsetType)>,
-        mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
-    ) -> OperationResult<()> {
-        for (user_data, key) in keys {
-            let bytes = self.get_dense_tq::<P>(key);
-            callback(user_data, key, bytes.to_vec());
-        }
-        Ok(())
-    }
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()>;
 }
 
 /// Read + bulk-ingest access to a multivector storage of TurboQuant encoded

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -476,13 +476,8 @@ pub trait DenseTQVectorStorage: VectorStorageRead {
     fn for_each_in_dense_tq_batch<F: FnMut(usize, &[u8])>(
         &self,
         keys: &[PointOffsetType],
-        mut f: F,
-    ) -> OperationResult<()> {
-        for (idx, &key) in keys.iter().enumerate() {
-            f(idx, &self.get_dense_tq::<Random>(key));
-        }
-        Ok(())
-    }
+        f: F,
+    ) -> OperationResult<()>;
 
     /// Batched byte counterpart of [`VectorStorageRead::read_vectors`]: calls
     /// `callback` with the raw encoded bytes of each vector. TQ counterpart of


### PR DESCRIPTION
Following the approach in #9893, but for other methods I found using an `ast-grep` script
<details>
<summary>Script</summary>

---

  in `default_batch_methods.yml`
  ```
  id: batch-trait-default-methods
  language: rust
  rule:
    kind: function_item
    has:
      field: name
      regex: batch          # e.g. only methods containing "batch"
    inside:
      kind: trait_item
      stopBy: end
      not:
        has:
          field: name
          regex: Universal
  message: default batch method in trait
  ```
  
  Then run with `sg scan -r default_batch_methods.yml`

---

</details>

I separated each by commits, so it is easy to review. Some actually found missing implementations, but most of them were fine.

Please note that `QueryScorer::score_stored_batch` adds implementations for tq multivectors, so help me validate those 🙏 .

Only with 9c7e7757b0e34b269b044543a9e9f713cfbc2eb0, we already make the cold searches 100x faster<sup>☨</sup>.

<sup>☨</sup> didn't really measure it, but insanely faster on s3 case.