### PR TITLE
[UIO] 2-stage `DiskCache::reopen`

### DIFF
--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -193,7 +193,7 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
         Ok(())
     }
 
-    fn file_info(&self, path: &Path) -> Option<FileInfo> {
+    fn cached_file_info(&self, path: &Path) -> Option<FileInfo> {
         self.files_info.as_ref()?.get(path).cloned()
     }
 }

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -192,6 +192,10 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
 
         Ok(())
     }
+
+    fn snapshot_len(&self, path: &Path) -> Option<u64> {
+        Some(self.file_info(path)?.size)
+    }
 }
 
 /// Construction context for [`CachedReadFs`]: the inner filesystem's own

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -193,8 +193,8 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
         Ok(())
     }
 
-    fn snapshot_len(&self, path: &Path) -> Option<u64> {
-        Some(self.file_info(path)?.size)
+    fn file_info(&self, path: &Path) -> Option<FileInfo> {
+        self.file_info(path).cloned()
     }
 }
 

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -194,7 +194,7 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
     }
 
     fn file_info(&self, path: &Path) -> Option<FileInfo> {
-        self.file_info(path).cloned()
+        self.files_info.as_ref()?.get(path).cloned()
     }
 }
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
@@ -3,7 +3,7 @@
 use std::ops::Range;
 use std::sync::atomic::Ordering;
 
-use super::{DiskCache, PendingReopen, State};
+use super::{DiskCache, ScheduledReopen, State};
 use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::simple_disk_cache::{DiskCacheRemote, to_block_range};
 use crate::universal_io::{OwnedPipeline, UioResult};
@@ -33,7 +33,7 @@ where
         let State::Ready {
             remote,
             local,
-            pending_reopen: _, // only ever touched under `&mut self`
+            scheduled_reopen: _, // only ever touched under `&mut self`
         } = (unsafe { &*self.state.data_ptr() })
         else {
             unreachable!("the `ready` flag guarantees the `Ready` variant")
@@ -61,9 +61,6 @@ where
         let (remote, local) = match std::mem::replace(&mut *state, State::Uninit) {
             State::Uninit => self.init_from_scratch(self.open_remote()?)?,
             State::OpenPrefill { pipeline } => self.init_from_open_prefill(pipeline)?,
-            State::ReopenPrefill { pipeline, local } => {
-                self.init_from_reopen_prefill(pipeline, local)?
-            }
             State::PartialPrefill { pipeline, len } => {
                 self.init_from_partial_prefill(pipeline, len)?
             }
@@ -75,7 +72,7 @@ where
         *state = State::Ready {
             remote,
             local,
-            pending_reopen: PendingReopen::Stale,
+            scheduled_reopen: ScheduledReopen::No,
         };
         self.is_ready.store(true, Ordering::Release);
 
@@ -112,30 +109,6 @@ where
             // to a from-scratch, zero-length mirror.
             None => self.init_from_scratch(pipeline.into_inner()),
         }
-    }
-
-    /// Resolve a [`State::ReopenPrefill`] tail read: resize the mirror and write
-    /// only the appended suffix. See [`super::reopen`].
-    pub(super) fn init_from_reopen_prefill(
-        &self,
-        mut pipeline: OwnedPipeline<R, u64>,
-        mut local: LocalState,
-    ) -> UioResult<(R, LocalState)> {
-        match pipeline.wait()? {
-            Some((start, bytes)) if !bytes.is_empty() => {
-                let end = start + bytes.len() as u64;
-                local.resize(&self.local_path, end)?;
-                let blocks_range = to_block_range(start..end);
-                // SAFETY: `bytes` covers `blocks_range` exactly, and the remote
-                // is immutable, so the mmap suffix is filled once with correct data.
-                unsafe { local.write_mmap_bytes(&bytes, blocks_range) }
-            }
-            // There is nothing to apply.
-            // TODO: double check that the remote didn't shrink?
-            Some(_) | None => {}
-        }
-
-        Ok((pipeline.into_inner(), local))
     }
 
     /// Resolve a [`State::PartialPrefill`] read: size the mirror from `len` and

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
@@ -3,7 +3,7 @@
 use std::ops::Range;
 use std::sync::atomic::Ordering;
 
-use super::{DiskCache, ScheduledReopen, State};
+use super::{DiskCache, State};
 use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::simple_disk_cache::{DiskCacheRemote, to_block_range};
 use crate::universal_io::{OwnedPipeline, UioResult};
@@ -69,11 +69,7 @@ where
             }
         };
 
-        *state = State::Ready {
-            remote,
-            local,
-            scheduled_reopen: ScheduledReopen::No,
-        };
+        *state = State::ready(remote, local);
         self.is_ready.store(true, Ordering::Release);
 
         Ok(())

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/init.rs
@@ -3,7 +3,7 @@
 use std::ops::Range;
 use std::sync::atomic::Ordering;
 
-use super::{DiskCache, State};
+use super::{DiskCache, PendingReopen, State};
 use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::simple_disk_cache::{DiskCacheRemote, to_block_range};
 use crate::universal_io::{OwnedPipeline, UioResult};
@@ -30,7 +30,12 @@ where
         }
 
         // SAFETY: self.ready tracks whether `state` is `State::Ready`, to make reads "lock-free".
-        let State::Ready { remote, local } = (unsafe { &*self.state.data_ptr() }) else {
+        let State::Ready {
+            remote,
+            local,
+            pending_reopen: _, // only ever touched under `&mut self`
+        } = (unsafe { &*self.state.data_ptr() })
+        else {
             unreachable!("the `ready` flag guarantees the `Ready` variant")
         };
         Ok(ReadyRef { remote, local })
@@ -67,7 +72,11 @@ where
             }
         };
 
-        *state = State::Ready { remote, local };
+        *state = State::Ready {
+            remote,
+            local,
+            pending_reopen: PendingReopen::Stale,
+        };
         self.is_ready.store(true, Ordering::Release);
 
         Ok(())

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
@@ -9,10 +9,8 @@ use parking_lot::Mutex;
 
 use super::DiskCacheRemote;
 use super::local_state::LocalState;
-use crate::mmap::AdviceSetting;
-use crate::universal_io::{
-    OpenOptions, OwnedPipeline, Populate, UioResult, UniversalRead, UniversalReadFs,
-};
+use crate::universal_io::simple_disk_cache::REMOTE_OPEN_OPTIONS;
+use crate::universal_io::{OpenOptions, OwnedPipeline, UioResult, UniversalRead, UniversalReadFs};
 
 mod init;
 mod read;
@@ -182,15 +180,11 @@ where
     }
 
     pub(super) fn open_remote(&self) -> UioResult<R> {
-        let remote_options = OpenOptions {
-            writeable: false,
-            populate: Populate::No,
-            need_sequential: false,
-            advice: AdviceSetting::Global,
-        };
-
-        self.remote_fs
-            .open(&self.remote_path, remote_options, self.remote_extra.clone())
+        self.remote_fs.open(
+            &self.remote_path,
+            REMOTE_OPEN_OPTIONS,
+            self.remote_extra.clone(),
+        )
     }
 }
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
@@ -98,20 +98,18 @@ pub(crate) enum State<R: UniversalRead + 'static> {
 #[derive(Debug)]
 pub(crate) enum ScheduledReopen<R: UniversalRead + 'static> {
     /// Nothing staged — the default at every [`State::Ready`] construction
-    /// site. `reopen` then schedules and waits inline.
+    /// site, and what a no-growth schedule leaves behind. `reopen` then
+    /// schedules and waits inline.
     No,
     /// Lazy populate (`No` / `Auto` / `Partial`): apply resizes the mirror to
-    /// `target_len` and lets the new blocks fault in on demand. Doubles as the
-    /// "already up to date" marker — a resize to the current length is a
-    /// no-op — which saves `reopen` the round-trip of asking for the length
-    /// again.
+    /// `target_len` and lets the new blocks fault in on demand.
     Resize { target_len: u64 },
     /// Populated (`Blocking` / `PreferBackground`): the appended tail is
     /// already in flight on a clone of the remote; apply resizes, drains it
-    /// and writes it. Holds exactly one read, whose user data is its `from`
-    /// offset.
+    /// and writes it. Holds exactly one read, whose user data is the block
+    /// range it covers, as in [`State::PartialPrefill`].
     Tail {
-        pipeline: OwnedPipeline<R, u64>,
+        pipeline: OwnedPipeline<R, Range<u32>>,
         target_len: u64,
     },
 }
@@ -132,6 +130,16 @@ impl<R: UniversalRead + 'static> ScheduledReopen<R> {
 }
 
 impl<R: UniversalRead + 'static> State<R> {
+    /// A live mirror with nothing staged — the default at every construction
+    /// site.
+    pub fn ready(remote: R, local: LocalState) -> Self {
+        State::Ready {
+            remote,
+            local,
+            scheduled_reopen: ScheduledReopen::No,
+        }
+    }
+
     #[inline]
     pub fn is_ready(&self) -> bool {
         match self {

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
@@ -68,26 +68,19 @@ pub(crate) enum State<R: UniversalRead + 'static> {
     Ready {
         remote: R,
         local: LocalState,
-        /// What the next [`reopen`] must do. Staged by [`reopen_schedule`],
-        /// consumed (reset to [`PendingReopen::Stale`]) by [`reopen`]. Only
+        /// What the next [`reopen`] must do. Staged by [`schedule_reopen`],
+        /// consumed (reset to [`ScheduledReopen::No`]) by [`reopen`]. Only
         /// touched under `&mut self`, and `ReadyRef` borrows just
         /// `remote`/`local`, so staging never disturbs the served state.
         ///
         /// [`reopen`]: UniversalRead::reopen
-        /// [`reopen_schedule`]: UniversalRead::reopen_schedule
-        pending_reopen: PendingReopen<R>,
+        /// [`schedule_reopen`]: UniversalRead::schedule_reopen
+        scheduled_reopen: ScheduledReopen<R>,
     },
     /// Eager open-time prefill: an in-flight whole-object read scheduled at open;
     /// init waits on it and writes the whole mirror. For `Populate::Blocking` /
     /// `PreferBackground`.
     OpenPrefill { pipeline: OwnedPipeline<R, ()> },
-    /// The reopen-time counterpart of [`OpenPrefill`](Self::OpenPrefill): an
-    /// in-flight read of just the appended tail (block-aligned old length → new
-    /// EOF). Init resizes the mirror and writes only that suffix. See [`reopen`].
-    ReopenPrefill {
-        pipeline: OwnedPipeline<R, u64>,
-        local: LocalState,
-    },
     /// Open-time partial prefill
     PartialPrefill {
         pipeline: OwnedPipeline<R, Range<u32>>,
@@ -96,34 +89,46 @@ pub(crate) enum State<R: UniversalRead + 'static> {
 }
 
 /// The obligation of the next [`reopen`](UniversalRead::reopen), staged ahead
-/// of time by [`reopen_schedule`](UniversalRead::reopen_schedule).
+/// of time by [`schedule_reopen`](UniversalRead::schedule_reopen).
 ///
 /// Staging deliberately leaves the mirror alone: its length keeps matching its
 /// persisted content until the apply, so readers observe nothing in between
 /// and components keep `len()` as their growth signal. Nothing else remembers
 /// the staged targets, hence the `target_len` on every variant.
 #[derive(Debug)]
-pub(crate) enum PendingReopen<R: UniversalRead + 'static> {
+pub(crate) enum ScheduledReopen<R: UniversalRead + 'static> {
     /// Nothing staged — the default at every [`State::Ready`] construction
-    /// site. `reopen` takes the legacy path, blocking `remote.len()` included.
-    Stale,
+    /// site. `reopen` then schedules and waits inline.
+    No,
     /// Lazy populate (`No` / `Auto` / `Partial`): apply resizes the mirror to
     /// `target_len` and lets the new blocks fault in on demand. Doubles as the
-    /// "already up to date" marker — a resize to the current length is a no-op
-    /// — which is what keeps apply off the legacy path.
+    /// "already up to date" marker — a resize to the current length is a
+    /// no-op — which saves `reopen` the round-trip of asking for the length
+    /// again.
     Resize { target_len: u64 },
     /// Populated (`Blocking` / `PreferBackground`): the appended tail is
-    /// already in flight on a clone of the remote; apply drains it, resizes
-    /// and writes it. User data is the read's `from` offset, as in
-    /// [`State::ReopenPrefill`].
-    ///
-    /// Holds exactly one read and is never superseded while staged — the
-    /// clone pins the remote's mapping on local backends. See
-    /// `reopen_schedule`.
+    /// already in flight on a clone of the remote; apply resizes, drains it
+    /// and writes it. Holds exactly one read, whose user data is its `from`
+    /// offset.
     Tail {
         pipeline: OwnedPipeline<R, u64>,
         target_len: u64,
     },
+}
+
+impl<R: UniversalRead + 'static> ScheduledReopen<R> {
+    /// Length the scheduled reopen would bring the mirror to, if anything is
+    /// staged.
+    pub(super) fn target_len(&self) -> Option<u64> {
+        match self {
+            ScheduledReopen::No => None,
+            ScheduledReopen::Resize { target_len }
+            | ScheduledReopen::Tail {
+                target_len,
+                pipeline: _,
+            } => Some(*target_len),
+        }
+    }
 }
 
 impl<R: UniversalRead + 'static> State<R> {
