### PR TITLE
fix: preserve int64 precision in integer range filters

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -2003,7 +2003,7 @@ impl TryFrom<FieldCondition> for segment::types::FieldCondition {
 
         let mut range = range.map(Range::into);
         if range.is_none() {
-            range = integer_range.map(IntegerRange::into);
+            range = integer_range.map(segment::types::RangeInterface::from);
         }
         if range.is_none() {
             range = datetime_range

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -25,7 +25,8 @@ use segment::index::query_optimization::rescore_formula::parsed_formula::{
     DatetimeExpression, DecayKind, ParsedExpression, ParsedFormula,
 };
 use segment::types::{
-    DateTimePayloadType, FloatPayloadType, VectorStorageDatatype, default_quantization_ignore_value,
+    DateTimePayloadType, FloatPayloadType, IntPayloadType, VectorStorageDatatype,
+    default_quantization_ignore_value,
 };
 use segment::vector_storage::query::{self as segment_query, NaiveFeedbackCoefficients};
 use sparse::common::sparse_vector::validate_sparse_vector_impl;
@@ -36,8 +37,8 @@ use super::qdrant::{
     BinaryQuantization, BoolIndexParams, CompressionRatio, DatetimeIndexParams, DatetimeRange,
     Direction, FacetHit, FacetHitInternal, FacetValue, FacetValueInternal, FieldType,
     FloatIndexParams, GeoIndexParams, GeoLineString, GroupId, HardwareUsage, HasVectorCondition,
-    KeywordIndexParams, KeywordPrefixParams, LookupLocation, MaxOptimizationThreads, Memory,
-    MultiVectorComparator, MultiVectorConfig, OrderBy, OrderValue, Range, RawVector,
+    IntegerRange, KeywordIndexParams, KeywordPrefixParams, LookupLocation, MaxOptimizationThreads,
+    Memory, MultiVectorComparator, MultiVectorConfig, OrderBy, OrderValue, Range, RawVector,
     RecommendStrategy, RetrievedPoint, SearchMatrixPair, SearchPointGroups, SearchPoints,
     ShardKeySelector, SliceCondition, StartFrom, StrictModeMultivector,
     StrictModeMultivectorConfig, StrictModeSparse, StrictModeSparseConfig, TurboQuantBitSize,
@@ -1992,6 +1993,7 @@ impl TryFrom<FieldCondition> for segment::types::FieldCondition {
             datetime_range,
             is_empty,
             is_null,
+            integer_range,
         } = value;
 
         let geo_bounding_box =
@@ -2000,6 +2002,9 @@ impl TryFrom<FieldCondition> for segment::types::FieldCondition {
         let geo_polygon = geo_polygon.map_or_else(|| Ok(None), |g| g.try_into().map(Some))?;
 
         let mut range = range.map(Range::into);
+        if range.is_none() {
+            range = integer_range.map(IntegerRange::into);
+        }
         if range.is_none() {
             range = datetime_range
                 .map(segment::types::RangeInterface::try_from)
@@ -2034,10 +2039,17 @@ impl From<segment::types::FieldCondition> for FieldCondition {
             is_null,
         } = value;
 
-        let (range, datetime_range) = match range {
-            Some(segment::types::RangeInterface::Float(range)) => (Some(Range::from(range)), None),
-            Some(segment::types::RangeInterface::DateTime(range)) => (None, Some(range.into())),
-            None => (None, None),
+        let (range, integer_range, datetime_range) = match range {
+            Some(segment::types::RangeInterface::Float(range)) => {
+                (Some(Range::from(range)), None, None)
+            }
+            Some(segment::types::RangeInterface::Integer(range)) => {
+                (None, Some(IntegerRange::from(range)), None)
+            }
+            Some(segment::types::RangeInterface::DateTime(range)) => {
+                (None, None, Some(range.into()))
+            }
+            None => (None, None, None),
         };
 
         Self {
@@ -2051,6 +2063,7 @@ impl From<segment::types::FieldCondition> for FieldCondition {
             datetime_range,
             is_empty,
             is_null,
+            integer_range,
         }
     }
 }
@@ -2203,6 +2216,26 @@ impl From<segment::types::Range<OrderedFloat<FloatPayloadType>>> for Range {
 impl From<Range> for segment::types::RangeInterface {
     fn from(value: Range) -> Self {
         Self::Float(value.into())
+    }
+}
+
+impl From<IntegerRange> for segment::types::Range<IntPayloadType> {
+    fn from(value: IntegerRange) -> Self {
+        let IntegerRange { lt, gt, gte, lte } = value;
+        Self { lt, gt, gte, lte }
+    }
+}
+
+impl From<segment::types::Range<IntPayloadType>> for IntegerRange {
+    fn from(value: segment::types::Range<IntPayloadType>) -> Self {
+        let segment::types::Range { lt, gt, gte, lte } = value;
+        Self { lt, gt, gte, lte }
+    }
+}
+
+impl From<IntegerRange> for segment::types::RangeInterface {
+    fn from(value: IntegerRange) -> Self {
+        Self::Integer(value.into())
     }
 }
 
@@ -3829,5 +3862,60 @@ fn datatype_to_grpc(dt: VectorStorageDatatype) -> grpc::Datatype {
         VectorStorageDatatype::Float16 => grpc::Datatype::Float16,
         VectorStorageDatatype::Uint8 => grpc::Datatype::Uint8,
         VectorStorageDatatype::Turbo4 => grpc::Datatype::Turbo4,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use segment::json_path::JsonPath;
+    use segment::types::{
+        FieldCondition as SegmentFieldCondition, Range as SegmentRange, RangeInterface,
+    };
+
+    use super::*;
+
+    #[test]
+    fn grpc_integer_range_converts_to_integer_range_interface() {
+        let value = -9_223_372_036_854_775_807_i64;
+        let condition = FieldCondition {
+            key: "x".into(),
+            integer_range: Some(IntegerRange {
+                gte: Some(value),
+                lte: Some(value),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let condition = SegmentFieldCondition::try_from(condition).unwrap();
+        let Some(RangeInterface::Integer(range)) = condition.range else {
+            panic!("expected integer range, got {:?}", condition.range);
+        };
+
+        assert_eq!(range.gte, Some(value));
+        assert_eq!(range.lte, Some(value));
+    }
+
+    #[test]
+    fn segment_integer_range_converts_to_grpc_integer_range() {
+        let value = -9_223_372_036_854_775_807_i64;
+        let key: JsonPath = "x".parse().unwrap();
+        let condition = SegmentFieldCondition::new_int_range(
+            key,
+            SegmentRange {
+                lt: None,
+                gt: None,
+                gte: Some(value),
+                lte: Some(value),
+            },
+        );
+
+        let condition = FieldCondition::from(condition);
+
+        assert!(condition.range.is_none());
+        assert!(condition.datetime_range.is_none());
+        let integer_range = condition.integer_range.unwrap();
+        assert_eq!(integer_range.gte, Some(value));
+        assert_eq!(integer_range.lte, Some(value));
     }
 }

--- a/lib/api/src/grpc/proto/qdrant_common.proto
+++ b/lib/api/src/grpc/proto/qdrant_common.proto
@@ -99,6 +99,8 @@ message FieldCondition {
   optional bool is_empty = 9;
   // Check if field is null
   optional bool is_null = 10;
+  // Check if integer points value lies in a given range
+  IntegerRange integer_range = 11;
 }
 
 message Match {
@@ -141,6 +143,13 @@ message Range {
   optional double gt = 2;
   optional double gte = 3;
   optional double lte = 4;
+}
+
+message IntegerRange {
+  optional int64 lt = 1;
+  optional int64 gt = 2;
+  optional int64 gte = 3;
+  optional int64 lte = 4;
 }
 
 message DatetimeRange {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -263,6 +263,9 @@ pub struct FieldCondition {
     /// Check if field is null
     #[prost(bool, optional, tag = "10")]
     pub is_null: ::core::option::Option<bool>,
+    /// Check if integer points value lies in a given range
+    #[prost(message, optional, tag = "11")]
+    pub integer_range: ::core::option::Option<IntegerRange>,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -333,6 +336,18 @@ pub struct Range {
     pub gte: ::core::option::Option<f64>,
     #[prost(double, optional, tag = "4")]
     pub lte: ::core::option::Option<f64>,
+}
+#[derive(serde::Serialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct IntegerRange {
+    #[prost(int64, optional, tag = "1")]
+    pub lt: ::core::option::Option<i64>,
+    #[prost(int64, optional, tag = "2")]
+    pub gt: ::core::option::Option<i64>,
+    #[prost(int64, optional, tag = "3")]
+    pub gte: ::core::option::Option<i64>,
+    #[prost(int64, optional, tag = "4")]
+    pub lte: ::core::option::Option<i64>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -290,6 +290,7 @@ impl Validate for grpc::FieldCondition {
                 values_count: None,
                 is_empty: None,
                 is_null: None,
+                integer_range: None,
             },
         );
 
@@ -313,6 +314,7 @@ impl Validate for grpc::FieldCondition {
             values_count: _,
             is_empty: _,
             is_null: _,
+            integer_range: _,
         } = self;
 
         errors.merge_self("geo_bounding_box", geo_bounding_box.validate());

--- a/lib/collection/src/problems/unindexed_field.rs
+++ b/lib/collection/src/problems/unindexed_field.rs
@@ -253,7 +253,7 @@ fn infer_index_from_field_condition(field_condition: &FieldCondition) -> Vec<Fie
             RangeInterface::DateTime(_) => {
                 required_indexes.push(FieldIndexType::DatetimeRange);
             }
-            RangeInterface::Float(_) => {
+            RangeInterface::Float(_) | RangeInterface::Integer(_) => {
                 required_indexes.push(FieldIndexType::FloatRange);
                 required_indexes.push(FieldIndexType::IntRange);
             }

--- a/lib/segment/src/data_types/order_by.rs
+++ b/lib/segment/src/data_types/order_by.rs
@@ -116,10 +116,8 @@ impl OrderBy {
         self.start_from
             .as_ref()
             .map(|start_from| match start_from {
-                // TODO: When we introduce integer ranges, we'll stop doing lossy conversion to f64 here
-                // Accepting an integer as start_from simplifies the client generation.
                 StartFrom::Integer(i) => {
-                    RangeInterface::Float(self.direction().as_range_from(OrderedFloat(*i as f64)))
+                    RangeInterface::Integer(self.direction().as_range_from(*i))
                 }
                 StartFrom::Float(f) => {
                     RangeInterface::Float(self.direction().as_range_from(OrderedFloat(*f)))

--- a/lib/segment/src/index/field_index/numeric_index/query.rs
+++ b/lib/segment/src/index/field_index/numeric_index/query.rs
@@ -36,6 +36,19 @@ use crate::types::{
     RangeInterface, UuidIntType, ValueVariants,
 };
 
+fn typed_range<T>(range: &RangeInterface) -> Range<T>
+where
+    T: Numericable,
+{
+    match range {
+        RangeInterface::Float(float_range) => T::from_f64_range(*float_range),
+        RangeInterface::Integer(int_range) => T::from_i64_range(*int_range),
+        RangeInterface::DateTime(datetime_range) => {
+            datetime_range.map(|dt| T::from_u128(dt.timestamp() as u128))
+        }
+    }
+}
+
 /// Histogram-driven cardinality estimation for a range condition.
 pub(super) fn range_cardinality<T, I>(
     index: &I,
@@ -50,12 +63,7 @@ where
         return Ok(CardinalityEstimation::exact(0));
     }
 
-    let range = match range {
-        RangeInterface::Float(float_range) => T::from_f64_range(*float_range),
-        RangeInterface::DateTime(datetime_range) => {
-            datetime_range.map(|dt| T::from_u128(dt.timestamp() as u128))
-        }
-    };
+    let range = typed_range::<T>(range);
 
     let lbound = if let Some(lte) = range.lte {
         Included(lte)
@@ -161,13 +169,7 @@ where
         return Ok(None);
     };
 
-    let (start_bound, end_bound) = match range_cond {
-        RangeInterface::Float(float_range) => T::from_f64_range(*float_range),
-        RangeInterface::DateTime(datetime_range) => {
-            datetime_range.map(|dt| T::from_u128(dt.timestamp() as u128))
-        }
-    }
-    .as_index_key_bounds();
+    let (start_bound, end_bound) = typed_range::<T>(range_cond).as_index_key_bounds();
 
     // map.range
     // Panics if range start > end. Panics if range start == end and both bounds are Excluded.
@@ -329,17 +331,9 @@ where
 
     let range = range.as_ref()?;
     // Convert the range bounds into the index's storage type `T`.
-    // `T::from_f64_range` / `T::from_u128` are total functions provided by
-    // `Numericable`, so every numeric variant (Int / Float / Datetime /
-    // Uuid) can serve any `RangeInterface` shape. For integer `T`, the
-    // float-range conversion rounds each bound *away* from the matching
-    // set so fractional bounds keep their `f64`-comparison semantics.
-    let typed_range = match range {
-        RangeInterface::Float(float_range) => T::from_f64_range(*float_range),
-        RangeInterface::DateTime(datetime_range) => {
-            datetime_range.map(|dt| T::from_u128(dt.timestamp() as u128))
-        }
-    };
+    // `Numericable` keeps JSON integer ranges exact for integer indexes,
+    // while preserving the existing float/date-time conversions.
+    let typed_range = typed_range::<T>(range);
 
     Some(RangeConditionChecker {
         index,
@@ -453,12 +447,7 @@ where
     T: Encodable + Numericable + StoredValue + Send + Sync + Default,
     I: NumericIndexRead<T>,
 {
-    let range = match range {
-        RangeInterface::Float(float_range) => T::from_f64_range(*float_range),
-        RangeInterface::DateTime(datetime_range) => {
-            datetime_range.map(|dt| T::from_u128(dt.timestamp() as u128))
-        }
-    };
+    let range = typed_range::<T>(range);
     let (start_bound, end_bound) = range.as_index_key_bounds();
 
     // map.range

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -19,7 +19,9 @@ use crate::index::field_index::{
     CardinalityEstimation, FieldIndexBuilderTrait, PayloadFieldIndexRead, ValueIndexer,
 };
 use crate::json_path::JsonPath;
-use crate::types::{FieldCondition, FloatPayloadType, Memory, Range, RangeInterface};
+use crate::types::{
+    FieldCondition, FloatPayloadType, IntPayloadType, Memory, Range, RangeInterface,
+};
 
 /// Generous default size for the deleted-points bitslice used in tests.
 ///
@@ -146,6 +148,28 @@ fn random_index(
     (temp_dir, index)
 }
 
+fn int_index_with_values(
+    values: &[(PointOffsetType, IntPayloadType)],
+) -> (TempDir, NumericIndex<IntPayloadType, IntPayloadType>) {
+    let temp_dir = Builder::new()
+        .prefix("test_int_numeric_index")
+        .tempdir()
+        .unwrap();
+    let mut builder =
+        NumericIndex::<IntPayloadType, IntPayloadType>::builder_gridstore(temp_dir.path().into());
+    builder.init().unwrap();
+
+    let hw_counter = HardwareCounterCell::new();
+    for (point_id, value) in values {
+        let payload = Value::from(*value);
+        builder
+            .add_point(*point_id, &[&payload], &hw_counter)
+            .unwrap();
+    }
+
+    (temp_dir, builder.finalize().unwrap())
+}
+
 fn cardinality_request(
     index: &NumericIndex<FloatPayloadType, FloatPayloadType>,
     query: Range<FloatPayloadType>,
@@ -203,6 +227,32 @@ fn test_set_empty_payload() {
     let values_count = index.inner().get_values(point_id).unwrap().count();
 
     assert_eq!(values_count, 0);
+}
+
+#[test]
+fn test_int_range_filter_preserves_large_i64_precision() {
+    let value = -9_223_372_036_854_775_807_i64;
+    let (_temp_dir, index) = int_index_with_values(&[(1, value), (2, i64::MIN)]);
+
+    let condition = FieldCondition::new_int_range(
+        JsonPath::new("unused"),
+        Range {
+            lt: None,
+            gt: None,
+            gte: Some(value),
+            lte: Some(value),
+        },
+    );
+    let hw_counter = HardwareCounterCell::new();
+
+    let point_ids = index
+        .inner()
+        .filter(&condition, &hw_counter)
+        .unwrap()
+        .unwrap()
+        .collect_vec();
+
+    assert_eq!(point_ids, vec![1]);
 }
 
 #[rstest]

--- a/lib/segment/src/index/field_index/numeric_point.rs
+++ b/lib/segment/src/index/field_index/numeric_point.rs
@@ -6,7 +6,7 @@ use ordered_float::OrderedFloat;
 use serde::Serialize;
 
 pub use self::point::Point;
-use crate::types::{FloatPayloadType, Range};
+use crate::types::{FloatPayloadType, IntPayloadType, Range};
 
 // bytemuck macros expand to code that triggers this clippy lint
 // The only reason this is its own module is so that we scope the lint suppression
@@ -93,6 +93,7 @@ pub trait Numericable: Num + PartialEq + PartialOrd + Copy + bytemuck::Pod + Sen
     fn max_value() -> Self;
     fn to_f64(self) -> f64;
     fn from_f64(x: f64) -> Self;
+    fn from_i64(x: IntPayloadType) -> Self;
     fn from_u128(x: u128) -> Self;
     fn min(self, b: Self) -> Self {
         if self < b { self } else { b }
@@ -115,6 +116,10 @@ pub trait Numericable: Num + PartialEq + PartialOrd + Copy + bytemuck::Pod + Sen
     fn from_f64_range(range: Range<OrderedFloat<FloatPayloadType>>) -> Range<Self> {
         range.map(|x| Self::from_f64(x.0))
     }
+
+    fn from_i64_range(range: Range<IntPayloadType>) -> Range<Self> {
+        range.map(Self::from_i64)
+    }
 }
 
 impl Numericable for i64 {
@@ -131,6 +136,9 @@ impl Numericable for i64 {
     }
     fn from_f64(x: f64) -> Self {
         x as Self
+    }
+    fn from_i64(x: IntPayloadType) -> Self {
+        x
     }
     fn from_u128(x: u128) -> Self {
         x as i64
@@ -164,6 +172,9 @@ impl Numericable for f64 {
     fn from_f64(x: f64) -> Self {
         x
     }
+    fn from_i64(x: IntPayloadType) -> Self {
+        x as Self
+    }
     fn from_u128(x: u128) -> Self {
         x as Self
     }
@@ -186,6 +197,10 @@ impl Numericable for u128 {
 
     fn from_f64(x: f64) -> Self {
         x as u128
+    }
+
+    fn from_i64(x: IntPayloadType) -> Self {
+        u128::try_from(x).unwrap_or_default()
     }
 
     fn from_u128(x: u128) -> Self {

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -7,9 +7,9 @@ use serde_json::Value;
 
 use crate::types::{
     AnyVariants, CheckGeoPoint, DateTimePayloadType, FieldCondition, FloatPayloadType,
-    GeoBoundingBox, GeoPoint, GeoPolygon, GeoRadius, Match, MatchAny, MatchExcept, MatchPhrase,
-    MatchPrefix, MatchText, MatchTextAny, MatchValue, Range, RangeInterface, ValueVariants,
-    ValuesCount,
+    GeoBoundingBox, GeoPoint, GeoPolygon, GeoRadius, IntPayloadType, Match, MatchAny, MatchExcept,
+    MatchPhrase, MatchPrefix, MatchText, MatchTextAny, MatchValue, Range, RangeInterface,
+    ValueVariants, ValuesCount,
 };
 
 /// Threshold representing the point to which iterating through an IndexSet is more efficient than using hashing.
@@ -87,6 +87,7 @@ impl ValueChecker for FieldCondition {
                 .as_ref()
                 .is_some_and(|range_interface| match range_interface {
                     RangeInterface::Float(condition) => condition.check_match(payload),
+                    RangeInterface::Integer(condition) => condition.check_match(payload),
                     RangeInterface::DateTime(condition) => condition.check_match(payload),
                 })
             || geo_radius
@@ -255,6 +256,28 @@ impl ValueChecker for Range<OrderedFloat<FloatPayloadType>> {
                 .as_f64()
                 .map(|number| self.check_range(OrderedFloat(number)))
                 .unwrap_or(false),
+            Value::Null
+            | Value::Bool(_)
+            | Value::String(_)
+            | Value::Array(_)
+            | Value::Object(_) => false,
+        }
+    }
+}
+
+impl ValueChecker for Range<IntPayloadType> {
+    fn check_match(&self, payload: &Value) -> bool {
+        match payload {
+            Value::Number(num) => {
+                if let Some(number) = num.as_i64() {
+                    self.check_range(number)
+                } else {
+                    num.as_f64().is_some_and(|number| {
+                        let float_range = self.map(|bound| OrderedFloat(bound as FloatPayloadType));
+                        float_range.check_range(OrderedFloat(number))
+                    })
+                }
+            }
             Value::Null
             | Value::Bool(_)
             | Value::String(_)
@@ -476,6 +499,21 @@ mod tests {
         });
         // 0 >= 1 is false -> a missing field does not match
         assert!(!gte_one.check_empty());
+    }
+
+    #[test]
+    fn test_int_range_checker_preserves_large_i64_precision() {
+        let value = -9_223_372_036_854_775_807_i64;
+        let payload = json!(value);
+        let range = Range {
+            lt: None,
+            gt: None,
+            gte: Some(value),
+            lte: Some(value),
+        };
+
+        assert!(range.check(&payload));
+        assert!(!range.check(&json!(i64::MIN)));
     }
 
     #[test]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -3237,11 +3237,13 @@ impl<'de> serde::Deserialize<'de> for RangeInterface {
                     .map_err(serde::de::Error::custom);
             }
 
-            let has_integer_bounds = keys.iter().any(|k| obj.contains_key(*k))
-                && keys
-                    .iter()
-                    .filter_map(|k| obj.get(*k))
-                    .all(|bound| bound.as_i64().is_some());
+            let bounds: Vec<_> = keys
+                .iter()
+                .filter_map(|k| obj.get(*k))
+                .filter(|bound| !bound.is_null())
+                .collect();
+            let has_integer_bounds =
+                !bounds.is_empty() && bounds.iter().all(|bound| bound.as_i64().is_some());
 
             if has_integer_bounds {
                 return serde_json::from_value::<Range<IntPayloadType>>(value)
@@ -5010,6 +5012,30 @@ mod tests {
 
         assert_eq!(range.gte, Some(value));
         assert_eq!(range.lte, Some(value));
+    }
+
+    #[test]
+    fn test_json_integer_range_ignores_null_bounds_for_detection() {
+        let value = 9_223_372_036_854_775_807_i64;
+        let json = format!(
+            r#"{{
+                "key": "x",
+                "range": {{
+                    "gte": {value},
+                    "lte": null
+                }}
+            }}"#
+        );
+
+        let Condition::Field(condition) = serde_json::from_str::<Condition>(&json).unwrap() else {
+            panic!("expected field condition");
+        };
+        let Some(RangeInterface::Integer(range)) = condition.range else {
+            panic!("expected integer range, got {:?}", condition.range);
+        };
+
+        assert_eq!(range.gte, Some(value));
+        assert_eq!(range.lte, None);
     }
 
     #[test]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -3159,6 +3159,7 @@ impl From<Vec<IntPayloadType>> for MatchExcept {
 #[serde(untagged)]
 pub enum RangeInterface {
     Float(Range<OrderedFloat<FloatPayloadType>>),
+    Integer(Range<IntPayloadType>),
     DateTime(Range<DateTimePayloadType>),
 }
 
@@ -3166,6 +3167,13 @@ impl Hash for RangeInterface {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         match self {
             RangeInterface::Float(range) => {
+                let Range { lt, gt, gte, lte } = range;
+                lt.hash(state);
+                gt.hash(state);
+                gte.hash(state);
+                lte.hash(state);
+            }
+            RangeInterface::Integer(range) => {
                 let Range { lt, gt, gte, lte } = range;
                 lt.hash(state);
                 gt.hash(state);
@@ -3186,6 +3194,14 @@ impl Hash for RangeInterface {
 #[derive(serde::Deserialize)]
 #[serde(untagged)]
 enum RangeInterfaceUntagged {
+    Integer(Range<IntPayloadType>),
+    Float(Range<OrderedFloatPayloadType>),
+    DateTime(Range<DateTimePayloadType>),
+}
+
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum HumanReadableRangeInterfaceFallback {
     Float(Range<OrderedFloatPayloadType>),
     DateTime(Range<DateTimePayloadType>),
 }
@@ -3200,6 +3216,7 @@ impl<'de> serde::Deserialize<'de> for RangeInterface {
     {
         if !deserializer.is_human_readable() {
             return RangeInterfaceUntagged::deserialize(deserializer).map(|parsed| match parsed {
+                RangeInterfaceUntagged::Integer(r) => RangeInterface::Integer(r),
                 RangeInterfaceUntagged::Float(r) => RangeInterface::Float(r),
                 RangeInterfaceUntagged::DateTime(r) => RangeInterface::DateTime(r),
             });
@@ -3219,15 +3236,27 @@ impl<'de> serde::Deserialize<'de> for RangeInterface {
                     .map(RangeInterface::DateTime)
                     .map_err(serde::de::Error::custom);
             }
+
+            let has_integer_bounds = keys.iter().any(|k| obj.contains_key(*k))
+                && keys
+                    .iter()
+                    .filter_map(|k| obj.get(*k))
+                    .all(|bound| bound.as_i64().is_some());
+
+            if has_integer_bounds {
+                return serde_json::from_value::<Range<IntPayloadType>>(value)
+                    .map(RangeInterface::Integer)
+                    .map_err(serde::de::Error::custom);
+            }
         }
 
-        // Fallback to existing untagged behavior
-        let parsed = serde_json::from_value::<RangeInterfaceUntagged>(value)
+        // Fallback to existing REST/JSON behavior.
+        let parsed = serde_json::from_value::<HumanReadableRangeInterfaceFallback>(value)
             .map_err(serde::de::Error::custom)?;
 
         Ok(match parsed {
-            RangeInterfaceUntagged::Float(r) => RangeInterface::Float(r),
-            RangeInterfaceUntagged::DateTime(r) => RangeInterface::DateTime(r),
+            HumanReadableRangeInterfaceFallback::Float(r) => RangeInterface::Float(r),
+            HumanReadableRangeInterfaceFallback::DateTime(r) => RangeInterface::DateTime(r),
         })
     }
 }
@@ -3236,7 +3265,7 @@ type OrderedFloatPayloadType = OrderedFloat<FloatPayloadType>;
 
 /// Range filter request
 #[macro_rules_attribute::macro_rules_derive(crate::common::macros::schemars_rename_generics)]
-#[derive_args(< OrderedFloatPayloadType > => "Range", < DateTimePayloadType > => "DatetimeRange")]
+#[derive_args(< OrderedFloatPayloadType > => "Range", < IntPayloadType > => "IntegerRange", < DateTimePayloadType > => "DatetimeRange")]
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct Range<T> {
@@ -3545,6 +3574,20 @@ impl FieldCondition {
             key,
             r#match: None,
             range: Some(RangeInterface::Float(range)),
+            geo_bounding_box: None,
+            geo_radius: None,
+            geo_polygon: None,
+            values_count: None,
+            is_empty: None,
+            is_null: None,
+        }
+    }
+
+    pub fn new_int_range(key: PayloadKeyType, range: Range<IntPayloadType>) -> Self {
+        Self {
+            key,
+            r#match: None,
+            range: Some(RangeInterface::Integer(range)),
             geo_bounding_box: None,
             geo_radius: None,
             geo_polygon: None,
@@ -4946,6 +4989,60 @@ mod tests {
     }
 
     #[test]
+    fn test_json_integer_range_preserves_i64_bounds() {
+        let value = -9_223_372_036_854_775_807_i64;
+        let json = format!(
+            r#"{{
+                "key": "x",
+                "range": {{
+                    "gte": {value},
+                    "lte": {value}
+                }}
+            }}"#
+        );
+
+        let Condition::Field(condition) = serde_json::from_str::<Condition>(&json).unwrap() else {
+            panic!("expected field condition");
+        };
+        let Some(RangeInterface::Integer(range)) = condition.range else {
+            panic!("expected integer range, got {:?}", condition.range);
+        };
+
+        assert_eq!(range.gte, Some(value));
+        assert_eq!(range.lte, Some(value));
+    }
+
+    #[test]
+    fn test_json_fractional_range_stays_float() {
+        let json = r#"{
+            "key": "x",
+            "range": {
+                "gte": 1.5
+            }
+        }"#;
+
+        let Condition::Field(condition) = serde_json::from_str::<Condition>(json).unwrap() else {
+            panic!("expected field condition");
+        };
+
+        assert_matches!(condition.range, Some(RangeInterface::Float(_)));
+    }
+
+    #[test]
+    fn test_json_empty_range_stays_float() {
+        let json = r#"{
+            "key": "x",
+            "range": {}
+        }"#;
+
+        let Condition::Field(condition) = serde_json::from_str::<Condition>(json).unwrap() else {
+            panic!("expected field condition");
+        };
+
+        assert_matches!(condition.range, Some(RangeInterface::Float(_)));
+    }
+
+    #[test]
     fn test_condition_non_string_key_returns_clear_error() {
         for json in [
             r#"{"key": null, "match": {"value": "A"}}"#,
@@ -4991,6 +5088,21 @@ mod tests {
         });
 
         // rmp-serde uses non-human-readable format
+        let binary = rmp_serde::to_vec(&range).expect("serialize");
+        let restored: RangeInterface = rmp_serde::from_slice(&binary).expect("deserialize");
+
+        assert_eq!(range, restored);
+    }
+
+    #[test]
+    fn test_range_interface_integer_binary_roundtrip() {
+        let range = RangeInterface::Integer(Range {
+            lt: None,
+            gt: None,
+            gte: Some(-9_223_372_036_854_775_807_i64),
+            lte: Some(-9_223_372_036_854_775_807_i64),
+        });
+
         let binary = rmp_serde::to_vec(&range).expect("serialize");
         let restored: RangeInterface = rmp_serde::from_slice(&binary).expect("deserialize");
 


### PR DESCRIPTION
Addresses #8538.

## Summary

This preserves exact int64 range bounds for integer payload filters instead of routing those bounds through floating point conversion.

The change adds an integer range representation internally and exposes an exact `integer_range` field in the gRPC `FieldCondition` API. REST/JSON integer range bounds are also deserialized as integer ranges when all provided bounds are valid `i64` values.

## Details

- Add `RangeInterface::Integer` for exact integer range bounds.
- Add gRPC `IntegerRange` and `FieldCondition.integer_range`.
- Convert gRPC integer ranges to and from the internal integer range representation.
- Keep existing double-based gRPC `range` behavior for backward compatibility.
- Keep fractional JSON range bounds as float ranges.
- Keep empty JSON ranges on the existing float-range path.
- Preserve exact integer comparisons in unindexed payload checks and integer numeric indexes.

## Tests

```text
$env:PROTOC='C:\Users\varun\Desktop\OpnSrcPrjcts\.tools\protoc-35.1\bin\protoc.exe'; cargo test -p api integer_range -- --nocapture
cargo test -p segment int_range -- --nocapture
cargo test -p segment range_interface -- --nocapture
cargo test -p segment json_ -- --nocapture
$env:PROTOC='C:\Users\varun\Desktop\OpnSrcPrjcts\.tools\protoc-35.1\bin\protoc.exe'; cargo check -p api -p collection
git diff --check
```