### PR TITLE
Serialize snapshot recoveries of the same shard

### DIFF
--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -25,7 +25,7 @@ use crate::shards::remote_shard::RemoteShard;
 use crate::shards::replica_set::ShardReplicaSet;
 use crate::shards::shard::{PeerId, ShardId};
 use crate::shards::shard_config::{self, ShardConfig};
-use crate::shards::shard_holder::recovery_guard::RecoveryProgressHandle;
+use crate::shards::shard_holder::recovery_guard::{RecoveryProgressHandle, ShardRecoveryGuard};
 use crate::shards::shard_holder::shard_mapping::ShardKeyMapping;
 use crate::shards::shard_holder::{SHARD_KEY_MAPPING_FILE, ShardHolder, shard_not_found_error};
 use crate::shards::shard_path;
@@ -375,6 +375,34 @@ impl Collection {
             .read()
             .await
             .assert_shard_exists(shard_id)
+    }
+
+    /// Start a snapshot recovery of `shard_id`, waiting for one already in progress to
+    /// finish.
+    ///
+    /// The returned guard holds the shard's recovery lock and must be held for the whole
+    /// recovery - clear, download and restore. See [`ShardRecoveryGuard`].
+    pub async fn start_shard_recovery(
+        &self,
+        shard_id: ShardId,
+    ) -> CollectionResult<ShardRecoveryGuard> {
+        // Release the shard holder before awaiting: the lock is held for the length of a
+        // snapshot download, which would stall the whole collection.
+        let replica_set = self
+            .shards_holder
+            .read()
+            .await
+            .get_shard(shard_id)
+            .cloned()
+            .ok_or_else(|| shard_not_found_error(shard_id))?;
+
+        let recovery_lock = replica_set.take_snapshot_recovery_lock().await;
+
+        Ok(self
+            .shards_holder
+            .read()
+            .await
+            .start_shard_recovery(shard_id, recovery_lock))
     }
 
     /// Drop the local shard and clear its on-disk data, before a shard snapshot

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -125,6 +125,10 @@ pub struct ShardReplicaSet {
     /// Local clock set, used to tag new operations on this shard.
     clock_set: Mutex<ClockSet>,
     pub partial_snapshot_meta: PartialSnapshotMeta,
+    /// Serializes full snapshot recoveries of this shard.
+    ///
+    /// See [`ShardReplicaSet::take_snapshot_recovery_lock`].
+    snapshot_recovery_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 pub type AbortShardTransfer = Arc<dyn Fn(ShardTransfer, &str) + Send + Sync>;
@@ -224,6 +228,7 @@ impl ShardReplicaSet {
             write_ordering_lock: Mutex::new(()),
             clock_set: Default::default(),
             partial_snapshot_meta: PartialSnapshotMeta::default(),
+            snapshot_recovery_lock: Default::default(),
         })
     }
 
@@ -355,6 +360,7 @@ impl ShardReplicaSet {
             write_ordering_lock: Mutex::new(()),
             clock_set: Default::default(),
             partial_snapshot_meta: PartialSnapshotMeta::default(),
+            snapshot_recovery_lock: Default::default(),
         };
 
         // `active_remote_shards` includes `Active` and `ReshardingScaleDown` replicas!

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::Arc;
 
 use common::fs::{safe_delete_with_suffix, sync_parent_dir_async};
 use common::save_on_disk::SaveOnDisk;
