### PR TITLE
feat: pin per-shard search pool to a core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,6 +2241,7 @@ dependencies = [
  "ahash",
  "bm25",
  "common",
+ "core_affinity",
  "fs-err",
  "itertools 0.15.0",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,6 +218,7 @@ bytes = "1.11.1"
 cc = "1.2"
 chrono = { version = "0.4.44", features = ["serde"] }
 clap = { version = "4.6.1", features = ["derive", "env"] }
+core_affinity = "0.8.3"
 criterion = "0.8.2"
 data-encoding = "2.11.0"
 ecow = { version = "0.3.0", features = ["serde"] }

--- a/lib/edge/Cargo.toml
+++ b/lib/edge/Cargo.toml
@@ -20,6 +20,7 @@ sparse = { path = "../sparse" }
 wal = { path = "../wal" }
 
 ahash = { workspace = true }
+core_affinity = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }

--- a/lib/edge/ffi/src/config.rs
+++ b/lib/edge/ffi/src/config.rs
@@ -1194,6 +1194,7 @@ impl From<&edge::EdgeConfig> for EdgeConfig {
             optimizers: _,
             wal_options: _,
             max_search_threads: _,
+            search_pool_core: _,
         } = c;
         let vector_data = vectors
             .iter()

--- a/lib/edge/python/qdrant_edge.pyi
+++ b/lib/edge/python/qdrant_edge.pyi
@@ -259,6 +259,7 @@ class EdgeConfig:
         quantization_config: Optional[QuantizationConfigType] = None,
         optimizers: Optional["EdgeOptimizersConfig"] = None,
         max_search_threads: Optional[int] = None,
+        search_pool_core: Optional[int] = None,
     ) -> None:
         """
         Create an EdgeConfig.
@@ -283,6 +284,10 @@ class EdgeConfig:
                                 runs per-segment reads in parallel and loads segments in
                                 parallel. None (the default) derives the count from the number
                                 of CPUs, matching the core search runtime.
+            search_pool_core: Pin every thread of the shard's search pool to this CPU core,
+                              bounding the shard's search compute to one core while keeping
+                              the pool's IO parallelism. Best-effort; None (the default)
+                              leaves thread placement to the OS scheduler.
         """
         ...
 
@@ -319,6 +324,11 @@ class EdgeConfig:
     @property
     def max_search_threads(self) -> Optional[int]:
         """Number of threads in the search thread pool, or None for the CPU-derived default."""
+        ...
+
+    @property
+    def search_pool_core(self) -> Optional[int]:
+        """CPU core the search pool is pinned to, or None for OS scheduling."""
         ...
 
 class EdgeVectorParams:

--- a/lib/edge/python/qdrant_edge.pyi
+++ b/lib/edge/python/qdrant_edge.pyi
@@ -284,10 +284,8 @@ class EdgeConfig:
                                 runs per-segment reads in parallel and loads segments in
                                 parallel. None (the default) derives the count from the number
                                 of CPUs, matching the core search runtime.
