### PR TITLE
[Raw payloads]: blobstore batched raw bytes read

### DIFF
--- a/lib/blobstore/src/blobstore/gridstore/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/mod.rs
@@ -437,6 +437,32 @@ where
         Ok(())
     }
 
+    /// Byte-blob analogue of [`Self::read_values`].
+    pub(super) fn read_values_bytes<P, U, E>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+        mut callback: impl FnMut(U, PointOffset, Option<&[u8]>) -> Result<(), E>,
+        hw_counter_cell: &CounterCell,
+    ) -> Result<(), E>
+    where
+        P: AccessPattern,
+        U: UserData,
+        E: From<BlobstoreError>,
+    {
+        self.with_view(|view| {
+            view.read_values_bytes::<P, _, _>(
+                point_offsets,
+                move |user_data, point_offset, bytes| -> Result<_, E> {
+                    callback(user_data, point_offset, bytes)?;
+                    Ok(true)
+                },
+                hw_counter_cell,
+            )
+        })?;
+
+        Ok(())
+    }
+
     #[cfg(test)]
     pub(super) fn get_pointer(&self, point_offset: PointOffset) -> Option<ValuePointer> {
         self.tracker.read().get(point_offset).ok().flatten()

--- a/lib/blobstore/src/blobstore/gridstore/reader.rs
+++ b/lib/blobstore/src/blobstore/gridstore/reader.rs
@@ -187,6 +187,30 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
         Ok(())
     }
 
+    /// Byte-blob analogue of [`Self::read_values`].
+    pub(crate) fn read_values_bytes<P, U, E>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+        mut callback: impl FnMut(U, PointOffset, Option<&[u8]>) -> Result<(), E>,
+        hw_counter_cell: &CounterCell,
+    ) -> Result<(), E>
+    where
+        P: AccessPattern,
+        U: UserData,
+        E: From<BlobstoreError>,
+    {
+        self.view().read_values_bytes::<P, _, _>(
+            point_offsets,
+            move |user_data, point_offset, bytes| -> Result<_, E> {
+                callback(user_data, point_offset, bytes)?;
+                Ok(true)
+            },
+            hw_counter_cell,
+        )?;
+
+        Ok(())
+    }
+
     /// Return the storage size in bytes (approximate: total page capacity).
     ///
     /// For the precise used-space calculation, use [`crate::Blobstore::get_storage_size_bytes`].

--- a/lib/blobstore/src/blobstore/gridstore/view.rs
+++ b/lib/blobstore/src/blobstore/gridstore/view.rs
@@ -110,6 +110,28 @@ impl<'a, V: Blob, S: UniversalRead, T: TrackerRead<S>> GridstoreView<'a, V, S, T
         U: UserData,
         E: From<BlobstoreError>,
     {
+        self.read_values_bytes::<P, _, _>(
+            point_offsets,
+            |user_data, point_offset, bytes| {
+                callback(user_data, point_offset, bytes.map(V::from_bytes))
+            },
+            hw_counter_cell,
+        )
+    }
+
+    /// Byte-blob analogue of [`Self::read_values`]: hands the callback each value in its
+    /// [`Blob`] encoding, always decompressed — the same bytes `V::to_bytes` would produce.
+    pub fn read_values_bytes<P, U, E>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+        mut callback: impl FnMut(U, PointOffset, Option<&[u8]>) -> Result<bool, E>,
+        hw_counter_cell: &CounterCell,
+    ) -> Result<bool, E>
+    where
+        P: AccessPattern,
+        U: UserData,
+        E: From<BlobstoreError>,
+    {
         let point_offsets = point_offsets
             .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset));
 
@@ -136,8 +158,7 @@ impl<'a, V: Blob, S: UniversalRead, T: TrackerRead<S>> GridstoreView<'a, V, S, T
                 hw_counter_cell.incr_delta(bytes.len());
 
                 let decompressed = self.decompress(bytes);
-                let value = V::from_bytes(&decompressed);
-                callback(user_data, point_offset, Some(value))
+                callback(user_data, point_offset, Some(&decompressed))
             },
         )
     }

--- a/lib/blobstore/src/blobstore/logstore/mod.rs
+++ b/lib/blobstore/src/blobstore/logstore/mod.rs
@@ -336,6 +336,32 @@ where
         Ok(())
     }
 
