### PR TITLE
fix(gridstore): correct operator precedence in Bitmask::create page-size assertion

### DIFF
--- a/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
@@ -82,7 +82,9 @@ impl<S: UniversalWrite> Bitmask<S> {
     /// Create a bitmask for one page
     pub(crate) fn create(fs: &S::Fs, dir: &Path, config: GridstoreConfig) -> Result<Self> {
         debug_assert!(
-            config.page_size_bytes % config.block_size_bytes * config.region_size_blocks == 0,
+            config
+                .page_size_bytes
+                .is_multiple_of(config.block_size_bytes * config.region_size_blocks),
             "Page size must be a multiple of block size * region size"
         );
 


### PR DESCRIPTION
Closes #9962

The `debug_assert!` in `Bitmask::create` wrote `page_size_bytes % block_size_bytes * region_size_blocks == 0`, which parses as `((page % block) * region) == 0`. Since `page_size` is always a multiple of `block_size`, that is always `0 == 0`, so the intended `block * region` check never ran.

This uses `page_size_bytes.is_multiple_of(block_size_bytes * region_size_blocks)`, matching the sibling assertion in `open()`. Practical impact is nil (it is a debug-only assertion and the real invariant is already enforced in the `StorageConfig` constructor at `config.rs:96`), so this is a correctness/clarity cleanup with no behavioral test.

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### AI disclosure (per CONTRIBUTING.md)

- [AI] fix(gridstore): correct operator precedence in the page-size debug assertion - AI-assisted, reviewed by me.
- Initial prompt: "In lib/gridstore/src/bitmask/mod.rs, the debug_assert in Bitmask::create uses `page % block * region == 0` which mis-parses and is always true; change it to page_size_bytes.is_multiple_of(block_size_bytes * region_size_blocks) matching open()."
