### PR TITLE
fix(collection): size WAL replay clamp by max_capacity, not available capacity

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -770,7 +770,10 @@ impl LocalShard {
 
         // Cap the number of WAL entries to move to the update queue size,
         // since the update queue is limited and must hold all pending operations.
-        let update_queue_size = self.update_sender.load().capacity();
+        // Use the total configured buffer (`max_capacity`), not the currently
+        // available slots (`capacity`), which is what `update_queue_length` below
+        // treats as the total too.
+        let update_queue_size = self.update_sender.load().max_capacity();
         let to = cmp::max(
             to,
             last_wal_index.saturating_sub(update_queue_size as u64 - 1),


### PR DESCRIPTION
Closes #9968

`load_from_wal` sized the WAL-replay handoff from `update_sender.capacity()` (currently-available slots, which vary at runtime) but treated it as the total queue size. In tokio's bounded mpsc, `capacity()` is available permits and `max_capacity()` is the configured buffer; the same file's `update_queue_length()` already uses `max_capacity()` as the total. This aligns `load_from_wal` with that, and removes the `update_queue_size as u64 - 1` underflow risk (max_capacity is >= 1; capacity can be 0).

It is latent today (the channel is empty at that call, so the values coincide), so this is a consistency + footgun fix rather than an active bug, with no behavioral test.

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### AI disclosure (per CONTRIBUTING.md)

- [AI] fix(collection): size WAL replay clamp by max_capacity - AI-assisted, reviewed by me.
- Initial prompt: "In lib/collection/src/shards/local_shard/mod.rs, load_from_wal uses update_sender.capacity() (available slots) as the total queue size; use max_capacity() to match update_queue_length() and remove the '- 1' underflow risk."

