### PR TITLE
tests: skip clear_ram_cache eviction test on tmpfs

### DIFF
--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -714,6 +714,17 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("dual.dat");
 
+        // On tmpfs the page cache is the backing store, so
+        // `POSIX_FADV_DONTNEED` cannot evict anything and the assertion below
+        // is unobservable (e.g. `/tmp` on Ubuntu 24.10+). Skip there.
+        let fs_type = nix::sys::statfs::statfs(dir.path())
+            .unwrap()
+            .filesystem_type();
+        if fs_type == nix::sys::statfs::TMPFS_MAGIC {
+            eprintln!("skipping: tempdir is on tmpfs, fadvise cannot evict its pages");
+            return;
+        }
+
         // Synced: only clean pages are evictable.
         let mut file = fs_err::File::create(&path).unwrap();
         file.write_all(&vec![7u8; LEN as usize]).unwrap();


### PR DESCRIPTION
## What

`clear_ram_cache_evicts_dual_mapped_file` (added in #9984) now skips itself when the tempdir is on tmpfs.

## Why

The test asserts that `clear_ram_cache()` drops residency below 10%, but `POSIX_FADV_DONTNEED` cannot evict pages of a tmpfs file: the page cache is the backing store, so there is nothing to drop them to. On machines where `/tmp` is tmpfs (the Ubuntu default since 24.10) the test always fails with:

```
not evicted: 8388608 of 8388608
```

Verified: fails on tmpfs, passes with `TMPDIR` pointed at ext4.

## How

`statfs` the tempdir and return early (with a note on stderr) when the filesystem magic is `TMPFS_MAGIC`. `nix` already ships the `fs` feature workspace-wide and the test is already Linux-only, so no new dependencies or cfg gates. CI runners keep `/tmp` on disk, so the real eviction path stays exercised there.

Known limitation: this guards only tmpfs, not other RAM-backed filesystems (e.g. ramfs). A capability probe would be more general, but this covers the common developer setup with a minimal diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)