### PR TITLE
[TQDT] Consistent folder structure

### DIFF
--- a/lib/segment/src/vector_storage/tests/test_appendable_turbo_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_turbo_vector_storage.rs
@@ -25,7 +25,7 @@ use crate::data_types::vectors::DenseVector;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::prefill_deleted::fill_turbo;
 use crate::vector_storage::turbo::shared::{
-    DELETED_PATH, TQDT_BITS, TQDT_MODE, TQDT_ROTATION, VECTORS_PATH,
+    DELETED_DIR_PATH, TQDT_BITS, TQDT_MODE, TQDT_ROTATION, VECTORS_DIR_PATH,
 };
 use crate::vector_storage::turbo::{
     AppendableMmapTurboVectorStorage, TurboVectorStorageImpl, open_appendable_turbo_vector_storage,
@@ -525,8 +525,8 @@ fn files_and_immutable_files_match_expected_layout() {
         open_appendable_turbo_vector_storage(dir.path(), DIM, distance, true).unwrap();
     insert_all(&mut storage, &make_vectors(DIM, COUNT, SEED), &hw_counter);
 
-    let vectors_dir = dir.path().join(VECTORS_PATH);
-    let deleted_dir = dir.path().join(DELETED_PATH);
+    let vectors_dir = dir.path().join(VECTORS_DIR_PATH);
+    let deleted_dir = dir.path().join(DELETED_DIR_PATH);
 
     // Hardcoded, not derived from the backend's own constants (the ones
     // `files()` itself uses) — sharing them would make this check circular

--- a/lib/segment/src/vector_storage/turbo/appendable_turbo_vector_storage.rs
+++ b/lib/segment/src/vector_storage/turbo/appendable_turbo_vector_storage.rs
@@ -20,7 +20,7 @@ use quantization::EncodedStorage;
 use quantization::turboquant::EncodedQueryTQ;
 use quantization::turboquant::quantization::TurboQuantizer;
 
-use super::shared::{self, DELETED_PATH, VECTORS_PATH};
+use super::shared::{self, DELETED_DIR_PATH, VECTORS_DIR_PATH};
 use crate::common::Flusher;
 use crate::common::flags::bitvec_flags::BitvecFlags;
 use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
@@ -80,14 +80,18 @@ impl AppendableMmapTurboVectorStorage {
         let quantizer = shared::build_quantizer(dim, distance);
         let storage = QuantizedChunkedStorage::new(
             MmapFs,
-            &path.join(VECTORS_PATH),
+            &path.join(VECTORS_DIR_PATH),
             quantizer.quantized_size(),
             in_ram,
         )?;
 
         let deleted = BitvecFlags::new(
             MmapFs,
-            DynamicStoredFlags::open(&MmapFs, &path.join(DELETED_PATH), Populate::from(in_ram))?,
+            DynamicStoredFlags::open(
+                &MmapFs,
+                &path.join(DELETED_DIR_PATH),
+                Populate::from(in_ram),
+            )?,
         )?;
         let deleted_count = deleted.count_trues();
         let quantization_buffer = vec![0.0; quantizer.get_padded_dim()];

--- a/lib/segment/src/vector_storage/turbo/multi_turbo/appendable_mmap_multi_turbo_vector_storage.rs
+++ b/lib/segment/src/vector_storage/turbo/multi_turbo/appendable_mmap_multi_turbo_vector_storage.rs
@@ -25,7 +25,9 @@ use quantization::turboquant::EncodedQueryTQ;
 use quantization::turboquant::quantization::TurboQuantizer;
 use smallvec::{SmallVec, smallvec};
 
-use super::super::shared::{DELETED_PATH, TQDT_BITS, TQDT_MODE, TQDT_ROTATION, VECTORS_PATH};
+use super::super::shared::{
+    DELETED_DIR_PATH, TQDT_BITS, TQDT_MODE, TQDT_ROTATION, VECTORS_DIR_PATH,
+};
 use crate::common::Flusher;
 use crate::common::flags::bitvec_flags::BitvecFlags;
 use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
@@ -46,7 +48,7 @@ use crate::vector_storage::{
     VectorStorage, VectorStorageRead,
 };
 
-pub(crate) const OFFSETS_PATH: &str = "tq_offsets.dat";
+pub(crate) const OFFSETS_DIR_PATH: &str = "tq_offsets";
 
 /// Multivector storage for TurboQuant encoded inner vectors.
 pub struct AppendableMmapMultiTurboVectorStorage {
@@ -120,14 +122,14 @@ pub fn open_appendable_turbo_multi_vector_storage(
 
     let storage = QuantizedChunkedStorage::new(
         MmapFs,
-        &path.join(VECTORS_PATH),
+        &path.join(VECTORS_DIR_PATH),
         quantizer.quantized_size(),
         in_ram,
     )?;
 
     let offsets = ChunkedVectors::open(
         MmapFs,
-        &path.join(OFFSETS_PATH),
+        &path.join(OFFSETS_DIR_PATH),
         1,
         AdviceSetting::Global,
         populate,
@@ -135,7 +137,7 @@ pub fn open_appendable_turbo_multi_vector_storage(
 
     let deleted = BitvecFlags::new(
         MmapFs,
-        DynamicStoredFlags::open(&MmapFs, &path.join(DELETED_PATH), populate)?,
+        DynamicStoredFlags::open(&MmapFs, &path.join(DELETED_DIR_PATH), populate)?,
     )?;
     let deleted_count = deleted.count_trues();
 
@@ -1889,9 +1891,9 @@ mod tests {
             &hw_counter,
         );
 
-        let vectors_dir = dir.path().join("tq_vectors.dat");
-        let offsets_dir = dir.path().join("tq_offsets.dat");
-        let deleted_dir = dir.path().join("deleted.dat");
+        let vectors_dir = dir.path().join("tq_vectors");
+        let offsets_dir = dir.path().join("tq_offsets");
+        let deleted_dir = dir.path().join("deleted");
 
         // Hardcoded, not derived from the constants `files()` itself uses.
         let mut expected_files = vec![

--- a/lib/segment/src/vector_storage/turbo/multi_turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/multi_turbo/mod.rs
@@ -9,7 +9,7 @@
 pub mod appendable_mmap_multi_turbo_vector_storage;
 pub mod read_only;
 
-pub(crate) use self::appendable_mmap_multi_turbo_vector_storage::OFFSETS_PATH;
+pub(crate) use self::appendable_mmap_multi_turbo_vector_storage::OFFSETS_DIR_PATH;
 pub use self::appendable_mmap_multi_turbo_vector_storage::{
     AppendableMmapMultiTurboVectorStorage, open_appendable_turbo_multi_vector_storage,
 };

--- a/lib/segment/src/vector_storage/turbo/multi_turbo/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/turbo/multi_turbo/read_only/lifecycle.rs
@@ -10,8 +10,8 @@ use crate::types::{Distance, MultiVectorConfig};
 use crate::vector_storage::chunked_vectors::ChunkedVectorsRead;
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::MultivectorMmapOffset;
 use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedChunkedStorageRead;
-use crate::vector_storage::turbo::multi_turbo::OFFSETS_PATH;
-use crate::vector_storage::turbo::shared::{self, DELETED_PATH, VECTORS_PATH};
+use crate::vector_storage::turbo::multi_turbo::OFFSETS_DIR_PATH;
+use crate::vector_storage::turbo::shared::{self, DELETED_DIR_PATH, VECTORS_DIR_PATH};
 
 impl<S: UniversalRead> ReadOnlyChunkedMultiTurboVectorStorage<S> {
     /// Schedule background prefetch of the files [`Self::open`] will read.
@@ -24,14 +24,14 @@ impl<S: UniversalRead> ReadOnlyChunkedMultiTurboVectorStorage<S> {
         advice: AdviceSetting,
         populate: Populate,
     ) -> OperationResult<()> {
-        QuantizedChunkedStorageRead::<S>::preopen(fs, &path.join(VECTORS_PATH), populate)?;
+        QuantizedChunkedStorageRead::<S>::preopen(fs, &path.join(VECTORS_DIR_PATH), populate)?;
         ChunkedVectorsRead::<MultivectorMmapOffset, S>::preopen(
             fs,
-            &path.join(OFFSETS_PATH),
+            &path.join(OFFSETS_DIR_PATH),
             advice,
             populate,
         )?;
-        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_PATH))?;
+        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_DIR_PATH))?;
         Ok(())
     }
 
@@ -51,7 +51,7 @@ impl<S: UniversalRead> ReadOnlyChunkedMultiTurboVectorStorage<S> {
 
         let storage = QuantizedChunkedStorageRead::open(
             fs,
-            &path.join(VECTORS_PATH),
+            &path.join(VECTORS_DIR_PATH),
             quantizer.quantized_size(),
         )?;
         // The chunked read backend maps lazily; warm it when the profile asks.
@@ -59,9 +59,10 @@ impl<S: UniversalRead> ReadOnlyChunkedMultiTurboVectorStorage<S> {
             storage.populate()?;
         }
 
-        let offsets = ChunkedVectorsRead::open(fs, &path.join(OFFSETS_PATH), 1, advice, populate)?;
+        let offsets =
+            ChunkedVectorsRead::open(fs, &path.join(OFFSETS_DIR_PATH), 1, advice, populate)?;
 
-        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_PATH))?;
+        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIR_PATH))?;
 
         Ok(Self {
             storage,

--- a/lib/segment/src/vector_storage/turbo/read_only/immutable/lifecycle.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/immutable/lifecycle.rs
@@ -7,7 +7,7 @@ use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
 use crate::common::operation_error::OperationResult;
 use crate::types::Distance;
 use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
-use crate::vector_storage::turbo::shared::{self, DELETED_PATH, VECTORS_PATH};
+use crate::vector_storage::turbo::shared::{self, DELETED_DIR_PATH, VECTORS_PATH};
 
 impl<S: UniversalRead> ReadOnlyImmutableTurboVectorStorage<S> {
     /// Schedule background prefetch of the files [`Self::open`] will read.
@@ -20,7 +20,7 @@ impl<S: UniversalRead> ReadOnlyImmutableTurboVectorStorage<S> {
         populate: Populate,
     ) -> OperationResult<()> {
         QuantizedStorage::<S>::preopen(fs, &path.join(VECTORS_PATH), populate)?;
-        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_PATH))?;
+        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_DIR_PATH))?;
         Ok(())
     }
 
@@ -43,7 +43,7 @@ impl<S: UniversalRead> ReadOnlyImmutableTurboVectorStorage<S> {
             storage.populate();
         }
 
-        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_PATH))?;
+        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIR_PATH))?;
 
         Ok(Self {
             storage,

--- a/lib/segment/src/vector_storage/turbo/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/lifecycle.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs};
 
-use super::super::shared::{self, DELETED_PATH, VECTORS_PATH};
+use super::super::shared::{self, DELETED_DIR_PATH, VECTORS_DIR_PATH};
 use super::ReadOnlyChunkedTurboVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
 use crate::common::operation_error::OperationResult;
@@ -19,8 +19,8 @@ impl<S: UniversalRead> ReadOnlyChunkedTurboVectorStorage<S> {
         path: &Path,
         populate: Populate,
     ) -> OperationResult<()> {
-        QuantizedChunkedStorageRead::<S>::preopen(fs, &path.join(VECTORS_PATH), populate)?;
-        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_PATH))?;
+        QuantizedChunkedStorageRead::<S>::preopen(fs, &path.join(VECTORS_DIR_PATH), populate)?;
+        InMemoryBitvecFlags::preopen(fs, &path.join(DELETED_DIR_PATH))?;
         Ok(())
     }
 
