### PR TITLE
Make `CreateShardKey` idempotent

### DIFF
--- a/lib/collection/src/collection/sharding_keys.rs
+++ b/lib/collection/src/collection/sharding_keys.rs
@@ -76,9 +76,19 @@ impl Collection {
             ShardingMethod::Custom => {}
         }
 
+        // Shard key mapping is updated atomically at the end of `create_shard_key`.
+        // If shard key already exists, either user submitted invalid/duplicate operation,
+        // or we are re-applying fully applied and persisted operation after crash.
+        // Returning "bad request" error is fine in both cases.
         if state.shards_key_mapping.contains_key(&shard_key) {
             return Err(CollectionError::bad_request(format!(
                 "Shard key {shard_key} already exists"
+            )));
+        }
+
+        if placement.is_empty() {
+            return Err(CollectionError::bad_request(format!(
+                "Shard key {shard_key} placement cannot be empty"
             )));
         }
 
@@ -102,17 +112,26 @@ impl Collection {
             )));
         }
 
-        let max_shard_id = state.max_shard_id();
+        let base_id = state.max_shard_id() + 1;
         let payload_schema = self.payload_index_schema.read().schema.clone();
 
-        for (idx, shard_replicas_placement) in placement.iter().enumerate() {
-            let shard_id = max_shard_id + idx as ShardId + 1;
+        // Create shards on disk *before* updating shard key mapping.
+        //
+        // `ShardHolder::load_shards` only loads shards that are present in the mapping,
+        // so directories that are not in the mapping do not affect startup and state after crash.
+        //
+        // On re-apply, `Collection::create_replica_set` cleanly re-creates any leftover directories.
+
+        let mut shards = Vec::with_capacity(placement.len());
+
+        for (idx, replicas) in placement.iter().enumerate() {
+            let shard_id = base_id + idx as ShardId;
 
             let replica_set = self
                 .create_replica_set(
                     shard_id,
                     Some(shard_key.clone()),
-                    shard_replicas_placement,
+                    replicas,
                     Some(init_state),
                 )
                 .await?;
@@ -132,18 +151,19 @@ impl Collection {
                         None,
                         hw_counter.clone(),
                         false,
-                    ) // TODO: Assign clock tag!? 🤔
+                    )
                     .await?;
             }
 
-            self.shards_holder
-                .write()
-                .await
-                .add_shard(shard_id, replica_set, Some(shard_key.clone()))
-                .await?;
+            shards.push((shard_id, replica_set));
         }
 
