### PR TITLE
fix: apply optimizers_overwrite to UpdateHandler thread config

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -146,6 +146,10 @@ pub struct LocalShard {
 
     /// Persist the applied op_num sequence number
     applied_seq_handler: Arc<AppliedSeqHandler>,
+
+    /// Effective optimizer config, with any node-local `optimizers_overwrite` applied.
+    /// Used everywhere the override must win over the persisted collection config.
+    effective_optimizers_config: OptimizersConfig,
 }
 
 /// Shard holds information about segments and WAL.
@@ -351,6 +355,7 @@ impl LocalShard {
             is_gracefully_stopped: false,
             update_operation_lock: scroll_read_lock,
             applied_seq_handler,
+            effective_optimizers_config,
         }
     }
 
@@ -757,10 +762,7 @@ impl LocalShard {
         // (the pre-`applied_seq` behavior) keeps the shard unavailable until every acknowledged
         // operation is applied, which is what every read path assumes.
         let prevent_unoptimized = self
-            .collection_config
-            .read()
-            .await
-            .optimizer_config
+            .effective_optimizers_config
             .prevent_unoptimized
             .unwrap_or_default();
         let op_num_upper_bound = if prevent_unoptimized {
@@ -1134,10 +1136,7 @@ impl LocalShard {
 
     pub async fn local_update_queue_info(&self) -> ShardUpdateQueueInfo {
         let prevent_unoptimized = self
-            .collection_config
-            .read()
-            .await
-            .optimizer_config
+            .effective_optimizers_config
             .prevent_unoptimized
             .unwrap_or(false);
 

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -257,6 +257,7 @@ impl LocalShard {
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         wal: SerdeWal<OperationWithClockTag>,
         optimizers: Arc<Vec<Arc<Optimizer>>>,
+        effective_optimizers_config: OptimizersConfig,
         optimizer_resource_budget: ResourceBudget,
         shard_path: &Path,
         clocks: LocalShardClocks,
@@ -297,10 +298,9 @@ impl LocalShard {
             update_runtime.clone(),
             segment_holder.clone(),
             locked_wal.clone(),
-            config.optimizer_config.flush_interval_sec,
-            config.optimizer_config.max_optimization_threads,
-            config
-                .optimizer_config
+            effective_optimizers_config.flush_interval_sec,
+            effective_optimizers_config.max_optimization_threads,
+            effective_optimizers_config
                 .prevent_unoptimized
                 .unwrap_or_default(),
             clocks.clone(),
@@ -536,6 +536,7 @@ impl LocalShard {
             payload_index_schema,
             wal,
             optimizers,
+            effective_optimizers_config,
             optimizer_resource_budget,
             shard_path,
             clocks,
@@ -703,6 +704,7 @@ impl LocalShard {
             payload_index_schema,
             wal,
             optimizers,
+            effective_optimizers_config,
             optimizer_resource_budget,
             shard_path,
             LocalShardClocks::default(),


### PR DESCRIPTION
## Problem

Fixes #9943

A node-local `storage.optimizers_overwrite.max_optimization_threads: 1` does not take effect when a collection's persisted `optimizer_config.max_optimization_threads` is `0`. Optimization stays disabled even after a restart, contradicting the documented contract that every value in `optimizers_overwrite` overrides the persisted collection config (config.yaml, and PR #4317 review r1616297014).

## Root cause

The override is merged correctly into the effective optimizer config in `Collection::build`, `Collection::load`, and `effective_optimizers_config()`, and the optimizers are built from that effective config. However `LocalShard::new`
constructed the `UpdateHandler` by reading `flush_interval_sec`, `max_optimization_threads` and prevent_unoptimized` directly from the persisted `collection_config` instead of the effective config.

With persisted `max_optimization_threads: 0` and an override of `1`, the optimizers were created but the `UpdateHandler` still gated on the persisted `0`. In `optimization_worker.rs`, `max_handles` becomes `0`, so the worker computes `limit == 0` and never schedules optimization.

## Fix

Pass the already-available `effective_optimizers_config` into `LocalShard::new` and use it for the `UpdateHandler` thread configuration, so the node-local override is honored regardless of the persisted value.

## AI disclosure

- [AI] fix: apply optimizers_overwrite to UpdateHandler thread config

Initial prompt intent: investigate why a node-local `optimizers_overwrite.max_optimization_threads` override is not applied when the persisted collection value is `0`, find the root cause, and implement the minimal correct fix. I have reviewed the change and understand it.
