### PR TITLE
fix(storage): cap tracing id in bytes, not chars, in extract_tracing_id

### DIFF
--- a/lib/storage/src/audit.rs
+++ b/lib/storage/src/audit.rs
@@ -21,7 +21,13 @@ pub const TRACING_ID_HEADERS: &[&str] = &["x-request-id", "x-tracing-id", "trace
 pub fn extract_tracing_id(get_header: impl Fn(&str) -> Option<String>) -> Option<String> {
     let value = TRACING_ID_HEADERS.iter().find_map(|h| get_header(h))?;
     if value.len() > MAX_TRACING_ID_LEN {
-        Some(value.chars().take(MAX_TRACING_ID_LEN).collect())
+        // Floor to a char boundary at or below MAX_TRACING_ID_LEN bytes so the
+        // cap is enforced in bytes (as documented) without splitting a code point.
+        let end = (0..=MAX_TRACING_ID_LEN)
+            .rev()
+            .find(|&i| value.is_char_boundary(i))
+            .unwrap_or(0);
+        Some(value[..end].to_string())
     } else {
         Some(value)
     }
@@ -273,4 +279,31 @@ pub fn audit_trust_forwarded_headers() -> bool {
 /// Returns `true` if the audit logger is configured to log API method paths.
 pub fn audit_log_api() -> bool {
     LOG_API.get().copied().unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tracing_id_is_capped_in_bytes_for_multibyte_input() {
+        // 300 four-byte chars ~= 1200 bytes. The old char-count truncation kept
+        // 256 chars (~1024 bytes), overshooting the documented byte cap.
+        let long = "😀".repeat(300);
+        let out = extract_tracing_id(|h| (h == TRACING_ID_HEADERS[0]).then(|| long.clone()))
+            .expect("header is present");
+        assert!(
+            out.len() <= MAX_TRACING_ID_LEN,
+            "tracing id not capped in bytes: {} bytes",
+            out.len()
+        );
+        assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn tracing_id_below_cap_is_unchanged() {
+        let out =
+            extract_tracing_id(|h| (h == TRACING_ID_HEADERS[0]).then(|| "req-123".to_string()));
+        assert_eq!(out.as_deref(), Some("req-123"));
+    }
 }


### PR DESCRIPTION
Closes #9956

`extract_tracing_id` is documented to cap the tracing ID at `MAX_TRACING_ID_LEN` bytes (256), but it guards on `value.len()` (bytes) while truncating with `value.chars().take(MAX_TRACING_ID_LEN)` (characters). For multibyte UTF-8 headers these disagree, so an attacker-controllable header can land at up to ~4x the documented byte cap in each audit log line.

This truncates on a UTF-8 char boundary at or below `MAX_TRACING_ID_LEN` bytes, matching the doc comment and the constant name, and never splits a code point. Adds regression tests (multibyte input capped in bytes; short input unchanged).

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### AI disclosure (per CONTRIBUTING.md)

- [AI] fix(storage): cap tracing id in bytes, not chars - the fix and regression tests were generated with AI assistance and reviewed by me.
- Initial prompt: "In lib/storage/src/audit.rs, extract_tracing_id guards on value.len() (bytes) but truncates with chars().take(MAX_TRACING_ID_LEN) (chars), so multibyte headers exceed the documented byte cap; truncate on a UTF-8 char boundary at or below MAX_TRACING_ID_LEN bytes and add regression tests."

