### PR TITLE
docs(segment): correct cardinality confidence level to ~0.95 for z=2.0

### DIFF
--- a/lib/segment/src/index/sample_estimation.rs
+++ b/lib/segment/src/index/sample_estimation.rs
@@ -4,7 +4,7 @@ use crate::common::operation_error::OperationResult;
 
 const MAX_ESTIMATED_POINTS: usize = 1000;
 
-/// Returns (expected cardinality ± confidence interval at 0.99)
+/// Returns (expected cardinality ± confidence interval at ~0.95, i.e. z = 2.0)
 /// Based on <https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Agresti%E2%80%93Coull_interval>
 fn confidence_agresti_coull_interval(trials: usize, positive: usize, total: usize) -> (i64, i64) {
     let z = 2.; // heuristics


### PR DESCRIPTION
Closes #9966

`confidence_agresti_coull_interval` uses `z = 2.0`, which is ~95.45% confidence, but its doc comment said 0.99 (0.99 would need `z ~ 2.576`). This corrects the comment to say ~0.95 for `z = 2.0`.

`z` is intentionally left unchanged: raising it would widen every interval and break `test_confidence_interval`, and the function is a private heuristic. Doc-only change.

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### AI disclosure (per CONTRIBUTING.md)

- [AI] docs(segment): correct cardinality confidence level to ~0.95 - AI-assisted, reviewed by me.
- Initial prompt: "In lib/segment/src/index/sample_estimation.rs the doc says confidence 0.99 but z = 2.0 is ~0.95; correct the comment without changing z."
