### PR TITLE
Bound how long a streamed shard snapshot waits for a concurrent one

### DIFF
--- a/lib/collection/src/shards/local_shard/snapshot.rs
+++ b/lib/collection/src/shards/local_shard/snapshot.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use common::save_on_disk::SaveOnDisk;
 use common::tar_ext;
@@ -27,6 +28,13 @@ use wal::{Wal, WalOptions};
 
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::local_shard::{LocalShard, LocalShardClocks};
+
+/// How long a *streamed* snapshot waits for its turn on the segment holder.
+///
+/// Kept below the 60s inactivity timeout the snapshot download applies on the
+/// receiving side, so the sender reports why it gave up before the receiver gives
+/// up on it.
+const STREAMED_SNAPSHOT_SEGMENT_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
 
 impl LocalShard {
     pub async fn snapshot_manifest(&self) -> CollectionResult<SnapshotManifest> {
@@ -344,12 +352,25 @@ pub fn snapshot_all_segments(
     // Snapshotting may take long-running read locks on segments blocking incoming writes, do
     // this through proxied segments to allow writes to continue.
 
+    // Snapshots of one shard serialize on the segment holder (see
+    // `proxy_all_segments_and_apply`), and a streamed snapshot lives for as long as
+    // its consumer keeps reading. A streamed snapshot has already committed a
+    // `200 OK` by the time it gets here, so waiting silently would hand the consumer
+    // a response that never produces a byte -- indistinguishable from a hung server.
+    // Bound the wait for those and fail with an explanation instead. Snapshots
+    // written to a local file have no waiting consumer, so they still queue.
+    let lock_timeout = match format {
+        SnapshotFormat::Streamable => Some(STREAMED_SNAPSHOT_SEGMENT_LOCK_TIMEOUT),
+        SnapshotFormat::Ancient | SnapshotFormat::Regular => None,
+    };
+
     proxy_all_segments_and_apply(
         segments,
         segments_path,
         segment_config,
         payload_index_schema,
         deferred_internal_id,
+        lock_timeout,
         |segment| {
             let read_segment = segment.read();
             let request_segment_manifest = if let Some(manifest) = manifest {
@@ -395,18 +416,32 @@ pub fn snapshot_all_segments(
 /// sourced from it.
 ///
 /// Before snapshotting all segments are forcefully flushed to ensure all data is persisted.
+///
+/// The segment holder's upgradable read lock admits only one holder at a time, so
+/// concurrent calls for the same shard run one after another. `lock_timeout` bounds
+/// how long this call waits for its turn; `None` waits indefinitely.
 pub fn proxy_all_segments_and_apply<F>(
     segments: LockedSegmentHolder,
     segments_path: &Path,
     segment_config: Option<SegmentConfig>,
     payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
     deferred_internal_id: Option<PointOffsetType>,
+    lock_timeout: Option<Duration>,
     mut operation: F,
 ) -> OperationResult<()>
 where
     F: FnMut(&RwLock<dyn StorageSegmentEntry>) -> OperationResult<()>,
 {
-    let segments_lock = segments.upgradable_read();
+    let segments_lock = match lock_timeout {
+        Some(timeout) => segments.try_upgradable_read_for(timeout).ok_or_else(|| {
+            OperationError::service_error(format!(
+                "Timed out after {}s waiting for exclusive access to the segment holder; \
+                     another snapshot of this shard is still in progress",
+                timeout.as_secs(),
+            ))
+        })?,
+        None => segments.upgradable_read(),
+    };
 
     // Proxy all segments
     // Proxied segments are sorted by flush ordering

--- a/lib/shard/src/segment_holder/locked.rs
+++ b/lib/shard/src/segment_holder/locked.rs
@@ -55,6 +55,18 @@ impl LockedSegmentHolder {
         self.holder.try_read_for(timeout)
     }
 
+    /// Like [`Self::upgradable_read`], but gives up after `timeout`.
+    ///
+    /// Only one upgradable reader is allowed at a time, so callers that hold this
+    /// guard for a long time (snapshots) block each other. Use this where waiting
+    /// forever is worse than failing.
+    pub fn try_upgradable_read_for(
+        &self,
+        timeout: Duration,
+    ) -> Option<RwLockUpgradableReadGuard<'_, SegmentHolder>> {
+        self.holder.try_upgradable_read_for(timeout)
+    }
+
     pub fn try_read(&self) -> Option<RwLockReadGuard<'_, SegmentHolder>> {
         self.holder.try_read()
     }

--- a/tests/consensus_tests/test_concurrent_shard_snapshot_streams.py
+++ b/tests/consensus_tests/test_concurrent_shard_snapshot_streams.py
@@ -1,0 +1,133 @@
+"""
+A streamed shard snapshot must not wait forever for a concurrent one to finish.
+
+Snapshots of one shard serialize on the segment holder's upgradable read lock,
+taken by `proxy_all_segments_and_apply` and held for the whole snapshot:
+
+    let segments_lock = segments.upgradable_read();
+
+`parking_lot` admits one upgradable reader at a time, and a *streamed* snapshot
+lives for as long as its consumer keeps reading. So a second stream used to park
+there indefinitely -- after actix had already committed a `200 OK`, leaving the
+consumer with a response that never produced a byte. Measured before the fix:
+30s, zero bytes, while the first stream was happily streaming 500+ KB.
+
+That is what a retried shard transfer hits when the previous attempt's stream was
+not torn down: its download looks hung rather than failing.
+
+Streamed snapshots now bound that wait and fail with an explanation. Snapshots
+written to a local file have no waiting consumer and still queue.
+
+    pytest tests/consensus_tests/test_concurrent_shard_snapshot_streams.py -s -v
+"""
+
+import pathlib
+import threading
+import time
+
+import requests
+
+from .assertions import assert_http_ok
+from .fixtures import create_collection, upsert_random_points
+from .utils import *
+
+COLLECTION_NAME = "test_collection"
+
+# Big enough that the first snapshot outlives the whole observation window.
+NUM_POINTS = 50_000
+
+# First download reads this much per step, then sleeps -- slow enough to keep the
+# sender parked mid-snapshot, holding the lock.
+THROTTLE_CHUNK = 4096
+THROTTLE_SLEEP = 0.2
+
+# Let the first stream get well inside `proxy_all_segments_and_apply`.
+LEAD_SECS = 3
+
+# `STREAMED_SNAPSHOT_SEGMENT_LOCK_TIMEOUT` in local_shard/snapshot.rs.
+SERVER_LOCK_TIMEOUT_SECS = 30
+
+# Generous, so that finishing early proves the *server* gave up rather than the
+# client timing out.
+CLIENT_TIMEOUT_SECS = 90
+
+LOCK_TIMEOUT_LOG = "waiting for exclusive access to the segment holder"
+
+
+class ThrottledDownload(threading.Thread):
+    """Hold a snapshot download open, reading slowly, until asked to stop."""
+
+    def __init__(self, url: str):
+        super().__init__(daemon=True)
+        self.url = url
+        self.bytes_read = 0
+        self._stop = threading.Event()
+
+    def run(self):
+        try:
+            with requests.get(self.url, stream=True, timeout=CLIENT_TIMEOUT_SECS) as resp:
+                for chunk in resp.iter_content(THROTTLE_CHUNK):
+                    self.bytes_read += len(chunk)
+                    if self._stop.is_set():
+                        return
+                    time.sleep(THROTTLE_SLEEP)
+        except requests.exceptions.RequestException:
+            pass
+
+    def stop(self):
+        self._stop.set()
+
+
+def test_streamed_snapshot_gives_up_waiting_for_a_concurrent_one(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    peer_dirs = make_peer_folders(tmp_path, 1)
+    peer_uri, _ = start_first_peer(peer_dirs[0], "peer_0_0.log")
+    wait_peer_added(peer_uri)
+
+    create_collection(peer_uri, shard_number=1, replication_factor=1)
+    wait_collection_exists_and_active_on_all_peers(COLLECTION_NAME, [peer_uri])
+    upsert_random_points(peer_uri, NUM_POINTS, batch_size=1000)
+
+    info = get_collection_cluster_info(peer_uri, COLLECTION_NAME)
+    shard_id = info["local_shards"][0]["shard_id"]
+    url = f"{peer_uri}/collections/{COLLECTION_NAME}/shards/{shard_id}/snapshot"
+
+    first = ThrottledDownload(url)
+    first.start()
+
+    time.sleep(LEAD_SECS)
+    assert first.is_alive(), "throttled download ended too early, raise NUM_POINTS"
+    assert first.bytes_read > 0, "first stream never produced any bytes"
+
+    started = time.monotonic()
+    received = 0
+    try:
+        with requests.get(url, stream=True, timeout=CLIENT_TIMEOUT_SECS) as resp:
+            assert_http_ok(resp)
+            for chunk in resp.iter_content(THROTTLE_CHUNK):
+                received += len(chunk)
+    except requests.exceptions.RequestException as err:
+        print(f"\nsecond stream ended with: {type(err).__name__}: {err}")
+    elapsed = time.monotonic() - started
+
+    print(
+        f"\nfirst stream read {first.bytes_read} bytes; "
+        f"second stream ended after {elapsed:.1f}s with {received} bytes"
+    )
+
+    first.stop()
+
+    # The second stream must give up on its own, not hang until the client's
+    # timeout. Allow slack over the server's 30s bound for snapshot setup.
+    assert elapsed < CLIENT_TIMEOUT_SECS - 15, (
+        f"second stream did not give up on its own: it ran {elapsed:.1f}s, which "
+        f"means it waited for the client timeout rather than the server's "
+        f"{SERVER_LOCK_TIMEOUT_SECS}s lock bound"
+    )
+
+    # And it must say why, rather than dying silently.
+    log = (pathlib.Path(init_pytest_log_folder()) / "peer_0_0.log").read_text()
+    assert LOCK_TIMEOUT_LOG in log, (
+        "sender should log why the concurrent snapshot was abandoned"
+    )


### PR DESCRIPTION
## Problem

Snapshots of one shard serialize on the segment holder's upgradable read lock, taken by `proxy_all_segments_and_apply` and held for the **whole** snapshot:

```rust
let segments_lock = segments.upgradable_read();
```

`parking_lot` admits one upgradable reader at a time, and a *streamed* snapshot lives for as long as its consumer keeps reading. So a second stream parks there indefinitely — after actix has already committed a `200 OK`, leaving the consumer with a response that never produces a byte.

Measured before this change, with one throttled download in flight:

```
first stream read 532484 bytes so far
second stream: ConnectionError: Read timed out.
headers received: True (status 200)
```

30 seconds, **zero bytes**, while the first stream was happily streaming. Indistinguishable from a hung server, and neither side logs anything.

A retried shard transfer hits exactly this when the previous attempt's stream was not torn down: its download looks hung rather than failing. Found while investigating a production transfer stuck in `recovering` for 3.5h.

## Change

Bound the wait for **streamed** snapshots and fail with an explanation:

```
Timed out after 30s waiting for exclusive access to the segment holder;
another snapshot of this shard is still in progress
```

30s is deliberately below the 60s inactivity timeout the receiving side applies to a snapshot download (`download_tar.rs`), so the sender reports why it gave up *before* the receiver gives up on it — the failure becomes attributable instead of an opaque read timeout.

Snapshots written to a local file (`SnapshotFormat::Regular` / `Ancient`) have no waiting consumer, so they still queue as before. The timeout is opt-in per call via a new `lock_timeout` parameter on `proxy_all_segments_and_apply`; `snapshot_all_segments` derives it from the format.

## Test

`tests/consensus_tests/test_concurrent_shard_snapshot_streams.py` holds one throttled download open and starts a second, asserting the second gives up on its own (measured 30.2s, against a 90s client timeout) and that the sender logs why.

Existing `cargo test -p collection --lib snapshot` passes (6 tests).

## Scope / follow-ups

- This makes the starvation visible and bounded; it does not remove it. Not holding the segment-holder lock across network I/O would, but that is a much larger change.
- Concurrent *recoveries* of one shard are a separate issue, in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)