@@ -37,7 +37,7 @@ impl<S: UniversalRead> ReadOnlyChunkedTurboVectorStorage<S> {
         let quantizer = shared::build_quantizer(dim, distance);
         let storage = QuantizedChunkedStorageRead::open(
             fs,
-            &path.join(VECTORS_PATH),
+            &path.join(VECTORS_DIR_PATH),
             quantizer.quantized_size(),
         )?;
 
@@ -46,7 +46,7 @@ impl<S: UniversalRead> ReadOnlyChunkedTurboVectorStorage<S> {
             storage.populate()?;
         }
 
-        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_PATH))?;
+        let deleted = InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIR_PATH))?;
 
         Ok(Self {
             storage,

--- a/lib/segment/src/vector_storage/turbo/shared.rs
+++ b/lib/segment/src/vector_storage/turbo/shared.rs
@@ -24,8 +24,11 @@ pub(crate) const TQDT_BITS: TQBits = TQBits::Bits4;
 pub(crate) const TQDT_MODE: TQMode = TQMode::Normal;
 pub(crate) const TQDT_ROTATION: TQRotation = TQRotation::Unpadded;
 
+/// Encoded vectors file of the single-file (non-appendable) layout.
 pub(crate) const VECTORS_PATH: &str = "tq_vectors.dat";
-pub(crate) const DELETED_PATH: &str = "deleted.dat";
+/// Encoded vectors directory (chunked) of the appendable layout.
+pub(crate) const VECTORS_DIR_PATH: &str = "tq_vectors";
+pub(crate) const DELETED_DIR_PATH: &str = "deleted";
 
 /// Build the quantizer for a dense `Turbo4` storage; fully determined by
 /// `(dim, distance)` and the fixed TQDT constants.

--- a/lib/segment/src/vector_storage/turbo/turbo_vector_storage.rs
+++ b/lib/segment/src/vector_storage/turbo/turbo_vector_storage.rs
@@ -25,7 +25,7 @@ use quantization::EncodedStorage;
 use quantization::turboquant::EncodedQueryTQ;
 use quantization::turboquant::quantization::TurboQuantizer;
 
-use super::shared::{self, DELETED_PATH, VECTORS_PATH};
+use super::shared::{self, DELETED_DIR_PATH, VECTORS_PATH};
 use crate::common::Flusher;
 use crate::common::flags::bitvec_flags::BitvecFlags;
 use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
@@ -168,7 +168,11 @@ impl<S: UniversalRead> TurboVectorStorageImpl<S> {
         fs_err::create_dir_all(path)?;
         let deleted = BitvecFlags::new(
             MmapFs,
-            DynamicStoredFlags::open(&MmapFs, &path.join(DELETED_PATH), Populate::from(populate))?,
+            DynamicStoredFlags::open(
+                &MmapFs,
+                &path.join(DELETED_DIR_PATH),
+                Populate::from(populate),
+            )?,
         )?;
         let deleted_count = deleted.count_trues();
         let quantization_buffer = vec![0.0; quantizer.get_padded_dim()];


### PR DESCRIPTION
Rename the TurboQuant Datatype (TQDT) on-disk paths to make them consistent with the other vector storages.

- `deleted.dat` directory → `deleted` (all TQ variants)
- appendable `tq_vectors.dat` / `tq_offsets.dat` directories → `tq_vectors` / `tq_offsets`
- single-file `tq_vectors.dat` unchanged — it is an actual file

| Storage variant | Item | Before | After | Kind |
|---|---|---|---|---|
| Single-file TQ (`TurboVectorStorageImpl`) | encoded vectors | `tq_vectors.dat` | `tq_vectors.dat` *(unchanged)* | file |
| Single-file TQ | deleted flags | `deleted.dat` | `deleted` | dir |
| Appendable TQ (`AppendableMmapTurboVectorStorage`) | encoded vectors | `tq_vectors.dat` | `tq_vectors` | dir |
| Appendable TQ | deleted flags | `deleted.dat` | `deleted` | dir |
| Multi-turbo (`AppendableMmapMultiTurboVectorStorage`) | encoded vectors | `tq_vectors.dat` | `tq_vectors` | dir |
| Multi-turbo | offsets | `tq_offsets.dat` | `tq_offsets` | dir |
| Multi-turbo | deleted flags | `deleted.dat` | `deleted` | dir |
