### PR TITLE
Stop growing appendable segments past `max_segment_size`

### DIFF
--- a/lib/collection/src/collection_manager/collection_updater.rs
+++ b/lib/collection/src/collection_manager/collection_updater.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -44,6 +45,7 @@ impl CollectionUpdater {
         operation: CollectionUpdateOperations,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
+        max_segment_size_bytes: Option<NonZeroUsize>,
         hw_counter: &HardwareCounterCell,
     ) -> CollectionResult<usize> {
         // Use block_in_place here to avoid blocking the current async executor
@@ -62,16 +64,29 @@ impl CollectionUpdater {
 
             match operation {
                 CollectionUpdateOperations::PointOperation(point_operation) => {
-                    process_point_operation(&segments_guard, op_num, point_operation, hw_counter)
+                    process_point_operation(
+                        &segments_guard,
+                        op_num,
+                        point_operation,
+                        max_segment_size_bytes,
+                        hw_counter,
+                    )
                 }
                 CollectionUpdateOperations::VectorOperation(vector_operation) => {
-                    process_vector_operation(&segments_guard, op_num, vector_operation, hw_counter)
+                    process_vector_operation(
+                        &segments_guard,
+                        op_num,
+                        vector_operation,
+                        max_segment_size_bytes,
+                        hw_counter,
+                    )
                 }
                 CollectionUpdateOperations::PayloadOperation(payload_operation) => {
                     process_payload_operation(
                         &segments_guard,
                         op_num,
                         payload_operation,
+                        max_segment_size_bytes,
                         hw_counter,
                     )
                 }
@@ -182,6 +197,7 @@ mod tests {
             Some(10.into()),
             None,
             &points,
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -213,7 +229,7 @@ mod tests {
 
         let hw_counter = HardwareCounterCell::new();
 
-        let res = upsert_points(&segments.read(), 100, &points, &hw_counter);
+        let res = upsert_points(&segments.read(), 100, &points, None, &hw_counter);
         assert_matches!(res, Ok(1));
 
         let records = retrieve_blocking(
@@ -251,6 +267,7 @@ mod tests {
             PointOperations::DeletePoints {
                 ids: vec![500.into()],
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -295,6 +312,7 @@ mod tests {
                 filter: None,
                 key: None,
             }),
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -334,6 +352,7 @@ mod tests {
                 keys: vec!["color".parse().unwrap(), "empty".parse().unwrap()],
                 filter: None,
             }),
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -380,6 +399,7 @@ mod tests {
             PayloadOps::ClearPayload {
                 points: vec![2.into()],
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -452,6 +472,7 @@ mod tests {
                 filter: None,
                 key: Some(meta_key_path.clone()),
             }),
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -516,6 +537,7 @@ mod tests {
                 filter: None,
                 key: Some(meta_key_path.clone()),
             }),
+            None,
             &hw_counter,
         )
         .unwrap();

--- a/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/indexing_optimizer.rs
@@ -631,6 +631,7 @@ mod tests {
             &locked_holder.read(),
             opnum.next().unwrap(),
             insert_point_ops,
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -696,6 +697,7 @@ mod tests {
             &locked_holder.read(),
             opnum.next().unwrap(),
             insert_point_ops,
+            None,
             &hw_counter,
         )
         .unwrap();

--- a/lib/collection/src/collection_manager/tests/mod.rs
+++ b/lib/collection/src/collection_manager/tests/mod.rs
@@ -76,7 +76,7 @@ fn test_update_proxy_segments() {
                 payload: None,
             },
         ];
-        upsert_points(&segments.read(), 1000 + i, &points, &hw_counter).unwrap();
+        upsert_points(&segments.read(), 1000 + i, &points, None, &hw_counter).unwrap();
     }
 
     let all_ids = segments
@@ -138,7 +138,7 @@ fn test_move_points_to_copy_on_write() {
 
     // Points should be marked as deleted in proxy segment
     // and moved to another appendable segment (segment2)
-    upsert_points(&segments.read(), 1001, &points, &hw_counter).unwrap();
+    upsert_points(&segments.read(), 1001, &points, None, &hw_counter).unwrap();
 
     let points = vec![
         PointStructPersisted {
@@ -153,7 +153,7 @@ fn test_move_points_to_copy_on_write() {
         },
     ];
 
-    upsert_points(&segments.read(), 1002, &points, &hw_counter).unwrap();
+    upsert_points(&segments.read(), 1002, &points, None, &hw_counter).unwrap();
 
     let segments_write = segments.write();
 
@@ -250,7 +250,7 @@ fn test_upsert_points_in_smallest_segment() {
             payload: None,
         })
         .collect();
-    upsert_points(&segments.read(), 1000, &points, &hw_counter).unwrap();
+    upsert_points(&segments.read(), 1000, &points, None, &hw_counter).unwrap();
 
     // Segment 1 and 2 are over capacity, we expect to have the new points in segment 3
     {
@@ -467,7 +467,7 @@ fn test_proxy_shared_updates() {
 
     let ids = vec![idx1, idx2];
 
-    set_payload(&holder, 30, &payload, &ids, &None, &hw_counter).unwrap();
+    set_payload(&holder, 30, &payload, &ids, &None, None, &hw_counter).unwrap();
 
     // Points should still be accessible in both proxies through write segment
     for &point_id in &ids {
@@ -604,7 +604,7 @@ fn test_proxy_shared_updates_same_version() {
 
     let ids = vec![idx1, idx2];
 
-    set_payload(&holder, 20, &payload, &ids, &None, &hw_counter).unwrap();
+    set_payload(&holder, 20, &payload, &ids, &None, None, &hw_counter).unwrap();
 
     // Points should still be accessible in both proxies through write segment
     for &point_id in &ids {

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -170,6 +170,7 @@ impl OptimizersConfig {
         get_deferred_points_threshold_bytes(
             self.prevent_unoptimized,
             self.get_indexing_threshold_kb(),
+            self.max_segment_size,
         )
     }
 }

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -848,6 +848,16 @@ impl LocalShard {
         // operations, so a name that is created and used within the replay window stays valid.
         let mut valid_vector_names = self.collection_config.read().await.params.vector_names();
 
+        // Steer replayed copy-on-write moves with the same size cap live updates use, so replay
+        // picks the same class of destination. A deferred destination keeps the source point
+        // alive while a plain one deletes it, and a mismatch with what the live apply did could
+        // resurrect stale source data after recovery.
+        let max_segment_size_bytes = self
+            .optimizers
+            .load()
+            .first()
+            .and_then(|optimizer| optimizer.threshold_config().max_segment_size_bytes());
+
         for entry in wal.read_range(from..to) {
             let (op_num, mut update) = entry.map_err(|e| {
                 CollectionError::service_error(format!(
@@ -879,6 +889,7 @@ impl LocalShard {
                 update.operation,
                 self.update_operation_lock.clone(),
                 self.update_tracker.clone(),
+                max_segment_size_bytes,
                 &HardwareCounterCell::disposable(), // Internal operation, no measurement needed.
             ) {
                 Err(err @ CollectionError::ServiceError { error, backtrace }) => {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -876,6 +876,9 @@ impl LocalShard {
                 update.operation,
                 self.update_operation_lock.clone(),
                 self.update_tracker.clone(),
+                // Synchronous replay applies uncapped: these operations were accepted once
+                // already, and steering them now could only shuffle destinations at load time.
+                None,
                 &HardwareCounterCell::disposable(), // Internal operation, no measurement needed.
             ) {
                 Err(err @ CollectionError::ServiceError { error, backtrace }) => {

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -235,6 +235,8 @@ impl UpdateHandler {
             scroll_read_lock,
             update_tracker,
             self.prevent_unoptimized,
+            self.optimizers.clone(),
+            self.payload_index_schema.clone(),
             optimization_finished_receiver,
             applied_seq_handler,
             cancel,

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -140,6 +140,7 @@ impl UpdateWorkers {
                 wal.clone(),
                 update_operation_lock.clone(),
                 update_tracker.clone(),
+                some_optimizer.threshold_config().max_segment_size_bytes(),
             )
             .await
             .is_err()
@@ -449,25 +450,11 @@ impl UpdateWorkers {
         thresholds_config: &OptimizerThresholds,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
     ) -> OperationResult<()> {
-        let no_segment_with_capacity = {
-            let segments_read = segments.read();
-            segments_read
-                .appendable_segments_ids()
-                .into_iter()
-                .filter_map(|segment_id| segments_read.get(segment_id))
-                .all(|segment| {
-                    let max_vector_size_bytes = segment
-                        .get()
-                        .read()
-                        .max_available_vectors_size_in_bytes()
-                        .unwrap_or_default();
-                    let max_segment_size_bytes = thresholds_config
-                        .max_segment_size_kb
-                        .saturating_mul(segment::common::BYTES_IN_KB);
-
-                    max_vector_size_bytes >= max_segment_size_bytes
-                })
-        };
+        // Same eligibility rule the segment holder steers copy-on-write moves with, so the segment
+        // provisioned here is exactly the one those moves then target.
+        let no_segment_with_capacity = !segments
+            .read()
+            .has_appendable_segment_with_capacity(thresholds_config.max_segment_size_bytes());
 
         if no_segment_with_capacity {
             log::debug!("Creating new appendable segment, all existing segments are over capacity");
@@ -517,6 +504,7 @@ impl UpdateWorkers {
         wal: LockedWal,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
+        max_segment_size_bytes: Option<std::num::NonZeroUsize>,
     ) -> CollectionResult<usize> {
         // Try to re-apply everything starting from the first failed operation
         let first_failed_operation_option = segments.read().failed_operation.iter().cloned().min();
@@ -536,6 +524,7 @@ impl UpdateWorkers {
                         operation.operation,
                         update_operation_lock.clone(),
                         update_tracker.clone(),
+                        max_segment_size_bytes,
                         &HardwareCounterCell::disposable(), // Internal operation, no measurement needed
                     )?;
                 }

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -140,6 +140,7 @@ impl UpdateWorkers {
                 wal.clone(),
                 update_operation_lock.clone(),
                 update_tracker.clone(),
+                some_optimizer.threshold_config().max_segment_size_bytes(),
             )
             .await
             .is_err()
@@ -449,25 +450,9 @@ impl UpdateWorkers {
         thresholds_config: &OptimizerThresholds,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
     ) -> OperationResult<()> {
-        let no_segment_with_capacity = {
-            let segments_read = segments.read();
-            segments_read
-                .appendable_segments_ids()
-                .into_iter()
-                .filter_map(|segment_id| segments_read.get(segment_id))
-                .all(|segment| {
-                    let max_vector_size_bytes = segment
-                        .get()
-                        .read()
-                        .max_available_vectors_size_in_bytes()
-                        .unwrap_or_default();
-                    let max_segment_size_bytes = thresholds_config
-                        .max_segment_size_kb
-                        .saturating_mul(segment::common::BYTES_IN_KB);
-
-                    max_vector_size_bytes >= max_segment_size_bytes
-                })
-        };
+        let no_segment_with_capacity = !segments
+            .read()
+            .has_appendable_segment_with_capacity(thresholds_config.max_segment_size_bytes());
 
         if no_segment_with_capacity {
             log::debug!("Creating new appendable segment, all existing segments are over capacity");
@@ -517,6 +502,7 @@ impl UpdateWorkers {
         wal: LockedWal,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
+        max_segment_size_bytes: Option<std::num::NonZeroUsize>,
     ) -> CollectionResult<usize> {
         // Try to re-apply everything starting from the first failed operation
         let first_failed_operation_option = segments.read().failed_operation.iter().cloned().min();
@@ -536,6 +522,7 @@ impl UpdateWorkers {
                         operation.operation,
                         update_operation_lock.clone(),
                         update_tracker.clone(),
+                        max_segment_size_bytes,
                         &HardwareCounterCell::disposable(), // Internal operation, no measurement needed
                     )?;
                 }

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -7,10 +7,8 @@ use cancel::CancellationToken;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use segment::types::SeqNumberType;
+use shard::operations::CollectionUpdateOperations;
 use shard::operations::optimization::OptimizerThresholds;
-use shard::operations::point_ops::PointOperations;
-use shard::operations::vector_ops::VectorOperations;
-use shard::operations::{CollectionUpdateOperations, payload_ops};
 use shard::optimizers::config::SegmentOptimizerConfig;
 use shard::payload_index_schema::PayloadIndexSchema;
 use shard::segment_holder::locked::LockedSegmentHolder;
@@ -41,48 +39,6 @@ fn send_feedback(
         feedback.send(result).unwrap_or_else(|_| {
             log::debug!("Can't report operation {op_num} result. Assume already not required");
         });
-    }
-}
-
-/// Whether applying `operation` can need somewhere to put a point, and so is worth checking
-/// capacity for beforehand.
-///
-/// Only operations reaching `apply_points_with_conditional_move` (or inserting outright) can be
-/// given a destination, so deletes and schema-only operations skip the check entirely rather than
-/// measuring every appendable segment for nothing. Deliberately matched exhaustively: a new
-/// operation must be classified by whoever adds it, not silently default either way.
-fn may_need_write_capacity(operation: &CollectionUpdateOperations) -> bool {
-    match operation {
-        CollectionUpdateOperations::PointOperation(operation) => match operation {
-            PointOperations::UpsertPoints(_)
-            | PointOperations::UpsertPointsConditional(_)
-            | PointOperations::UpsertPointsRaw(_)
-            | PointOperations::SyncPoints(_)
-            | PointOperations::SyncPointsRaw(_) => true,
-            // Deletes never move a point, they only mark it.
-            PointOperations::DeletePoints { .. } | PointOperations::DeletePointsByFilter(_) => {
-                false
-            }
-        },
-        // Deleting a named vector from a point in an immutable segment moves the point too.
-        CollectionUpdateOperations::VectorOperation(operation) => match operation {
-            VectorOperations::UpdateVectors(_)
-            | VectorOperations::DeleteVectors(..)
-            | VectorOperations::DeleteVectorsByFilter(..) => true,
-        },
-        // Every payload operation copy-on-write moves the points it touches.
-        CollectionUpdateOperations::PayloadOperation(operation) => match operation {
-            payload_ops::PayloadOps::SetPayload(_)
-            | payload_ops::PayloadOps::DeletePayload(_)
-            | payload_ops::PayloadOps::ClearPayload { .. }
-            | payload_ops::PayloadOps::ClearPayloadByFilter(_)
-            | payload_ops::PayloadOps::OverwritePayload(_) => true,
-        },
-        // Schema-only, applied to every segment in place.
-        CollectionUpdateOperations::FieldIndexOperation(_)
-        | CollectionUpdateOperations::VectorNameOperation(_) => false,
-        #[cfg(feature = "staging")]
-        CollectionUpdateOperations::StagingOperation(_) => false,
     }
 }
 
@@ -226,11 +182,12 @@ impl UpdateWorkers {
                     // Classified before the operation is moved into the blocking task. Deletes and
                     // schema-only operations never need a destination, so they skip measuring
                     // every appendable segment.
-                    let operation_capacity_optimizer = if may_need_write_capacity(&operation) {
-                        capacity_optimizer.clone()
-                    } else {
-                        None
-                    };
+                    let operation_capacity_optimizer =
+                        if operation.may_need_appendable_destination() {
+                            capacity_optimizer.clone()
+                        } else {
+                            None
+                        };
                     let payload_index_schema_clone = payload_index_schema.clone();
                     let operation_result = tokio::task::spawn_blocking(move || {
                         // Give the operation a destination below the size cap before applying it,
@@ -487,11 +444,8 @@ impl UpdateWorkers {
 #[cfg(test)]
 mod tests {
     use common::save_on_disk::SaveOnDisk;
-    use segment::types::{Distance, PayloadFieldSchema, PayloadSchemaType};
+    use segment::types::Distance;
     use shard::fixtures::random_segment;
-    use shard::operations::payload_ops::PayloadOps;
-    use shard::operations::point_ops::{PointInsertOperationsInternal, PointOperations};
-    use shard::operations::vector_ops::VectorOperations;
     use shard::optimizers::config::SegmentOptimizerConfig;
     use shard::segment_holder::SegmentHolder;
     use tempfile::Builder;
@@ -499,51 +453,7 @@ mod tests {
     use super::*;
     use crate::operations::types::VectorsConfig;
     use crate::operations::vector_params_builder::VectorParamsBuilder;
-    use crate::operations::{CreateIndex, FieldIndexOperations};
     use crate::optimizers_builder::build_segment_optimizer_config;
-
-    /// Only operations that can be given a destination are worth measuring capacity for. Getting
-    /// this wrong is silent either way: too narrow skips provisioning for an operation that needs
-    /// it, too broad puts segment measurements back on every delete.
-    #[test]
-    fn test_may_need_write_capacity_classification() {
-        let point_ids = vec![1.into()];
-
-        // Moves or inserts points.
-        assert!(may_need_write_capacity(
-            &CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-                PointInsertOperationsInternal::PointsList(vec![]),
-            )),
-        ));
-        assert!(may_need_write_capacity(
-            &CollectionUpdateOperations::PayloadOperation(PayloadOps::ClearPayload {
-                points: point_ids.clone(),
-            }),
-        ));
-        // Deleting a named vector moves the point out of an immutable segment too.
-        assert!(may_need_write_capacity(
-            &CollectionUpdateOperations::VectorOperation(VectorOperations::DeleteVectors(
-                point_ids.clone().into(),
-                vec!["dense".into()],
-            )),
-        ));
-
-        // Marks points, never moves them.
-        assert!(!may_need_write_capacity(
-            &CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints {
-                ids: point_ids,
-            }),
-        ));
-        // Schema-only, applied to every segment in place.
-        assert!(!may_need_write_capacity(
-            &CollectionUpdateOperations::FieldIndexOperation(FieldIndexOperations::CreateIndex(
-                CreateIndex {
-                    field_name: "city".parse().unwrap(),
-                    field_schema: Some(PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword)),
-                },
-            )),
-        ));
-    }
 
     fn capacity_fixture(
         dir: &std::path::Path,

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -58,7 +58,9 @@ fn max_segment_size_bytes(optimizers: &[Arc<Optimizer>]) -> Option<NonZeroUsize>
 ///
 /// Best effort by design: a provisioning failure is logged and the operation is applied anyway,
 /// falling back to the pre-existing behaviour of writing into a full segment. Running out of
-/// capacity must never fail a write.
+/// capacity must never fail a write. The optimization worker deliberately panics on the same
+/// failure; here it must not, because a client write is in flight and losing capacity only costs
+/// segment size, not correctness.
 ///
 /// Blocking: builds a segment on disk, so this must be called from a blocking context.
 fn ensure_capacity_for_update(
@@ -67,7 +69,10 @@ fn ensure_capacity_for_update(
     payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
 ) {
     // Source the required parameters from the first optimizer, like the optimization worker does.
+    // That worker already logs and refuses to run without optimizers, so do not repeat the error
+    // for every operation passing through here.
     let Some(some_optimizer) = optimizers.first() else {
+        debug_assert!(false, "No optimizers configured");
         return;
     };
 

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -1,10 +1,13 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Instant;
 
 use cancel::CancellationToken;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::save_on_disk::SaveOnDisk;
 use segment::types::SeqNumberType;
 use shard::operations::CollectionUpdateOperations;
+use shard::payload_index_schema::PayloadIndexSchema;
 use shard::segment_holder::locked::LockedSegmentHolder;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::{oneshot, watch};
@@ -16,7 +19,7 @@ use crate::operations::types::{CollectionError, CollectionResult, UpdateStatus};
 use crate::profiling::interface::log_request_to_collector;
 use crate::shards::CollectionId;
 use crate::shards::update_tracker::UpdateTracker;
-use crate::update_handler::{OperationData, OptimizerSignal, UpdateSignal};
+use crate::update_handler::{OperationData, Optimizer, OptimizerSignal, UpdateSignal};
 use crate::update_workers::UpdateWorkers;
 use crate::update_workers::applied_seq::AppliedSeqHandler;
 use crate::update_workers::internal_update_result::InternalUpdateResult;
@@ -50,10 +53,19 @@ impl UpdateWorkers {
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
         prevent_unoptimized: bool,
+        optimizers: Arc<Vec<Arc<Optimizer>>>,
+        payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         optimization_finished_receiver: watch::Receiver<()>,
         applied_seq_handler: Arc<AppliedSeqHandler>,
         cancel: CancellationToken,
     ) -> Receiver<UpdateSignal> {
+        // Take thresholds from the first optimizer, like the optimization worker does.
+        // Resolved once, a config update restarts the workers.
+        let capacity_optimizer = optimizers.first().cloned();
+        let max_segment_size_bytes = capacity_optimizer
+            .as_ref()
+            .and_then(|optimizer| optimizer.threshold_config().max_segment_size_bytes());
+
         let receiver = loop {
             let signal = tokio::select! {
                 biased; // biased to check cancellation first
@@ -120,7 +132,25 @@ impl UpdateWorkers {
 
                     let wait = sender.is_some();
                     let segments_clone = segments.clone();
+                    let capacity_optimizer_clone = capacity_optimizer.clone();
+                    let payload_index_schema_clone = payload_index_schema.clone();
                     let operation_result = tokio::task::spawn_blocking(move || {
+                        // Make sure a destination below the size cap exists before applying.
+                        // Best effort, a failure here must not fail the write itself.
+                        if let Some(optimizer) = capacity_optimizer_clone
+                            && let Err(err) = Self::ensure_appendable_segment_with_capacity(
+                                &segments_clone,
+                                optimizer.segments_path(),
+                                optimizer.segment_optimizer_config(),
+                                optimizer.threshold_config(),
+                                payload_index_schema_clone,
+                            )
+                        {
+                            log::error!(
+                                "Failed to provision appendable capacity, applying anyway: {err}"
+                            );
+                        }
+
                         Self::update_worker_internal(
                             collection_name_clone,
                             operation,
@@ -130,6 +160,7 @@ impl UpdateWorkers {
                             segments_clone,
                             update_operation_lock_clone,
                             update_tracker_clone,
+                            max_segment_size_bytes,
                             hw_measurements,
                         )
                     })
@@ -311,6 +342,7 @@ impl UpdateWorkers {
         segments: LockedSegmentHolder,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
+        max_segment_size_bytes: Option<NonZeroUsize>,
         hw_measurements: HwMeasurementAcc,
     ) -> CollectionResult<usize> {
         // If wait flag is set, explicitly flush WAL first
@@ -337,6 +369,7 @@ impl UpdateWorkers {
                 operation,
                 update_operation_lock.clone(),
                 update_tracker.clone(),
+                max_segment_size_bytes,
                 &hw_measurements.get_counter_cell(),
             )
         });
@@ -354,5 +387,178 @@ impl UpdateWorkers {
         });
 
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use cancel::CancellationToken;
+    use common::counter::hardware_accumulator::HwMeasurementAcc;
+    use common::save_on_disk::SaveOnDisk;
+    use segment::common::BYTES_IN_KB;
+    use segment::entry::entry_point::SegmentEntry as _;
+    use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
+    use segment::types::{
+        Condition, Distance, FieldCondition, Filter, Match, MatchValue, ValueVariants,
+    };
+    use shard::fixtures::random_segment;
+    use shard::operations::OperationWithClockTag;
+    use shard::operations::payload_ops::{PayloadOps, SetPayloadOp};
+    use shard::segment_holder::SegmentHolder;
+    use shard::wal::SerdeWal;
+    use tempfile::Builder;
+    use tokio::sync::{Mutex as TokioMutex, RwLock as TokioRwLock, mpsc, oneshot, watch};
+    use wal::WalOptions;
+
+    use super::*;
+    use crate::config::CollectionConfigInternal;
+    use crate::operations::types::VectorsConfig;
+    use crate::operations::vector_params_builder::VectorParamsBuilder;
+    use crate::optimizers_builder::build_optimizers;
+    use crate::tests::fixtures::create_collection_config;
+
+    /// Check that the update worker provisions a segment with capacity before applying, and
+    /// applies with the size cap. The optimization worker is not running here, so the new
+    /// segment can only come from the update worker itself.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_update_worker_provisions_capacity_before_applying() {
+        let dir = Builder::new().prefix("shard").tempdir().unwrap();
+        let hw_counter = common::counter::hardware_counter::HardwareCounterCell::new();
+
+        // With 256-dim vectors a single point exceeds the 1 KB cap configured below.
+        // The non-appendable segment holds the point the filtered update matches.
+        const DIM: usize = 256;
+        let mut holder = SegmentHolder::default();
+        let full_id = holder.add_new(random_segment(dir.path(), 100, 3, DIM));
+        let mut source = build_simple_segment(dir.path(), DIM, Distance::Dot).unwrap();
+        source
+            .upsert_point(
+                1,
+                100.into(),
+                segment::data_types::vectors::only_default_vector(&vec![1.0; DIM]),
+                &hw_counter,
+            )
+            .unwrap();
+        source
+            .set_payload(
+                1,
+                100.into(),
+                &segment::payload_json! {"city": "Berlin".to_owned()},
+                &None,
+                &hw_counter,
+            )
+            .unwrap();
+        source.appendable_flag = false;
+        holder.add_new(source);
+        let segments = LockedSegmentHolder::new(holder);
+        assert_eq!(segments.read().len(), 2);
+
+        let full_size = segments
+            .read()
+            .get(full_id)
+            .unwrap()
+            .get()
+            .read()
+            .max_available_vectors_size_in_bytes()
+            .unwrap();
+        assert!(
+            full_size > BYTES_IN_KB,
+            "Segment should exceed the 1 KB cap"
+        );
+
+        let mut config: CollectionConfigInternal = create_collection_config();
+        config.params.vectors =
+            VectorsConfig::Single(VectorParamsBuilder::new(DIM as u64, Distance::Dot).build());
+        config.optimizer_config.max_segment_size = Some(1);
+        let config = Arc::new(TokioRwLock::new(config));
+
+        let optimizers = {
+            let read = config.read().await;
+            build_optimizers(
+                dir.path(),
+                config.clone(),
+                &read.params,
+                &read.optimizer_config,
+                &read.hnsw_config,
+                &Default::default(),
+                &read.quantization_config,
+            )
+        };
+
+        let payload_index_schema =
+            Arc::new(SaveOnDisk::load_or_init_default(dir.path().join("payload.schema")).unwrap());
+        let wal: SerdeWal<OperationWithClockTag> =
+            SerdeWal::new(dir.path(), WalOptions::default()).unwrap();
+        let wal = Arc::new(TokioMutex::new(wal));
+
+        let (update_sender, update_receiver) = mpsc::channel(8);
+        let (optimize_sender, _optimize_receiver) = mpsc::channel(8);
+        let (_finished_sender, finished_receiver) = watch::channel(());
+        let cancel = CancellationToken::new();
+
+        let worker = tokio::spawn(UpdateWorkers::update_worker_fn(
+            "test".to_string(),
+            update_receiver,
+            optimize_sender,
+            wal,
+            segments.clone(),
+            Arc::new(TokioRwLock::new(())),
+            UpdateTracker::default(),
+            false,
+            optimizers,
+            payload_index_schema,
+            finished_receiver,
+            Arc::new(AppliedSeqHandler::load_or_init(dir.path(), 0)),
+            cancel.clone(),
+        ));
+
+        let (feedback_sender, feedback_receiver) = oneshot::channel();
+        update_sender
+            .send(UpdateSignal::Operation(OperationData {
+                op_num: 10,
+                operation: Some(Box::new(CollectionUpdateOperations::PayloadOperation(
+                    PayloadOps::SetPayload(SetPayloadOp {
+                        payload: segment::payload_json! {"color": "red".to_owned()},
+                        points: None,
+                        filter: Some(Filter::new_must(Condition::Field(
+                            FieldCondition::new_match(
+                                "city".parse().unwrap(),
+                                Match::Value(MatchValue {
+                                    value: ValueVariants::String("Berlin".to_string()),
+                                }),
+                            ),
+                        ))),
+                        key: None,
+                    }),
+                ))),
+                sender: Some(feedback_sender),
+                wait_for_deferred: false,
+                hw_measurements: HwMeasurementAcc::new(),
+            }))
+            .await
+            .unwrap();
+
+        feedback_receiver.await.unwrap().unwrap();
+
+        assert_eq!(
+            segments.read().len(),
+            3,
+            "Worker should provision a new appendable segment before applying",
+        );
+        assert!(
+            !segments
+                .read()
+                .get(full_id)
+                .unwrap()
+                .get()
+                .read()
+                .has_point(100.into(), common::types::DeferredBehavior::WithDeferred),
+            "Moved point should not land in the full segment",
+        );
+
+        cancel.cancel();
+        let _ = worker.await;
     }
 }

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -394,3 +394,179 @@ impl UpdateWorkers {
         result
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use cancel::CancellationToken;
+    use common::counter::hardware_accumulator::HwMeasurementAcc;
+    use common::save_on_disk::SaveOnDisk;
+    use segment::common::BYTES_IN_KB;
+    use segment::entry::entry_point::SegmentEntry as _;
+    use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
+    use segment::types::{
+        Condition, Distance, FieldCondition, Filter, Match, MatchValue, ValueVariants,
+    };
+    use shard::fixtures::random_segment;
+    use shard::operations::OperationWithClockTag;
+    use shard::operations::payload_ops::{PayloadOps, SetPayloadOp};
+    use shard::segment_holder::SegmentHolder;
+    use shard::wal::SerdeWal;
+    use tempfile::Builder;
+    use tokio::sync::{Mutex as TokioMutex, RwLock as TokioRwLock, mpsc, oneshot, watch};
+    use wal::WalOptions;
+
+    use super::*;
+    use crate::config::CollectionConfigInternal;
+    use crate::operations::types::VectorsConfig;
+    use crate::operations::vector_params_builder::VectorParamsBuilder;
+    use crate::optimizers_builder::build_optimizers;
+    use crate::tests::fixtures::create_collection_config;
+
+    /// The worker must provision capacity itself, before applying, and must apply with the cap.
+    ///
+    /// Only the update worker runs here: at shard level the optimization worker provisions on
+    /// every wake-up too, so a new segment appearing would prove nothing about this path.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_update_worker_provisions_capacity_before_applying() {
+        let dir = Builder::new().prefix("shard").tempdir().unwrap();
+        let hw_counter = common::counter::hardware_counter::HardwareCounterCell::new();
+
+        // 1 KB is one vector of size 256, so a handful of points puts the appendable segment over
+        // the cap set below. The immutable segment holds the point the filtered update matches, so
+        // applying it has to move that point somewhere.
+        const DIM: usize = 256;
+        let mut holder = SegmentHolder::default();
+        let full_id = holder.add_new(random_segment(dir.path(), 100, 3, DIM));
+        let mut source = build_simple_segment(dir.path(), DIM, Distance::Dot).unwrap();
+        source
+            .upsert_point(
+                1,
+                100.into(),
+                segment::data_types::vectors::only_default_vector(&vec![1.0; DIM]),
+                &hw_counter,
+            )
+            .unwrap();
+        source
+            .set_payload(
+                1,
+                100.into(),
+                &segment::payload_json! {"city": "Berlin".to_owned()},
+                &None,
+                &hw_counter,
+            )
+            .unwrap();
+        source.appendable_flag = false;
+        holder.add_new(source);
+        let segments = LockedSegmentHolder::new(holder);
+        assert_eq!(segments.read().len(), 2);
+
+        // A cap the existing appendable segment is already at.
+        let full_size = segments
+            .read()
+            .get(full_id)
+            .unwrap()
+            .get()
+            .read()
+            .max_available_vectors_size_in_bytes()
+            .unwrap();
+        assert!(
+            full_size > BYTES_IN_KB,
+            "the fixture must exceed the 1 KB cap set below, measured {full_size}",
+        );
+
+        let mut config: CollectionConfigInternal = create_collection_config();
+        config.params.vectors =
+            VectorsConfig::Single(VectorParamsBuilder::new(DIM as u64, Distance::Dot).build());
+        config.optimizer_config.max_segment_size = Some(1);
+        let config = Arc::new(TokioRwLock::new(config));
+
+        let optimizers = {
+            let read = config.read().await;
+            build_optimizers(
+                dir.path(),
+                config.clone(),
+                &read.params,
+                &read.optimizer_config,
+                &read.hnsw_config,
+                &Default::default(),
+                &read.quantization_config,
+            )
+        };
+
+        let payload_index_schema =
+            Arc::new(SaveOnDisk::load_or_init_default(dir.path().join("payload.schema")).unwrap());
+        let wal: SerdeWal<OperationWithClockTag> =
+            SerdeWal::new(dir.path(), WalOptions::default()).unwrap();
+        let wal = Arc::new(TokioMutex::new(wal));
+
+        let (update_sender, update_receiver) = mpsc::channel(8);
+        let (optimize_sender, _optimize_receiver) = mpsc::channel(8);
+        let (_finished_sender, finished_receiver) = watch::channel(());
+        let cancel = CancellationToken::new();
+
+        let worker = tokio::spawn(UpdateWorkers::update_worker_fn(
+            "test".to_string(),
+            update_receiver,
+            optimize_sender,
+            wal,
+            segments.clone(),
+            Arc::new(TokioRwLock::new(())),
+            UpdateTracker::default(),
+            false,
+            optimizers,
+            payload_index_schema,
+            finished_receiver,
+            Arc::new(AppliedSeqHandler::load_or_init(dir.path(), 0)),
+            cancel.clone(),
+        ));
+
+        let (feedback_sender, feedback_receiver) = oneshot::channel();
+        update_sender
+            .send(UpdateSignal::Operation(OperationData {
+                op_num: 10,
+                operation: Some(Box::new(CollectionUpdateOperations::PayloadOperation(
+                    PayloadOps::SetPayload(SetPayloadOp {
+                        payload: segment::payload_json! {"color": "red".to_owned()},
+                        points: None,
+                        filter: Some(Filter::new_must(Condition::Field(
+                            FieldCondition::new_match(
+                                "city".parse().unwrap(),
+                                Match::Value(MatchValue {
+                                    value: ValueVariants::String("Berlin".to_string()),
+                                }),
+                            ),
+                        ))),
+                        key: None,
+                    }),
+                ))),
+                sender: Some(feedback_sender),
+                wait_for_deferred: false,
+                hw_measurements: HwMeasurementAcc::new(),
+            }))
+            .await
+            .unwrap();
+
+        feedback_receiver.await.unwrap().unwrap();
+
+        assert_eq!(
+            segments.read().len(),
+            3,
+            "the worker must provision a fresh appendable segment before applying",
+        );
+        assert!(
+            !segments
+                .read()
+                .get(full_id)
+                .unwrap()
+                .get()
+                .read()
+                .has_point(100.into(), common::types::DeferredBehavior::WithDeferred),
+            "the worker must apply with the cap, so the moved point avoids the full segment",
+        );
+
+        cancel.cancel();
+        let _ = worker.await;
+    }
+}

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -1,4 +1,5 @@
 use std::num::NonZeroUsize;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -6,7 +7,11 @@ use cancel::CancellationToken;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use segment::types::SeqNumberType;
-use shard::operations::CollectionUpdateOperations;
+use shard::operations::optimization::OptimizerThresholds;
+use shard::operations::point_ops::PointOperations;
+use shard::operations::vector_ops::VectorOperations;
+use shard::operations::{CollectionUpdateOperations, payload_ops};
+use shard::optimizers::config::SegmentOptimizerConfig;
 use shard::payload_index_schema::PayloadIndexSchema;
 use shard::segment_holder::locked::LockedSegmentHolder;
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -39,13 +44,46 @@ fn send_feedback(
     }
 }
 
-/// The soft appendable segment size cap, sourced live from the first optimizer like the
-/// optimization worker does, so the steering below and the provisioning above cannot disagree on
-/// what "full" means. `None` (uncapped) when no optimizers are configured.
-fn max_segment_size_bytes(optimizers: &[Arc<Optimizer>]) -> Option<NonZeroUsize> {
-    optimizers
-        .first()
-        .and_then(|optimizer| optimizer.threshold_config().max_segment_size_bytes())
+/// Whether applying `operation` can need somewhere to put a point, and so is worth checking
+/// capacity for beforehand.
+///
+/// Only operations reaching `apply_points_with_conditional_move` (or inserting outright) can be
+/// given a destination, so deletes and schema-only operations skip the check entirely rather than
+/// measuring every appendable segment for nothing. Deliberately matched exhaustively: a new
+/// operation must be classified by whoever adds it, not silently default either way.
+fn may_need_write_capacity(operation: &CollectionUpdateOperations) -> bool {
+    match operation {
+        CollectionUpdateOperations::PointOperation(operation) => match operation {
+            PointOperations::UpsertPoints(_)
+            | PointOperations::UpsertPointsConditional(_)
+            | PointOperations::UpsertPointsRaw(_)
+            | PointOperations::SyncPoints(_)
+            | PointOperations::SyncPointsRaw(_) => true,
+            // Deletes never move a point, they only mark it.
+            PointOperations::DeletePoints { .. } | PointOperations::DeletePointsByFilter(_) => {
+                false
+            }
+        },
+        // Deleting a named vector from a point in an immutable segment moves the point too.
+        CollectionUpdateOperations::VectorOperation(operation) => match operation {
+            VectorOperations::UpdateVectors(_)
+            | VectorOperations::DeleteVectors(..)
+            | VectorOperations::DeleteVectorsByFilter(..) => true,
+        },
+        // Every payload operation copy-on-write moves the points it touches.
+        CollectionUpdateOperations::PayloadOperation(operation) => match operation {
+            payload_ops::PayloadOps::SetPayload(_)
+            | payload_ops::PayloadOps::DeletePayload(_)
+            | payload_ops::PayloadOps::ClearPayload { .. }
+            | payload_ops::PayloadOps::ClearPayloadByFilter(_)
+            | payload_ops::PayloadOps::OverwritePayload(_) => true,
+        },
+        // Schema-only, applied to every segment in place.
+        CollectionUpdateOperations::FieldIndexOperation(_)
+        | CollectionUpdateOperations::VectorNameOperation(_) => false,
+        #[cfg(feature = "staging")]
+        CollectionUpdateOperations::StagingOperation(_) => false,
+    }
 }
 
 /// Provision a fresh appendable segment when every existing one reached `max_segment_size`, so the
@@ -65,22 +103,16 @@ fn max_segment_size_bytes(optimizers: &[Arc<Optimizer>]) -> Option<NonZeroUsize>
 /// Blocking: builds a segment on disk, so this must be called from a blocking context.
 fn ensure_capacity_for_update(
     segments: &LockedSegmentHolder,
-    optimizers: &[Arc<Optimizer>],
+    segments_path: &Path,
+    segment_config: &SegmentOptimizerConfig,
+    thresholds_config: &OptimizerThresholds,
     payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
 ) {
-    // Source the required parameters from the first optimizer, like the optimization worker does.
-    // That worker already logs and refuses to run without optimizers, so do not repeat the error
-    // for every operation passing through here.
-    let Some(some_optimizer) = optimizers.first() else {
-        debug_assert!(false, "No optimizers configured");
-        return;
-    };
-
     let result = UpdateWorkers::ensure_appendable_segment_with_capacity(
         segments,
-        some_optimizer.segments_path(),
-        some_optimizer.segment_optimizer_config(),
-        some_optimizer.threshold_config(),
+        segments_path,
+        segment_config,
+        thresholds_config,
         payload_index_schema,
     );
 
@@ -111,6 +143,20 @@ impl UpdateWorkers {
         applied_seq_handler: Arc<AppliedSeqHandler>,
         cancel: CancellationToken,
     ) -> Receiver<UpdateSignal> {
+        // Capacity provisioning and the size cap both come from the first optimizer, like the
+        // optimization worker does, so the two cannot disagree on what "full" means. Resolved once:
+        // the optimizer set is fixed for this worker's lifetime, since a config update restarts the
+        // workers. The optimization worker already logs and refuses to run without optimizers, so
+        // do not repeat that error for every operation here.
+        let capacity_optimizer = optimizers.first().cloned();
+        debug_assert!(
+            capacity_optimizer.is_some(),
+            "No optimizers configured, appendable segment capacity will not be provisioned",
+        );
+        let max_segment_size_bytes = capacity_optimizer
+            .as_ref()
+            .and_then(|optimizer| optimizer.threshold_config().max_segment_size_bytes());
+
         let receiver = loop {
             let signal = tokio::select! {
                 biased; // biased to check cancellation first
@@ -177,16 +223,27 @@ impl UpdateWorkers {
 
                     let wait = sender.is_some();
                     let segments_clone = segments.clone();
-                    let optimizers_clone = optimizers.clone();
+                    // Classified before the operation is moved into the blocking task. Deletes and
+                    // schema-only operations never need a destination, so they skip measuring
+                    // every appendable segment.
+                    let operation_capacity_optimizer = if may_need_write_capacity(&operation) {
+                        capacity_optimizer.clone()
+                    } else {
+                        None
+                    };
                     let payload_index_schema_clone = payload_index_schema.clone();
                     let operation_result = tokio::task::spawn_blocking(move || {
                         // Give the operation a destination below the size cap before applying it,
                         // rather than letting it grow an already full segment.
-                        ensure_capacity_for_update(
-                            &segments_clone,
-                            &optimizers_clone,
-                            payload_index_schema_clone,
-                        );
+                        if let Some(optimizer) = operation_capacity_optimizer {
+                            ensure_capacity_for_update(
+                                &segments_clone,
+                                optimizer.segments_path(),
+                                optimizer.segment_optimizer_config(),
+                                optimizer.threshold_config(),
+                                payload_index_schema_clone,
+                            );
+                        }
 
                         Self::update_worker_internal(
                             collection_name_clone,
@@ -197,7 +254,7 @@ impl UpdateWorkers {
                             segments_clone,
                             update_operation_lock_clone,
                             update_tracker_clone,
-                            max_segment_size_bytes(&optimizers_clone),
+                            max_segment_size_bytes,
                             hw_measurements,
                         )
                     })
@@ -424,5 +481,158 @@ impl UpdateWorkers {
         });
 
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::save_on_disk::SaveOnDisk;
+    use segment::types::{Distance, PayloadFieldSchema, PayloadSchemaType};
+    use shard::fixtures::random_segment;
+    use shard::operations::payload_ops::PayloadOps;
+    use shard::operations::point_ops::{PointInsertOperationsInternal, PointOperations};
+    use shard::operations::vector_ops::VectorOperations;
+    use shard::optimizers::config::SegmentOptimizerConfig;
+    use shard::segment_holder::SegmentHolder;
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::operations::types::VectorsConfig;
+    use crate::operations::vector_params_builder::VectorParamsBuilder;
+    use crate::operations::{CreateIndex, FieldIndexOperations};
+    use crate::optimizers_builder::build_segment_optimizer_config;
+
+    /// Only operations that can be given a destination are worth measuring capacity for. Getting
+    /// this wrong is silent either way: too narrow skips provisioning for an operation that needs
+    /// it, too broad puts segment measurements back on every delete.
+    #[test]
+    fn test_may_need_write_capacity_classification() {
+        let point_ids = vec![1.into()];
+
+        // Moves or inserts points.
+        assert!(may_need_write_capacity(
+            &CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+                PointInsertOperationsInternal::PointsList(vec![]),
+            )),
+        ));
+        assert!(may_need_write_capacity(
+            &CollectionUpdateOperations::PayloadOperation(PayloadOps::ClearPayload {
+                points: point_ids.clone(),
+            }),
+        ));
+        // Deleting a named vector moves the point out of an immutable segment too.
+        assert!(may_need_write_capacity(
+            &CollectionUpdateOperations::VectorOperation(VectorOperations::DeleteVectors(
+                point_ids.clone().into(),
+                vec!["dense".into()],
+            )),
+        ));
+
+        // Marks points, never moves them.
+        assert!(!may_need_write_capacity(
+            &CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints {
+                ids: point_ids,
+            }),
+        ));
+        // Schema-only, applied to every segment in place.
+        assert!(!may_need_write_capacity(
+            &CollectionUpdateOperations::FieldIndexOperation(FieldIndexOperations::CreateIndex(
+                CreateIndex {
+                    field_name: "city".parse().unwrap(),
+                    field_schema: Some(PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword)),
+                },
+            )),
+        ));
+    }
+
+    fn capacity_fixture(
+        dir: &std::path::Path,
+        max_segment_size_kb: usize,
+    ) -> (
+        SegmentOptimizerConfig,
+        OptimizerThresholds,
+        Arc<SaveOnDisk<PayloadIndexSchema>>,
+    ) {
+        let collection_params = crate::config::CollectionParams {
+            vectors: VectorsConfig::Single(VectorParamsBuilder::new(256, Distance::Dot).build()),
+            ..crate::config::CollectionParams::empty()
+        };
+        let segment_config = build_segment_optimizer_config(
+            &collection_params,
+            &Default::default(),
+            &Default::default(),
+        );
+        let thresholds = OptimizerThresholds {
+            max_segment_size_kb,
+            memmap_threshold_kb: 1_000_000,
+            indexing_threshold_kb: 1_000_000,
+            deferred_internal_id: None,
+        };
+        let payload_index_schema =
+            Arc::new(SaveOnDisk::load_or_init_default(dir.join("payload.schema")).unwrap());
+        (segment_config, thresholds, payload_index_schema)
+    }
+
+    /// The pre-flight is what gives the destination filter something below the cap to pick. Without
+    /// it the filter has nothing to prefer until the optimizer wakes up, which is too late for the
+    /// operation being applied now.
+    #[test]
+    fn test_ensure_capacity_for_update_provisions_when_all_segments_are_full() {
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        // 1 KB is one vector of size 256, so the seeded segments are all over the cap.
+        let (segment_config, thresholds, payload_index_schema) = capacity_fixture(dir.path(), 1);
+
+        let mut holder = SegmentHolder::default();
+        holder.add_new(random_segment(dir.path(), 100, 3, 256));
+        holder.add_new(random_segment(dir.path(), 100, 3, 256));
+        let segments = LockedSegmentHolder::new(holder);
+
+        ensure_capacity_for_update(
+            &segments,
+            dir.path(),
+            &segment_config,
+            &thresholds,
+            payload_index_schema.clone(),
+        );
+        assert_eq!(
+            segments.read().len(),
+            3,
+            "a fresh appendable segment must be provisioned when every segment is at the cap",
+        );
+
+        // The fresh segment is empty, so the next operation finds capacity and provisions nothing.
+        ensure_capacity_for_update(
+            &segments,
+            dir.path(),
+            &segment_config,
+            &thresholds,
+            payload_index_schema,
+        );
+        assert_eq!(
+            segments.read().len(),
+            3,
+            "a segment below the cap must not trigger another one",
+        );
+    }
+
+    /// Uncapped means uncapped: no provisioning, whatever the segments measure.
+    #[test]
+    fn test_ensure_capacity_for_update_is_a_no_op_without_a_cap() {
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let (segment_config, thresholds, payload_index_schema) = capacity_fixture(dir.path(), 0);
+
+        let mut holder = SegmentHolder::default();
+        holder.add_new(random_segment(dir.path(), 100, 3, 256));
+        let segments = LockedSegmentHolder::new(holder);
+
+        ensure_capacity_for_update(
+            &segments,
+            dir.path(),
+            &segment_config,
+            &thresholds,
+            payload_index_schema,
+        );
+
+        assert_eq!(segments.read().len(), 1, "no cap, nothing to provision");
     }
 }

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -1,5 +1,4 @@
 use std::num::NonZeroUsize;
-use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -8,8 +7,6 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use segment::types::SeqNumberType;
 use shard::operations::CollectionUpdateOperations;
-use shard::operations::optimization::OptimizerThresholds;
-use shard::optimizers::config::SegmentOptimizerConfig;
 use shard::payload_index_schema::PayloadIndexSchema;
 use shard::segment_holder::locked::LockedSegmentHolder;
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -42,43 +39,6 @@ fn send_feedback(
     }
 }
 
-/// Provision a fresh appendable segment when every existing one reached `max_segment_size`, so the
-/// operation about to be applied has a destination below the cap to move points into.
-///
-/// Without this, a filtered payload or vector operation copy-on-write moves points into whichever
-/// appendable segment locks first, growing an already full segment without bound: the optimizer
-/// provisions capacity only on its own wake-up, which is too late for the operation being applied
-/// now.
-///
-/// Best effort by design: a provisioning failure is logged and the operation is applied anyway,
-/// falling back to the pre-existing behaviour of writing into a full segment. Running out of
-/// capacity must never fail a write. The optimization worker deliberately panics on the same
-/// failure; here it must not, because a client write is in flight and losing capacity only costs
-/// segment size, not correctness.
-///
-/// Blocking: builds a segment on disk, so this must be called from a blocking context.
-fn ensure_capacity_for_update(
-    segments: &LockedSegmentHolder,
-    segments_path: &Path,
-    segment_config: &SegmentOptimizerConfig,
-    thresholds_config: &OptimizerThresholds,
-    payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
-) {
-    let result = UpdateWorkers::ensure_appendable_segment_with_capacity(
-        segments,
-        segments_path,
-        segment_config,
-        thresholds_config,
-        payload_index_schema,
-    );
-
-    if let Err(err) = result {
-        log::error!(
-            "Failed to provision an appendable segment with capacity, applying anyway: {err}"
-        );
-    }
-}
-
 impl UpdateWorkers {
     /// Main loop of the update worker.
     ///
@@ -99,11 +59,8 @@ impl UpdateWorkers {
         applied_seq_handler: Arc<AppliedSeqHandler>,
         cancel: CancellationToken,
     ) -> Receiver<UpdateSignal> {
-        // Capacity provisioning and the size cap both come from the first optimizer, like the
-        // optimization worker does, so the two cannot disagree on what "full" means. Resolved once:
-        // the optimizer set is fixed for this worker's lifetime, since a config update restarts the
-        // workers. The optimization worker already logs and refuses to run without optimizers, so
-        // do not repeat that error for every operation here.
+        // Sourced from the first optimizer like the optimization worker does, so the two cannot
+        // disagree on what "full" means. Resolved once: a config update restarts the workers.
         let capacity_optimizer = optimizers.first().cloned();
         debug_assert!(
             capacity_optimizer.is_some(),
@@ -179,9 +136,7 @@ impl UpdateWorkers {
 
                     let wait = sender.is_some();
                     let segments_clone = segments.clone();
-                    // Classified before the operation is moved into the blocking task. Deletes and
-                    // schema-only operations never need a destination, so they skip measuring
-                    // every appendable segment.
+                    // Classified before the operation is moved into the blocking task.
                     let operation_capacity_optimizer =
                         if operation.may_need_appendable_destination() {
                             capacity_optimizer.clone()
@@ -191,14 +146,19 @@ impl UpdateWorkers {
                     let payload_index_schema_clone = payload_index_schema.clone();
                     let operation_result = tokio::task::spawn_blocking(move || {
                         // Give the operation a destination below the size cap before applying it,
-                        // rather than letting it grow an already full segment.
-                        if let Some(optimizer) = operation_capacity_optimizer {
-                            ensure_capacity_for_update(
+                        // rather than letting it grow an already full segment. Best effort: unlike
+                        // the optimization worker, a failure here must not take down a live write.
+                        if let Some(optimizer) = operation_capacity_optimizer
+                            && let Err(err) = Self::ensure_appendable_segment_with_capacity(
                                 &segments_clone,
                                 optimizer.segments_path(),
                                 optimizer.segment_optimizer_config(),
                                 optimizer.threshold_config(),
                                 payload_index_schema_clone,
+                            )
+                        {
+                            log::error!(
+                                "Failed to provision appendable capacity, applying anyway: {err}"
                             );
                         }
 
@@ -438,111 +398,5 @@ impl UpdateWorkers {
         });
 
         result
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use common::save_on_disk::SaveOnDisk;
-    use segment::types::Distance;
-    use shard::fixtures::random_segment;
-    use shard::optimizers::config::SegmentOptimizerConfig;
-    use shard::segment_holder::SegmentHolder;
-    use tempfile::Builder;
-
-    use super::*;
-    use crate::operations::types::VectorsConfig;
-    use crate::operations::vector_params_builder::VectorParamsBuilder;
-    use crate::optimizers_builder::build_segment_optimizer_config;
-
-    fn capacity_fixture(
-        dir: &std::path::Path,
-        max_segment_size_kb: usize,
-    ) -> (
-        SegmentOptimizerConfig,
-        OptimizerThresholds,
-        Arc<SaveOnDisk<PayloadIndexSchema>>,
-    ) {
-        let collection_params = crate::config::CollectionParams {
-            vectors: VectorsConfig::Single(VectorParamsBuilder::new(256, Distance::Dot).build()),
-            ..crate::config::CollectionParams::empty()
-        };
-        let segment_config = build_segment_optimizer_config(
-            &collection_params,
-            &Default::default(),
-            &Default::default(),
-        );
-        let thresholds = OptimizerThresholds {
-            max_segment_size_kb,
-            memmap_threshold_kb: 1_000_000,
-            indexing_threshold_kb: 1_000_000,
-            deferred_internal_id: None,
-        };
-        let payload_index_schema =
-            Arc::new(SaveOnDisk::load_or_init_default(dir.join("payload.schema")).unwrap());
-        (segment_config, thresholds, payload_index_schema)
-    }
-
-    /// The pre-flight is what gives the destination filter something below the cap to pick. Without
-    /// it the filter has nothing to prefer until the optimizer wakes up, which is too late for the
-    /// operation being applied now.
-    #[test]
-    fn test_ensure_capacity_for_update_provisions_when_all_segments_are_full() {
-        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-        // 1 KB is one vector of size 256, so the seeded segments are all over the cap.
-        let (segment_config, thresholds, payload_index_schema) = capacity_fixture(dir.path(), 1);
-
-        let mut holder = SegmentHolder::default();
-        holder.add_new(random_segment(dir.path(), 100, 3, 256));
-        holder.add_new(random_segment(dir.path(), 100, 3, 256));
-        let segments = LockedSegmentHolder::new(holder);
-
-        ensure_capacity_for_update(
-            &segments,
-            dir.path(),
-            &segment_config,
-            &thresholds,
-            payload_index_schema.clone(),
-        );
-        assert_eq!(
-            segments.read().len(),
-            3,
-            "a fresh appendable segment must be provisioned when every segment is at the cap",
-        );
-
-        // The fresh segment is empty, so the next operation finds capacity and provisions nothing.
-        ensure_capacity_for_update(
-            &segments,
-            dir.path(),
-            &segment_config,
-            &thresholds,
-            payload_index_schema,
-        );
-        assert_eq!(
-            segments.read().len(),
-            3,
-            "a segment below the cap must not trigger another one",
-        );
-    }
-
-    /// Uncapped means uncapped: no provisioning, whatever the segments measure.
-    #[test]
-    fn test_ensure_capacity_for_update_is_a_no_op_without_a_cap() {
-        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-        let (segment_config, thresholds, payload_index_schema) = capacity_fixture(dir.path(), 0);
-
-        let mut holder = SegmentHolder::default();
-        holder.add_new(random_segment(dir.path(), 100, 3, 256));
-        let segments = LockedSegmentHolder::new(holder);
-
-        ensure_capacity_for_update(
-            &segments,
-            dir.path(),
-            &segment_config,
-            &thresholds,
-            payload_index_schema,
-        );
-
-        assert_eq!(segments.read().len(), 1, "no cap, nothing to provision");
     }
 }

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -136,19 +136,13 @@ impl UpdateWorkers {
 
                     let wait = sender.is_some();
                     let segments_clone = segments.clone();
-                    // Classified before the operation is moved into the blocking task.
-                    let operation_capacity_optimizer =
-                        if operation.may_need_appendable_destination() {
-                            capacity_optimizer.clone()
-                        } else {
-                            None
-                        };
+                    let capacity_optimizer_clone = capacity_optimizer.clone();
                     let payload_index_schema_clone = payload_index_schema.clone();
                     let operation_result = tokio::task::spawn_blocking(move || {
                         // Give the operation a destination below the size cap before applying it,
                         // rather than letting it grow an already full segment. Best effort: unlike
                         // the optimization worker, a failure here must not take down a live write.
-                        if let Some(optimizer) = operation_capacity_optimizer
+                        if let Some(optimizer) = capacity_optimizer_clone
                             && let Err(err) = Self::ensure_appendable_segment_with_capacity(
                                 &segments_clone,
                                 optimizer.segments_path(),

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -1,10 +1,13 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Instant;
 
 use cancel::CancellationToken;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::save_on_disk::SaveOnDisk;
 use segment::types::SeqNumberType;
 use shard::operations::CollectionUpdateOperations;
+use shard::payload_index_schema::PayloadIndexSchema;
 use shard::segment_holder::locked::LockedSegmentHolder;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::{oneshot, watch};
@@ -16,7 +19,7 @@ use crate::operations::types::{CollectionError, CollectionResult, UpdateStatus};
 use crate::profiling::interface::log_request_to_collector;
 use crate::shards::CollectionId;
 use crate::shards::update_tracker::UpdateTracker;
-use crate::update_handler::{OperationData, OptimizerSignal, UpdateSignal};
+use crate::update_handler::{OperationData, Optimizer, OptimizerSignal, UpdateSignal};
 use crate::update_workers::UpdateWorkers;
 use crate::update_workers::applied_seq::AppliedSeqHandler;
 use crate::update_workers::internal_update_result::InternalUpdateResult;
@@ -36,6 +39,53 @@ fn send_feedback(
     }
 }
 
+/// The soft appendable segment size cap, sourced live from the first optimizer like the
+/// optimization worker does, so the steering below and the provisioning above cannot disagree on
+/// what "full" means. `None` (uncapped) when no optimizers are configured.
+fn max_segment_size_bytes(optimizers: &[Arc<Optimizer>]) -> Option<NonZeroUsize> {
+    optimizers
+        .first()
+        .and_then(|optimizer| optimizer.threshold_config().max_segment_size_bytes())
+}
+
+/// Provision a fresh appendable segment when every existing one reached `max_segment_size`, so the
+/// operation about to be applied has a destination below the cap to move points into.
+///
+/// Without this, a filtered payload or vector operation copy-on-write moves points into whichever
+/// appendable segment locks first, growing an already full segment without bound: the optimizer
+/// provisions capacity only on its own wake-up, which is too late for the operation being applied
+/// now.
+///
+/// Best effort by design: a provisioning failure is logged and the operation is applied anyway,
+/// falling back to the pre-existing behaviour of writing into a full segment. Running out of
+/// capacity must never fail a write.
+///
+/// Blocking: builds a segment on disk, so this must be called from a blocking context.
+fn ensure_capacity_for_update(
+    segments: &LockedSegmentHolder,
+    optimizers: &[Arc<Optimizer>],
+    payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
+) {
+    // Source the required parameters from the first optimizer, like the optimization worker does.
+    let Some(some_optimizer) = optimizers.first() else {
+        return;
+    };
+
+    let result = UpdateWorkers::ensure_appendable_segment_with_capacity(
+        segments,
+        some_optimizer.segments_path(),
+        some_optimizer.segment_optimizer_config(),
+        some_optimizer.threshold_config(),
+        payload_index_schema,
+    );
+
+    if let Err(err) = result {
+        log::error!(
+            "Failed to provision an appendable segment with capacity, applying anyway: {err}"
+        );
+    }
+}
+
 impl UpdateWorkers {
     /// Main loop of the update worker.
     ///
@@ -50,6 +100,8 @@ impl UpdateWorkers {
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
         prevent_unoptimized: bool,
+        optimizers: Arc<Vec<Arc<Optimizer>>>,
+        payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         optimization_finished_receiver: watch::Receiver<()>,
         applied_seq_handler: Arc<AppliedSeqHandler>,
         cancel: CancellationToken,
@@ -120,7 +172,17 @@ impl UpdateWorkers {
 
                     let wait = sender.is_some();
                     let segments_clone = segments.clone();
+                    let optimizers_clone = optimizers.clone();
+                    let payload_index_schema_clone = payload_index_schema.clone();
                     let operation_result = tokio::task::spawn_blocking(move || {
+                        // Give the operation a destination below the size cap before applying it,
+                        // rather than letting it grow an already full segment.
+                        ensure_capacity_for_update(
+                            &segments_clone,
+                            &optimizers_clone,
+                            payload_index_schema_clone,
+                        );
+
                         Self::update_worker_internal(
                             collection_name_clone,
                             operation,
@@ -130,6 +192,7 @@ impl UpdateWorkers {
                             segments_clone,
                             update_operation_lock_clone,
                             update_tracker_clone,
+                            max_segment_size_bytes(&optimizers_clone),
                             hw_measurements,
                         )
                     })
@@ -311,6 +374,7 @@ impl UpdateWorkers {
         segments: LockedSegmentHolder,
         update_operation_lock: Arc<tokio::sync::RwLock<()>>,
         update_tracker: UpdateTracker,
+        max_segment_size_bytes: Option<NonZeroUsize>,
         hw_measurements: HwMeasurementAcc,
     ) -> CollectionResult<usize> {
         // If wait flag is set, explicitly flush WAL first
@@ -337,6 +401,7 @@ impl UpdateWorkers {
                 operation,
                 update_operation_lock.clone(),
                 update_tracker.clone(),
+                max_segment_size_bytes,
                 &hw_measurements.get_counter_cell(),
             )
         });

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -62,10 +62,6 @@ impl UpdateWorkers {
         // Sourced from the first optimizer like the optimization worker does, so the two cannot
         // disagree on what "full" means. Resolved once: a config update restarts the workers.
         let capacity_optimizer = optimizers.first().cloned();
-        debug_assert!(
-            capacity_optimizer.is_some(),
-            "No optimizers configured, appendable segment capacity will not be provisioned",
-        );
         let max_segment_size_bytes = capacity_optimizer
             .as_ref()
             .and_then(|optimizer| optimizer.threshold_config().max_segment_size_bytes());
@@ -424,18 +420,16 @@ mod tests {
     use crate::optimizers_builder::build_optimizers;
     use crate::tests::fixtures::create_collection_config;
 
-    /// The worker must provision capacity itself, before applying, and must apply with the cap.
-    ///
-    /// Only the update worker runs here: at shard level the optimization worker provisions on
-    /// every wake-up too, so a new segment appearing would prove nothing about this path.
+    /// The worker must provision capacity before applying, and apply with the cap. Only the
+    /// update worker runs here: the optimization worker provisions on every wake-up too, so a new
+    /// segment appearing would prove nothing about this path.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_update_worker_provisions_capacity_before_applying() {
         let dir = Builder::new().prefix("shard").tempdir().unwrap();
         let hw_counter = common::counter::hardware_counter::HardwareCounterCell::new();
 
-        // 1 KB is one vector of size 256, so a handful of points puts the appendable segment over
-        // the cap set below. The immutable segment holds the point the filtered update matches, so
-        // applying it has to move that point somewhere.
+        // 1 KB is one vector of size 256, so a few points put the appendable segment over the cap
+        // below. The immutable segment holds the point the filtered update matches.
         const DIM: usize = 256;
         let mut holder = SegmentHolder::default();
         let full_id = holder.add_new(random_segment(dir.path(), 100, 3, DIM));
@@ -462,7 +456,6 @@ mod tests {
         let segments = LockedSegmentHolder::new(holder);
         assert_eq!(segments.read().len(), 2);
 
-        // A cap the existing appendable segment is already at.
         let full_size = segments
             .read()
             .get(full_id)

--- a/lib/edge/src/edge_shard/update.rs
+++ b/lib/edge/src/edge_shard/update.rs
@@ -36,13 +36,20 @@ impl EdgeShard {
 
         let result = match operation {
             CollectionUpdateOperations::PointOperation(point_operation) => {
-                process_point_operation(&segments_guard, operation_id, point_operation, &hw_counter)
+                process_point_operation(
+                    &segments_guard,
+                    operation_id,
+                    point_operation,
+                    None, // edge shards have a single appendable segment, no size cap to apply
+                    &hw_counter,
+                )
             }
             CollectionUpdateOperations::VectorOperation(vector_operation) => {
                 process_vector_operation(
                     &segments_guard,
                     operation_id,
                     vector_operation,
+                    None,
                     &hw_counter,
                 )
             }
@@ -51,6 +58,7 @@ impl EdgeShard {
                     &segments_guard,
                     operation_id,
                     payload_operation,
+                    None,
                     &hw_counter,
                 )
             }

--- a/lib/edge/src/edge_shard/update.rs
+++ b/lib/edge/src/edge_shard/update.rs
@@ -36,13 +36,22 @@ impl EdgeShard {
 
         let result = match operation {
             CollectionUpdateOperations::PointOperation(point_operation) => {
-                process_point_operation(&segments_guard, operation_id, point_operation, &hw_counter)
+                process_point_operation(
+                    &segments_guard,
+                    operation_id,
+                    point_operation,
+                    // Edge shards keep a single appendable segment, so there is no destination to
+                    // steer between and no size cap to apply.
+                    None,
+                    &hw_counter,
+                )
             }
             CollectionUpdateOperations::VectorOperation(vector_operation) => {
                 process_vector_operation(
                     &segments_guard,
                     operation_id,
                     vector_operation,
+                    None,
                     &hw_counter,
                 )
             }
@@ -51,6 +60,7 @@ impl EdgeShard {
                     &segments_guard,
                     operation_id,
                     payload_operation,
+                    None,
                     &hw_counter,
                 )
             }

--- a/lib/shard/src/operations/mod.rs
+++ b/lib/shard/src/operations/mod.rs
@@ -49,17 +49,12 @@ impl CollectionUpdateOperations {
         )
     }
 
-    /// Whether applying this operation can need somewhere to put a point, either by inserting a
-    /// new one or by copy-on-write moving an existing one out of an immutable segment.
+    /// Whether applying this operation can need somewhere to put a point, by inserting one or by
+    /// copy-on-write moving one out of an immutable segment.
     ///
-    /// This mirrors which operations reach
-    /// [`apply_points_with_conditional_move`](crate::segment_holder::SegmentHolder::apply_points_with_conditional_move)
-    /// or insert outright, and lives beside them on purpose: an operation that starts moving points
-    /// must be reclassified here, or capacity stops being provisioned for it and appendable
-    /// segments grow past `max_segment_size` again.
-    ///
-    /// Matched exhaustively so a new operation has to be classified rather than silently
-    /// defaulting either way.
+    /// Mirrors which operations reach `apply_points_with_conditional_move`. An operation that
+    /// starts moving points must be reclassified here, or capacity silently stops being
+    /// provisioned for it. Exhaustive so a new operation has to be classified.
     pub fn may_need_appendable_destination(&self) -> bool {
         match self {
             Self::PointOperation(op) => match op {

--- a/lib/shard/src/operations/mod.rs
+++ b/lib/shard/src/operations/mod.rs
@@ -49,6 +49,51 @@ impl CollectionUpdateOperations {
         )
     }
 
+    /// Whether applying this operation can need somewhere to put a point, either by inserting a
+    /// new one or by copy-on-write moving an existing one out of an immutable segment.
+    ///
+    /// This mirrors which operations reach
+    /// [`apply_points_with_conditional_move`](crate::segment_holder::SegmentHolder::apply_points_with_conditional_move)
+    /// or insert outright, and lives beside them on purpose: an operation that starts moving points
+    /// must be reclassified here, or capacity stops being provisioned for it and appendable
+    /// segments grow past `max_segment_size` again.
+    ///
+    /// Matched exhaustively so a new operation has to be classified rather than silently
+    /// defaulting either way.
+    pub fn may_need_appendable_destination(&self) -> bool {
+        match self {
+            Self::PointOperation(op) => match op {
+                PointOperations::UpsertPoints(_)
+                | PointOperations::UpsertPointsConditional(_)
+                | PointOperations::UpsertPointsRaw(_)
+                | PointOperations::SyncPoints(_)
+                | PointOperations::SyncPointsRaw(_) => true,
+                // Deletes never move a point, they only mark it.
+                PointOperations::DeletePoints { .. } | PointOperations::DeletePointsByFilter(_) => {
+                    false
+                }
+            },
+            // Deleting a named vector from a point in an immutable segment moves the point too.
+            Self::VectorOperation(op) => match op {
+                vector_ops::VectorOperations::UpdateVectors(_)
+                | vector_ops::VectorOperations::DeleteVectors(..)
+                | vector_ops::VectorOperations::DeleteVectorsByFilter(..) => true,
+            },
+            // Every payload operation copy-on-write moves the points it touches.
+            Self::PayloadOperation(op) => match op {
+                payload_ops::PayloadOps::SetPayload(_)
+                | payload_ops::PayloadOps::DeletePayload(_)
+                | payload_ops::PayloadOps::ClearPayload { .. }
+                | payload_ops::PayloadOps::ClearPayloadByFilter(_)
+                | payload_ops::PayloadOps::OverwritePayload(_) => true,
+            },
+            // Schema-only, applied to every segment in place.
+            Self::FieldIndexOperation(_) | Self::VectorNameOperation(_) => false,
+            #[cfg(feature = "staging")]
+            Self::StagingOperation(_) => false,
+        }
+    }
+
     pub fn point_ids(&self) -> Option<Vec<PointIdType>> {
         match self {
             Self::PointOperation(op) => op.point_ids(),
@@ -288,6 +333,53 @@ mod tests {
     use super::point_ops::*;
     use super::vector_ops::*;
     use super::*;
+
+    /// Only operations that can be given a destination are worth provisioning capacity for.
+    /// Getting this wrong is silent either way: too narrow stops provisioning for an operation
+    /// that moves points, and appendable segments grow past `max_segment_size` again; too broad
+    /// puts a measurement of every appendable segment back on operations that never move one.
+    #[test]
+    fn test_may_need_appendable_destination() {
+        let point_ids = vec![PointIdType::from(1)];
+
+        // Inserts points.
+        assert!(
+            CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+                PointInsertOperationsInternal::PointsList(vec![]),
+            ))
+            .may_need_appendable_destination(),
+        );
+        // Copy-on-write moves the points it touches.
+        assert!(
+            CollectionUpdateOperations::PayloadOperation(PayloadOps::ClearPayload {
+                points: point_ids.clone(),
+            })
+            .may_need_appendable_destination(),
+        );
+        // Deleting a named vector moves the point out of an immutable segment too.
+        assert!(
+            CollectionUpdateOperations::VectorOperation(VectorOperations::DeleteVectors(
+                point_ids.clone().into(),
+                vec!["dense".into()],
+            ))
+            .may_need_appendable_destination(),
+        );
+
+        // Marks points, never moves them.
+        assert!(
+            !CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints {
+                ids: point_ids,
+            })
+            .may_need_appendable_destination(),
+        );
+        // Schema-only, applied to every segment in place.
+        assert!(
+            !CollectionUpdateOperations::FieldIndexOperation(FieldIndexOperations::DeleteIndex(
+                "city".parse().unwrap(),
+            ))
+            .may_need_appendable_destination(),
+        );
+    }
 
     proptest::proptest! {
         #[test]

--- a/lib/shard/src/operations/mod.rs
+++ b/lib/shard/src/operations/mod.rs
@@ -49,46 +49,6 @@ impl CollectionUpdateOperations {
         )
     }
 
-    /// Whether applying this operation can need somewhere to put a point, by inserting one or by
-    /// copy-on-write moving one out of an immutable segment.
-    ///
-    /// Mirrors which operations reach `apply_points_with_conditional_move`. An operation that
-    /// starts moving points must be reclassified here, or capacity silently stops being
-    /// provisioned for it. Exhaustive so a new operation has to be classified.
-    pub fn may_need_appendable_destination(&self) -> bool {
-        match self {
-            Self::PointOperation(op) => match op {
-                PointOperations::UpsertPoints(_)
-                | PointOperations::UpsertPointsConditional(_)
-                | PointOperations::UpsertPointsRaw(_)
-                | PointOperations::SyncPoints(_)
-                | PointOperations::SyncPointsRaw(_) => true,
-                // Deletes never move a point, they only mark it.
-                PointOperations::DeletePoints { .. } | PointOperations::DeletePointsByFilter(_) => {
-                    false
-                }
-            },
-            // Deleting a named vector from a point in an immutable segment moves the point too.
-            Self::VectorOperation(op) => match op {
-                vector_ops::VectorOperations::UpdateVectors(_)
-                | vector_ops::VectorOperations::DeleteVectors(..)
-                | vector_ops::VectorOperations::DeleteVectorsByFilter(..) => true,
-            },
-            // Every payload operation copy-on-write moves the points it touches.
-            Self::PayloadOperation(op) => match op {
-                payload_ops::PayloadOps::SetPayload(_)
-                | payload_ops::PayloadOps::DeletePayload(_)
-                | payload_ops::PayloadOps::ClearPayload { .. }
-                | payload_ops::PayloadOps::ClearPayloadByFilter(_)
-                | payload_ops::PayloadOps::OverwritePayload(_) => true,
-            },
-            // Schema-only, applied to every segment in place.
-            Self::FieldIndexOperation(_) | Self::VectorNameOperation(_) => false,
-            #[cfg(feature = "staging")]
-            Self::StagingOperation(_) => false,
-        }
-    }
-
     pub fn point_ids(&self) -> Option<Vec<PointIdType>> {
         match self {
             Self::PointOperation(op) => op.point_ids(),
@@ -328,53 +288,6 @@ mod tests {
     use super::point_ops::*;
     use super::vector_ops::*;
     use super::*;
-
-    /// Only operations that can be given a destination are worth provisioning capacity for.
-    /// Getting this wrong is silent either way: too narrow stops provisioning for an operation
-    /// that moves points, and appendable segments grow past `max_segment_size` again; too broad
-    /// puts a measurement of every appendable segment back on operations that never move one.
-    #[test]
-    fn test_may_need_appendable_destination() {
-        let point_ids = vec![PointIdType::from(1)];
-
-        // Inserts points.
-        assert!(
-            CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-                PointInsertOperationsInternal::PointsList(vec![]),
-            ))
-            .may_need_appendable_destination(),
-        );
-        // Copy-on-write moves the points it touches.
-        assert!(
-            CollectionUpdateOperations::PayloadOperation(PayloadOps::ClearPayload {
-                points: point_ids.clone(),
-            })
-            .may_need_appendable_destination(),
-        );
-        // Deleting a named vector moves the point out of an immutable segment too.
-        assert!(
-            CollectionUpdateOperations::VectorOperation(VectorOperations::DeleteVectors(
-                point_ids.clone().into(),
-                vec!["dense".into()],
-            ))
-            .may_need_appendable_destination(),
-        );
-
-        // Marks points, never moves them.
-        assert!(
-            !CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints {
-                ids: point_ids,
-            })
-            .may_need_appendable_destination(),
-        );
-        // Schema-only, applied to every segment in place.
-        assert!(
-            !CollectionUpdateOperations::FieldIndexOperation(FieldIndexOperations::DeleteIndex(
-                "city".parse().unwrap(),
-            ))
-            .may_need_appendable_destination(),
-        );
-    }
 
     proptest::proptest! {
         #[test]

--- a/lib/shard/src/operations/optimization.rs
+++ b/lib/shard/src/operations/optimization.rs
@@ -1,6 +1,9 @@
+use std::num::NonZeroUsize;
+
 use common::progress_tracker::ProgressTree;
 use common::types::PointOffsetType;
 use schemars::JsonSchema;
+use segment::common::BYTES_IN_KB;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -128,4 +131,13 @@ pub struct OptimizerThresholds {
     pub memmap_threshold_kb: usize,
     pub indexing_threshold_kb: usize,
     pub deferred_internal_id: Option<PointOffsetType>,
+}
+
+impl OptimizerThresholds {
+    /// The appendable segment size cap in bytes, or `None` when `max_segment_size_kb` is zero
+    /// (uncapped). The single derivation of the cap: the segment holder steers writes with it and
+    /// the optimizer provisions against it, so the two cannot disagree on what "full" means.
+    pub fn max_segment_size_bytes(&self) -> Option<NonZeroUsize> {
+        NonZeroUsize::new(self.max_segment_size_kb.saturating_mul(BYTES_IN_KB))
+    }
 }

--- a/lib/shard/src/operations/optimization.rs
+++ b/lib/shard/src/operations/optimization.rs
@@ -141,26 +141,3 @@ impl OptimizerThresholds {
         NonZeroUsize::new(self.max_segment_size_kb.saturating_mul(BYTES_IN_KB))
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// `max_segment_size_kb` of zero means uncapped, which switches the whole steering off. Guard
-    /// the conversion, since a `Some(0)` here would instead make every segment look full.
-    #[test]
-    fn test_max_segment_size_bytes() {
-        let thresholds = |max_segment_size_kb| OptimizerThresholds {
-            max_segment_size_kb,
-            memmap_threshold_kb: 0,
-            indexing_threshold_kb: 0,
-            deferred_internal_id: None,
-        };
-
-        assert_eq!(thresholds(0).max_segment_size_bytes(), None);
-        assert_eq!(
-            thresholds(2).max_segment_size_bytes(),
-            NonZeroUsize::new(2 * BYTES_IN_KB),
-        );
-    }
-}

--- a/lib/shard/src/operations/optimization.rs
+++ b/lib/shard/src/operations/optimization.rs
@@ -141,3 +141,26 @@ impl OptimizerThresholds {
         NonZeroUsize::new(self.max_segment_size_kb.saturating_mul(BYTES_IN_KB))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `max_segment_size_kb` of zero means uncapped, which switches the whole steering off. Guard
+    /// the conversion, since a `Some(0)` here would instead make every segment look full.
+    #[test]
+    fn test_max_segment_size_bytes() {
+        let thresholds = |max_segment_size_kb| OptimizerThresholds {
+            max_segment_size_kb,
+            memmap_threshold_kb: 0,
+            indexing_threshold_kb: 0,
+            deferred_internal_id: None,
+        };
+
+        assert_eq!(thresholds(0).max_segment_size_bytes(), None);
+        assert_eq!(
+            thresholds(2).max_segment_size_bytes(),
+            NonZeroUsize::new(2 * BYTES_IN_KB),
+        );
+    }
+}

--- a/lib/shard/src/operations/optimization.rs
+++ b/lib/shard/src/operations/optimization.rs
@@ -1,6 +1,9 @@
+use std::num::NonZeroUsize;
+
 use common::progress_tracker::ProgressTree;
 use common::types::PointOffsetType;
 use schemars::JsonSchema;
+use segment::common::BYTES_IN_KB;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -128,4 +131,11 @@ pub struct OptimizerThresholds {
     pub memmap_threshold_kb: usize,
     pub indexing_threshold_kb: usize,
     pub deferred_internal_id: Option<PointOffsetType>,
+}
+
+impl OptimizerThresholds {
+    /// Maximum segment size in bytes, or `None` when `max_segment_size_kb` is zero (uncapped).
+    pub fn max_segment_size_bytes(&self) -> Option<NonZeroUsize> {
+        NonZeroUsize::new(self.max_segment_size_kb.saturating_mul(BYTES_IN_KB))
+    }
 }

--- a/lib/shard/src/optimizers/config.rs
+++ b/lib/shard/src/optimizers/config.rs
@@ -307,41 +307,32 @@ mod tests {
     /// them from disagreeing.
     #[test]
     fn deferred_threshold_is_clamped_to_max_segment_size() {
-        let bytes = |kb: usize| NonZeroUsize::new(kb * BYTES_IN_KB);
+        let kb = |kb: usize| NonZeroUsize::new(kb * BYTES_IN_KB);
+        let disabled_indexing = NonZeroUsize::new(usize::MAX.saturating_mul(BYTES_IN_KB));
 
-        // Off unless enabled.
-        assert_eq!(
-            get_deferred_points_threshold_bytes(None, 10_000, Some(1_000)),
-            None,
-        );
-        assert_eq!(
-            get_deferred_points_threshold_bytes(Some(false), 10_000, Some(1_000)),
-            None,
-        );
+        // (prevent_unoptimized, indexing_threshold_kb, max_segment_size_kb, expected)
+        let cases = [
+            (None, 10_000, Some(1_000), None),
+            (Some(false), 10_000, Some(1_000), None),
+            // A cap above the threshold does not bind, one below it wins.
+            (Some(true), 10_000, Some(256_000), kb(10_000)),
+            (Some(true), 100_000, Some(1_000), kb(1_000)),
+            // Auto-derived caps are resolved elsewhere, disabled indexing stays unreachable.
+            (Some(true), 100_000, None, kb(100_000)),
+            (Some(true), usize::MAX, Some(1_000), disabled_indexing),
+        ];
 
-        // A cap above the indexing threshold does not bind.
-        assert_eq!(
-            get_deferred_points_threshold_bytes(Some(true), 10_000, Some(256_000)),
-            bytes(10_000),
-        );
-
-        // A cap below the threshold wins.
-        assert_eq!(
-            get_deferred_points_threshold_bytes(Some(true), 100_000, Some(1_000)),
-            bytes(1_000),
-        );
-
-        // Auto-derived caps are resolved elsewhere.
-        assert_eq!(
-            get_deferred_points_threshold_bytes(Some(true), 100_000, None),
-            bytes(100_000),
-        );
-
-        // Disabled indexing keeps its unreachable threshold.
-        assert_eq!(
-            get_deferred_points_threshold_bytes(Some(true), usize::MAX, Some(1_000)),
-            NonZeroUsize::new(usize::MAX.saturating_mul(BYTES_IN_KB)),
-        );
+        for (prevent_unoptimized, indexing_threshold_kb, max_segment_size_kb, expected) in cases {
+            assert_eq!(
+                get_deferred_points_threshold_bytes(
+                    prevent_unoptimized,
+                    indexing_threshold_kb,
+                    max_segment_size_kb,
+                ),
+                expected,
+                "{prevent_unoptimized:?} / {indexing_threshold_kb} / {max_segment_size_kb:?}",
+            );
+        }
     }
 
     #[test]

--- a/lib/shard/src/optimizers/config.rs
+++ b/lib/shard/src/optimizers/config.rs
@@ -285,15 +285,21 @@ pub fn get_deferred_points_threshold_bytes(
     indexing_threshold_kb: usize,
     max_segment_size_kb: Option<usize>,
 ) -> Option<NonZeroUsize> {
-    (prevent_unoptimized == Some(true))
-        .then(|| match max_segment_size_kb {
-            Some(max_segment_size_kb) if indexing_threshold_kb != usize::MAX => {
-                indexing_threshold_kb.min(max_segment_size_kb)
-            }
-            _ => indexing_threshold_kb,
-        })
-        .map(|threshold_kb| threshold_kb.saturating_mul(BYTES_IN_KB))
-        .and_then(NonZeroUsize::new)
+    if prevent_unoptimized != Some(true) {
+        return None;
+    }
+
+    // A zero cap means uncapped, as everywhere else the cap is read, so it must not clamp the
+    // threshold to zero and switch deferring off altogether.
+    let mut threshold_kb = indexing_threshold_kb;
+    if let Some(max_segment_size_kb) = max_segment_size_kb
+        && max_segment_size_kb > 0
+        && indexing_threshold_kb != usize::MAX
+    {
+        threshold_kb = threshold_kb.min(max_segment_size_kb);
+    }
+
+    NonZeroUsize::new(threshold_kb.saturating_mul(BYTES_IN_KB))
 }
 
 #[cfg(test)]
@@ -317,8 +323,10 @@ mod tests {
             // A cap above the threshold does not bind, one below it wins.
             (Some(true), 10_000, Some(256_000), kb(10_000)),
             (Some(true), 100_000, Some(1_000), kb(1_000)),
-            // Auto-derived caps are resolved elsewhere, disabled indexing stays unreachable.
+            // Auto-derived caps are resolved elsewhere, and a zero cap means uncapped rather
+            // than a cap of zero, which would switch deferring off.
             (Some(true), 100_000, None, kb(100_000)),
+            (Some(true), 100_000, Some(0), kb(100_000)),
             (Some(true), usize::MAX, Some(1_000), disabled_indexing),
         ];
 

--- a/lib/shard/src/optimizers/config.rs
+++ b/lib/shard/src/optimizers/config.rs
@@ -271,13 +271,29 @@ pub fn get_max_segment_size_kb(
 }
 
 /// Build deferred points threshold in bytes when `prevent_unoptimized` is true.
+///
+/// The threshold is clamped to an explicitly configured `max_segment_size`, since a segment past
+/// the threshold keeps deferring points until optimized and would otherwise be allowed to grow
+/// beyond the size cap. Disabled indexing (`usize::MAX`) is left alone.
 pub fn get_deferred_points_threshold_bytes(
     prevent_unoptimized: Option<bool>,
     indexing_threshold_kb: usize,
+    max_segment_size_kb: Option<usize>,
 ) -> Option<NonZeroUsize> {
-    (prevent_unoptimized == Some(true))
-        .then(|| indexing_threshold_kb.saturating_mul(BYTES_IN_KB))
-        .and_then(NonZeroUsize::new)
+    if prevent_unoptimized != Some(true) {
+        return None;
+    }
+
+    // A zero cap means uncapped, like everywhere else the cap is read.
+    let mut threshold_kb = indexing_threshold_kb;
+    if let Some(max_segment_size_kb) = max_segment_size_kb
+        && max_segment_size_kb > 0
+        && indexing_threshold_kb != usize::MAX
+    {
+        threshold_kb = threshold_kb.min(max_segment_size_kb);
+    }
+
+    NonZeroUsize::new(threshold_kb.saturating_mul(BYTES_IN_KB))
 }
 
 #[cfg(test)]
@@ -285,6 +301,37 @@ mod tests {
     use std::sync::Mutex;
 
     use super::*;
+
+    #[test]
+    fn deferred_threshold_is_clamped_to_max_segment_size() {
+        let kb = |kb: usize| NonZeroUsize::new(kb * BYTES_IN_KB);
+        let disabled_indexing = NonZeroUsize::new(usize::MAX.saturating_mul(BYTES_IN_KB));
+
+        // (prevent_unoptimized, indexing_threshold_kb, max_segment_size_kb, expected)
+        let cases = [
+            (None, 10_000, Some(1_000), None),
+            (Some(false), 10_000, Some(1_000), None),
+            (Some(true), 10_000, Some(256_000), kb(10_000)),
+            (Some(true), 100_000, Some(1_000), kb(1_000)),
+            // `None` and zero cap both mean uncapped
+            (Some(true), 100_000, None, kb(100_000)),
+            (Some(true), 100_000, Some(0), kb(100_000)),
+            // disabled indexing is not clamped
+            (Some(true), usize::MAX, Some(1_000), disabled_indexing),
+        ];
+
+        for (prevent_unoptimized, indexing_threshold_kb, max_segment_size_kb, expected) in cases {
+            assert_eq!(
+                get_deferred_points_threshold_bytes(
+                    prevent_unoptimized,
+                    indexing_threshold_kb,
+                    max_segment_size_kb,
+                ),
+                expected,
+                "{prevent_unoptimized:?} / {indexing_threshold_kb} / {max_segment_size_kb:?}",
+            );
+        }
+    }
 
     #[test]
     fn live_vector_names_provider_reads_current_state() {

--- a/lib/shard/src/optimizers/config.rs
+++ b/lib/shard/src/optimizers/config.rs
@@ -272,21 +272,14 @@ pub fn get_max_segment_size_kb(
 
 /// Build deferred points threshold in bytes when `prevent_unoptimized` is true.
 ///
-/// Clamped to an explicitly configured `max_segment_size`: points start deferring once a segment
-/// passes this threshold, and the segment then keeps growing as a staging area until an
-/// optimization promotes them, so a threshold above the segment size cap would size the staging
-/// area beyond what a segment is ever allowed to reach. Nothing validates `indexing_threshold`
-/// against `max_segment_size`, so that inverted configuration is reachable.
+/// Clamped to an explicitly configured `max_segment_size`: a segment defers points once past this
+/// threshold and grows as a staging area until optimized, so a threshold above the size cap would
+/// size that staging area beyond what a segment may reach. Nothing validates the two against each
+/// other, so the inverted configuration is reachable.
 ///
-/// Two deliberate non-clamps:
-///
-/// - An auto-derived cap (`max_segment_size` unset) is left alone. It is already
-///   [`DEFAULT_MAX_SEGMENT_PER_CPU_KB`] per indexing thread, well above the default indexing
-///   threshold, and resolving it here would need the indexing thread count at every call site.
-/// - Disabled indexing (`indexing_threshold_kb` is [`usize::MAX`]) is left alone, so the clamp can
-///   only ever lower an already-reachable threshold, never make deferral reachable where it was
-///   not. Deferred points are promoted by building an HNSW index, which is exactly what disabling
-///   indexing opts out of.
+/// An auto-derived cap is left alone (it is already [`DEFAULT_MAX_SEGMENT_PER_CPU_KB`] per indexing
+/// thread), as is disabled indexing ([`usize::MAX`]), so the clamp only lowers an already-reachable
+/// threshold and never makes deferral reachable where it was not.
 pub fn get_deferred_points_threshold_bytes(
     prevent_unoptimized: Option<bool>,
     indexing_threshold_kb: usize,
@@ -309,15 +302,14 @@ mod tests {
 
     use super::*;
 
-    /// The deferred threshold decides how large a staging segment grows before its points start
-    /// deferring, so it must not exceed the size a segment is allowed to reach. Nothing validates
-    /// `indexing_threshold` against `max_segment_size`, so the inverted configuration is reachable
-    /// and the clamp is what keeps the two from disagreeing.
+    /// The staging area a deferred segment forms must not be sized beyond what a segment may
+    /// reach. Nothing validates the two settings against each other, so the clamp is what keeps
+    /// them from disagreeing.
     #[test]
     fn deferred_threshold_is_clamped_to_max_segment_size() {
         let bytes = |kb: usize| NonZeroUsize::new(kb * BYTES_IN_KB);
 
-        // Off unless `prevent_unoptimized` is enabled.
+        // Off unless enabled.
         assert_eq!(
             get_deferred_points_threshold_bytes(None, 10_000, Some(1_000)),
             None,
@@ -333,20 +325,19 @@ mod tests {
             bytes(10_000),
         );
 
-        // A cap below the indexing threshold wins: the staging area cannot outgrow a segment.
+        // A cap below the threshold wins.
         assert_eq!(
             get_deferred_points_threshold_bytes(Some(true), 100_000, Some(1_000)),
             bytes(1_000),
         );
 
-        // An auto-derived cap is resolved elsewhere and left alone here.
+        // Auto-derived caps are resolved elsewhere.
         assert_eq!(
             get_deferred_points_threshold_bytes(Some(true), 100_000, None),
             bytes(100_000),
         );
 
-        // Disabled indexing keeps its unreachable threshold: the clamp may only lower an
-        // already-reachable one, never make deferral reachable where it was not.
+        // Disabled indexing keeps its unreachable threshold.
         assert_eq!(
             get_deferred_points_threshold_bytes(Some(true), usize::MAX, Some(1_000)),
             NonZeroUsize::new(usize::MAX.saturating_mul(BYTES_IN_KB)),

--- a/lib/shard/src/optimizers/config.rs
+++ b/lib/shard/src/optimizers/config.rs
@@ -271,12 +271,35 @@ pub fn get_max_segment_size_kb(
 }
 
 /// Build deferred points threshold in bytes when `prevent_unoptimized` is true.
+///
+/// Clamped to an explicitly configured `max_segment_size`: points start deferring once a segment
+/// passes this threshold, and the segment then keeps growing as a staging area until an
+/// optimization promotes them, so a threshold above the segment size cap would size the staging
+/// area beyond what a segment is ever allowed to reach. Nothing validates `indexing_threshold`
+/// against `max_segment_size`, so that inverted configuration is reachable.
+///
+/// Two deliberate non-clamps:
+///
+/// - An auto-derived cap (`max_segment_size` unset) is left alone. It is already
+///   [`DEFAULT_MAX_SEGMENT_PER_CPU_KB`] per indexing thread, well above the default indexing
+///   threshold, and resolving it here would need the indexing thread count at every call site.
+/// - Disabled indexing (`indexing_threshold_kb` is [`usize::MAX`]) is left alone, so the clamp can
+///   only ever lower an already-reachable threshold, never make deferral reachable where it was
+///   not. Deferred points are promoted by building an HNSW index, which is exactly what disabling
+///   indexing opts out of.
 pub fn get_deferred_points_threshold_bytes(
     prevent_unoptimized: Option<bool>,
     indexing_threshold_kb: usize,
+    max_segment_size_kb: Option<usize>,
 ) -> Option<NonZeroUsize> {
     (prevent_unoptimized == Some(true))
-        .then(|| indexing_threshold_kb.saturating_mul(BYTES_IN_KB))
+        .then(|| match max_segment_size_kb {
+            Some(max_segment_size_kb) if indexing_threshold_kb != usize::MAX => {
+                indexing_threshold_kb.min(max_segment_size_kb)
+            }
+            _ => indexing_threshold_kb,
+        })
+        .map(|threshold_kb| threshold_kb.saturating_mul(BYTES_IN_KB))
         .and_then(NonZeroUsize::new)
 }
 
@@ -285,6 +308,50 @@ mod tests {
     use std::sync::Mutex;
 
     use super::*;
+
+    /// The deferred threshold decides how large a staging segment grows before its points start
+    /// deferring, so it must not exceed the size a segment is allowed to reach. Nothing validates
+    /// `indexing_threshold` against `max_segment_size`, so the inverted configuration is reachable
+    /// and the clamp is what keeps the two from disagreeing.
+    #[test]
+    fn deferred_threshold_is_clamped_to_max_segment_size() {
+        let bytes = |kb: usize| NonZeroUsize::new(kb * BYTES_IN_KB);
+
+        // Off unless `prevent_unoptimized` is enabled.
+        assert_eq!(
+            get_deferred_points_threshold_bytes(None, 10_000, Some(1_000)),
+            None,
+        );
+        assert_eq!(
+            get_deferred_points_threshold_bytes(Some(false), 10_000, Some(1_000)),
+            None,
+        );
+
+        // A cap above the indexing threshold does not bind.
+        assert_eq!(
+            get_deferred_points_threshold_bytes(Some(true), 10_000, Some(256_000)),
+            bytes(10_000),
+        );
+
+        // A cap below the indexing threshold wins: the staging area cannot outgrow a segment.
+        assert_eq!(
+            get_deferred_points_threshold_bytes(Some(true), 100_000, Some(1_000)),
+            bytes(1_000),
+        );
+
+        // An auto-derived cap is resolved elsewhere and left alone here.
+        assert_eq!(
+            get_deferred_points_threshold_bytes(Some(true), 100_000, None),
+            bytes(100_000),
+        );
+
+        // Disabled indexing keeps its unreachable threshold: the clamp may only lower an
+        // already-reachable one, never make deferral reachable where it was not.
+        assert_eq!(
+            get_deferred_points_threshold_bytes(Some(true), usize::MAX, Some(1_000)),
+            NonZeroUsize::new(usize::MAX.saturating_mul(BYTES_IN_KB)),
+        );
+    }
 
     #[test]
     fn live_vector_names_provider_reads_current_state() {

--- a/lib/shard/src/resolve.rs
+++ b/lib/shard/src/resolve.rs
@@ -313,7 +313,7 @@ mod tests {
         let CollectionUpdateOperations::PointOperation(op) = resolved else {
             unreachable!()
         };
-        process_point_operation(&holder, 100, op, &hw_counter).unwrap();
+        process_point_operation(&holder, 100, op, None, &hw_counter).unwrap();
         delete_points_by_filter(&twin_holder, 100, &filter, &hw_counter).unwrap();
 
         let remaining = points_by_filter(&holder, &filter, &hw_counter).unwrap();

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -8,6 +8,7 @@ mod tests;
 
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::sync::Arc;
@@ -428,6 +429,67 @@ impl SegmentHolder {
     /// Return appendable segment IDs sorted by IDs
     pub fn appendable_segments_ids(&self) -> Vec<SegmentId> {
         self.appendable_segments.keys().copied().collect()
+    }
+
+    /// Return appendable segment IDs smaller than `max_segment_size_bytes`, sorted by IDs.
+    ///
+    /// Segments that cannot be measured right now stay eligible, the size cap is best effort.
+    fn eligible_appendable_segments_ids(
+        &self,
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> Vec<SegmentId> {
+        let Some(max_segment_size_bytes) = max_segment_size_bytes else {
+            return self.appendable_segments_ids();
+        };
+
+        self.appendable_segments
+            .iter()
+            .filter(|(_, locked_segment)| {
+                let segment_arc = locked_segment.get();
+                let Some(segment) = segment_arc.try_read() else {
+                    return true;
+                };
+                match segment.max_available_vectors_size_in_bytes() {
+                    Ok(size) => size < max_segment_size_bytes.get(),
+                    Err(err) => {
+                        log::error!("Failed to get segment size, ignoring: {err}");
+                        true
+                    }
+                }
+            })
+            .map(|(segment_id, _)| *segment_id)
+            .collect()
+    }
+
+    /// Whether at least one appendable segment is smaller than `max_segment_size_bytes`.
+    /// Also `false` when there is no appendable segment at all.
+    pub fn has_appendable_segment_with_capacity(
+        &self,
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> bool {
+        !self
+            .eligible_appendable_segments_ids(max_segment_size_bytes)
+            .is_empty()
+    }
+
+    /// Candidate destinations for copy-on-write moves, computed lazily on the first move and
+    /// kept in `cache` for the rest of the call.
+    ///
+    /// Falls back to all appendable segments when none is below the cap, a write must not fail
+    /// for lack of capacity.
+    fn cow_destination_candidates<'a>(
+        &self,
+        cache: &'a mut Option<Vec<SegmentId>>,
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> &'a [SegmentId] {
+        cache.get_or_insert_with(|| {
+            let eligible = self.eligible_appendable_segments_ids(max_segment_size_bytes);
+            if eligible.is_empty() {
+                self.appendable_segments_ids()
+            } else {
+                eligible
+            }
+        })
     }
 
     /// Return non-appendable segment IDs sorted by IDs
@@ -1000,6 +1062,7 @@ impl SegmentHolder {
         ids: &[PointIdType],
         mut point_operation: F,
         mut point_cow_operation: G,
+        max_segment_size_bytes: Option<NonZeroUsize>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<AHashSet<PointIdType>>
     where
@@ -1011,8 +1074,7 @@ impl SegmentHolder {
             &mut Payload,
         ),
     {
-        // Choose random appendable segment from this
-        let appendable_segments = self.appendable_segments_ids();
+        let mut destination_cache: Option<Vec<SegmentId>> = None;
 
         let mut applied_points: AHashSet<PointIdType> = Default::default();
         let stopped = AtomicBool::new(false);
@@ -1031,7 +1093,10 @@ impl SegmentHolder {
                 point_operation(point_id, write_segment)?
             } else {
                 self.aloha_random_write(
-                    &appendable_segments,
+                    self.cow_destination_candidates(
+                        &mut destination_cache,
+                        max_segment_size_bytes,
+                    ),
                     |appendable_idx, appendable_write_segment| {
                         // If we are moving point from one segment to another,
                         // we must guarantee, that data in new segment will be persisted before

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -1066,8 +1066,6 @@ impl SegmentHolder {
             &mut Payload,
         ),
     {
-        // Lazily-computed move destinations, shared across this call; see
-        // `cow_destination_candidates`.
         let mut destination_cache: Option<Vec<SegmentId>> = None;
 
         let mut applied_points: AHashSet<PointIdType> = Default::default();

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -433,13 +433,9 @@ impl SegmentHolder {
 
     /// Appendable segment IDs measuring below `max_segment_size_bytes`, sorted by ID.
     ///
-    /// Segments that cannot be measured right now (read-lock contention, size error) stay eligible:
-    /// the cap is soft, and liveness wins over precision. Every appendable segment is eligible
-    /// without a cap.
-    ///
-    /// Single origin of the eligibility rule: the copy-on-write move destinations and the
-    /// optimizer's capacity-ensure step both derive from it, so the segment the optimizer
-    /// provisions when it finds no capacity is exactly the one those moves then target.
+    /// Segments that cannot be measured right now stay eligible: the cap is soft and liveness wins
+    /// over precision. Shared with the optimizer's capacity-ensure step, so the segment it
+    /// provisions is exactly the one copy-on-write moves then target.
     fn eligible_appendable_segments_ids(
         &self,
         max_segment_size_bytes: Option<NonZeroUsize>,
@@ -467,10 +463,8 @@ impl SegmentHolder {
             .collect()
     }
 
-    /// Whether at least one appendable segment is below `max_segment_size_bytes`. `false` when
-    /// there are no appendable segments at all, so a caller provisioning capacity creates the
-    /// first one. Eligibility follows
-    /// [`eligible_appendable_segments_ids`](Self::eligible_appendable_segments_ids).
+    /// Whether at least one appendable segment is below `max_segment_size_bytes`. `false` without
+    /// any appendable segment, so a caller provisioning capacity creates the first one.
     pub fn has_appendable_segment_with_capacity(
         &self,
         max_segment_size_bytes: Option<NonZeroUsize>,
@@ -480,16 +474,11 @@ impl SegmentHolder {
             .is_empty()
     }
 
-    /// Copy-on-write move destinations for one [`apply_points_with_conditional_move`] call,
-    /// computed on the first point that actually needs a move (a batch applying fully in place must
-    /// not pay for the size measurements) and cached for the rest of the call.
+    /// Copy-on-write move destinations, computed on the first point that needs a move (a batch
+    /// applying fully in place pays for no measurements) and cached for the rest of the call.
     ///
-    /// Prefers appendable segments below the size cap, and falls back to every appendable segment
-    /// when none is: the cap is soft and a write must never fail for lack of capacity. Callers
-    /// batch points, so the cap is re-evaluated per batch and a destination can overshoot it by at
-    /// most one batch worth of points.
-    ///
-    /// [`apply_points_with_conditional_move`]: Self::apply_points_with_conditional_move
+    /// Falls back to every appendable segment when none is below the cap: a write must never fail
+    /// for lack of capacity. Callers batch points, so a destination can overshoot by one batch.
     fn cow_destination_candidates<'a>(
         &self,
         cache: &'a mut Option<Vec<SegmentId>>,

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -431,9 +431,25 @@ impl SegmentHolder {
         self.appendable_segments.keys().copied().collect()
     }
 
-    /// Return appendable segment IDs smaller than `max_segment_size_bytes`, sorted by IDs.
+    /// Whether `segment` is smaller than `max_segment_size_bytes`.
     ///
-    /// Segments that cannot be measured right now stay eligible, the size cap is best effort.
+    /// A segment that cannot be measured right now counts as having capacity, the size cap is
+    /// best effort.
+    fn segment_has_capacity(segment: &LockedSegment, max_segment_size_bytes: NonZeroUsize) -> bool {
+        let segment_arc = segment.get();
+        let Some(segment) = segment_arc.try_read() else {
+            return true;
+        };
+        match segment.max_available_vectors_size_in_bytes() {
+            Ok(size) => size < max_segment_size_bytes.get(),
+            Err(err) => {
+                log::error!("Failed to get segment size, ignoring: {err}");
+                true
+            }
+        }
+    }
+
+    /// Return appendable segment IDs smaller than `max_segment_size_bytes`, sorted by IDs.
     fn eligible_appendable_segments_ids(
         &self,
         max_segment_size_bytes: Option<NonZeroUsize>,
@@ -444,19 +460,7 @@ impl SegmentHolder {
 
         self.appendable_segments
             .iter()
-            .filter(|(_, locked_segment)| {
-                let segment_arc = locked_segment.get();
-                let Some(segment) = segment_arc.try_read() else {
-                    return true;
-                };
-                match segment.max_available_vectors_size_in_bytes() {
-                    Ok(size) => size < max_segment_size_bytes.get(),
-                    Err(err) => {
-                        log::error!("Failed to get segment size, ignoring: {err}");
-                        true
-                    }
-                }
-            })
+            .filter(|(_, segment)| Self::segment_has_capacity(segment, max_segment_size_bytes))
             .map(|(segment_id, _)| *segment_id)
             .collect()
     }
@@ -467,9 +471,13 @@ impl SegmentHolder {
         &self,
         max_segment_size_bytes: Option<NonZeroUsize>,
     ) -> bool {
-        !self
-            .eligible_appendable_segments_ids(max_segment_size_bytes)
-            .is_empty()
+        let Some(max_segment_size_bytes) = max_segment_size_bytes else {
+            return !self.appendable_segments.is_empty();
+        };
+
+        self.appendable_segments
+            .values()
+            .any(|segment| Self::segment_has_capacity(segment, max_segment_size_bytes))
     }
 
     /// Candidate destinations for copy-on-write moves, computed lazily on the first move and

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -8,6 +8,7 @@ mod tests;
 
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::sync::Arc;
@@ -428,6 +429,80 @@ impl SegmentHolder {
     /// Return appendable segment IDs sorted by IDs
     pub fn appendable_segments_ids(&self) -> Vec<SegmentId> {
         self.appendable_segments.keys().copied().collect()
+    }
+
+    /// Appendable segment IDs measuring below `max_segment_size_bytes`, sorted by ID.
+    ///
+    /// Segments that cannot be measured right now (read-lock contention, size error) stay eligible:
+    /// the cap is soft, and liveness wins over precision. Every appendable segment is eligible
+    /// without a cap.
+    ///
+    /// Single origin of the eligibility rule: the copy-on-write move destinations and the
+    /// optimizer's capacity-ensure step both derive from it, so the segment the optimizer
+    /// provisions when it finds no capacity is exactly the one those moves then target.
+    fn eligible_appendable_segments_ids(
+        &self,
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> Vec<SegmentId> {
+        let Some(max_segment_size_bytes) = max_segment_size_bytes else {
+            return self.appendable_segments_ids();
+        };
+
+        self.appendable_segments
+            .iter()
+            .filter(|(_, locked_segment)| {
+                let segment_arc = locked_segment.get();
+                let Some(segment) = segment_arc.try_read() else {
+                    return true;
+                };
+                match segment.max_available_vectors_size_in_bytes() {
+                    Ok(size) => size < max_segment_size_bytes.get(),
+                    Err(err) => {
+                        log::error!("Failed to get segment size, ignoring: {err}");
+                        true
+                    }
+                }
+            })
+            .map(|(segment_id, _)| *segment_id)
+            .collect()
+    }
+
+    /// Whether at least one appendable segment is below `max_segment_size_bytes`. `false` when
+    /// there are no appendable segments at all, so a caller provisioning capacity creates the
+    /// first one. Eligibility follows
+    /// [`eligible_appendable_segments_ids`](Self::eligible_appendable_segments_ids).
+    pub fn has_appendable_segment_with_capacity(
+        &self,
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> bool {
+        !self
+            .eligible_appendable_segments_ids(max_segment_size_bytes)
+            .is_empty()
+    }
+
+    /// Copy-on-write move destinations for one [`apply_points_with_conditional_move`] call,
+    /// computed on the first point that actually needs a move (a batch applying fully in place must
+    /// not pay for the size measurements) and cached for the rest of the call.
+    ///
+    /// Prefers appendable segments below the size cap, and falls back to every appendable segment
+    /// when none is: the cap is soft and a write must never fail for lack of capacity. Callers
+    /// batch points, so the cap is re-evaluated per batch and a destination can overshoot it by at
+    /// most one batch worth of points.
+    ///
+    /// [`apply_points_with_conditional_move`]: Self::apply_points_with_conditional_move
+    fn cow_destination_candidates<'a>(
+        &self,
+        cache: &'a mut Option<Vec<SegmentId>>,
+        max_segment_size_bytes: Option<NonZeroUsize>,
+    ) -> &'a [SegmentId] {
+        cache.get_or_insert_with(|| {
+            let eligible = self.eligible_appendable_segments_ids(max_segment_size_bytes);
+            if eligible.is_empty() {
+                self.appendable_segments_ids()
+            } else {
+                eligible
+            }
+        })
     }
 
     /// Return non-appendable segment IDs sorted by IDs
@@ -990,6 +1065,7 @@ impl SegmentHolder {
         ids: &[PointIdType],
         mut point_operation: F,
         mut point_cow_operation: G,
+        max_segment_size_bytes: Option<NonZeroUsize>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<AHashSet<PointIdType>>
     where
@@ -1001,8 +1077,9 @@ impl SegmentHolder {
             &mut Payload,
         ),
     {
-        // Choose random appendable segment from this
-        let appendable_segments = self.appendable_segments_ids();
+        // Lazily-computed move destinations, shared across this call; see
+        // `cow_destination_candidates`.
+        let mut destination_cache: Option<Vec<SegmentId>> = None;
 
         let mut applied_points: AHashSet<PointIdType> = Default::default();
         let stopped = AtomicBool::new(false);
@@ -1021,7 +1098,10 @@ impl SegmentHolder {
                 point_operation(point_id, write_segment)?
             } else {
                 self.aloha_random_write(
-                    &appendable_segments,
+                    self.cow_destination_candidates(
+                        &mut destination_cache,
+                        max_segment_size_bytes,
+                    ),
                     |appendable_idx, appendable_write_segment| {
                         // If we are moving point from one segment to another,
                         // we must guarantee, that data in new segment will be persisted before

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -2330,3 +2330,149 @@ fn test_cow_move_falls_back_when_every_segment_reached_the_size_cap() {
         "the move must still land, overshooting the cap",
     );
 }
+
+/// A deferred staging segment that reached the size cap must still take the move when it is the
+/// only appendable segment. The cap only ever narrows the choice of destination, so it must not
+/// starve a `prevent_unoptimized` staging area: the write lands, and the point stays visible
+/// through the retained source exactly as it does uncapped.
+#[test]
+fn test_cow_move_into_capped_deferred_staging_segment_keeps_point_visible() {
+    use crate::fixtures::build_segment_with_deferred_1;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    // Staging area: appendable, holds deferred points, and has reached the cap.
+    let staging = build_segment_with_deferred_1(dir.path());
+
+    let mut source = empty_segment(dir.path());
+    source
+        .upsert_point(
+            10,
+            100.into(),
+            segment::data_types::vectors::only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
+            &hw_counter,
+        )
+        .unwrap();
+    source.appendable_flag = false;
+
+    let mut holder = SegmentHolder::default();
+    let source_id = holder.add_new(source);
+    let staging_id = holder.add_new(staging);
+
+    assert!(
+        holder
+            .get(staging_id)
+            .unwrap()
+            .get()
+            .read()
+            .has_deferred_points(),
+        "the fixture must hold deferred points, or this tests nothing",
+    );
+
+    // Cap at the staging segment's own size: it is the only appendable segment and it is not
+    // below the cap, so the fallback has to pick it anyway.
+    let staging_size = segment_size(&holder, staging_id);
+    assert!(staging_size > 0, "the fixture must measure non-empty");
+
+    holder
+        .apply_points_with_conditional_move(
+            20,
+            &[100.into()],
+            |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
+            |_, _, _, _| {},
+            NonZeroUsize::new(staging_size),
+            &hw_counter,
+        )
+        .expect("a staging segment at the cap must still accept the move");
+
+    let staging_segment = holder.get(staging_id).unwrap().get();
+    let staging_segment = staging_segment.read();
+    let source_segment = holder.get(source_id).unwrap().get();
+    let source_segment = source_segment.read();
+
+    assert!(
+        staging_segment.point_version(100.into()).is_some(),
+        "the moved point must exist in the staging segment",
+    );
+    assert!(
+        staging_segment.point_is_deferred(100.into()),
+        "past the deferred offset the moved point lands deferred, as it does uncapped",
+    );
+    assert!(
+        source_segment.point_version(100.into()).is_some(),
+        "a deferred destination copy must keep the visible source, or the point disappears",
+    );
+}
+
+/// With a segment below the cap available next to a full deferred staging segment, the move goes
+/// to the one below the cap. The point becomes visible immediately (no deferred copy, source
+/// dropped) and the staging area keeps its own backlog untouched for the optimizer to promote.
+#[test]
+fn test_cow_move_prefers_uncapped_segment_over_full_deferred_staging_segment() {
+    use crate::fixtures::build_segment_with_deferred_1;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    // Staging segment first, so it is the lower segment id: `aloha_random_write` takes the first
+    // destination it can lock, so without the cap filter it would be the one chosen.
+    let mut holder = SegmentHolder::default();
+    let staging_id = holder.add_new(build_segment_with_deferred_1(dir.path()));
+    let fresh_id = holder.add_new(empty_segment(dir.path()));
+
+    let mut source = empty_segment(dir.path());
+    source
+        .upsert_point(
+            10,
+            100.into(),
+            segment::data_types::vectors::only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
+            &hw_counter,
+        )
+        .unwrap();
+    source.appendable_flag = false;
+    let source_id = holder.add_new(source);
+
+    let staging_size = segment_size(&holder, staging_id);
+    assert!(staging_size > 0, "the fixture must measure non-empty");
+
+    holder
+        .apply_points_with_conditional_move(
+            20,
+            &[100.into()],
+            |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
+            |_, _, _, _| {},
+            NonZeroUsize::new(staging_size),
+            &hw_counter,
+        )
+        .unwrap();
+
+    let fresh_segment = holder.get(fresh_id).unwrap().get();
+    let fresh_segment = fresh_segment.read();
+    assert!(
+        fresh_segment.point_version(100.into()).is_some(),
+        "the moved point must land in the segment below the cap",
+    );
+    assert!(
+        !fresh_segment.point_is_deferred(100.into()),
+        "a segment below the cap has no deferred offset here, so the point is visible at once",
+    );
+
+    let staging_segment = holder.get(staging_id).unwrap().get();
+    let staging_segment = staging_segment.read();
+    assert!(
+        staging_segment.point_version(100.into()).is_none(),
+        "the full staging segment must not receive the move",
+    );
+    assert!(
+        staging_segment.has_deferred_points(),
+        "the staging backlog must be left intact for the optimizer to promote",
+    );
+
+    let source_segment = holder.get(source_id).unwrap().get();
+    let source_segment = source_segment.read();
+    assert!(
+        source_segment.point_version(100.into()).is_none(),
+        "a visible destination copy lets the source be dropped, as it does uncapped",
+    );
+}

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -2225,52 +2225,23 @@ fn test_has_appendable_segment_with_capacity() {
     let mut holder = SegmentHolder::default();
     assert!(
         !holder.has_appendable_segment_with_capacity(None),
-        "a holder without appendable segments has no capacity, so a caller provisions the first one",
+        "no appendable segment means no capacity, so a caller provisions the first one",
     );
 
     let segment_id = holder.add_new(build_segment_1(dir.path()));
     let size = segment_size(&holder, segment_id);
     assert!(size > 0, "the fixture must measure non-empty");
 
-    assert!(
-        holder.has_appendable_segment_with_capacity(None),
-        "without a cap every appendable segment has capacity",
-    );
-    assert!(
-        !holder.has_appendable_segment_with_capacity(NonZeroUsize::new(size)),
-        "a segment that reached the cap has no capacity left",
-    );
-    assert!(
-        holder.has_appendable_segment_with_capacity(NonZeroUsize::new(size + 1)),
-        "a segment below the cap has capacity",
-    );
-}
+    assert!(holder.has_appendable_segment_with_capacity(None));
+    assert!(!holder.has_appendable_segment_with_capacity(NonZeroUsize::new(size)));
+    assert!(holder.has_appendable_segment_with_capacity(NonZeroUsize::new(size + 1)));
 
-/// A segment busy under a write lock counts as having capacity. Treating it as full would exclude
-/// it as a destination and make the optimizer provision a replacement it does not need. This also
-/// relaxes the optimizer's own check, which used to block on the read lock.
-#[test]
-fn test_unmeasurable_appendable_segment_stays_eligible() {
-    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-
-    let mut holder = SegmentHolder::default();
-    let segment_id = holder.add_new(build_segment_1(dir.path()));
-
-    // A cap no segment holding data can be below.
-    let cap = NonZeroUsize::new(1);
-    assert!(
-        !holder.has_appendable_segment_with_capacity(cap),
-        "a measurable segment over the cap has no capacity left",
-    );
-
+    // A segment busy under a write lock cannot be measured and stays eligible. Treating it as
+    // full would make the optimizer provision a replacement it does not need. This also relaxes
+    // the optimizer's own check, which used to block on the read lock.
     let locked_segment = holder.get(segment_id).unwrap().get();
     let _write_guard = locked_segment.write();
-
-    assert!(
-        holder.has_appendable_segment_with_capacity(cap),
-        "a segment that cannot be measured must stay eligible, or lock contention alone makes \
-         the holder look full",
-    );
+    assert!(holder.has_appendable_segment_with_capacity(NonZeroUsize::new(1)));
 }
 
 /// Moves must land in a segment below the cap, or a filtered payload operation keeps growing one

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -64,6 +64,7 @@ fn test_apply_to_appendable() {
             |point_id, _, _, _| {
                 moved_to_appendable.push(point_id);
             },
+            None,
             &HardwareCounterCell::new(),
         )
         .unwrap();
@@ -188,6 +189,7 @@ fn test_apply_and_move_old_versions(
                 Ok(true)
             },
             |point_id, _, _, _| processed_points2.push(point_id),
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -279,6 +281,7 @@ fn test_cow_operation() {
                 );
                 payload.0.insert(PAYLOAD_KEY.to_string(), 2.into());
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -343,6 +346,7 @@ fn test_cow_move_append_only_single_slot() {
                 );
                 payload.0.insert(PAYLOAD_KEY.to_string(), 2.into());
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -461,7 +465,8 @@ fn test_cow_move_does_not_degrade_turbo_vectors() {
                 101 + round,
                 &[point_id],
                 |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
-                |_, _, _, _| {}, // no-op: a pure move
+                |_, _, _, _| {},
+                None, // no-op: a pure move
                 &hw_counter,
             )
             .unwrap();
@@ -593,6 +598,7 @@ fn test_cow_move_overlay_preserves_untouched_turbo_vector() {
                     VectorInternal::Dense(fresh_replace.clone()),
                 );
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -691,6 +697,7 @@ fn test_cow_move_delete_name_preserves_survivor() {
             |_, raw_vectors, _, _| {
                 raw_vectors.retain(|(name, _)| name != DROP);
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -787,7 +794,8 @@ fn test_cow_move_allows_role_config_differences() {
             101,
             &[point_id],
             |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
-            |_, _, _, _| {}, // no-op: a pure move
+            |_, _, _, _| {},
+            None, // no-op: a pure move
             &hw_counter,
         )
         .unwrap();
@@ -2008,6 +2016,7 @@ fn test_cow_skips_delete_when_destination_is_deferred() {
             &[100.into()],
             |_, _| unreachable!("point is in non-appendable, should take CoW path"),
             |_, _, _, _| {},
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -2175,6 +2184,7 @@ fn test_cow_deletes_source_when_destination_is_not_deferred() {
             &[100.into()],
             |_, _| unreachable!("point is in non-appendable, should take CoW path"),
             |_, _, _, _| {},
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -2194,5 +2204,129 @@ fn test_cow_deletes_source_when_destination_is_not_deferred() {
     assert!(
         non_app.point_version(100.into()).is_none(),
         "Point 100 should be deleted from the source"
+    );
+}
+
+/// Measured size of an appendable segment, as the size cap sees it.
+fn segment_size(holder: &SegmentHolder, segment_id: SegmentId) -> usize {
+    holder
+        .get(segment_id)
+        .unwrap()
+        .get()
+        .read()
+        .max_available_vectors_size_in_bytes()
+        .unwrap()
+}
+
+#[test]
+fn test_has_appendable_segment_with_capacity() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut holder = SegmentHolder::default();
+    assert!(
+        !holder.has_appendable_segment_with_capacity(None),
+        "a holder without appendable segments has no capacity, so a caller provisions the first one",
+    );
+
+    let segment_id = holder.add_new(build_segment_1(dir.path()));
+    let size = segment_size(&holder, segment_id);
+    assert!(size > 0, "the fixture must measure non-empty");
+
+    assert!(
+        holder.has_appendable_segment_with_capacity(None),
+        "without a cap every appendable segment has capacity",
+    );
+    assert!(
+        !holder.has_appendable_segment_with_capacity(NonZeroUsize::new(size)),
+        "a segment that reached the cap has no capacity left",
+    );
+    assert!(
+        holder.has_appendable_segment_with_capacity(NonZeroUsize::new(size + 1)),
+        "a segment below the cap has capacity",
+    );
+}
+
+/// Copy-on-write moves must land in an appendable segment below the size cap, or a filtered
+/// payload operation keeps growing a segment that is already too big (the segment overgrow bug).
+/// The over-cap segment is added first on purpose: `aloha_random_write` takes the first
+/// destination it can lock, so it would be the one chosen without the cap steering.
+#[test]
+fn test_cow_move_prefers_appendable_segment_below_size_cap() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut source = build_segment_2(dir.path());
+    source.appendable_flag = false;
+
+    let mut holder = SegmentHolder::default();
+    let full_id = holder.add_new(build_segment_1(dir.path()));
+    let free_id = holder.add_new(empty_segment(dir.path()));
+    holder.add_new(source);
+
+    // Cap right at the full segment's size: eligibility is `size < cap`, so it drops out while the
+    // empty one stays.
+    let full_size = segment_size(&holder, full_id);
+    assert!(full_size > 0, "the fixture must measure non-empty");
+
+    let hw_counter = HardwareCounterCell::new();
+    holder
+        .apply_points_with_conditional_move(
+            100,
+            &[11.into()],
+            |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
+            |_, _, _, _| {},
+            NonZeroUsize::new(full_size),
+            &hw_counter,
+        )
+        .unwrap();
+
+    let free_segment = holder.get(free_id).unwrap().get();
+    assert!(
+        free_segment
+            .read()
+            .has_point(11.into(), common::types::DeferredBehavior::WithDeferred),
+        "the moved point must land in the segment below the cap",
+    );
+
+    let full_segment = holder.get(full_id).unwrap().get();
+    assert!(
+        !full_segment
+            .read()
+            .has_point(11.into(), common::types::DeferredBehavior::WithDeferred),
+        "the segment that reached the cap must not grow further",
+    );
+}
+
+/// The cap is soft: when every appendable segment reached it, the move falls back to them all
+/// rather than failing. Running out of capacity must never fail a write, it may only overshoot.
+#[test]
+fn test_cow_move_falls_back_when_every_segment_reached_the_size_cap() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut source = build_segment_2(dir.path());
+    source.appendable_flag = false;
+
+    let mut holder = SegmentHolder::default();
+    let destination_id = holder.add_new(build_segment_1(dir.path()));
+    holder.add_new(source);
+
+    let hw_counter = HardwareCounterCell::new();
+    holder
+        .apply_points_with_conditional_move(
+            100,
+            &[11.into()],
+            |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
+            |_, _, _, _| {},
+            // One byte: no appendable segment can ever be below it.
+            NonZeroUsize::new(1),
+            &hw_counter,
+        )
+        .expect("running out of capacity must not fail the write");
+
+    let destination = holder.get(destination_id).unwrap().get();
+    assert!(
+        destination
+            .read()
+            .has_point(11.into(), common::types::DeferredBehavior::WithDeferred),
+        "the move must still land, overshooting the cap",
     );
 }

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -2246,10 +2246,9 @@ fn test_has_appendable_segment_with_capacity() {
     );
 }
 
-/// A segment that cannot be measured right now counts as having capacity. The cap is soft, so a
-/// segment busy under a write lock must not be treated as full: that would exclude it as a move
-/// destination and make the optimizer provision a replacement it does not need. Note this also
-/// relaxes the optimizer's own capacity check, which used to block on the read lock instead.
+/// A segment busy under a write lock counts as having capacity. Treating it as full would exclude
+/// it as a destination and make the optimizer provision a replacement it does not need. This also
+/// relaxes the optimizer's own check, which used to block on the read lock.
 #[test]
 fn test_unmeasurable_appendable_segment_stays_eligible() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
@@ -2274,10 +2273,9 @@ fn test_unmeasurable_appendable_segment_stays_eligible() {
     );
 }
 
-/// Copy-on-write moves must land in an appendable segment below the size cap, or a filtered
-/// payload operation keeps growing a segment that is already too big (the segment overgrow bug).
-/// The over-cap segment is added first on purpose: `aloha_random_write` takes the first
-/// destination it can lock, so it would be the one chosen without the cap steering.
+/// Moves must land in a segment below the cap, or a filtered payload operation keeps growing one
+/// that is already too big. The over-cap segment is added first on purpose: `aloha_random_write`
+/// takes the first destination it can lock, so it is what gets chosen without the steering.
 #[test]
 fn test_cow_move_prefers_appendable_segment_below_size_cap() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
@@ -2324,45 +2322,9 @@ fn test_cow_move_prefers_appendable_segment_below_size_cap() {
     );
 }
 
-/// The cap is soft: when every appendable segment reached it, the move falls back to them all
-/// rather than failing. Running out of capacity must never fail a write, it may only overshoot.
-#[test]
-fn test_cow_move_falls_back_when_every_segment_reached_the_size_cap() {
-    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-
-    let mut source = build_segment_2(dir.path());
-    source.appendable_flag = false;
-
-    let mut holder = SegmentHolder::default();
-    let destination_id = holder.add_new(build_segment_1(dir.path()));
-    holder.add_new(source);
-
-    let hw_counter = HardwareCounterCell::new();
-    holder
-        .apply_points_with_conditional_move(
-            100,
-            &[11.into()],
-            |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
-            |_, _, _, _| {},
-            // One byte: no appendable segment can ever be below it.
-            NonZeroUsize::new(1),
-            &hw_counter,
-        )
-        .expect("running out of capacity must not fail the write");
-
-    let destination = holder.get(destination_id).unwrap().get();
-    assert!(
-        destination
-            .read()
-            .has_point(11.into(), common::types::DeferredBehavior::WithDeferred),
-        "the move must still land, overshooting the cap",
-    );
-}
-
-/// A deferred staging segment that reached the size cap must still take the move when it is the
-/// only appendable segment. The cap only ever narrows the choice of destination, so it must not
-/// starve a `prevent_unoptimized` staging area: the write lands, and the point stays visible
-/// through the retained source exactly as it does uncapped.
+/// A deferred staging segment at the cap must still take the move when it is the only appendable
+/// one: the cap narrows the choice of destination, it must never starve a `prevent_unoptimized`
+/// staging area. The point stays visible through the retained source, as it does uncapped.
 #[test]
 fn test_cow_move_into_capped_deferred_staging_segment_keeps_point_visible() {
     use crate::fixtures::build_segment_with_deferred_1;
@@ -2433,9 +2395,9 @@ fn test_cow_move_into_capped_deferred_staging_segment_keeps_point_visible() {
     );
 }
 
-/// With a segment below the cap available next to a full deferred staging segment, the move goes
-/// to the one below the cap. The point becomes visible immediately (no deferred copy, source
-/// dropped) and the staging area keeps its own backlog untouched for the optimizer to promote.
+/// With a segment below the cap available, the move goes there rather than to the full deferred
+/// staging segment: visible at once, source dropped, and the staging backlog left for the
+/// optimizer to promote.
 #[test]
 fn test_cow_move_prefers_uncapped_segment_over_full_deferred_staging_segment() {
     use crate::fixtures::build_segment_with_deferred_1;

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -2246,6 +2246,34 @@ fn test_has_appendable_segment_with_capacity() {
     );
 }
 
+/// A segment that cannot be measured right now counts as having capacity. The cap is soft, so a
+/// segment busy under a write lock must not be treated as full: that would exclude it as a move
+/// destination and make the optimizer provision a replacement it does not need. Note this also
+/// relaxes the optimizer's own capacity check, which used to block on the read lock instead.
+#[test]
+fn test_unmeasurable_appendable_segment_stays_eligible() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut holder = SegmentHolder::default();
+    let segment_id = holder.add_new(build_segment_1(dir.path()));
+
+    // A cap no segment holding data can be below.
+    let cap = NonZeroUsize::new(1);
+    assert!(
+        !holder.has_appendable_segment_with_capacity(cap),
+        "a measurable segment over the cap has no capacity left",
+    );
+
+    let locked_segment = holder.get(segment_id).unwrap().get();
+    let _write_guard = locked_segment.write();
+
+    assert!(
+        holder.has_appendable_segment_with_capacity(cap),
+        "a segment that cannot be measured must stay eligible, or lock contention alone makes \
+         the holder look full",
+    );
+}
+
 /// Copy-on-write moves must land in an appendable segment below the size cap, or a filtered
 /// payload operation keeps growing a segment that is already too big (the segment overgrow bug).
 /// The over-cap segment is added first on purpose: `aloha_random_write` takes the first

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -64,6 +64,7 @@ fn test_apply_to_appendable() {
             |point_id, _, _, _| {
                 moved_to_appendable.push(point_id);
             },
+            None,
             &HardwareCounterCell::new(),
         )
         .unwrap();
@@ -188,6 +189,7 @@ fn test_apply_and_move_old_versions(
                 Ok(true)
             },
             |point_id, _, _, _| processed_points2.push(point_id),
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -279,6 +281,7 @@ fn test_cow_operation() {
                 );
                 payload.0.insert(PAYLOAD_KEY.to_string(), 2.into());
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -343,6 +346,7 @@ fn test_cow_move_append_only_single_slot() {
                 );
                 payload.0.insert(PAYLOAD_KEY.to_string(), 2.into());
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -462,6 +466,7 @@ fn test_cow_move_does_not_degrade_turbo_vectors() {
                 &[point_id],
                 |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
                 |_, _, _, _| {}, // no-op: a pure move
+                None,
                 &hw_counter,
             )
             .unwrap();
@@ -593,6 +598,7 @@ fn test_cow_move_overlay_preserves_untouched_turbo_vector() {
                     VectorInternal::Dense(fresh_replace.clone()),
                 );
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -691,6 +697,7 @@ fn test_cow_move_delete_name_preserves_survivor() {
             |_, raw_vectors, _, _| {
                 raw_vectors.retain(|(name, _)| name != DROP);
             },
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -788,6 +795,7 @@ fn test_cow_move_allows_role_config_differences() {
             &[point_id],
             |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
             |_, _, _, _| {}, // no-op: a pure move
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -2008,6 +2016,7 @@ fn test_cow_skips_delete_when_destination_is_deferred() {
             &[100.into()],
             |_, _| unreachable!("point is in non-appendable, should take CoW path"),
             |_, _, _, _| {},
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -2175,6 +2184,7 @@ fn test_cow_deletes_source_when_destination_is_not_deferred() {
             &[100.into()],
             |_, _| unreachable!("point is in non-appendable, should take CoW path"),
             |_, _, _, _| {},
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -2194,5 +2204,227 @@ fn test_cow_deletes_source_when_destination_is_not_deferred() {
     assert!(
         non_app.point_version(100.into()).is_none(),
         "Point 100 should be deleted from the source"
+    );
+}
+
+/// Segment size as seen by the size cap.
+fn segment_size(holder: &SegmentHolder, segment_id: SegmentId) -> usize {
+    holder
+        .get(segment_id)
+        .unwrap()
+        .get()
+        .read()
+        .max_available_vectors_size_in_bytes()
+        .unwrap()
+}
+
+#[test]
+fn test_has_appendable_segment_with_capacity() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut holder = SegmentHolder::default();
+    assert!(
+        !holder.has_appendable_segment_with_capacity(None),
+        "Empty holder should have no capacity",
+    );
+
+    let segment_id = holder.add_new(build_segment_1(dir.path()));
+    let size = segment_size(&holder, segment_id);
+    assert!(size > 0, "Segment should have non-zero size");
+
+    assert!(holder.has_appendable_segment_with_capacity(None));
+    assert!(!holder.has_appendable_segment_with_capacity(NonZeroUsize::new(size)));
+    assert!(holder.has_appendable_segment_with_capacity(NonZeroUsize::new(size + 1)));
+
+    // A segment busy under a write lock cannot be measured and stays eligible
+    let locked_segment = holder.get(segment_id).unwrap().get();
+    let _write_guard = locked_segment.write();
+    assert!(holder.has_appendable_segment_with_capacity(NonZeroUsize::new(1)));
+}
+
+#[test]
+fn test_cow_move_prefers_appendable_segment_below_size_cap() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut source = build_segment_2(dir.path());
+    source.appendable_flag = false;
+
+    let mut holder = SegmentHolder::default();
+    // The full segment is added first, `aloha_random_write` would pick it without the steering
+    let full_id = holder.add_new(build_segment_1(dir.path()));
+    let free_id = holder.add_new(empty_segment(dir.path()));
+    holder.add_new(source);
+
+    // Cap at the full segment's size, the strict comparison makes it ineligible
+    let full_size = segment_size(&holder, full_id);
+    assert!(full_size > 0, "Segment should have non-zero size");
+
+    let hw_counter = HardwareCounterCell::new();
+    holder
+        .apply_points_with_conditional_move(
+            100,
+            &[11.into()],
+            |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
+            |_, _, _, _| {},
+            NonZeroUsize::new(full_size),
+            &hw_counter,
+        )
+        .unwrap();
+
+    let free_segment = holder.get(free_id).unwrap().get();
+    assert!(
+        free_segment
+            .read()
+            .has_point(11.into(), common::types::DeferredBehavior::WithDeferred),
+        "Moved point should land in the segment below the cap",
+    );
+
+    let full_segment = holder.get(full_id).unwrap().get();
+    assert!(
+        !full_segment
+            .read()
+            .has_point(11.into(), common::types::DeferredBehavior::WithDeferred),
+        "Segment at the cap should not receive the point",
+    );
+}
+
+/// A deferred staging segment at the cap still takes the move when it is the only appendable
+/// segment, and the point stays visible through the retained source.
+#[test]
+fn test_cow_move_into_capped_deferred_staging_segment_keeps_point_visible() {
+    use crate::fixtures::build_segment_with_deferred_1;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let staging = build_segment_with_deferred_1(dir.path());
+
+    let mut source = empty_segment(dir.path());
+    source
+        .upsert_point(
+            10,
+            100.into(),
+            segment::data_types::vectors::only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
+            &hw_counter,
+        )
+        .unwrap();
+    source.appendable_flag = false;
+
+    let mut holder = SegmentHolder::default();
+    let source_id = holder.add_new(source);
+    let staging_id = holder.add_new(staging);
+
+    assert!(
+        holder
+            .get(staging_id)
+            .unwrap()
+            .get()
+            .read()
+            .has_deferred_points(),
+        "Staging segment should hold deferred points",
+    );
+
+    // The staging segment is the only appendable one and it is at the cap,
+    // so the fallback picks it anyway
+    let staging_size = segment_size(&holder, staging_id);
+    assert!(staging_size > 0, "Segment should have non-zero size");
+
+    holder
+        .apply_points_with_conditional_move(
+            20,
+            &[100.into()],
+            |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
+            |_, _, _, _| {},
+            NonZeroUsize::new(staging_size),
+            &hw_counter,
+        )
+        .expect("Staging segment at the cap should still accept the move");
+
+    let staging_segment = holder.get(staging_id).unwrap().get();
+    let staging_segment = staging_segment.read();
+    let source_segment = holder.get(source_id).unwrap().get();
+    let source_segment = source_segment.read();
+
+    assert!(
+        staging_segment.point_version(100.into()).is_some(),
+        "Moved point should be in the staging segment",
+    );
+    assert!(
+        staging_segment.point_is_deferred(100.into()),
+        "Point past the deferred offset should land deferred",
+    );
+    assert!(
+        source_segment.point_version(100.into()).is_some(),
+        "Source should be kept while the destination copy is deferred",
+    );
+}
+
+/// With a segment below the cap available, the move goes there instead of the full deferred
+/// staging segment.
+#[test]
+fn test_cow_move_prefers_uncapped_segment_over_full_deferred_staging_segment() {
+    use crate::fixtures::build_segment_with_deferred_1;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    // The staging segment is added first, `aloha_random_write` would pick it without the steering
+    let mut holder = SegmentHolder::default();
+    let staging_id = holder.add_new(build_segment_with_deferred_1(dir.path()));
+    let fresh_id = holder.add_new(empty_segment(dir.path()));
+
+    let mut source = empty_segment(dir.path());
+    source
+        .upsert_point(
+            10,
+            100.into(),
+            segment::data_types::vectors::only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
+            &hw_counter,
+        )
+        .unwrap();
+    source.appendable_flag = false;
+    let source_id = holder.add_new(source);
+
+    let staging_size = segment_size(&holder, staging_id);
+    assert!(staging_size > 0, "Segment should have non-zero size");
+
+    holder
+        .apply_points_with_conditional_move(
+            20,
+            &[100.into()],
+            |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
+            |_, _, _, _| {},
+            NonZeroUsize::new(staging_size),
+            &hw_counter,
+        )
+        .unwrap();
+
+    let fresh_segment = holder.get(fresh_id).unwrap().get();
+    let fresh_segment = fresh_segment.read();
+    assert!(
+        fresh_segment.point_version(100.into()).is_some(),
+        "Moved point should land in the segment below the cap",
+    );
+    assert!(
+        !fresh_segment.point_is_deferred(100.into()),
+        "Point should be immediately visible, the fresh segment has no deferred offset",
+    );
+
+    let staging_segment = holder.get(staging_id).unwrap().get();
+    let staging_segment = staging_segment.read();
+    assert!(
+        staging_segment.point_version(100.into()).is_none(),
+        "Full staging segment should not receive the move",
+    );
+    assert!(
+        staging_segment.has_deferred_points(),
+        "Deferred backlog should be left intact",
+    );
+
+    let source_segment = holder.get(source_id).unwrap().get();
+    let source_segment = source_segment.read();
+    assert!(
+        source_segment.point_version(100.into()).is_none(),
+        "Source copy should be deleted, the destination copy is visible",
     );
 }

--- a/lib/shard/src/update/mod.rs
+++ b/lib/shard/src/update/mod.rs
@@ -8,6 +8,8 @@ mod points;
 mod tests;
 mod vectors;
 
+use std::num::NonZeroUsize;
+
 use common::counter::hardware_counter::HardwareCounterCell;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::types::{Payload, SeqNumberType};
@@ -36,6 +38,7 @@ pub fn process_point_operation(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     point_operation: PointOperations,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     match point_operation {
@@ -46,12 +49,22 @@ pub fn process_point_operation(
                 // touches no segment; bump so WAL can acknowledge it.
                 segments.bump_max_segment_version_overwrite(op_num);
             }
-            let res = upsert_points(segments, op_num, points.iter(), hw_counter)?;
+            let res = upsert_points(
+                segments,
+                op_num,
+                points.iter(),
+                max_segment_size_bytes,
+                hw_counter,
+            )?;
             Ok(res)
         }
-        PointOperations::UpsertPointsConditional(operation) => {
-            conditional_upsert(segments, op_num, operation, hw_counter)
-        }
+        PointOperations::UpsertPointsConditional(operation) => conditional_upsert(
+            segments,
+            op_num,
+            operation,
+            max_segment_size_bytes,
+            hw_counter,
+        ),
         PointOperations::DeletePoints { ids } => delete_points(segments, op_num, &ids, hw_counter),
         PointOperations::DeletePointsByFilter(filter) => {
             delete_points_by_filter(segments, op_num, &filter, hw_counter)
@@ -63,6 +76,7 @@ pub fn process_point_operation(
                 operation.from_id,
                 operation.to_id,
                 &operation.points,
+                max_segment_size_bytes,
                 hw_counter,
             )?;
             Ok(deleted + new + updated)
@@ -73,7 +87,13 @@ pub fn process_point_operation(
                 // An empty upsert touches no segment; bump so WAL can acknowledge it.
                 segments.bump_max_segment_version_overwrite(op_num);
             }
-            let res = upsert_points_raw(segments, op_num, &points, hw_counter)?;
+            let res = upsert_points_raw(
+                segments,
+                op_num,
+                &points,
+                max_segment_size_bytes,
+                hw_counter,
+            )?;
             Ok(res)
         }
         PointOperations::SyncPointsRaw(mut operation) => {
@@ -84,6 +104,7 @@ pub fn process_point_operation(
                 operation.from_id,
                 operation.to_id,
                 &operation.points,
+                max_segment_size_bytes,
                 hw_counter,
             )?;
             Ok(deleted + new + updated)
@@ -123,18 +144,33 @@ pub fn process_vector_operation(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     vector_operation: VectorOperations,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     match vector_operation {
-        VectorOperations::UpdateVectors(update_vectors) => {
-            update_vectors_conditional(segments, op_num, update_vectors, hw_counter)
-        }
-        VectorOperations::DeleteVectors(ids, vector_names) => {
-            delete_vectors(segments, op_num, &ids.points, &vector_names, hw_counter)
-        }
-        VectorOperations::DeleteVectorsByFilter(filter, vector_names) => {
-            delete_vectors_by_filter(segments, op_num, &filter, &vector_names, hw_counter)
-        }
+        VectorOperations::UpdateVectors(update_vectors) => update_vectors_conditional(
+            segments,
+            op_num,
+            update_vectors,
+            max_segment_size_bytes,
+            hw_counter,
+        ),
+        VectorOperations::DeleteVectors(ids, vector_names) => delete_vectors(
+            segments,
+            op_num,
+            &ids.points,
+            &vector_names,
+            max_segment_size_bytes,
+            hw_counter,
+        ),
+        VectorOperations::DeleteVectorsByFilter(filter, vector_names) => delete_vectors_by_filter(
+            segments,
+            op_num,
+            &filter,
+            &vector_names,
+            max_segment_size_bytes,
+            hw_counter,
+        ),
     }
 }
 
@@ -142,15 +178,32 @@ pub fn process_payload_operation(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     payload_operation: PayloadOps,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     match payload_operation {
         PayloadOps::SetPayload(sp) => {
             let payload: Payload = sp.payload;
             if let Some(points) = sp.points {
-                set_payload(segments, op_num, &payload, &points, &sp.key, hw_counter)
+                set_payload(
+                    segments,
+                    op_num,
+                    &payload,
+                    &points,
+                    &sp.key,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else if let Some(filter) = sp.filter {
-                set_payload_by_filter(segments, op_num, &payload, &filter, &sp.key, hw_counter)
+                set_payload_by_filter(
+                    segments,
+                    op_num,
+                    &payload,
+                    &filter,
+                    &sp.key,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(
@@ -160,9 +213,23 @@ pub fn process_payload_operation(
         }
         PayloadOps::DeletePayload(dp) => {
             if let Some(points) = dp.points {
-                delete_payload(segments, op_num, &points, &dp.keys, hw_counter)
+                delete_payload(
+                    segments,
+                    op_num,
+                    &points,
+                    &dp.keys,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else if let Some(filter) = dp.filter {
-                delete_payload_by_filter(segments, op_num, &filter, &dp.keys, hw_counter)
+                delete_payload_by_filter(
+                    segments,
+                    op_num,
+                    &filter,
+                    &dp.keys,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(
@@ -171,17 +238,31 @@ pub fn process_payload_operation(
             }
         }
         PayloadOps::ClearPayload { ref points, .. } => {
-            clear_payload(segments, op_num, points, hw_counter)
+            clear_payload(segments, op_num, points, max_segment_size_bytes, hw_counter)
         }
         PayloadOps::ClearPayloadByFilter(ref filter) => {
-            clear_payload_by_filter(segments, op_num, filter, hw_counter)
+            clear_payload_by_filter(segments, op_num, filter, max_segment_size_bytes, hw_counter)
         }
         PayloadOps::OverwritePayload(sp) => {
             let payload: Payload = sp.payload;
             if let Some(points) = sp.points {
-                overwrite_payload(segments, op_num, &payload, &points, hw_counter)
+                overwrite_payload(
+                    segments,
+                    op_num,
+                    &payload,
+                    &points,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else if let Some(filter) = sp.filter {
-                overwrite_payload_by_filter(segments, op_num, &payload, &filter, hw_counter)
+                overwrite_payload_by_filter(
+                    segments,
+                    op_num,
+                    &payload,
+                    &filter,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(

--- a/lib/shard/src/update/mod.rs
+++ b/lib/shard/src/update/mod.rs
@@ -8,6 +8,8 @@ mod points;
 mod tests;
 mod vectors;
 
+use std::num::NonZeroUsize;
+
 use common::counter::hardware_counter::HardwareCounterCell;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::types::{Payload, SeqNumberType};
@@ -36,6 +38,7 @@ pub fn process_point_operation(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     point_operation: PointOperations,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     match point_operation {
@@ -46,12 +49,22 @@ pub fn process_point_operation(
                 // touches no segment; bump so WAL can acknowledge it.
                 segments.bump_max_segment_version_overwrite(op_num);
             }
-            let res = upsert_points(segments, op_num, points.iter(), hw_counter)?;
+            let res = upsert_points(
+                segments,
+                op_num,
+                points.iter(),
+                max_segment_size_bytes,
+                hw_counter,
+            )?;
             Ok(res)
         }
-        PointOperations::UpsertPointsConditional(operation) => {
-            conditional_upsert(segments, op_num, operation, hw_counter)
-        }
+        PointOperations::UpsertPointsConditional(operation) => conditional_upsert(
+            segments,
+            op_num,
+            operation,
+            max_segment_size_bytes,
+            hw_counter,
+        ),
         PointOperations::DeletePoints { ids } => delete_points(segments, op_num, &ids, hw_counter),
         PointOperations::DeletePointsByFilter(filter) => {
             delete_points_by_filter(segments, op_num, &filter, hw_counter)
@@ -63,6 +76,7 @@ pub fn process_point_operation(
                 operation.from_id,
                 operation.to_id,
                 &operation.points,
+                max_segment_size_bytes,
                 hw_counter,
             )?;
             Ok(deleted + new + updated)
@@ -72,7 +86,13 @@ pub fn process_point_operation(
                 // An empty upsert touches no segment; bump so WAL can acknowledge it.
                 segments.bump_max_segment_version_overwrite(op_num);
             }
-            let res = upsert_points_raw(segments, op_num, points.iter(), hw_counter)?;
+            let res = upsert_points_raw(
+                segments,
+                op_num,
+                points.iter(),
+                max_segment_size_bytes,
+                hw_counter,
+            )?;
             Ok(res)
         }
         PointOperations::SyncPointsRaw(operation) => {
@@ -82,6 +102,7 @@ pub fn process_point_operation(
                 operation.from_id,
                 operation.to_id,
                 &operation.points,
+                max_segment_size_bytes,
                 hw_counter,
             )?;
             Ok(deleted + new + updated)
@@ -111,18 +132,33 @@ pub fn process_vector_operation(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     vector_operation: VectorOperations,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     match vector_operation {
-        VectorOperations::UpdateVectors(update_vectors) => {
-            update_vectors_conditional(segments, op_num, update_vectors, hw_counter)
-        }
-        VectorOperations::DeleteVectors(ids, vector_names) => {
-            delete_vectors(segments, op_num, &ids.points, &vector_names, hw_counter)
-        }
-        VectorOperations::DeleteVectorsByFilter(filter, vector_names) => {
-            delete_vectors_by_filter(segments, op_num, &filter, &vector_names, hw_counter)
-        }
+        VectorOperations::UpdateVectors(update_vectors) => update_vectors_conditional(
+            segments,
+            op_num,
+            update_vectors,
+            max_segment_size_bytes,
+            hw_counter,
+        ),
+        VectorOperations::DeleteVectors(ids, vector_names) => delete_vectors(
+            segments,
+            op_num,
+            &ids.points,
+            &vector_names,
+            max_segment_size_bytes,
+            hw_counter,
+        ),
+        VectorOperations::DeleteVectorsByFilter(filter, vector_names) => delete_vectors_by_filter(
+            segments,
+            op_num,
+            &filter,
+            &vector_names,
+            max_segment_size_bytes,
+            hw_counter,
+        ),
     }
 }
 
@@ -130,15 +166,32 @@ pub fn process_payload_operation(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     payload_operation: PayloadOps,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     match payload_operation {
         PayloadOps::SetPayload(sp) => {
             let payload: Payload = sp.payload;
             if let Some(points) = sp.points {
-                set_payload(segments, op_num, &payload, &points, &sp.key, hw_counter)
+                set_payload(
+                    segments,
+                    op_num,
+                    &payload,
+                    &points,
+                    &sp.key,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else if let Some(filter) = sp.filter {
-                set_payload_by_filter(segments, op_num, &payload, &filter, &sp.key, hw_counter)
+                set_payload_by_filter(
+                    segments,
+                    op_num,
+                    &payload,
+                    &filter,
+                    &sp.key,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(
@@ -148,9 +201,23 @@ pub fn process_payload_operation(
         }
         PayloadOps::DeletePayload(dp) => {
             if let Some(points) = dp.points {
-                delete_payload(segments, op_num, &points, &dp.keys, hw_counter)
+                delete_payload(
+                    segments,
+                    op_num,
+                    &points,
+                    &dp.keys,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else if let Some(filter) = dp.filter {
-                delete_payload_by_filter(segments, op_num, &filter, &dp.keys, hw_counter)
+                delete_payload_by_filter(
+                    segments,
+                    op_num,
+                    &filter,
+                    &dp.keys,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(
@@ -159,17 +226,31 @@ pub fn process_payload_operation(
             }
         }
         PayloadOps::ClearPayload { ref points, .. } => {
-            clear_payload(segments, op_num, points, hw_counter)
+            clear_payload(segments, op_num, points, max_segment_size_bytes, hw_counter)
         }
         PayloadOps::ClearPayloadByFilter(ref filter) => {
-            clear_payload_by_filter(segments, op_num, filter, hw_counter)
+            clear_payload_by_filter(segments, op_num, filter, max_segment_size_bytes, hw_counter)
         }
         PayloadOps::OverwritePayload(sp) => {
             let payload: Payload = sp.payload;
             if let Some(points) = sp.points {
-                overwrite_payload(segments, op_num, &payload, &points, hw_counter)
+                overwrite_payload(
+                    segments,
+                    op_num,
+                    &payload,
+                    &points,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else if let Some(filter) = sp.filter {
-                overwrite_payload_by_filter(segments, op_num, &payload, &filter, hw_counter)
+                overwrite_payload_by_filter(
+                    segments,
+                    op_num,
+                    &payload,
+                    &filter,
+                    max_segment_size_bytes,
+                    hw_counter,
+                )
             } else {
                 // TODO: BadRequest (prev) vs BadInput (current)!?
                 Err(OperationError::validation_error(

--- a/lib/shard/src/update/payload.rs
+++ b/lib/shard/src/update/payload.rs
@@ -1,5 +1,7 @@
 //! Payload operations: set, delete, clear and overwrite payloads.
 
+use std::num::NonZeroUsize;
+
 use common::counter::hardware_counter::HardwareCounterCell;
 use segment::common::operation_error::OperationResult;
 use segment::json_path::JsonPath;
@@ -17,6 +19,7 @@ pub fn set_payload(
     payload: &Payload,
     points: &[PointIdType],
     key: &Option<JsonPath>,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let mut total_updated_points = 0;
@@ -30,6 +33,7 @@ pub fn set_payload(
                 Some(key) => old_payload.merge_by_key(payload, key),
                 None => old_payload.merge(payload),
             },
+            max_segment_size_bytes,
             hw_counter,
         )?;
 
@@ -52,10 +56,19 @@ pub fn set_payload_by_filter(
     payload: &Payload,
     filter: &Filter,
     key: &Option<JsonPath>,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let affected_points = points_by_filter(segments, filter, hw_counter)?;
-    let points_updated = set_payload(segments, op_num, payload, &affected_points, key, hw_counter)?;
+    let points_updated = set_payload(
+        segments,
+        op_num,
+        payload,
+        &affected_points,
+        key,
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
 
     if points_updated == 0 {
         // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.
@@ -71,6 +84,7 @@ pub fn delete_payload(
     op_num: SeqNumberType,
     points: &[PointIdType],
     keys: &[PayloadKeyType],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let mut total_deleted_points = 0;
@@ -91,6 +105,7 @@ pub fn delete_payload(
                     payload.remove(key);
                 }
             },
+            max_segment_size_bytes,
             hw_counter,
         )?;
 
@@ -112,10 +127,18 @@ pub fn delete_payload_by_filter(
     op_num: SeqNumberType,
     filter: &Filter,
     keys: &[PayloadKeyType],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let affected_points = points_by_filter(segments, filter, hw_counter)?;
-    let points_updated = delete_payload(segments, op_num, &affected_points, keys, hw_counter)?;
+    let points_updated = delete_payload(
+        segments,
+        op_num,
+        &affected_points,
+        keys,
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
 
     if points_updated == 0 {
         // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.
@@ -130,6 +153,7 @@ pub fn clear_payload(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: &[PointIdType],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let mut total_updated_points = 0;
@@ -140,6 +164,7 @@ pub fn clear_payload(
             batch,
             |id, write_segment| write_segment.clear_payload(op_num, id, hw_counter),
             |_, _, _, payload| payload.0.clear(),
+            max_segment_size_bytes,
             hw_counter,
         )?;
         check_unprocessed_points(batch, &updated_points)?;
@@ -160,10 +185,17 @@ pub fn clear_payload_by_filter(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     filter: &Filter,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let points_to_clear = points_by_filter(segments, filter, hw_counter)?;
-    let points_cleared = clear_payload(segments, op_num, &points_to_clear, hw_counter)?;
+    let points_cleared = clear_payload(
+        segments,
+        op_num,
+        &points_to_clear,
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
 
     if points_cleared == 0 {
         // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.
@@ -179,6 +211,7 @@ pub fn overwrite_payload(
     op_num: SeqNumberType,
     payload: &Payload,
     points: &[PointIdType],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let mut total_updated_points = 0;
@@ -191,6 +224,7 @@ pub fn overwrite_payload(
             |_, _, _, old_payload| {
                 *old_payload = payload.clone();
             },
+            max_segment_size_bytes,
             hw_counter,
         )?;
 
@@ -212,11 +246,18 @@ pub fn overwrite_payload_by_filter(
     op_num: SeqNumberType,
     payload: &Payload,
     filter: &Filter,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let affected_points = points_by_filter(segments, filter, hw_counter)?;
-    let points_updated =
-        overwrite_payload(segments, op_num, payload, &affected_points, hw_counter)?;
+    let points_updated = overwrite_payload(
+        segments,
+        op_num,
+        payload,
+        &affected_points,
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
 
     if points_updated == 0 {
         // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.

--- a/lib/shard/src/update/points/sync.rs
+++ b/lib/shard/src/update/points/sync.rs
@@ -1,5 +1,6 @@
 //! Point syncs: replace a point range with the given set, plain and raw.
 
+use std::num::NonZeroUsize;
 use std::sync::atomic::AtomicBool;
 
 use ahash::{AHashMap, AHashSet};
@@ -31,9 +32,18 @@ pub fn sync_points(
     from_id: Option<PointIdType>,
     to_id: Option<PointIdType>,
     points: &[PointStructPersisted],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<(usize, usize, usize)> {
-    sync_points_impl(segments, op_num, from_id, to_id, points, hw_counter)
+    sync_points_impl(
+        segments,
+        op_num,
+        from_id,
+        to_id,
+        points,
+        max_segment_size_bytes,
+        hw_counter,
+    )
 }
 
 /// Same as [`sync_points`], but for points carrying raw vector bytes verbatim.
@@ -43,10 +53,19 @@ pub fn sync_points_raw(
     from_id: Option<PointIdType>,
     to_id: Option<PointIdType>,
     points: &[PointStructRawPersisted],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<(usize, usize, usize)> {
     super::upsert::ensure_payloads_decoded(points)?;
-    sync_points_impl(segments, op_num, from_id, to_id, points, hw_counter)
+    sync_points_impl(
+        segments,
+        op_num,
+        from_id,
+        to_id,
+        points,
+        max_segment_size_bytes,
+        hw_counter,
+    )
 }
 
 /// A point struct that can be compared against its stored counterpart, to
@@ -84,6 +103,7 @@ fn sync_points_impl<P>(
     from_id: Option<PointIdType>,
     to_id: Option<PointIdType>,
     points: &[P],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<(usize, usize, usize)>
 where
@@ -138,7 +158,13 @@ where
     });
 
     // 5. Upsert points which differ from the stored ones
-    let num_replaced = upsert_points_impl(segments, op_num, points_to_update, hw_counter)?;
+    let num_replaced = upsert_points_impl(
+        segments,
+        op_num,
+        points_to_update,
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
     debug_assert!(
         num_replaced <= num_updated,
         "number of replaced points cannot be greater than points to update ({num_replaced} <= {num_updated})",

--- a/lib/shard/src/update/points/sync.rs
+++ b/lib/shard/src/update/points/sync.rs
@@ -1,5 +1,6 @@
 //! Point syncs: replace a point range with the given set, plain and raw.
 
+use std::num::NonZeroUsize;
 use std::sync::atomic::AtomicBool;
 
 use ahash::{AHashMap, AHashSet};
@@ -31,9 +32,18 @@ pub fn sync_points(
     from_id: Option<PointIdType>,
     to_id: Option<PointIdType>,
     points: &[PointStructPersisted],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<(usize, usize, usize)> {
-    sync_points_impl(segments, op_num, from_id, to_id, points, hw_counter)
+    sync_points_impl(
+        segments,
+        op_num,
+        from_id,
+        to_id,
+        points,
+        max_segment_size_bytes,
+        hw_counter,
+    )
 }
 
 /// Same as [`sync_points`], but for points carrying raw vector bytes verbatim.
@@ -43,9 +53,18 @@ pub fn sync_points_raw(
     from_id: Option<PointIdType>,
     to_id: Option<PointIdType>,
     points: &[PointStructRawPersisted],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<(usize, usize, usize)> {
-    sync_points_impl(segments, op_num, from_id, to_id, points, hw_counter)
+    sync_points_impl(
+        segments,
+        op_num,
+        from_id,
+        to_id,
+        points,
+        max_segment_size_bytes,
+        hw_counter,
+    )
 }
 
 /// A point struct that can be compared against its stored counterpart, to
@@ -83,6 +102,7 @@ fn sync_points_impl<P>(
     from_id: Option<PointIdType>,
     to_id: Option<PointIdType>,
     points: &[P],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<(usize, usize, usize)>
 where
@@ -137,7 +157,13 @@ where
     });
 
     // 5. Upsert points which differ from the stored ones
-    let num_replaced = upsert_points_impl(segments, op_num, points_to_update, hw_counter)?;
+    let num_replaced = upsert_points_impl(
+        segments,
+        op_num,
+        points_to_update,
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
     debug_assert!(
         num_replaced <= num_updated,
         "number of replaced points cannot be greater than points to update ({num_replaced} <= {num_updated})",

--- a/lib/shard/src/update/points/upsert.rs
+++ b/lib/shard/src/update/points/upsert.rs
@@ -1,5 +1,7 @@
 //! Point upserts: plain, conditional and raw.
 
+use std::num::NonZeroUsize;
+
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::flags::feature_flags;
@@ -29,12 +31,13 @@ pub fn upsert_points<'a, T>(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: T,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize>
 where
     T: IntoIterator<Item = &'a PointStructPersisted>,
 {
-    upsert_points_impl(segments, op_num, points, hw_counter)
+    upsert_points_impl(segments, op_num, points, max_segment_size_bytes, hw_counter)
 }
 
 /// Same as [`upsert_points`], but for points carrying raw vector bytes verbatim.
@@ -42,10 +45,11 @@ pub fn upsert_points_raw(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: &[PointStructRawPersisted],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     ensure_payloads_decoded(points)?;
-    upsert_points_impl(segments, op_num, points, hw_counter)
+    upsert_points_impl(segments, op_num, points, max_segment_size_bytes, hw_counter)
 }
 
 /// Applying a point writes [`PointStructRawPersisted::payload`], so one still holding a
@@ -108,6 +112,7 @@ pub fn conditional_upsert(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     operation: ConditionalInsertOperationInternal,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let ConditionalInsertOperationInternal {
@@ -119,7 +124,13 @@ pub fn conditional_upsert(
     retain_conditional_upsert_points(segments, &mut points_op, condition, update_mode, hw_counter)?;
 
     let points = points_op.into_point_vec();
-    let upserted_points = upsert_points(segments, op_num, points.iter(), hw_counter)?;
+    let upserted_points = upsert_points(
+        segments,
+        op_num,
+        points.iter(),
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
 
     if upserted_points == 0 {
         // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.
@@ -208,6 +219,7 @@ pub(super) fn upsert_points_impl<'a, P>(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: impl IntoIterator<Item = &'a P>,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize>
 where
@@ -233,6 +245,7 @@ where
             |id, raw_vectors, updated_vectors, old_payload| {
                 points_map[&id].write_moved(raw_vectors, updated_vectors, old_payload)
             },
+            max_segment_size_bytes,
             hw_counter,
         )?;
 

--- a/lib/shard/src/update/points/upsert.rs
+++ b/lib/shard/src/update/points/upsert.rs
@@ -1,5 +1,7 @@
 //! Point upserts: plain, conditional and raw.
 
+use std::num::NonZeroUsize;
+
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::DeferredBehavior;
@@ -29,12 +31,13 @@ pub fn upsert_points<'a, T>(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: T,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize>
 where
     T: IntoIterator<Item = &'a PointStructPersisted>,
 {
-    upsert_points_impl(segments, op_num, points, hw_counter)
+    upsert_points_impl(segments, op_num, points, max_segment_size_bytes, hw_counter)
 }
 
 /// Same as [`upsert_points`], but for points carrying raw vector bytes verbatim.
@@ -42,12 +45,13 @@ pub fn upsert_points_raw<'a, T>(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: T,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize>
 where
     T: IntoIterator<Item = &'a PointStructRawPersisted>,
 {
-    upsert_points_impl(segments, op_num, points, hw_counter)
+    upsert_points_impl(segments, op_num, points, max_segment_size_bytes, hw_counter)
 }
 
 /// Drop from `points_op` every point that the conditional-upsert
@@ -98,6 +102,7 @@ pub fn conditional_upsert(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     operation: ConditionalInsertOperationInternal,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let ConditionalInsertOperationInternal {
@@ -109,7 +114,13 @@ pub fn conditional_upsert(
     retain_conditional_upsert_points(segments, &mut points_op, condition, update_mode, hw_counter)?;
 
     let points = points_op.into_point_vec();
-    let upserted_points = upsert_points(segments, op_num, points.iter(), hw_counter)?;
+    let upserted_points = upsert_points(
+        segments,
+        op_num,
+        points.iter(),
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
 
     if upserted_points == 0 {
         // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.
@@ -163,6 +174,7 @@ pub(super) fn upsert_points_impl<'a, P>(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: impl IntoIterator<Item = &'a P>,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize>
 where
@@ -182,6 +194,7 @@ where
             |id, raw_vectors, updated_vectors, old_payload| {
                 points_map[&id].write_moved(raw_vectors, updated_vectors, old_payload)
             },
+            max_segment_size_bytes,
             hw_counter,
         )?;
 

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -145,7 +145,7 @@ fn test_upsert_points_raw_moves_point_from_non_appendable() {
         },
     ];
 
-    let updated = upsert_points_raw(&holder, 100, &points, &hw_counter).unwrap();
+    let updated = upsert_points_raw(&holder, 100, &points, None, &hw_counter).unwrap();
     assert_eq!(updated, 1);
 
     {
@@ -196,8 +196,8 @@ fn test_apply_refuses_an_undecoded_payload_blob() {
         )),
     }];
 
-    assert!(upsert_points_raw(&holder, 100, &points, &hw_counter).is_err());
-    assert!(sync_points_raw(&holder, 101, None, None, &points, &hw_counter).is_err());
+    assert!(upsert_points_raw(&holder, 100, &points, None, &hw_counter).is_err());
+    assert!(sync_points_raw(&holder, 101, None, None, &points, None, &hw_counter).is_err());
 
     assert!(
         retrieve_raw_record(&holder, holder.iter().next().unwrap().0, 1).is_none(),
@@ -242,6 +242,7 @@ fn test_sync_points_raw() {
         None,
         None,
         &[point_2, point_3, point_100],
+        None,
         &hw_counter,
     )
     .unwrap();
@@ -436,7 +437,7 @@ fn test_set_payload_by_filter_deferred_filter_matches_deferred() {
     let filter = city_filter("Amsterdam");
     let payload: segment::types::Payload = payload_json! {"color": "red"};
     let updated =
-        set_payload_by_filter(&holder, 10, &payload, &filter, &None, &hw_counter).unwrap();
+        set_payload_by_filter(&holder, 10, &payload, &filter, &None, None, &hw_counter).unwrap();
 
     assert!(updated > 0, "Should have updated at least one point");
 }
@@ -462,7 +463,7 @@ fn test_set_payload_by_filter_deferred_filter_matches_old_copy() {
     let filter = city_filter("Berlin");
     let payload: segment::types::Payload = payload_json! {"color": "red"};
     let updated =
-        set_payload_by_filter(&holder, 10, &payload, &filter, &None, &hw_counter).unwrap();
+        set_payload_by_filter(&holder, 10, &payload, &filter, &None, None, &hw_counter).unwrap();
 
     assert_eq!(
         updated, 0,
@@ -506,7 +507,7 @@ fn test_delete_payload_by_filter_deferred_filter_matches_deferred() {
 
     let filter = city_filter("Amsterdam");
     let keys: Vec<PayloadKeyType> = vec!["city".parse().unwrap()];
-    let updated = delete_payload_by_filter(&holder, 10, &filter, &keys, &hw_counter).unwrap();
+    let updated = delete_payload_by_filter(&holder, 10, &filter, &keys, None, &hw_counter).unwrap();
 
     assert!(updated > 0, "Should have updated at least one point");
 }
@@ -531,7 +532,7 @@ fn test_delete_payload_by_filter_deferred_filter_matches_old_copy() {
 
     let filter = city_filter("Berlin");
     let keys: Vec<PayloadKeyType> = vec!["city".parse().unwrap()];
-    let updated = delete_payload_by_filter(&holder, 10, &filter, &keys, &hw_counter).unwrap();
+    let updated = delete_payload_by_filter(&holder, 10, &filter, &keys, None, &hw_counter).unwrap();
 
     assert_eq!(
         updated, 0,
@@ -574,7 +575,7 @@ fn test_clear_payload_by_filter_deferred_filter_matches_deferred() {
     holder.add_new(appendable);
 
     let filter = city_filter("Amsterdam");
-    let updated = clear_payload_by_filter(&holder, 10, &filter, &hw_counter).unwrap();
+    let updated = clear_payload_by_filter(&holder, 10, &filter, None, &hw_counter).unwrap();
 
     assert!(updated > 0, "Should have updated at least one point");
 }
@@ -598,7 +599,7 @@ fn test_clear_payload_by_filter_deferred_filter_matches_old_copy() {
     let sid_app = holder.add_new(appendable);
 
     let filter = city_filter("Berlin");
-    let updated = clear_payload_by_filter(&holder, 10, &filter, &hw_counter).unwrap();
+    let updated = clear_payload_by_filter(&holder, 10, &filter, None, &hw_counter).unwrap();
 
     assert_eq!(
         updated, 0,
@@ -642,7 +643,8 @@ fn test_overwrite_payload_by_filter_deferred_filter_matches_deferred() {
 
     let filter = city_filter("Amsterdam");
     let payload: segment::types::Payload = payload_json! {"color": "red"};
-    let updated = overwrite_payload_by_filter(&holder, 10, &payload, &filter, &hw_counter).unwrap();
+    let updated =
+        overwrite_payload_by_filter(&holder, 10, &payload, &filter, None, &hw_counter).unwrap();
 
     assert!(updated > 0, "Should have updated at least one point");
 }
@@ -667,7 +669,8 @@ fn test_overwrite_payload_by_filter_deferred_filter_matches_old_copy() {
 
     let filter = city_filter("Berlin");
     let payload: segment::types::Payload = payload_json! {"color": "red"};
-    let updated = overwrite_payload_by_filter(&holder, 10, &payload, &filter, &hw_counter).unwrap();
+    let updated =
+        overwrite_payload_by_filter(&holder, 10, &payload, &filter, None, &hw_counter).unwrap();
 
     assert_eq!(
         updated, 0,
@@ -712,7 +715,7 @@ fn test_delete_vectors_by_filter_deferred_filter_matches_deferred() {
     let filter = city_filter("Amsterdam");
     let vector_names = vec![DEFAULT_VECTOR_NAME.into()];
     let deleted =
-        delete_vectors_by_filter(&holder, 10, &filter, &vector_names, &hw_counter).unwrap();
+        delete_vectors_by_filter(&holder, 10, &filter, &vector_names, None, &hw_counter).unwrap();
 
     assert!(deleted > 0, "Should have deleted at least one vector");
 }
@@ -738,7 +741,7 @@ fn test_delete_vectors_by_filter_deferred_filter_matches_old_copy() {
     let filter = city_filter("Berlin");
     let vector_names = vec![DEFAULT_VECTOR_NAME.into()];
     let deleted =
-        delete_vectors_by_filter(&holder, 10, &filter, &vector_names, &hw_counter).unwrap();
+        delete_vectors_by_filter(&holder, 10, &filter, &vector_names, None, &hw_counter).unwrap();
 
     assert_eq!(
         deleted, 0,
@@ -849,7 +852,7 @@ fn test_upsert_cow_move_replaces_whole_point() {
     seed(&mut in_place);
     let mut holder = SegmentHolder::default();
     let sid = holder.add_new(in_place);
-    upsert_points(&holder, 101, [&incoming], &hw_counter).unwrap();
+    upsert_points(&holder, 101, [&incoming], None, &hw_counter).unwrap();
     let segment = holder.get(sid).unwrap().get();
     check(&*segment.read(), "in-place");
 
@@ -864,7 +867,7 @@ fn test_upsert_cow_move_replaces_whole_point() {
     let mut holder = SegmentHolder::default();
     holder.add_new(source);
     let sid = holder.add_new(destination);
-    upsert_points(&holder, 101, [&incoming], &hw_counter).unwrap();
+    upsert_points(&holder, 101, [&incoming], None, &hw_counter).unwrap();
     let segment = holder.get(sid).unwrap().get();
     check(&*segment.read(), "CoW move");
 }
@@ -998,7 +1001,16 @@ fn create_field_index_flushes_cow_destinations_before_source() {
     // copy-on-write arm upserts the updated point into the destination, deletes it from
     // the source, and records the flush dependency edge.
     let payload = payload_json! {"other": "value"};
-    let moved = set_payload(&holder, 100, &payload, &[1.into()], &None, &hw_counter).unwrap();
+    let moved = set_payload(
+        &holder,
+        100,
+        &payload,
+        &[1.into()],
+        &None,
+        None,
+        &hw_counter,
+    )
+    .unwrap();
     assert_eq!(moved, 1);
 
     create_field_index(&holder, 200, &key, Some(&schema), &hw_counter).unwrap();

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -1,4 +1,3 @@
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -19,8 +18,8 @@ use crate::operations::point_ops::PointStructRawPersisted;
 use crate::segment_holder::{FlushMode, SegmentHolder};
 use crate::update::{
     clear_payload_by_filter, create_field_index, delete_payload_by_filter, delete_points_by_filter,
-    delete_vectors_by_filter, overwrite_payload_by_filter, process_payload_operation,
-    set_payload_by_filter, sync_points_raw, upsert_points_raw,
+    delete_vectors_by_filter, overwrite_payload_by_filter, set_payload_by_filter, sync_points_raw,
+    upsert_points_raw,
 };
 
 #[test]
@@ -902,71 +901,5 @@ fn create_field_index_pins_pending_payload_state() {
     assert!(
         hits.is_empty(),
         "filtered reads must agree with payload storage: the row was cleared",
-    );
-}
-
-/// The size cap has to survive the whole dispatch chain, from `process_payload_operation` down to
-/// the destination choice. Every forward on that path type-checks with `None`, so one dropped
-/// along the way would silently stop steering writes with nothing failing. This is the filtered
-/// `set_payload` that #9158 reports, driven through the dispatcher rather than the holder.
-#[test]
-fn test_set_payload_by_filter_steers_away_from_full_segment() {
-    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
-    let hw_counter = HardwareCounterCell::new();
-
-    // The full segment is added first, so `aloha_random_write` would pick it without the cap.
-    let mut holder = SegmentHolder::default();
-    let full_id = holder.add_new(build_segment_1(dir.path()));
-    let free_id = holder.add_new(empty_segment(dir.path()));
-    holder.add_new(build_non_appendable_with_city(
-        dir.path(),
-        100,
-        10,
-        "Berlin",
-    ));
-
-    let full_size = holder
-        .get(full_id)
-        .unwrap()
-        .get()
-        .read()
-        .max_available_vectors_size_in_bytes()
-        .unwrap();
-    assert!(full_size > 0, "the fixture must measure non-empty");
-
-    let payload: segment::types::Payload = payload_json! {"color": "red"};
-    process_payload_operation(
-        &holder,
-        20,
-        crate::operations::payload_ops::PayloadOps::SetPayload(
-            crate::operations::payload_ops::SetPayloadOp {
-                payload,
-                points: None,
-                filter: Some(city_filter("Berlin")),
-                key: None,
-            },
-        ),
-        NonZeroUsize::new(full_size),
-        &hw_counter,
-    )
-    .unwrap();
-
-    assert!(
-        holder
-            .get(free_id)
-            .unwrap()
-            .get()
-            .read()
-            .has_point(100.into(), common::types::DeferredBehavior::WithDeferred),
-        "the moved point must land in the segment below the cap",
-    );
-    assert!(
-        !holder
-            .get(full_id)
-            .unwrap()
-            .get()
-            .read()
-            .has_point(100.into(), common::types::DeferredBehavior::WithDeferred),
-        "the segment at the cap must not grow further",
     );
 }

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -125,7 +125,7 @@ fn test_upsert_points_raw_moves_point_from_non_appendable() {
         },
     ];
 
-    let updated = upsert_points_raw(&holder, 100, points.iter(), &hw_counter).unwrap();
+    let updated = upsert_points_raw(&holder, 100, points.iter(), None, &hw_counter).unwrap();
     assert_eq!(updated, 1);
 
     {
@@ -187,6 +187,7 @@ fn test_sync_points_raw() {
         None,
         None,
         &[point_2, point_3, point_100],
+        None,
         &hw_counter,
     )
     .unwrap();
@@ -381,7 +382,7 @@ fn test_set_payload_by_filter_deferred_filter_matches_deferred() {
     let filter = city_filter("Amsterdam");
     let payload: segment::types::Payload = payload_json! {"color": "red"};
     let updated =
-        set_payload_by_filter(&holder, 10, &payload, &filter, &None, &hw_counter).unwrap();
+        set_payload_by_filter(&holder, 10, &payload, &filter, &None, None, &hw_counter).unwrap();
 
     assert!(updated > 0, "Should have updated at least one point");
 }
@@ -407,7 +408,7 @@ fn test_set_payload_by_filter_deferred_filter_matches_old_copy() {
     let filter = city_filter("Berlin");
     let payload: segment::types::Payload = payload_json! {"color": "red"};
     let updated =
-        set_payload_by_filter(&holder, 10, &payload, &filter, &None, &hw_counter).unwrap();
+        set_payload_by_filter(&holder, 10, &payload, &filter, &None, None, &hw_counter).unwrap();
 
     assert_eq!(
         updated, 0,
@@ -451,7 +452,7 @@ fn test_delete_payload_by_filter_deferred_filter_matches_deferred() {
 
     let filter = city_filter("Amsterdam");
     let keys: Vec<PayloadKeyType> = vec!["city".parse().unwrap()];
-    let updated = delete_payload_by_filter(&holder, 10, &filter, &keys, &hw_counter).unwrap();
+    let updated = delete_payload_by_filter(&holder, 10, &filter, &keys, None, &hw_counter).unwrap();
 
     assert!(updated > 0, "Should have updated at least one point");
 }
@@ -476,7 +477,7 @@ fn test_delete_payload_by_filter_deferred_filter_matches_old_copy() {
 
     let filter = city_filter("Berlin");
     let keys: Vec<PayloadKeyType> = vec!["city".parse().unwrap()];
-    let updated = delete_payload_by_filter(&holder, 10, &filter, &keys, &hw_counter).unwrap();
+    let updated = delete_payload_by_filter(&holder, 10, &filter, &keys, None, &hw_counter).unwrap();
 
     assert_eq!(
         updated, 0,
@@ -519,7 +520,7 @@ fn test_clear_payload_by_filter_deferred_filter_matches_deferred() {
     holder.add_new(appendable);
 
     let filter = city_filter("Amsterdam");
-    let updated = clear_payload_by_filter(&holder, 10, &filter, &hw_counter).unwrap();
+    let updated = clear_payload_by_filter(&holder, 10, &filter, None, &hw_counter).unwrap();
 
     assert!(updated > 0, "Should have updated at least one point");
 }
@@ -543,7 +544,7 @@ fn test_clear_payload_by_filter_deferred_filter_matches_old_copy() {
     let sid_app = holder.add_new(appendable);
 
     let filter = city_filter("Berlin");
-    let updated = clear_payload_by_filter(&holder, 10, &filter, &hw_counter).unwrap();
+    let updated = clear_payload_by_filter(&holder, 10, &filter, None, &hw_counter).unwrap();
 
     assert_eq!(
         updated, 0,
@@ -587,7 +588,8 @@ fn test_overwrite_payload_by_filter_deferred_filter_matches_deferred() {
 
     let filter = city_filter("Amsterdam");
     let payload: segment::types::Payload = payload_json! {"color": "red"};
-    let updated = overwrite_payload_by_filter(&holder, 10, &payload, &filter, &hw_counter).unwrap();
+    let updated =
+        overwrite_payload_by_filter(&holder, 10, &payload, &filter, None, &hw_counter).unwrap();
 
     assert!(updated > 0, "Should have updated at least one point");
 }
@@ -612,7 +614,8 @@ fn test_overwrite_payload_by_filter_deferred_filter_matches_old_copy() {
 
     let filter = city_filter("Berlin");
     let payload: segment::types::Payload = payload_json! {"color": "red"};
-    let updated = overwrite_payload_by_filter(&holder, 10, &payload, &filter, &hw_counter).unwrap();
+    let updated =
+        overwrite_payload_by_filter(&holder, 10, &payload, &filter, None, &hw_counter).unwrap();
 
     assert_eq!(
         updated, 0,
@@ -657,7 +660,7 @@ fn test_delete_vectors_by_filter_deferred_filter_matches_deferred() {
     let filter = city_filter("Amsterdam");
     let vector_names = vec![DEFAULT_VECTOR_NAME.into()];
     let deleted =
-        delete_vectors_by_filter(&holder, 10, &filter, &vector_names, &hw_counter).unwrap();
+        delete_vectors_by_filter(&holder, 10, &filter, &vector_names, None, &hw_counter).unwrap();
 
     assert!(deleted > 0, "Should have deleted at least one vector");
 }
@@ -683,7 +686,7 @@ fn test_delete_vectors_by_filter_deferred_filter_matches_old_copy() {
     let filter = city_filter("Berlin");
     let vector_names = vec![DEFAULT_VECTOR_NAME.into()];
     let deleted =
-        delete_vectors_by_filter(&holder, 10, &filter, &vector_names, &hw_counter).unwrap();
+        delete_vectors_by_filter(&holder, 10, &filter, &vector_names, None, &hw_counter).unwrap();
 
     assert_eq!(
         deleted, 0,
@@ -794,7 +797,7 @@ fn test_upsert_cow_move_replaces_whole_point() {
     seed(&mut in_place);
     let mut holder = SegmentHolder::default();
     let sid = holder.add_new(in_place);
-    upsert_points(&holder, 101, [&incoming], &hw_counter).unwrap();
+    upsert_points(&holder, 101, [&incoming], None, &hw_counter).unwrap();
     let segment = holder.get(sid).unwrap().get();
     check(&*segment.read(), "in-place");
 
@@ -809,7 +812,7 @@ fn test_upsert_cow_move_replaces_whole_point() {
     let mut holder = SegmentHolder::default();
     holder.add_new(source);
     let sid = holder.add_new(destination);
-    upsert_points(&holder, 101, [&incoming], &hw_counter).unwrap();
+    upsert_points(&holder, 101, [&incoming], None, &hw_counter).unwrap();
     let segment = holder.get(sid).unwrap().get();
     check(&*segment.read(), "CoW move");
 }

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -18,8 +19,8 @@ use crate::operations::point_ops::PointStructRawPersisted;
 use crate::segment_holder::{FlushMode, SegmentHolder};
 use crate::update::{
     clear_payload_by_filter, create_field_index, delete_payload_by_filter, delete_points_by_filter,
-    delete_vectors_by_filter, overwrite_payload_by_filter, set_payload_by_filter, sync_points_raw,
-    upsert_points_raw,
+    delete_vectors_by_filter, overwrite_payload_by_filter, process_payload_operation,
+    set_payload_by_filter, sync_points_raw, upsert_points_raw,
 };
 
 #[test]
@@ -901,5 +902,71 @@ fn create_field_index_pins_pending_payload_state() {
     assert!(
         hits.is_empty(),
         "filtered reads must agree with payload storage: the row was cleared",
+    );
+}
+
+/// The size cap has to survive the whole dispatch chain, from `process_payload_operation` down to
+/// the destination choice. Every forward on that path type-checks with `None`, so one dropped
+/// along the way would silently stop steering writes with nothing failing. This is the filtered
+/// `set_payload` that #9158 reports, driven through the dispatcher rather than the holder.
+#[test]
+fn test_set_payload_by_filter_steers_away_from_full_segment() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    // The full segment is added first, so `aloha_random_write` would pick it without the cap.
+    let mut holder = SegmentHolder::default();
+    let full_id = holder.add_new(build_segment_1(dir.path()));
+    let free_id = holder.add_new(empty_segment(dir.path()));
+    holder.add_new(build_non_appendable_with_city(
+        dir.path(),
+        100,
+        10,
+        "Berlin",
+    ));
+
+    let full_size = holder
+        .get(full_id)
+        .unwrap()
+        .get()
+        .read()
+        .max_available_vectors_size_in_bytes()
+        .unwrap();
+    assert!(full_size > 0, "the fixture must measure non-empty");
+
+    let payload: segment::types::Payload = payload_json! {"color": "red"};
+    process_payload_operation(
+        &holder,
+        20,
+        crate::operations::payload_ops::PayloadOps::SetPayload(
+            crate::operations::payload_ops::SetPayloadOp {
+                payload,
+                points: None,
+                filter: Some(city_filter("Berlin")),
+                key: None,
+            },
+        ),
+        NonZeroUsize::new(full_size),
+        &hw_counter,
+    )
+    .unwrap();
+
+    assert!(
+        holder
+            .get(free_id)
+            .unwrap()
+            .get()
+            .read()
+            .has_point(100.into(), common::types::DeferredBehavior::WithDeferred),
+        "the moved point must land in the segment below the cap",
+    );
+    assert!(
+        !holder
+            .get(full_id)
+            .unwrap()
+            .get()
+            .read()
+            .has_point(100.into(), common::types::DeferredBehavior::WithDeferred),
+        "the segment at the cap must not grow further",
     );
 }

--- a/lib/shard/src/update/vectors.rs
+++ b/lib/shard/src/update/vectors.rs
@@ -1,5 +1,7 @@
 //! Named-vector operations: update and delete vectors of existing points.
 
+use std::num::NonZeroUsize;
+
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use segment::common::operation_error::OperationResult;
@@ -17,6 +19,7 @@ pub fn update_vectors_conditional(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: UpdateVectorsOp,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let UpdateVectorsOp {
@@ -25,7 +28,7 @@ pub fn update_vectors_conditional(
     } = points;
 
     let Some(filter_condition) = update_filter else {
-        return update_vectors(segments, op_num, points, hw_counter);
+        return update_vectors(segments, op_num, points, max_segment_size_bytes, hw_counter);
     };
 
     let point_ids: Vec<_> = points.iter().map(|point| point.id).collect();
@@ -34,7 +37,7 @@ pub fn update_vectors_conditional(
         select_excluded_by_filter_ids(segments, point_ids, filter_condition, hw_counter)?;
 
     points.retain(|p| !points_to_exclude.contains(&p.id));
-    update_vectors(segments, op_num, points, hw_counter)
+    update_vectors(segments, op_num, points, max_segment_size_bytes, hw_counter)
 }
 
 /// Update the specified named vectors of a point, keeping unspecified vectors intact.
@@ -42,6 +45,7 @@ fn update_vectors(
     segments: &SegmentHolder,
     op_num: SeqNumberType,
     points: Vec<PointVectorsPersisted>,
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     // Build a map of vectors to update per point, merge updates on same point ID
@@ -70,6 +74,7 @@ fn update_vectors(
                     updated_vectors.insert_ref(vector_name, vector_ref);
                 }
             },
+            max_segment_size_bytes,
             hw_counter,
         )?;
         check_unprocessed_points(batch, &updated_points)?;
@@ -91,6 +96,7 @@ pub fn delete_vectors(
     op_num: SeqNumberType,
     points: &[PointIdType],
     vector_names: &[VectorNameBuf],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let mut total_deleted_points = 0;
@@ -109,6 +115,7 @@ pub fn delete_vectors(
             |_, raw_vectors, _, _| {
                 raw_vectors.retain(|(name, _)| !vector_names.contains(name));
             },
+            max_segment_size_bytes,
             hw_counter,
         )?;
         check_unprocessed_points(batch, &modified_points)?;
@@ -130,11 +137,18 @@ pub fn delete_vectors_by_filter(
     op_num: SeqNumberType,
     filter: &Filter,
     vector_names: &[VectorNameBuf],
+    max_segment_size_bytes: Option<NonZeroUsize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<usize> {
     let affected_points = points_by_filter(segments, filter, hw_counter)?;
-    let vectors_deleted =
-        delete_vectors(segments, op_num, &affected_points, vector_names, hw_counter)?;
+    let vectors_deleted = delete_vectors(
+        segments,
+        op_num,
+        &affected_points,
+        vector_names,
+        max_segment_size_bytes,
+        hw_counter,
+    )?;
 
     if vectors_deleted == 0 {
         // In case we didn't hit any points, we suggest this op_num to the segment-holder to make WAL acknowledge this operation.


### PR DESCRIPTION
Fixes #9158.

Filter-based payload and vector operations copy-on-write move points out of immutable segments into an appendable one. The destination is whichever appendable segment `aloha_random_write` can lock first, with no size check, so once a segment reaches `max_segment_size` such writes keep growing it without bound.

This is a smaller alternative to #9906, where the condition became a recoverable failure with inline retry and typed gRPC reasons. Here nothing fails, the cap is just a preference on the write path.

### Approach

`apply_points_with_conditional_move` now hands `aloha_random_write` only the appendable segments under `max_segment_size`, falling back to all of them when none qualifies. The cap is soft, a write may overshoot but never fails. Candidates are computed lazily on the first point that needs a move, and a segment that cannot be measured right now stays eligible.

If every appendable segment has reached the cap, the update worker creates a fresh one before applying. Without this the filter has nothing to prefer, since the optimizer only provisions on its own wake-up. It reuses the optimizer's `ensure_appendable_segment_with_capacity`, so both use the same eligibility rule. This is best effort, a failure is logged and the operation applies anyway.

The deferred points threshold used by `prevent_unoptimized` is now clamped to `max_segment_size`. Nothing validates the two settings against each other, so the staging area a deferring segment forms could otherwise be sized beyond what a segment may reach.

The cap is passed as a parameter and read from the optimizer thresholds at each call site, edge shards pass `None`. WAL replay steers with the same cap as live updates, so both pick the same class of destination: a deferred destination keeps the source point while a plain one deletes it, and a live/replay mismatch could resurrect stale data after recovery. Most of the added lines are that threading.

### Limitations

- Capacity is checked once per operation, so an operation moving more than one fresh segment holds still overshoots. This bounds steady-state growth rather than eliminating the #9158 case entirely.
- Destinations are re-picked per 32-point batch, so a segment can exceed the cap by one batch.
- Already-oversized segments are not shrunk.

### Behaviour changes

- The capacity check uses `try_read`, so an unmeasurable segment counts as having room. This also applies to the optimizer's own check, which now provisions slightly less eagerly under contention.
- `max_segment_size_kb = 0` means uncapped rather than "every segment is full". Near unreachable via the API (`min = 1` validation, auto-derived value at least 256 MB).
