### PR TITLE
docs: describe StartResharding fields in OpenAPI

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -15227,12 +15227,14 @@
             "$ref": "#/components/schemas/ReshardingDirection"
           },
           "peer_id": {
+            "description": "Peer to create the new shard on, or to migrate points away from when scaling down. If not specified, the least loaded peer is picked when scaling up, a peer holding the removed shard when scaling down.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0,
             "nullable": true
           },
           "shard_key": {
+            "description": "Custom shard key to reshard, must already exist. If not specified, shards without a shard key are resharded.",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/ShardKey"

--- a/lib/collection/src/operations/cluster_ops.rs
+++ b/lib/collection/src/operations/cluster_ops.rs
@@ -325,10 +325,17 @@ pub struct AbortShardTransfer {
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, Validate)]
 pub struct StartResharding {
+    /// Unique identifier of this resharding operation, random if not specified.
     #[schemars(skip)]
     pub uuid: Option<Uuid>,
+    /// Whether to add a shard (`up`) or remove the last shard (`down`).
     pub direction: ReshardingDirection,
+    /// Peer to create the new shard on, or to migrate points away from when scaling down.
+    /// If not specified, the least loaded peer is picked when scaling up, a peer holding the
+    /// removed shard when scaling down.
     pub peer_id: Option<PeerId>,
+    /// Custom shard key to reshard, must already exist.
+    /// If not specified, shards without a shard key are resharded.
     pub shard_key: Option<ShardKey>,
 }
 


### PR DESCRIPTION
## What

Adds doc comments to the `StartResharding` cluster operation fields, so the generated OpenAPI documentation explains what they do, and regenerates `openapi.json`.

Previously all fields were undocumented — a user calling `start_resharding` had no way to know what `peer_id` or `shard_key` select.

Descriptions follow the resolution logic in `src/common/collections.rs`:
- `peer_id` — peer that hosts the new shard when scaling up, or drives point migration off the removed shard when scaling down; defaults to the least loaded peer / a peer already holding the removed shard.
- `shard_key` — custom shard key to reshard, must already exist; defaults to the shards without a shard key.
- `direction`, `uuid` — documented in code (not rendered: `direction` is a bare `$ref`, `uuid` is `schemars(skip)`).

## Notes

No functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)