### PR TITLE
fix(sparse): guard compressed posting chunk offset u32 conversion

### DIFF
--- a/lib/sparse/src/index/compressed_posting_list.rs
+++ b/lib/sparse/src/index/compressed_posting_list.rs
@@ -378,7 +378,8 @@ impl CompressedPostingBuilder {
                 let chunk_size = BitPackerImpl::compressed_block_size(chunk_bits);
                 chunks.push(CompressedPostingChunk {
                     initial,
-                    offset: data_size as u32,
+                    offset: u32::try_from(data_size)
+                        .expect("data_size should fit in u32, (smaller than 4GB)"),
                     weights: chunk
                         .iter()
                         .map(|e| Weight::from_f32(quantization_params, e.weight))


### PR DESCRIPTION
Fixes #9964

`CompressedPostingBuilder::build` in `lib/sparse/src/index/compressed_posting_list.rs`
tracks each chunk's running compressed-id byte offset in a `usize` (`data_size`) and
stores it on the chunk as a `u32` via an unchecked `data_size as u32` cast.

If the accumulated compressed id-data for a single posting list ever exceeds
`u32::MAX` bytes (~4 GB), that cast silently truncates and the stored offset wraps
to a small value. `get_chunk_size` derives each chunk's byte range by subtracting
consecutive offsets, so a wrapped offset produces a bogus range, `id_data` is sliced
at the wrong place, and the decompressor decodes corrupt ids: silent index corruption
instead of a clean failure.

This replaces the unchecked cast with a checked `u32::try_from(...).expect(...)` that
fails fast, matching the guarded conversion already used in the sibling `posting_list`
builder (`lib/posting_list/src/builder.rs`). Reaching 4 GB in a single dimension is far
outside realistic usage, so this is a defensive, fail-fast hardening change that brings
the compressed-sparse path in line with its sibling rather than a fix for an
observed-in-practice regression; there is no feasible regression test at that scale.

Verified with `cargo check -p sparse` (compiles clean).
