### PR TITLE
fix: evict page cache of files that are mapped twice

### DIFF
--- a/lib/common/common/src/mmap/advice.rs
+++ b/lib/common/common/src/mmap/advice.rs
@@ -147,8 +147,11 @@ pub trait Madviseable {
 
     /// Hint to the OS that pages backing this memory map can be reclaimed.
     ///
-    /// Uses `madvise(MADV_PAGEOUT)` on Linux 5.4+, which writes back any dirty
-    /// pages and frees the resident memory while keeping the mapping valid.
+    /// Uses `madvise(MADV_PAGEOUT)` on Linux 5.4+, which reclaims resident
+    /// memory while keeping the mapping valid. Not all pages are reclaimed:
+    /// dirty file-backed pages are kept (only kswapd may write them back, not
+    /// this direct-reclaim context), as are pages mapped by more than one page
+    /// table — see [`Madviseable::drop_page_tables`] for that case.
     /// On older kernels or non-Linux platforms this is a no-op, since there is
     /// no portable userspace equivalent.
     fn clear_cache(&self) {
@@ -209,8 +212,8 @@ pub trait Madviseable {
 /// Issue `madvise(MADV_PAGEOUT)` for the given memory region.
 ///
 /// Mmap base addresses are always page-aligned, so callers do not need to
-/// adjust the slice. The kernel will write back any dirty pages and reclaim
-/// the resident memory while keeping the mapping valid.
+/// adjust the slice. The kernel reclaims resident memory while keeping the
+/// mapping valid; dirty file-backed pages are skipped, not written back.
 #[cfg(target_os = "linux")]
 fn pageout_slice(slice: &[u8]) {
     if slice.is_empty() {

--- a/lib/common/common/src/mmap/advice.rs
+++ b/lib/common/common/src/mmap/advice.rs
@@ -3,8 +3,11 @@
 
 use std::hint::black_box;
 use std::num::Wrapping;
+use std::path::Path;
 use std::{io, slice};
 
+#[cfg(unix)]
+use memmap2::UncheckedAdvice;
 use serde::Deserialize;
 
 /// Global [`Advice`] value, to trivially set [`Advice`] value
@@ -172,45 +175,35 @@ pub trait Madviseable {
         }
     }
 
-    /// Zap this mapping's page-table entries with `madvise(MADV_DONTNEED)`. Pages stay
-    /// in the page cache, dirty ones included, and refault on the next access.
+    /// Zap this mapping's page-table entries with `madvise(MADV_DONTNEED)`.
+    /// Pages stay in the page cache, dirty ones included, and refault on the
+    /// next access.
     ///
-    /// # Warning
+    /// # Safety
     ///
-    /// Only safe for `MAP_SHARED` file-backed mappings. On a private or anonymous
-    /// mapping this *discards* the data.
-    fn drop_page_tables(&self) {
+    /// See [`UncheckedAdvice::DontNeed`]/[`memmap2::Mmap::unchecked_advise`].
+    /// The mapping must be `MAP_SHARED` and file-backed. On a private or
+    /// anonymous mapping this discards the data.
+    unsafe fn drop_page_tables(&self, diag_path: &Path) {
+        #[cfg(not(unix))]
+        let _ = diag_path;
+
         #[cfg(unix)]
-        self.dontneed_impl();
+        if let Err(e) = unsafe { self.unchecked_advise_impl(UncheckedAdvice::DontNeed) } {
+            log::warn!("Failed to call madvise(MADV_DONTNEED) for {diag_path:?}: {e}");
+        }
     }
 
+    /// Like [`Madviseable::advise_impl`], but for [`UncheckedAdvice`] values.
+    ///
+    /// # Safety
+    ///
+    /// See [`UncheckedAdvice`]/[`memmap2::Mmap::unchecked_advise`].
     #[cfg(unix)]
-    fn dontneed_impl(&self);
+    unsafe fn unchecked_advise_impl(&self, advice: UncheckedAdvice) -> io::Result<()>;
 
     #[cfg(target_os = "linux")]
     fn pageout_impl(&self);
-}
-
-/// Issue `madvise(MADV_DONTNEED)` for the given memory region.
-///
-/// Issued directly because `memmap2` only exposes this advice through its `unsafe`
-/// unchecked API. See [`Madviseable::drop_page_tables`] for when it is safe.
-#[cfg(unix)]
-fn dontneed_slice(slice: &[u8]) {
-    if slice.is_empty() {
-        return;
-    }
-    let res = unsafe {
-        nix::libc::madvise(
-            slice.as_ptr() as *mut _,
-            slice.len(),
-            nix::libc::MADV_DONTNEED,
-        )
-    };
-    if res != 0 {
-        let err = io::Error::last_os_error();
-        log::warn!("Failed to call madvise(MADV_DONTNEED): {err}");
-    }
 }
 
 /// Issue `madvise(MADV_PAGEOUT)` for the given memory region.
@@ -247,8 +240,8 @@ impl Madviseable for memmap2::Mmap {
     }
 
     #[cfg(unix)]
-    fn dontneed_impl(&self) {
-        dontneed_slice(self);
+    unsafe fn unchecked_advise_impl(&self, advice: UncheckedAdvice) -> io::Result<()> {
+        unsafe { self.unchecked_advise(advice) }
     }
 
     #[cfg(target_os = "linux")]
@@ -268,8 +261,8 @@ impl Madviseable for memmap2::MmapMut {
     }
 
     #[cfg(unix)]
-    fn dontneed_impl(&self) {
-        dontneed_slice(self);
+    unsafe fn unchecked_advise_impl(&self, advice: UncheckedAdvice) -> io::Result<()> {
+        unsafe { self.unchecked_advise(advice) }
     }
 
     #[cfg(target_os = "linux")]
@@ -290,9 +283,8 @@ impl Madviseable for memmap2::MmapRaw {
     }
 
     #[cfg(unix)]
-    fn dontneed_impl(&self) {
-        let mmap = unsafe { slice::from_raw_parts(self.as_ptr(), self.len()) };
-        dontneed_slice(mmap);
+    unsafe fn unchecked_advise_impl(&self, advice: UncheckedAdvice) -> io::Result<()> {
+        unsafe { self.unchecked_advise(advice) }
     }
 
     #[cfg(target_os = "linux")]

--- a/lib/common/common/src/mmap/advice.rs
+++ b/lib/common/common/src/mmap/advice.rs
@@ -172,8 +172,45 @@ pub trait Madviseable {
         }
     }
 
+    /// Zap this mapping's page-table entries with `madvise(MADV_DONTNEED)`. Pages stay
+    /// in the page cache, dirty ones included, and refault on the next access.
+    ///
+    /// # Warning
+    ///
+    /// Only safe for `MAP_SHARED` file-backed mappings. On a private or anonymous
+    /// mapping this *discards* the data.
+    fn drop_page_tables(&self) {
+        #[cfg(unix)]
+        self.dontneed_impl();
+    }
+
+    #[cfg(unix)]
+    fn dontneed_impl(&self);
+
     #[cfg(target_os = "linux")]
     fn pageout_impl(&self);
+}
+
+/// Issue `madvise(MADV_DONTNEED)` for the given memory region.
+///
+/// Issued directly because `memmap2` only exposes this advice through its `unsafe`
+/// unchecked API. See [`Madviseable::drop_page_tables`] for when it is safe.
+#[cfg(unix)]
+fn dontneed_slice(slice: &[u8]) {
+    if slice.is_empty() {
+        return;
+    }
+    let res = unsafe {
+        nix::libc::madvise(
+            slice.as_ptr() as *mut _,
+            slice.len(),
+            nix::libc::MADV_DONTNEED,
+        )
+    };
+    if res != 0 {
+        let err = io::Error::last_os_error();
+        log::warn!("Failed to call madvise(MADV_DONTNEED): {err}");
+    }
 }
 
 /// Issue `madvise(MADV_PAGEOUT)` for the given memory region.
@@ -209,6 +246,11 @@ impl Madviseable for memmap2::Mmap {
         populate_simple(self);
     }
 
+    #[cfg(unix)]
+    fn dontneed_impl(&self) {
+        dontneed_slice(self);
+    }
+
     #[cfg(target_os = "linux")]
     fn pageout_impl(&self) {
         pageout_slice(self);
@@ -223,6 +265,11 @@ impl Madviseable for memmap2::MmapMut {
 
     fn populate_simple_impl(&self) {
         populate_simple(self);
+    }
+
+    #[cfg(unix)]
+    fn dontneed_impl(&self) {
+        dontneed_slice(self);
     }
 
     #[cfg(target_os = "linux")]
@@ -240,6 +287,12 @@ impl Madviseable for memmap2::MmapRaw {
     fn populate_simple_impl(&self) {
         let mmap = unsafe { slice::from_raw_parts(self.as_ptr(), self.len()) };
         populate_simple(mmap);
+    }
+
+    #[cfg(unix)]
+    fn dontneed_impl(&self) {
+        let mmap = unsafe { slice::from_raw_parts(self.as_ptr(), self.len()) };
+        dontneed_slice(mmap);
     }
 
     #[cfg(target_os = "linux")]

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -256,10 +256,16 @@ impl UniversalRead for MmapFile {
     }
 
     fn clear_ram_cache(&self) -> UioResult<()> {
-        self.mmap.lock().clear_cache();
+        // `MADV_PAGEOUT` skips pages with more than one page-table reference,
+        // `POSIX_FADV_DONTNEED` skips pages with any: with `need_sequential`'s two
+        // mappings, pages faulted through both survive either call. Zapping the PTEs
+        // first leaves the page cache evictable — the mappings stay valid and refault
+        // on access. Dirty pages are kept, not lost; flushing first evicts them too.
+        self.mmap.lock().drop_page_tables();
         if let Some(mmap_seq) = &self.mmap_seq {
-            mmap_seq.lock().clear_cache();
+            mmap_seq.lock().drop_page_tables();
         }
+        crate::fs::clear_disk_cache(&self.path)?;
         Ok(())
     }
 
@@ -685,5 +691,52 @@ mod tests {
         // pre-created flusher takes the fdatasync path.
         assert!(clone.append_file.get().is_some());
         flusher().unwrap();
+    }
+
+    /// A `need_sequential` file is mapped twice, and `MADV_PAGEOUT` refuses pages
+    /// carrying more than one page-table reference. Without zapping the page tables
+    /// first, every page touched through both mappings stays cached forever.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn clear_ram_cache_evicts_dual_mapped_file() {
+        use std::io::Write as _;
+
+        use crate::generic_consts::{Random, Sequential};
+
+        const LEN: u64 = 8 * 1024 * 1024;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dual.dat");
+
+        // Synced: only clean pages are evictable.
+        let mut file = fs_err::File::create(&path).unwrap();
+        file.write_all(&vec![7u8; LEN as usize]).unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+
+        let options = OpenOptions {
+            writeable: false,
+            need_sequential: true,
+            populate: Populate::No,
+            advice: AdviceSetting::Global,
+        };
+        let mmap = MmapFs.open(&path, options, ()).unwrap();
+
+        // Fault every page through both the random and the sequential mapping.
+        for bytes in [
+            mmap.read_bytes(0..LEN, Random, 1).unwrap(),
+            mmap.read_bytes(0..LEN, Sequential, 1).unwrap(),
+        ] {
+            assert_eq!(bytes.iter().map(|byte| *byte as u64).sum::<u64>(), 7 * LEN);
+        }
+
+        let (size, resident) = MmapFile::probe_memory_stats(&path).unwrap();
+        assert_eq!(size, LEN);
+        assert!(resident > LEN / 2, "not cached: {resident} of {size}");
+
+        mmap.clear_ram_cache().unwrap();
+
+        let (_, resident) = MmapFile::probe_memory_stats(&path).unwrap();
+        assert!(resident < LEN / 10, "not evicted: {resident} of {size}");
     }
 }

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -727,7 +727,10 @@ mod tests {
             mmap.read_bytes(0..LEN, Random, 1).unwrap(),
             mmap.read_bytes(0..LEN, Sequential, 1).unwrap(),
         ] {
-            assert_eq!(bytes.iter().map(|byte| *byte as u64).sum::<u64>(), 7 * LEN);
+            assert_eq!(
+                bytes.iter().map(|byte| u64::from(*byte)).sum::<u64>(),
+                7 * LEN
+            );
         }
 
         let (size, resident) = MmapFile::probe_memory_stats(&path).unwrap();

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -261,9 +261,15 @@ impl UniversalRead for MmapFile {
         // mappings, pages faulted through both survive either call. Zapping the PTEs
         // first leaves the page cache evictable — the mappings stay valid and refault
         // on access. Dirty pages are kept, not lost; flushing first evicts them too.
-        self.mmap.lock().drop_page_tables();
-        if let Some(mmap_seq) = &self.mmap_seq {
-            mmap_seq.lock().drop_page_tables();
+        //
+        // SAFETY: `open_mmap` only creates `MAP_SHARED` file-backed mappings
+        // (`map_raw`/`map_raw_read_only`), for which `MADV_DONTNEED` only drops
+        // the page-table entries and never discards data.
+        unsafe {
+            self.mmap.lock().drop_page_tables(&self.path);
+            if let Some(mmap_seq) = &self.mmap_seq {
+                mmap_seq.lock().drop_page_tables(&self.path);
+            }
         }
         crate::fs::clear_disk_cache(&self.path)?;
         Ok(())


### PR DESCRIPTION
## Problem

`clear_cache()` on a `memory: cold` vector storage is a silent no-op — after optimization finishes the whole storage is still resident in the page cache:

```
"storage": {"disk_bytes":1025632503, "ram_bytes":0, "cached_bytes":1024583927, ...}
"payload": {"disk_bytes":521636866,  "ram_bytes":0, "cached_bytes":456375201,  ...}
```

## Cause

`MmapFile` opened with `need_sequential` keeps **two** mappings of the same file (`MADV_RANDOM` + `MADV_SEQUENTIAL`, `universal_io/mmap/mod.rs:143`). `MADV_PAGEOUT` skips any page carrying more than one page-table reference ("do not interfere with other mappings of this folio"), so every page faulted through both mappings is never reclaimed — advising both mappings does not help. The `madvise` calls are issued and return 0; nothing is evicted.

Quantization is one way to get there: `QuantizedVectors::create` reads the raw vectors via `get_dense::<Sequential>` while `populate_vector_storages()` populated the random mapping. Measured through `SegmentBuilder` (200k x 256, `memory: cold`):

| | `matrix.dat` after build |
|---|---|
| without quantization | 100% -> 1.1% resident |
| with quantization | 100% -> **100%** resident |

`POSIX_FADV_DONTNEED` alone does not fix it either — it skips pages with any page-table reference. Isolated repro of the three combinations (same file, two live mappings, all pages faulted through both):

```
MADV_PAGEOUT on both mappings:              100.00%
  + posix_fadvise(DONTNEED):                100.00%
MADV_DONTNEED on both (drops PTEs only):    100.00%
  + posix_fadvise(DONTNEED):                  0.00%
```

## Fix

Zap the page tables of every mapping first, then evict through the file. `MADV_DONTNEED` on a shared file mapping only drops the PTEs — the mappings stay valid, the data stays in the page cache and refaults on the next access — which makes `POSIX_FADV_DONTNEED` able to reclaim.

Dirty pages are still kept, and still not lost: `MADV_PAGEOUT` did not write back filesystem pages either, so this is not a new precondition. Callers that flush before evicting (e.g. `SegmentBuilder::build`) get a complete eviction; the rest keep whatever writeback has not caught up with yet.

Result on the same 200k x 256 build with quantization: `matrix.dat` **100% -> 0.0%** resident, whole segment 67% -> 2.4%.

## Scope

Other components that open with `need_sequential` and were affected the same way: payload storage (gridstore pages), the disk id tracker reader, quantized multivector offsets.

## Tests

New `clear_ram_cache_evicts_dual_mapped_file` in `universal_io::mmap` — maps a file with `need_sequential`, faults every page through both access patterns, asserts the cache is dropped. Fails on the previous implementation with `not evicted: 8388608 of 8388608`.

`cargo test -p common` passes (246). `cargo test -p segment --lib`: 975 pass, 4 fail — all four fail identically on `dev` without this change.

_(Replaces #9983, which GitHub closed when the branch was renamed.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)