@@ -131,10 +136,7 @@ impl<R: UniversalRead + 'static> State<R> {
     pub fn is_ready(&self) -> bool {
         match self {
             State::Ready { .. } => true,
-            State::Uninit
-            | State::OpenPrefill { .. }
-            | State::ReopenPrefill { .. }
-            | State::PartialPrefill { .. } => false,
+            State::Uninit | State::OpenPrefill { .. } | State::PartialPrefill { .. } => false,
         }
     }
 
@@ -142,10 +144,7 @@ impl<R: UniversalRead + 'static> State<R> {
     pub fn is_uninit(&self) -> bool {
         match self {
             State::Uninit => true,
-            State::Ready { .. }
-            | State::OpenPrefill { .. }
-            | State::ReopenPrefill { .. }
-            | State::PartialPrefill { .. } => false,
+            State::Ready { .. } | State::OpenPrefill { .. } | State::PartialPrefill { .. } => false,
         }
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
@@ -65,7 +65,18 @@ pub(crate) enum State<R: UniversalRead + 'static> {
     /// Uninitialized start. Chosen for `Populate::No` / `Auto`.
     Uninit,
     /// The live mirror: the opened `remote` handle paired with its local mmap.
-    Ready { remote: R, local: LocalState },
+    Ready {
+        remote: R,
+        local: LocalState,
+        /// What the next [`reopen`] must do. Staged by [`reopen_schedule`],
+        /// consumed (reset to [`PendingReopen::Stale`]) by [`reopen`]. Only
+        /// touched under `&mut self`, and `ReadyRef` borrows just
+        /// `remote`/`local`, so staging never disturbs the served state.
+        ///
+        /// [`reopen`]: UniversalRead::reopen
+        /// [`reopen_schedule`]: UniversalRead::reopen_schedule
+        pending_reopen: PendingReopen<R>,
+    },
     /// Eager open-time prefill: an in-flight whole-object read scheduled at open;
     /// init waits on it and writes the whole mirror. For `Populate::Blocking` /
     /// `PreferBackground`.
@@ -81,6 +92,37 @@ pub(crate) enum State<R: UniversalRead + 'static> {
     PartialPrefill {
         pipeline: OwnedPipeline<R, Range<u32>>,
         len: u64,
+    },
+}
+
+/// The obligation of the next [`reopen`](UniversalRead::reopen), staged ahead
+/// of time by [`reopen_schedule`](UniversalRead::reopen_schedule).
+///
+/// Staging deliberately leaves the mirror alone: its length keeps matching its
+/// persisted content until the apply, so readers observe nothing in between
+/// and components keep `len()` as their growth signal. Nothing else remembers
+/// the staged targets, hence the `target_len` on every variant.
+#[derive(Debug)]
+pub(crate) enum PendingReopen<R: UniversalRead + 'static> {
+    /// Nothing staged — the default at every [`State::Ready`] construction
+    /// site. `reopen` takes the legacy path, blocking `remote.len()` included.
+    Stale,
+    /// Lazy populate (`No` / `Auto` / `Partial`): apply resizes the mirror to
+    /// `target_len` and lets the new blocks fault in on demand. Doubles as the
+    /// "already up to date" marker — a resize to the current length is a no-op
+    /// — which is what keeps apply off the legacy path.
+    Resize { target_len: u64 },
+    /// Populated (`Blocking` / `PreferBackground`): the appended tail is
+    /// already in flight on a clone of the remote; apply drains it, resizes
+    /// and writes it. User data is the read's `from` offset, as in
+    /// [`State::ReopenPrefill`].
+    ///
+    /// Holds exactly one read and is never superseded while staged — the
+    /// clone pins the remote's mapping on local backends. See
+    /// `reopen_schedule`.
+    Tail {
+        pipeline: OwnedPipeline<R, u64>,
+        target_len: u64,
     },
 }
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -3,15 +3,17 @@
 //! growth handling in [`super::reopen`].
 use std::borrow::Cow;
 use std::ops::Range;
+use std::path::Path;
 
 use super::DiskCache;
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Sequential};
+use crate::universal_io::cached_fs::FileInfo;
 use crate::universal_io::simple_disk_cache::fs::DiskCacheFs;
 use crate::universal_io::simple_disk_cache::pipeline::DiskCachePipeline;
 use crate::universal_io::simple_disk_cache::{BLOCK_SIZE, DiskCacheRemote};
 use crate::universal_io::{
-    CachedReadFs, Item, ReadPipeline, ReadRange, UioResult, UniversalKind, UniversalRead, UserData,
+    Item, ReadPipeline, ReadRange, UioResult, UniversalKind, UniversalRead, UserData,
 };
 
 impl<R> DiskCache<R>
@@ -60,8 +62,11 @@ where
         self.reopen_impl()
     }
 
