### PR TITLE
[LiveReload] Add `live_preload`

### DIFF
--- a/lib/blobstore/src/blobstore/gridstore/pages.rs
+++ b/lib/blobstore/src/blobstore/gridstore/pages.rs
@@ -9,7 +9,7 @@ use common::maybe_uninit::assume_init_vec;
 use common::mmap::{Advice, AdviceSetting};
 use common::universal_io::{
     CachedReadFs, FileIndex, Flusher, OpenOptions, Populate, ReadPipeline, ReadRange,
-    UniversalRead, UniversalReadFileOps, UniversalReadFs, UniversalWrite, UserData,
+    UniversalRead, UniversalReadFs, UniversalWrite, UserData,
 };
 use itertools::Either;
 
@@ -460,7 +460,11 @@ impl<S: UniversalRead> Pages<S> {
     /// - Should only be called on read-only instances of the Pages.
     /// - Only appending new data is supported, for modifications of existing data there are no consistency guarantees.
     /// - Partial writes are possible, it is up to the caller to read only fully written data.
-    pub fn live_reload(&mut self, fs: &S::Fs, populate: Populate) -> Result<()> {
+    pub fn live_reload<Fs: UniversalReadFs<File = S>>(
+        &mut self,
+        fs: &Fs,
+        populate: Populate,
+    ) -> Result<()> {
         let num_pages = self.pages.len();
         let next_page_id = num_pages as PageId;
 

--- a/lib/blobstore/src/blobstore/gridstore/reader.rs
+++ b/lib/blobstore/src/blobstore/gridstore/reader.rs
@@ -230,7 +230,7 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
     /// tracker file is mutated in place and carries no reliable
     /// cheaply-readable change signal, so there is no "nothing changed"
     /// fast path. Both refreshes are cheap for non-populated readers.
-    pub(crate) fn live_reload(&mut self, fs: &S::Fs) -> Result<()> {
+    pub(crate) fn live_reload<Fs: UniversalReadFs<File = S>>(&mut self, fs: &Fs) -> Result<()> {
         self.tracker.live_reload(fs)?;
         self.pages.live_reload(fs, self.populate)?;
 

--- a/lib/blobstore/src/blobstore/logstore/page.rs
+++ b/lib/blobstore/src/blobstore/logstore/page.rs
@@ -6,8 +6,7 @@ use common::generic_consts::AccessPattern;
 use common::mmap::{Advice, AdviceSetting};
 use common::universal_io::{
     CachedReadFs, IsNotFound, OpenOptions, Populate, ReadPipeline, ReadRange, UniversalAppend,
-    UniversalIoError, UniversalRead, UniversalReadFileOps, UniversalReadFs, UniversalWriteFileOps,
-    UserData,
+    UniversalIoError, UniversalRead, UniversalReadFs, UniversalWriteFileOps, UserData,
 };
 
 use crate::Result;
@@ -210,7 +209,11 @@ impl<S: UniversalRead> AppendOnlyPages<S> {
 
     /// Reload the pages from "disk", making newly appended value data visible to reads and the
     /// reported storage size.
-    pub(super) fn live_reload(&mut self, fs: &S::Fs, populate: Populate) -> Result<()> {
+    pub(super) fn live_reload<Fs: UniversalReadFs<File = S>>(
+        &mut self,
+        fs: &Fs,
+        populate: Populate,
+    ) -> Result<()> {
         let page_list: HashMap<_, _> = fs
             .list_files(&self.dir.join(PAGE_FILE_NAME_PREFIX))?
             .into_iter()

--- a/lib/blobstore/src/blobstore/logstore/reader.rs
+++ b/lib/blobstore/src/blobstore/logstore/reader.rs
@@ -207,7 +207,7 @@ impl<V: Blob, S: UniversalRead> LogstoreReader<V, S> {
     /// - Data is append-only, existing mappings and value data never change.
     /// - Partial writes are possible, but ignored: a trailing partial tracker entry is not
     ///   counted.
-    pub(crate) fn live_reload(&mut self, fs: &S::Fs) -> Result<()> {
+    pub(crate) fn live_reload<Fs: UniversalReadFs<File = S>>(&mut self, fs: &Fs) -> Result<()> {
         // A writer always updates the pages before the tracker, and it is not synchronized with
         // readers. Observe the tracker first, so that the mappings counted here are backed by
         // page data that the page reload below is guaranteed to see. Observing the pages first

--- a/lib/blobstore/src/blobstore/reader.rs
+++ b/lib/blobstore/src/blobstore/reader.rs
@@ -225,7 +225,7 @@ impl<V: Blob, S: UniversalRead> BlobstoreReader<V, S> {
     /// - Only appending new data is supported, for modifications of existing data there are no consistency guarantees.
     /// - Partial writes are possible, it is up to the caller to read only fully written data.
     ///
-    pub fn live_reload(&mut self, fs: &S::Fs) -> Result<()> {
+    pub fn live_reload<Fs: UniversalReadFs<File = S>>(&mut self, fs: &Fs) -> Result<()> {
         match self {
             Self::Gridstore(reader) => reader.live_reload(fs),
             Self::Logstore(reader) => reader.live_reload(fs),

--- a/lib/segment/src/common/live_reload.rs
+++ b/lib/segment/src/common/live_reload.rs
@@ -1,6 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
 
 use crate::common::operation_error::OperationResult;
 
@@ -28,15 +29,21 @@ use crate::common::operation_error::OperationResult;
 ///
 /// [`UniversalRead`]: common::universal_io::UniversalRead
 pub(crate) trait LiveReload {
-    /// Filesystem context (`S::Fs` of the backing [`UniversalRead`]) used to
-    /// re-read on-disk state during a reload.
-    ///
-    /// [`UniversalRead`]: common::universal_io::UniversalRead
-    type Fs;
+    type File: UniversalRead;
 
-    fn live_reload(
+    #[expect(dead_code)]
+    fn live_preload<Fs: CachedReadFs<File = Self::File>>(
+        &self,
+        cached_fs: &Fs,
+    ) -> OperationResult<()> {
+        let _ = cached_fs;
+        // todo(uio): don't provide default implementation
+        Ok(())
+    }
+
+    fn live_reload<Fs: UniversalReadFs<File = Self::File>>(
         &mut self,
-        fs: &Self::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/common/live_reload.rs
+++ b/lib/segment/src/common/live_reload.rs
@@ -1,6 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
 
 use crate::common::operation_error::OperationResult;
 
@@ -28,15 +29,21 @@ use crate::common::operation_error::OperationResult;
 ///
 /// [`UniversalRead`]: common::universal_io::UniversalRead
 pub(crate) trait LiveReload {
-    /// Filesystem context (`S::Fs` of the backing [`UniversalRead`]) used to
-    /// re-read on-disk state during a reload.
-    ///
-    /// [`UniversalRead`]: common::universal_io::UniversalRead
-    type Fs;
+    type File: UniversalRead;
 
-    fn live_reload(
+    #[expect(dead_code)]
+    fn live_preload<Fs: CachedReadFs<File = Self::File>>(
         &mut self,
-        fs: &Self::Fs,
+        cached_fs: &Fs,
+    ) -> OperationResult<()> {
+        let _ = cached_fs;
+        // todo(uio): don't provide default implementation
+        Ok(())
+    }
+
+    fn live_reload<Fs: UniversalReadFs<File = Self::File>>(
+        &mut self,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
@@ -1,6 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalReadFs;
 
 use super::ReadOnlyBoolIndex;
 use crate::common::operation_error::OperationResult;
@@ -8,11 +9,11 @@ use crate::index::UniversalReadExt;
 use crate::index::field_index::LiveReload;
 
 impl<S: UniversalReadExt> LiveReload for ReadOnlyBoolIndex<S> {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         _deleted_points: &SortedSlice<'_, PointOffsetType>,
         _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalReadFs;
 
 pub(crate) use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
@@ -273,11 +274,11 @@ impl<S: UniversalReadExt> ReadOnlyFieldIndex<S> {
 }
 
 impl<S: UniversalReadExt> LiveReload for ReadOnlyFieldIndex<S> {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index/live_reload.rs
@@ -1,18 +1,18 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ImmutableFullTextIndex;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
 
 impl<S: UniversalRead> LiveReload for ImmutableFullTextIndex<S> {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        _fs: &S::Fs,
+        _fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/live_reload.rs
@@ -2,7 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Sequential;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyAppendableFullTextIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -13,11 +13,11 @@ use crate::index::field_index::full_text_index::inverted_index::{
 };
 
 impl<S: UniversalRead> LiveReload for ReadOnlyAppendableFullTextIndex<S> {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/full_text_index/on_disk_text_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/on_disk_text_index/live_reload.rs
@@ -1,18 +1,18 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::OnDiskFullTextIndex;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
 
 impl<S: UniversalRead> LiveReload for OnDiskFullTextIndex<S> {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        _fs: &S::Fs,
+        _fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/full_text_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/live_reload.rs
@@ -1,18 +1,18 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyFullTextIndex;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
 
 impl<S: UniversalRead> LiveReload for ReadOnlyFullTextIndex<S> {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index/live_reload.rs
@@ -1,18 +1,18 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ImmutableGeoIndex;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
 
 impl<S: UniversalRead> LiveReload for ImmutableGeoIndex<S> {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        _fs: &S::Fs,
+        _fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs
@@ -2,7 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Sequential;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyAppendableGeoIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -10,11 +10,11 @@ use crate::index::field_index::LiveReload;
 use crate::types::{GeoPoint, RawGeoPoint};
 
 impl<S: UniversalRead> LiveReload for ReadOnlyAppendableGeoIndex<S> {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/live_reload.rs
@@ -1,18 +1,18 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::OnDiskGeoIndex;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
 
 impl<S: UniversalRead> LiveReload for OnDiskGeoIndex<S> {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        _fs: &S::Fs,
+        _fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/geo_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/live_reload.rs
@@ -1,18 +1,18 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyGeoIndex;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
 
 impl<S: UniversalRead> LiveReload for ReadOnlyGeoIndex<S> {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/live_reload.rs
@@ -3,7 +3,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::persisted_hashmap::Key;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ImmutableMapIndex;
 use crate::common::operation_error::OperationResult;
@@ -16,11 +16,11 @@ where
     N: MapIndexKey + Key + ?Sized,
     S: UniversalRead,
 {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        _fs: &S::Fs,
+        _fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/live_reload.rs
@@ -4,7 +4,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Sequential;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
@@ -15,11 +15,11 @@ impl<N: MapIndexKey + ?Sized, S: UniversalRead> LiveReload for ReadOnlyAppendabl
 where
     Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/live_reload.rs
@@ -2,7 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::persisted_hashmap::Key;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
@@ -14,11 +14,11 @@ where
     N: MapIndexKey + Key + ?Sized,
     S: UniversalRead,
 {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        _fs: &S::Fs,
+        _fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/map_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/read_only/live_reload.rs
@@ -3,7 +3,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::persisted_hashmap::Key;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::super::MapIndexKey;
 use super::ReadOnlyMapIndex;
@@ -14,11 +14,11 @@ impl<N: MapIndexKey + Key + ?Sized, S: UniversalRead> LiveReload for ReadOnlyMap
 where
     Vec<<N as MapIndexKey>::Owned>: Blob + Send + Sync,
 {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/live_reload.rs
@@ -1,18 +1,18 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyNullIndex;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
 
 impl<S: UniversalRead> LiveReload for ReadOnlyNullIndex<S> {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         _deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/live_reload.rs
@@ -2,7 +2,7 @@ use blobstore::Blob;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ImmutableNumericIndex;
 use crate::common::operation_error::OperationResult;
@@ -16,11 +16,11 @@ impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default, S: Univer
 where
     Vec<T>: Blob,
 {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        _fs: &S::Fs,
+        _fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/live_reload.rs
@@ -4,7 +4,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Sequential;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyAppendableNumericIndex;
 use crate::common::operation_error::OperationResult;
@@ -17,11 +17,11 @@ impl<T: Encodable + Numericable + Send + Sync + Default, S: UniversalRead> LiveR
 where
     Vec<T>: Blob,
 {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
@@ -13,11 +13,11 @@ use crate::index::field_index::on_disk_point_to_values::StoredValue;
 impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalRead> LiveReload
     for OnDiskNumericIndex<T, S>
 {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        _fs: &S::Fs,
+        _fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/numeric_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_only/live_reload.rs
@@ -2,7 +2,7 @@ use blobstore::Blob;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::{Encodable, ReadOnlyNumericIndex};
 use crate::common::operation_error::OperationResult;
@@ -18,11 +18,11 @@ impl<
 where
     Vec<T>: Blob,
 {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/live_reload.rs
@@ -2,7 +2,7 @@ use blobstore::Blob;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyNumericIndexInner;
 use crate::common::operation_error::OperationResult;
@@ -16,11 +16,11 @@ impl<T: Encodable + Numericable + StoredValue + Send + Sync + Default + 'static,
 where
     Vec<T>: Blob,
 {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/read_only/live_reload.rs
+++ b/lib/segment/src/index/read_only/live_reload.rs
@@ -1,6 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalReadFs;
 
 use super::VectorIndexReadEnum;
 use crate::common::live_reload::LiveReload;
@@ -8,7 +9,7 @@ use crate::common::operation_error::OperationResult;
 use crate::index::UniversalReadExt;
 
 impl<S: UniversalReadExt> LiveReload for VectorIndexReadEnum<S> {
-    type Fs = S::Fs;
+    type File = S;
 
     /// No-op for the persisted variants: read-only vector indexes are immutable —
     /// the HNSW graph and the compressed sparse inverted indexes are built once,
@@ -21,9 +22,9 @@ impl<S: UniversalReadExt> LiveReload for VectorIndexReadEnum<S> {
     /// be folded into its inverted index to stay searchable. Deletions still
     /// need no index surgery — stale postings are filtered at search time via
     /// the deleted bitslices.
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        _fs: &S::Fs,
+        _fs: &Fs,
         _deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/index/struct_payload_index/read_only/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/mod.rs
@@ -7,6 +7,7 @@ use atomic_refcell::AtomicRefCell;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
+use common::universal_io::UniversalReadFs;
 
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
@@ -71,11 +72,11 @@ impl<S: UniversalReadExt> ReadOnlyStructPayloadIndex<S> {
 }
 
 impl<S: UniversalReadExt> LiveReload for ReadOnlyStructPayloadIndex<S> {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/payload_storage/read_only/live_reload.rs
+++ b/lib/segment/src/payload_storage/read_only/live_reload.rs
@@ -1,18 +1,18 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyPayloadStorage;
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 
 impl<S: UniversalRead> LiveReload for ReadOnlyPayloadStorage<S> {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         _deleted_points: &SortedSlice<'_, PointOffsetType>,
         _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/vector_storage/chunked_vectors/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read_only/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::super::chunks::read_chunks_from;
 use super::super::config::{read_status_len, status_file};
@@ -10,7 +10,7 @@ use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 
 impl<T: bytemuck::Pod + Send, S: UniversalRead> LiveReload for ReadOnlyChunkedVectors<T, S> {
-    type Fs = S::Fs;
+    type File = S;
 
     /// Refresh the chunks that can have gained vectors since the last load; a
     /// no-op when the length is unchanged (the status file is read fresh, so
@@ -24,9 +24,9 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> LiveReload for ReadOnlyChunkedVe
     /// that can have gained vectors — is dropped and re-opened fresh,
     /// alongside adopting newly created chunk files. Deletions/new points are
     /// tracked by callers, so they are unused here.
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         _deleted_points: &SortedSlice<'_, PointOffsetType>,
         _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/live_reload.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyImmutableDenseVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -11,13 +11,13 @@ use crate::data_types::primitive::PrimitiveVectorElement;
 impl<T: PrimitiveVectorElement, S: UniversalRead> LiveReload
     for ReadOnlyImmutableDenseVectorStorage<T, S>
 {
-    type Fs = S::Fs;
+    type File = S;
 
     /// Vector data is immutable, so only the in-memory deletion flags are patched
     /// from the authoritative `deleted_points`; `fs` and `new_points` are unused.
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        _fs: &S::Fs,
+        _fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/vector_storage/dense/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyChunkedDenseVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -11,14 +11,14 @@ use crate::data_types::primitive::PrimitiveVectorElement;
 impl<T: PrimitiveVectorElement, S: UniversalRead> LiveReload
     for ReadOnlyChunkedDenseVectorStorage<T, S>
 {
-    type Fs = S::Fs;
+    type File = S;
 
     /// Reload the chunked vectors, apply `deleted_points`, and fold in the
     /// persisted deletion of each appended offset — a live point may have a
     /// deleted vector slot recorded only on disk.
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/vector_storage/multi_dense/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -11,14 +11,14 @@ use crate::data_types::primitive::PrimitiveVectorElement;
 impl<T: PrimitiveVectorElement, S: UniversalRead> LiveReload
     for ReadOnlyChunkedMultiDenseVectorStorage<T, S>
 {
-    type Fs = S::Fs;
+    type File = S;
 
     /// Reload the vectors and offsets, apply `deleted_points`, and fold in the
     /// persisted deletion of each appended offset — a live point may have a
     /// deleted vector slot recorded only on disk.
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,
@@ -28,7 +28,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> LiveReload
         self.offsets
             .live_reload(fs, deleted_points, new_points, hw_counter)?;
         self.deleted.insert_all(deleted_points);
-        self.deleted.reload_appended::<S>(fs, new_points)?;
+        self.deleted.reload_appended(fs, new_points)?;
 
         Ok(())
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/live_reload.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/live_reload.rs
@@ -1,19 +1,19 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
 use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedChunkedStorageRead;
 
 impl<S: UniversalRead> LiveReload for QuantizedChunkedStorageRead<S> {
-    type Fs = <S as UniversalRead>::Fs;
+    type File = S;
 
     /// Pick up quantized vectors a writer appended to the chunked backing.
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &Self::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/live_reload.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/live_reload.rs
@@ -1,19 +1,19 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::MultivectorOffsetsStorageChunkedRead;
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
 
 impl<S: UniversalRead> LiveReload for MultivectorOffsetsStorageChunkedRead<S> {
-    type Fs = <S as UniversalRead>::Fs;
+    type File = S;
 
     /// Pick up offsets a writer appended to the chunked backing.
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &Self::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/live_reload.rs
@@ -1,19 +1,19 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::{ReadOnlyQuantizedVectorStorage, ReadOnlyQuantizedVectors};
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 
 impl<S: UniversalRead> LiveReload for ReadOnlyQuantizedVectors<S> {
-    type Fs = S::Fs;
+    type File = S;
 
     /// Reload appended quantized vectors from disk (chunked layouts only).
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,
@@ -24,14 +24,14 @@ impl<S: UniversalRead> LiveReload for ReadOnlyQuantizedVectors<S> {
 }
 
 impl<S: UniversalRead> LiveReload for ReadOnlyQuantizedVectorStorage<S> {
-    type Fs = S::Fs;
+    type File = S;
 
     /// Pick up quantized vectors a writer appended. Only the chunked (appendable)
     /// layouts grow; Ram/Mmap are immutable, so they no-op. Deletions aren't
     /// tracked here — they live in the raw vector storage.
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/vector_storage/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/read_only/live_reload.rs
@@ -1,18 +1,18 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::VectorStorageReadEnum;
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 
 impl<S: UniversalRead> LiveReload for VectorStorageReadEnum<S> {
-    type Fs = S::Fs;
+    type File = S;
 
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/vector_storage/sparse/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/live_reload.rs
@@ -1,20 +1,20 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlySparseVectorStorage;
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 
 impl<S: UniversalRead> LiveReload for ReadOnlySparseVectorStorage<S> {
-    type Fs = S::Fs;
+    type File = S;
 
     /// Reload the Blobstore, apply `deleted_points`, fold in the persisted
     /// deletion of each appended offset, and recompute `next_point_offset`.
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/vector_storage/turbo/multi_turbo/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/turbo/multi_turbo/read_only/live_reload.rs
@@ -1,21 +1,21 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyChunkedMultiTurboVectorStorage;
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 
 impl<S: UniversalRead> LiveReload for ReadOnlyChunkedMultiTurboVectorStorage<S> {
-    type Fs = S::Fs;
+    type File = S;
 
     /// Reload the vectors and offsets, apply `deleted_points`, and fold in the
     /// persisted deletion of each appended offset — a live point may have a
     /// deleted vector slot recorded only on disk.
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/vector_storage/turbo/read_only/immutable/live_reload.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/immutable/live_reload.rs
@@ -1,20 +1,20 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyImmutableTurboVectorStorage;
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 
 impl<S: UniversalRead> LiveReload for ReadOnlyImmutableTurboVectorStorage<S> {
-    type Fs = S::Fs;
+    type File = S;
 
     /// Vector data is immutable, so only the in-memory deletion flags are patched
     /// from the authoritative `deleted_points`; `fs` and `new_points` are unused.
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        _fs: &S::Fs,
+        _fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         _new_points: &SortedSlice<'_, PointOffsetType>,
         _hw_counter: &HardwareCounterCell,

--- a/lib/segment/src/vector_storage/turbo/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/live_reload.rs
@@ -1,21 +1,21 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyChunkedTurboVectorStorage;
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
 
 impl<S: UniversalRead> LiveReload for ReadOnlyChunkedTurboVectorStorage<S> {
-    type Fs = S::Fs;
+    type File = S;
 
     /// Reload the chunked vectors, apply `deleted_points`, and fold in the
     /// persisted deletion of each appended offset — a live point may have a
     /// deleted vector slot recorded only on disk.
-    fn live_reload(
+    fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,
         new_points: &SortedSlice<'_, PointOffsetType>,
         hw_counter: &HardwareCounterCell,


### PR DESCRIPTION
This PR changes the `LiveReload` trait to support a new `live_preload` method.

To do this, we must also switch from having the `Fs` to `File` as the associated type (see 2ed945674c7f).

Everything else is just adjusting existing implementations to this change.

For now, we are providing `live_preload` as a bypass default method to allow implementing it one component at a time



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>