@@ -84,6 +85,44 @@ impl ShardReplicaSet {
         &self,
     ) -> CollectionResult<tokio::sync::OwnedRwLockWriteGuard<()>> {
         self.partial_snapshot_meta.try_take_recovery_lock()
+    }
+
+    /// Exclusive access to full snapshot recovery of this shard, waiting for one in
+    /// progress to finish. Waiters are served in arrival order.
+    ///
+    /// Must be held across the whole recovery - clear, download and restore - each of
+    /// which is destructive on its own. While held, no other recovery of this shard can
+    /// make progress, so the recovery that reports success is the last one to touch the
+    /// shard and cannot be rolled back by one that is still in flight.
+    ///
+    /// Callers go through [`Collection::start_shard_recovery`], which folds this into the
+    /// [`ShardRecoveryGuard`] rather than leaving it to be held separately.
+    ///
+    /// [`Collection::start_shard_recovery`]: crate::collection::Collection::start_shard_recovery
+    /// [`ShardRecoveryGuard`]: crate::shards::shard_holder::recovery_guard::ShardRecoveryGuard
+    pub(crate) async fn take_snapshot_recovery_lock(&self) -> tokio::sync::OwnedMutexGuard<()> {
+        if let Ok(recovery_lock) = Arc::clone(&self.snapshot_recovery_lock).try_lock_owned() {
+            return recovery_lock;
+        }
+
+        log::warn!(
+            "Snapshot recovery of shard {}:{} is waiting for a recovery of the same shard \
+             that is already in progress",
+            self.collection_id,
+            self.shard_id,
+        );
+
+        let waiting_since = std::time::Instant::now();
+        let recovery_lock = Arc::clone(&self.snapshot_recovery_lock).lock_owned().await;
+
+        log::info!(
+            "Snapshot recovery of shard {}:{} waited {:.1}s for the previous recovery to finish",
+            self.collection_id,
+            self.shard_id,
+            waiting_since.elapsed().as_secs_f32(),
+        );
+
+        recovery_lock
     }
 
     pub fn restore_snapshot(
@@ -450,187 +489,4 @@ async fn wait_restore_local_replica_before_flag_hook_for_test(shard_flag: &Path)
 }
 
 #[cfg(test)]
