### PR TITLE
Reject concurrent snapshot recoveries of the same shard

### DIFF
--- a/lib/collection/src/shards/local_shard/snapshot.rs
+++ b/lib/collection/src/shards/local_shard/snapshot.rs
@@ -42,6 +42,26 @@ impl LocalShard {
 
     pub fn restore_snapshot(snapshot_path: &Path) -> CollectionResult<()> {
         log::info!("Restoring shard snapshot {}", snapshot_path.display());
+
+        // Staging delay: widen the restore window. Restoring a shard snapshot is not
+        // cancel safe, so a caller that walked away cannot stop it, and a retried
+        // recovery can arrive while this one is still writing the shard. This delay
+        // makes that overlap reproducible. Exercised by
+        // `test_concurrent_shard_recovery.py`.
+        #[cfg(feature = "staging")]
+        {
+            let delay_secs: f64 = std::env::var("QDRANT__STAGING__SHARD_SNAPSHOT_RESTORE_DELAY")
+                .ok()
+                .and_then(|str| str.parse().ok())
+                .unwrap_or(0.0);
+
+            if delay_secs > 0.0 {
+                log::debug!("Staging: Delaying shard snapshot restore for {delay_secs}s");
+                std::thread::sleep(std::time::Duration::from_secs_f64(delay_secs));
+                log::debug!("Staging: Delay complete, restoring shard snapshot");
+            }
+        }
+
         SnapshotUtils::restore_unpacked_snapshot(snapshot_path)?;
         Ok(())
     }

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -493,8 +493,11 @@ impl ShardHolder {
     /// Returns a [`ShardRecoveryGuard`] that must be held for the duration of the
     /// recovery. Dropping the guard - on success, error, or cancellation - stops
     /// tracking and removes the progress entry.
-    pub fn start_shard_recovery(&self, shard_id: ShardId) -> ShardRecoveryGuard {
-        self.active_recoveries.start(shard_id)
+    ///
+    /// Returns `None` if this shard is already being recovered, in which case the
+    /// caller must not start a second recovery. See [`ActiveRecoveries::try_start`].
+    pub fn try_start_shard_recovery(&self, shard_id: ShardId) -> Option<ShardRecoveryGuard> {
+        self.active_recoveries.try_start(shard_id)
     }
 
     pub fn get_shard_transfer_info(

--- a/lib/collection/src/shards/shard_holder/recovery_guard.rs
+++ b/lib/collection/src/shards/shard_holder/recovery_guard.rs
@@ -29,16 +29,27 @@ pub struct ActiveRecoveries {
 impl ActiveRecoveries {
     /// Start tracking a recovery for `shard_id`, returning a guard that stops
     /// tracking on drop.
-    pub fn start(&self, shard_id: ShardId) -> ShardRecoveryGuard {
+    ///
+    /// Returns `None` if a recovery for this shard is already in progress.
+    /// Recovering clears the shard and rewrites it from the snapshot, so two
+    /// recoveries running at once would each clobber the other's work. This is
+    /// reachable whenever a caller retries: the previous attempt keeps running
+    /// because restoring a shard snapshot is not cancel safe.
+    pub fn try_start(&self, shard_id: ShardId) -> Option<ShardRecoveryGuard> {
+        let mut recoveries = self.recoveries.lock();
+
+        if recoveries.contains_key(&shard_id) {
+            return None;
+        }
+
         let progress = Arc::new(Mutex::new(RecoveryProgress::new()));
-        self.recoveries
-            .lock()
-            .insert(shard_id, Arc::clone(&progress));
-        ShardRecoveryGuard {
+        recoveries.insert(shard_id, Arc::clone(&progress));
+
+        Some(ShardRecoveryGuard {
             active_recoveries: self.clone(),
             shard_id,
             progress,
-        }
+        })
     }
 
     /// Format the recovery progress comment for `shard_id`, if a recovery is active.

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -190,11 +190,23 @@ pub async fn recover_shard_snapshot(
 
         // Guard tracks recovery progress and removes it on drop, on every exit path
         // (success, error, or cancellation), so stale timings are never reported.
+        //
+        // It also makes recovery exclusive per shard. The next step clears the shard
+        // before downloading, so a second recovery starting while the first is still
+        // running would wipe the shard the first one is writing. That is reachable
+        // whenever the caller retries, because restoring a snapshot is not cancel
+        // safe and keeps running after the caller has walked away.
         let recovery_guard = collection
             .shards_holder()
             .read()
             .await
-            .start_shard_recovery(shard_id);
+            .try_start_shard_recovery(shard_id)
+            .ok_or_else(|| StorageError::ShardUnavailable {
+                description: format!(
+                    "Shard {shard_id} of collection {collection_name} is already \
+                     being recovered from a snapshot"
+                ),
+            })?;
 
         // For shard transfers, drop the existing shard and clear its on-disk data
         // before downloading the new snapshot so we don't need space for both copies.

--- a/tests/consensus_tests/test_concurrent_shard_recovery.py
+++ b/tests/consensus_tests/test_concurrent_shard_recovery.py
@@ -1,0 +1,96 @@
+"""
+A second snapshot recovery of the same shard must be rejected while one is
+already running.
+
+Recovering a shard snapshot clears the shard and rewrites it from the snapshot.
+Restoring is explicitly *not* cancel safe (`recover_shard_snapshot_impl`) and runs
+in a `spawn_blocking` task, so a caller that walks away -- a dropped HTTP request,
+or a shard transfer whose `recover` RPC was retried -- cannot stop it. Without
+exclusion, the retried recovery calls `clear_local_shard_for_snapshot_recovery`
+and wipes the shard directory the previous restore is still writing.
+
+The staging restore delay holds the first recovery inside its restore long enough
+for a second request to land on top of it.
+
+Requires the `staging` feature for `QDRANT__STAGING__SHARD_SNAPSHOT_RESTORE_DELAY`:
+
+    cargo build --features staging
+    pytest tests/consensus_tests/test_concurrent_shard_recovery.py -s -v
+"""
+
+import concurrent.futures
+import pathlib
+
+import requests
+
+from .assertions import assert_http_ok
+from .fixtures import create_collection, upsert_random_points
+from .utils import *
+
+COLLECTION_NAME = "test_collection"
+NUM_POINTS = 1_000
+
+# Long enough that the second request certainly lands while the first is inside
+# its restore, short enough to keep the test quick.
+RESTORE_DELAY_SECS = 15
+
+
+def test_second_recovery_of_same_shard_is_rejected(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    env = {"QDRANT__STAGING__SHARD_SNAPSHOT_RESTORE_DELAY": str(RESTORE_DELAY_SECS)}
+    peer_dirs = make_peer_folders(tmp_path, 1)
+    peer_uri, _ = start_first_peer(peer_dirs[0], "peer_0_0.log", extra_env=env)
+    wait_peer_added(peer_uri)
+
+    create_collection(peer_uri, shard_number=1, replication_factor=1)
+    wait_collection_exists_and_active_on_all_peers(COLLECTION_NAME, [peer_uri])
+    upsert_random_points(peer_uri, NUM_POINTS, batch_size=100)
+
+    info = get_collection_cluster_info(peer_uri, COLLECTION_NAME)
+    shard_id = info["local_shards"][0]["shard_id"]
+
+    # Take a shard snapshot to recover from, so both requests have real work to do.
+    r = requests.post(f"{peer_uri}/collections/{COLLECTION_NAME}/shards/{shard_id}/snapshots")
+    assert_http_ok(r)
+    snapshot_name = r.json()["result"]["name"]
+
+    recover_url = (
+        f"{peer_uri}/collections/{COLLECTION_NAME}/shards/{shard_id}/snapshots/recover"
+    )
+
+    def recover():
+        return requests.put(
+            recover_url, json={"location": snapshot_name}, params={"wait": "true"}
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(recover)
+        # Give the first request time to take the recovery guard and enter its
+        # (delayed) restore before the second one arrives.
+        time.sleep(RESTORE_DELAY_SECS / 3)
+        second = pool.submit(recover)
+
+        responses = [first.result(timeout=120), second.result(timeout=120)]
+
+    statuses = sorted(r.status_code for r in responses)
+    bodies = [r.text for r in responses]
+
+    print(f"\nrecovery response statuses: {statuses}")
+
+    assert statuses == [200, 503], (
+        f"expected one recovery to succeed and the overlapping one to be rejected "
+        f"with 503, got {statuses}: {bodies}"
+    )
+
+    rejected = next(r for r in responses if r.status_code == 503)
+    assert "already being recovered" in rejected.text, (
+        f"503 should explain the conflict, got: {rejected.text}"
+    )
+
+    # The surviving recovery must leave the shard intact.
+    r = requests.post(
+        f"{peer_uri}/collections/{COLLECTION_NAME}/points/count", json={"exact": True}
+    )
+    assert_http_ok(r)
+    assert r.json()["result"]["count"] == NUM_POINTS


### PR DESCRIPTION
## Problem

Recovering a shard snapshot clears the shard and rewrites it. `recover_shard_snapshot_impl` is explicitly **not cancel safe** and its restore runs in a `spawn_blocking` task, so a caller that walks away cannot stop it.

That means two recoveries of the same shard overlap whenever the caller retries — and the second one calls `clear_local_shard_for_snapshot_recovery`, wiping the shard directory the first one is still writing.

This is reachable in normal operation. A snapshot shard transfer retries its `recover` RPC (`DEFAULT_RETRIES = 2`, plus up to `MAX_RETRY_COUNT = 3` driver retries), and each retry starts a fresh recovery on the receiver while the previous one keeps running. Reproduced locally as **four concurrent restores of the same shard directory**:

```
13:32:06.73  Restoring shard snapshot …
13:32:07.71  Restoring shard snapshot …   <- while #1 still running
13:32:08.97  Restoring shard snapshot …
13:32:11.34  Restoring shard snapshot …
```

Found while investigating a production shard transfer stuck in `recovering` for 3.5h.

## Change

`ActiveRecoveries` already tracks in-flight recoveries per shard for progress reporting, but `start` silently overwrote the entry. Replace it with `try_start`, which returns `None` when a recovery is already registered for that shard.

`recover_shard_snapshot` then rejects with `ShardUnavailable`, which maps to **HTTP 503** and gRPC **`Unavailable`** — a code `TransportChannelPool` already retries with backoff. So a transfer whose RPC was retried now waits for the running recovery instead of racing it.

## Test

`tests/consensus_tests/test_concurrent_shard_recovery.py` fires two overlapping recoveries of one shard and asserts `[200, 503]`, that the 503 explains the conflict, and that the surviving recovery leaves the shard intact.

Deterministic via a new `QDRANT__STAGING__SHARD_SNAPSHOT_RESTORE_DELAY` hook (gated by the existing `staging` feature) that widens the restore window.

## Scope / follow-ups

- Only `recover_shard_snapshot` takes the guard. The snapshot **upload** paths call `recover_shard_snapshot_impl` directly (`snapshot_api.rs:556/739/919`) and remain unguarded — pre-existing, deliberately left out to keep this minimal.
- Sender-side snapshot-stream starvation is a separate issue, in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)