### PR TITLE
Recover from appendable segment overflow (core + replica resilience) (#9158)

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -30,7 +30,25 @@ impl CollectionUpdater {
                 if collection_error.is_transient() {
                     let mut write_segments = segments.write();
                     write_segments.failed_operation.insert(op_num);
-                    log::error!("Update operation failed: {collection_error}")
+                    if collection_error.is_out_of_appendable_capacity() {
+                        // Expected backpressure rather than a failure: the update worker retries
+                        // inline and recovery re-applies the operation once the optimizer
+                        // provisions a fresh appendable segment.
+                        log::debug!(
+                            "Update operation {op_num} ran out of appendable capacity, \
+                             it will be retried: {collection_error}"
+                        )
+                    } else {
+                        log::error!("Update operation failed: {collection_error}")
+                    }
+                } else if segments.write().failed_operation.remove(&op_num) {
+                    // A previously failed operation declined non-transiently on re-apply: it can
+                    // never succeed anymore (e.g. later operations deleted the points it
+                    // references). Drop it so it stops pinning the WAL acknowledge forever.
+                    log::warn!(
+                        "Update operation {op_num} declined on re-apply, dropping it: \
+                         {collection_error}"
+                    )
                 } else {
                     log::warn!("Update operation declined: {collection_error}")
                 }
@@ -135,6 +153,91 @@ mod tests {
     use crate::operations::point_ops::{
         PointOperations, PointStructPersisted, VectorStructPersisted,
     };
+
+    /// `failed_operation` pins the WAL acknowledge, so every transition in and out of it is
+    /// load-bearing: an entry that is never removed stalls the acknowledge forever, and one that
+    /// is removed too eagerly drops an operation that still needed re-applying.
+    fn failed_operations(segments: &LockedSegmentHolder) -> Vec<SeqNumberType> {
+        segments.read().failed_operation.iter().copied().collect()
+    }
+
+    fn empty_holder() -> LockedSegmentHolder {
+        LockedSegmentHolder::new(SegmentHolder::default())
+    }
+
+    #[test]
+    fn test_transient_failure_is_queued_for_recovery() {
+        let segments = empty_holder();
+
+        CollectionUpdater::handle_update_result(
+            &segments,
+            42,
+            &Err(CollectionError::service_error("all segments at the cap")),
+        );
+
+        assert_eq!(
+            failed_operations(&segments),
+            vec![42],
+            "a transient failure must be queued so recovery re-applies it",
+        );
+    }
+
+    #[test]
+    fn test_successful_reapply_clears_failed_operation() {
+        let segments = empty_holder();
+        segments.write().failed_operation.extend([42, 43]);
+
+        CollectionUpdater::handle_update_result(&segments, 42, &Ok(1));
+
+        assert_eq!(
+            failed_operations(&segments),
+            vec![43],
+            "a successful re-apply must unpin its own operation and leave the others",
+        );
+    }
+
+    #[test]
+    fn test_non_transient_decline_on_reapply_drops_failed_operation() {
+        let segments = empty_holder();
+        segments.write().failed_operation.extend([42, 43]);
+
+        // A queued operation can start declining once later operations changed what it sees, e.g.
+        // deleted the points it references. It can never succeed again, so holding the acknowledge
+        // for it would stall the WAL forever.
+        CollectionUpdater::handle_update_result(
+            &segments,
+            42,
+            &Err(CollectionError::PointNotFound {
+                missed_point_id: 1.into(),
+            }),
+        );
+
+        assert_eq!(
+            failed_operations(&segments),
+            vec![43],
+            "a queued operation that declines can never succeed, it must stop pinning the WAL",
+        );
+    }
+
+    #[test]
+    fn test_non_transient_decline_of_unqueued_operation_keeps_others() {
+        let segments = empty_holder();
+        segments.write().failed_operation.extend([42]);
+
+        // First-time decline of an unrelated operation: it was never queued, and it must not
+        // disturb the operation that is.
+        CollectionUpdater::handle_update_result(
+            &segments,
+            99,
+            &Err(CollectionError::bad_input("malformed".to_string())),
+        );
+
+        assert_eq!(
+            failed_operations(&segments),
+            vec![42],
+            "declining a never-queued operation must not touch the recovery queue",
+        );
+    }
 
     #[test]
     fn test_sync_ops() {

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -40,7 +40,10 @@ mod tests {
     use shard::optimizers::segment_optimizer::SegmentOptimizer;
     use shard::segment_holder::locked::LockedSegmentHolder;
     use shard::segment_holder::{FlushMode, SegmentId};
-    use shard::update::{process_field_index_operation, process_point_operation};
+    use shard::update::{
+        PAYLOAD_OP_BATCH_SIZE, process_field_index_operation, process_payload_operation,
+        process_point_operation,
+    };
     use tempfile::Builder;
 
     use super::*;
@@ -1120,6 +1123,237 @@ mod tests {
         assert!(
             any_hnsw,
             "an HNSW index should have been created to promote the deferred points",
+        );
+    }
+
+    /// Regression test for segment overgrow on `set_payload_by_filter` (#9158).
+    ///
+    /// When all points of a collection live in immutable (indexed) segments and
+    /// `set_payload` is executed via a filter that matches all points, the
+    /// `apply_points_with_conditional_move` mechanism CoW-moves every matched
+    /// point into an appendable segment. With the appendable segment size cap
+    /// armed, the operation fails with the recoverable `OutOfAppendableCapacity`
+    /// error once every appendable segment reaches the cap, instead of growing
+    /// one past `max_segment_size`.
+    ///
+    /// In production the failed operation wakes the optimizer, whose wake-up
+    /// provisions a fresh appendable segment and re-applies the operation from
+    /// `failed_operation` recovery. This test drives that loop synchronously:
+    /// fail, ensure capacity, retry with the same op number (already-applied
+    /// points are skipped by their point version).
+    #[test]
+    fn test_set_payload_by_filter_does_not_overgrow_segment() {
+        init();
+
+        let dim = 256;
+        // Each random_segment with 200 points and 256-dim f32 vectors has roughly
+        // ~200 KB of vector data on its own, well above the threshold below.
+        let points_per_segment = 200u64;
+        // Use a small max segment size so the combined indexed size exceeds it,
+        // but each individual indexed segment fits below it.
+        let max_segment_size_kb = 300;
+
+        let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
+        let segments_temp_dir = Builder::new()
+            .prefix("segments_temp_dir")
+            .tempdir()
+            .unwrap();
+        let mut opnum = 101..1_000_000;
+
+        // --- 1. Build two sizeable random segments (initially appendable). ---
+        let segment_a = random_segment(
+            segments_dir.path(),
+            opnum.next().unwrap(),
+            points_per_segment,
+            dim,
+        );
+        let segment_b = random_segment(
+            segments_dir.path(),
+            opnum.next().unwrap(),
+            points_per_segment,
+            dim,
+        );
+
+        let segment_config = segment_a.segment_config.clone();
+
+        let mut holder = SegmentHolder::default();
+        let segment_a_id = holder.add_new(segment_a);
+        let segment_b_id = holder.add_new(segment_b);
+
+        let locked_holder = LockedSegmentHolder::new(holder);
+
+        // --- 2. Run indexing optimizer to convert both segments to indexed
+        // (non-appendable) segments. ---
+        let index_optimizer = new_indexing_optimizer(
+            2,
+            OptimizerThresholds {
+                max_segment_size_kb,
+                memmap_threshold_kb: 1_000_000,
+                indexing_threshold_kb: 10, // Always optimize / index
+                deferred_internal_id: None,
+            },
+            segments_dir.path().to_owned(),
+            segments_temp_dir.path().to_owned(),
+            CollectionParams {
+                vectors: VectorsConfig::Single(
+                    VectorParamsBuilder::new(
+                        segment_config.vector_data[DEFAULT_VECTOR_NAME].size as u64,
+                        segment_config.vector_data[DEFAULT_VECTOR_NAME].distance,
+                    )
+                    .build(),
+                ),
+                ..CollectionParams::empty()
+            },
+            Default::default(),
+            HnswGlobalConfig::default(),
+            Default::default(),
+        );
+
+        // Index both raw segments. Each gets converted into an indexed
+        // non-appendable segment and a fresh empty appendable segment is
+        // created by the optimizer.
+        index_optimizer.optimize_for_test(locked_holder.clone(), vec![segment_a_id]);
+        index_optimizer.optimize_for_test(locked_holder.clone(), vec![segment_b_id]);
+
+        // Sanity check: we now have indexed segments larger combined than the
+        // configured max segment size.
+        let indexed_total: usize = locked_holder
+            .read()
+            .iter()
+            .map(|(_sid, segment)| {
+                let segment = segment.get().read();
+                if segment.is_appendable() {
+                    0
+                } else {
+                    segment
+                        .max_available_vectors_size_in_bytes()
+                        .unwrap_or_default()
+                }
+            })
+            .sum();
+        let max_segment_size_bytes = max_segment_size_kb * 1024;
+        assert!(
+            indexed_total > max_segment_size_bytes,
+            "Expected combined indexed size ({indexed_total}) to exceed max_segment_size ({max_segment_size_bytes})",
+        );
+
+        // Sanity: at least 2 indexed (non-appendable) segments exist.
+        let indexed_count = locked_holder
+            .read()
+            .iter()
+            .filter(|(_sid, segment)| !segment.get().read().is_appendable())
+            .count();
+        assert!(
+            indexed_count >= 2,
+            "Expected at least 2 indexed segments after optimization, got {indexed_count}",
+        );
+
+        // Arm the appendable segment size cap, as `UpdateHandler::run_workers` does on a real
+        // shard.
+        locked_holder
+            .write()
+            .set_max_segment_size_bytes(std::num::NonZeroUsize::new(max_segment_size_bytes));
+
+        let payload_schema_file = segments_dir.path().join("payload.schema");
+        let payload_index_schema: std::sync::Arc<
+            common::save_on_disk::SaveOnDisk<shard::payload_index_schema::PayloadIndexSchema>,
+        > = std::sync::Arc::new(
+            common::save_on_disk::SaveOnDisk::load_or_init_default(payload_schema_file).unwrap(),
+        );
+
+        // --- 3. Run set_payload by filter that matches ALL points. ---
+        // An empty filter matches every point in the collection.
+        let payload: segment::types::Payload = payload_json! {"new_field": "value"};
+
+        let hw_counter = HardwareCounterCell::new();
+
+        let payload_op = crate::operations::payload_ops::PayloadOps::SetPayload(
+            crate::operations::payload_ops::SetPayloadOp {
+                payload,
+                points: None,
+                filter: Some(segment::types::Filter::default()),
+                key: None,
+            },
+        );
+
+        // Drive the recovery loop synchronously: the operation fails with the recoverable
+        // capacity error once all appendable segments reach the cap; the optimizer wake-up
+        // provisions a fresh appendable segment and recovery re-applies the operation under
+        // the same op number, resuming where it stopped.
+        let payload_op_num = opnum.next().unwrap();
+        let mut capacity_failures = 0;
+        let result = loop {
+            let result = process_payload_operation(
+                &locked_holder.read(),
+                payload_op_num,
+                payload_op.clone(),
+                &hw_counter,
+            );
+            match result {
+                Err(err) if err.is_out_of_appendable_capacity() && capacity_failures < 8 => {
+                    capacity_failures += 1;
+                    let created =
+                        crate::update_workers::UpdateWorkers::ensure_appendable_segment_with_capacity(
+                            &locked_holder,
+                            index_optimizer.segments_path(),
+                            index_optimizer.segment_optimizer_config(),
+                            index_optimizer.threshold_config(),
+                            payload_index_schema.clone(),
+                        )
+                        .unwrap();
+                    assert!(
+                        created,
+                        "a capacity error implies all appendable segments are at the cap, \
+                         so the ensure step must create a fresh one",
+                    );
+                }
+                other => break other,
+            }
+        };
+
+        assert!(
+            result.is_ok(),
+            "set_payload_by_filter should succeed after capacity recovery: {result:?}",
+        );
+        assert!(
+            capacity_failures > 0,
+            "the operation should have hit the capacity error at least once",
+        );
+
+        // --- 4. Verify no segment exceeds max_segment_size (plus the documented one-batch
+        // overshoot tolerance of the per-batch capacity check), and every point survived. ---
+        let point_size_bytes = dim * size_of::<f32>();
+        let batch_tolerance_bytes = PAYLOAD_OP_BATCH_SIZE * point_size_bytes;
+
+        let mut total_points = 0;
+        let largest_segment_bytes = locked_holder
+            .read()
+            .iter()
+            .map(|(sid, segment)| {
+                let s = segment.get().read();
+                let size = s.max_available_vectors_size_in_bytes().unwrap_or_default();
+                let info = s.info().unwrap();
+                log::info!(
+                    "segment {sid:?}: appendable={} num_points={} num_vectors={} size_bytes={size}",
+                    s.is_appendable(),
+                    info.num_points,
+                    info.num_vectors,
+                );
+                total_points += info.num_points;
+                size
+            })
+            .max()
+            .unwrap_or_default();
+
+        assert_eq!(
+            total_points as u64,
+            2 * points_per_segment,
+            "every point must survive the capacity recovery",
+        );
+        assert!(
+            largest_segment_bytes <= max_segment_size_bytes + batch_tolerance_bytes,
+            "A segment overgrew the configured max_segment_size: largest={largest_segment_bytes} bytes, \
+             max={max_segment_size_bytes} bytes, tolerance={batch_tolerance_bytes} bytes",
         );
     }
 }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1096,6 +1096,29 @@ impl CollectionError {
         matches!(self, Self::PreConditionFailed { .. })
     }
 
+    /// Whether this is the flattened [`OperationError::OutOfAppendableCapacity`] error: all
+    /// appendable segments reached `max_segment_size`. The typed variant does not survive the
+    /// conversion to a (transient) shard-unavailable error, so it is recognized by its message,
+    /// which a test on the variant locks in place.
+    ///
+    /// Matched anywhere in the message rather than at its start: a replica that reports the
+    /// condition over gRPC comes back as a service error wrapping the status text, and the
+    /// replica set must recognize that form too or it deactivates a replica that recovers on
+    /// its own.
+    #[expect(clippy::wildcard_enum_match_arm, reason = "error handling")]
+    pub fn is_out_of_appendable_capacity(&self) -> bool {
+        let message = match self {
+            // Raised on this peer.
+            Self::ShardUnavailable { description } => description.as_str(),
+            // Reported by a remote replica, wrapped in the gRPC status text.
+            Self::ServiceError { error, .. } => error.as_str(),
+            _ => return false,
+        };
+
+        message
+            .contains(segment::common::operation_error::OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX)
+    }
+
     pub fn is_missing_point(&self) -> bool {
         #[expect(clippy::wildcard_enum_match_arm, reason = "error handling")]
         match self {
@@ -1175,10 +1198,11 @@ impl From<OperationError> for CollectionError {
             OperationError::VariableTypeError { .. } => Self::bad_input(err.to_string()),
             OperationError::NonFiniteNumber { .. } => Self::bad_input(err.to_string()),
             // Normally handled by segment provisioning before reaching this conversion; if it
-            // leaks, stay transient so failed-operation recovery re-applies the operation.
-            OperationError::OutOfAppendableCapacity { .. } => Self::ServiceError {
-                error: err.to_string(),
-                backtrace: None,
+            // leaks, stay transient so failed-operation recovery re-applies the operation. It is
+            // temporary backpressure rather than an internal failure, so it maps to the
+            // unavailable (503) family instead of a service error (500).
+            OperationError::OutOfAppendableCapacity { .. } => Self::ShardUnavailable {
+                description: err.to_string(),
             },
         }
     }
@@ -1908,5 +1932,48 @@ impl PeerMetadata {
     /// Whether this metadata has a different version than our current Qdrant instance.
     pub fn is_different_version(&self) -> bool {
         self.version != *defaults::QDRANT_VERSION
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The update worker recognizes the capacity condition by message, because the typed variant
+    /// does not survive the conversion below. This locks the whole chain: the variant's message,
+    /// the conversion into a shard-unavailable error, and the detection. Asserting on
+    /// `OperationError` alone would still pass if the conversion started wrapping the message.
+    #[test]
+    fn test_out_of_appendable_capacity_survives_conversion() {
+        let err = CollectionError::from(OperationError::OutOfAppendableCapacity {
+            max_segment_size_bytes: 1024,
+        });
+
+        assert!(
+            err.is_out_of_appendable_capacity(),
+            "the update worker would stop retrying capacity failures: {err}",
+        );
+        assert!(
+            err.is_transient(),
+            "failed-operation recovery must re-apply the operation",
+        );
+    }
+
+    /// A replica reporting the condition sends it as an unavailable status carrying the error
+    /// message (see the `StorageError` conversion), which comes back as a service error wrapping
+    /// that text. The replica set must still recognize it, or it deactivates a replica that
+    /// recovers on its own.
+    #[test]
+    fn test_out_of_appendable_capacity_survives_remote_round_trip() {
+        let err = CollectionError::from(OperationError::OutOfAppendableCapacity {
+            max_segment_size_bytes: 1024,
+        });
+
+        let remote_err = CollectionError::from(tonic::Status::unavailable(err.to_string()));
+
+        assert!(
+            remote_err.is_out_of_appendable_capacity(),
+            "the replica set would deactivate the reporting replica: {remote_err}",
+        );
     }
 }

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -735,6 +735,37 @@ impl LocalShard {
         let mut newest_clocks = self.wal.newest_clocks.lock().await;
         let wal = self.wal.wal.lock().await;
 
+        // Disarm the appendable-segment size cap for the synchronous replay below: it applies
+        // operations exactly as they were originally accepted. A capacity error here could not
+        // recover (recovery runs on optimizer wake-ups, which only process signals once the
+        // shard serves updates) and would fail the whole shard load. The cap re-arms after the
+        // replay, before the remaining WAL tail is queued to the update worker, where recovery
+        // is live.
+        //
+        // Restored by a guard rather than inline: the replay below returns early on several
+        // error paths, and leaving the cap disarmed there would let the shard run uncapped for
+        // its whole lifetime.
+        struct RearmCapOnDrop<'a> {
+            segments: &'a LockedSegmentHolder,
+            cap: Option<std::num::NonZeroUsize>,
+        }
+
+        impl Drop for RearmCapOnDrop<'_> {
+            fn drop(&mut self) {
+                self.segments.write().set_max_segment_size_bytes(self.cap);
+            }
+        }
+
+        let rearm_cap = {
+            let mut segments = self.segments.write();
+            let cap = segments.max_segment_size_bytes();
+            segments.set_max_segment_size_bytes(None);
+            RearmCapOnDrop {
+                segments: &self.segments,
+                cap,
+            }
+        };
+
         let from = wal.first_index();
         let last_wal_index = from + wal.len(false);
 
@@ -933,6 +964,11 @@ impl LocalShard {
             // version.
             segments.flush_all(FlushMode::Sync, true)?;
         }
+
+        // Synchronous replay is done; re-arm the appendable-segment size cap for the queued WAL
+        // tail and everything after. Explicit rather than left to the end of the function, so the
+        // cap is back before the tail reaches the update worker.
+        drop(rearm_cap);
 
         bar.finish();
         if !show_progress_bar {

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -189,7 +189,9 @@ impl ShardReplicaSet {
             self.forward_update(leader_peer, operation, wait, timeout, ordering, hw_measurement_acc)
                 .await
                 .map_err(|err| {
-                    if err.is_transient() {
+                    // A leader that ran out of appendable capacity recovers on its own, so it is
+                    // not deactivated over that either (see `handle_failed_replicas`).
+                    if err.is_transient() && !err.is_out_of_appendable_capacity() {
                         // Deactivate the peer if forwarding failed with transient error
                         let replica_state = self.replica_state.read();
 
@@ -737,6 +739,16 @@ impl ShardReplicaSet {
                 continue;
             }
 
+            // Ignore capacity errors: every appendable segment of that replica reached
+            // `max_segment_size`, which is local, expected and self-healing. The operation is
+            // queued in `failed_operation` and pins the WAL acknowledge, so the optimizer
+            // wake-up provisions a fresh appendable segment and recovery re-applies it. Marking
+            // the replica dead over it would force a full transfer to recover a replica that
+            // catches up on its own.
+            if err.is_out_of_appendable_capacity() {
+                continue;
+            }
+
             if err.is_transient() || peer_state == ReplicaState::Initializing {
                 // If the error is transient, we should not deactivate the peer
                 // before allowing other operations to continue.
@@ -875,6 +887,7 @@ mod tests {
 
     use common::budget::ResourceBudget;
     use common::save_on_disk::SaveOnDisk;
+    use segment::common::operation_error::OperationError;
     use segment::types::Distance;
     use tempfile::{Builder, TempDir};
     use tokio::runtime::Handle;
@@ -972,6 +985,42 @@ mod tests {
 
         assert_eq!(rs.highest_replica_peer_id(), Some(5));
         assert_eq!(rs.highest_alive_replica_peer_id(), Some(4));
+    }
+
+    /// A replica that ran out of appendable capacity must keep its state: the operation is
+    /// pinned in `failed_operation` and re-applied once the optimizer provisions a fresh
+    /// appendable segment, so deactivating would force a full transfer to recover a replica
+    /// that catches up on its own.
+    #[tokio::test]
+    async fn test_capacity_failure_does_not_deactivate_replica() {
+        let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+        let rs = new_shard_replica_set(&collection_dir).await;
+
+        for peer_id in [1, 2, 3] {
+            rs.set_replica_state(peer_id, ReplicaState::Active)
+                .await
+                .unwrap();
+        }
+
+        let capacity_failures = vec![(
+            2,
+            CollectionError::from(OperationError::OutOfAppendableCapacity {
+                max_segment_size_bytes: 1024,
+            }),
+        )];
+        let wait_for_deactivation =
+            rs.handle_failed_replicas(&capacity_failures, &rs.replica_state.read(), false);
+
+        assert!(!wait_for_deactivation);
+        assert!(!rs.is_locally_disabled(2));
+
+        // Any other transient failure still deactivates the replica.
+        let service_failures = vec![(3, CollectionError::service_error("something went wrong"))];
+        let wait_for_deactivation =
+            rs.handle_failed_replicas(&service_failures, &rs.replica_state.read(), false);
+
+        assert!(wait_for_deactivation);
+        assert!(rs.is_locally_disabled(3));
     }
 
     const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
@@ -7,6 +8,7 @@ use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use parking_lot::Mutex;
+use segment::common::BYTES_IN_KB;
 use segment::types::SeqNumberType;
 use shard::operations::CollectionUpdateOperations;
 use shard::segment_holder::locked::LockedSegmentHolder;
@@ -189,6 +191,25 @@ impl UpdateHandler {
     }
 
     pub fn run_workers(&mut self, update_receiver: Receiver<UpdateSignal>) {
+        // Mirror the resolved optimizer size threshold into the segment holder, both on shard
+        // creation and on optimizer config updates (which restart the workers). With the cap set,
+        // the update path reports `OutOfAppendableCapacity` instead of growing an appendable
+        // segment past `max_segment_size`; the failed operation then wakes the optimizer, whose
+        // capacity-ensure step provisions a fresh appendable segment, and failed-operation
+        // recovery re-applies the operation. Synchronous WAL replay disarms the cap for its own
+        // window (see `load_from_wal`), since no recovery loop is processing signals there.
+        if let Some(optimizer) = self.optimizers.first() {
+            let max_segment_size_bytes = NonZeroUsize::new(
+                optimizer
+                    .threshold_config()
+                    .max_segment_size_kb
+                    .saturating_mul(BYTES_IN_KB),
+            );
+            self.segments
+                .write()
+                .set_max_segment_size_bytes(max_segment_size_bytes);
+        }
+
         let (tx, rx) = mpsc::channel(self.shared_storage_config.update_queue_size);
 
         // Optimization notifier is triggered when a new optimization is finished

--- a/lib/collection/src/update_workers/flush_workers.rs
+++ b/lib/collection/src/update_workers/flush_workers.rs
@@ -142,3 +142,61 @@ impl UpdateWorkers {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use common::counter::hardware_counter::HardwareCounterCell;
+    use segment::data_types::vectors::only_default_vector;
+    use segment::entry::entry_point::SegmentEntry as _;
+    use shard::segment_holder::SegmentHolder;
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::collection_manager::fixtures::empty_segment;
+
+    /// `failed_operation` is what keeps a failed operation replayable: it caps the version the
+    /// flush worker acknowledges in the WAL, so the entry stays on disk until the operation is
+    /// re-applied. Both halves of the recovery contract rest on this, queueing a transient failure
+    /// and dropping one that can never succeed again.
+    #[test]
+    fn test_failed_operation_pins_wal_acknowledge() {
+        let dir = Builder::new().prefix("segments").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        let mut segment = empty_segment(dir.path());
+        segment
+            .upsert_point(
+                10,
+                1.into(),
+                only_default_vector(&[1.0, 0.0, 1.0, 1.0]),
+                &hw_counter,
+            )
+            .unwrap();
+
+        let mut holder = SegmentHolder::default();
+        holder.add_new(segment);
+        let segments = LockedSegmentHolder::new(holder);
+        segments.read().flush_all(FlushMode::Sync, true).unwrap();
+
+        assert_eq!(
+            UpdateWorkers::flush_segments(segments.clone()).unwrap(),
+            10,
+            "with nothing queued the acknowledge follows the persisted version",
+        );
+
+        segments.write().failed_operation.insert(5);
+        assert_eq!(
+            UpdateWorkers::flush_segments(segments.clone()).unwrap(),
+            5,
+            "a queued operation must hold the acknowledge below itself",
+        );
+
+        // Dropping the entry is what a non-transient decline does, and it must release the pin.
+        segments.write().failed_operation.remove(&5);
+        assert_eq!(
+            UpdateWorkers::flush_segments(segments.clone()).unwrap(),
+            10,
+            "dropping the queued operation must let the acknowledge advance again",
+        );
+    }
+}

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -110,17 +110,21 @@ impl UpdateWorkers {
 
             // Ensure we have at least one appendable segment with enough capacity
             // Source required parameters from first optimizer
-            let result = Self::ensure_appendable_segment_with_capacity(
+            let created_appendable_segment = match Self::ensure_appendable_segment_with_capacity(
                 &segments,
                 some_optimizer.segments_path(),
                 some_optimizer.segment_optimizer_config(),
                 some_optimizer.threshold_config(),
                 payload_index_schema.clone(),
-            );
-            if let Err(err) = result {
-                log::error!("Failed to ensure there are appendable segments with capacity: {err}");
-                panic!("Failed to ensure there are appendable segments with capacity: {err}");
-            }
+            ) {
+                Ok(created) => created,
+                Err(err) => {
+                    log::error!(
+                        "Failed to ensure there are appendable segments with capacity: {err}"
+                    );
+                    panic!("Failed to ensure there are appendable segments with capacity: {err}");
+                }
+            };
 
             // Backstop: reconcile the segment manifest with the live segment set. Registration
             // normally happens at each publication site via the `NewSegmentToken`; this wake-up is
@@ -144,6 +148,24 @@ impl UpdateWorkers {
             .await
             .is_err()
             {
+                // Failed-operation recovery could not complete. When this wake-up just
+                // provisioned a fresh appendable segment, the failure is likely
+                // `OutOfAppendableCapacity` part-way through an operation that moves more data
+                // than one segment holds: it filled the new segment and needs another. Wake
+                // ourselves again so the next capacity-ensure provisions the next segment and
+                // recovery resumes where it stopped (applied points are skipped by version).
+                // Progress-guarded: if the provisioned segment stayed empty, the next wake-up
+                // creates nothing and this re-signal chain stops.
+                // `try_send` rather than an awaited send: this is our own signal channel, so
+                // awaiting a full one would deadlock the loop that drains it.
+                if created_appendable_segment
+                    && let Err(err) = sender.try_send(OptimizerSignal::Nop)
+                {
+                    log::warn!(
+                        "Could not re-signal the optimizer to continue capacity recovery, \
+                         it resumes on the next wake-up: {err}"
+                    );
+                }
                 let _ = optimization_finished_sender.send(());
                 continue;
             }
@@ -442,31 +464,24 @@ impl UpdateWorkers {
     /// created.
     ///
     /// Capacity is determined based on `optimizers.max_segment_size_kb`.
+    ///
+    /// Returns whether a new segment was created.
     pub fn ensure_appendable_segment_with_capacity(
         segments: &LockedSegmentHolder,
         segments_path: &Path,
         segment_config: &SegmentOptimizerConfig,
         thresholds_config: &OptimizerThresholds,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
-    ) -> OperationResult<()> {
+    ) -> OperationResult<bool> {
         let no_segment_with_capacity = {
-            let segments_read = segments.read();
-            segments_read
-                .appendable_segments_ids()
-                .into_iter()
-                .filter_map(|segment_id| segments_read.get(segment_id))
-                .all(|segment| {
-                    let max_vector_size_bytes = segment
-                        .get()
-                        .read()
-                        .max_available_vectors_size_in_bytes()
-                        .unwrap_or_default();
-                    let max_segment_size_bytes = thresholds_config
-                        .max_segment_size_kb
-                        .saturating_mul(segment::common::BYTES_IN_KB);
-
-                    max_vector_size_bytes >= max_segment_size_bytes
-                })
+            let max_segment_size_bytes = std::num::NonZeroUsize::new(
+                thresholds_config
+                    .max_segment_size_kb
+                    .saturating_mul(segment::common::BYTES_IN_KB),
+            );
+            !segments
+                .read()
+                .has_appendable_segment_with_capacity(max_segment_size_bytes)
         };
 
         if no_segment_with_capacity {
@@ -486,7 +501,7 @@ impl UpdateWorkers {
             write_guard.add_new_locked(new_segment);
         }
 
-        Ok(())
+        Ok(no_segment_with_capacity)
     }
 
     /// Trigger optimizers when CPU budget is available
@@ -530,17 +545,155 @@ impl UpdateWorkers {
                             "Failed to read WAL during recovery: {e}"
                         ))
                     })?;
-                    CollectionUpdater::update(
+                    let result = CollectionUpdater::update(
                         &segments,
                         op_num,
                         operation.operation,
                         update_operation_lock.clone(),
                         update_tracker.clone(),
                         &HardwareCounterCell::disposable(), // Internal operation, no measurement needed
-                    )?;
+                    );
+                    match result {
+                        Ok(_) => {}
+                        // Abort recovery and retry on a later wake-up.
+                        Err(err) if err.is_transient() => return Err(err),
+                        // A non-transient decline can never succeed; skip it like WAL replay
+                        // does on shard load, instead of aborting recovery forever. A replayed
+                        // operation can legitimately decline this way when later (already
+                        // applied) operations changed the state it sees, e.g. deleted one of
+                        // its points. `CollectionUpdater` already dropped it from
+                        // `failed_operation`, unblocking the WAL acknowledge.
+                        Err(err) => {
+                            log::warn!(
+                                "Skipping failed operation {op_num} during recovery, \
+                                 it was declined: {err}"
+                            );
+                        }
+                    }
                 }
             }
         };
         Ok(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+
+    use common::counter::hardware_accumulator::HwMeasurementAcc;
+    use common::types::DeferredBehavior;
+    use segment::data_types::vectors::only_default_vector;
+    use segment::entry::entry_point::SegmentEntry as _;
+    use segment::payload_json;
+    use segment::types::{PayloadContainer, WithPayload};
+    use shard::operations::OperationWithClockTag;
+    use shard::retrieve::retrieve_blocking::retrieve_blocking;
+    use shard::segment_holder::SegmentHolder;
+    use shard::wal::{SerdeWal, WalRawRecord};
+    use tempfile::Builder;
+    use wal::WalOptions;
+
+    use super::*;
+    use crate::collection_manager::fixtures::{TEST_TIMEOUT, empty_segment};
+    use crate::operations::CollectionUpdateOperations;
+    use crate::operations::payload_ops::{PayloadOps, SetPayloadOp};
+    use crate::shards::update_tracker::UpdateTracker;
+
+    fn set_payload_op(point_id: u64, color: &str) -> CollectionUpdateOperations {
+        CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(SetPayloadOp {
+            payload: payload_json! {"color": color},
+            points: Some(vec![point_id.into()]),
+            filter: None,
+            key: None,
+        }))
+    }
+
+    /// A queued operation can start declining non-transiently once later operations changed the
+    /// state it sees. Recovery used to propagate that error, which aborted the whole pass and left
+    /// the operation queued, so every later wake-up retried the same doomed operation and the WAL
+    /// acknowledge never advanced. It must be skipped instead, exactly like WAL replay does.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_try_recover_skips_declined_operation_and_continues() {
+        let segments_dir = Builder::new().prefix("segments").tempdir().unwrap();
+        let wal_dir = Builder::new().prefix("wal").tempdir().unwrap();
+
+        // Seed the point at version 0 so the replayed operations below, whose op numbers are WAL
+        // indices starting at 0, are not skipped as already applied.
+        let hw_counter = HardwareCounterCell::new();
+        let mut segment = empty_segment(segments_dir.path());
+        segment
+            .upsert_point(
+                0,
+                1.into(),
+                only_default_vector(&[1.0, 0.0, 1.0, 1.0]),
+                &hw_counter,
+            )
+            .unwrap();
+
+        let mut holder = SegmentHolder::default();
+        holder.add_new(segment);
+        let segments = LockedSegmentHolder::new(holder);
+
+        let mut wal: SerdeWal<OperationWithClockTag> =
+            SerdeWal::new(wal_dir.path(), WalOptions::default()).unwrap();
+
+        // Declines with `PointNotFound`, which is not transient: point 999 does not exist.
+        let declining_op_num = wal
+            .write(
+                &WalRawRecord::new(&OperationWithClockTag::new(
+                    set_payload_op(999, "red"),
+                    None,
+                ))
+                .unwrap(),
+            )
+            .unwrap();
+        // Queued behind it, and must still be applied once the declined one is skipped.
+        wal.write(
+            &WalRawRecord::new(&OperationWithClockTag::new(set_payload_op(1, "blue"), None))
+                .unwrap(),
+        )
+        .unwrap();
+
+        segments.write().failed_operation.insert(declining_op_num);
+
+        UpdateWorkers::try_recover(
+            segments.clone(),
+            Arc::new(TokioMutex::new(wal)),
+            Arc::new(tokio::sync::RwLock::new(())),
+            UpdateTracker::default(),
+        )
+        .await
+        .expect("a declined operation must not abort recovery");
+
+        assert!(
+            segments.read().failed_operation.is_empty(),
+            "the declined operation must stop pinning the WAL acknowledge",
+        );
+
+        let is_stopped = AtomicBool::new(false);
+        let records = retrieve_blocking(
+            segments,
+            &[1.into()],
+            &WithPayload::from(true),
+            &false.into(),
+            TEST_TIMEOUT,
+            &is_stopped,
+            HwMeasurementAcc::new(),
+            DeferredBehavior::VisibleOnly,
+        )
+        .unwrap();
+
+        assert_eq!(
+            records[&1.into()]
+                .payload
+                .as_ref()
+                .and_then(|payload| payload
+                    .get_value(&"color".parse().unwrap())
+                    .first()
+                    .cloned()),
+            Some(&serde_json::json!("blue")),
+            "recovery must keep applying the operations queued behind the declined one",
+        );
     }
 }

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -141,7 +141,18 @@ impl UpdateWorkers {
                             .await
                             .and(Ok(update_res))
                             .map_err(|send_err| send_err.into()),
-                        Ok(Err(err)) => Err(err),
+                        Ok(Err(err)) => {
+                            // A transient failure (e.g. all appendable segments reached
+                            // `max_segment_size`) was queued in `failed_operation`. Wake the
+                            // optimizer so its capacity-ensure step can provision a fresh
+                            // appendable segment and `try_recover` re-applies the operation.
+                            // `Nop` rather than `Operation`: it must run recovery even when
+                            // optimization handles are maxed out.
+                            if err.is_transient() {
+                                let _ = optimize_sender.send(OptimizerSignal::Nop).await;
+                            }
+                            Err(err)
+                        }
                         Err(err) => Err(CollectionError::from(err)),
                     };
 

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -92,11 +92,20 @@ pub enum OperationError {
     /// All appendable segments reached `max_segment_size`, so there is no valid destination for
     /// new or moved points. Recoverable by provisioning a fresh appendable segment and re-applying
     /// the operation; already-applied points are skipped by their point version.
+    ///
+    /// The message must keep starting with [`OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX`]: the
+    /// collection-level error conversion flattens this variant into a generic shard-unavailable
+    /// error, and the update worker recognizes the condition by that prefix.
     #[error(
         "All appendable segments reached the maximum segment size of {max_segment_size_bytes} bytes"
     )]
     OutOfAppendableCapacity { max_segment_size_bytes: usize },
 }
+
+/// Message prefix of [`OperationError::OutOfAppendableCapacity`], for recognizing the condition
+/// after the variant is flattened into an untyped error (locked by a test below).
+pub const OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX: &str =
+    "All appendable segments reached the maximum segment size";
 
 impl OperationError {
     /// Create a new service error with a description and a backtrace
@@ -437,6 +446,18 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+
+    #[test]
+    fn test_out_of_appendable_capacity_message_prefix() {
+        let err = OperationError::OutOfAppendableCapacity {
+            max_segment_size_bytes: 1024,
+        };
+        assert!(
+            err.to_string()
+                .starts_with(OUT_OF_APPENDABLE_CAPACITY_MESSAGE_PREFIX),
+            "the update worker recognizes the flattened error by this prefix",
+        );
+    }
 
     #[test]
     fn test_not_found_classification() {

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -8,6 +8,7 @@ mod tests;
 
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::sync::Arc;
@@ -135,6 +136,16 @@ pub struct SegmentHolder {
     /// funnels through [`add_existing_locked`](Self::add_existing_locked) and
     /// [`remove`](Self::remove), which reconcile it.
     segment_manifest: Option<Arc<SaveOnDisk<SegmentsManifest>>>,
+
+    /// Soft cap on appendable segment size for the update path, mirroring the resolved optimizer
+    /// `max_segment_size_kb` threshold (set by the shard on load and on optimizer config updates).
+    ///
+    /// When set, the update path avoids inserting or CoW-moving points into appendable segments
+    /// whose vector size already reached the cap, and reports
+    /// [`OperationError::OutOfAppendableCapacity`] when no appendable segment is below it. `None`
+    /// disables capacity checks (the pre-existing behavior: any appendable segment is a valid
+    /// destination, regardless of size).
+    max_segment_size_bytes: Option<NonZeroUsize>,
 }
 
 impl Drop for SegmentHolder {
@@ -620,9 +631,98 @@ impl SegmentHolder {
             .collect()
     }
 
+    /// Set the soft cap on appendable segment size used by the update path.
+    ///
+    /// Mirrors the resolved optimizer `max_segment_size_kb` threshold; `None` disables capacity
+    /// checks. See [`SegmentHolder::max_segment_size_bytes`].
+    pub fn set_max_segment_size_bytes(&mut self, max_segment_size_bytes: Option<NonZeroUsize>) {
+        self.max_segment_size_bytes = max_segment_size_bytes;
+    }
+
+    pub fn max_segment_size_bytes(&self) -> Option<NonZeroUsize> {
+        self.max_segment_size_bytes
+    }
+
+    /// Whether at least one appendable segment is below the given size cap.
+    ///
+    /// `false` when there are no appendable segments at all. Eligibility follows
+    /// [`eligible_appendable_segments`](Self::eligible_appendable_segments) with the given cap.
+    pub fn has_appendable_segment_with_capacity(
+        &self,
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> bool {
+        !self
+            .eligible_appendable_segments(max_segment_size_bytes)
+            .is_empty()
+    }
+
+    /// Appendable segments below the given size cap, with their measured sizes.
+    ///
+    /// Segments that cannot be measured right now (read-lock contention, size errors) stay
+    /// eligible and report `None`: the cap is a soft limit and liveness wins over precision.
+    /// With no cap, every appendable segment is eligible.
+    ///
+    /// Single origin of the eligibility semantics: every capacity decision (the destination
+    /// filter, the capacity error, the updater's wait predicate, the optimizer's ensure step)
+    /// derives from this list so they can never disagree.
+    fn eligible_appendable_segments(
+        &self,
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> Vec<(SegmentId, Option<usize>)> {
+        let appendable_segments = self.appendable_segments_ids();
+
+        let mut eligible = Vec::with_capacity(appendable_segments.len());
+        for segment_id in appendable_segments {
+            let Some(locked_segment) = self.get(segment_id) else {
+                continue;
+            };
+            let size = match locked_segment.get().try_read() {
+                None => None,
+                Some(segment) => match segment.max_available_vectors_size_in_bytes() {
+                    Ok(size) => Some(size),
+                    Err(err) => {
+                        log::error!("Failed to get segment size, ignoring: {err}");
+                        None
+                    }
+                },
+            };
+            let under_cap = match (size, max_segment_size_bytes) {
+                (Some(size), Some(max_segment_size_bytes)) => size < max_segment_size_bytes.get(),
+                _ => true,
+            };
+            if under_cap {
+                eligible.push((segment_id, size));
+            }
+        }
+        eligible
+    }
+
+    /// Appendable segments eligible as write destinations under the configured size cap, with
+    /// their measured sizes.
+    ///
+    /// This is the single origin of [`OperationError::OutOfAppendableCapacity`], returned when
+    /// appendable segments exist but every measurable one reached the cap. The updater recovers
+    /// by signalling the optimizer (whose wake-up provisions a fresh appendable segment) and
+    /// re-applying the operation; already-applied points are then skipped by their point version.
+    fn appendable_segments_with_capacity(
+        &self,
+    ) -> OperationResult<Vec<(SegmentId, Option<usize>)>> {
+        let eligible = self.eligible_appendable_segments(self.max_segment_size_bytes);
+
+        if eligible.is_empty()
+            && !self.appendable_segments.is_empty()
+            && let Some(max_segment_size_bytes) = self.max_segment_size_bytes
+        {
+            return Err(OperationError::OutOfAppendableCapacity {
+                max_segment_size_bytes: max_segment_size_bytes.get(),
+            });
+        }
+        Ok(eligible)
+    }
+
     /// Get a random appendable segment
     ///
-    /// If you want the smallest segment, use `random_appendable_segment_with_capacity` instead.
+    /// If you want the smallest segment, use `smallest_appendable_segment` instead.
     pub fn random_appendable_segment(&self) -> Option<LockedSegment> {
         let segment_ids: Vec<_> = self.appendable_segments_ids();
         segment_ids
@@ -637,38 +737,38 @@ impl SegmentHolder {
     ///
     /// This attempts a non-blocking read-lock on all segments to find the smallest one. Segments
     /// that cannot be read-locked at this time are skipped. If no segment can be read-locked at
-    /// all, a random one is returned.
+    /// all, a random one is returned without a size check.
+    ///
+    /// # Errors
+    ///
+    /// - [`OperationError::OutOfAppendableCapacity`] when a size cap is configured and every
+    ///   measurable segment reached it (see
+    ///   [`appendable_segments_with_capacity`](Self::appendable_segments_with_capacity)).
+    /// - Service error when there are no appendable segments at all.
     ///
     /// If capacity is not important use `random_appendable_segment` instead because it is cheaper.
-    pub fn smallest_appendable_segment(&self) -> Option<LockedSegment> {
-        let segment_ids: Vec<_> = self.appendable_segments_ids();
+    pub fn smallest_appendable_segment(&self) -> OperationResult<LockedSegment> {
+        let candidates = self.appendable_segments_with_capacity()?;
 
-        // Try a non-blocking read lock on all segments and return the smallest one
-        let smallest_segment = segment_ids
+        // Prefer the smallest measurable candidate; fall back to a random one when none could
+        // be measured.
+        let chosen = candidates
             .iter()
-            .filter_map(|segment_id| self.get(*segment_id))
-            .filter_map(|locked_segment| {
-                match locked_segment
-                    .get()
-                    .try_read()
-                    .map(|segment| segment.max_available_vectors_size_in_bytes())?
-                {
-                    Ok(size) => Some((locked_segment, size)),
-                    Err(err) => {
-                        log::error!("Failed to get segment size, ignoring: {err}");
-                        None
-                    }
-                }
-            })
-            .min_by_key(|(_, segment_size)| *segment_size);
-        if let Some((smallest_segment, _)) = smallest_segment {
-            return Some(LockedSegment::clone(smallest_segment));
-        }
+            .filter_map(|(segment_id, size)| size.map(|size| (*segment_id, size)))
+            .min_by_key(|(_, size)| *size)
+            .map(|(segment_id, _)| segment_id)
+            .or_else(|| {
+                candidates
+                    .choose(&mut rand::rng())
+                    .map(|(segment_id, _)| *segment_id)
+            });
 
-        // Fall back to picking a random segment
-        segment_ids
-            .choose(&mut rand::rng())
-            .and_then(|idx| self.appendable_segments.get(idx).cloned())
+        chosen
+            .and_then(|segment_id| self.appendable_segments.get(&segment_id))
+            .cloned()
+            .ok_or_else(|| {
+                OperationError::service_error("No appendable segments exist, expected at least one")
+            })
     }
 
     /// Selects point ids, which is stored in this segment
@@ -1004,6 +1104,13 @@ impl SegmentHolder {
         // Choose random appendable segment from this
         let appendable_segments = self.appendable_segments_ids();
 
+        // CoW-move destination candidates below the size cap. Computed lazily on the first point
+        // that actually needs a move — a batch that applies fully in place must not fail just
+        // because all appendable segments are full — and reused for the rest of this call.
+        // Callers batch points (e.g. 32 per call), so capacity is checked once per batch, not
+        // per point; a destination may overshoot the cap by at most one batch worth of points.
+        let mut eligible_segments: Option<Vec<SegmentId>> = None;
+
         let mut applied_points: AHashSet<PointIdType> = Default::default();
         let stopped = AtomicBool::new(false);
 
@@ -1020,8 +1127,22 @@ impl SegmentHolder {
             let is_applied = if can_apply_operation {
                 point_operation(point_id, write_segment)?
             } else {
+                let destination_candidates: &[SegmentId] = if self.max_segment_size_bytes.is_some()
+                {
+                    if eligible_segments.is_none() {
+                        let eligible = self
+                            .appendable_segments_with_capacity()?
+                            .into_iter()
+                            .map(|(segment_id, _size)| segment_id)
+                            .collect();
+                        eligible_segments = Some(eligible);
+                    }
+                    eligible_segments.as_ref().unwrap()
+                } else {
+                    &appendable_segments
+                };
                 self.aloha_random_write(
-                    &appendable_segments,
+                    destination_candidates,
                     |appendable_idx, appendable_write_segment| {
                         // If we are moving point from one segment to another,
                         // we must guarantee, that data in new segment will be persisted before

--- a/lib/shard/src/update/mod.rs
+++ b/lib/shard/src/update/mod.rs
@@ -15,8 +15,9 @@ use segment::types::{Payload, SeqNumberType};
 pub use self::field_index::{create_field_index, delete_field_index};
 pub(crate) use self::helpers::{points_by_filter, select_excluded_by_filter_ids};
 pub use self::payload::{
-    clear_payload, clear_payload_by_filter, delete_payload, delete_payload_by_filter,
-    overwrite_payload, overwrite_payload_by_filter, set_payload, set_payload_by_filter,
+    PAYLOAD_OP_BATCH_SIZE, clear_payload, clear_payload_by_filter, delete_payload,
+    delete_payload_by_filter, overwrite_payload, overwrite_payload_by_filter, set_payload,
+    set_payload_by_filter,
 };
 pub(crate) use self::points::retain_conditional_upsert_points;
 pub use self::points::{

--- a/lib/shard/src/update/payload.rs
+++ b/lib/shard/src/update/payload.rs
@@ -8,8 +8,11 @@ use segment::types::{Filter, Payload, PayloadKeyType, PointIdType, SeqNumberType
 use super::helpers::{check_unprocessed_points, points_by_filter};
 use crate::segment_holder::SegmentHolder;
 
-/// Batch size when modifying payload
-const PAYLOAD_OP_BATCH_SIZE: usize = 32;
+/// Batch size when modifying payload.
+///
+/// Also the overshoot bound of the appendable segment size cap: capacity is checked once per
+/// batch, so a CoW-move destination can grow past the cap by at most this many points.
+pub const PAYLOAD_OP_BATCH_SIZE: usize = 32;
 
 pub fn set_payload(
     segments: &SegmentHolder,

--- a/lib/shard/src/update/points/upsert.rs
+++ b/lib/shard/src/update/points/upsert.rs
@@ -4,7 +4,7 @@ use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::DeferredBehavior;
 use parking_lot::RwLockWriteGuard;
-use segment::common::operation_error::{OperationError, OperationResult};
+use segment::common::operation_error::OperationResult;
 use segment::data_types::named_vectors::NamedVectors;
 use segment::entry::entry_point::SegmentEntry;
 use segment::types::{Filter, Payload, PointIdType, SeqNumberType, VectorNameBuf};
@@ -187,18 +187,17 @@ where
 
         res += updated_points.len();
         // Insert new points, which was not updated or existed
-        let new_point_ids = ids_chunk
+        let new_point_ids: Vec<PointIdType> = ids_chunk
             .iter()
             .copied()
-            .filter(|x| !updated_points.contains(x));
+            .filter(|x| !updated_points.contains(x))
+            .collect();
 
-        {
-            let default_write_segment =
-                segments.smallest_appendable_segment().ok_or_else(|| {
-                    OperationError::service_error(
-                        "No appendable segments exist, expected at least one",
-                    )
-                })?;
+        // Only look up an insert destination when there is something to insert: the lookup
+        // fails with `OutOfAppendableCapacity` when all appendable segments are at the size
+        // cap, and a chunk that updated every point in place needs no capacity at all.
+        if !new_point_ids.is_empty() {
+            let default_write_segment = segments.smallest_appendable_segment()?;
 
             let segment_arc = default_write_segment.get();
             let mut write_segment = segment_arc.write();
@@ -210,7 +209,7 @@ where
                 )?);
             }
             RwLockWriteGuard::unlock_fair(write_segment);
-        };
+        }
     }
 
     Ok(res)

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -7,7 +8,8 @@ use segment::entry::ReadSegmentEntry as _;
 use segment::entry::entry_point::SegmentEntry as _;
 use segment::payload_json;
 use segment::types::{
-    Condition, FieldCondition, Filter, Match, MatchValue, PayloadKeyType, ValueVariants,
+    Condition, FieldCondition, Filter, Match, MatchValue, PayloadKeyType, PointIdType,
+    ValueVariants,
 };
 use tempfile::Builder;
 
@@ -18,8 +20,8 @@ use crate::operations::point_ops::PointStructRawPersisted;
 use crate::segment_holder::{FlushMode, SegmentHolder};
 use crate::update::{
     clear_payload_by_filter, create_field_index, delete_payload_by_filter, delete_points_by_filter,
-    delete_vectors_by_filter, overwrite_payload_by_filter, set_payload_by_filter, sync_points_raw,
-    upsert_points_raw,
+    delete_vectors_by_filter, overwrite_payload_by_filter, set_payload, set_payload_by_filter,
+    sync_points_raw, upsert_points_raw,
 };
 
 #[test]
@@ -898,5 +900,62 @@ fn create_field_index_pins_pending_payload_state() {
     assert!(
         hits.is_empty(),
         "filtered reads must agree with payload storage: the row was cleared",
+    );
+}
+
+/// Fixtures use dim-4 f32 vectors: 16 bytes per point.
+const TEST_POINT_SIZE_BYTES: usize = 16;
+
+#[test]
+fn test_capacity_error_when_all_appendable_at_cap() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let mut non_appendable = build_segment_1(dir.path()); // points 1-5
+    non_appendable.appendable_flag = false;
+
+    // Fill the only appendable segment up to the cap of 2 points.
+    let mut appendable = empty_segment(dir.path());
+    for point_id in [100u64, 101] {
+        appendable
+            .upsert_point(
+                10,
+                point_id.into(),
+                only_default_vector(&[1.0, 0.0, 1.0, 0.0]),
+                &hw_counter,
+            )
+            .unwrap();
+    }
+
+    let mut holder = SegmentHolder::default();
+    holder.add_new(non_appendable);
+    holder.add_new(appendable);
+    holder.set_max_segment_size_bytes(NonZeroUsize::new(2 * TEST_POINT_SIZE_BYTES));
+
+    // Setting payload on the points of the non-appendable segment needs to CoW-move them,
+    // but no appendable segment is below the cap: the operation must fail with the
+    // recoverable capacity error instead of growing the full destination further.
+    let points: Vec<PointIdType> = (1..=5u64).map(PointIdType::from).collect();
+    let err = set_payload(
+        &holder,
+        100,
+        &payload_json! {"town": "Amsterdam"},
+        &points,
+        &None,
+        &hw_counter,
+    )
+    .expect_err("no appendable segment below the cap can accept the moved points");
+    assert!(
+        err.is_out_of_appendable_capacity(),
+        "expected OutOfAppendableCapacity, got: {err}",
+    );
+
+    // The insert path reports the same error instead of writing past the cap.
+    let err = holder
+        .smallest_appendable_segment()
+        .expect_err("even the smallest appendable segment is at the cap");
+    assert!(
+        err.is_out_of_appendable_capacity(),
+        "expected OutOfAppendableCapacity, got: {err}",
     );
 }


### PR DESCRIPTION
Split out of #9906 (part 1 of 2). This is the complete, correct fix for #9158; the inline update-worker retry is layered on top in the stacked follow-up.

Filter-based payload/vector operations CoW-move points from immutable segments into an appendable segment with no size check, growing it far past `max_segment_size` (#9158). Instead of provisioning capacity inside the update path, the update fails recoverably and reuses the machinery around it:

1. The update path filters CoW-move destinations and upsert targets to appendable segments under the configured cap, checked once per batch. When none is under the cap, the operation fails with the recoverable `OutOfAppendableCapacity` error (its producer, until now inert).
2. The error maps to a transient shard-unavailable failure, so the collection updater queues it in `failed_operation`, pinning the WAL acknowledge: the operation survives restarts.
3. The update worker wakes the optimizer on transient failures. The optimizer wake-up ensures an under-cap appendable segment exists (creating one if not) and runs failed-operation recovery, which re-applies the operation; already-applied points are skipped by version, exactly like WAL replay.
4. An operation moving more data than one segment holds fails again after filling the fresh segment; the wake-up re-signals itself to provision the next one, progress-guarded so an empty segment stops the chain.

**Replica resilience:** a replica or leader that runs out of appendable capacity self-heals via the recovery above, so it is not deactivated over that condition; deactivating would force a full transfer to recover a replica that catches up on its own. The condition is recognized both locally and when reported by a remote replica over gRPC.

## Testing

- `cargo check -p collection --tests`: clean.
- 13 core + replica unit/integration tests pass, including the `set_payload_by_filter does not overgrow segment` regression test for #9158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