+    /// Byte-blob analogue of [`Self::read_values`].
+    pub(super) fn read_values_bytes<P, U, E>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+        mut callback: impl FnMut(U, PointOffset, Option<&[u8]>) -> Result<(), E>,
+        hw_counter_cell: &CounterCell,
+    ) -> Result<(), E>
+    where
+        P: AccessPattern,
+        U: UserData,
+        E: From<BlobstoreError>,
+    {
+        self.with_view(|view| {
+            view.read_values_bytes::<P, _, _>(
+                point_offsets,
+                move |user_data, point_offset, bytes| -> Result<_, E> {
+                    callback(user_data, point_offset, bytes)?;
+                    Ok(true)
+                },
+                hw_counter_cell,
+            )
+        })?;
+
+        Ok(())
+    }
+
     #[cfg(test)]
     pub(super) fn get_pointer(&self, point_offset: PointOffset) -> Option<ValuePointer> {
         self.tracker

--- a/lib/blobstore/src/blobstore/logstore/reader.rs
+++ b/lib/blobstore/src/blobstore/logstore/reader.rs
@@ -166,6 +166,30 @@ impl<V: Blob, S: UniversalRead> LogstoreReader<V, S> {
         Ok(())
     }
 
+    /// Byte-blob analogue of [`Self::read_values`].
+    pub(crate) fn read_values_bytes<P, U, E>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+        mut callback: impl FnMut(U, PointOffset, Option<&[u8]>) -> Result<(), E>,
+        hw_counter_cell: &CounterCell,
+    ) -> Result<(), E>
+    where
+        P: AccessPattern,
+        U: UserData,
+        E: From<BlobstoreError>,
+    {
+        self.view().read_values_bytes::<P, _, _>(
+            point_offsets,
+            move |user_data, point_offset, bytes| -> Result<_, E> {
+                callback(user_data, point_offset, bytes)?;
+                Ok(true)
+            },
+            hw_counter_cell,
+        )?;
+
+        Ok(())
+    }
+
     /// Return the storage size in bytes (precise, the exact amount of appended value data).
     pub(crate) fn get_storage_size_bytes(&self) -> usize {
         self.view().get_storage_size_bytes()

--- a/lib/blobstore/src/blobstore/logstore/view.rs
+++ b/lib/blobstore/src/blobstore/logstore/view.rs
@@ -106,6 +106,28 @@ impl<'a, V: Blob, S: UniversalRead> LogstoreView<'a, V, S> {
         U: UserData,
         E: From<BlobstoreError>,
     {
+        self.read_values_bytes::<P, _, _>(
+            point_offsets,
+            |user_data, point_offset, bytes| {
+                callback(user_data, point_offset, bytes.map(V::from_bytes))
+            },
+            hw_counter_cell,
+        )
+    }
+
+    /// Byte-blob analogue of [`Self::read_values`]: hands the callback each value in its
+    /// [`Blob`] encoding, always decompressed — the same bytes `V::to_bytes` would produce.
+    pub(crate) fn read_values_bytes<P, U, E>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+        mut callback: impl FnMut(U, PointOffset, Option<&[u8]>) -> Result<bool, E>,
+        hw_counter_cell: &CounterCell,
+    ) -> Result<bool, E>
+    where
+        P: AccessPattern,
+        U: UserData,
+        E: From<BlobstoreError>,
+    {
         let point_offsets = point_offsets
             .map(|(user_data, point_offset)| ((user_data, point_offset), point_offset));
 
@@ -131,8 +153,7 @@ impl<'a, V: Blob, S: UniversalRead> LogstoreView<'a, V, S> {
                 hw_counter_cell.incr_delta(bytes.len());
 
                 let decompressed = self.config.compression.decompress(bytes);
-                let value = V::from_bytes(&decompressed);
-                callback(user_data, point_offset, Some(value))
+                callback(user_data, point_offset, Some(&decompressed))
             },
         )
     }

--- a/lib/blobstore/src/blobstore/mod.rs
+++ b/lib/blobstore/src/blobstore/mod.rs
@@ -264,6 +264,31 @@ where
         }
     }
 