-mod tests {
-    use std::collections::HashSet;
-    use std::num::NonZeroU32;
-    use std::sync::Arc;
-
-    use common::budget::ResourceBudget;
-    use common::save_on_disk::SaveOnDisk;
-    use segment::types::Distance;
-    use tempfile::{Builder, TempDir};
-    use tokio::runtime::Handle;
-    use tokio::sync::{RwLock, oneshot};
-
-    use super::*;
-    use crate::collection::payload_index_schema::PayloadIndexSchema;
-    use crate::common::adaptive_handle::AdaptiveSearchHandle;
-    use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
-    use crate::operations::shared_storage_config::SharedStorageConfig;
-    use crate::operations::types::VectorsConfig;
-    use crate::operations::vector_params_builder::VectorParamsBuilder;
-    use crate::optimizers_builder::OptimizersConfig;
-    use crate::shards::channel_service::ChannelService;
-    use crate::shards::replica_set::replica_set_state::ReplicaState;
-    use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
-    use crate::shards::shard::ShardId;
-
-    const TEST_COLLECTION_ID: &str = "test_collection";
-    const TEST_TARGET_SHARD_ID: ShardId = 1;
-    const TEST_SOURCE_SHARD_ID: ShardId = 2;
-    const TEST_PEER_ID: PeerId = 1;
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_cancel_snapshot_recovery_before_initializing_flag_does_not_mark_dirty() {
-        let target_collection_dir = Builder::new()
-            .prefix("snapshot-recovery-cancel-target")
-            .tempdir()
-            .unwrap();
-        let source_collection_dir = Builder::new()
-            .prefix("snapshot-recovery-cancel-source")
-            .tempdir()
-            .unwrap();
-
-        let target_replica_set =
-            new_shard_replica_set(&target_collection_dir, TEST_TARGET_SHARD_ID).await;
-        let source_replica_set =
-            new_shard_replica_set(&source_collection_dir, TEST_SOURCE_SHARD_ID).await;
-
-        let source_shard_path = source_collection_dir
-            .path()
-            .join(TEST_SOURCE_SHARD_ID.to_string());
-        assert!(
-            LocalShard::check_data(&source_shard_path),
-            "test fixture must create a valid source local shard"
-        );
-
-        let shard_flag =
-            shard_initializing_flag_path(target_collection_dir.path(), TEST_TARGET_SHARD_ID);
-        let (reached_tx, reached_rx) = oneshot::channel();
-        let (release_tx, release_rx) = oneshot::channel();
-        install_restore_local_replica_before_flag_hook(shard_flag.clone(), reached_tx, release_rx);
-
-        let cancel = cancel::CancellationToken::new();
-        let restore = target_replica_set.restore_local_replica_from(
-            &source_shard_path,
-            RecoveryType::Full,
-            target_collection_dir.path(),
-            cancel.clone(),
-        );
-        tokio::pin!(restore);
-
-        tokio::select! {
-            _ = reached_rx => {}
-            result = &mut restore => {
-                panic!("snapshot recovery completed before the cancellation window: {result:?}");
-            }
-        }
-
-        cancel.cancel();
-        let _ = release_tx.send(());
-
-        let result = restore.await;
-        assert!(
-            matches!(result, Err(CollectionError::Cancelled { .. })),
-            "recovery should observe cancellation before creating the initializing flag, got {result:?}"
-        );
-        assert!(
-            !shard_flag.exists(),
-            "cancellation before destructive restore starts must not leave a false dirty marker"
-        );
-        assert!(
-            !target_replica_set.is_dummy().await,
-            "cancellation before destructive restore starts must keep the old local shard installed"
-        );
-
-        let local = target_replica_set.local.read().await;
-        assert!(
-            matches!(local.as_ref(), Some(Shard::Local(_))),
-            "the old local shard should remain installed"
-        );
-        drop(local);
-
-        target_replica_set.stop_gracefully().await;
-        source_replica_set.stop_gracefully().await;
-    }
-
-    fn install_restore_local_replica_before_flag_hook(
-        shard_flag: std::path::PathBuf,
-        reached: oneshot::Sender<()>,
-        release: oneshot::Receiver<()>,
-    ) {
-        let mut hook = RESTORE_LOCAL_REPLICA_BEFORE_FLAG_HOOK.lock().unwrap();
-        assert!(
-            hook.is_none(),
-            "restore-local-replica test hook is already installed"
-        );
-        *hook = Some((shard_flag, reached, release));
-    }
-
-    async fn new_shard_replica_set(collection_dir: &TempDir, shard_id: ShardId) -> ShardReplicaSet {
-        let update_runtime = Handle::current();
-        let search_runtime = AdaptiveSearchHandle::current_for_tests();
-
-        let wal_config = WalConfig {
-            wal_capacity_mb: 1,
-            wal_segments_ahead: 0,
-            wal_retain_closed: 1,
-        };
-
-        let collection_params = CollectionParams {
-            vectors: VectorsConfig::Single(VectorParamsBuilder::new(4, Distance::Dot).build()),
-            shard_number: NonZeroU32::new(1).unwrap(),
-            replication_factor: NonZeroU32::new(1).unwrap(),
-            write_consistency_factor: NonZeroU32::new(1).unwrap(),
-            ..CollectionParams::empty()
-        };
-
-        let optimizers_config = OptimizersConfig::fixture();
-        let config = CollectionConfigInternal {
-            params: collection_params,
-            optimizer_config: optimizers_config.clone(),
-            wal_config,
-            hnsw_config: Default::default(),
-            quantization_config: None,
-            strict_mode_config: None,
-            uuid: None,
-            metadata: None,
-        };
-
-        let payload_index_schema_file = collection_dir.path().join("payload-schema.json");
-        let payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>> =
-            Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
-        let shared_config = Arc::new(RwLock::new(config));
-
-        ShardReplicaSet::build(
-            shard_id,
-            None,
-            TEST_COLLECTION_ID.to_string(),
-            TEST_PEER_ID,
-            true,
-            HashSet::new(),
-            dummy_on_replica_failure(),
-            dummy_abort_shard_transfer(),
-            collection_dir.path(),
-            shared_config,
-            optimizers_config.clone(),
-            Arc::new(SharedStorageConfig::default()),
-            payload_index_schema,
-            ChannelService::default(),
-            update_runtime,
-            search_runtime,
-            ResourceBudget::default(),
-            Some(ReplicaState::Active),
-        )
-        .await
-        .unwrap()
-    }
-
-    fn dummy_on_replica_failure() -> ChangePeerFromState {
-        Arc::new(move |_peer_id, _shard_id, _from_state| {})
-    }
-
-    fn dummy_abort_shard_transfer() -> AbortShardTransfer {
-        Arc::new(|_shard_transfer, _reason| {})
-    }
-}
+mod tests;

