### PR TITLE
refactor(edge-ffi): model Match.Any/Except as a typed AnyVariants one-of

### DIFF
--- a/lib/edge/ffi/src/filter.rs
+++ b/lib/edge/ffi/src/filter.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 
 use ahash::AHashSet;
 use segment::types::{
-    AnyVariants, Condition as SegmentCondition, DateTimePayloadType,
+    AnyVariants as SegmentAnyVariants, Condition as SegmentCondition, DateTimePayloadType,
     FieldCondition as SegmentFieldCondition, Filter as SegmentFilter,
     GeoBoundingBox as SegmentGeoBoundingBox, GeoLineString as SegmentGeoLineString,
     GeoPoint as SegmentGeoPoint, GeoPolygon as SegmentGeoPolygon, GeoRadius as SegmentGeoRadius,
@@ -294,12 +294,37 @@ impl From<ValueVariants> for SegmentValueVariants {
     }
 }
 
+// ── AnyVariants ─────────────────────────────────────────────────────────────
+
+/// A homogeneous set of match values for [`Match::Any`] / [`Match::Except`]:
+/// either strings or integers. The type enforces "exactly one" — mirroring the
+/// engine's own `AnyVariants`, the gRPC `oneof`, and every official Qdrant
+/// client (none of which allows both or neither). An empty set is valid: `Any`
+/// then matches nothing and `Except` matches everything.
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum AnyVariants {
+    /// Match against a set of string values.
+    Strings { values: Vec<String> },
+    /// Match against a set of integer values.
+    Integers { values: Vec<i64> },
+}
+
+impl From<AnyVariants> for SegmentAnyVariants {
+    fn from(v: AnyVariants) -> Self {
+        match v {
+            AnyVariants::Strings { values } => {
+                SegmentAnyVariants::Strings(values.into_iter().collect())
+            }
+            AnyVariants::Integers { values } => {
+                SegmentAnyVariants::Integers(values.into_iter().collect())
+            }
+        }
+    }
+}
+
 // ── Match ───────────────────────────────────────────────────────────────────
 
 /// How a [`FieldCondition`] compares a payload field.
-///
-/// For each variant, exactly one of its alternative payloads should be set
-/// (e.g. for `Any`, pass either `strings` or `integers`, not both).
 #[derive(Clone, Debug, uniffi::Enum)]
 pub enum Match {
     /// Exact scalar match.
@@ -316,20 +341,10 @@ pub enum Match {
     /// Prefix match: some word of the field must start with `prefix`
     /// (requires a full-text index on the payload key).
     Prefix { prefix: String },
-    /// The field value must equal any of the given strings or integers.
-    Any {
-        #[uniffi(default = None)]
-        strings: Option<Vec<String>>,
-        #[uniffi(default = None)]
-        integers: Option<Vec<i64>>,
-    },
-    /// The field value must equal none of the given strings or integers.
-    Except {
-        #[uniffi(default = None)]
-        strings: Option<Vec<String>>,
-        #[uniffi(default = None)]
-        integers: Option<Vec<i64>>,
-    },
+    /// The field value must equal any of the given values (IN).
+    Any { any: AnyVariants },
+    /// The field value must equal none of the given values (NOT IN).
+    Except { except: AnyVariants },
 }
 
 impl TryFrom<Match> for SegmentMatch {
@@ -344,40 +359,10 @@ impl TryFrom<Match> for SegmentMatch {
             Match::TextAny { text_any } => Ok(SegmentMatch::TextAny(MatchTextAny { text_any })),
             Match::Phrase { phrase } => Ok(SegmentMatch::Phrase(MatchPhrase { phrase })),
             Match::Prefix { prefix } => Ok(SegmentMatch::Prefix(MatchPrefix { prefix })),
-            Match::Any { strings, integers } => {
-                let any = match (strings, integers) {
-                    (None, None) => {
-                        return Err(crate::error::EdgeError::invalid_argument(
-                            "Match::Any requires either `strings` or `integers`",
-                        ));
-                    }
-                    (Some(_), Some(_)) => {
-                        return Err(crate::error::EdgeError::invalid_argument(
-                            "Match::Any: set either `strings` or `integers`, not both",
-                        ));
-                    }
-                    (Some(strings), None) => AnyVariants::Strings(strings.into_iter().collect()),
-                    (None, Some(integers)) => AnyVariants::Integers(integers.into_iter().collect()),
-                };
-                Ok(SegmentMatch::Any(MatchAny { any }))
-            }
-            Match::Except { strings, integers } => {
-                let except = match (strings, integers) {
-                    (None, None) => {
-                        return Err(crate::error::EdgeError::invalid_argument(
-                            "Match::Except requires either `strings` or `integers`",
-                        ));
-                    }
-                    (Some(_), Some(_)) => {
-                        return Err(crate::error::EdgeError::invalid_argument(
-                            "Match::Except: set either `strings` or `integers`, not both",
-                        ));
-                    }
-                    (Some(strings), None) => AnyVariants::Strings(strings.into_iter().collect()),
-                    (None, Some(integers)) => AnyVariants::Integers(integers.into_iter().collect()),
-                };
-                Ok(SegmentMatch::Except(MatchExcept { except }))
-            }
+            Match::Any { any } => Ok(SegmentMatch::Any(MatchAny { any: any.into() })),
+            Match::Except { except } => Ok(SegmentMatch::Except(MatchExcept {
+                except: except.into(),
+            })),
         }
     }
 }