+    /// Byte-blob analogue of [`Self::read_values`]: hands the callback each value in its
+    /// [`Blob`] encoding, always decompressed — the same bytes `V::to_bytes` would produce,
+    /// valid as [`put_value_bytes`](Self::put_value_bytes) input regardless of either
+    /// storage's compression setting.
+    pub fn read_values_bytes<P, U, E>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+        callback: impl FnMut(U, PointOffset, Option<&[u8]>) -> Result<(), E>,
+        hw_counter_cell: &CounterCell,
+    ) -> Result<(), E>
+    where
+        P: AccessPattern,
+        U: UserData,
+        E: From<BlobstoreError>,
+    {
+        match self {
+            Blobstore::Gridstore(storage) => {
+                storage.read_values_bytes::<P, U, E>(point_offsets, callback, hw_counter_cell)
+            }
+            Blobstore::Logstore(storage) => {
+                storage.read_values_bytes::<P, U, E>(point_offsets, callback, hw_counter_cell)
+            }
+        }
+    }
+
     #[cfg(test)]
     pub fn get_pointer(&self, point_offset: PointOffset) -> Option<ValuePointer> {
         match self {

--- a/lib/blobstore/src/blobstore/reader.rs
+++ b/lib/blobstore/src/blobstore/reader.rs
@@ -184,6 +184,29 @@ impl<V: Blob, S: UniversalRead> BlobstoreReader<V, S> {
         }
     }
 
+    /// Byte-blob analogue of [`Self::read_values`]: hands the callback each value in its
+    /// [`Blob`] encoding, always decompressed — the same bytes `V::to_bytes` would produce.
+    pub fn read_values_bytes<P, U, E>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffset)>,
+        callback: impl FnMut(U, PointOffset, Option<&[u8]>) -> Result<(), E>,
+        hw_counter_cell: &CounterCell,
+    ) -> Result<(), E>
+    where
+        P: AccessPattern,
+        U: UserData,
+        E: From<BlobstoreError>,
+    {
+        match self {
+            Self::Gridstore(reader) => {
+                reader.read_values_bytes::<P, U, E>(point_offsets, callback, hw_counter_cell)
+            }
+            Self::Logstore(reader) => {
+                reader.read_values_bytes::<P, U, E>(point_offsets, callback, hw_counter_cell)
+            }
+        }
+    }
+
     /// Return the storage size in bytes.
     ///
     /// Approximate (total page capacity) in mutable mode, exact in append-only mode.

--- a/lib/blobstore/src/blobstore/tests.rs
+++ b/lib/blobstore/src/blobstore/tests.rs
@@ -213,6 +213,57 @@ fn test_value_bytes_cross_compression(
 }
 
 #[rstest]
+fn test_read_values_bytes(
+    #[values(Mode::Mutable, Mode::AppendOnly)] mode: Mode,
+    #[values(Compression::None, Compression::LZ4)] compression: Compression,
+) {
+    let (_dir, mut storage) = empty_storage_compression(mode, compression);
+
+    let hw_counter = HardwareCounterCell::new();
+    let hw_counter_ref = hw_counter.ref_payload_io_write_counter();
+
+    let rng = &mut rand::make_rng::<rand::rngs::SmallRng>();
+    let payloads = (0..10).map(|_| random_payload(rng, 2)).collect::<Vec<_>>();
+
+    for (point_offset, payload) in payloads.iter().enumerate() {
+        storage
+            .put_value(point_offset as PointOffset, payload, hw_counter_ref)
+            .unwrap();
+    }
+
+    // Include offsets past the end: like `read_values`, they must not yield a value.
+    let offsets: Vec<PointOffset> = (0..payloads.len() as PointOffset + 2).collect();
+
+    // Slots are pre-filled with the expected absent value, so this does not rely on
+    // the batched read invoking the callback for offsets that have no pointer at all
+    // (it may skip them, exactly like `read_values`).
+    let mut batch: Vec<Option<Vec<u8>>> = vec![None; offsets.len()];
+    storage
+        .read_values_bytes::<Random, _, BlobstoreError>(
+            offsets.iter().copied().enumerate(),
+            |idx, _, bytes| {
+                batch[idx] = bytes.map(<[u8]>::to_vec);
+                Ok(())
+            },
+            hw_counter.payload_io_read_counter(),
+        )
+        .unwrap();
+
+    for (idx, &point_offset) in offsets.iter().enumerate() {
+        // Agrees with the single-value byte read, and with the values as they were stored.
+        let single = storage
+            .get_value_bytes::<Random>(point_offset, &hw_counter)
+            .unwrap();
+        assert_eq!(batch[idx], single, "mismatch at offset {point_offset}");
+        assert_eq!(
+            batch[idx],
+            payloads.get(point_offset as usize).map(Blob::to_bytes),
+            "mismatch at offset {point_offset}",
+        );
+    }
+}
+
+#[rstest]
 fn test_storage_files(#[values(Mode::Mutable, Mode::AppendOnly)] mode: Mode) {
     let (dir, mut storage) = empty_storage_mode(mode);
 


### PR DESCRIPTION
Add `read_values_bytes`, the byte-blob analogue of `read_values`, so callers that want the stored blob rather than the parsed value keep the batched (io_uring-friendly) read path instead of looping over `get_value_bytes`. `read_values` becomes a thin adapter over it.
