### PR TITLE
fix(sparse): use checked usize->u32 for compressed posting chunk offset

### DIFF
--- a/lib/sparse/src/index/compressed_posting_list.rs
+++ b/lib/sparse/src/index/compressed_posting_list.rs
@@ -387,7 +387,8 @@ impl CompressedPostingBuilder {
                 let chunk_size = BitPackerImpl::compressed_block_size(chunk_bits);
                 chunks.push(CompressedPostingChunk {
                     initial,
-                    offset: data_size as u32,
+                    offset: u32::try_from(data_size)
+                        .expect("posting id_data should fit in u32 (< 4GB)"),
                     weights: chunk
                         .iter()
                         .map(|e| Weight::from_f32(quantization_params, e.weight))


### PR DESCRIPTION
Closes #9964

`CompressedPostingBuilder` stored the running chunk byte offset with `data_size as u32`, which silently truncates if a posting list's compressed id-data ever exceeds `u32::MAX` bytes, producing a wrong offset and, via `get_chunk_size`, corrupt reads. This uses `u32::try_from(..).expect(..)` so it fails loudly, matching the guarded sibling in the `posting_list` crate (`builder.rs:66`).

Reaching 4 GB of compressed ids in a single posting list is far outside realistic usage, so this is defensive hardening with no feasible regression test; the value is parity with the guarded sibling and fail-fast instead of silent corruption.

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### AI disclosure (per CONTRIBUTING.md)

- [AI] fix(sparse): checked usize->u32 for compressed posting chunk offset - AI-assisted, reviewed by me.
- Initial prompt: "In lib/sparse/src/index/compressed_posting_list.rs, the chunk offset uses `data_size as u32` which silently truncates > u32::MAX; replace with u32::try_from(data_size).expect(..) matching the sibling in lib/posting_list/src/builder.rs."

