### PR TITLE
fix: document maximum 65536 for VectorParams.size in OpenAPI schema

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7505,6 +7505,7 @@
             "description": "Size of a vectors used",
             "type": "integer",
             "format": "uint64",
+            "maximum": 65536,
             "minimum": 1
           },
           "distance": {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1372,6 +1372,7 @@ impl From<Datatype> for VectorStorageDatatype {
 pub struct VectorParams {
     /// Size of a vectors used
     #[validate(custom(function = "validate_nonzerou64_range_min_1_max_65536"))]
+    #[schemars(range(min = 1, max = 65536))]
     pub size: NonZeroU64,
     /// Type of distance function used for measuring distance between vectors
     pub distance: Distance,

--- a/tests/openapi/test_limits.py
+++ b/tests/openapi/test_limits.py
@@ -2,7 +2,7 @@ import pytest
 import requests
 
 from .helpers.collection_setup import drop_collection
-from .helpers.helpers import request_with_validation
+from .helpers.helpers import qdrant_host_headers, request_with_validation
 from .helpers.settings import QDRANT_HOST
 
 
@@ -43,7 +43,8 @@ def test_vector_dimension_limit(collection_name):
                 "size": dim_max + 1,
                 "distance": "Dot",
             },
-        }
+        },
+        headers=qdrant_host_headers(),
     )
     assert not response.ok
     error = response.json()['status']['error']

--- a/tests/openapi/test_limits.py
+++ b/tests/openapi/test_limits.py
@@ -1,7 +1,9 @@
 import pytest
+import requests
 
 from .helpers.collection_setup import drop_collection
 from .helpers.helpers import request_with_validation
+from .helpers.settings import QDRANT_HOST
 
 
 @pytest.fixture(autouse=True)
@@ -31,11 +33,12 @@ def test_vector_dimension_limit(collection_name):
 
     drop_collection(collection_name)
 
-    response = request_with_validation(
-        api='/collections/{collection_name}',
-        method="PUT",
-        path_params={'collection_name': collection_name},
-        body={
+    # `size` now carries a client-side OpenAPI maximum, so bypass
+    # request_with_validation (which would short-circuit on it) to confirm the
+    # server-side Validate derive is what rejects an over-limit dimension.
+    response = requests.put(
+        f"{QDRANT_HOST}/collections/{collection_name}",
+        json={
             "vectors": {
                 "size": dim_max + 1,
                 "distance": "Dot",


### PR DESCRIPTION
## Problem

Schema consumers see `VectorParams.size` as `{ "minimum": 1 }` with no upper bound, but the server enforces `1..=65536` at runtime. A request with `size` above 65536 is rejected with a 422 that the published OpenAPI schema doesn't predict, so clients and code generators that validate against the schema treat such requests as valid. (#9942) 

## Cause

`VectorParams.size` (`NonZeroU64`) is validated by a custom function (`validate_nonzerou64_range_min_1_max_65536`). `schemars` can't see inside a custom validator, so only the `minimum: 1` implied by `NonZeroU64` reaches the schema. The sibling DenseVectorConfig.size` uses the declarative `#[validate(range(min = 1, max = 65536))]`, which schemars does read — which is why it already documents `maximum: 65536`.

## Fix

Add `#[schemars(range(min = 1, max = 65536))]` to `VectorParams.size` so the schema documents the same bound. Runtime validation is untouched (the custom validator still runs); this only affects schema generation. Regenerated `docs/redoc/master/openapi.json` — the sole change is `VectorParams.size` gaining `"maximum": 65536`, matching `DenseVectorConfig.size`.

Closes #9942