--- a/lib/collection/src/shards/replica_set/snapshots/tests.rs
+++ b/lib/collection/src/shards/replica_set/snapshots/tests.rs
@@ -1,0 +1,382 @@
+use std::collections::HashSet;
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+use common::budget::ResourceBudget;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::save_on_disk::SaveOnDisk;
+use common::types::DeferredBehavior;
+use segment::types::Distance;
+use tempfile::{Builder, TempDir};
+use tokio::runtime::Handle;
+use tokio::sync::{RwLock, oneshot};
+
+use super::*;
+use crate::collection::payload_index_schema::PayloadIndexSchema;
+use crate::common::adaptive_handle::AdaptiveSearchHandle;
+use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
+use crate::operations::point_ops::{
+    PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,
+};
+use crate::operations::shared_storage_config::SharedStorageConfig;
+use crate::operations::types::{CountRequestInternal, VectorsConfig};
+use crate::operations::vector_params_builder::VectorParamsBuilder;
+use crate::operations::{CollectionUpdateOperations, OperationWithClockTag};
+use crate::optimizers_builder::OptimizersConfig;
+use crate::shards::channel_service::ChannelService;
+use crate::shards::replica_set::replica_set_state::ReplicaState;
+use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
+use crate::shards::shard::ShardId;
+use crate::shards::shard_trait::WaitUntil;
+
+const TEST_COLLECTION_ID: &str = "test_collection";
+const TEST_TARGET_SHARD_ID: ShardId = 1;
+const TEST_SOURCE_SHARD_ID: ShardId = 2;
+const TEST_PEER_ID: PeerId = 1;
+
+/// How long the abandoned recovery stalls before restoring, once it is clear the
+/// retry is not going to finish because it is queued behind it.
+const STALLED_RECOVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cancel_snapshot_recovery_before_initializing_flag_does_not_mark_dirty() {
+    let target_collection_dir = Builder::new()
+        .prefix("snapshot-recovery-cancel-target")
+        .tempdir()
+        .unwrap();
+    let source_collection_dir = Builder::new()
+        .prefix("snapshot-recovery-cancel-source")
+        .tempdir()
+        .unwrap();
+
+    let target_replica_set =
+        new_shard_replica_set(&target_collection_dir, TEST_TARGET_SHARD_ID).await;
+    let source_replica_set =
+        new_shard_replica_set(&source_collection_dir, TEST_SOURCE_SHARD_ID).await;
+
+    let source_shard_path = source_collection_dir
+        .path()
+        .join(TEST_SOURCE_SHARD_ID.to_string());
+    assert!(
+        LocalShard::check_data(&source_shard_path),
+        "test fixture must create a valid source local shard"
+    );
+
+    let shard_flag =
+        shard_initializing_flag_path(target_collection_dir.path(), TEST_TARGET_SHARD_ID);
+    let (reached_tx, reached_rx) = oneshot::channel();
+    let (release_tx, release_rx) = oneshot::channel();
+    install_restore_local_replica_before_flag_hook(shard_flag.clone(), reached_tx, release_rx);
+
+    let cancel = cancel::CancellationToken::new();
+    let restore = target_replica_set.restore_local_replica_from(
+        &source_shard_path,
+        RecoveryType::Full,
+        target_collection_dir.path(),
+        cancel.clone(),
+    );
+    tokio::pin!(restore);
+
+    tokio::select! {
+        _ = reached_rx => {}
+        result = &mut restore => {
+            panic!("snapshot recovery completed before the cancellation window: {result:?}");
+        }
+    }
+
+    cancel.cancel();
+    let _ = release_tx.send(());
+
+    let result = restore.await;
+    assert!(
+        matches!(result, Err(CollectionError::Cancelled { .. })),
+        "recovery should observe cancellation before creating the initializing flag, got {result:?}"
+    );
+    assert!(
+        !shard_flag.exists(),
+        "cancellation before destructive restore starts must not leave a false dirty marker"
+    );
+    assert!(
+        !target_replica_set.is_dummy().await,
+        "cancellation before destructive restore starts must keep the old local shard installed"
+    );
+
+    let local = target_replica_set.local.read().await;
+    assert!(
+        matches!(local.as_ref(), Some(Shard::Local(_))),
+        "the old local shard should remain installed"
+    );
+    drop(local);
+
+    target_replica_set.stop_gracefully().await;
+    source_replica_set.stop_gracefully().await;
+}
+
+/// An abandoned snapshot recovery must not roll back the one that replaced it.
+///
+/// Unserialized, two recoveries of one shard resolve as *last to finish wins*, and the
+/// abandoned one wins: it is abandoned because it stalled, so it finishes after the
+/// retry it was replaced by, and restores on top of it.
+///
+/// ```text
+/// stalled: clear -> download ..........................-> restore -> rolls back retry
+/// retry:      clear -> download -> restore -> Ok to caller -> caller writes
+/// ```
+#[tokio::test(flavor = "multi_thread")]
+async fn test_abandoned_snapshot_recovery_does_not_roll_back_the_retry() {
+    let target_collection_dir = Builder::new()
+        .prefix("concurrent-recovery-target")
+        .tempdir()
+        .unwrap();
+
+    let target_replica_set =
+        Arc::new(new_shard_replica_set(&target_collection_dir, TEST_TARGET_SHARD_ID).await);
+
+    // `clear_local_for_snapshot_recovery` refuses to run on a source-of-truth replica.
+    // The receiving replica of a snapshot transfer sits in `PartialSnapshot`.
+    target_replica_set
+        .set_replica_state(TEST_PEER_ID, ReplicaState::PartialSnapshot)
+        .await
+        .unwrap();
+
+    // One downloaded copy of the shard snapshot per recovery: `restore_local_replica_from`
+    // moves the data out of the directory it is given, so they cannot share one.
+    let (_stalled_snapshot_dir, stalled_snapshot) = new_shard_snapshot().await;
+    let (_retry_snapshot_dir, retry_snapshot) = new_shard_snapshot().await;
+
+    let (stalled_cleared_tx, stalled_cleared_rx) = oneshot::channel();
+    let (retry_done_tx, retry_done_rx) = oneshot::channel();
+
+    // The recovery that will be abandoned. It clears the shard, then stalls in its
+    // download for as long as the retry needs.
+    let stalled_recovery = {
+        let replica_set = Arc::clone(&target_replica_set);
+        let collection_path = target_collection_dir.path().to_path_buf();
+
+        tokio::spawn(async move {
+            let _recovery_lock = replica_set.take_snapshot_recovery_lock().await;
+
+            replica_set
+                .clear_local_for_snapshot_recovery(&collection_path)
+                .await
+                .unwrap();
+
+            let _ = stalled_cleared_tx.send(());
+
+            // Stall until the retry is done - or, once recoveries are serialized, until
+            // it is clear the retry cannot proceed because it is waiting on this lock.
+            let _ = tokio::time::timeout(STALLED_RECOVERY_TIMEOUT, retry_done_rx).await;
+
+            replica_set
+                .restore_local_replica_from(
+                    &stalled_snapshot,
+                    RecoveryType::Full,
+                    &collection_path,
+                    cancel::CancellationToken::new(),
+                )
+                .await
+                .unwrap()
+        })
+    };
+
+    // The retry lands while the stalled recovery is in flight.
+    stalled_cleared_rx.await.unwrap();
+
+    let retry_recovery = {
+        let replica_set = Arc::clone(&target_replica_set);
+        let collection_path = target_collection_dir.path().to_path_buf();
+
+        tokio::spawn(async move {
+            let _recovery_lock = replica_set.take_snapshot_recovery_lock().await;
+
+            replica_set
+                .clear_local_for_snapshot_recovery(&collection_path)
+                .await
+                .unwrap();
+
+            let restored = replica_set
+                .restore_local_replica_from(
+                    &retry_snapshot,
+                    RecoveryType::Full,
+                    &collection_path,
+                    cancel::CancellationToken::new(),
+                )
+                .await
+                .unwrap();
+
+            // The retry reported success, so its caller acts on it: the sender switches
+            // the transfer to `Partial` and flushes its queue proxy into the shard.
+            replica_set
+                .set_replica_state(TEST_PEER_ID, ReplicaState::Partial)
+                .await
+                .unwrap();
+            upsert_point(&replica_set, 42).await;
+
+            let _ = retry_done_tx.send(());
+
+            restored
+        })
+    };
+
+    assert!(
+        retry_recovery.await.unwrap(),
+        "the retry should have restored the shard"
+    );
+    assert!(
+        stalled_recovery.await.unwrap(),
+        "the stalled recovery should have restored the shard"
+    );
+
+    assert_eq!(
+        count_points(&target_replica_set).await,
+        1,
+        "the abandoned recovery rolled back the retry that replaced it: the write \
+         the caller made after the retry reported success was discarded",
+    );
+
+    target_replica_set.stop_gracefully().await;
+}
+
+/// Build a valid unpacked shard snapshot to recover from.
+///
+/// Returns the temp dir - which the caller must keep alive - and the replica path
+/// inside it, in the shape `restore_local_replica_from` expects.
+async fn new_shard_snapshot() -> (TempDir, std::path::PathBuf) {
+    let collection_dir = Builder::new()
+        .prefix("concurrent-recovery-snapshot")
+        .tempdir()
+        .unwrap();
+
+    let replica_set = new_shard_replica_set(&collection_dir, TEST_SOURCE_SHARD_ID).await;
+    replica_set.force_flush_local_for_test().await;
+    replica_set.stop_gracefully().await;
+
+    let replica_path = collection_dir.path().join(TEST_SOURCE_SHARD_ID.to_string());
+    assert!(
+        LocalShard::check_data(&replica_path),
+        "test fixture must produce a valid shard snapshot"
+    );
+
+    (collection_dir, replica_path)
+}
+
+async fn upsert_point(replica_set: &ShardReplicaSet, id: u64) {
+    let operation = OperationWithClockTag::from(CollectionUpdateOperations::PointOperation(
+        PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsList(vec![
+            PointStructPersisted {
+                id: id.into(),
+                vector: VectorStructPersisted::Single(vec![0.1, 0.2, 0.3, 0.4]),
+                payload: None,
+            },
+        ])),
+    ));
+
+    replica_set
+        .update_local(
+            operation,
+            WaitUntil::Visible,
+            None,
+            HwMeasurementAcc::new(),
+            false,
+        )
+        .await
+        .expect("failed to upsert point")
+        .expect("local shard must be present");
+}
+
+async fn count_points(replica_set: &ShardReplicaSet) -> usize {
+    replica_set
+        .count_local(
+            Arc::new(CountRequestInternal {
+                filter: None,
+                exact: true,
+            }),
+            None,
+            HwMeasurementAcc::new(),
+            DeferredBehavior::VisibleOnly,
+        )
+        .await
+        .expect("failed to count points")
+        .expect("local shard must be present")
+        .count
+}
+
+fn install_restore_local_replica_before_flag_hook(
+    shard_flag: std::path::PathBuf,
+    reached: oneshot::Sender<()>,
+    release: oneshot::Receiver<()>,
+) {
+    let mut hook = RESTORE_LOCAL_REPLICA_BEFORE_FLAG_HOOK.lock().unwrap();
+    assert!(
+        hook.is_none(),
+        "restore-local-replica test hook is already installed"
+    );
+    *hook = Some((shard_flag, reached, release));
+}
+
+async fn new_shard_replica_set(collection_dir: &TempDir, shard_id: ShardId) -> ShardReplicaSet {
+    let update_runtime = Handle::current();
+    let search_runtime = AdaptiveSearchHandle::current_for_tests();
+
+    let wal_config = WalConfig {
+        wal_capacity_mb: 1,
+        wal_segments_ahead: 0,
+        wal_retain_closed: 1,
+    };
+
+    let collection_params = CollectionParams {
+        vectors: VectorsConfig::Single(VectorParamsBuilder::new(4, Distance::Dot).build()),
+        shard_number: NonZeroU32::new(1).unwrap(),
+        replication_factor: NonZeroU32::new(1).unwrap(),
+        write_consistency_factor: NonZeroU32::new(1).unwrap(),
+        ..CollectionParams::empty()
+    };
+
+    let optimizers_config = OptimizersConfig::fixture();
+    let config = CollectionConfigInternal {
+        params: collection_params,
+        optimizer_config: optimizers_config.clone(),
+        wal_config,
+        hnsw_config: Default::default(),
+        quantization_config: None,
+        strict_mode_config: None,
+        uuid: None,
+        metadata: None,
+    };
+
+    let payload_index_schema_file = collection_dir.path().join("payload-schema.json");
+    let payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>> =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+    let shared_config = Arc::new(RwLock::new(config));
+
+    ShardReplicaSet::build(
+        shard_id,
+        None,
+        TEST_COLLECTION_ID.to_string(),
+        TEST_PEER_ID,
+        true,
+        HashSet::new(),
+        dummy_on_replica_failure(),
+        dummy_abort_shard_transfer(),
+        collection_dir.path(),
+        shared_config,
+        optimizers_config.clone(),
+        Arc::new(SharedStorageConfig::default()),
+        payload_index_schema,
+        ChannelService::default(),
+        update_runtime,
+        search_runtime,
+        ResourceBudget::default(),
+        Some(ReplicaState::Active),
+    )
+    .await
+    .unwrap()
+}
+
+fn dummy_on_replica_failure() -> ChangePeerFromState {
+    Arc::new(move |_peer_id, _shard_id, _from_state| {})
+}
+
+fn dummy_abort_shard_transfer() -> AbortShardTransfer {
+    Arc::new(|_shard_transfer, _reason| {})
+}

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -488,13 +488,19 @@ impl ShardHolder {
         (incoming, outgoing)
     }
 