-    fn schedule_reopen<Fs: CachedReadFs>(&mut self, cached_fs: &Fs) -> UioResult<()> {
-        self.schedule_reopen_impl(cached_fs)
+    fn schedule_reopen<F: FnOnce(&Path) -> Option<FileInfo>>(
+        &mut self,
+        get_file_info: F,
+    ) -> UioResult<()> {
+        self.schedule_reopen_impl(get_file_info)
     }
 
     fn read_bytes<P: AccessPattern>(

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -60,8 +60,8 @@ where
         self.reopen_impl()
     }
 
-    fn reopen_schedule(&mut self, known_len: Option<u64>) -> UioResult<()> {
-        self.reopen_schedule_impl(known_len)
+    fn schedule_reopen(&mut self, known_len: Option<u64>) -> UioResult<()> {
+        self.schedule_reopen_impl(known_len)
     }
 
     fn read_bytes<P: AccessPattern>(

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -11,7 +11,7 @@ use crate::universal_io::simple_disk_cache::fs::DiskCacheFs;
 use crate::universal_io::simple_disk_cache::pipeline::DiskCachePipeline;
 use crate::universal_io::simple_disk_cache::{BLOCK_SIZE, DiskCacheRemote};
 use crate::universal_io::{
-    Item, ReadPipeline, ReadRange, UioResult, UniversalKind, UniversalRead, UserData,
+    CachedReadFs, Item, ReadPipeline, ReadRange, UioResult, UniversalKind, UniversalRead, UserData,
 };
 
 impl<R> DiskCache<R>
@@ -60,8 +60,8 @@ where
         self.reopen_impl()
     }
 
-    fn schedule_reopen(&mut self, known_len: Option<u64>) -> UioResult<()> {
-        self.schedule_reopen_impl(known_len)
+    fn schedule_reopen<Fs: CachedReadFs>(&mut self, cached_fs: &Fs) -> UioResult<()> {
+        self.schedule_reopen_impl(cached_fs)
     }
 
     fn read_bytes<P: AccessPattern>(

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -60,6 +60,10 @@ where
         self.reopen_impl()
     }
 
+    fn reopen_schedule(&mut self, known_len: Option<u64>) -> UioResult<()> {
+        self.reopen_schedule_impl(known_len)
+    }
+
     fn read_bytes<P: AccessPattern>(
         &self,
         range: Range<u64>,

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -37,7 +37,7 @@ where
     // Returns `true` if a pending reopen was resolved, `false` otherwise.
     fn resolve_pending_reopen(&mut self) -> UioResult<bool> {
         let State::Ready {
-            remote: _,
+            remote,
             local,
             scheduled_reopen,
         } = self.state.get_mut()
@@ -50,6 +50,10 @@ where
             ScheduledReopen::No => Ok(false),
             ScheduledReopen::Resize { target_len } => {
                 local.resize(&self.local_path, target_len)?;
+
+                // reopen remote, so we can read up to the new length.
+                remote.reopen()?;
+
                 Ok(true)
             }
             ScheduledReopen::Tail {
@@ -68,6 +72,9 @@ where
                     // and the new blocks fault in on demand.
                     Some(_) | None => {}
                 }
+
+                // replace remote with the one from the owned pipeline
+                *remote = pipeline.into_inner();
 
                 Ok(true)
             }
@@ -113,11 +120,7 @@ where
 
         let local_len = local.mmap().len::<u8>()?;
 
-        // With a known length, decide before touching the remote: the common
-        // no-growth sweep then costs no round-trip, and a kept staged tail
-        // never has its remote reopened out from under its pipeline clone
-        // (`MmapFile` clones share the mapping). Without one, ask the remote
-        // — the blocking `reopen()` fallback.
+        // If we don't have a known length, reopen the remote to tell the new length.
         let remote_len = match known_len {
             Some(known_len) => known_len,
             None => {
@@ -141,20 +144,17 @@ where
             return Ok(());
         }
 
-        // Make the held remote reflect the current length. If length wasn't
-        // provided, this is already done above.
-        if known_len.is_some() {
-            remote.reopen()?;
-        }
-
-        *scheduled_reopen = match self.open_options.populate {
+        let new_scheduled_reopen = match self.open_options.populate {
             Populate::Blocking | Populate::PreferBackground => {
                 // Schedule the read of the new tail blocks.
                 let (blocks_range, byte_range) =
                     block_aligned_fetch(local_len..remote_len, remote_len)
                         .expect("the byte range is non-empty");
 
-                let mut pipeline = OwnedPipeline::new(remote.clone())?;
+                // Fresh handle: the staged fetch must not share a mapping with
+                // the held remote, which later reopens would remap.
+                let new_remote = self.open_remote()?;
+                let mut pipeline = OwnedPipeline::new(new_remote)?;
                 // FIXME: check can_schedule in a loop?
                 pipeline.schedule::<Sequential>(blocks_range, byte_range, REMOTE_READ_ALIGNMENT)?;
 
@@ -168,6 +168,17 @@ where
                 target_len: remote_len,
             },
         };
+
+        // Re-borrow the state: `open_remote` above needs `&self`.
+        let State::Ready {
+            remote: _,
+            local: _,
+            scheduled_reopen,
+        } = self.state.get_mut()
+        else {
+            unreachable!("state was Ready above");
+        };
+        *scheduled_reopen = new_scheduled_reopen;
 
         Ok(())
     }

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -1,19 +1,17 @@
 //! [`Reopen`] the local mirror after the (append-only) remote has grown,
 //! either in one blocking step or split into a schedule and an apply phase
-//! ([`reopen_schedule`]).
+//! ([`schedule_reopen`]).
 //!
 //! [`reopen`]: crate::universal_io::UniversalRead::reopen
-//! [`reopen_schedule`]: crate::universal_io::UniversalRead::reopen_schedule
+//! [`schedule_reopen`]: crate::universal_io::UniversalRead::schedule_reopen
 
 use std::io::{self, ErrorKind};
-use std::path::Path;
 
-use super::{DiskCache, PendingReopen, State};
+use super::{DiskCache, ScheduledReopen, State};
 use crate::generic_consts::Sequential;
-use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::simple_disk_cache::pipeline::REMOTE_READ_ALIGNMENT;
 use crate::universal_io::simple_disk_cache::{
-    BLOCK_SIZE, DiskCacheRemote, block_aligned_fetch, to_block_range,
+    DiskCacheRemote, block_aligned_fetch, to_block_range,
 };
 use crate::universal_io::{OwnedPipeline, Populate, UioResult, UniversalIoError, UniversalRead};
 
@@ -23,237 +21,145 @@ where
 {
     /// Body of [`UniversalRead::reopen`](crate::universal_io::UniversalRead::reopen).
     pub(super) fn reopen_impl(&mut self) -> UioResult<()> {
-        // Apply whatever `reopen_schedule` staged, if anything. This is the
-        // only place the mirror grows: `resize` remaps the mmap, which is
-        // sound only under `&mut self`, with no reader holding a slice.
-        if let State::Ready {
-            remote: _,
-            local,
-            pending_reopen,
-        } = self.state.get_mut()
-        {
-            match std::mem::replace(pending_reopen, PendingReopen::Stale) {
-                // Nothing staged: fall through to the blocking path below.
-                PendingReopen::Stale => {}
-                PendingReopen::Resize { target_len } => {
-                    return local.resize(&self.local_path, target_len);
-                }
-                PendingReopen::Tail {
-                    pipeline,
-                    target_len,
-                } => return Self::apply_tail(&self.local_path, local, pipeline, target_len),
-            }
+        if self.resolve_pending_reopen()? {
+            return Ok(());
         }
 
-        // `&mut self` gives exclusive access, so we can transition `state`
-        // directly without locking or touching the `ready` gate concurrently.
-        //
-        // Resolve any in-flight prefill so we hold a concrete mirror.
-        let (mut remote, mut local) = match std::mem::replace(self.state.get_mut(), State::Uninit) {
-            // If it is still `Uninit`, we can let the first read initialize it later.
-            State::Uninit => return Ok(()),
-            State::Ready {
-                remote,
-                local,
-                pending_reopen: _, // just observed as `Stale`
-            } => (remote, local),
-            State::OpenPrefill { pipeline } => self.init_from_open_prefill(pipeline)?,
-            State::ReopenPrefill { pipeline, local } => {
-                self.init_from_reopen_prefill(pipeline, local)?
-            }
-            State::PartialPrefill { pipeline, len } => {
-                self.init_from_partial_prefill(pipeline, len)?
-            }
-        };
-        *self.is_ready.get_mut() = false;
-
-        // Reopen remote so it reflects current length
-        remote.reopen()?;
-
-        let local_len = local.mmap().len::<u8>()?;
-
-        match self.open_options.populate {
-            Populate::Auto | Populate::No | Populate::Partial(_) => {
-                let remote_len = remote.len::<u8>()?;
-
-                // The remote is assumed to be append-only; a smaller file is unexpected.
-                if local_len > remote_len {
-                    return Err(UniversalIoError::Io(io::Error::new(
-                        ErrorKind::UnexpectedEof,
-                        format!(
-                            "Reopen encountered a smaller file than expected; old_len: {local_len}, new_len: {remote_len}"
-                        ),
-                    )));
-                }
-                // Make the new length visible; new blocks will be filled lazily on read.
-                local.resize(&self.local_path, remote_len)?;
-
-                *self.state.get_mut() = State::Ready {
-                    remote,
-                    local,
-                    pending_reopen: PendingReopen::Stale,
-                };
-                *self.is_ready.get_mut() = true;
-            }
-            Populate::Blocking | Populate::PreferBackground => {
-                // Re-fetch from the start of the (possibly partial) tail block so
-                // we still make an page-aligned read.
-                let from = local_len.saturating_sub(local_len % BLOCK_SIZE as u64);
-
-                let mut pipeline = OwnedPipeline::new(remote)?;
-
-                // FIXME: check can_schedule in a loop?
-                pipeline.schedule_whole(from, from)?;
-
-                *self.state.get_mut() = State::ReopenPrefill { pipeline, local };
-
-                // For blocking, resolve the prefill now instead of on first read.
-                if matches!(self.open_options.populate, Populate::Blocking) {
-                    self.init_state()?;
-                }
-            }
-        }
+        // If not previously done, schedule and wait blockingly
+        self.schedule_reopen_impl(None)?;
+        self.resolve_pending_reopen()?;
 
         Ok(())
     }
 
-    /// Body of [`UniversalRead::reopen_schedule`].
+    // Apply whatever `schedule_reopen` staged, if anything.
+    //
+    // Returns `true` if a pending reopen was resolved, `false` otherwise.
+    fn resolve_pending_reopen(&mut self) -> UioResult<bool> {
+        let State::Ready {
+            remote: _,
+            local,
+            scheduled_reopen,
+        } = self.state.get_mut()
+        else {
+            return Ok(false);
+        };
+
+        match std::mem::replace(scheduled_reopen, ScheduledReopen::No) {
+            // Nothing staged
+            ScheduledReopen::No => Ok(false),
+            ScheduledReopen::Resize { target_len } => {
+                local.resize(&self.local_path, target_len)?;
+                Ok(true)
+            }
+            ScheduledReopen::Tail {
+                mut pipeline,
+                target_len,
+            } => {
+                local.resize(&self.local_path, target_len)?;
+
+                match pipeline.wait()? {
+                    Some((from, bytes)) if !bytes.is_empty() => {
+                        let end = from + bytes.len() as u64;
+                        assert_eq!(
+                            end, target_len,
+                            "Expected the bytes and the scheduled read to be the same length"
+                        );
+
+                        let blocks_range = to_block_range(from..end);
+                        // SAFETY: `bytes` covers `blocks_range` exactly, and the remote
+                        // is immutable, so the mmap suffix is filled once with correct data.
+                        unsafe { local.write_mmap_bytes(&bytes, blocks_range) }
+                    }
+                    // Nothing landed: the resize still makes the length visible,
+                    // and the new blocks fault in on demand.
+                    Some(_) | None => {}
+                }
+
+                Ok(true)
+            }
+        }
+    }
+
+    /// Body of [`UniversalRead::schedule_reopen`].
     ///
     /// Records what the next [`reopen_impl`](Self::reopen_impl) must do and,
     /// for populated files, puts the tail fetch in flight — without waiting on
     /// it and without touching the mirror, so readers see no change until the
     /// apply.
     ///
-    /// [`UniversalRead::reopen_schedule`]: crate::universal_io::UniversalRead::reopen_schedule
-    pub(super) fn reopen_schedule_impl(&mut self, known_len: Option<u64>) -> UioResult<()> {
-        // Without a length there is nothing to stage: leave `Stale` so
-        // `reopen` asks the remote itself.
-        let Some(known_len) = known_len else {
-            return Ok(());
-        };
-
-        // A prefill can only be resolved by waiting on it — bounded to the
-        // first schedule after open, which may race the open-time fetch.
-        if !self.state.get_mut().is_ready() && !self.state.get_mut().is_uninit() {
+    /// [`UniversalRead::schedule_reopen`]: crate::universal_io::UniversalRead::schedule_reopen
+    pub(super) fn schedule_reopen_impl(&mut self, known_len: Option<u64>) -> UioResult<()> {
+        // Wait for scheduled prefill, if any.
+        if !self.is_ready() {
+            // warn: this will do a length request if uninit, but when using a
+            // cached fs to create the file it should never be uninit.
             self.init_state()?;
         }
 
-        // Cold start: materializing here is IO-free (the open is construction
-        // only) and saves the `len()` round-trip the first read would pay.
-        if self.state.get_mut().is_uninit() {
-            let remote = self.open_remote()?;
-            let local = LocalState::new(&self.local_path, known_len, self.open_options)?;
-
-            *self.state.get_mut() = State::Ready {
-                remote,
-                local,
-                // The mirror already sits at `known_len`; without this marker
-                // the next `reopen` would go down the blocking path.
-                pending_reopen: PendingReopen::Resize {
-                    target_len: known_len,
-                },
-            };
-            *self.is_ready.get_mut() = true;
-            return Ok(());
-        }
-
-        let populate = self.open_options.populate;
         let State::Ready {
             remote,
             local,
-            pending_reopen,
+            scheduled_reopen,
         } = self.state.get_mut()
         else {
-            unreachable!("prefills were resolved and `Uninit` handled above")
+            unreachable!("init_state drives state to Ready");
         };
 
-        // A staged tail holds a clone of `remote`, and clones share the
-        // mapping on local backends — reopening the held handle now would
-        // dangle it. A staged tail is therefore never superseded: growth past
-        // its target is picked up by the next schedule, once `reopen` consumed
-        // this one.
-        if matches!(pending_reopen, PendingReopen::Tail { .. }) {
-            return Ok(());
-        }
-
-        // Make the remote reflect the current length before staging: a no-op
-        // for the async bridge, but load-bearing for local remotes, where a
-        // stale handle would fetch an empty tail and later lazy faults would
-        // read past the mapping. Local stat/remap only, no IO wait.
+        // Make the remote reflect the current length, even if it is already
+        // larger what we'll request.
         remote.reopen()?;
 
-        let mirror_len = local.mmap().len::<u8>()?;
-        let staged_len = match pending_reopen {
-            PendingReopen::Stale => mirror_len,
-            PendingReopen::Resize { target_len } => *target_len,
-            PendingReopen::Tail { .. } => unreachable!("returned above"),
+        let remote_len = if let Some(known_len) = known_len {
+            known_len
+        } else {
+            remote.len::<u8>()?
         };
 
-        // Growth past what is already staged is the only thing worth
-        // scheduling; a shorter `known_len` never downgrades a staged target.
-        let grew = known_len > staged_len;
-        if !grew && !matches!(pending_reopen, PendingReopen::Stale) {
+        // Reject operation if we find a smaller remote.
+        let local_len = local.mmap().len::<u8>()?;
+        if remote_len < local_len {
+            return Err(UniversalIoError::Io(io::Error::new(
+                ErrorKind::UnexpectedEof,
+                format!(
+                    "Reopen encountered a smaller file than expected; old_len: {local_len}, new_len: {remote_len}"
+                ),
+            )));
+        }
+
+        // Check if length has grown
+        if scheduled_reopen.target_len() == Some(remote_len) || remote_len == local_len {
             return Ok(());
         }
 
-        let populated = matches!(populate, Populate::Blocking | Populate::PreferBackground);
-        if !grew || !populated {
-            // Lazy populate never fetches ahead — that would pull bytes that
-            // may never be read. Same variant marks the no-growth case, where
-            // the resize is a no-op.
-            *pending_reopen = PendingReopen::Resize {
-                target_len: known_len,
-            };
-            return Ok(());
-        }
+        *scheduled_reopen = match self.open_options.populate {
+            Populate::Blocking | Populate::PreferBackground => {
+                // Populated and grown: fetch the appended tail on a clone of the
+                // remote (a refcount bump for the async bridge). The read is bounded
+                // to `remote` — the file's cut for this refresh — and starts at the
+                // block-aligned floor of the mirror, as in `reopen_impl`.
+                let (_, byte_range) = block_aligned_fetch(local_len..remote_len, remote_len)
+                    .expect("the byte range is non-empty");
 
-        // Populated and grown: fetch the appended tail on a clone of the
-        // remote (a refcount bump for the async bridge). The read is bounded
-        // to `known_len` — the file's cut for this refresh — and starts at the
-        // block-aligned floor of the mirror, as in `reopen_impl`.
-        let (_, byte_range) = block_aligned_fetch(mirror_len..known_len, known_len)
-            .expect("growth leaves a non-empty range to fetch");
+                let mut pipeline = OwnedPipeline::new(remote.clone())?;
+                // FIXME: check can_schedule in a loop?
+                pipeline.schedule::<Sequential>(
+                    byte_range.start,
+                    byte_range,
+                    REMOTE_READ_ALIGNMENT,
+                )?;
 
-        let mut pipeline = OwnedPipeline::new(remote.clone())?;
-        // FIXME: check can_schedule in a loop?
-        pipeline.schedule::<Sequential>(byte_range.start, byte_range, REMOTE_READ_ALIGNMENT)?;
-
-        *pending_reopen = PendingReopen::Tail {
-            pipeline,
-            target_len: known_len,
+                ScheduledReopen::Tail {
+                    pipeline,
+                    target_len: remote_len,
+                }
+            }
+            // No prefetch for lazy population
+            Populate::Auto | Populate::No | Populate::Partial(_) => ScheduledReopen::Resize {
+                target_len: remote_len,
+            },
         };
 
         Ok(())
-    }
-
-    /// Drain a staged tail fetch into the mirror: resize to the read's end,
-    /// write the (block-aligned) suffix, then settle at `target_len`.
-    ///
-    /// Takes the mirror by argument rather than through `&mut self` so the
-    /// caller can keep its disjoint borrow of `state`.
-    fn apply_tail(
-        local_path: &Path,
-        local: &mut LocalState,
-        mut pipeline: OwnedPipeline<R, u64>,
-        target_len: u64,
-    ) -> UioResult<()> {
-        // Exactly one read is scheduled per staged tail, so one `wait` drains
-        // it. Normally it has already landed by the time we get here.
-        match pipeline.wait()? {
-            Some((from, bytes)) if !bytes.is_empty() => {
-                let end = from + bytes.len() as u64;
-                local.resize(local_path, end)?;
-                let blocks_range = to_block_range(from..end);
-                // SAFETY: `bytes` covers `blocks_range` exactly, and the remote
-                // is immutable, so the mmap suffix is filled once with correct data.
-                unsafe { local.write_mmap_bytes(&bytes, blocks_range) }
-            }
-            // Nothing landed: the resize below still makes the length visible,
-            // and the new blocks fault in on demand.
-            Some(_) | None => {}
-        }
-
-        // Normally a no-op — the read was bounded to `target_len`.
-        local.resize(local_path, target_len)
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -10,9 +10,7 @@ use std::io::{self, ErrorKind};
 use super::{DiskCache, ScheduledReopen, State};
 use crate::generic_consts::Sequential;
 use crate::universal_io::simple_disk_cache::pipeline::REMOTE_READ_ALIGNMENT;
-use crate::universal_io::simple_disk_cache::{
-    DiskCacheRemote, block_aligned_fetch, to_block_range,
-};
+use crate::universal_io::simple_disk_cache::{DiskCacheRemote, block_aligned_fetch};
 use crate::universal_io::{OwnedPipeline, Populate, UioResult, UniversalIoError, UniversalRead};
 
 impl<R> DiskCache<R>
@@ -59,16 +57,9 @@ where
                 local.resize(&self.local_path, target_len)?;
 
                 match pipeline.wait()? {
-                    Some((from, bytes)) if !bytes.is_empty() => {
-                        let end = from + bytes.len() as u64;
-                        assert_eq!(
-                            end, target_len,
-                            "Expected the bytes and the scheduled read to be the same length"
-                        );
-
-                        let blocks_range = to_block_range(from..end);
-                        // SAFETY: `bytes` covers `blocks_range` exactly, and the remote
-                        // is immutable, so the mmap suffix is filled once with correct data.
+                    Some((blocks_range, bytes)) if !bytes.is_empty() => {
+                        // SAFETY: `bytes` covers `blocks_range` exactly
+                        // (clamped to EOF)
                         unsafe { local.write_mmap_bytes(&bytes, blocks_range) }
                     }
                     // Nothing landed: the resize still makes the length visible,
@@ -91,11 +82,10 @@ where
     /// [`UniversalRead::schedule_reopen`]: crate::universal_io::UniversalRead::schedule_reopen
     pub(super) fn schedule_reopen_impl(&mut self, known_len: Option<u64>) -> UioResult<()> {
         // Wait for scheduled prefill, if any.
-        if !self.is_ready() {
-            // warn: this will do a length request if uninit, but when using a
-            // cached fs to create the file it should never be uninit.
-            self.init_state()?;
-        }
+        //
+        // warn: this will do a length request if uninit, but when using a
+        // cached fs to create the file it should never be uninit.
+        self.init_state()?;
 
         let State::Ready {
             remote,
@@ -106,18 +96,22 @@ where
             unreachable!("init_state drives state to Ready");
         };
 
-        // Make the remote reflect the current length, even if it is already
-        // larger what we'll request.
-        remote.reopen()?;
+        let local_len = local.mmap().len::<u8>()?;
 
-        let remote_len = if let Some(known_len) = known_len {
-            known_len
-        } else {
-            remote.len::<u8>()?
+        // With a known length, decide before touching the remote: the common
+        // no-growth sweep then costs no round-trip, and a kept staged tail
+        // never has its remote reopened out from under its pipeline clone
+        // (`MmapFile` clones share the mapping). Without one, ask the remote
+        // — the blocking `reopen()` fallback.
+        let remote_len = match known_len {
+            Some(known_len) => known_len,
+            None => {
+                remote.reopen()?;
+                remote.len::<u8>()?
+            }
         };
 
         // Reject operation if we find a smaller remote.
-        let local_len = local.mmap().len::<u8>()?;
         if remote_len < local_len {
             return Err(UniversalIoError::Io(io::Error::new(
                 ErrorKind::UnexpectedEof,
@@ -132,22 +126,22 @@ where
             return Ok(());
         }
 
+        // Make the held remote reflect the current length. If length wasn't
+        // provided, this is already done above.
+        if known_len.is_some() {
+            remote.reopen()?;
+        }
+
         *scheduled_reopen = match self.open_options.populate {
             Populate::Blocking | Populate::PreferBackground => {
-                // Populated and grown: fetch the appended tail on a clone of the
-                // remote (a refcount bump for the async bridge). The read is bounded
-                // to `remote` — the file's cut for this refresh — and starts at the
-                // block-aligned floor of the mirror, as in `reopen_impl`.
-                let (_, byte_range) = block_aligned_fetch(local_len..remote_len, remote_len)
-                    .expect("the byte range is non-empty");
+                // Schedule the read of the new tail blocks.
+                let (blocks_range, byte_range) =
+                    block_aligned_fetch(local_len..remote_len, remote_len)
+                        .expect("the byte range is non-empty");
 
                 let mut pipeline = OwnedPipeline::new(remote.clone())?;
                 // FIXME: check can_schedule in a loop?
-                pipeline.schedule::<Sequential>(
-                    byte_range.start,
-                    byte_range,
-                    REMOTE_READ_ALIGNMENT,
-                )?;
+                pipeline.schedule::<Sequential>(blocks_range, byte_range, REMOTE_READ_ALIGNMENT)?;
 
                 ScheduledReopen::Tail {
                     pipeline,

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -1,11 +1,20 @@
-//! [`Reopen`] the local mirror after the (append-only) remote has grown.
+//! [`Reopen`] the local mirror after the (append-only) remote has grown,
+//! either in one blocking step or split into a schedule and an apply phase
+//! ([`reopen_schedule`]).
 //!
 //! [`reopen`]: crate::universal_io::UniversalRead::reopen
+//! [`reopen_schedule`]: crate::universal_io::UniversalRead::reopen_schedule
 
 use std::io::{self, ErrorKind};
+use std::path::Path;
 
-use super::{DiskCache, State};
-use crate::universal_io::simple_disk_cache::{BLOCK_SIZE, DiskCacheRemote};
+use super::{DiskCache, PendingReopen, State};
+use crate::generic_consts::Sequential;
+use crate::universal_io::simple_disk_cache::local_state::LocalState;
+use crate::universal_io::simple_disk_cache::pipeline::REMOTE_READ_ALIGNMENT;
+use crate::universal_io::simple_disk_cache::{
+    BLOCK_SIZE, DiskCacheRemote, block_aligned_fetch, to_block_range,
+};
 use crate::universal_io::{OwnedPipeline, Populate, UioResult, UniversalIoError, UniversalRead};
 
 impl<R> DiskCache<R>
@@ -14,6 +23,28 @@ where
 {
     /// Body of [`UniversalRead::reopen`](crate::universal_io::UniversalRead::reopen).
     pub(super) fn reopen_impl(&mut self) -> UioResult<()> {
+        // Apply whatever `reopen_schedule` staged, if anything. This is the
+        // only place the mirror grows: `resize` remaps the mmap, which is
+        // sound only under `&mut self`, with no reader holding a slice.
+        if let State::Ready {
+            remote: _,
+            local,
+            pending_reopen,
+        } = self.state.get_mut()
+        {
+            match std::mem::replace(pending_reopen, PendingReopen::Stale) {
+                // Nothing staged: fall through to the blocking path below.
+                PendingReopen::Stale => {}
+                PendingReopen::Resize { target_len } => {
+                    return local.resize(&self.local_path, target_len);
+                }
+                PendingReopen::Tail {
+                    pipeline,
+                    target_len,
+                } => return Self::apply_tail(&self.local_path, local, pipeline, target_len),
+            }
+        }
+
         // `&mut self` gives exclusive access, so we can transition `state`
         // directly without locking or touching the `ready` gate concurrently.
         //
@@ -21,7 +52,11 @@ where
         let (mut remote, mut local) = match std::mem::replace(self.state.get_mut(), State::Uninit) {
             // If it is still `Uninit`, we can let the first read initialize it later.
             State::Uninit => return Ok(()),
-            State::Ready { remote, local } => (remote, local),
+            State::Ready {
+                remote,
+                local,
+                pending_reopen: _, // just observed as `Stale`
+            } => (remote, local),
             State::OpenPrefill { pipeline } => self.init_from_open_prefill(pipeline)?,
             State::ReopenPrefill { pipeline, local } => {
                 self.init_from_reopen_prefill(pipeline, local)?
@@ -53,7 +88,11 @@ where
                 // Make the new length visible; new blocks will be filled lazily on read.
                 local.resize(&self.local_path, remote_len)?;
 
-                *self.state.get_mut() = State::Ready { remote, local };
+                *self.state.get_mut() = State::Ready {
+                    remote,
+                    local,
+                    pending_reopen: PendingReopen::Stale,
+                };
                 *self.is_ready.get_mut() = true;
             }
             Populate::Blocking | Populate::PreferBackground => {
@@ -76,5 +115,145 @@ where
         }
 
         Ok(())
+    }
+
+    /// Body of [`UniversalRead::reopen_schedule`].
+    ///
+    /// Records what the next [`reopen_impl`](Self::reopen_impl) must do and,
+    /// for populated files, puts the tail fetch in flight — without waiting on
+    /// it and without touching the mirror, so readers see no change until the
+    /// apply.
+    ///
+    /// [`UniversalRead::reopen_schedule`]: crate::universal_io::UniversalRead::reopen_schedule
+    pub(super) fn reopen_schedule_impl(&mut self, known_len: Option<u64>) -> UioResult<()> {
+        // Without a length there is nothing to stage: leave `Stale` so
+        // `reopen` asks the remote itself.
+        let Some(known_len) = known_len else {
+            return Ok(());
+        };
+
+        // A prefill can only be resolved by waiting on it — bounded to the
+        // first schedule after open, which may race the open-time fetch.
+        if !self.state.get_mut().is_ready() && !self.state.get_mut().is_uninit() {
+            self.init_state()?;
+        }
+
+        // Cold start: materializing here is IO-free (the open is construction
+        // only) and saves the `len()` round-trip the first read would pay.
+        if self.state.get_mut().is_uninit() {
+            let remote = self.open_remote()?;
+            let local = LocalState::new(&self.local_path, known_len, self.open_options)?;
+
+            *self.state.get_mut() = State::Ready {
+                remote,
+                local,
+                // The mirror already sits at `known_len`; without this marker
+                // the next `reopen` would go down the blocking path.
+                pending_reopen: PendingReopen::Resize {
+                    target_len: known_len,
+                },
+            };
+            *self.is_ready.get_mut() = true;
+            return Ok(());
+        }
+
+        let populate = self.open_options.populate;
+        let State::Ready {
+            remote,
+            local,
+            pending_reopen,
+        } = self.state.get_mut()
+        else {
+            unreachable!("prefills were resolved and `Uninit` handled above")
+        };
+
+        // A staged tail holds a clone of `remote`, and clones share the
+        // mapping on local backends — reopening the held handle now would
+        // dangle it. A staged tail is therefore never superseded: growth past
+        // its target is picked up by the next schedule, once `reopen` consumed
+        // this one.
+        if matches!(pending_reopen, PendingReopen::Tail { .. }) {
+            return Ok(());
+        }
+
+        // Make the remote reflect the current length before staging: a no-op
+        // for the async bridge, but load-bearing for local remotes, where a
+        // stale handle would fetch an empty tail and later lazy faults would
+        // read past the mapping. Local stat/remap only, no IO wait.
+        remote.reopen()?;
+
+        let mirror_len = local.mmap().len::<u8>()?;
+        let staged_len = match pending_reopen {
+            PendingReopen::Stale => mirror_len,
+            PendingReopen::Resize { target_len } => *target_len,
+            PendingReopen::Tail { .. } => unreachable!("returned above"),
+        };
+
+        // Growth past what is already staged is the only thing worth
+        // scheduling; a shorter `known_len` never downgrades a staged target.
+        let grew = known_len > staged_len;
+        if !grew && !matches!(pending_reopen, PendingReopen::Stale) {
+            return Ok(());
+        }
+
+        let populated = matches!(populate, Populate::Blocking | Populate::PreferBackground);
+        if !grew || !populated {
+            // Lazy populate never fetches ahead — that would pull bytes that
+            // may never be read. Same variant marks the no-growth case, where
+            // the resize is a no-op.
+            *pending_reopen = PendingReopen::Resize {
+                target_len: known_len,
+            };
+            return Ok(());
+        }
+
+        // Populated and grown: fetch the appended tail on a clone of the
+        // remote (a refcount bump for the async bridge). The read is bounded
+        // to `known_len` — the file's cut for this refresh — and starts at the
+        // block-aligned floor of the mirror, as in `reopen_impl`.
+        let (_, byte_range) = block_aligned_fetch(mirror_len..known_len, known_len)
+            .expect("growth leaves a non-empty range to fetch");
+
+        let mut pipeline = OwnedPipeline::new(remote.clone())?;
+        // FIXME: check can_schedule in a loop?
+        pipeline.schedule::<Sequential>(byte_range.start, byte_range, REMOTE_READ_ALIGNMENT)?;
+
+        *pending_reopen = PendingReopen::Tail {
+            pipeline,
+            target_len: known_len,
+        };
+
+        Ok(())
+    }
+
+    /// Drain a staged tail fetch into the mirror: resize to the read's end,
+    /// write the (block-aligned) suffix, then settle at `target_len`.
+    ///
+    /// Takes the mirror by argument rather than through `&mut self` so the
+    /// caller can keep its disjoint borrow of `state`.
+    fn apply_tail(
+        local_path: &Path,
+        local: &mut LocalState,
+        mut pipeline: OwnedPipeline<R, u64>,
+        target_len: u64,
+    ) -> UioResult<()> {
+        // Exactly one read is scheduled per staged tail, so one `wait` drains
+        // it. Normally it has already landed by the time we get here.
+        match pipeline.wait()? {
+            Some((from, bytes)) if !bytes.is_empty() => {
+                let end = from + bytes.len() as u64;
+                local.resize(local_path, end)?;
+                let blocks_range = to_block_range(from..end);
+                // SAFETY: `bytes` covers `blocks_range` exactly, and the remote
+                // is immutable, so the mmap suffix is filled once with correct data.
+                unsafe { local.write_mmap_bytes(&bytes, blocks_range) }
+            }
+            // Nothing landed: the resize below still makes the length visible,
+            // and the new blocks fault in on demand.
+            Some(_) | None => {}
+        }
+
+        // Normally a no-op — the read was bounded to `target_len`.
+        local.resize(local_path, target_len)
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -11,7 +11,9 @@ use super::{DiskCache, ScheduledReopen, State};
 use crate::generic_consts::Sequential;
 use crate::universal_io::simple_disk_cache::pipeline::REMOTE_READ_ALIGNMENT;
 use crate::universal_io::simple_disk_cache::{DiskCacheRemote, block_aligned_fetch};
-use crate::universal_io::{OwnedPipeline, Populate, UioResult, UniversalIoError, UniversalRead};
+use crate::universal_io::{
+    CachedReadFs, OwnedPipeline, Populate, UioResult, UniversalIoError, UniversalRead,
+};
 
 impl<R> DiskCache<R>
 where
@@ -24,7 +26,7 @@ where
         }
 
         // If not previously done, schedule and wait blockingly
-        self.schedule_reopen_impl(None)?;
+        self.schedule_reopen_with_len(None)?;
         self.resolve_pending_reopen()?;
 
         Ok(())
@@ -72,6 +74,16 @@ where
         }
     }
 
+    pub(super) fn schedule_reopen_impl<Fs: CachedReadFs>(&mut self, fs: &Fs) -> UioResult<()> {
+        let Some(file_info) = fs.file_info(&self.remote_path) else {
+            return Err(UniversalIoError::NotFound {
+                path: self.remote_path.clone(),
+            });
+        };
+
+        self.schedule_reopen_with_len(Some(file_info.size))
+    }
+
     /// Body of [`UniversalRead::schedule_reopen`].
     ///
     /// Records what the next [`reopen_impl`](Self::reopen_impl) must do and,
@@ -80,7 +92,7 @@ where
     /// apply.
     ///
     /// [`UniversalRead::schedule_reopen`]: crate::universal_io::UniversalRead::schedule_reopen
-    pub(super) fn schedule_reopen_impl(&mut self, known_len: Option<u64>) -> UioResult<()> {
+    pub(super) fn schedule_reopen_with_len(&mut self, known_len: Option<u64>) -> UioResult<()> {
         // Wait for scheduled prefill, if any.
         //
         // warn: this will do a length request if uninit, but when using a

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -6,14 +6,14 @@
 //! [`schedule_reopen`]: crate::universal_io::UniversalRead::schedule_reopen
 
 use std::io::{self, ErrorKind};
+use std::path::Path;
 
 use super::{DiskCache, ScheduledReopen, State};
 use crate::generic_consts::Sequential;
+use crate::universal_io::cached_fs::FileInfo;
 use crate::universal_io::simple_disk_cache::pipeline::REMOTE_READ_ALIGNMENT;
 use crate::universal_io::simple_disk_cache::{DiskCacheRemote, block_aligned_fetch};
-use crate::universal_io::{
-    CachedReadFs, OwnedPipeline, Populate, UioResult, UniversalIoError, UniversalRead,
-};
+use crate::universal_io::{OwnedPipeline, Populate, UioResult, UniversalIoError, UniversalRead};
 
 impl<R> DiskCache<R>
 where
@@ -74,8 +74,11 @@ where
         }
     }
 
-    pub(super) fn schedule_reopen_impl<Fs: CachedReadFs>(&mut self, fs: &Fs) -> UioResult<()> {
-        let Some(file_info) = fs.file_info(&self.remote_path) else {
+    pub(super) fn schedule_reopen_impl<F: FnOnce(&Path) -> Option<FileInfo>>(
+        &mut self,
+        get_file_info: F,
+    ) -> UioResult<()> {
+        let Some(file_info) = get_file_info(&self.remote_path) else {
             return Err(UniversalIoError::NotFound {
                 path: self.remote_path.clone(),
             });

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -49,10 +49,10 @@ where
             // Nothing staged
             ScheduledReopen::No => Ok(false),
             ScheduledReopen::Resize { target_len } => {
-                local.resize(&self.local_path, target_len)?;
-
                 // reopen remote, so we can read up to the new length.
                 remote.reopen()?;
+
+                local.resize(&self.local_path, target_len)?;
 
                 Ok(true)
             }
@@ -60,9 +60,12 @@ where
                 mut pipeline,
                 target_len,
             } => {
+                let fetched = pipeline.wait()?;
+
+                // resize only after pipeline.wait() returns Ok
                 local.resize(&self.local_path, target_len)?;
 
-                match pipeline.wait()? {
+                match fetched {
                     Some((blocks_range, bytes)) if !bytes.is_empty() => {
                         // SAFETY: `bytes` covers `blocks_range` exactly
                         // (clamped to EOF)

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::config::DiskCacheConfig;
-use super::file::{DiskCache, PendingReopen, State};
+use super::file::{DiskCache, ScheduledReopen, State};
 use super::pipeline::REMOTE_READ_ALIGNMENT;
 use super::{DiskCacheRemote, block_aligned_fetch};
 use crate::generic_consts::Sequential;
@@ -216,7 +216,7 @@ where
                 State::Ready {
                     remote,
                     local,
-                    pending_reopen: PendingReopen::Stale,
+                    scheduled_reopen: ScheduledReopen::No,
                 }
             }
             // Even if we know length, we don't need it to do `schedule_whole`.
@@ -268,7 +268,7 @@ where
                     State::Ready {
                         remote,
                         local,
-                        pending_reopen: PendingReopen::Stale,
+                        scheduled_reopen: ScheduledReopen::No,
                     }
                 }
             }

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::config::DiskCacheConfig;
-use super::file::{DiskCache, ScheduledReopen, State};
+use super::file::{DiskCache, State};
 use super::pipeline::REMOTE_READ_ALIGNMENT;
 use super::{DiskCacheRemote, block_aligned_fetch};
 use crate::generic_consts::Sequential;
@@ -213,11 +213,7 @@ where
 
                 let local = LocalState::new(&local_path, len, options)?;
 
-                State::Ready {
-                    remote,
-                    local,
-                    scheduled_reopen: ScheduledReopen::No,
-                }
+                State::ready(remote, local)
             }
             // Even if we know length, we don't need it to do `schedule_whole`.
             (None | Some(_), Populate::Blocking | Populate::PreferBackground) => {
@@ -265,11 +261,7 @@ where
                 } else {
                     // empty byte range, just initialize with length.
                     let local = LocalState::new(&local_path, file_len, options)?;
-                    State::Ready {
-                        remote,
-                        local,
-                        scheduled_reopen: ScheduledReopen::No,
-                    }
+                    State::ready(remote, local)
                 }
             }
         };

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::config::DiskCacheConfig;
-use super::file::{DiskCache, State};
+use super::file::{DiskCache, PendingReopen, State};
 use super::pipeline::REMOTE_READ_ALIGNMENT;
 use super::{DiskCacheRemote, block_aligned_fetch};
 use crate::generic_consts::Sequential;
@@ -213,7 +213,11 @@ where
 
                 let local = LocalState::new(&local_path, len, options)?;
 
-                State::Ready { remote, local }
+                State::Ready {
+                    remote,
+                    local,
+                    pending_reopen: PendingReopen::Stale,
+                }
             }
             // Even if we know length, we don't need it to do `schedule_whole`.
             (None | Some(_), Populate::Blocking | Populate::PreferBackground) => {
@@ -261,7 +265,11 @@ where
                 } else {
                     // empty byte range, just initialize with length.
                     let local = LocalState::new(&local_path, file_len, options)?;
-                    State::Ready { remote, local }
+                    State::Ready {
+                        remote,
+                        local,
+                        pending_reopen: PendingReopen::Stale,
+                    }
                 }
             }
         };

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -8,7 +8,7 @@ use super::file::{DiskCache, State};
 use super::pipeline::REMOTE_READ_ALIGNMENT;
 use super::{DiskCacheRemote, block_aligned_fetch};
 use crate::generic_consts::Sequential;
-use crate::mmap::AdviceSetting;
+use crate::universal_io::simple_disk_cache::REMOTE_OPEN_OPTIONS;
 use crate::universal_io::simple_disk_cache::local_state::LocalState;
 use crate::universal_io::{
     ListedFile, OpenExtra, OpenOptions, OwnedPipeline, Populate, UioResult, UniversalIoError,
@@ -95,16 +95,8 @@ impl<R: UniversalRead> DiskCacheFs<R> {
         path: impl AsRef<Path>,
         extra: <R::Fs as UniversalReadFs>::OpenExtra,
     ) -> UioResult<R> {
-        self.remote_fs.open(
-            path.as_ref(),
-            OpenOptions {
-                writeable: false,
-                need_sequential: true,
-                populate: Populate::No,
-                advice: AdviceSetting::Global,
-            },
-            extra,
-        )
+        self.remote_fs
+            .open(path.as_ref(), REMOTE_OPEN_OPTIONS, extra)
     }
 }
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
@@ -20,7 +20,6 @@ pub trait DiskCacheRemote:
     UniversalRead<
         Fs: Clone + Send + Sync + UniversalReadFs<OpenExtra: Clone + Send + Sync>,
         ReadPipeline<'static, ()>: Send,
-        ReadPipeline<'static, u64>: Send,
         ReadPipeline<'static, Range<u32>>: Send,
     > + Clone
     + 'static
@@ -33,7 +32,6 @@ where
     R::Fs: Clone + Send + Sync,
     <R::Fs as UniversalReadFs>::OpenExtra: Clone + Send + Sync,
     R::ReadPipeline<'static, ()>: Send,
-    R::ReadPipeline<'static, u64>: Send,
     R::ReadPipeline<'static, Range<u32>>: Send,
 {
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
@@ -13,7 +13,8 @@ pub use config::DiskCacheConfig;
 pub use file::DiskCache;
 pub use fs::{DiskCacheFs, DiskCacheFsContext};
 
-use crate::universal_io::{UniversalRead, UniversalReadFs};
+use crate::mmap::AdviceSetting;
+use crate::universal_io::{OpenOptions, Populate, UniversalRead, UniversalReadFs};
 
 /// Trait bundle for remote backends that can be cached by [`DiskCache`].
 pub trait DiskCacheRemote:
@@ -42,6 +43,13 @@ where
 /// Matches `disk_cache::BLOCK_SIZE` and is a small multiple of typical
 /// filesystem block sizes (usually 4 KiB).
 const BLOCK_SIZE: usize = 16 * 1024; // 16kB
+
+const REMOTE_OPEN_OPTIONS: OpenOptions = OpenOptions {
+    writeable: false,
+    populate: Populate::No,
+    need_sequential: false,
+    advice: AdviceSetting::Global,
+};
 
 fn to_block_range(byte_range: Range<u64>) -> Range<u32> {
     let start = (byte_range.start / BLOCK_SIZE as u64) as u32;

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -13,8 +13,9 @@ use super::{
 use crate::generic_consts::{Random, Sequential};
 use crate::mmap::AdviceSetting;
 use crate::universal_io::{
-    MmapFile, OpenOptions, Populate, ReadPipeline, ReadRange, UniversalAppend, UniversalFlush,
-    UniversalIoError, UniversalRead, UniversalReadFileOps, UniversalReadFs, UniversalWrite,
+    CachedFs, CachedReadFs, MmapFile, OpenOptions, Populate, ReadPipeline, ReadRange,
+    UniversalAppend, UniversalFlush, UniversalIoError, UniversalRead, UniversalReadFileOps,
+    UniversalReadFs, UniversalWrite,
 };
 
 // The disk cache is strictly read-only: mutating it must stay a
@@ -128,6 +129,19 @@ impl Scenario {
     /// Slice of the remote data corresponding to `range`.
     fn slice(&self, range: &std::ops::Range<u64>) -> &[u8] {
         &self.data[range.start as usize..range.end as usize]
+    }
+
+    /// A `CachedFs` over this scenario's fs with the listing snapshot taken —
+    /// the schedule-phase view of the remote. Take a fresh one after growing
+    /// the remote, as a refresh pass would.
+    fn snapshot_fs<R>(&self) -> CachedFs<DiskCacheFs<R>>
+    where
+        R: DiskCacheRemote,
+        <R::Fs as UniversalReadFileOps>::ContextConfig: Default,
+    {
+        let mut cached_fs = CachedFs::new(self.fs(), &self.remote_path).unwrap();
+        cached_fs.cache_file_info().unwrap();
+        cached_fs
     }
 
     /// Append `additional_bytes` bytes to the remote file in-place.
@@ -442,7 +456,7 @@ mod tests_mod {
         let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
 
         let new_data = scn.grow_remote(BLOCK_SIZE);
-        cache.schedule_reopen(Some(new_data.len() as u64)).unwrap();
+        cache.schedule_reopen(&scn.snapshot_fs::<R>()).unwrap();
 
         // Nothing changed yet: same length, and the appended region is still
         // out of bounds.
@@ -481,7 +495,7 @@ mod tests_mod {
         let mut cache = scn.open::<R>(PREFILL);
         assert!(!cache.is_ready());
 
-        cache.schedule_reopen(Some(scn.data.len() as u64)).unwrap();
+        cache.schedule_reopen(&scn.snapshot_fs::<R>()).unwrap();
 
         assert!(cache.is_ready());
         assert_eq!(cache.len::<u8>().unwrap(), scn.data.len() as u64);
@@ -511,7 +525,7 @@ mod tests_mod {
             )
         };
 
-        cache.schedule_reopen(Some(scn.data.len() as u64)).unwrap();
+        cache.schedule_reopen(&scn.snapshot_fs::<R>()).unwrap();
         cache.reopen().unwrap();
 
         let local = cache.state().unwrap().local;
@@ -528,10 +542,10 @@ mod tests_mod {
 
         let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
 
-        let first_len = scn.grow_remote(BLOCK_SIZE).len() as u64;
-        cache.schedule_reopen(Some(first_len)).unwrap();
+        scn.grow_remote(BLOCK_SIZE);
+        cache.schedule_reopen(&scn.snapshot_fs::<R>()).unwrap();
         let new_data = scn.grow_remote(BLOCK_SIZE);
-        cache.schedule_reopen(Some(new_data.len() as u64)).unwrap();
+        cache.schedule_reopen(&scn.snapshot_fs::<R>()).unwrap();
 
         cache.reopen().unwrap();
 
@@ -550,14 +564,32 @@ mod tests_mod {
         let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
 
         let new_data = scn.grow_remote(BLOCK_SIZE);
-        cache.schedule_reopen(Some(new_data.len() as u64)).unwrap();
-        cache.schedule_reopen(Some(new_data.len() as u64)).unwrap();
+        let snapshot_fs = scn.snapshot_fs::<R>();
+        cache.schedule_reopen(&snapshot_fs).unwrap();
+        cache.schedule_reopen(&snapshot_fs).unwrap();
 
         cache.reopen().unwrap();
 
         assert_eq!(cache.len::<u8>().unwrap(), new_data.len() as u64);
         let bytes = cache.read_whole::<u8>().unwrap();
         assert_eq!(&*bytes, &new_data[..]);
+    }
+
+    /// Scheduling against a snapshot that does not cover the file fails with
+    /// `NotFound` — the file resolves its own remote path, so there is no
+    /// path argument to mispair.
+    #[test]
+    fn reopen_schedule_missing_from_snapshot_errors() {
+        let scn = Scenario::new(BLOCK_SIZE);
+        let mut cache = scn.open::<R>(PREFILL);
+
+        // Snapshot over a prefix that matches nothing.
+        let missing_prefix = scn.remote_path.with_file_name("other");
+        let mut snapshot_fs = CachedFs::new(scn.fs::<R>(), &missing_prefix).unwrap();
+        snapshot_fs.cache_file_info().unwrap();
+
+        let err = cache.schedule_reopen(&snapshot_fs).unwrap_err();
+        assert_matches!(err, UniversalIoError::NotFound { .. });
     }
 
     /// `Populate::Partial` prefetches only the requested (block-aligned) range;

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -486,7 +486,7 @@ mod tests_mod {
         assert!(cache.is_ready());
         assert_eq!(cache.len::<u8>().unwrap(), scn.data.len() as u64);
 
-        // Applying the (no-growth) marker must stay off the blocking path and
+        // A later reopen (nothing staged — the length didn't grow) must
         // leave the mirror alone.
         cache.reopen().unwrap();
         assert_eq!(cache.len::<u8>().unwrap(), scn.data.len() as u64);
@@ -495,8 +495,8 @@ mod tests_mod {
         assert_eq!(&*bytes, &scn.data[..]);
     }
 
-    /// Staging an unchanged length is a no-op marker: it must neither resize
-    /// nor invalidate, and must keep `reopen` off the blocking path.
+    /// Scheduling an unchanged length stages nothing; the schedule/apply pair
+    /// must neither resize nor invalidate.
     #[test]
     fn reopen_schedule_no_growth_does_not_repopulate() {
         let scn = Scenario::new(BLOCK_SIZE * 3);
@@ -516,7 +516,7 @@ mod tests_mod {
 
         let local = cache.state().unwrap().local;
         assert_eq!(local.mmap().len::<u8>().unwrap(), len_before);
-        assert_eq!(local.fetched.lock().clone(), fetched_before);
+        assert_eq!(*local.fetched.lock(), fetched_before);
     }
 
     /// Two schedules without an apply in between: the second supersedes the

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -1,7 +1,7 @@
 use std::assert_matches;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use fs_err as fs;
@@ -12,6 +12,7 @@ use super::{
 };
 use crate::generic_consts::{Random, Sequential};
 use crate::mmap::AdviceSetting;
+use crate::universal_io::cached_fs::FileInfo;
 use crate::universal_io::{
     CachedFs, CachedReadFs, MmapFile, OpenOptions, Populate, ReadPipeline, ReadRange,
     UniversalAppend, UniversalFlush, UniversalIoError, UniversalRead, UniversalReadFileOps,
@@ -131,17 +132,17 @@ impl Scenario {
         &self.data[range.start as usize..range.end as usize]
     }
 
-    /// A `CachedFs` over this scenario's fs with the listing snapshot taken —
-    /// the schedule-phase view of the remote. Take a fresh one after growing
-    /// the remote, as a refresh pass would.
-    fn snapshot_fs<R>(&self) -> CachedFs<DiskCacheFs<R>>
+    /// A `get_file_info` for `schedule_reopen`, backed by a `CachedFs`
+    /// listing snapshot taken now — the schedule-phase view of the remote.
+    /// Take a fresh one after growing the remote, as a refresh pass would.
+    fn snapshot_file_info<R>(&self) -> impl Fn(&Path) -> Option<FileInfo>
     where
         R: DiskCacheRemote,
         <R::Fs as UniversalReadFileOps>::ContextConfig: Default,
     {
-        let mut cached_fs = CachedFs::new(self.fs(), &self.remote_path).unwrap();
+        let mut cached_fs = CachedFs::new(self.fs::<R>(), &self.remote_path).unwrap();
         cached_fs.cache_file_info().unwrap();
-        cached_fs
+        move |path| cached_fs.file_info(path).cloned()
     }
 
     /// Append `additional_bytes` bytes to the remote file in-place.
@@ -456,7 +457,9 @@ mod tests_mod {
         let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
 
         let new_data = scn.grow_remote(BLOCK_SIZE);
-        cache.schedule_reopen(&scn.snapshot_fs::<R>()).unwrap();
+        cache
+            .schedule_reopen(scn.snapshot_file_info::<R>())
+            .unwrap();
 
         // Nothing changed yet: same length, and the appended region is still
         // out of bounds.
@@ -495,7 +498,9 @@ mod tests_mod {
         let mut cache = scn.open::<R>(PREFILL);
         assert!(!cache.is_ready());
 
-        cache.schedule_reopen(&scn.snapshot_fs::<R>()).unwrap();
+        cache
+            .schedule_reopen(scn.snapshot_file_info::<R>())
+            .unwrap();
 
         assert!(cache.is_ready());
         assert_eq!(cache.len::<u8>().unwrap(), scn.data.len() as u64);
@@ -525,7 +530,9 @@ mod tests_mod {
             )
         };
 
-        cache.schedule_reopen(&scn.snapshot_fs::<R>()).unwrap();
+        cache
+            .schedule_reopen(scn.snapshot_file_info::<R>())
+            .unwrap();
         cache.reopen().unwrap();
 
         let local = cache.state().unwrap().local;
@@ -543,9 +550,13 @@ mod tests_mod {
         let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
 
         scn.grow_remote(BLOCK_SIZE);
-        cache.schedule_reopen(&scn.snapshot_fs::<R>()).unwrap();
+        cache
+            .schedule_reopen(scn.snapshot_file_info::<R>())
+            .unwrap();
         let new_data = scn.grow_remote(BLOCK_SIZE);
-        cache.schedule_reopen(&scn.snapshot_fs::<R>()).unwrap();
+        cache
+            .schedule_reopen(scn.snapshot_file_info::<R>())
+            .unwrap();
 
         cache.reopen().unwrap();
 
@@ -564,9 +575,9 @@ mod tests_mod {
         let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
 
         let new_data = scn.grow_remote(BLOCK_SIZE);
-        let snapshot_fs = scn.snapshot_fs::<R>();
-        cache.schedule_reopen(&snapshot_fs).unwrap();
-        cache.schedule_reopen(&snapshot_fs).unwrap();
+        let get_file_info = scn.snapshot_file_info::<R>();
+        cache.schedule_reopen(&get_file_info).unwrap();
+        cache.schedule_reopen(&get_file_info).unwrap();
 
         cache.reopen().unwrap();
 
@@ -583,12 +594,7 @@ mod tests_mod {
         let scn = Scenario::new(BLOCK_SIZE);
         let mut cache = scn.open::<R>(PREFILL);
 
-        // Snapshot over a prefix that matches nothing.
-        let missing_prefix = scn.remote_path.with_file_name("other");
-        let mut snapshot_fs = CachedFs::new(scn.fs::<R>(), &missing_prefix).unwrap();
-        snapshot_fs.cache_file_info().unwrap();
-
-        let err = cache.schedule_reopen(&snapshot_fs).unwrap_err();
+        let err = cache.schedule_reopen(|_| None).unwrap_err();
         assert_matches!(err, UniversalIoError::NotFound { .. });
     }
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -452,6 +452,146 @@ mod tests_mod {
         assert_eq!(&*bytes, &new_data[BLOCK_SIZE..BLOCK_SIZE * 2]);
     }
 
+    /// Staging must be invisible to readers: the mirror keeps its old length
+    /// (so components keep `len()` as their growth signal) until `reopen`
+    /// applies the staged work.
+    #[test]
+    fn reopen_schedule_is_invisible_until_reopen() {
+        let mut scn = Scenario::new(BLOCK_SIZE * 2);
+        let mut cache = scn.open::<R>(PREFILL);
+
+        let original_len = scn.data.len() as u64;
+        let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
+
+        let new_data = scn.grow_remote(BLOCK_SIZE);
+        cache.reopen_schedule(Some(new_data.len() as u64)).unwrap();
+
+        // Nothing changed yet: same length, and the appended region is still
+        // out of bounds.
+        assert_eq!(cache.len::<u8>().unwrap(), original_len);
+        let err = cache
+            .read::<_, u8>(ReadRange::new(original_len, BLOCK_SIZE as u64), Sequential)
+            .unwrap_err();
+        assert_matches!(err, UniversalIoError::OutOfBounds { .. });
+
+        cache.reopen().unwrap();
+
+        assert_eq!(cache.len::<u8>().unwrap(), new_data.len() as u64);
+        // A populated cache staged the tail fetch, so the appended block is
+        // already local; a lazy one only learned the new length.
+        let new_block = (original_len / BLOCK_SIZE as u64) as u32;
+        assert_eq!(
+            cache
+                .state()
+                .unwrap()
+                .local
+                .contains(new_block..new_block + 1),
+            PREFILL,
+        );
+
+        let bytes = cache
+            .read::<_, u8>(ReadRange::new(original_len, BLOCK_SIZE as u64), Sequential)
+            .unwrap();
+        assert_eq!(&*bytes, &new_data[original_len as usize..]);
+    }
+
+    /// Without a known length there is nothing to stage, so `reopen` falls
+    /// back to asking the remote itself.
+    #[test]
+    fn reopen_schedule_without_length_keeps_blocking_path() {
+        let mut scn = Scenario::new(BLOCK_SIZE * 2);
+        let mut cache = scn.open::<R>(PREFILL);
+
+        let original_len = scn.data.len() as u64;
+        let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
+
+        let new_data = scn.grow_remote(BLOCK_SIZE);
+        cache.reopen_schedule(None).unwrap();
+        assert_eq!(cache.len::<u8>().unwrap(), original_len);
+
+        cache.reopen().unwrap();
+
+        let bytes = cache
+            .read::<_, u8>(ReadRange::new(original_len, BLOCK_SIZE as u64), Sequential)
+            .unwrap();
+        assert_eq!(&*bytes, &new_data[original_len as usize..]);
+    }
+
+    /// Staging against a cold cache materializes the mirror at the known
+    /// length, IO-free — the first read then needs no `len` round-trip.
+    #[test]
+    fn reopen_schedule_materializes_cold_mirror() {
+        let scn = Scenario::new(BLOCK_SIZE * 2 + 100);
+        let mut cache = scn.open::<R>(PREFILL);
+        assert!(!cache.is_ready());
+
+        cache.reopen_schedule(Some(scn.data.len() as u64)).unwrap();
+
+        assert!(cache.is_ready());
+        assert_eq!(cache.len::<u8>().unwrap(), scn.data.len() as u64);
+
+        // Applying the (no-growth) marker must stay off the blocking path and
+        // leave the mirror alone.
+        cache.reopen().unwrap();
+        assert_eq!(cache.len::<u8>().unwrap(), scn.data.len() as u64);
+
+        let bytes = cache.read_whole::<u8>().unwrap();
+        assert_eq!(&*bytes, &scn.data[..]);
+    }
+
+    /// Staging an unchanged length is a no-op marker: it must neither resize
+    /// nor invalidate, and must keep `reopen` off the blocking path.
+    #[test]
+    fn reopen_schedule_no_growth_does_not_repopulate() {
+        let scn = Scenario::new(BLOCK_SIZE * 3);
+        let mut cache = scn.open::<R>(PREFILL);
+
+        let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
+        let (len_before, fetched_before) = {
+            let local = cache.state().unwrap().local;
+            (
+                local.mmap().len::<u8>().unwrap(),
+                local.fetched.lock().clone(),
+            )
+        };
+
+        cache.reopen_schedule(Some(scn.data.len() as u64)).unwrap();
+        cache.reopen().unwrap();
+
+        let local = cache.state().unwrap().local;
+        assert_eq!(local.mmap().len::<u8>().unwrap(), len_before);
+        assert_eq!(local.fetched.lock().clone(), fetched_before);
+    }
+
+    /// Two schedules without an apply in between. A pending resize is
+    /// superseded by the larger length; a pending tail is not (its in-flight
+    /// fetch borrows a clone of the remote), so its growth lands one refresh
+    /// later.
+    #[test]
+    fn reopen_schedule_twice_without_apply() {
+        let mut scn = Scenario::new(BLOCK_SIZE * 2);
+        let mut cache = scn.open::<R>(PREFILL);
+
+        let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
+
+        let first_len = scn.grow_remote(BLOCK_SIZE).len() as u64;
+        cache.reopen_schedule(Some(first_len)).unwrap();
+        let new_data = scn.grow_remote(BLOCK_SIZE);
+        cache.reopen_schedule(Some(new_data.len() as u64)).unwrap();
+
+        cache.reopen().unwrap();
+
+        if PREFILL {
+            assert_eq!(cache.len::<u8>().unwrap(), first_len);
+            cache.reopen_schedule(Some(new_data.len() as u64)).unwrap();
+            cache.reopen().unwrap();
+        }
+
+        assert_eq!(cache.len::<u8>().unwrap(), new_data.len() as u64);
+        let bytes = cache.read_whole::<u8>().unwrap();
+        assert_eq!(&*bytes, &new_data[..]);
+    }
+
     /// `Populate::Partial` prefetches only the requested (block-aligned) range;
     /// blocks outside it stay unfetched until read, then fault in lazily.
     #[test]

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -330,28 +330,6 @@ mod tests_mod {
         assert!(!local_path.exists());
     }
 
-    /// Reopen with no prior reads leaves the local mirror untouched.
-    #[test]
-    fn reopen_without_prior_reads_keeps_local_uninitialized() {
-        let scn = Scenario::new(BLOCK_SIZE * 2);
-        let mut cache = scn.open::<R>(PREFILL);
-        let expected_local = cache.local_path.clone();
-        assert!(!expected_local.exists());
-
-        cache.reopen().unwrap();
-
-        // it it was scheduled for prefill, it materializes the local file
-        if PREFILL {
-            assert!(expected_local.exists());
-        } else {
-            assert!(!expected_local.exists());
-        }
-
-        // In both Populate::No and Populate::PreferBackground, we still
-        // have local marked as uninitialized at this point
-        assert!(!cache.is_ready());
-    }
-
     /// Reopen on an unchanged remote must not resize, repopulate, or mutate
     /// the fetched bitmap.
     #[test]
@@ -464,7 +442,7 @@ mod tests_mod {
         let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
 
         let new_data = scn.grow_remote(BLOCK_SIZE);
-        cache.reopen_schedule(Some(new_data.len() as u64)).unwrap();
+        cache.schedule_reopen(Some(new_data.len() as u64)).unwrap();
 
         // Nothing changed yet: same length, and the appended region is still
         // out of bounds.
@@ -495,37 +473,15 @@ mod tests_mod {
         assert_eq!(&*bytes, &new_data[original_len as usize..]);
     }
 
-    /// Without a known length there is nothing to stage, so `reopen` falls
-    /// back to asking the remote itself.
-    #[test]
-    fn reopen_schedule_without_length_keeps_blocking_path() {
-        let mut scn = Scenario::new(BLOCK_SIZE * 2);
-        let mut cache = scn.open::<R>(PREFILL);
-
-        let original_len = scn.data.len() as u64;
-        let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
-
-        let new_data = scn.grow_remote(BLOCK_SIZE);
-        cache.reopen_schedule(None).unwrap();
-        assert_eq!(cache.len::<u8>().unwrap(), original_len);
-
-        cache.reopen().unwrap();
-
-        let bytes = cache
-            .read::<_, u8>(ReadRange::new(original_len, BLOCK_SIZE as u64), Sequential)
-            .unwrap();
-        assert_eq!(&*bytes, &new_data[original_len as usize..]);
-    }
-
     /// Staging against a cold cache materializes the mirror at the known
-    /// length, IO-free — the first read then needs no `len` round-trip.
+    /// length, and applying it changes nothing.
     #[test]
     fn reopen_schedule_materializes_cold_mirror() {
         let scn = Scenario::new(BLOCK_SIZE * 2 + 100);
         let mut cache = scn.open::<R>(PREFILL);
         assert!(!cache.is_ready());
 
-        cache.reopen_schedule(Some(scn.data.len() as u64)).unwrap();
+        cache.schedule_reopen(Some(scn.data.len() as u64)).unwrap();
 
         assert!(cache.is_ready());
         assert_eq!(cache.len::<u8>().unwrap(), scn.data.len() as u64);
@@ -555,7 +511,7 @@ mod tests_mod {
             )
         };
 
-        cache.reopen_schedule(Some(scn.data.len() as u64)).unwrap();
+        cache.schedule_reopen(Some(scn.data.len() as u64)).unwrap();
         cache.reopen().unwrap();
 
         let local = cache.state().unwrap().local;
@@ -563,10 +519,8 @@ mod tests_mod {
         assert_eq!(local.fetched.lock().clone(), fetched_before);
     }
 
-    /// Two schedules without an apply in between. A pending resize is
-    /// superseded by the larger length; a pending tail is not (its in-flight
-    /// fetch borrows a clone of the remote), so its growth lands one refresh
-    /// later.
+    /// Two schedules without an apply in between: the second supersedes the
+    /// first, so one `reopen` lands all the growth.
     #[test]
     fn reopen_schedule_twice_without_apply() {
         let mut scn = Scenario::new(BLOCK_SIZE * 2);
@@ -575,17 +529,31 @@ mod tests_mod {
         let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
 
         let first_len = scn.grow_remote(BLOCK_SIZE).len() as u64;
-        cache.reopen_schedule(Some(first_len)).unwrap();
+        cache.schedule_reopen(Some(first_len)).unwrap();
         let new_data = scn.grow_remote(BLOCK_SIZE);
-        cache.reopen_schedule(Some(new_data.len() as u64)).unwrap();
+        cache.schedule_reopen(Some(new_data.len() as u64)).unwrap();
 
         cache.reopen().unwrap();
 
-        if PREFILL {
-            assert_eq!(cache.len::<u8>().unwrap(), first_len);
-            cache.reopen_schedule(Some(new_data.len() as u64)).unwrap();
-            cache.reopen().unwrap();
-        }
+        assert_eq!(cache.len::<u8>().unwrap(), new_data.len() as u64);
+        let bytes = cache.read_whole::<u8>().unwrap();
+        assert_eq!(&*bytes, &new_data[..]);
+    }
+
+    /// Re-scheduling the same length keeps the first staging as is — the
+    /// staged tail's in-flight read must survive to be applied.
+    #[test]
+    fn reopen_schedule_twice_with_same_length() {
+        let mut scn = Scenario::new(BLOCK_SIZE * 2);
+        let mut cache = scn.open::<R>(PREFILL);
+
+        let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
+
+        let new_data = scn.grow_remote(BLOCK_SIZE);
+        cache.schedule_reopen(Some(new_data.len() as u64)).unwrap();
+        cache.schedule_reopen(Some(new_data.len() as u64)).unwrap();
+
+        cache.reopen().unwrap();
 
         assert_eq!(cache.len::<u8>().unwrap(), new_data.len() as u64);
         let bytes = cache.read_whole::<u8>().unwrap();

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 use std::path::Path;
 
+use crate::universal_io::cached_fs::FileInfo;
 use crate::universal_io::traits::open_extra::OpenExtra;
 use crate::universal_io::traits::read::UniversalRead;
 use crate::universal_io::{ListedFile, OpenOptions, UioResult, UniversalIoError};
@@ -144,24 +145,19 @@ pub trait CachedReadFs: UniversalReadFs {
         open_extra: Option<Self::OpenExtra>,
     ) -> UioResult<()>;
 
-    /// Length of `path` in the listing snapshot; `None` when the path is
-    /// absent, or before the snapshot was taken.
-    fn snapshot_len(&self, path: &Path) -> Option<u64>;
+    /// Return the file info from the current snapshot.
+    fn file_info(&self, path: &Path) -> Option<FileInfo>;
 
-    /// Stage the reopen of an *already-held* handle against the snapshot's
-    /// length — the counterpart of [`Self::schedule_prefetch`], which only
-    /// covers files reloaded through fresh handles.
+    /// Provided helper to schedule a reopen of a file.
     ///
-    /// Fails with `NotFound` for a path absent from the snapshot, as
-    /// [`UniversalReadFs::open`] does; best-effort callers swallow it and let
-    /// the error resurface on the later read.
-    fn pre_reopen(&self, path: &Path, file: &mut Self::File) -> UioResult<()> {
-        let Some(known_len) = self.snapshot_len(path) else {
+    /// `path` should be the same as the file's path.
+    fn schedule_reopen(&self, path: &Path, file: &mut Self::File) -> UioResult<()> {
+        let Some(file_info) = self.file_info(path) else {
             return Err(UniversalIoError::NotFound {
                 path: path.to_path_buf(),
             });
         };
 
-        file.reopen_schedule(Some(known_len))
+        file.schedule_reopen(Some(file_info.size))
     }
 }

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use crate::universal_io::traits::open_extra::OpenExtra;
 use crate::universal_io::traits::read::UniversalRead;
-use crate::universal_io::{ListedFile, OpenOptions, UioResult};
+use crate::universal_io::{ListedFile, OpenOptions, UioResult, UniversalIoError};
 
 /// Filesystem-level handle for read-only operations.
 ///
@@ -143,4 +143,25 @@ pub trait CachedReadFs: UniversalReadFs {
         open_arguments: Option<OpenOptions>,
         open_extra: Option<Self::OpenExtra>,
     ) -> UioResult<()>;
+
+    /// Length of `path` in the listing snapshot; `None` when the path is
+    /// absent, or before the snapshot was taken.
+    fn snapshot_len(&self, path: &Path) -> Option<u64>;
+
+    /// Stage the reopen of an *already-held* handle against the snapshot's
+    /// length — the counterpart of [`Self::schedule_prefetch`], which only
+    /// covers files reloaded through fresh handles.
+    ///
+    /// Fails with `NotFound` for a path absent from the snapshot, as
+    /// [`UniversalReadFs::open`] does; best-effort callers swallow it and let
+    /// the error resurface on the later read.
+    fn pre_reopen(&self, path: &Path, file: &mut Self::File) -> UioResult<()> {
+        let Some(known_len) = self.snapshot_len(path) else {
+            return Err(UniversalIoError::NotFound {
+                path: path.to_path_buf(),
+            });
+        };
+
+        file.reopen_schedule(Some(known_len))
+    }
 }

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -146,5 +146,5 @@ pub trait CachedReadFs: UniversalReadFs {
     ) -> UioResult<()>;
 
     /// Return the file info from the current snapshot.
-    fn file_info(&self, path: &Path) -> Option<FileInfo>;
+    fn cached_file_info(&self, path: &Path) -> Option<FileInfo>;
 }

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use crate::universal_io::cached_fs::FileInfo;
 use crate::universal_io::traits::open_extra::OpenExtra;
 use crate::universal_io::traits::read::UniversalRead;
-use crate::universal_io::{ListedFile, OpenOptions, UioResult, UniversalIoError};
+use crate::universal_io::{ListedFile, OpenOptions, UioResult};
 
 /// Filesystem-level handle for read-only operations.
 ///
@@ -147,17 +147,4 @@ pub trait CachedReadFs: UniversalReadFs {
 
     /// Return the file info from the current snapshot.
     fn file_info(&self, path: &Path) -> Option<FileInfo>;
-
-    /// Provided helper to schedule a reopen of a file.
-    ///
-    /// `path` should be the same as the file's path.
-    fn schedule_reopen(&self, path: &Path, file: &mut Self::File) -> UioResult<()> {
-        let Some(file_info) = self.file_info(path) else {
-            return Err(UniversalIoError::NotFound {
-                path: path.to_path_buf(),
-            });
-        };
-
-        file.schedule_reopen(Some(file_info.size))
-    }
 }

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -70,7 +70,7 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     /// so there is nothing worth pre-staging. Only [`DiskCache`] overrides it.
     ///
     /// [`DiskCache`]: crate::universal_io::DiskCache
-    fn reopen_schedule(&mut self, known_len: Option<u64>) -> UioResult<()> {
+    fn schedule_reopen(&mut self, known_len: Option<u64>) -> UioResult<()> {
         let _ = known_len;
         Ok(())
     }

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -58,6 +58,23 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     /// This may be a no-op in some implementations.
     fn reopen(&mut self) -> UioResult<()>;
 
+    /// Stage the work that the next [`reopen`](Self::reopen) must do, given
+    /// the file's length as observed externally (e.g. a listing snapshot).
+    ///
+    /// Lets a caller submit the fetches of many reopens up front and only pay
+    /// the (already in-flight) tail of the wait when applying them. Contract:
+    /// must not wait on IO, and must have no reader-observable effect — no
+    /// length change, no cache invalidation.
+    ///
+    /// Defaults to a no-op: local backends' `reopen` is a stat plus a remap,
+    /// so there is nothing worth pre-staging. Only [`DiskCache`] overrides it.
+    ///
+    /// [`DiskCache`]: crate::universal_io::DiskCache
+    fn reopen_schedule(&mut self, known_len: Option<u64>) -> UioResult<()> {
+        let _ = known_len;
+        Ok(())
+    }
+
     /// Prefer [`read_batch`] if you need high performance.
     #[inline]
     fn read<P: AccessPattern, T: Item>(

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -1,13 +1,13 @@
 use std::borrow::Cow;
 use std::fmt::Debug;
 use std::ops::Range;
+use std::path::Path;
 
 use super::{Item, ReadPipeline, UniversalReadFs, UserData};
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Sequential};
-use crate::universal_io::{
-    CachedReadFs, ReadBytesItem, ReadRange, UioResult, UniversalIoError, UniversalKind,
-};
+use crate::universal_io::cached_fs::FileInfo;
+use crate::universal_io::{ReadBytesItem, ReadRange, UioResult, UniversalIoError, UniversalKind};
 
 /// Per-file handle for universal read access.
 ///
@@ -61,8 +61,9 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     fn reopen(&mut self) -> UioResult<()>;
 
     /// Stage the work that the next [`reopen`](Self::reopen) must do, reading
-    /// the file's current length from `cached_fs`'s listing snapshot (the
-    /// implementation resolves its own path, so there is nothing to mispair).
+    /// the file's current length via `get_file_info` — typically backed by a
+    /// [`CachedReadFs`] listing snapshot. The implementation resolves its own
+    /// path, so there is nothing to mispair.
     ///
     /// Lets a caller submit the fetches of many reopens up front and only pay
     /// the (already in-flight) tail of the wait when applying them. Contract:
@@ -74,9 +75,13 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     /// Defaults to a no-op: local backends' `reopen` is a stat plus a remap,
     /// so there is nothing worth pre-staging. Only [`DiskCache`] overrides it.
     ///
+    /// [`CachedReadFs`]: crate::universal_io::CachedReadFs
     /// [`DiskCache`]: crate::universal_io::DiskCache
-    fn schedule_reopen<Fs: CachedReadFs>(&mut self, cached_fs: &Fs) -> UioResult<()> {
-        let _ = cached_fs;
+    fn schedule_reopen<F: FnOnce(&Path) -> Option<FileInfo>>(
+        &mut self,
+        get_file_info: F,
+    ) -> UioResult<()> {
+        let _ = get_file_info;
         Ok(())
     }
 

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -63,8 +63,10 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     ///
     /// Lets a caller submit the fetches of many reopens up front and only pay
     /// the (already in-flight) tail of the wait when applying them. Contract:
-    /// must not wait on IO, and must have no reader-observable effect — no
-    /// length change, no cache invalidation.
+    /// must not wait on the data fetch (with `Some`, resolving a pending
+    /// open-time prefill is the one bounded exception), and staging must be
+    /// invisible to readers of an already-live mirror — no length change, no
+    /// cache invalidation.
     ///
     /// Defaults to a no-op: local backends' `reopen` is a stat plus a remap,
     /// so there is nothing worth pre-staging. Only [`DiskCache`] overrides it.

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -5,7 +5,9 @@ use std::ops::Range;
 use super::{Item, ReadPipeline, UniversalReadFs, UserData};
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Sequential};
-use crate::universal_io::{ReadBytesItem, ReadRange, UioResult, UniversalIoError, UniversalKind};
+use crate::universal_io::{
+    CachedReadFs, ReadBytesItem, ReadRange, UioResult, UniversalIoError, UniversalKind,
+};
 
 /// Per-file handle for universal read access.
 ///
@@ -58,22 +60,23 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     /// This may be a no-op in some implementations.
     fn reopen(&mut self) -> UioResult<()>;
 
-    /// Stage the work that the next [`reopen`](Self::reopen) must do, given
-    /// the file's length as observed externally (e.g. a listing snapshot).
+    /// Stage the work that the next [`reopen`](Self::reopen) must do, reading
+    /// the file's current length from `cached_fs`'s listing snapshot (the
+    /// implementation resolves its own path, so there is nothing to mispair).
     ///
     /// Lets a caller submit the fetches of many reopens up front and only pay
     /// the (already in-flight) tail of the wait when applying them. Contract:
-    /// must not wait on the data fetch (with `Some`, resolving a pending
-    /// open-time prefill is the one bounded exception), and staging must be
-    /// invisible to readers of an already-live mirror — no length change, no
-    /// cache invalidation.
+    /// must not wait on the data fetch (resolving a pending open-time prefill
+    /// is the one bounded exception), and staging must be invisible to
+    /// readers of an already-live mirror — no length change, no cache
+    /// invalidation.
     ///
     /// Defaults to a no-op: local backends' `reopen` is a stat plus a remap,
     /// so there is nothing worth pre-staging. Only [`DiskCache`] overrides it.
     ///
     /// [`DiskCache`]: crate::universal_io::DiskCache
-    fn schedule_reopen(&mut self, known_len: Option<u64>) -> UioResult<()> {
-        let _ = known_len;
+    fn schedule_reopen<Fs: CachedReadFs>(&mut self, cached_fs: &Fs) -> UioResult<()> {
+        let _ = cached_fs;
         Ok(())
     }
 

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -116,6 +116,11 @@ where
     }
 
     #[inline]
+    fn reopen_schedule(&mut self, known_len: Option<u64>) -> UioResult<()> {
+        self.0.reopen_schedule(known_len)
+    }
+
+    #[inline]
     fn read<P: AccessPattern, T: Item>(
         &self,
         range: ReadRange,

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -116,8 +116,8 @@ where
     }
 
     #[inline]
-    fn reopen_schedule(&mut self, known_len: Option<u64>) -> UioResult<()> {
-        self.0.reopen_schedule(known_len)
+    fn schedule_reopen(&mut self, known_len: Option<u64>) -> UioResult<()> {
+        self.0.schedule_reopen(known_len)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -8,10 +8,11 @@ use bytemuck::TransparentWrapper;
 use super::WrappedReadPipeline;
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
+use crate::universal_io::cached_fs::FileInfo;
 use crate::universal_io::traits::UniversalReadFileOps;
 use crate::universal_io::{
-    CachedReadFs, Item, ListedFile, OpenOptions, ReadBytesItem, ReadRange, UioResult,
-    UniversalIoError, UniversalKind, UniversalRead, UniversalReadFs, UserData,
+    Item, ListedFile, OpenOptions, ReadBytesItem, ReadRange, UioResult, UniversalIoError,
+    UniversalKind, UniversalRead, UniversalReadFs, UserData,
 };
 
 #[derive(Debug, TransparentWrapper)]
@@ -116,8 +117,11 @@ where
     }
 
     #[inline]
-    fn schedule_reopen<Fs: CachedReadFs>(&mut self, cached_fs: &Fs) -> UioResult<()> {
-        self.0.schedule_reopen(cached_fs)
+    fn schedule_reopen<F: FnOnce(&Path) -> Option<FileInfo>>(
+        &mut self,
+        get_file_info: F,
+    ) -> UioResult<()> {
+        self.0.schedule_reopen(get_file_info)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -10,8 +10,8 @@ use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::traits::UniversalReadFileOps;
 use crate::universal_io::{
-    Item, ListedFile, OpenOptions, ReadBytesItem, ReadRange, UioResult, UniversalIoError,
-    UniversalKind, UniversalRead, UniversalReadFs, UserData,
+    CachedReadFs, Item, ListedFile, OpenOptions, ReadBytesItem, ReadRange, UioResult,
+    UniversalIoError, UniversalKind, UniversalRead, UniversalReadFs, UserData,
 };
 
 #[derive(Debug, TransparentWrapper)]
@@ -116,8 +116,8 @@ where
     }
 
     #[inline]
-    fn schedule_reopen(&mut self, known_len: Option<u64>) -> UioResult<()> {
-        self.0.schedule_reopen(known_len)
+    fn schedule_reopen<Fs: CachedReadFs>(&mut self, cached_fs: &Fs) -> UioResult<()> {
+        self.0.schedule_reopen(cached_fs)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -71,10 +71,10 @@ where
         self.inner.reopen()
     }
 
-    /// Forwards [`UniversalRead::reopen_schedule`]: a missing forwarder would
+    /// Forwards [`UniversalRead::schedule_reopen`]: a missing forwarder would
     /// silently no-op and send the wrapped file down the blocking path.
-    pub fn reopen_schedule(&mut self, known_len: Option<u64>) -> UioResult<()> {
-        self.inner.reopen_schedule(known_len)
+    pub fn schedule_reopen(&mut self, known_len: Option<u64>) -> UioResult<()> {
+        self.inner.schedule_reopen(known_len)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -71,6 +71,12 @@ where
         self.inner.reopen()
     }
 
+    /// Forwards [`UniversalRead::reopen_schedule`]: a missing forwarder would
+    /// silently no-op and send the wrapped file down the blocking path.
+    pub fn reopen_schedule(&mut self, known_len: Option<u64>) -> UioResult<()> {
+        self.inner.reopen_schedule(known_len)
+    }
+
     #[inline]
     pub fn read<P: AccessPattern>(
         &self,

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -7,9 +7,9 @@ use bytemuck::TransparentWrapper;
 
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
-    ByteOffset, FileIndex, Flusher, Item, OpenOptions, ReadRange, UioResult, UniversalAppend,
-    UniversalFlush, UniversalIoError, UniversalKind, UniversalRead, UniversalReadFs,
-    UniversalWrite, UserData,
+    ByteOffset, CachedReadFs, FileIndex, Flusher, Item, OpenOptions, ReadRange, UioResult,
+    UniversalAppend, UniversalFlush, UniversalIoError, UniversalKind, UniversalRead,
+    UniversalReadFs, UniversalWrite, UserData,
 };
 
 /// A wrapper around [`UniversalRead`]/[`UniversalWrite`] that binds the element
@@ -71,10 +71,8 @@ where
         self.inner.reopen()
     }
 
-    /// Forwards [`UniversalRead::schedule_reopen`]: a missing forwarder would
-    /// silently no-op and send the wrapped file down the blocking path.
-    pub fn schedule_reopen(&mut self, known_len: Option<u64>) -> UioResult<()> {
-        self.inner.schedule_reopen(known_len)
+    pub fn schedule_reopen<Fs: CachedReadFs>(&mut self, cached_fs: &Fs) -> UioResult<()> {
+        self.inner.schedule_reopen(cached_fs)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -6,10 +6,11 @@ use std::path::Path;
 use bytemuck::TransparentWrapper;
 
 use crate::generic_consts::AccessPattern;
+use crate::universal_io::cached_fs::FileInfo;
 use crate::universal_io::{
-    ByteOffset, CachedReadFs, FileIndex, Flusher, Item, OpenOptions, ReadRange, UioResult,
-    UniversalAppend, UniversalFlush, UniversalIoError, UniversalKind, UniversalRead,
-    UniversalReadFs, UniversalWrite, UserData,
+    ByteOffset, FileIndex, Flusher, Item, OpenOptions, ReadRange, UioResult, UniversalAppend,
+    UniversalFlush, UniversalIoError, UniversalKind, UniversalRead, UniversalReadFs,
+    UniversalWrite, UserData,
 };
 
 /// A wrapper around [`UniversalRead`]/[`UniversalWrite`] that binds the element
@@ -71,8 +72,11 @@ where
         self.inner.reopen()
     }
 
-    pub fn schedule_reopen<Fs: CachedReadFs>(&mut self, cached_fs: &Fs) -> UioResult<()> {
-        self.inner.schedule_reopen(cached_fs)
+    pub fn schedule_reopen<F: FnOnce(&Path) -> Option<FileInfo>>(
+        &mut self,
+        get_file_info: F,
+    ) -> UioResult<()> {
+        self.inner.schedule_reopen(get_file_info)
     }
 
     #[inline]


### PR DESCRIPTION
## What
This PR reworks reopen functionality in DiskCache, so that it can be done in two steps:
1. Schedule the read for the new tail data of the remote file.
2. Apply this new tail and size to the local file.

## Why
As the fist step toward parallel live-reloading, we must follow a similar approach as what we did with `preopen` and `open` for each component. So that we schedule every component's data in parallel, then it should be quick to process the new data afterwards.

For `reopen`, however, since we are updating an existing file, we can't fully delegate it to `CachedFs`.

## How
Adds a new method to `UniversalRead`, where we are able to provide the new length.

```rust
trait UniversalRead {
    // ...

    fn schedule_reopen<F: FnOnce(&Path) -> Option<FileInfo>>(&mut self, get_file_info: F) -> UioResult<()> {
        let _ = cached_fs;
        Ok(())
    }

    // ... 
```

From the `Fs` side, we expose an interface for getting the file info that was read during a fresh LISTing
```rust
pub trait CachedReadFs: UniversalReadFs {
    // ...

    /// Return the file info from the current snapshot.
    fn file_info(&self, path: &Path) -> Option<FileInfo>;
}
```

This lets `DiskCache<R>` implement the reopening process in the two steps described above, while other backends can simply ignore the scheduling step, and don't need to know anything about `CachedReadFs` trait.

