### PR TITLE
fix: Flush after prefilling deleted vectors

### DIFF
--- a/lib/segment/src/vector_storage/prefill_deleted.rs
+++ b/lib/segment/src/vector_storage/prefill_deleted.rs
@@ -12,6 +12,7 @@ use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowMultiVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::data_types::vectors::TypedMultiDenseVector;
+use crate::vector_storage::VectorStorage;
 
 // Append `count` deleted placeholders in the storage's own element type. The
 // placeholder content is irrelevant — every entry is flagged deleted — so we
@@ -153,6 +154,9 @@ impl VectorStorageEnum {
 
             VectorStorageEnum::SparseVolatile(v) => fill_sparse(v, count, &stopped),
             VectorStorageEnum::SparseMmap(v) => fill_sparse(v, count, &stopped),
-        }
+        }?;
+
+        // Make sure any buffered updates are persisted.
+        self.flusher()()
     }
 }


### PR DESCRIPTION
When creating a named vector storage, we were persisting the new segment state before flushing the new storage.

This caused the buffered prefill to not be fully persisted for a brief window. If a crash occurred before the next flush, replay would think that the created named vector was applied successfully and expose zeroed vectors as live vectors.

This PR fixes this by flushing after doing the zeroed vectors prefill.