-    /// Start tracking recovery progress for a shard (destination side).
+    /// Start a snapshot recovery of a shard (destination side).
     ///
-    /// Returns a [`ShardRecoveryGuard`] that must be held for the duration of the
-    /// recovery. Dropping the guard - on success, error, or cancellation - stops
-    /// tracking and removes the progress entry.
-    pub fn start_shard_recovery(&self, shard_id: ShardId) -> ShardRecoveryGuard {
-        self.active_recoveries.start(shard_id)
+    /// Requires the shard's recovery lock, which the returned [`ShardRecoveryGuard`]
+    /// takes ownership of. Prefer [`Collection::start_shard_recovery`], which acquires
+    /// the lock and calls this.
+    ///
+    /// [`Collection::start_shard_recovery`]: crate::collection::Collection::start_shard_recovery
+    pub fn start_shard_recovery(
+        &self,
+        shard_id: ShardId,
+        recovery_lock: tokio::sync::OwnedMutexGuard<()>,
+    ) -> ShardRecoveryGuard {
+        self.active_recoveries.start(shard_id, recovery_lock)
     }
 
     pub fn get_shard_transfer_info(

--- a/lib/collection/src/shards/shard_holder/recovery_guard.rs
+++ b/lib/collection/src/shards/shard_holder/recovery_guard.rs
@@ -29,7 +29,16 @@ pub struct ActiveRecoveries {
 impl ActiveRecoveries {
     /// Start tracking a recovery for `shard_id`, returning a guard that stops
     /// tracking on drop.
-    pub fn start(&self, shard_id: ShardId) -> ShardRecoveryGuard {
+    ///
+    /// Takes ownership of the shard's recovery lock, so a recovery cannot be started
+    /// without holding it. See [`ShardReplicaSet::take_snapshot_recovery_lock`].
+    ///
+    /// [`ShardReplicaSet::take_snapshot_recovery_lock`]: crate::shards::replica_set::ShardReplicaSet::take_snapshot_recovery_lock
+    pub fn start(
+        &self,
+        shard_id: ShardId,
+        recovery_lock: tokio::sync::OwnedMutexGuard<()>,
+    ) -> ShardRecoveryGuard {
         let progress = Arc::new(Mutex::new(RecoveryProgress::new()));
         self.recoveries
             .lock()
@@ -38,6 +47,7 @@ impl ActiveRecoveries {
             active_recoveries: self.clone(),
             shard_id,
             progress,
+            recovery_lock,
         }
     }
 
@@ -61,16 +71,23 @@ impl ActiveRecoveries {
     }
 }
 
-/// RAII guard for tracking an active snapshot recovery on the destination side.
+/// RAII guard for an active snapshot recovery on the destination side.
 ///
-/// While held, the recovery progress is registered in [`ActiveRecoveries`] so it can
-/// be reported in the transfer status. On drop - including early returns, errors, and
-/// cancellation - the entry is removed again, ensuring that stale recovery comments
-/// are never reported for subsequent transfers.
+/// While held, this is the only recovery of the shard that can make progress, and its
+/// progress is registered in [`ActiveRecoveries`] so it can be reported in the transfer
+/// status. On drop - including early returns, errors, and cancellation - the lock is
+/// released and the entry removed, so stale recovery comments are never reported for
+/// subsequent transfers.
+///
+/// Must be held for the whole recovery: it is what keeps a recovery that is still in
+/// flight from restoring on top of one that already reported success.
 pub struct ShardRecoveryGuard {
     active_recoveries: ActiveRecoveries,
     shard_id: ShardId,
     progress: RecoveryProgressHandle,
+    /// Released on drop, letting the next queued recovery of this shard start.
+    #[expect(dead_code, reason = "held for its `Drop`")]
+    recovery_lock: tokio::sync::OwnedMutexGuard<()>,
 }
 
 impl ShardRecoveryGuard {

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -188,13 +188,16 @@ pub async fn recover_shard_snapshot(
         let (collection, download_dir) =
             cancel::future::cancel_on_token(cancel.clone(), pre_recovery_task).await??;
 
-        // Guard tracks recovery progress and removes it on drop, on every exit path
-        // (success, error, or cancellation), so stale timings are never reported.
-        let recovery_guard = collection
-            .shards_holder()
-            .read()
-            .await
-            .start_shard_recovery(shard_id);
+        // Waits for a recovery of this shard already in progress, then holds it excluded
+        // for the whole recovery below and reports progress meanwhile. An abandoned
+        // recovery keeps running - `recover_shard_snapshot_impl` is not cancel safe - and
+        // would otherwise restore on top of the recovery that replaced it, discarding
+        // writes the caller made after being told it had succeeded.
+        let recovery_guard = cancel::future::cancel_on_token(
+            cancel.clone(),
+            collection.start_shard_recovery(shard_id),
+        )
+        .await??;
 
         // For shard transfers, drop the existing shard and clear its on-disk data
         // before downloading the new snapshot so we don't need space for both copies.
@@ -298,8 +301,8 @@ pub async fn recover_shard_snapshot(
         )
         .await;
 
-        // `recovery_guard` is dropped here (and on every early return above),
-        // which stops tracking recovery progress for this shard.
+        // `recovery_guard` is dropped here (and on every early return above), releasing
+        // the shard for the next queued recovery and stopping progress tracking.
         drop(recovery_guard);
 
         result


### PR DESCRIPTION
Replaces #10017, which was closed — its premise was wrong. `shard_path` is only ever mutated under `local.write()`, so a second recovery never wipes a directory the first is still writing. The real defect is different.

## Problem

Two snapshot recoveries of one shard resolve as **last to finish wins**. `restore_local_replica_from` is destructive on its own (for a full recovery it takes the `LocalShard::clear` + `move_data` branch), and nothing is atomic across the download that precedes it.

That picks the wrong winner. A recovery gets abandoned because it *stalled* — which is exactly why its caller timed out and retried — so it finishes **after** the retry that replaced it, and restores on top of it. It keeps running because `recover_shard_snapshot_impl` is not cancel safe, so a caller that walked away cannot stop it.

```
stalled: clear -> download ..........................-> restore -> rolls back retry
retry:      clear -> download -> restore -> Ok to caller -> caller writes
```

The retry's `Ok` is what the sender of a snapshot shard transfer acts on: it switches the transfer to `Partial` and flushes its queue proxy into the shard. The stalled recovery then restores its own copy on top and discards those writes — acknowledged, then lost.

Reachable in normal operation: a snapshot shard transfer retries its `recover` RPC (`DEFAULT_RETRIES = 2`, plus up to `MAX_RETRY_COUNT = 3` driver retries). Found while investigating a production shard transfer stuck in `Recovering` for 3.5h.

## Change

A per-shard recovery lock on `ShardReplicaSet`, held across the **whole** recovery — clear, download and restore — so what a caller asked for last is what survives. Clearing before the download is kept, so recovery still never needs disk space for two copies of the shard.

`ShardRecoveryGuard` already existed to track recovery progress for exactly this span, so the lock is folded into it rather than added alongside. `ActiveRecoveries::start` now takes ownership of the lock guard, so a recovery cannot be registered without holding it — enforced by the signature, not by convention — and `Collection::start_shard_recovery` is the single call that acquires both:

```rust
let recovery_guard = cancel::future::cancel_on_token(
    cancel.clone(),
    collection.start_shard_recovery(shard_id),
).await??;
```

It clones the `Arc<ShardReplicaSet>` and releases the shard holder *before* awaiting the lock, since holding it for the length of a snapshot download would stall the whole collection.

Queueing behind another recovery is logged (`warn` on entering the wait, `info` with the duration on acquiring). An abandoned recovery is otherwise invisible — no live caller, no request, no error — and surfaces only as a transfer sitting in `Recovering`.

## Test

`test_abandoned_snapshot_recovery_does_not_roll_back_the_retry` drives two concurrent recoveries with the stalled one starting first, and asserts the write made after the retry reported success survives. No cluster, no sleeps in the failing path, no `staging` feature — it drives `ShardReplicaSet` directly.

Verified it discriminates: with the lock neutralized (fresh mutex per call) it fails with `left: 0, right: 1`; with the real lock it passes.

The existing `mod tests` was moved out of `snapshots.rs` into `snapshots/tests.rs` — that file was heading past 800 lines.

## Notes for review

- **`tests/shard-snapshot-api.sh` should pass unchanged.** `recover-local-concurrent` / `recover-remote-concurrent` fire 10 concurrent recoveries and expect all to return 200; they now queue instead of racing. Worth confirming in CI — this is the suite that #10017 broke.
- **The snapshot *upload* paths remain unguarded.** `snapshot_api.rs:556/739/919` call `recover_shard_snapshot_impl` directly and take neither the guard nor the lock, so a manual upload can still overlap a transfer recovery. Pre-existing; left out to keep this focused, and now cheap to close since acquiring is one call.
- **The retry budget is unchanged and still tight.** ~100ms + ~200ms of gRPC backoff plus 1s/2s of driver delay is a few seconds against a multi-minute restore. This PR makes concurrent recoveries safe, not fast; a stalled predecessor can still burn the caller's retries. Separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)