### PR TITLE
fix(api): reject empty multi-dense vector instead of panicking in RawVector conversion

### DIFF
--- a/lib/api/src/conversions/vectors.rs
+++ b/lib/api/src/conversions/vectors.rs
@@ -635,9 +635,11 @@ impl TryFrom<grpc::RawVector> for VectorInternal {
             Variant::Sparse(sparse) => {
                 VectorInternal::Sparse(sparse::common::sparse_vector::SparseVector::from(sparse))
             }
-            Variant::MultiDense(multi_dense) => {
-                VectorInternal::MultiDense(MultiDenseVectorInternal::from(multi_dense))
-            }
+            Variant::MultiDense(multi_dense) => VectorInternal::MultiDense(
+                MultiDenseVectorInternal::try_from_matrix(multi_dense.into_matrix()).map_err(
+                    |e| Status::invalid_argument(format!("Malformed multi-dense vector: {e}")),
+                )?,
+            ),
         };
 
         Ok(vector)
@@ -647,5 +649,21 @@ impl TryFrom<grpc::RawVector> for VectorInternal {
 impl From<NamedVectorStruct> for grpc::RawVector {
     fn from(value: NamedVectorStruct) -> Self {
         Self::from(value.to_vector())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_vector_with_empty_multi_dense_is_rejected() {
+        let raw = grpc::RawVector {
+            variant: Some(grpc::raw_vector::Variant::MultiDense(
+                grpc::MultiDenseVector { vectors: vec![] },
+            )),
+        };
+
+        assert!(VectorInternal::try_from(raw).is_err());
     }
 }

--- a/lib/api/src/conversions/vectors.rs
+++ b/lib/api/src/conversions/vectors.rs
@@ -664,6 +664,9 @@ mod tests {
             )),
         };
 
-        assert!(VectorInternal::try_from(raw).is_err());
+        assert_eq!(
+            VectorInternal::try_from(raw).unwrap_err().code(),
+            tonic::Code::InvalidArgument,
+        );
     }
 }


### PR DESCRIPTION
Closes #9954

`TryFrom<grpc::RawVector> for VectorInternal` converted a `MultiDense` variant via the infallible `From<grpc::MultiDenseVector>`, which indexes `vectors[0]` and panics on an empty `vectors` list. That path is reachable from the internal query RPCs via a peer-supplied `RawVector`, so a malformed or empty multi-dense message panics the receiving node instead of returning an error.

This routes the arm through the fallible `MultiDenseVectorInternal::try_from_matrix` (as the sibling conversions in the same file already do), so an empty multi-dense vector returns `invalid_argument`. Adds a regression test. Continues the empty-vector hardening from #9070 / #9308.

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### AI disclosure (per CONTRIBUTING.md)

- [AI] fix(api): reject empty multi-dense vector in RawVector conversion - the fix and regression test were generated with AI assistance and reviewed by me.
- Initial prompt: "In lib/api/src/conversions/vectors.rs, TryFrom<grpc::RawVector> converts MultiDense via the infallible From<grpc::MultiDenseVector> which panics on an empty vectors list; route it through the fallible try_from_matrix like the sibling conversions and add a regression test."