-            search_pool_core: Pin every thread of the shard's search pool to this CPU core,
-                              bounding the shard's search compute to one core while keeping
-                              the pool's IO parallelism. Best-effort; None (the default)
-                              leaves thread placement to the OS scheduler.
+            search_pool_core: Pin every search pool thread to this CPU core (best-effort),
+                              bounding search compute to one core. None = OS scheduling.
         """
         ...
 

--- a/lib/edge/python/src/config/mod.rs
+++ b/lib/edge/python/src/config/mod.rs
@@ -25,7 +25,9 @@ pub struct PyEdgeConfig(pub EdgeConfig);
 #[pymethods]
 impl PyEdgeConfig {
     #[new]
-    #[pyo3(signature = (vectors=None, sparse_vectors=None, on_disk_payload=None, hnsw_config=None, quantization_config=None, optimizers=None, max_search_threads=None))]
+    #[pyo3(signature = (vectors=None, sparse_vectors=None, on_disk_payload=None, hnsw_config=None, quantization_config=None, optimizers=None, max_search_threads=None, search_pool_core=None))]
+    // Python-facing keyword arguments mirror EdgeConfig's fields one-to-one.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         #[pyo3(from_py_with = option_edge_vectors_helper)] vectors: Option<
             HashMap<String, PyEdgeVectorParams>,
@@ -36,6 +38,7 @@ impl PyEdgeConfig {
         quantization_config: Option<PyQuantizationConfig>,
         optimizers: Option<PyEdgeOptimizersConfig>,
         max_search_threads: Option<usize>,
+        search_pool_core: Option<usize>,
     ) -> PyResult<Self> {
         let vectors = vectors.unwrap_or_default();
         let sparse_vectors = sparse_vectors.unwrap_or_default();
@@ -57,9 +60,7 @@ impl PyEdgeConfig {
             optimizers: optimizers.map(|o| o.0),
             wal_options: None,
             max_search_threads,
-            // Server-side (multi-tenant worker) knob; not exposed to the
-            // embedded Python bindings.
-            search_pool_core: None,
+            search_pool_core,
         }))
     }
 
@@ -96,6 +97,11 @@ impl PyEdgeConfig {
     #[getter]
     pub fn max_search_threads(&self) -> Option<usize> {
         self.0.max_search_threads
+    }
+
+    #[getter]
+    pub fn search_pool_core(&self) -> Option<usize> {
+        self.0.search_pool_core
     }
 
     pub fn __repr__(&self) -> String {

--- a/lib/edge/python/src/config/mod.rs
+++ b/lib/edge/python/src/config/mod.rs
@@ -57,6 +57,9 @@ impl PyEdgeConfig {
             optimizers: optimizers.map(|o| o.0),
             wal_options: None,
             max_search_threads,
+            // Server-side (multi-tenant worker) knob; not exposed to the
+            // embedded Python bindings.
+            search_pool_core: None,
         }))
     }
 
@@ -111,6 +114,7 @@ impl PyEdgeConfig {
             optimizers: _,
             wal_options: _,
             max_search_threads: _,
+            search_pool_core: _,
         } = self.0;
     }
 }

--- a/lib/edge/src/builders/edge_config.rs
+++ b/lib/edge/src/builders/edge_config.rs
@@ -29,6 +29,7 @@ pub struct EdgeConfigBuilder {
     optimizers: Option<EdgeOptimizersConfig>,
     wal_options: Option<WalOptions>,
     max_search_threads: Option<usize>,
+    search_pool_core: Option<usize>,
 }
 
 impl EdgeConfigBuilder {
@@ -101,6 +102,14 @@ impl EdgeConfigBuilder {
         self
     }
 
+    /// Pin every thread of the shard's search pool to the given CPU core, bounding the shard's
+    /// search compute to one core while keeping the pool's IO overlap. See
+    /// [`EdgeConfig::search_pool_core`].
+    pub fn search_pool_core(mut self, core: usize) -> Self {
+        self.search_pool_core = Some(core);
+        self
+    }
+
     pub fn build(self) -> EdgeConfig {
         // Exhaustively destructure Self and construct EdgeConfig: adding a
         // field to either type forces a compile error here.
@@ -113,6 +122,7 @@ impl EdgeConfigBuilder {
             optimizers,
             wal_options,
             max_search_threads,
+            search_pool_core,
         } = self;
         EdgeConfig {
             on_disk_payload,
@@ -123,6 +133,7 @@ impl EdgeConfigBuilder {
             optimizers,
             wal_options,
             max_search_threads,
+            search_pool_core,
         }
     }
 }

--- a/lib/edge/src/builders/edge_config.rs
+++ b/lib/edge/src/builders/edge_config.rs
@@ -102,8 +102,7 @@ impl EdgeConfigBuilder {
         self
     }
 
-    /// Pin every thread of the shard's search pool to the given CPU core, bounding the shard's
-    /// search compute to one core while keeping the pool's IO overlap. See
+    /// Pin every thread of the shard's search pool to the given CPU core (best-effort). See
     /// [`EdgeConfig::search_pool_core`].
     pub fn search_pool_core(mut self, core: usize) -> Self {
         self.search_pool_core = Some(core);

--- a/lib/edge/src/config/shard.rs
+++ b/lib/edge/src/config/shard.rs
@@ -65,11 +65,9 @@ pub struct EdgeConfig {
     /// [`EdgeConfig::search_thread_count`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_search_threads: Option<usize>,
-    /// Pin every thread of this shard's search pool to the given CPU core. Bounds the shard's
-    /// search *compute* to one core no matter how many pool threads run — the threads still
-    /// overlap on object-storage IO, which is what a large pool is for. Serverless uses this so
-    /// one collection cannot overtake a whole multi-tenant worker. `None` (the default) leaves
-    /// thread placement to the OS scheduler.
+    /// Pin every thread of this shard's search pool to the given CPU core: bounds the shard's
+    /// search compute to one core while keeping the pool's IO overlap. Best-effort. `None` (the
+    /// default) leaves thread placement to the OS scheduler.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub search_pool_core: Option<usize>,
 }

--- a/lib/edge/src/config/shard.rs
+++ b/lib/edge/src/config/shard.rs
@@ -65,6 +65,13 @@ pub struct EdgeConfig {
     /// [`EdgeConfig::search_thread_count`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_search_threads: Option<usize>,
+    /// Pin every thread of this shard's search pool to the given CPU core. Bounds the shard's
+    /// search *compute* to one core no matter how many pool threads run — the threads still
+    /// overlap on object-storage IO, which is what a large pool is for. Serverless uses this so
+    /// one collection cannot overtake a whole multi-tenant worker. `None` (the default) leaves
+    /// thread placement to the OS scheduler.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search_pool_core: Option<usize>,
 }
 
 impl EdgeConfig {
@@ -107,6 +114,7 @@ impl EdgeConfig {
             optimizers,
             wal_options,
             max_search_threads,
+            search_pool_core,
         } = self;
         Self {
             on_disk_payload: on_disk_payload.or(base.on_disk_payload),
@@ -125,6 +133,7 @@ impl EdgeConfig {
             optimizers: optimizers.or_else(|| base.optimizers.clone()),
             wal_options: wal_options.or_else(|| base.wal_options.clone()),
             max_search_threads: max_search_threads.or(base.max_search_threads),
+            search_pool_core: search_pool_core.or(base.search_pool_core),
         }
     }
 
@@ -193,6 +202,7 @@ impl EdgeConfig {
             optimizers: None,
             wal_options: None,
             max_search_threads: None,
+            search_pool_core: None,
         }
     }
 

--- a/lib/edge/src/edge_shard/mod.rs
+++ b/lib/edge/src/edge_shard/mod.rs
@@ -66,7 +66,7 @@ impl EdgeShard {
         let mut segments = SegmentHolder::default();
         ensure_appendable_segment(&mut segments, path, &segments_path, &config)?;
 
-        let search_pool = build_search_pool(config.search_thread_count())?;
+        let search_pool = build_search_pool(config.search_thread_count(), config.search_pool_core)?;
 
         let config_path = path.join(EDGE_CONFIG_FILE);
         let config = Arc::new(
@@ -139,7 +139,7 @@ impl EdgeShard {
 
         ensure_appendable_segment(&mut segments, path, &segments_path, &config)?;
 
-        let search_pool = build_search_pool(config.search_thread_count())?;
+        let search_pool = build_search_pool(config.search_thread_count(), config.search_pool_core)?;
 
         let config_path = path.join(EDGE_CONFIG_FILE);
         let config = Arc::new(

--- a/lib/edge/src/edge_shard/optimize.rs
+++ b/lib/edge/src/edge_shard/optimize.rs
@@ -885,6 +885,7 @@ mod tests {
             optimizers: None,
             wal_options: None,
             max_search_threads: None,
+            search_pool_core: None,
         }
     }
 

--- a/lib/edge/src/read_only/lifecycle.rs
+++ b/lib/edge/src/read_only/lifecycle.rs
@@ -90,10 +90,12 @@ impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
     {
         let provided_config = config.unwrap_or_default();
 
-        // Segments never carry `max_search_threads`, so the pool is sized from the caller-provided
-        // config alone: the CPU-derived default unless explicitly set.
-        let search_pool =
-            crate::read_view::build_search_pool(provided_config.search_thread_count())?;
+        // Segments never carry `max_search_threads` / `search_pool_core`, so the pool is sized and
+        // pinned from the caller-provided config alone: the CPU-derived default unless set.
+        let search_pool = crate::read_view::build_search_pool(
+            provided_config.search_thread_count(),
+            provided_config.search_pool_core,
+        )?;
 
         let shard = Self {
             path: path.to_path_buf(),

--- a/lib/edge/src/read_only/tests.rs
+++ b/lib/edge/src/read_only/tests.rs
@@ -49,6 +49,7 @@ fn test_config() -> EdgeConfig {
         optimizers: None,
         wal_options: None,
         max_search_threads: None,
+        search_pool_core: None,
     }
 }
 
@@ -365,6 +366,7 @@ fn provided_config_overrides_tunables_at_open() {
         optimizers: None,
         wal_options: None,
         max_search_threads: Some(2),
+        search_pool_core: None,
     };
 
     let follower = ReadOnlyEdgeShard::<MmapFile>::open_with_enumerator(

--- a/lib/edge/src/read_view/mod.rs
+++ b/lib/edge/src/read_view/mod.rs
@@ -76,8 +76,11 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
 ///
 /// `pin_core` pins every pool thread to the given CPU core
 /// ([`EdgeConfig::search_pool_core`]): the pool keeps its IO overlap but its compute is bounded
-/// to one core. Pinning is best-effort — an unsupported platform or an out-of-range core id logs
-/// a warning and the thread runs unpinned (macOS in particular only honours affinity as a hint).
+/// to one core. Pinning is best-effort — a core id that is not among the available cores is
+/// rejected up front with a warning and the threads run unpinned (the platform affinity calls
+/// must never see an out-of-range id: libc's `CPU_SET` does no bounds check and would panic),
+/// and a pin that still fails at thread start only logs (macOS in particular honours affinity
+/// as a hint).
 ///
 /// Returns an error (rather than panicking) when the underlying thread spawn fails — this runs
 /// during shard open/load and follower open, so a transient resource failure must not abort the
@@ -86,6 +89,17 @@ pub(crate) fn build_search_pool(
     num_threads: usize,
     pin_core: Option<usize>,
 ) -> OperationResult<Arc<ThreadPool>> {
+    // Validate against the actually-available cores BEFORE installing the
+    // handler: out-of-range ids must never reach the platform affinity APIs.
+    let pin_core = pin_core.filter(|core| {
+        let available =
+            core_affinity::get_core_ids().is_some_and(|ids| ids.iter().any(|c| c.id == *core));
+        if !available {
+            log::warn!("search pool core {core} is not available; leaving threads unpinned");
+        }
+        available
+    });
+
     let mut builder = ThreadPoolBuilder::new()
         .num_threads(num_threads)
         .thread_name(|idx| format!("edge-search-{idx}"));
@@ -107,8 +121,9 @@ mod tests {
     use super::*;
 
     /// Pinning is best-effort: the pool must build and run work both with a
-    /// valid core id and with an out-of-range one (the start handler only
-    /// warns on a failed pin — it must never break the pool).
+    /// valid core id and with an out-of-range one. The invalid id is rejected
+    /// by the up-front availability check — it must never reach the platform
+    /// affinity calls (libc's `CPU_SET` would panic on it) or break the pool.
     #[test]
     fn pinned_pool_builds_and_runs() {
         let pool = build_search_pool(2, Some(0)).unwrap();

--- a/lib/edge/src/read_view/mod.rs
+++ b/lib/edge/src/read_view/mod.rs
@@ -74,16 +74,48 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
 /// callers pass `config.search_thread_count()` so a configured `0` is expanded to the CPU-derived
 /// default that matches the core search runtime.
 ///
+/// `pin_core` pins every pool thread to the given CPU core
+/// ([`EdgeConfig::search_pool_core`]): the pool keeps its IO overlap but its compute is bounded
+/// to one core. Pinning is best-effort — an unsupported platform or an out-of-range core id logs
+/// a warning and the thread runs unpinned (macOS in particular only honours affinity as a hint).
+///
 /// Returns an error (rather than panicking) when the underlying thread spawn fails — this runs
 /// during shard open/load and follower open, so a transient resource failure must not abort the
 /// process.
-pub(crate) fn build_search_pool(num_threads: usize) -> OperationResult<Arc<ThreadPool>> {
-    let pool = ThreadPoolBuilder::new()
+pub(crate) fn build_search_pool(
+    num_threads: usize,
+    pin_core: Option<usize>,
+) -> OperationResult<Arc<ThreadPool>> {
+    let mut builder = ThreadPoolBuilder::new()
         .num_threads(num_threads)
-        .thread_name(|idx| format!("edge-search-{idx}"))
-        .build()
-        .map_err(|err| {
-            OperationError::service_error(format!("failed to build edge search thread pool: {err}"))
-        })?;
+        .thread_name(|idx| format!("edge-search-{idx}"));
+    if let Some(core) = pin_core {
+        builder = builder.start_handler(move |idx| {
+            if !core_affinity::set_for_current(core_affinity::CoreId { id: core }) {
+                log::warn!("failed to pin edge search thread {idx} to core {core}");
+            }
+        });
+    }
+    let pool = builder.build().map_err(|err| {
+        OperationError::service_error(format!("failed to build edge search thread pool: {err}"))
+    })?;
     Ok(Arc::new(pool))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pinning is best-effort: the pool must build and run work both with a
+    /// valid core id and with an out-of-range one (the start handler only
+    /// warns on a failed pin — it must never break the pool).
+    #[test]
+    fn pinned_pool_builds_and_runs() {
+        let pool = build_search_pool(2, Some(0)).unwrap();
+        let sum: i32 = pool.install(|| (0..4).sum());
+        assert_eq!(sum, 6);
+
+        let pool = build_search_pool(1, Some(usize::MAX)).unwrap();
+        assert_eq!(pool.install(|| 1 + 1), 2);
+    }
 }

--- a/lib/edge/src/read_view/mod.rs
+++ b/lib/edge/src/read_view/mod.rs
@@ -74,13 +74,9 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
 /// callers pass `config.search_thread_count()` so a configured `0` is expanded to the CPU-derived
 /// default that matches the core search runtime.
 ///
-/// `pin_core` pins every pool thread to the given CPU core
-/// ([`EdgeConfig::search_pool_core`]): the pool keeps its IO overlap but its compute is bounded
-/// to one core. Pinning is best-effort — a core id that is not among the available cores is
-/// rejected up front with a warning and the threads run unpinned (the platform affinity calls
-/// must never see an out-of-range id: libc's `CPU_SET` does no bounds check and would panic),
-/// and a pin that still fails at thread start only logs (macOS in particular honours affinity
-/// as a hint).
+/// `pin_core` pins every pool thread to the given CPU core ([`EdgeConfig::search_pool_core`]):
+/// the pool keeps its IO overlap but its compute is bounded to one core. Best-effort — an
+/// unavailable core id or a failed pin only warns (macOS honours affinity as a hint).
 ///
 /// Returns an error (rather than panicking) when the underlying thread spawn fails — this runs
 /// during shard open/load and follower open, so a transient resource failure must not abort the
@@ -89,8 +85,8 @@ pub(crate) fn build_search_pool(
     num_threads: usize,
     pin_core: Option<usize>,
 ) -> OperationResult<Arc<ThreadPool>> {
-    // Validate against the actually-available cores BEFORE installing the
-    // handler: out-of-range ids must never reach the platform affinity APIs.
+    // Out-of-range ids must never reach the platform affinity calls: libc's
+    // `CPU_SET` has no bounds check.
     let pin_core = pin_core.filter(|core| {
         let available =
             core_affinity::get_core_ids().is_some_and(|ids| ids.iter().any(|c| c.id == *core));
@@ -120,10 +116,7 @@ pub(crate) fn build_search_pool(
 mod tests {
     use super::*;
 
-    /// Pinning is best-effort: the pool must build and run work both with a
-    /// valid core id and with an out-of-range one. The invalid id is rejected
-    /// by the up-front availability check — it must never reach the platform
-    /// affinity calls (libc's `CPU_SET` would panic on it) or break the pool.
+    /// Best-effort pinning: valid and out-of-range core ids must both yield a working pool.
     #[test]
     fn pinned_pool_builds_and_runs() {
         let pool = build_search_pool(2, Some(0)).unwrap();

--- a/lib/edge/src/test_helpers.rs
+++ b/lib/edge/src/test_helpers.rs
@@ -33,6 +33,7 @@ pub(crate) fn test_config() -> EdgeConfig {
         optimizers: Default::default(),
         wal_options: None,
         max_search_threads: None,
+        search_pool_core: None,
     }
 }
 


### PR DESCRIPTION
Adds `EdgeConfig.search_pool_core: Option<usize>`: when set, every thread of the shard's search pool is pinned to that CPU core (rayon `start_handler` + `core_affinity`).

Serverless workers run one shard — and one search pool — per collection. The pool's thread count sizes IO parallelism, so it cannot double as the CPU limiter; pinning bounds a collection to ~one core of compute while keeping the IO overlap. The caller picks the core per shard.

- Best-effort: unavailable ids / failed pins only warn (macOS treats affinity as a hint); `None` keeps current behaviour.
- `core_affinity` promoted from transitive dep (foyer-storage) to workspace dep.
- Plumbing mirrors `max_search_threads` (builder, merge, serde-optional, python bindings).