-        Ok(())
+        // Persist mapping and register new shards
+        self.shards_holder
+            .write()
+            .await
+            .add_shards(shards, Some(shard_key))
+            .await
     }
 
     pub async fn drop_shard_key(&self, shard_key: ShardKey) -> CollectionResult<()> {

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -264,6 +264,10 @@ impl ShardHolder {
         shards: Vec<(ShardId, ShardReplicaSet)>,
         shard_key: Option<ShardKey>,
     ) -> CollectionResult<()> {
+        if shards.is_empty() {
+            return Ok(());
+        }
+
         // Persist mapping first: it is the only fallible step, so a failed write leaves
         // in-memory state untouched.
         if let Some(shard_key) = &shard_key {

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -251,34 +251,59 @@ impl ShardHolder {
         shard: ShardReplicaSet,
         shard_key: Option<ShardKey>,
     ) -> CollectionResult<()> {
-        let evicted = self.shards.insert(shard_id, Arc::new(shard));
-        if let Some(evicted) = evicted {
-            debug_assert!(false, "Overwriting existing shard id {shard_id}");
-            evicted.stop_gracefully().await;
-        }
+        self.add_shards(vec![(shard_id, shard)], shard_key).await
+    }
 
-        self.rings
-            .entry(shard_key.clone())
-            .or_insert_with(HashRingRouter::single)
-            .add(shard_id);
+    /// Add batch of shards to shard holder and atomically update shard key mapping.
+    ///
+    /// ## Cancel safety
+    ///
+    /// This function is **not** cancel safe.
+    pub async fn add_shards(
+        &mut self,
+        shards: Vec<(ShardId, ShardReplicaSet)>,
+        shard_key: Option<ShardKey>,
+    ) -> CollectionResult<()> {
+        // Persist mapping first: it is the only fallible step, so a failed write leaves
+        // in-memory state untouched.
+        if let Some(shard_key) = &shard_key {
+            self.key_mapping.write_optional(|mapping| {
+                let mut mapping = mapping.clone();
+                let shard_ids = mapping.entry(shard_key.clone()).or_default();
 
-        if let Some(shard_key) = shard_key {
-            self.key_mapping.write_optional(|key_mapping| {
-                let has_id = key_mapping
-                    .get(&shard_key)
-                    .map(|shard_ids| shard_ids.contains(&shard_id))
-                    .unwrap_or(false);
+                let mut changed = false;
 
-                if has_id {
-                    return None;
+                for &(shard_id, _) in &shards {
+                    changed |= shard_ids.insert(shard_id);
                 }
-                let mut copy_of_mapping = key_mapping.clone();
-                let shard_ids = copy_of_mapping.entry(shard_key.clone()).or_default();
-                shard_ids.insert(shard_id);
-                Some(copy_of_mapping)
+
+                if changed { Some(mapping) } else { None }
             })?;
-            self.shard_id_to_key_mapping.insert(shard_id, shard_key);
         }
+
+        let ring = self
+            .rings
+            .entry(shard_key.clone())
+            .or_insert_with(HashRingRouter::single);
+
+        for &(shard_id, _) in &shards {
+            ring.add(shard_id);
+        }
+
+        for (shard_id, shard) in shards {
+            let evicted = self.shards.insert(shard_id, Arc::new(shard));
+
+            if let Some(evicted) = evicted {
+                debug_assert!(false, "Overwriting existing shard id {shard_id}");
+                evicted.stop_gracefully().await;
+            }
+
+            if let Some(shard_key) = &shard_key {
+                self.shard_id_to_key_mapping
+                    .insert(shard_id, shard_key.clone());
+            }
+        }
+
         Ok(())
     }
 

--- a/lib/collection/tests/integration/create_shard_key_test.rs
+++ b/lib/collection/tests/integration/create_shard_key_test.rs
@@ -1,0 +1,270 @@
+//! `Collection::create_shard_key` treats `shard_key_mapping.json` as the operation's single
+//! commit point: it is written once, after every shard of the key exists on disk. These tests
+//! cover the states a consensus re-apply can land in — nothing committed, everything committed —
+//! plus the duplicate-key case that must never be mistaken for a replay.
+
+use std::num::NonZeroU32;
+use std::path::Path;
+use std::sync::Arc;
+
+use collection::collection::Collection;
+use collection::config::{CollectionConfigInternal, CollectionParams, ShardingMethod, WalConfig};
+use collection::operations::types::CollectionError;
+use collection::operations::vector_params_builder::VectorParamsBuilder;
+use collection::shards::channel_service::ChannelService;
+use collection::shards::collection_shard_distribution::CollectionShardDistribution;
+use collection::shards::replica_set::replica_set_state::ReplicaState;
+use collection::shards::shard::{PeerId, ShardId, ShardsPlacement};
+use collection::shards::shard_holder::SHARD_KEY_MAPPING_FILE;
+use common::budget::ResourceBudget;
+use segment::types::{Distance, ShardKey};
+use tempfile::Builder;
+use tonic::transport::Uri;
+
+use crate::common::{
+    REST_PORT, TEST_OPTIMIZERS_CONFIG, dummy_abort_shard_transfer, dummy_on_replica_failure,
+    dummy_request_shard_transfer,
+};
+
+const COLLECTION_ID: &str = "test_create_shard_key";
+const PEER_ID: PeerId = 0;
+
+fn key(name: &str) -> ShardKey {
+    ShardKey::Keyword(name.into())
+}
+
+/// A placement of `shards` single-replica shards, all on the local peer
+fn placement(shards: usize) -> ShardsPlacement {
+    vec![vec![PEER_ID]; shards]
+}
+
+fn custom_sharding_config() -> CollectionConfigInternal {
+    let params = CollectionParams {
+        vectors: VectorParamsBuilder::new(4, Distance::Dot).build().into(),
+        shard_number: NonZeroU32::new(1).unwrap(),
+        sharding_method: Some(ShardingMethod::Custom),
+        ..CollectionParams::empty()
+    };
+
+    CollectionConfigInternal {
+        params,
+        optimizer_config: TEST_OPTIMIZERS_CONFIG.clone(),
+        wal_config: WalConfig {
+            wal_capacity_mb: 1,
+            wal_segments_ahead: 0,
+            wal_retain_closed: 1,
+        },
+        hnsw_config: Default::default(),
+        quantization_config: Default::default(),
+        strict_mode_config: Default::default(),
+        uuid: None,
+        metadata: None,
+    }
+}
+
+/// `create_shard_key` rejects placements referencing peers it does not know about, so the local
+/// peer has to be resolvable through the channel service.
+fn channel_service() -> ChannelService {
+    let channel_service = ChannelService::new(REST_PORT, false, None, None);
+    channel_service
+        .id_to_address
+        .write()
+        .insert(PEER_ID, Uri::from_static("http://127.0.0.1:6333"));
+    channel_service
+}
+
+/// Custom sharding starts out with no shards at all, so the distribution is empty
+async fn new_collection(path: &Path) -> Collection {
+    Collection::new(
+        COLLECTION_ID.to_string(),
+        PEER_ID,
+        path,
+        &path.join("snapshots"),
+        &custom_sharding_config(),
+        Arc::default(),
+        CollectionShardDistribution::all_local(Some(0), PEER_ID),
+        None,
+        channel_service(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
+        None,
+        None,
+        ResourceBudget::default(),
+        None,
+    )
+    .await
+    .unwrap()
+}
+
+async fn load_collection(path: &Path) -> Collection {
+    Collection::load(
+        COLLECTION_ID.to_string(),
+        PEER_ID,
+        path,
+        &path.join("snapshots"),
+        Arc::default(),
+        channel_service(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
+        None,
+        None,
+        ResourceBudget::default(),
+        None,
+    )
+    .await
+}
+
+/// Shard ids the key mapping associates with `shard_key`
+async fn mapped_shard_ids(collection: &Collection, shard_key: &ShardKey) -> Vec<ShardId> {
+    let mut ids = collection.get_shard_ids(shard_key).await.unwrap();
+    ids.sort_unstable();
+    ids
+}
+
+/// Shard ids actually registered in the shard holder
+async fn registered_shard_ids(collection: &Collection) -> Vec<ShardId> {
+    let mut ids: Vec<_> = collection.state().await.shards.keys().copied().collect();
+    ids.sort_unstable();
+    ids
+}
+
+fn assert_bad_request(err: CollectionError) {
+    assert!(
+        matches!(err, CollectionError::BadRequest { .. }),
+        "expected a dismissable user error, got {err:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_shard_key_allocates_contiguous_ids() {
+    let dir = Builder::new().prefix("collection").tempdir().unwrap();
+    let collection = new_collection(dir.path()).await;
+
+    collection
+        .create_shard_key(key("k"), placement(3), ReplicaState::Active)
+        .await
+        .unwrap();
+
+    // Ids are allocated past `max_shard_id`, which starts at 0 for an empty mapping
+    assert_eq!(mapped_shard_ids(&collection, &key("k")).await, [1, 2, 3]);
+    assert_eq!(registered_shard_ids(&collection).await, [1, 2, 3]);
+
+    collection.stop_gracefully().await;
+}
+
+/// A crash anywhere before the mapping write leaves the peer in its pre-operation state, so the
+/// re-apply runs from scratch and lands on the same shard ids — on top of the directories the
+/// crashed attempt left behind.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_shard_key_replays_after_crash_before_commit() {
+    let dir = Builder::new().prefix("collection").tempdir().unwrap();
+
+    {
+        let collection = new_collection(dir.path()).await;
+        collection
+            .create_shard_key(key("k"), placement(3), ReplicaState::Active)
+            .await
+            .unwrap();
+        collection.stop_gracefully().await;
+    }
+
+    // Roll the mapping back to what it was before the operation, keeping the shard directories.
+    // This is the on-disk state of a peer that died partway through the create loop.
+    fs_err::write(dir.path().join(SHARD_KEY_MAPPING_FILE), "[]").unwrap();
+    for shard_id in 1..=3 {
+        assert!(dir.path().join(shard_id.to_string()).is_dir());
+    }
+
+    let collection = load_collection(dir.path()).await;
+
+    // Nothing was committed, so nothing is visible: `load_shards` only loads shards the mapping
+    // references
+    assert!(collection.state().await.shards_key_mapping.is_empty());
+    assert!(registered_shard_ids(&collection).await.is_empty());
+
+    collection
+        .create_shard_key(key("k"), placement(3), ReplicaState::Active)
+        .await
+        .unwrap();
+
+    assert_eq!(mapped_shard_ids(&collection, &key("k")).await, [1, 2, 3]);
+    assert_eq!(registered_shard_ids(&collection).await, [1, 2, 3]);
+
+    collection.stop_gracefully().await;
+}
+
+/// Re-applying an entry that already committed is dismissed, and changes nothing
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_shard_key_replay_after_commit_is_dismissed() {
+    let dir = Builder::new().prefix("collection").tempdir().unwrap();
+    let collection = new_collection(dir.path()).await;
+
+    collection
+        .create_shard_key(key("k"), placement(2), ReplicaState::Active)
+        .await
+        .unwrap();
+
+    let err = collection
+        .create_shard_key(key("k"), placement(2), ReplicaState::Active)
+        .await
+        .unwrap_err();
+    assert_bad_request(err);
+
+    assert_eq!(mapped_shard_ids(&collection, &key("k")).await, [1, 2]);
+    assert_eq!(registered_shard_ids(&collection).await, [1, 2]);
+
+    collection.stop_gracefully().await;
+}
+
+/// A duplicate `CreateShardKey` for an existing key is not a replay, and must not be reconciled
+/// against the ids that key already holds: those ids anchor an allocation that runs straight into
+/// live shards belonging to other keys.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_shard_key_duplicate_with_different_placement_is_rejected() {
+    let dir = Builder::new().prefix("collection").tempdir().unwrap();
+    let collection = new_collection(dir.path()).await;
+
+    collection
+        .create_shard_key(key("k"), placement(2), ReplicaState::Active)
+        .await
+        .unwrap();
+    collection
+        .create_shard_key(key("other"), placement(1), ReplicaState::Active)
+        .await
+        .unwrap();
+
+    assert_eq!(mapped_shard_ids(&collection, &key("k")).await, [1, 2]);
+    assert_eq!(mapped_shard_ids(&collection, &key("other")).await, [3]);
+
+    // Anchoring on the ids of "k" and skipping the ones it already has would allocate shard 3 —
+    // which "other" owns — and overwrite it
+    let err = collection
+        .create_shard_key(key("k"), placement(3), ReplicaState::Active)
+        .await
+        .unwrap_err();
+    assert_bad_request(err);
+
+    assert_eq!(mapped_shard_ids(&collection, &key("k")).await, [1, 2]);
+    assert_eq!(mapped_shard_ids(&collection, &key("other")).await, [3]);
+    assert_eq!(registered_shard_ids(&collection).await, [1, 2, 3]);
+
+    collection.stop_gracefully().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_shard_key_rejects_empty_placement() {
+    let dir = Builder::new().prefix("collection").tempdir().unwrap();
+    let collection = new_collection(dir.path()).await;
+
+    let err = collection
+        .create_shard_key(key("k"), placement(0), ReplicaState::Active)
+        .await
+        .unwrap_err();
+    assert_bad_request(err);
+
+    assert!(collection.state().await.shards_key_mapping.is_empty());
+
+    collection.stop_gracefully().await;
+}

--- a/lib/collection/tests/integration/main.rs
+++ b/lib/collection/tests/integration/main.rs
@@ -2,6 +2,7 @@ mod collection_restore_test;
 mod collection_test;
 mod common;
 mod continuous_snapshot_test;
+mod create_shard_key_test;
 mod distance_matrix_test;
 mod grouping_test;
 mod lookup_test;


### PR DESCRIPTION
When creating new shard key, we create shards *and update shard-key mapping* ***one-by-one***.

So if we crash *while* creating new shards, on re-apply we would detect that shard key already exist (because shard key already exists in shard-key mapping) and reject operation with "bad request", and end up with *some*, but *not all* shards created on the node.

This PR changes the process, so that we create all shards first, and then update shard-key mapping atomically at the end of the operation. This way on re-apply we either deterministically re-create all shards or log "bad request" error (if crash happened after shard-key mappings were updated, but before updating consensus apply queue).

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
