### PR TITLE
Remove wrong debug assertion

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/live_reload.rs
@@ -37,7 +37,6 @@ impl<S: UniversalRead> LiveReload for ReadOnlyAppendableFullTextIndex<S> {
                 new_points.iter().map(|&id| ((), id)),
                 |_, point_offset, maybe_value: Option<Vec<u8>>| {
                     let Some(value) = maybe_value else {
-                        debug_assert!(false, "This should be unreachable");
                         return Ok(true);
                     };
                     // The stored document is already tokenized, so we replay the


### PR DESCRIPTION
Remove wrong debug_assert!() from text indexes `live_reload`.
It is reachable because points can have no payload assigned.

Analogue the same logic in geo index [doesn't have this assertion](https://github.com/qdrant/qdrant/blob/efc0c7961b8985351844eef6dff2f318ca124356/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs#L36). Neither does [map index](https://github.com/qdrant/qdrant/blob/efc0c7961b8985351844eef6dff2f318ca124356/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/live_reload.rs#L40).