@@ -806,9 +791,9 @@ fn assert_every_filter_condition_is_mapped(c: SegmentCondition) {
                     // [`Match::Any`]
                     SegmentMatch::Any(MatchAny { any }) => match any {
                         // [`Match::Any`] `strings`
-                        AnyVariants::Strings(_) => {}
+                        SegmentAnyVariants::Strings(_) => {}
                         // [`Match::Any`] `integers`
-                        AnyVariants::Integers(_) => {}
+                        SegmentAnyVariants::Integers(_) => {}
                     },
                     // [`Match::Except`] (same `AnyVariants` split as `Any`)
                     SegmentMatch::Except(MatchExcept { except: _ }) => {}

--- a/lib/edge/ffi/tests/conversions.rs
+++ b/lib/edge/ffi/tests/conversions.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use qdrant_edge_ffi::config::{Distance, EdgeConfig, VectorDataConfig};
 use qdrant_edge_ffi::error::EdgeError;
 use qdrant_edge_ffi::filter::{
-    Condition, FieldCondition, Filter, GeoLineString, GeoPoint, GeoPolygon, GeoRadius, Match,
+    AnyVariants, Condition, FieldCondition, Filter, GeoLineString, GeoPoint, GeoPolygon, GeoRadius,
+    Match,
 };
 use qdrant_edge_ffi::types::{PointId, WithPayload};
 use qdrant_edge_ffi::{CountRequest, EdgeShard};
@@ -163,7 +164,10 @@ fn filter_must_with_bad_key_returns_error() {
     assert!(r.is_err());
 }
 
-// ── Match::Any / Match::Except fallibility (C1) ───────────────────────────────
+// ── Match::Any / Match::Except conversion ─────────────────────────────────────
+// The strings-XOR-integers constraint is now enforced by the `AnyVariants` sum
+// type, so the old (None,None) / (Some,Some) error cases are unrepresentable —
+// only the valid mappings remain to check.
 
 fn field_with_match(m: Match) -> Condition {
     Condition::Field {
@@ -181,43 +185,32 @@ fn field_with_match(m: Match) -> Condition {
 }
 
 #[test]
-fn match_any_both_none_returns_error() {
+fn match_any_strings_ok() {
     let cond = field_with_match(Match::Any {
-        strings: None,
-        integers: None,
-    });
-    let r: Result<SegmentCondition, _> = cond.try_into();
-    assert!(r.is_err());
-}
-
-#[test]
-fn match_any_both_set_returns_error() {
-    let cond = field_with_match(Match::Any {
-        strings: Some(vec!["a".to_string()]),
-        integers: Some(vec![1]),
-    });
-    let r: Result<SegmentCondition, _> = cond.try_into();
-    assert!(r.is_err());
-}
-
-#[test]
-fn match_any_strings_only_ok() {
-    let cond = field_with_match(Match::Any {
-        strings: Some(vec!["hello".to_string()]),
-        integers: None,
+        any: AnyVariants::Strings {
+            values: vec!["hello".to_string()],
+        },
     });
     let r: Result<SegmentCondition, _> = cond.try_into();
     assert!(r.is_ok());
 }
 
 #[test]
-fn match_except_neither_returns_error() {
-    let cond = field_with_match(Match::Except {
-        strings: None,
-        integers: None,
+fn match_any_integers_ok() {
+    let cond = field_with_match(Match::Any {
+        any: AnyVariants::Integers { values: vec![1, 2] },
     });
     let r: Result<SegmentCondition, _> = cond.try_into();
-    assert!(r.is_err());
+    assert!(r.is_ok());
+}
+
+#[test]
+fn match_except_integers_ok() {
+    let cond = field_with_match(Match::Except {
+        except: AnyVariants::Integers { values: vec![7] },
+    });
+    let r: Result<SegmentCondition, _> = cond.try_into();
+    assert!(r.is_ok());
 }
 
 // ── WithPayload::Fields bad key (I2) ─────────────────────────────────────────


### PR DESCRIPTION
## Model `Match.Any` / `Match.Except` as a typed one-of

Follow-up to #9987 (default optional fields). While adding those defaults it
became clear `Match::Any/Except` had a modeling smell they exposed.

`Match::Any/Except` took `{ strings: Option<Vec<String>>, integers: Option<Vec<i64>> }`
with a **runtime** XOR check — two of the four representable states were invalid
(`(None,None)` / `(Some,Some)` → `InvalidArgument`). With #9987 defaulting those
two Options, the *empty* call (the all-invalid combination) became the easiest
thing to type in Kotlin/Swift: it compiles and then fails on-device.

Replace with a typed sum type:
```rust
pub enum AnyVariants { Strings { values: Vec<String> }, Integers { values: Vec<i64> } }
Match::Any { any: AnyVariants }   //  Except { except: AnyVariants }
```

This matches **every other Qdrant surface**, none of which allows both/neither:
- the engine's own `AnyVariants` (`lib/segment/src/types.rs`),
- the gRPC `oneof` (`RepeatedStrings` / `RepeatedIntegers`),
- the crate's existing `ValueVariants` (same nesting pattern, already shipped),
- and all official clients — Python `Union[List[str], List[int]]`, Java/Go/Rust
  typed constructors, JS `string[] | number[]`.

"Exactly one" is now enforced at **compile time**; the two `InvalidArgument`
paths disappear and the field-default question is moot. Empty sets stay valid
(`Any` → matches nothing, `Except` → matches everything), mirroring the engine's
`condition_checker`.

Generated bindings: `Match.Any(AnyVariants.Strings(listOf("black", "yellow")))`.

## Verification
- `cargo test -p qdrant-edge-ffi --tests`: **122 passed, 0 failed** (the 3 now-unrepresentable XOR-error tests replaced with typed-mapping tests).
- `cargo clippy -p qdrant-edge-ffi --all-targets`: clean.
- Regenerated bindings expose the typed `AnyVariants` sum type.
- Modeling backed by the engine, the gRPC proto, and all 5 official Qdrant clients.

FFI-only. The mobile SDK examples (#9985 Kotlin / #9979 Swift) update their
`Match.Any` call sites on their own branches.
