### PR TITLE
Fix TQ quantized vector layout alignment

### DIFF
--- a/lib/quantization/src/encoded_vectors_tq.rs
+++ b/lib/quantization/src/encoded_vectors_tq.rs
@@ -342,7 +342,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsTQ<TStorage> {
     }
 
     pub fn layout(&self) -> Layout {
-        Layout::from_size_align(self.quantized_vector_size(), align_of::<f32>()).unwrap()
+        Layout::from_size_align(self.quantized_vector_size(), align_of::<u8>()).unwrap()
     }
 
     pub fn get_metadata(&self) -> &Metadata {

--- a/lib/quantization/tests/integration/test_tq.rs
+++ b/lib/quantization/tests/integration/test_tq.rs
@@ -1064,4 +1064,72 @@ mod tests {
             "bits={bits:?}: Plus recall regressed (Normal={normal:.3}, Plus={plus:.3})"
         );
     }
+
+    #[test]
+    fn test_tq_layout_size_is_multiple_of_alignment() {
+        const LAYOUT_DIMS: &[usize] = &[1, 7, 33, 65, 100, 756, 768];
+        let vectors_count = 8;
+
+        for &dim in LAYOUT_DIMS {
+            for &bits in BITS {
+                for &distance in &[
+                    DistanceType::Dot,
+                    DistanceType::Cosine,
+                    DistanceType::L1,
+                    DistanceType::L2,
+                ] {
+                    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                    let vector_data: Vec<Vec<f32>> = (0..vectors_count)
+                        .map(|_| {
+                            let vector: Vec<f32> =
+                                (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+                            match distance {
+                                DistanceType::Cosine => normalize(&vector),
+                                DistanceType::Dot | DistanceType::L1 | DistanceType::L2 => vector,
+                            }
+                        })
+                        .collect();
+                    let vector_parameters = VectorParameters {
+                        dim,
+                        deprecated_count: None,
+                        distance_type: distance,
+                        invert: false,
+                    };
+
+                    for &mode in &[TQMode::Normal, TQMode::Plus] {
+                        let quantized_vector_size = encoded_vectors_tq::get_quantized_vector_size(
+                            &vector_parameters,
+                            bits,
+                            mode,
+                        );
+                        let encoded = EncodedVectorsTQ::encode(
+                            vector_data.iter(),
+                            TestEncodedStorageBuilder::new(None, quantized_vector_size),
+                            &vector_parameters,
+                            vectors_count,
+                            bits,
+                            mode,
+                            TQRotation::Padded,
+                            false,
+                            1,
+                            None,
+                            &AtomicBool::new(false),
+                        )
+                        .unwrap();
+
+                        let layout = encoded.layout();
+                        assert_eq!(layout.size(), quantized_vector_size);
+                        assert_eq!(
+                            layout.size() % layout.align(),
+                            0,
+                            "dim={dim} bits={bits:?} distance={distance:?} mode={mode:?}: \
+                             layout size {} is not a multiple of alignment {}",
+                            layout.size(),
+                            layout.align(),
+                        );
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
@coszio found a bug with the optimizer, causing a crash loop.

Steps to reproduce:
1. Create a new collection with inline storage and TQ as a quantization
2. Use DIM=300
3. Crashloop in optimizer because of this condition: 

This bug does not reproduce for common production dimensions like 384/512/768/1024/1536/etc.

The reason is a wrong quantized vector byte alignment. It was 4 but we dont use anywhere this alignment. This PR just changes aligment 4 into alignment 1.

It's safe for already created TQ quantizations because for correct storages alignmant changes nothing, for dims with bug it was impossible to create a quantization - nothing to support