### PR TITLE
fix(hnsw): clamp zero sample in get_random_layer to avoid usize::MAX level

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -391,8 +391,18 @@ impl GraphLayersBuilder {
     {
         let distribution = Uniform::new(0.0, 1.0).unwrap();
         let sample: f64 = rng.sample(distribution);
-        let picked_level = -sample.ln() * self.level_factor;
-        picked_level.round() as usize
+        Self::level_from_sample(sample, self.level_factor)
+    }
+
+    /// Map a uniform `[0, 1)` sample to a geometric level.
+    ///
+    /// `Uniform::new(0.0, 1.0)` is half-open, so `sample` can be exactly `0.0`.
+    /// `ln(0.0)` is `-inf`, and `(-(-inf) * factor).round() as usize` saturates
+    /// to `usize::MAX`, which then makes `set_levels` allocate unboundedly.
+    /// Clamp to the smallest positive `f64` so the level stays bounded.
+    fn level_from_sample(sample: f64, level_factor: f64) -> usize {
+        let sample = sample.max(f64::MIN_POSITIVE);
+        (-sample.ln() * level_factor).round() as usize
     }
 
     pub(crate) fn get_point_level(&self, point_id: PointOffsetType) -> usize {
@@ -617,6 +627,17 @@ mod tests {
     use crate::vector_storage::{DEFAULT_STOPPED, VectorStorageRead as _};
 
     const M: usize = 8;
+
+    #[test]
+    fn get_random_layer_handles_zero_sample() {
+        // A zero uniform sample used to make ln(0) = -inf and saturate the
+        // level to usize::MAX; the clamp must keep it bounded.
+        let level_factor = 1.0 / (M as f64).ln();
+        let level = GraphLayersBuilder::level_from_sample(0.0, level_factor);
+        assert!(level < 1024, "zero sample produced an unbounded level: {level}");
+        // A normal mid-range sample still yields a small level.
+        assert!(GraphLayersBuilder::level_from_sample(0.5, level_factor) < 1024);
+    }
 
     #[cfg(not(windows))]
     fn parallel_graph_build<R>(

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -391,8 +391,18 @@ impl GraphLayersBuilder {
     {
         let distribution = Uniform::new(0.0, 1.0).unwrap();
         let sample: f64 = rng.sample(distribution);
-        let picked_level = -sample.ln() * self.level_factor;
-        picked_level.round() as usize
+        Self::level_from_sample(sample, self.level_factor)
+    }
+
+    /// Map a uniform `[0, 1)` sample to a geometric level.
+    ///
+    /// `Uniform::new(0.0, 1.0)` is half-open, so `sample` can be exactly `0.0`.
+    /// `ln(0.0)` is `-inf`, and `(-(-inf) * factor).round() as usize` saturates
+    /// to `usize::MAX`, which then makes `set_levels` allocate unboundedly.
+    /// Clamp to the smallest positive `f64` so the level stays bounded.
+    fn level_from_sample(sample: f64, level_factor: f64) -> usize {
+        let sample = sample.max(f64::MIN_POSITIVE);
+        (-sample.ln() * level_factor).round() as usize
     }
 
     pub(crate) fn get_point_level(&self, point_id: PointOffsetType) -> usize {
@@ -617,6 +627,20 @@ mod tests {
     use crate::vector_storage::{DEFAULT_STOPPED, VectorStorageRead as _};
 
     const M: usize = 8;
+
+    #[test]
+    fn get_random_layer_handles_zero_sample() {
+        // A zero uniform sample used to make ln(0) = -inf and saturate the
+        // level to usize::MAX; the clamp must keep it bounded.
+        let level_factor = 1.0 / (M as f64).ln();
+        let level = GraphLayersBuilder::level_from_sample(0.0, level_factor);
+        assert!(
+            level < 1024,
+            "zero sample produced an unbounded level: {level}"
+        );
+        // A normal mid-range sample still yields a small level.
+        assert!(GraphLayersBuilder::level_from_sample(0.5, level_factor) < 1024);
+    }
 
     #[cfg(not(windows))]
     fn parallel_graph_build<R>(


### PR DESCRIPTION
Closes #9958

`get_random_layer` draws from a half-open `[0, 1)` uniform, so `sample` can be exactly `0.0`. Then `ln(0.0)` is `-inf`, `-(-inf) * level_factor` is `+inf`, and `(+inf).round() as usize` saturates to `usize::MAX`. That level flows into `set_levels`, which then tries to grow the per-point layer vector to ~`usize::MAX`, exhausting memory / panicking and killing the index build.

This clamps the sample to `f64::MIN_POSITIVE` before the log (same idea as hnswlib's epsilon guard). I pulled the sample-to-level math into a small `level_from_sample` helper so the clamp is unit-testable, and added a test that a zero sample stays bounded.

The trigger is astronomically rare (~2^-52 per draw), so this is a robustness guard rather than a bug anyone has hit; the blast radius if it fires is the whole build.

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### AI disclosure (per CONTRIBUTING.md)

- [AI] fix(hnsw): clamp zero sample in get_random_layer - the fix, helper extraction, and test were generated with AI assistance and reviewed by me.
- Initial prompt: "In lib/segment/src/index/hnsw_index/graph_layers_builder.rs, get_random_layer can draw sample=0.0 from a half-open uniform, making ln(0)=-inf saturate the level to usize::MAX and blow up set_levels; clamp the sample to f64::MIN_POSITIVE, extract a testable level_from_sample helper, and add a test."

