### PR TITLE
fix(api): preserve u64 payload values above i64::MAX instead of a lossy f64

### DIFF
--- a/lib/api/src/conversions/json.rs
+++ b/lib/api/src/conversions/json.rs
@@ -26,6 +26,11 @@ pub fn json_to_proto(json_value: serde_json::Value) -> Value {
         serde_json::Value::Number(n) => {
             if let Some(int) = n.as_i64() {
                 Kind::IntegerValue(int)
+            } else if let Some(uint) = n.as_u64() {
+                // A u64 above i64::MAX has no lossless proto int or double slot,
+                // so preserve it as a string instead of silently narrowing it to
+                // a lossy f64.
+                Kind::StringValue(uint.to_string())
             } else {
                 Kind::DoubleValue(n.as_f64().unwrap())
             }
@@ -103,6 +108,20 @@ mod tests {
     use super::*;
     use crate::grpc::qdrant::value::Kind;
     use crate::grpc::qdrant::{Struct, Value};
+
+    #[test]
+    fn u64_above_i64_max_is_preserved_not_narrowed() {
+        // serde_json stores this as a u64 (no arbitrary_precision feature), and
+        // it does not fit in an i64, so the old code narrowed it to a lossy f64.
+        let v = serde_json::json!(18446744073709551615u64);
+        assert!(v.as_i64().is_none(), "test value must exceed i64::MAX");
+
+        let kind = json_to_proto(v).kind.expect("kind present");
+        assert!(
+            matches!(&kind, Kind::StringValue(s) if s == "18446744073709551615"),
+            "u64 > i64::MAX should be preserved losslessly, not narrowed to f64"
+        );
+    }
 
     fn gen_proto_json_dicts() -> (HashMap<String, serde_json::Value>, HashMap<String, Value>) {
         let raw_json = r#"


### PR DESCRIPTION
Closes #9960

`json_to_proto` only produced an `IntegerValue` when the number fit in an `i64`; a `u64` above `i64::MAX` fell through to `DoubleValue(as_f64())`, which rounds it (f64 has a 53-bit mantissa) and silently corrupts the value. serde_json here stores a full `u64` (no `arbitrary_precision`), so this is reachable for payload integers.

The proto `Value` has no unsigned-64 slot, so this preserves such values as a `StringValue` rather than narrowing. That keeps the value lossless; the alternative (erroring) would change the function signature to `Result`, so happy to go that way instead if you prefer. Adds a regression test.

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### AI disclosure (per CONTRIBUTING.md)

- [AI] fix(api): preserve u64 payload values above i64::MAX instead of a lossy f64 - the fix and regression test were generated with AI assistance and reviewed by me.
- Initial prompt: "In lib/api/src/conversions/json.rs, json_to_proto narrows a u64 > i64::MAX to a lossy f64 via the else DoubleValue arm; add an else-if as_u64() arm that preserves it as a StringValue, and add a regression test."

