### PR TITLE
Model tester for Edge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,6 +1325,7 @@ dependencies = [
  "common",
  "count-min-sketch",
  "criterion",
+ "edge",
  "env_logger",
  "fnv",
  "fs-err",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,6 +1423,7 @@ dependencies = [
  "common",
  "count-min-sketch",
  "criterion",
+ "edge",
  "env_logger",
  "fnv",
  "fs-err 3.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ data-consistency-check = ["collection/data-consistency-check"]
 gpu = ["gpu/gpu", "segment/gpu"]
 deb = []
 staging = ["collection/staging", "storage/staging", "shard/staging"]
+# Edge-follower verification in the model_testing binary (see lib/collection model_testing).
+edge-verify = ["collection/edge-verify"]
 
 [dev-dependencies]
 serde_urlencoded = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ data-consistency-check = ["collection/data-consistency-check"]
 gpu = ["gpu/gpu", "segment/gpu"]
 deb = []
 staging = ["collection/staging", "storage/staging", "shard/staging"]
+# Edge-follower verification in the model_testing binary (see lib/collection model_testing).
+edge-verify = ["collection/edge-verify"]
 
 [dev-dependencies]
 serde_urlencoded = "0.7"

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -16,6 +16,7 @@ testing = ["common/testing", "segment/testing", "shard/testing"]
 tracing = ["dep:tracing", "api/tracing", "segment/tracing"]
 data-consistency-check = []
 staging = ["shard/staging"]
+edge-verify = ["dep:edge"]
 
 [dev-dependencies]
 criterion = { workspace = true }
@@ -73,6 +74,7 @@ cancel = { path = "../common/cancel" }
 issues = { path = "../common/issues" }
 segment = { path = "../segment", default-features = false }
 shard = { path = "../shard", default-features = false, features = ["api"] }
+edge = { path = "../edge", optional = true }
 sparse = { path = "../sparse" }
 api = { path = "../api" }
 wal = { path = "../wal" }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -15,8 +15,11 @@ workspace = true
 testing = ["common/testing", "segment/testing", "shard/testing"]
 tracing = ["dep:tracing", "api/tracing", "segment/tracing"]
 data-consistency-check = []
-staging = ["shard/staging"]
-edge-verify = ["dep:edge"]
+# `edge?/staging` keeps feature-unified builds coherent: with `edge-verify` on, `shard/staging`
+# adds the `StagingOperation` variant, and edge's match over it is gated on its own `staging`.
+staging = ["shard/staging", "edge?/staging"]
+# Implies `testing`: the only consumer is the model_testing module, which is testing-gated.
+edge-verify = ["dep:edge", "testing"]
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/lib/collection/src/model_testing/edge_verify.rs
+++ b/lib/collection/src/model_testing/edge_verify.rs
@@ -1,0 +1,231 @@
+//! Edge read-only follower verification (`edge-verify` cargo feature).
+//!
+//! Opens each shard directory of the soak collection as an [`edge::ReadOnlyEdgeShard`] —
+//! the same reader Qdrant Edge uses to follow a leader-written shard — and reconstructs a
+//! model-shaped map from follower scrolls. The run loop compares it against the in-memory
+//! model at quiesced checkpoints (op loop idle, snapshot drained, all shards force-flushed),
+//! because a follower only ever sees flushed state.
+//!
+//! Without the feature, [`EdgeVerifier::open`] panics with a rebuild hint, so the
+//! `edge_verify` run parameter exists unconditionally and fails loudly instead of silently
+//! skipping checks.
+
+#[cfg(feature = "edge-verify")]
+use std::collections::BTreeMap;
+use std::path::Path;
+
+#[cfg(feature = "edge-verify")]
+use common::universal_io::{MmapFile, MmapFs};
+#[cfg(feature = "edge-verify")]
+use edge::{EdgeShardRead, ReadOnlyEdgeShard, ScrollRequest};
+#[cfg(feature = "edge-verify")]
+use segment::data_types::vectors::{VectorInternal, VectorStructInternal};
+#[cfg(feature = "edge-verify")]
+use segment::types::{WithPayloadInterface, WithVector};
+#[cfg(feature = "edge-verify")]
+use shard::retrieve::record_internal::RecordInternal;
+
+use super::Model;
+#[cfg(feature = "edge-verify")]
+use super::ModelEntry;
+#[cfg(feature = "edge-verify")]
+use super::VectorValue;
+#[cfg(feature = "edge-verify")]
+use super::op::canonical_sparse;
+#[cfg(feature = "edge-verify")]
+use crate::shards::shard_path;
+
+/// One page per follower scroll call; the follower returns a continuation offset.
+#[cfg(feature = "edge-verify")]
+const SCROLL_PAGE: usize = 1000;
+
+/// Read-only Edge followers over the soak collection's shard directories, one per shard.
+/// Opened once and kept across checkpoints, so each [`Self::observe`] exercises
+/// `refresh` + `live_reload` deltas (segment churn, in-place appends/deletes) rather than
+/// fresh one-shot opens.
+pub(super) struct EdgeVerifier {
+    #[cfg(feature = "edge-verify")]
+    shards: Vec<ReadOnlyEdgeShard<MmapFile>>,
+}
+
+impl EdgeVerifier {
+    /// Open a follower over every shard directory. Requires the leader to write segment
+    /// manifests (`write_segment_manifest` feature flag, set before the collection is
+    /// built): the follower discovers segments through the manifest, which is what keeps
+    /// discovery safe under optimizer churn — in-construction segments are not listed.
+    #[cfg(feature = "edge-verify")]
+    pub(super) fn open(collection_dir: &Path, shard_count: u32) -> Self {
+        assert!(
+            common::flags::feature_flags().write_segment_manifest,
+            "edge-verify requires the write_segment_manifest feature flag; \
+             set it in init_feature_flags before building the collection",
+        );
+        let shards = (0..shard_count)
+            .map(|shard_id| {
+                let path = shard_path(collection_dir, shard_id);
+                ReadOnlyEdgeShard::<MmapFile>::open(MmapFs, &path, None, None).unwrap_or_else(|e| {
+                    panic!("failed to open edge follower over {}: {e}", path.display())
+                })
+            })
+            .collect();
+        Self { shards }
+    }
+
+    #[cfg(not(feature = "edge-verify"))]
+    pub(super) fn open(_collection_dir: &Path, _shard_count: u32) -> Self {
+        panic!(
+            "model_testing was built without the `edge-verify` cargo feature; \
+             rebuild with `--features edge-verify` to use --edge-verify",
+        );
+    }
+
+    /// Refresh every follower and scroll the full collection into a model-shaped map.
+    /// Only meaningful at a quiesced checkpoint: op loop idle, background snapshot
+    /// drained, and every shard force-flushed — the follower sees flushed state only.
+    #[cfg(feature = "edge-verify")]
+    pub(super) fn observe(&self, ctx: &str) -> Model {
+        let mut out = Model::new();
+        for follower in &self.shards {
+            follower.refresh().unwrap_or_else(|e| {
+                panic!(
+                    "{ctx}: follower refresh of {} failed: {e}",
+                    follower.path().display(),
+                )
+            });
+            let mut offset = None;
+            loop {
+                let (records, next) = follower
+                    .scroll(ScrollRequest {
+                        offset,
+                        limit: Some(SCROLL_PAGE),
+                        filter: None,
+                        with_payload: Some(WithPayloadInterface::Bool(true)),
+                        with_vector: WithVector::Bool(true),
+                        order_by: None,
+                    })
+                    .unwrap_or_else(|e| {
+                        panic!(
+                            "{ctx}: follower scroll of {} failed: {e}",
+                            follower.path().display(),
+                        )
+                    });
+                for record in records {
+                    let id = record.id;
+                    if out.insert(id, record_to_model_entry(record, ctx)).is_some() {
+                        panic!("{ctx}: point {id:?} returned by more than one shard follower");
+                    }
+                }
+                match next {
+                    Some(next_offset) => offset = Some(next_offset),
+                    None => break,
+                }
+            }
+        }
+        out
+    }
+
+    // `&self` mirrors the real method so call sites compile identically in both configs.
+    #[allow(clippy::unused_self)]
+    #[cfg(not(feature = "edge-verify"))]
+    pub(super) fn observe(&self, _ctx: &str) -> Model {
+        unreachable!("EdgeVerifier cannot be constructed without the edge-verify feature")
+    }
+}
+
+/// Convert one follower scroll record into the model's entry shape: named vectors with
+/// sparse canonicalized (the engine returns them sorted, but canonicalizing here keeps the
+/// conversion total) and multi-dense flattened to rows; a missing payload is the empty one.
+#[cfg(feature = "edge-verify")]
+fn record_to_model_entry(record: RecordInternal, ctx: &str) -> ModelEntry {
+    let RecordInternal {
+        id,
+        payload,
+        vector,
+        shard_key: _,
+        order_value: _,
+    } = record;
+    let named = match vector {
+        Some(VectorStructInternal::Named(named)) => named,
+        Some(other @ (VectorStructInternal::Single(_) | VectorStructInternal::MultiDense(_))) => {
+            panic!("{ctx}: expected named vectors for {id:?}, got {other:?}")
+        }
+        None => panic!("{ctx}: vector missing in follower scroll result for {id:?}"),
+    };
+    let mut vectors = BTreeMap::new();
+    for (name, value) in named {
+        let v = match value {
+            VectorInternal::Dense(v) => VectorValue::Dense(v),
+            VectorInternal::Sparse(sv) => VectorValue::Sparse(canonical_sparse(&sv)),
+            VectorInternal::MultiDense(m) => {
+                VectorValue::MultiDense(m.multi_vectors().map(<[f32]>::to_vec).collect())
+            }
+        };
+        vectors.insert(name, v);
+    }
+    ModelEntry {
+        vectors,
+        payload: payload.unwrap_or_default(),
+    }
+}
+
+#[cfg(all(test, feature = "edge-verify"))]
+mod tests {
+    use std::collections::HashMap;
+
+    use segment::data_types::vectors::{
+        MultiDenseVectorInternal, VectorInternal, VectorStructInternal,
+    };
+    use segment::types::{Payload, PointIdType};
+    use shard::retrieve::record_internal::RecordInternal;
+    use sparse::common::sparse_vector::SparseVector;
+
+    use super::record_to_model_entry;
+    use crate::model_testing::VectorValue;
+
+    /// Sparse vectors canonicalize (sorted indices, zero entries dropped), multi-dense
+    /// flattens to rows, and a missing payload becomes the empty payload — matching how
+    /// the model stores entries.
+    #[test]
+    fn record_conversion_matches_model_shape() {
+        let record = RecordInternal {
+            id: PointIdType::NumId(7),
+            payload: None,
+            vector: Some(VectorStructInternal::Named(HashMap::from([
+                ("a".to_string(), VectorInternal::Dense(vec![1.0, 2.0])),
+                (
+                    "s".to_string(),
+                    VectorInternal::Sparse(SparseVector {
+                        indices: vec![5, 2, 9],
+                        values: vec![0.5, 0.0, 1.5],
+                    }),
+                ),
+                (
+                    "m".to_string(),
+                    VectorInternal::MultiDense(MultiDenseVectorInternal::new(
+                        vec![1.0, 2.0, 3.0, 4.0],
+                        2,
+                    )),
+                ),
+            ]))),
+            shard_key: None,
+            order_value: None,
+        };
+
+        let entry = record_to_model_entry(record, "test");
+
+        assert_eq!(entry.vectors["a"], VectorValue::Dense(vec![1.0, 2.0]));
+        // (2, 0.0) dropped, remaining pairs sorted by index.
+        assert_eq!(
+            entry.vectors["s"],
+            VectorValue::Sparse(SparseVector {
+                indices: vec![5, 9],
+                values: vec![0.5, 1.5],
+            }),
+        );
+        assert_eq!(
+            entry.vectors["m"],
+            VectorValue::MultiDense(vec![vec![1.0, 2.0], vec![3.0, 4.0]]),
+        );
+        assert_eq!(entry.payload, Payload::default());
+    }
+}

--- a/lib/collection/src/model_testing/edge_verify.rs
+++ b/lib/collection/src/model_testing/edge_verify.rs
@@ -41,7 +41,7 @@ const SCROLL_PAGE: usize = 1000;
 
 /// Read-only Edge followers over the soak collection's shard directories, one per shard.
 /// Opened once and kept across checkpoints, so each [`Self::observe`] exercises
-/// `refresh` + `live_reload` deltas (segment churn, in-place appends/deletes) rather than
+/// `live_reload` deltas (segment churn, in-place appends/deletes) rather than
 /// fresh one-shot opens.
 pub(super) struct EdgeVerifier {
     #[cfg(feature = "edge-verify")]
@@ -93,9 +93,9 @@ impl EdgeVerifier {
     pub(super) fn observe(&self, ctx: &str) -> Model {
         let mut out = Model::new();
         for follower in &self.shards {
-            follower.refresh().unwrap_or_else(|e| {
+            follower.live_reload().unwrap_or_else(|e| {
                 panic!(
-                    "{ctx}: follower refresh of {} failed: {e}",
+                    "{ctx}: follower live_reload of {} failed: {e}",
                     follower.path().display(),
                 )
             });

--- a/lib/collection/src/model_testing/edge_verify.rs
+++ b/lib/collection/src/model_testing/edge_verify.rs
@@ -49,16 +49,23 @@ pub(super) struct EdgeVerifier {
 }
 
 impl EdgeVerifier {
-    /// Open a follower over every shard directory. Requires the leader to write segment
-    /// manifests (`write_segment_manifest` feature flag, set before the collection is
-    /// built): the follower discovers segments through the manifest, which is what keeps
-    /// discovery safe under optimizer churn — in-construction segments are not listed.
+    /// Open a follower over every shard directory. Requires the leader to run under the
+    /// full serverless-compatible contract (`serverless_compatible` feature flag, set
+    /// before the collection is built), not just segment manifests:
+    /// `write_segment_manifest` gives the follower safe segment discovery under optimizer
+    /// churn (in-construction segments are not listed), and `append_only_mutations` is
+    /// what makes leader writes observable at all: the follower's live-reload delta is
+    /// keyed on newly appended offsets, so an in-place rewrite of an existing point is
+    /// invisible to it and produces false model divergences (repro: manifest-only run of
+    /// `harness_edge_verify` with seed 362077359617665433 diverges at op 564).
     #[cfg(feature = "edge-verify")]
     pub(super) fn open(collection_dir: &Path, shard_count: u32) -> Self {
         assert!(
-            common::flags::feature_flags().write_segment_manifest,
-            "edge-verify requires the write_segment_manifest feature flag; \
-             set it in init_feature_flags before building the collection",
+            common::flags::feature_flags().serverless_compatible(),
+            "edge-verify requires the serverless_compatible feature-flag bundle \
+             (manifest discovery + append-only mutations); call \
+             enable_serverless_compatible() before init_feature_flags, before the \
+             collection is built",
         );
         let shards = (0..shard_count)
             .map(|shard_id| {

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -925,11 +925,11 @@ pub async fn run(
 /// flushed state), refresh + scroll the followers, and compare against the model. Callers
 /// must be between ops with any background snapshot drained.
 ///
-/// Skipped (with a warning) while an optimization is in flight: deletes against a proxied
-/// segment are buffered in the proxy's in-memory map and cannot reach segment files until
-/// the optimization finishes, so a follower comparison at such a boundary would report
-/// deleted points as live. The trace record is only written for checkpoints that actually
-/// run.
+/// With the optimizer enabled this skips *most checkpoints*, often including the final one,
+/// so a run can end having compared nothing. The skip becomes unnecessary *once proxy point
+/// deletions are persisted*.
+///
+/// TODO(model tester): Remove this check once proxy deletions are persisted.
 async fn edge_checkpoint(
     collection: &Collection,
     verifier: &edge_verify::EdgeVerifier,

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -1,4 +1,5 @@
 mod apply;
+mod edge_verify;
 mod fixture;
 mod op;
 mod trace;
@@ -505,6 +506,12 @@ pub(super) enum VectorValue {
 /// `shutdown` lets the caller request an early stop (e.g. on Ctrl-C). The op loop
 /// checks it before each iteration and exits cleanly when set; post-run verification
 /// + summary + reload still run with whatever ops were applied.
+///
+/// With `edge_verify`, every shard directory is also opened through an Edge read-only
+/// follower ([`edge_verify::EdgeVerifier`]) and compared against the model at quiesced
+/// checkpoints: end of run and each mid-run restart. Requires the `edge-verify` cargo
+/// feature and the `write_segment_manifest` feature flag. The flag draws no rng and does
+/// not change the candidate universe, so op streams are seed-comparable with non-edge runs.
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     seed: u64,
@@ -522,6 +529,7 @@ pub async fn run(
     pre_restart_check: bool,
     enable_force_off: bool,
     disable_snapshots: bool,
+    edge_verify: bool,
     duration: Option<Duration>,
     shutdown: Arc<AtomicBool>,
 ) {
@@ -539,6 +547,11 @@ pub async fn run(
     // `Arc` so a background `CreateSnapshot` task can hold the collection alive while the main loop
     // keeps writing to it. Reassigned (restart / final reload) by replacing the `Arc`.
     let mut collection = Arc::new(collection);
+
+    // Edge read-only followers over the shard dirs, kept open across checkpoints so each
+    // one exercises refresh/live_reload deltas. `None` without --edge-verify.
+    let edge_verifier =
+        edge_verify.then(|| edge_verify::EdgeVerifier::open(&collection_dir, shard_count));
 
     // Trace lives at the storage-path root (next to `collection/` and `snapshots/`) so the
     // fixture's per-run wipe of those subdirs leaves it alone; `File::create` truncates so each
@@ -560,6 +573,7 @@ pub async fn run(
         swarm_interval,
         enable_force_off,
         disable_snapshots,
+        edge_verify,
         duration,
     );
 
@@ -727,6 +741,19 @@ pub async fn run(
             // unsafe.
             log::info!("op:{i} restart: drain_snapshot");
             drain_snapshot(&collection, &snapshots_dir, &mut pending_snapshot, i).await;
+            // Edge checkpoint at the restart boundary: quiesced (snapshot drained, op loop
+            // idle), and the follower survives the leader's close+reopen below for free.
+            if let Some(verifier) = &edge_verifier {
+                edge_checkpoint(
+                    &collection,
+                    verifier,
+                    &model,
+                    &mut trace,
+                    i,
+                    &format!("edge at restart op:{i}"),
+                )
+                .await;
+            }
             // Newest-clocks recovery point must survive the close+reopen exactly; captured here
             // (snapshot drained, op loop idle) and compared after the reload below. See
             // [`verify::assert_clocks_match`] for why both mismatch directions are bugs.
@@ -861,6 +888,19 @@ pub async fn run(
     // path), then close and reopen and re-verify — mirrors blobstore tests.rs:488-516.
     log::info!("reload: drain_snapshot");
     drain_snapshot(&collection, &snapshots_dir, &mut pending_snapshot, applied).await;
+    // Final edge checkpoint: after the optimizer settled and the snapshot drained, before
+    // the leader closes for the reload check.
+    if let Some(verifier) = &edge_verifier {
+        edge_checkpoint(
+            &collection,
+            verifier,
+            &model,
+            &mut trace,
+            applied,
+            "edge final",
+        )
+        .await;
+    }
     // Same clock-durability capture as the mid-run restart path, for the final reload.
     let pre_clocks = verify::collect_clock_ticks(&collection).await;
     log::info!("reload: stop_gracefully");
@@ -890,6 +930,33 @@ pub async fn run(
     // After the model check, same as the restart path (see the comment there for ordering).
     let post_clocks = verify::collect_clock_ticks(&collection).await;
     verify::assert_clocks_match(&pre_clocks, &post_clocks, "reloaded");
+}
+
+/// Quiesced edge-follower checkpoint: force-flush every shard (a follower only sees
+/// flushed state), refresh + scroll the followers, and compare against the model. Callers
+/// must be between ops with any background snapshot drained.
+///
+/// Skipped (with a warning) while an optimization is in flight: deletes against a proxied
+/// segment are buffered in the proxy's in-memory map and cannot reach segment files until
+/// the optimization finishes, so a follower comparison at such a boundary would report
+/// deleted points as live. The trace record is only written for checkpoints that actually
+/// run.
+async fn edge_checkpoint(
+    collection: &Collection,
+    verifier: &edge_verify::EdgeVerifier,
+    model: &Model,
+    trace: &mut trace::Trace,
+    tick: usize,
+    ctx: &str,
+) {
+    if verify::has_proxy_segments(collection).await {
+        log::warn!("{ctx}: optimizer busy (proxy segments present), skipping edge checkpoint");
+        return;
+    }
+    trace.edge_verify(tick, model.len());
+    verify::flush_all_local_shards(collection).await;
+    let observed = verifier.observe(ctx);
+    verify::assert_matches_model(&observed, model, ctx);
 }
 
 /// Upper bound on how long we wait for a background snapshot to finish when draining it, so a hung
@@ -998,6 +1065,7 @@ mod tests {
         restart_probability: f64,
         disable_snapshots: bool,
         op_num: usize,
+        edge_verify: bool,
     ) {
         let storage_dir = tempfile::tempdir().expect("failed to create temp dir");
         let seed = rand::rng().random();
@@ -1023,6 +1091,7 @@ mod tests {
             false, // pre_restart_check
             false, // enable_force_off
             disable_snapshots,
+            edge_verify,
             None, // duration: bounded by op_num
             Arc::new(AtomicBool::new(false)),
         )
@@ -1047,6 +1116,7 @@ mod tests {
             0.0,
             SNAPSHOTS_OFF,
             OP_NUM,
+            false,
         )
         .await;
     }
@@ -1068,7 +1138,15 @@ mod tests {
     async fn harness_no_restarts() {
         // op_num halved: optimizer churn makes this the slowest no-restart variant; trim it so
         // it isn't marked SLOW by nextest (coverage is recovered across many seeded CI runs).
-        smoke("harness_no_restarts", false, 0.0, SNAPSHOTS_OFF, OP_NUM / 2).await;
+        smoke(
+            "harness_no_restarts",
+            false,
+            0.0,
+            SNAPSHOTS_OFF,
+            OP_NUM / 2,
+            false,
+        )
+        .await;
     }
 
     /// Same configuration as [`harness_no_optimizer_no_restarts`], plus seeded mid-run
@@ -1080,7 +1158,15 @@ mod tests {
     /// seed the op stream differs from a no-restart run.
     #[tokio::test(flavor = "multi_thread")]
     async fn harness_no_optimizer() {
-        smoke("harness_no_optimizer", true, 0.002, SNAPSHOTS_OFF, OP_NUM).await;
+        smoke(
+            "harness_no_optimizer",
+            true,
+            0.002,
+            SNAPSHOTS_OFF,
+            OP_NUM,
+            false,
+        )
+        .await;
     }
 
     /// Same configuration as [`harness_no_optimizer`], but with the optimizer enabled:
@@ -1099,7 +1185,7 @@ mod tests {
     async fn harness() {
         // op_num quartered: optimizer churn + restarts make this the slowest variant; trim it so
         // it isn't the suite's long pole (coverage is recovered across many seeded CI runs).
-        smoke("harness", false, 0.002, SNAPSHOTS_OFF, OP_NUM / 4).await;
+        smoke("harness", false, 0.002, SNAPSHOTS_OFF, OP_NUM / 4, false).await;
     }
 
     /// Snapshot-focused gate: snapshots enabled (`SNAPSHOTS_ON`) plus seeded restarts. Each
@@ -1121,6 +1207,36 @@ mod tests {
             0.001,
             SNAPSHOTS_ON,
             OP_NUM,
+            false,
+        )
+        .await;
+    }
+
+    /// Edge-follower gate (`edge-verify` feature): the optimizer-on, restarts-on cell with
+    /// an Edge read-only follower verified at every restart and at end of run. Optimizer
+    /// churn exercises manifest-driven segment discovery under the follower (segments
+    /// appear and vanish between refreshes); restarts exercise the quiesced
+    /// flush + refresh + full-compare checkpoints mid-run.
+    ///
+    /// Not run by default CI (needs the feature):
+    /// `cargo nextest run -p collection --features edge-verify -E 'test(harness_edge_verify)'`
+    #[cfg(feature = "edge-verify")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn harness_edge_verify() {
+        // Followers discover segments through the manifest, which the leader only writes
+        // when this flag is on; set it before the fixture builds the collection. A second
+        // init in the same process (plain `cargo test`) only logs a warning, and manifests
+        // turning on for sibling tests is harmless.
+        let mut flags = common::flags::FeatureFlags::default();
+        flags.write_segment_manifest = true;
+        common::flags::init_feature_flags(flags);
+        smoke(
+            "harness_edge_verify",
+            false,
+            0.002,
+            SNAPSHOTS_OFF,
+            OP_NUM / 4,
+            true,
         )
         .await;
     }

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -510,8 +510,12 @@ pub(super) enum VectorValue {
 /// With `edge_verify`, every shard directory is also opened through an Edge read-only
 /// follower ([`edge_verify::EdgeVerifier`]) and compared against the model at quiesced
 /// checkpoints: end of run and each mid-run restart. Requires the `edge-verify` cargo
-/// feature and the `write_segment_manifest` feature flag. The flag draws no rng and does
-/// not change the candidate universe, so op streams are seed-comparable with non-edge runs.
+/// feature and the `serverless_compatible` feature-flag bundle (manifest discovery plus
+/// append-only mutations; see [`edge_verify::EdgeVerifier::open`]). The flag draws no rng
+/// and does not change the candidate universe, so op streams are seed-comparable with
+/// non-edge runs; note however that each checkpoint force-flushes every shard, so with
+/// `edge_verify` the mid-run close+reopen no longer exercises the cold, unflushed
+/// WAL-replay recovery path (see the no-flush comment in the restart block).
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     seed: u64,
@@ -724,7 +728,10 @@ pub async fn run(
             }
             // Close + reopen + full model verification. Does NOT force a flush — mirrors
             // what a real user gets from `stop_gracefully`, which is the path that exposes
-            // the WAL-replay bug class.
+            // the WAL-replay bug class. Caveat: with `edge_verify` the checkpoint below
+            // force-flushes every shard right before this close, so edge runs reload from
+            // flushed state and largely lose that coverage; run without --edge-verify when
+            // hunting WAL-replay bugs.
             //
             // `Collection::load` (inside `reopen_collection`) draws its own
             // "Recovering collection" progress bar to stderr. Two independent indicatif bars on
@@ -921,15 +928,22 @@ pub async fn run(
     verify::assert_clocks_match(&pre_clocks, &post_clocks, "reloaded");
 }
 
-/// Quiesced edge-follower checkpoint: force-flush every shard (a follower only sees
-/// flushed state), refresh + scroll the followers, and compare against the model. Callers
-/// must be between ops with any background snapshot drained.
+/// Quiesced edge-follower checkpoint: wait (bounded) for in-flight optimizations to
+/// settle, force-flush every shard (a follower only sees flushed state), refresh + scroll
+/// the followers, and compare against the model. Callers must be between ops with any
+/// background snapshot drained.
 ///
-/// With the optimizer enabled this skips *most checkpoints*, often including the final one,
-/// so a run can end having compared nothing. The skip becomes unnecessary *once proxy point
-/// deletions are persisted*.
+/// The wait exists because deletes against a proxied segment live only in the proxy's
+/// in-memory map until the optimization finishes: no flush can make a follower see them,
+/// so comparing while proxies exist reports false divergences. Skipping outright instead
+/// of waiting made optimizer-on runs silently compare nothing (every restart landed on a
+/// busy optimizer); waiting converges quickly here because the op loop is idle. If
+/// proxies persist past the deadline the checkpoint degrades to a skip, recorded in the
+/// trace as `EdgeVerifySkipped`. An optimization *starting* after the wait is benign:
+/// with the op loop idle a fresh proxy has no buffered deletes, and the follower's
+/// refresh absorbs segment churn, so the race with the flush + observe below is safe.
 ///
-/// TODO(model tester): Remove this check once proxy deletions are persisted.
+/// TODO(model tester): drop the wait/skip once proxy deletions are persisted.
 async fn edge_checkpoint(
     collection: &Collection,
     verifier: &edge_verify::EdgeVerifier,
@@ -938,8 +952,12 @@ async fn edge_checkpoint(
     tick: usize,
     ctx: &str,
 ) {
-    if verify::has_proxy_segments(collection).await {
-        log::warn!("{ctx}: optimizer busy (proxy segments present), skipping edge checkpoint");
+    if !verify::wait_for_no_proxy_segments(collection).await {
+        log::warn!(
+            "{ctx}: optimizer still busy at deadline (proxy segments present), \
+             skipping edge checkpoint"
+        );
+        trace.edge_verify_skipped(tick);
         return;
     }
     trace.edge_verify(tick, model.len());
@@ -1210,15 +1228,27 @@ mod tests {
     ///
     /// Not run by default CI (needs the feature):
     /// `cargo nextest run -p collection --features edge-verify -E 'test(harness_edge_verify)'`
+    ///
+    /// KNOWN BLOCKER, unrelated to the edge code: the serverless bundle's append-only
+    /// mode trips a pre-existing `debug_assert` in `segment::index::query_estimator`
+    /// (`available_vectors` exceeds `available_points` once clone-and-tombstone copies
+    /// accumulate), so this test currently flakes on that panic. It reproduces with
+    /// `edge_verify = false` under the same flags (e.g. seed 362077359617665433), so the
+    /// gate must not be wired into CI until that engine bug is fixed.
     #[cfg(feature = "edge-verify")]
     #[tokio::test(flavor = "multi_thread")]
     async fn harness_edge_verify() {
-        // Followers discover segments through the manifest, which the leader only writes
-        // when this flag is on; set it before the fixture builds the collection. A second
-        // init in the same process (plain `cargo test`) only logs a warning, and manifests
-        // turning on for sibling tests is harmless.
+        // The follower assumes the serverless leader contract, same as the binary's
+        // --edge-verify path: manifest-driven segment discovery plus append-only
+        // mutations. Manifests alone are NOT enough: an in-place point rewrite produces
+        // no live-reload delta, the follower serves stale data, and the checkpoint
+        // reports a false divergence (repro: seed 362077359617665433 with manifest-only
+        // flags diverges at op 564). Set before the fixture builds the collection. A
+        // second init in the same process (plain `cargo test`) only logs a warning;
+        // sibling harness tests picking up the bundle mid-run is acceptable there, and
+        // nextest runs one test per process anyway.
         let mut flags = common::flags::FeatureFlags::default();
-        flags.write_segment_manifest = true;
+        flags.enable_serverless_compatible();
         common::flags::init_feature_flags(flags);
         smoke(
             "harness_edge_verify",

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -936,11 +936,11 @@ pub async fn run(
 /// flushed state), refresh + scroll the followers, and compare against the model. Callers
 /// must be between ops with any background snapshot drained.
 ///
-/// Skipped (with a warning) while an optimization is in flight: deletes against a proxied
-/// segment are buffered in the proxy's in-memory map and cannot reach segment files until
-/// the optimization finishes, so a follower comparison at such a boundary would report
-/// deleted points as live. The trace record is only written for checkpoints that actually
-/// run.
+/// With the optimizer enabled this skips *most checkpoints*, often including the final one,
+/// so a run can end having compared nothing. The skip becomes unnecessary *once proxy point
+/// deletions are persisted*.
+///
+/// TODO(model tester): Remove this check once proxy deletions are persisted.
 async fn edge_checkpoint(
     collection: &Collection,
     verifier: &edge_verify::EdgeVerifier,

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -1,4 +1,5 @@
 mod apply;
+mod edge_verify;
 mod fixture;
 mod op;
 mod trace;
@@ -505,6 +506,12 @@ pub(super) enum VectorValue {
 /// `shutdown` lets the caller request an early stop (e.g. on Ctrl-C). The op loop
 /// checks it before each iteration and exits cleanly when set; post-run verification
 /// + summary + reload still run with whatever ops were applied.
+///
+/// With `edge_verify`, every shard directory is also opened through an Edge read-only
+/// follower ([`edge_verify::EdgeVerifier`]) and compared against the model at quiesced
+/// checkpoints: end of run and each mid-run restart. Requires the `edge-verify` cargo
+/// feature and the `write_segment_manifest` feature flag. The flag draws no rng and does
+/// not change the candidate universe, so op streams are seed-comparable with non-edge runs.
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     seed: u64,
@@ -523,6 +530,7 @@ pub async fn run(
     pre_restart_check: bool,
     enable_force_off: bool,
     disable_snapshots: bool,
+    edge_verify: bool,
     duration: Option<Duration>,
     shutdown: Arc<AtomicBool>,
 ) {
@@ -541,6 +549,11 @@ pub async fn run(
     // `Arc` so a background `CreateSnapshot` task can hold the collection alive while the main loop
     // keeps writing to it. Reassigned (restart / final reload) by replacing the `Arc`.
     let mut collection = Arc::new(collection);
+
+    // Edge read-only followers over the shard dirs, kept open across checkpoints so each
+    // one exercises refresh/live_reload deltas. `None` without --edge-verify.
+    let edge_verifier =
+        edge_verify.then(|| edge_verify::EdgeVerifier::open(&collection_dir, shard_count));
 
     // Trace lives at the storage-path root (next to `collection/` and `snapshots/`) so the
     // fixture's per-run wipe of those subdirs leaves it alone; `File::create` truncates so each
@@ -562,6 +575,7 @@ pub async fn run(
         swarm_interval,
         enable_force_off,
         disable_snapshots,
+        edge_verify,
         duration,
     );
 
@@ -728,6 +742,19 @@ pub async fn run(
             // the task ends — and reopening the same dir with the old collection still open is
             // unsafe.
             drain_snapshot(&collection, &snapshots_dir, &mut pending_snapshot, i).await;
+            // Edge checkpoint at the restart boundary: quiesced (snapshot drained, op loop
+            // idle), and the follower survives the leader's close+reopen below for free.
+            if let Some(verifier) = &edge_verifier {
+                edge_checkpoint(
+                    &collection,
+                    verifier,
+                    &model,
+                    &mut trace,
+                    i,
+                    &format!("edge at restart op:{i}"),
+                )
+                .await;
+            }
             // Newest-clocks recovery point must survive the close+reopen exactly; captured here
             // (snapshot drained, op loop idle) and compared after the reload below. See
             // [`verify::assert_clocks_match`] for why both mismatch directions are bugs.
@@ -854,6 +881,19 @@ pub async fn run(
     // Finish any background snapshot before closing (it holds an `Arc` clone — see the restart
     // path), then close and reopen and re-verify — mirrors blobstore tests.rs:488-516.
     drain_snapshot(&collection, &snapshots_dir, &mut pending_snapshot, applied).await;
+    // Final edge checkpoint: after the optimizer settled and the snapshot drained, before
+    // the leader closes for the reload check.
+    if let Some(verifier) = &edge_verifier {
+        edge_checkpoint(
+            &collection,
+            verifier,
+            &model,
+            &mut trace,
+            applied,
+            "edge final",
+        )
+        .await;
+    }
     // Same clock-durability capture as the mid-run restart path, for the final reload.
     let pre_clocks = verify::collect_clock_ticks(&collection).await;
     collection.stop_gracefully().await;
@@ -879,6 +919,33 @@ pub async fn run(
     // After the model check, same as the restart path (see the comment there for ordering).
     let post_clocks = verify::collect_clock_ticks(&collection).await;
     verify::assert_clocks_match(&pre_clocks, &post_clocks, "reloaded");
+}
+
+/// Quiesced edge-follower checkpoint: force-flush every shard (a follower only sees
+/// flushed state), refresh + scroll the followers, and compare against the model. Callers
+/// must be between ops with any background snapshot drained.
+///
+/// Skipped (with a warning) while an optimization is in flight: deletes against a proxied
+/// segment are buffered in the proxy's in-memory map and cannot reach segment files until
+/// the optimization finishes, so a follower comparison at such a boundary would report
+/// deleted points as live. The trace record is only written for checkpoints that actually
+/// run.
+async fn edge_checkpoint(
+    collection: &Collection,
+    verifier: &edge_verify::EdgeVerifier,
+    model: &Model,
+    trace: &mut trace::Trace,
+    tick: usize,
+    ctx: &str,
+) {
+    if verify::has_proxy_segments(collection).await {
+        log::warn!("{ctx}: optimizer busy (proxy segments present), skipping edge checkpoint");
+        return;
+    }
+    trace.edge_verify(tick, model.len());
+    verify::flush_all_local_shards(collection).await;
+    let observed = verifier.observe(ctx);
+    verify::assert_matches_model(&observed, model, ctx);
 }
 
 /// Upper bound on how long we wait for a background snapshot to finish when draining it, so a hung
@@ -987,6 +1054,7 @@ mod tests {
         restart_probability: f64,
         disable_snapshots: bool,
         op_num: usize,
+        edge_verify: bool,
     ) {
         let storage_dir = tempfile::tempdir().expect("failed to create temp dir");
         let seed = rand::rng().random();
@@ -1013,6 +1081,7 @@ mod tests {
             false, // pre_restart_check
             false, // enable_force_off
             disable_snapshots,
+            edge_verify,
             None, // duration: bounded by op_num
             Arc::new(AtomicBool::new(false)),
         )
@@ -1037,6 +1106,7 @@ mod tests {
             0.0,
             SNAPSHOTS_OFF,
             OP_NUM,
+            false,
         )
         .await;
     }
@@ -1058,7 +1128,15 @@ mod tests {
     async fn harness_no_restarts() {
         // op_num halved: optimizer churn makes this the slowest no-restart variant; trim it so
         // it isn't marked SLOW by nextest (coverage is recovered across many seeded CI runs).
-        smoke("harness_no_restarts", false, 0.0, SNAPSHOTS_OFF, OP_NUM / 2).await;
+        smoke(
+            "harness_no_restarts",
+            false,
+            0.0,
+            SNAPSHOTS_OFF,
+            OP_NUM / 2,
+            false,
+        )
+        .await;
     }
 
     /// Same configuration as [`harness_no_optimizer_no_restarts`], plus seeded mid-run
@@ -1070,7 +1148,15 @@ mod tests {
     /// seed the op stream differs from a no-restart run.
     #[tokio::test(flavor = "multi_thread")]
     async fn harness_no_optimizer() {
-        smoke("harness_no_optimizer", true, 0.002, SNAPSHOTS_OFF, OP_NUM).await;
+        smoke(
+            "harness_no_optimizer",
+            true,
+            0.002,
+            SNAPSHOTS_OFF,
+            OP_NUM,
+            false,
+        )
+        .await;
     }
 
     /// Same configuration as [`harness_no_optimizer`], but with the optimizer enabled:
@@ -1089,7 +1175,7 @@ mod tests {
     async fn harness() {
         // op_num quartered: optimizer churn + restarts make this the slowest variant; trim it so
         // it isn't the suite's long pole (coverage is recovered across many seeded CI runs).
-        smoke("harness", false, 0.002, SNAPSHOTS_OFF, OP_NUM / 4).await;
+        smoke("harness", false, 0.002, SNAPSHOTS_OFF, OP_NUM / 4, false).await;
     }
 
     /// Snapshot-focused gate: snapshots enabled (`SNAPSHOTS_ON`) plus seeded restarts. Each
@@ -1111,6 +1197,36 @@ mod tests {
             0.001,
             SNAPSHOTS_ON,
             OP_NUM,
+            false,
+        )
+        .await;
+    }
+
+    /// Edge-follower gate (`edge-verify` feature): the optimizer-on, restarts-on cell with
+    /// an Edge read-only follower verified at every restart and at end of run. Optimizer
+    /// churn exercises manifest-driven segment discovery under the follower (segments
+    /// appear and vanish between refreshes); restarts exercise the quiesced
+    /// flush + refresh + full-compare checkpoints mid-run.
+    ///
+    /// Not run by default CI (needs the feature):
+    /// `cargo nextest run -p collection --features edge-verify -E 'test(harness_edge_verify)'`
+    #[cfg(feature = "edge-verify")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn harness_edge_verify() {
+        // Followers discover segments through the manifest, which the leader only writes
+        // when this flag is on; set it before the fixture builds the collection. A second
+        // init in the same process (plain `cargo test`) only logs a warning, and manifests
+        // turning on for sibling tests is harmless.
+        let mut flags = common::flags::FeatureFlags::default();
+        flags.write_segment_manifest = true;
+        common::flags::init_feature_flags(flags);
+        smoke(
+            "harness_edge_verify",
+            false,
+            0.002,
+            SNAPSHOTS_OFF,
+            OP_NUM / 4,
+            true,
         )
         .await;
     }

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -510,8 +510,12 @@ pub(super) enum VectorValue {
 /// With `edge_verify`, every shard directory is also opened through an Edge read-only
 /// follower ([`edge_verify::EdgeVerifier`]) and compared against the model at quiesced
 /// checkpoints: end of run and each mid-run restart. Requires the `edge-verify` cargo
-/// feature and the `write_segment_manifest` feature flag. The flag draws no rng and does
-/// not change the candidate universe, so op streams are seed-comparable with non-edge runs.
+/// feature and the `serverless_compatible` feature-flag bundle (manifest discovery plus
+/// append-only mutations; see [`edge_verify::EdgeVerifier::open`]). The flag draws no rng
+/// and does not change the candidate universe, so op streams are seed-comparable with
+/// non-edge runs; note however that each checkpoint force-flushes every shard, so with
+/// `edge_verify` the mid-run close+reopen no longer exercises the cold, unflushed
+/// WAL-replay recovery path (see the no-flush comment in the restart block).
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     seed: u64,
@@ -722,7 +726,10 @@ pub async fn run(
             }
             // Close + reopen + full model verification. Does NOT force a flush — mirrors
             // what a real user gets from `stop_gracefully`, which is the path that exposes
-            // the WAL-replay bug class.
+            // the WAL-replay bug class. Caveat: with `edge_verify` the checkpoint below
+            // force-flushes every shard right before this close, so edge runs reload from
+            // flushed state and largely lose that coverage; run without --edge-verify when
+            // hunting WAL-replay bugs.
             //
             // `Collection::load` (inside `reopen_collection`) draws its own
             // "Recovering collection" progress bar to stderr. Two independent indicatif bars on
@@ -932,15 +939,22 @@ pub async fn run(
     verify::assert_clocks_match(&pre_clocks, &post_clocks, "reloaded");
 }
 
-/// Quiesced edge-follower checkpoint: force-flush every shard (a follower only sees
-/// flushed state), refresh + scroll the followers, and compare against the model. Callers
-/// must be between ops with any background snapshot drained.
+/// Quiesced edge-follower checkpoint: wait (bounded) for in-flight optimizations to
+/// settle, force-flush every shard (a follower only sees flushed state), refresh + scroll
+/// the followers, and compare against the model. Callers must be between ops with any
+/// background snapshot drained.
 ///
-/// With the optimizer enabled this skips *most checkpoints*, often including the final one,
-/// so a run can end having compared nothing. The skip becomes unnecessary *once proxy point
-/// deletions are persisted*.
+/// The wait exists because deletes against a proxied segment live only in the proxy's
+/// in-memory map until the optimization finishes: no flush can make a follower see them,
+/// so comparing while proxies exist reports false divergences. Skipping outright instead
+/// of waiting made optimizer-on runs silently compare nothing (every restart landed on a
+/// busy optimizer); waiting converges quickly here because the op loop is idle. If
+/// proxies persist past the deadline the checkpoint degrades to a skip, recorded in the
+/// trace as `EdgeVerifySkipped`. An optimization *starting* after the wait is benign:
+/// with the op loop idle a fresh proxy has no buffered deletes, and the follower's
+/// refresh absorbs segment churn, so the race with the flush + observe below is safe.
 ///
-/// TODO(model tester): Remove this check once proxy deletions are persisted.
+/// TODO(model tester): drop the wait/skip once proxy deletions are persisted.
 async fn edge_checkpoint(
     collection: &Collection,
     verifier: &edge_verify::EdgeVerifier,
@@ -949,8 +963,12 @@ async fn edge_checkpoint(
     tick: usize,
     ctx: &str,
 ) {
-    if verify::has_proxy_segments(collection).await {
-        log::warn!("{ctx}: optimizer busy (proxy segments present), skipping edge checkpoint");
+    if !verify::wait_for_no_proxy_segments(collection).await {
+        log::warn!(
+            "{ctx}: optimizer still busy at deadline (proxy segments present), \
+             skipping edge checkpoint"
+        );
+        trace.edge_verify_skipped(tick);
         return;
     }
     trace.edge_verify(tick, model.len());
@@ -1220,15 +1238,27 @@ mod tests {
     ///
     /// Not run by default CI (needs the feature):
     /// `cargo nextest run -p collection --features edge-verify -E 'test(harness_edge_verify)'`
+    ///
+    /// KNOWN BLOCKER, unrelated to the edge code: the serverless bundle's append-only
+    /// mode trips a pre-existing `debug_assert` in `segment::index::query_estimator`
+    /// (`available_vectors` exceeds `available_points` once clone-and-tombstone copies
+    /// accumulate), so this test currently flakes on that panic. It reproduces with
+    /// `edge_verify = false` under the same flags (e.g. seed 362077359617665433), so the
+    /// gate must not be wired into CI until that engine bug is fixed.
     #[cfg(feature = "edge-verify")]
     #[tokio::test(flavor = "multi_thread")]
     async fn harness_edge_verify() {
-        // Followers discover segments through the manifest, which the leader only writes
-        // when this flag is on; set it before the fixture builds the collection. A second
-        // init in the same process (plain `cargo test`) only logs a warning, and manifests
-        // turning on for sibling tests is harmless.
+        // The follower assumes the serverless leader contract, same as the binary's
+        // --edge-verify path: manifest-driven segment discovery plus append-only
+        // mutations. Manifests alone are NOT enough: an in-place point rewrite produces
+        // no live-reload delta, the follower serves stale data, and the checkpoint
+        // reports a false divergence (repro: seed 362077359617665433 with manifest-only
+        // flags diverges at op 564). Set before the fixture builds the collection. A
+        // second init in the same process (plain `cargo test`) only logs a warning;
+        // sibling harness tests picking up the bundle mid-run is acceptable there, and
+        // nextest runs one test per process anyway.
         let mut flags = common::flags::FeatureFlags::default();
-        flags.write_segment_manifest = true;
+        flags.enable_serverless_compatible();
         common::flags::init_feature_flags(flags);
         smoke(
             "harness_edge_verify",

--- a/lib/collection/src/model_testing/trace.rs
+++ b/lib/collection/src/model_testing/trace.rs
@@ -97,6 +97,7 @@ impl Trace {
         swarm_interval: usize,
         enable_force_off: bool,
         disable_snapshots: bool,
+        edge_verify: bool,
         duration: Option<Duration>,
     ) {
         self.write(&json!({
@@ -113,6 +114,7 @@ impl Trace {
             "restart_probability": restart_probability,
             "swarm_interval": swarm_interval,
             "disable_snapshots": disable_snapshots,
+            "edge_verify": edge_verify,
             "enable_force_off": enable_force_off,
             // null in op-count mode; seconds when the run is time-bounded (`--duration`).
             "duration_sec": duration.map(|d| d.as_secs()),
@@ -150,6 +152,17 @@ impl Trace {
             "kind": "Restart",
             "pre_points": pre_points,
             "pre_segments": pre_segments,
+        }));
+    }
+
+    /// Records a quiesced edge-follower checkpoint (force-flush + refresh + full compare)
+    /// at op `tick`. Written BEFORE the checkpoint runs, so a divergence panic is
+    /// attributable to it in the trace.
+    pub(super) fn edge_verify(&mut self, tick: usize, points: usize) {
+        self.write(&json!({
+            "op": tick,
+            "kind": "EdgeVerify",
+            "points": points,
         }));
     }
 

--- a/lib/collection/src/model_testing/trace.rs
+++ b/lib/collection/src/model_testing/trace.rs
@@ -22,9 +22,11 @@
 //!
 //! | `kind`         | When                                            | Extra fields |
 //! |----------------|-------------------------------------------------|---|
-//! | `Header`       | First line — run configuration                  | `seed`, `op_num`, `shard_count`, `id_pool`, `disable_optimizer`, `max_segment_size_kb`, `indexing_threshold_kb`, `flush_interval_sec`, `restart_probability`, `swarm_interval`, `disable_snapshots`, `enable_force_off`, `duration_sec` (null unless `--duration`) |
+//! | `Header`       | First line — run configuration                  | `seed`, `op_num`, `shard_count`, `id_pool`, `disable_optimizer`, `max_segment_size_kb`, `indexing_threshold_kb`, `flush_interval_sec`, `restart_probability`, `swarm_interval`, `disable_snapshots`, `edge_verify`, `enable_force_off`, `duration_sec` (null unless `--duration`) |
 //! | *(op variant)* | Each `Op` from the workload generator           | See `op_payload` below — `id`/`ids`/etc. depending on variant |
 //! | `Restart`      | Mid-run close+reopen+verify                     | `pre_points`, `pre_segments` |
+//! | `EdgeVerify`   | Edge-follower checkpoint (restart / end of run) | `points` (model size; written before the compare so a divergence panic is attributable) |
+//! | `EdgeVerifySkipped` | Edge checkpoint skipped: optimizer still busy at deadline | |
 //! | `LiveVerify`   | End-of-run scroll vs model, before reload       | `model_points`, `engine_points`, `segments`, `optimized_points`, `extra`, `missing` |
 //! | `ReloadVerify` | End-of-run scroll vs model, after final reload  | `model_points`, `engine_points`, `extra`, `missing` |
 //!
@@ -167,6 +169,16 @@ impl Trace {
             "op": tick,
             "kind": "EdgeVerify",
             "points": points,
+        }));
+    }
+
+    /// Records an edge checkpoint that was SKIPPED because the optimizer still held proxy
+    /// segments at the deadline. Without this event a trace with no `EdgeVerify` entries
+    /// is indistinguishable from a run that never checkpointed at all.
+    pub(super) fn edge_verify_skipped(&mut self, tick: usize) {
+        self.write(&json!({
+            "op": tick,
+            "kind": "EdgeVerifySkipped",
         }));
     }
 

--- a/lib/collection/src/model_testing/trace.rs
+++ b/lib/collection/src/model_testing/trace.rs
@@ -22,9 +22,11 @@
 //!
 //! | `kind`         | When                                            | Extra fields |
 //! |----------------|-------------------------------------------------|---|
-//! | `Header`       | First line — run configuration                  | `seed`, `op_num`, `shard_count`, `id_pool`, `disable_optimizer`, `max_segment_size_kb`, `indexing_threshold_kb`, `flush_interval_sec`, `restart_probability`, `swarm_interval`, `disable_snapshots`, `enable_force_off`, `duration_sec` (null unless `--duration`) |
+//! | `Header`       | First line — run configuration                  | `seed`, `op_num`, `shard_count`, `id_pool`, `disable_optimizer`, `max_segment_size_kb`, `indexing_threshold_kb`, `flush_interval_sec`, `restart_probability`, `swarm_interval`, `disable_snapshots`, `edge_verify`, `enable_force_off`, `duration_sec` (null unless `--duration`) |
 //! | *(op variant)* | Each `Op` from the workload generator           | See `op_payload` below — `id`/`ids`/etc. depending on variant |
 //! | `Restart`      | Mid-run close+reopen+verify                     | `pre_points`, `pre_segments` |
+//! | `EdgeVerify`   | Edge-follower checkpoint (restart / end of run) | `points` (model size; written before the compare so a divergence panic is attributable) |
+//! | `EdgeVerifySkipped` | Edge checkpoint skipped: optimizer still busy at deadline | |
 //! | `LiveVerify`   | End-of-run scroll vs model, before reload       | `model_points`, `engine_points`, `segments`, `optimized_points`, `extra`, `missing` |
 //! | `ReloadVerify` | End-of-run scroll vs model, after final reload  | `model_points`, `engine_points`, `extra`, `missing` |
 //!
@@ -163,6 +165,16 @@ impl Trace {
             "op": tick,
             "kind": "EdgeVerify",
             "points": points,
+        }));
+    }
+
+    /// Records an edge checkpoint that was SKIPPED because the optimizer still held proxy
+    /// segments at the deadline. Without this event a trace with no `EdgeVerify` entries
+    /// is indistinguishable from a run that never checkpointed at all.
+    pub(super) fn edge_verify_skipped(&mut self, tick: usize) {
+        self.write(&json!({
+            "op": tick,
+            "kind": "EdgeVerifySkipped",
         }));
     }
 

--- a/lib/collection/src/model_testing/trace.rs
+++ b/lib/collection/src/model_testing/trace.rs
@@ -101,6 +101,7 @@ impl Trace {
         swarm_interval: usize,
         enable_force_off: bool,
         disable_snapshots: bool,
+        edge_verify: bool,
         duration: Option<Duration>,
     ) {
         self.write(&json!({
@@ -117,6 +118,7 @@ impl Trace {
             "restart_probability": restart_probability,
             "swarm_interval": swarm_interval,
             "disable_snapshots": disable_snapshots,
+            "edge_verify": edge_verify,
             "enable_force_off": enable_force_off,
             // null in op-count mode; seconds when the run is time-bounded (`--duration`).
             "duration_sec": duration.map(|d| d.as_secs()),
@@ -154,6 +156,17 @@ impl Trace {
             "kind": "Restart",
             "pre_points": pre_points,
             "pre_segments": pre_segments,
+        }));
+    }
+
+    /// Records a quiesced edge-follower checkpoint (force-flush + refresh + full compare)
+    /// at op `tick`. Written BEFORE the checkpoint runs, so a divergence panic is
+    /// attributable to it in the trace.
+    pub(super) fn edge_verify(&mut self, tick: usize, points: usize) {
+        self.write(&json!({
+            "op": tick,
+            "kind": "EdgeVerify",
+            "points": points,
         }));
     }
 

--- a/lib/collection/src/model_testing/verify.rs
+++ b/lib/collection/src/model_testing/verify.rs
@@ -271,3 +271,30 @@ pub(super) async fn wait_for_optimizer(collection: &Collection) {
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
+
+/// Force-flush every local shard synchronously so all applied state is on disk.
+///
+/// The Edge follower's visibility contract is "flushed, then refreshed": segment files, the
+/// mutable id tracker, and payload data reach disk only on flush, so every edge checkpoint
+/// flushes first. Only meaningful at a quiescent boundary (op loop idle, background
+/// snapshot drained), same as [`collect_clock_ticks`].
+pub(super) async fn flush_all_local_shards(collection: &Collection) {
+    let holder = collection.shards_holder.read().await;
+    for (_shard_id, replica_set) in holder.get_shards() {
+        replica_set.full_flush_local().await;
+    }
+}
+
+/// Whether any local shard currently holds proxy segments, i.e. an optimization is in
+/// flight. Deletes against a proxied segment live only in the proxy's in-memory map (and
+/// the WAL) until the optimization finishes — no flush can put them into segment files —
+/// so edge checkpoints skip the comparison while this is true.
+pub(super) async fn has_proxy_segments(collection: &Collection) -> bool {
+    let holder = collection.shards_holder.read().await;
+    for (_shard_id, replica_set) in holder.get_shards() {
+        if replica_set.local_has_proxy_segments().await {
+            return true;
+        }
+    }
+    false
+}

--- a/lib/collection/src/model_testing/verify.rs
+++ b/lib/collection/src/model_testing/verify.rs
@@ -288,7 +288,7 @@ pub(super) async fn flush_all_local_shards(collection: &Collection) {
 /// Whether any local shard currently holds proxy segments, i.e. an optimization is in
 /// flight. Deletes against a proxied segment live only in the proxy's in-memory map (and
 /// the WAL) until the optimization finishes — no flush can put them into segment files —
-/// so edge checkpoints skip the comparison while this is true.
+/// so edge checkpoints wait for this to clear before comparing.
 pub(super) async fn has_proxy_segments(collection: &Collection) -> bool {
     let holder = collection.shards_holder.read().await;
     for (_shard_id, replica_set) in holder.get_shards() {
@@ -297,4 +297,20 @@ pub(super) async fn has_proxy_segments(collection: &Collection) -> bool {
         }
     }
     false
+}
+
+/// Wait (bounded) for in-flight optimizations to finish, i.e. for proxy segments to
+/// disappear. Only meaningful at a quiescent boundary (op loop idle, same as
+/// [`has_proxy_segments`]): with no new updates arriving, in-flight optimizations
+/// converge on their own. Returns `false` if proxies are still present at the deadline,
+/// so a hung optimizer degrades to a recorded skip instead of stalling the run.
+pub(super) async fn wait_for_no_proxy_segments(collection: &Collection) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while has_proxy_segments(collection).await {
+        if Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    true
 }

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -7,6 +7,8 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt as _, StreamExt as _};
 use itertools::Itertools as _;
+use shard::locked_segment::LockedSegment;
+use shard::segment_holder::FlushMode;
 use tokio::sync::oneshot;
 use tokio::task::yield_now;
 use tokio_util::task::AbortOnDropHandle;
@@ -844,6 +846,66 @@ impl ShardReplicaSet {
         match self.local.read().await.deref() {
             Some(local) => local.plunge_async().await.map(Some),
             None => Ok(None),
+        }
+    }
+
+    /// Synchronously force-flush the local shard's segments (WAL-applied state → disk).
+    ///
+    /// Model-testing helper, like [`Self::plunge_local_async`]: an Edge read-only follower
+    /// only sees flushed state, so the soak flushes before comparing follower reads against
+    /// its model. Panics on a missing or proxied local shard — the soak never transfers
+    /// shards, so anything but a plain local shard is a harness bug.
+    pub async fn full_flush_local(&self) {
+        let local = self.local.read().await;
+        match local.as_ref() {
+            Some(Shard::Local(shard)) => {
+                // Same as the testing-gated `LocalShard::full_flush`, inlined because that
+                // helper needs `feature = "testing"` and this must compile in plain builds.
+                shard
+                    .segments
+                    .read()
+                    .flush_all(FlushMode::Sync, true)
+                    .unwrap();
+            }
+            Some(
+                shard @ (Shard::Proxy(_)
+                | Shard::ForwardProxy(_)
+                | Shard::QueueProxy(_)
+                | Shard::Dummy(_)),
+            ) => panic!(
+                "full_flush_local: expected a plain local shard, got {}",
+                shard.variant_name(),
+            ),
+            None => panic!("full_flush_local: replica set has no local shard"),
+        }
+    }
+
+    /// Whether the local shard currently holds any proxy segments, i.e. an optimization is
+    /// in flight.
+    ///
+    /// Model-testing helper, like [`Self::full_flush_local`]: deletes against a proxied
+    /// segment are buffered in the proxy's in-memory `deleted_points` map and reach segment
+    /// files only when the optimization finishes, so no flush can make an Edge follower see
+    /// them — edge checkpoints are skipped while this is true. Same local-shard contract as
+    /// `full_flush_local`: panics on a missing or proxied (shard-level) local shard.
+    pub async fn local_has_proxy_segments(&self) -> bool {
+        let local = self.local.read().await;
+        match local.as_ref() {
+            Some(Shard::Local(shard)) => shard
+                .segments
+                .read()
+                .iter()
+                .any(|(_id, segment)| matches!(segment, LockedSegment::Proxy(_))),
+            Some(
+                shard @ (Shard::Proxy(_)
+                | Shard::ForwardProxy(_)
+                | Shard::QueueProxy(_)
+                | Shard::Dummy(_)),
+            ) => panic!(
+                "local_has_proxy_segments: expected a plain local shard, got {}",
+                shard.variant_name(),
+            ),
+            None => panic!("local_has_proxy_segments: replica set has no local shard"),
         }
     }
 }

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -7,6 +7,8 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt as _, StreamExt as _};
 use itertools::Itertools as _;
+use shard::locked_segment::LockedSegment;
+use shard::segment_holder::FlushMode;
 use tokio::sync::oneshot;
 use tokio::task::yield_now;
 use tokio_util::task::AbortOnDropHandle;
@@ -865,6 +867,66 @@ impl ShardReplicaSet {
         match self.local.read().await.deref() {
             Some(local) => local.plunge_async().await.map(Some),
             None => Ok(None),
+        }
+    }
+
+    /// Synchronously force-flush the local shard's segments (WAL-applied state → disk).
+    ///
+    /// Model-testing helper, like [`Self::plunge_local_async`]: an Edge read-only follower
+    /// only sees flushed state, so the soak flushes before comparing follower reads against
+    /// its model. Panics on a missing or proxied local shard — the soak never transfers
+    /// shards, so anything but a plain local shard is a harness bug.
+    pub async fn full_flush_local(&self) {
+        let local = self.local.read().await;
+        match local.as_ref() {
+            Some(Shard::Local(shard)) => {
+                // Same as the testing-gated `LocalShard::full_flush`, inlined because that
+                // helper needs `feature = "testing"` and this must compile in plain builds.
+                shard
+                    .segments
+                    .read()
+                    .flush_all(FlushMode::Sync, true)
+                    .unwrap();
+            }
+            Some(
+                shard @ (Shard::Proxy(_)
+                | Shard::ForwardProxy(_)
+                | Shard::QueueProxy(_)
+                | Shard::Dummy(_)),
+            ) => panic!(
+                "full_flush_local: expected a plain local shard, got {}",
+                shard.variant_name(),
+            ),
+            None => panic!("full_flush_local: replica set has no local shard"),
+        }
+    }
+
+    /// Whether the local shard currently holds any proxy segments, i.e. an optimization is
+    /// in flight.
+    ///
+    /// Model-testing helper, like [`Self::full_flush_local`]: deletes against a proxied
+    /// segment are buffered in the proxy's in-memory `deleted_points` map and reach segment
+    /// files only when the optimization finishes, so no flush can make an Edge follower see
+    /// them — edge checkpoints are skipped while this is true. Same local-shard contract as
+    /// `full_flush_local`: panics on a missing or proxied (shard-level) local shard.
+    pub async fn local_has_proxy_segments(&self) -> bool {
+        let local = self.local.read().await;
+        match local.as_ref() {
+            Some(Shard::Local(shard)) => shard
+                .segments
+                .read()
+                .iter()
+                .any(|(_id, segment)| matches!(segment, LockedSegment::Proxy(_))),
+            Some(
+                shard @ (Shard::Proxy(_)
+                | Shard::ForwardProxy(_)
+                | Shard::QueueProxy(_)
+                | Shard::Dummy(_)),
+            ) => panic!(
+                "local_has_proxy_segments: expected a plain local shard, got {}",
+                shard.variant_name(),
+            ),
+            None => panic!("local_has_proxy_segments: replica set has no local shard"),
         }
     }
 }

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -7,8 +7,8 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt as _, StreamExt as _};
 use itertools::Itertools as _;
+#[cfg(feature = "testing")]
 use shard::locked_segment::LockedSegment;
-use shard::segment_holder::FlushMode;
 use tokio::sync::oneshot;
 use tokio::task::yield_now;
 use tokio_util::task::AbortOnDropHandle;
@@ -872,22 +872,15 @@ impl ShardReplicaSet {
 
     /// Synchronously force-flush the local shard's segments (WAL-applied state → disk).
     ///
-    /// Model-testing helper, like [`Self::plunge_local_async`]: an Edge read-only follower
-    /// only sees flushed state, so the soak flushes before comparing follower reads against
-    /// its model. Panics on a missing or proxied local shard — the soak never transfers
-    /// shards, so anything but a plain local shard is a harness bug.
+    /// Model-testing helper: an Edge read-only follower only sees flushed state, so the
+    /// soak flushes before comparing follower reads against its model. Panics on a
+    /// missing or proxied local shard: the soak never transfers shards, so anything but
+    /// a plain local shard is a harness bug.
+    #[cfg(feature = "testing")]
     pub async fn full_flush_local(&self) {
         let local = self.local.read().await;
         match local.as_ref() {
-            Some(Shard::Local(shard)) => {
-                // Same as the testing-gated `LocalShard::full_flush`, inlined because that
-                // helper needs `feature = "testing"` and this must compile in plain builds.
-                shard
-                    .segments
-                    .read()
-                    .flush_all(FlushMode::Sync, true)
-                    .unwrap();
-            }
+            Some(Shard::Local(shard)) => shard.full_flush(),
             Some(
                 shard @ (Shard::Proxy(_)
                 | Shard::ForwardProxy(_)
@@ -907,8 +900,10 @@ impl ShardReplicaSet {
     /// Model-testing helper, like [`Self::full_flush_local`]: deletes against a proxied
     /// segment are buffered in the proxy's in-memory `deleted_points` map and reach segment
     /// files only when the optimization finishes, so no flush can make an Edge follower see
-    /// them — edge checkpoints are skipped while this is true. Same local-shard contract as
-    /// `full_flush_local`: panics on a missing or proxied (shard-level) local shard.
+    /// them; edge checkpoints wait for this to clear before comparing. Same local-shard
+    /// contract as `full_flush_local`: panics on a missing or proxied (shard-level) local
+    /// shard.
+    #[cfg(feature = "testing")]
     pub async fn local_has_proxy_segments(&self) -> bool {
         let local = self.local.read().await;
         match local.as_ref() {

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -7,8 +7,8 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt as _, StreamExt as _};
 use itertools::Itertools as _;
+#[cfg(feature = "testing")]
 use shard::locked_segment::LockedSegment;
-use shard::segment_holder::FlushMode;
 use tokio::sync::oneshot;
 use tokio::task::yield_now;
 use tokio_util::task::AbortOnDropHandle;
@@ -851,22 +851,15 @@ impl ShardReplicaSet {
 
     /// Synchronously force-flush the local shard's segments (WAL-applied state → disk).
     ///
-    /// Model-testing helper, like [`Self::plunge_local_async`]: an Edge read-only follower
-    /// only sees flushed state, so the soak flushes before comparing follower reads against
-    /// its model. Panics on a missing or proxied local shard — the soak never transfers
-    /// shards, so anything but a plain local shard is a harness bug.
+    /// Model-testing helper: an Edge read-only follower only sees flushed state, so the
+    /// soak flushes before comparing follower reads against its model. Panics on a
+    /// missing or proxied local shard: the soak never transfers shards, so anything but
+    /// a plain local shard is a harness bug.
+    #[cfg(feature = "testing")]
     pub async fn full_flush_local(&self) {
         let local = self.local.read().await;
         match local.as_ref() {
-            Some(Shard::Local(shard)) => {
-                // Same as the testing-gated `LocalShard::full_flush`, inlined because that
-                // helper needs `feature = "testing"` and this must compile in plain builds.
-                shard
-                    .segments
-                    .read()
-                    .flush_all(FlushMode::Sync, true)
-                    .unwrap();
-            }
+            Some(Shard::Local(shard)) => shard.full_flush(),
             Some(
                 shard @ (Shard::Proxy(_)
                 | Shard::ForwardProxy(_)
@@ -886,8 +879,10 @@ impl ShardReplicaSet {
     /// Model-testing helper, like [`Self::full_flush_local`]: deletes against a proxied
     /// segment are buffered in the proxy's in-memory `deleted_points` map and reach segment
     /// files only when the optimization finishes, so no flush can make an Edge follower see
-    /// them — edge checkpoints are skipped while this is true. Same local-shard contract as
-    /// `full_flush_local`: panics on a missing or proxied (shard-level) local shard.
+    /// them; edge checkpoints wait for this to clear before comparing. Same local-shard
+    /// contract as `full_flush_local`: panics on a missing or proxied (shard-level) local
+    /// shard.
+    #[cfg(feature = "testing")]
     pub async fn local_has_proxy_segments(&self) -> bool {
         let local = self.local.read().await;
         match local.as_ref() {

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -80,6 +80,12 @@ impl FeatureFlags {
         self.serverless_compatible
     }
 
+    /// Turn on serverless-compatible mode. The implied sub-flags are applied
+    /// when the flags are passed to [`init_feature_flags`].
+    pub fn enable_serverless_compatible(&mut self) {
+        self.serverless_compatible = true;
+    }
+
     fn all() -> Self {
         Self {
             all: true,

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -115,6 +115,12 @@ impl FeatureFlags {
         self.serverless_compatible
     }
 
+    /// Turn on serverless-compatible mode. The implied sub-flags are applied
+    /// when the flags are passed to [`init_feature_flags`].
+    pub fn enable_serverless_compatible(&mut self) {
+        self.serverless_compatible = true;
+    }
+
     fn all() -> Self {
         Self {
             all: true,

--- a/src/model_testing.rs
+++ b/src/model_testing.rs
@@ -156,6 +156,18 @@ struct Args {
     /// the swarm config is unchanged either way.
     #[clap(long, default_value_t = false)]
     disable_snapshots: bool,
+
+    /// Also verify the collection through an Edge read-only follower: one
+    /// `ReadOnlyEdgeShard` per shard dir, checked at quiesced checkpoints (end of run, and
+    /// each mid-run restart) by force-flushing every shard, refreshing the followers, and
+    /// comparing a full follower scroll against the model.
+    ///
+    /// Requires building with `--features edge-verify` (panics otherwise). Enables the
+    /// `write_segment_manifest` feature flag so followers discover segments through the
+    /// manifest. Draws no rng and does not change the candidate universe, so op streams
+    /// are seed-comparable with non-edge runs.
+    #[clap(long, default_value_t = false)]
+    edge_verify: bool,
 }
 
 fn main() {
@@ -182,7 +194,16 @@ fn main() {
 
 async fn run_main(args: Args) {
     env_logger::init();
-    init_feature_flags(FeatureFlags::default());
+    let mut feature_flags = FeatureFlags::default();
+    if args.edge_verify {
+        // Read-only Edge followers assume the serverless leader contract: segment
+        // discovery through the manifest and append-only mutations (an in-place slot
+        // rewrite is invisible to a follower's live-reload). Force the whole
+        // serverless_compatible bundle so the soak exercises exactly that contract.
+        // Must be set before the fixture builds the collection.
+        feature_flags.enable_serverless_compatible();
+    }
+    init_feature_flags(feature_flags);
     let _ = MULTI_MMAP_SUPPORT_CHECK_RESULT.set(true);
     init_requests_profile_collector(tokio::runtime::Handle::current());
 
@@ -230,7 +251,7 @@ async fn run_main(args: Args) {
          storage_path={} disable_optimizer={} max_segment_size_kb={} indexing_threshold_kb={} \
          flush_interval_sec={} restart_probability={} swarm_interval={} \
          on_disk={} async_scorer={} pre_restart_check={} enable_force_off={} \
-         disable_snapshots={}",
+         disable_snapshots={} edge_verify={}",
         args.seed,
         args.shard_count,
         args.id_pool,
@@ -247,6 +268,7 @@ async fn run_main(args: Args) {
         args.pre_restart_check,
         args.enable_force_off,
         args.disable_snapshots,
+        args.edge_verify,
     );
     let start = Instant::now();
     collection::model_testing::run(
@@ -266,6 +288,7 @@ async fn run_main(args: Args) {
         args.pre_restart_check,
         args.enable_force_off,
         args.disable_snapshots,
+        args.edge_verify,
         args.duration_sec.map(Duration::from_secs),
         shutdown,
     )

--- a/src/model_testing.rs
+++ b/src/model_testing.rs
@@ -149,6 +149,18 @@ struct Args {
     /// the swarm config is unchanged either way.
     #[clap(long, default_value_t = false)]
     disable_snapshots: bool,
+
+    /// Also verify the collection through an Edge read-only follower: one
+    /// `ReadOnlyEdgeShard` per shard dir, checked at quiesced checkpoints (end of run, and
+    /// each mid-run restart) by force-flushing every shard, refreshing the followers, and
+    /// comparing a full follower scroll against the model.
+    ///
+    /// Requires building with `--features edge-verify` (panics otherwise). Enables the
+    /// `write_segment_manifest` feature flag so followers discover segments through the
+    /// manifest. Draws no rng and does not change the candidate universe, so op streams
+    /// are seed-comparable with non-edge runs.
+    #[clap(long, default_value_t = false)]
+    edge_verify: bool,
 }
 
 fn main() {
@@ -175,7 +187,16 @@ fn main() {
 
 async fn run_main(args: Args) {
     env_logger::init();
-    init_feature_flags(FeatureFlags::default());
+    let mut feature_flags = FeatureFlags::default();
+    if args.edge_verify {
+        // Read-only Edge followers assume the serverless leader contract: segment
+        // discovery through the manifest and append-only mutations (an in-place slot
+        // rewrite is invisible to a follower's live-reload). Force the whole
+        // serverless_compatible bundle so the soak exercises exactly that contract.
+        // Must be set before the fixture builds the collection.
+        feature_flags.enable_serverless_compatible();
+    }
+    init_feature_flags(feature_flags);
     let _ = MULTI_MMAP_SUPPORT_CHECK_RESULT.set(true);
     init_requests_profile_collector(tokio::runtime::Handle::current());
 
@@ -223,7 +244,7 @@ async fn run_main(args: Args) {
          storage_path={} disable_optimizer={} max_segment_size_kb={} indexing_threshold_kb={} \
          restart_probability={} swarm_interval={} \
          on_disk={} async_scorer={} pre_restart_check={} enable_force_off={} \
-         disable_snapshots={}",
+         disable_snapshots={} edge_verify={}",
         args.seed,
         args.shard_count,
         args.id_pool,
@@ -239,6 +260,7 @@ async fn run_main(args: Args) {
         args.pre_restart_check,
         args.enable_force_off,
         args.disable_snapshots,
+        args.edge_verify,
     );
     let start = Instant::now();
     collection::model_testing::run(
@@ -257,6 +279,7 @@ async fn run_main(args: Args) {
         args.pre_restart_check,
         args.enable_force_off,
         args.disable_snapshots,
+        args.edge_verify,
         args.duration_sec.map(Duration::from_secs),
         shutdown,
     )

--- a/src/model_testing.rs
+++ b/src/model_testing.rs
@@ -162,10 +162,14 @@ struct Args {
     /// each mid-run restart) by force-flushing every shard, refreshing the followers, and
     /// comparing a full follower scroll against the model.
     ///
-    /// Requires building with `--features edge-verify` (panics otherwise). Enables the
-    /// `write_segment_manifest` feature flag so followers discover segments through the
-    /// manifest. Draws no rng and does not change the candidate universe, so op streams
-    /// are seed-comparable with non-edge runs.
+    /// Requires building with `--features edge-verify` (panics otherwise). Forces the
+    /// whole `serverless_compatible` feature-flag bundle (manifest discovery, append-only
+    /// mutations, compact bitmask): the follower's live-reload only observes appended
+    /// offsets, so in-place mutations would be invisible to it. Draws no rng and does not
+    /// change the candidate universe, so op streams are seed-comparable with non-edge
+    /// runs. Two coverage caveats: append-only mode changes leader mutation semantics vs
+    /// a default run, and each checkpoint force-flushes every shard, so mid-run restarts
+    /// no longer exercise cold unflushed WAL-replay recovery.
     #[clap(long, default_value_t = false)]
     edge_verify: bool,
 }

--- a/src/model_testing.rs
+++ b/src/model_testing.rs
@@ -155,10 +155,14 @@ struct Args {
     /// each mid-run restart) by force-flushing every shard, refreshing the followers, and
     /// comparing a full follower scroll against the model.
     ///
-    /// Requires building with `--features edge-verify` (panics otherwise). Enables the
-    /// `write_segment_manifest` feature flag so followers discover segments through the
-    /// manifest. Draws no rng and does not change the candidate universe, so op streams
-    /// are seed-comparable with non-edge runs.
+    /// Requires building with `--features edge-verify` (panics otherwise). Forces the
+    /// whole `serverless_compatible` feature-flag bundle (manifest discovery, append-only
+    /// mutations, compact bitmask): the follower's live-reload only observes appended
+    /// offsets, so in-place mutations would be invisible to it. Draws no rng and does not
+    /// change the candidate universe, so op streams are seed-comparable with non-edge
+    /// runs. Two coverage caveats: append-only mode changes leader mutation semantics vs
+    /// a default run, and each checkpoint force-flushes every shard, so mid-run restarts
+    /// no longer exercise cold unflushed WAL-replay recovery.
     #[clap(long, default_value_t = false)]
     edge_verify: bool,
 }


### PR DESCRIPTION
Adds support for creating and verifying edge followers to the model tester.

### Usage
Build the model tester with the `edge-verify` feature:
```
cargo build --features "service_debug edge-verify" --bin model_testing
```

Run it with `--edge-verify`
```
./target/debug/model_testing --seed 42 --shard-count 1 --op-num 2000 --restart-probability 0.002 --disable-optimizer --edge-verify
```

# Open Issues
During an optimization, point deletes exist only in the proxy's in-memory `deleted_points` map and are applied to the new segment right before the swap.
A follower reads only flushed segment files, so mid-optimization it would still see those points **as alive**.
Checkpoints [are therefore skipped for now](https://github.com/qdrant/qdrant/pull/9944/changes#diff-b24c7e674b639e1c66fc863a5742dbadf821f0b484035d601b27d44c34b9a72bR941), until proxy deletions are persisted to disk.