### PR TITLE
bitpacking_ordered: batched reads

### DIFF
--- a/lib/common/common/benches/bitpacking.rs
+++ b/lib/common/common/benches/bitpacking.rs
@@ -1,7 +1,6 @@
 use std::hint::black_box;
 use std::io::Write;
 use std::path::Path;
-use std::range::Range;
 
 use common::bitpacking::{BitReader, BitWriter};
 use common::bitpacking_links::{iterate_packed_links, pack_links};
@@ -148,7 +147,7 @@ pub fn bench_bitpacking_ordered(c: &mut Criterion) {
     });
 
     let mut rng = SmallRng::seed_from_u64(42);
-    let mut out = [Range::from(0..0); MAX_BATCH_SIZE];
+    let mut out = [(0, 0); MAX_BATCH_SIZE];
     group.bench_function("batch/slice_reader", |b| {
         b.iter_batched(
             || random_batch(&mut rng, values.len()),
@@ -202,15 +201,15 @@ fn bench_uio_batch<Fs: UniversalReadFs>(
 
     let len = reader.decompressed_len();
     let mut rng = SmallRng::seed_from_u64(42);
-    let mut out = [Range::from(0..0); MAX_BATCH_SIZE];
+    let mut out = [(0, 0); MAX_BATCH_SIZE];
     group.bench_function(name, |b| {
         b.iter_batched(
             || random_batch(&mut rng, len),
             |indices| {
                 let out = &mut out[..indices.len()];
                 for result in reader.read_pairs_iter(&storage, 0, &indices).unwrap() {
-                    let (position, range) = result.unwrap();
-                    out[position] = range;
+                    let (position, pair) = result.unwrap();
+                    out[position] = pair;
                 }
                 black_box(out);
             },

--- a/lib/common/common/benches/bitpacking.rs
+++ b/lib/common/common/benches/bitpacking.rs
@@ -1,12 +1,21 @@
 use std::hint::black_box;
+use std::io::Write;
+use std::path::Path;
+use std::range::Range;
 
 use common::bitpacking::{BitReader, BitWriter};
 use common::bitpacking_links::{iterate_packed_links, pack_links};
 use common::bitpacking_ordered;
-use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use common::mmap::AdviceSetting;
+#[cfg(target_os = "linux")]
+use common::universal_io::IoUringFs;
+use common::universal_io::{MmapFs, OpenOptions, Populate, UniversalReadFs};
+use criterion::measurement::WallTime;
+use criterion::{BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main};
 use itertools::Itertools as _;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng as _};
+use tempfile::NamedTempFile;
 use zerocopy::IntoBytes;
 
 pub fn bench_bitpacking(c: &mut Criterion) {
@@ -117,13 +126,14 @@ pub fn bench_bitpacking_ordered(c: &mut Criterion) {
     drop(group);
     let mut group = c.benchmark_group("bitpacking_ordered");
 
-    let (compressed, parameters) = bitpacking_ordered::compress(&values);
-    let (decompressor, _) = bitpacking_ordered::Reader::new(parameters, &compressed).unwrap();
+    let (compressed, params) = bitpacking_ordered::compress(&values);
+    let reader = params.validate().unwrap();
+    let slice_reader = reader.slice_reader(&compressed).unwrap();
     println!(
         "Original size: {:.1} MB, compressed size: {:.1} MB, {:?}",
         values.as_bytes().len() as f64 / 1e6,
         compressed.len() as f64 / 1e6,
-        decompressor.parameters(),
+        params,
     );
 
     let mut rng = SmallRng::seed_from_u64(42);
@@ -138,24 +148,71 @@ pub fn bench_bitpacking_ordered(c: &mut Criterion) {
     });
 
     let mut rng = SmallRng::seed_from_u64(42);
-    group.bench_function("get", |b| {
+    let mut out = [Range::from(0..0); MAX_BATCH_SIZE];
+    group.bench_function("batch/slice_reader", |b| {
         b.iter_batched(
-            || rng.random_range(0..values.len()),
-            |i| {
-                black_box(decompressor.get(i));
+            || random_batch(&mut rng, values.len()),
+            |indices| {
+                for (&index, out) in indices.iter().zip(&mut out) {
+                    *out = slice_reader.read_pair(index).unwrap();
+                }
+                black_box(&mut out);
             },
             BatchSize::SmallInput,
         )
     });
 
+    let mut file = NamedTempFile::new().unwrap();
+    file.write_all(&compressed).unwrap();
+
+    bench_uio_batch(&mut group, "batch/uio_mmap", &MmapFs, file.path(), reader);
+    #[cfg(target_os = "linux")]
+    bench_uio_batch(
+        &mut group,
+        "batch/uio_io_uring",
+        &IoUringFs,
+        file.path(),
+        reader,
+    );
+}
+
+const MAX_BATCH_SIZE: usize = 32;
+
+fn random_batch(rng: &mut SmallRng, len: usize) -> Vec<usize> {
+    let batch_size = rng.random_range(1..=MAX_BATCH_SIZE);
+    (0..batch_size)
+        .map(|_| rng.random_range(0..len - 1))
+        .collect()
+}
+
+fn bench_uio_batch<Fs: UniversalReadFs>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    name: &str,
+    fs: &Fs,
+    path: &Path,
+    reader: bitpacking_ordered::Reader,
+) {
+    let options = OpenOptions {
+        writeable: false,
+        need_sequential: false,
+        populate: Populate::Blocking,
+        advice: AdviceSetting::Global,
+    };
+    let storage = fs.open(path, options, Default::default()).unwrap();
+
+    let len = reader.decompressed_len();
     let mut rng = SmallRng::seed_from_u64(42);
-    group.bench_function("get2", |b| {
+    let mut out = [Range::from(0..0); MAX_BATCH_SIZE];
+    group.bench_function(name, |b| {
         b.iter_batched(
-            || rng.random_range(0..values.len() - 1),
-            |i| {
-                let a = decompressor.get(i);
-                let b = decompressor.get(i + 1);
-                black_box((a, b));
+            || random_batch(&mut rng, len),
+            |indices| {
+                let out = &mut out[..indices.len()];
+                for result in reader.read_pairs_iter(&storage, 0, &indices).unwrap() {
+                    let (position, range) = result.unwrap();
+                    out[position] = range;
+                }
+                black_box(out);
             },
             BatchSize::SmallInput,
         )

--- a/lib/common/common/benches/bitpacking_tango.rs
+++ b/lib/common/common/benches/bitpacking_tango.rs
@@ -138,7 +138,7 @@ fn benchmarks_ordered() -> impl IntoBenchmarks {
     }
 
     struct StateDependent<'a> {
-        decompressor: bitpacking_ordered::Reader<'a>,
+        slice_reader: bitpacking_ordered::SliceReader<'a>,
     }
 
     self_cell::self_cell! {
@@ -153,45 +153,32 @@ fn benchmarks_ordered() -> impl IntoBenchmarks {
         let values =
             bitpacking_ordered::gen_test_sequence(&mut SmallRng::seed_from_u64(42), 32, 1 << 22);
 
-        let (compressed, parameters) = bitpacking_ordered::compress(&values);
+        let (compressed, params) = bitpacking_ordered::compress(&values);
 
         State::new(StateOwner { values, compressed }, |owner| {
-            let (decompressor, _) =
-                bitpacking_ordered::Reader::new(parameters, &owner.compressed).unwrap();
+            let reader = params.validate().unwrap();
+            let slice_reader = reader.slice_reader(&owner.compressed).unwrap();
             println!(
                 "Original size: {:.1} MB, compressed size: {:.1} MB, {:?}",
                 owner.values.as_bytes().len() as f64 / 1e6,
                 owner.compressed.len() as f64 / 1e6,
-                decompressor.parameters(),
+                params,
             );
-            StateDependent { decompressor }
+            StateDependent { slice_reader }
         })
     });
 
-    [
-        b.benchmark_fn("ordered/get", {
-            move |b: Bencher, state| {
-                let mut rng = rand::make_rng::<SmallRng>();
-                let len = state.borrow_owner().values.len() - 1;
-                b.iter(move || {
-                    let i = rng.random_range(0..len);
-                    black_box(state.borrow_dependent().decompressor.get(i));
-                })
-            }
-        }),
-        b.benchmark_fn("ordered/get2", {
-            move |b: Bencher, state| {
-                let mut rng = rand::make_rng::<SmallRng>();
-                let len = state.borrow_owner().values.len() - 1;
-                b.iter(move || {
-                    let i = rng.random_range(0..len);
-                    let a = state.borrow_dependent().decompressor.get(i);
-                    let b = state.borrow_dependent().decompressor.get(i + 1);
-                    black_box((a, b));
-                })
-            }
-        }),
-    ]
+    [b.benchmark_fn("ordered/read_pair", {
+        move |b: Bencher, state| {
+            let mut rng = rand::make_rng::<SmallRng>();
+            let len = state.borrow_owner().values.len() - 1;
+            b.iter(move || {
+                let i = rng.random_range(0..len);
+                let r = state.borrow_dependent().slice_reader.read_pair(i);
+                black_box(r);
+            })
+        }
+    })]
 }
 
 #[expect(clippy::type_complexity)]

--- a/lib/common/common/src/bitpacking_ordered.rs
+++ b/lib/common/common/src/bitpacking_ordered.rs
@@ -39,16 +39,19 @@
 //! - `bitpad` is a bit padding (0..7 bits) so the chunk is byte-aligned.
 
 use std::ops::RangeInclusive;
+use std::range::Range;
 
 use thiserror::Error;
 use zerocopy::little_endian::U64;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use crate::bitpacking::{BitWriter, make_bitmask, packed_bits};
+use crate::generic_consts::Random;
+use crate::universal_io::{ReadBytesItem, UioResult, UniversalIoError, UniversalRead};
 
 /// The size of the tail padding.
-/// These extra 7 bytes after the last chunk allows the decompressor to safely
-/// perform unchecked unaligned 8-byte reads.
+/// These extra 7 bytes after the last chunk let the decompressor read a whole
+/// 8-byte word even when a delta ends in the last byte of the last chunk.
 const TAIL_SIZE: usize = size_of::<u64>() - 1;
 
 /// The allowed range for the `delta_bits` parameter.
@@ -73,7 +76,7 @@ pub fn compress(values: &[u64]) -> (Vec<u8>, Parameters) {
 
 /// Compress the data with given parameters.
 fn compress_with_parameters(values: &[u64], parameters: Parameters) -> Vec<u8> {
-    let expected_size = parameters.total_chunks_size_bytes().unwrap() + TAIL_SIZE;
+    let expected_size = parameters.compressed_size_bytes().unwrap();
     let mut compressed = Vec::with_capacity(expected_size);
 
     for chunk in values.chunks(1 << parameters.chunk_len_log2) {
@@ -100,127 +103,49 @@ fn compress_with_parameters(values: &[u64], parameters: Parameters) -> Vec<u8> {
     compressed
 }
 
-#[derive(Clone, Debug)]
-pub struct Reader<'a> {
-    base_bits: u8,
-    base_mask: u64,
-    delta_bits: u8,
-    delta_mask: u64,
-    chunk_len_log2: u8,
-    chunk_len_mask: usize,
-    chunk_size_bytes: usize,
-    compressed: &'a [u8],
-    len: usize,
-}
-
 #[derive(Error, Debug)]
 #[error("decompression error: {0}")]
 pub struct DecompressionError(String);
 
-impl<'a> Reader<'a> {
-    pub fn new(
-        parameters: Parameters,
-        bytes: &'a [u8],
-    ) -> Result<(Self, &'a [u8]), DecompressionError> {
-        // Safety checks: the `get()` method doesn't perform bounds checking,
-        // so we need to be extra cautious here, including checking for
-        // overflows.
-        if !parameters.valid() {
-            return Err(DecompressionError("invalid parameters".to_string()));
-        }
-        let total_size_bytes = parameters
-            .total_chunks_size_bytes()
-            .and_then(|size| size.checked_add(TAIL_SIZE))
-            .ok_or_else(|| DecompressionError("invalid parameters".to_string()))?;
+/// [`Reader`] bundled with in-memory compressed data.
+#[derive(Clone, Debug)]
+pub struct SliceReader<'a> {
+    reader: Reader,
+    data: &'a [u8],
+}
 
-        let (compressed, bytes) = bytes.split_at_checked(total_size_bytes).ok_or_else(|| {
-            DecompressionError(format!(
-                "insufficient length (compressed data, expected {total_size_bytes} bytes, got {})",
-                bytes.len(),
-            ))
-        })?;
-
-        let result = Self {
-            base_bits: parameters.base_bits,
-            base_mask: make_bitmask(parameters.base_bits),
-            delta_bits: parameters.delta_bits,
-            delta_mask: make_bitmask(parameters.delta_bits),
-            chunk_len_log2: parameters.chunk_len_log2,
-            chunk_len_mask: make_bitmask(parameters.chunk_len_log2),
-            chunk_size_bytes: parameters.chunk_size_bytes().unwrap(),
-            compressed,
-            len: parameters.length.get() as usize,
-        };
-
-        // Safety checks: the `get()` method doesn't perform bounds checking.
-        // The assertions below ensure that the `compressed` slice holds enough
-        // bytes for any index reachable by `get()`.
-        if let Some(max_index) = result.len.checked_sub(1) {
-            let chunk_offset = (max_index >> result.chunk_len_log2) * result.chunk_size_bytes;
-            // *base*
-            assert!(chunk_offset + size_of::<u64>() <= result.compressed.len());
-
-            let max_value_index = result.chunk_len_mask;
-            if max_value_index > 0 {
-                let delta_offset_bits =
-                    result.base_bits as usize + (max_value_index - 1) * result.delta_bits as usize;
-                // *delta*
-                assert!(
-                    chunk_offset + delta_offset_bits / u8::BITS as usize + size_of::<u64>()
-                        <= result.compressed.len()
-                );
-            }
-        }
-
-        Ok((result, bytes))
-    }
-
-    /// Parameters used to compress the data.
-    #[cfg(feature = "testing")]
-    pub fn parameters(&self) -> Parameters {
-        Parameters {
-            length: U64::new(self.len as u64),
-            base_bits: self.base_bits,
-            delta_bits: self.delta_bits,
-            chunk_len_log2: self.chunk_len_log2,
-        }
-    }
-
-    /// The number of values in the decompressed data.
+impl<'a> SliceReader<'a> {
+    /// Read `value[index]..value[index + 1]`. `index + 1` should be less than
+    /// [`Reader::decompressed_len()`].
     #[inline]
-    #[expect(clippy::len_without_is_empty, reason = "len() is cheap")]
-    pub fn len(&self) -> usize {
-        self.len
-    }
-
-    /// Get the value at the given index.
-    #[inline]
-    pub fn get(&self, index: usize) -> Option<u64> {
-        if index >= self.len {
+    pub fn read_pair(&self, index: usize) -> Option<Range<u64>> {
+        // Each pair needs `index + 1`, so the last value is not a valid index.
+        if index >= self.reader.decompressed_len().saturating_sub(1) {
             return None;
         }
-
-        let chunk_offset = (index >> self.chunk_len_log2) * self.chunk_size_bytes;
-        let value_index = index & self.chunk_len_mask;
-        let chunk_ptr = self.compressed.as_ptr().wrapping_add(chunk_offset);
-        // SAFETY: see the *base* comment in `new()`.
-        let base = unsafe { read_u64_le(chunk_ptr) } & self.base_mask;
-        if value_index == 0 {
-            return Some(base);
-        }
-        let delta_offset_bits =
-            self.base_bits as usize + (value_index - 1) * self.delta_bits as usize;
-        // SAFETY: see the *delta* comment in `new()`.
-        let delta = (unsafe { read_u64_le(chunk_ptr.add(delta_offset_bits / u8::BITS as usize)) }
-            >> (delta_offset_bits % u8::BITS as usize))
-            & self.delta_mask;
-        Some(base + delta)
+        let end_index = index + 1;
+        let chunk = &self.data[self.reader.chunk_offset(index)..];
+        let start = self.reader.decode_chunk(index, chunk);
+        let end = if end_index & self.reader.chunk_len_mask != 0 {
+            self.reader.decode_chunk(end_index, chunk)
+        } else {
+            let chunk = &self.data[self.reader.chunk_offset(end_index)..];
+            self.reader.decode_chunk(end_index, chunk)
+        };
+        Some(Range { start, end })
     }
 }
 
-#[inline(always)]
-unsafe fn read_u64_le(ptr: *const u8) -> u64 {
-    unsafe { u64::from_le(ptr.cast::<u64>().read_unaligned()) }
+/// Validated [`Parameters`] with precomputed values, plus the decompression
+/// logic.
+#[derive(Clone, Copy, Debug)]
+pub struct Reader {
+    params: Parameters,
+    base_mask: u64,
+    delta_mask: u64,
+    /// `chunk_len - 1`, i.e. the maximum in-chunk index.
+    chunk_len_mask: usize,
+    chunk_size_bytes: usize,
 }
 
 /// Compression parameters. Required for decompression.
@@ -238,16 +163,33 @@ pub struct Parameters {
 }
 
 impl Parameters {
-    /// Check if the parameters are valid.
-    fn valid(self) -> bool {
-        u32::from(self.base_bits) <= u64::BITS
+    pub fn validate(self) -> Result<Reader, DecompressionError> {
+        let valid = (1..=u64::BITS as u8).contains(&self.base_bits)
             && DELTA_BITS_RANGE.contains(&self.delta_bits)
             && self.chunk_len_log2 <= MAX_CHUNK_LEN_LOG2
+            && self.compressed_size_bytes().is_some();
+        if !valid {
+            return Err(DecompressionError("invalid parameters".to_string()));
+        }
+        Ok(Reader {
+            params: self,
+            base_mask: make_bitmask(self.base_bits),
+            delta_mask: make_bitmask(self.delta_bits),
+            chunk_len_mask: make_bitmask(self.chunk_len_log2),
+            chunk_size_bytes: self.chunk_size_bytes().unwrap(),
+        })
+    }
+
+    /// Size of the compressed data, including the tail.
+    fn compressed_size_bytes(self) -> Option<usize> {
+        let chunks_count = (self.length.get() as usize).div_ceil(1 << self.chunk_len_log2);
+        chunks_count
+            .checked_mul(self.chunk_size_bytes()?)?
+            .checked_add(TAIL_SIZE)
     }
 
     /// Size of a single chunk in bytes.
-    /// Returns `None` on overflow: see safety comments in [`Reader::new()`].
-    #[deny(clippy::arithmetic_side_effects, reason = "extra cautious for safety")]
+    /// Returns `None` on overflow.
     fn chunk_size_bytes(self) -> Option<usize> {
         let bits = (self.base_bits as usize).checked_add(
             (self.delta_bits as usize).checked_mul(make_bitmask::<usize>(self.chunk_len_log2))?,
@@ -255,18 +197,10 @@ impl Parameters {
         Some(bits.div_ceil(u8::BITS as usize))
     }
 
-    /// Size of the compressed data, without the tail.
-    /// Returns `None` on overflow: see safety comments in [`Reader::new()`].
-    #[deny(clippy::arithmetic_side_effects, reason = "extra cautious for safety")]
-    fn total_chunks_size_bytes(self) -> Option<usize> {
-        let chunks_count = (self.length.get() as usize).div_ceil(1 << self.chunk_len_log2);
-        chunks_count.checked_mul(self.chunk_size_bytes()?)
-    }
-
     /// Find the best compression parameters for the given values.
     fn find_best(values: &[u64]) -> Self {
         Self::try_all(values)
-            .min_by_key(|parameters| parameters.total_chunks_size_bytes())
+            .min_by_key(|parameters| parameters.compressed_size_bytes().unwrap())
             .unwrap()
     }
 
@@ -277,7 +211,8 @@ impl Parameters {
             .map(move |chunk_len_log2| {
                 let mut delta_bits = *DELTA_BITS_RANGE.start();
                 for chunk in values.chunks(1 << chunk_len_log2) {
-                    delta_bits = delta_bits.max(packed_bits(chunk.last().unwrap() - chunk[0]));
+                    let delta = chunk.last().unwrap().strict_sub(chunk[0]);
+                    delta_bits = delta_bits.max(packed_bits(delta));
                 }
                 Parameters {
                     length: U64::new(values.len() as u64),
@@ -286,7 +221,100 @@ impl Parameters {
                     chunk_len_log2,
                 }
             })
-            .filter(|parameters| DELTA_BITS_RANGE.contains(&parameters.delta_bits))
+            .filter(|params| DELTA_BITS_RANGE.contains(&params.delta_bits))
+    }
+}
+
+impl Reader {
+    /// Create a [`SliceReader`] from the compressed data slice.
+    pub fn slice_reader(self, bytes: &[u8]) -> Result<SliceReader<'_>, DecompressionError> {
+        let size = self.compressed_size_bytes();
+        let Some(data) = bytes.get(..size) else {
+            return Err(DecompressionError(format!(
+                "insufficient length (compressed data, expected {size} bytes, got {})",
+                bytes.len(),
+            )));
+        };
+        Ok(SliceReader { reader: self, data })
+    }
+
+    /// Number of values in the decompressed data.
+    #[inline]
+    pub fn decompressed_len(self) -> usize {
+        self.params.length.get() as usize
+    }
+
+    /// Size of the compressed data in bytes, including the tail.
+    #[inline]
+    pub fn compressed_size_bytes(self) -> usize {
+        self.params.compressed_size_bytes().unwrap() // Checked by `Parameters::validate`.
+    }
+
+    /// For each `i` in `indices`, read a pair of values:
+    /// `value[i]` and `value[i + 1]`.
+    pub fn read_pairs_iter<'a, S: UniversalRead>(
+        self,
+        storage: &'a S,
+        file_offset: u64,
+        indices: &'a [usize],
+    ) -> UioResult<impl Iterator<Item = UioResult<(usize, Range<u64>)>> + 'a> {
+        // Each range needs `index + 1`, so the last value is not a valid index.
+        let max_index = self.decompressed_len().saturating_sub(1);
+        if let Some(&index) = indices.iter().find(|&&index| index >= max_index) {
+            return Err(UniversalIoError::OutOfBounds {
+                start: index as u64,
+                end: index as u64 + 2,
+                elements: self.decompressed_len(),
+            });
+        }
+
+        // One read per range, from `index`'s chunk through the end of what
+        // `index + 1` needs. Both values share a chunk unless `index` ends one.
+        let chunk_read_len = (self.chunk_size_bytes + TAIL_SIZE) as u64;
+        let items = indices.iter().enumerate().map(move |(position, &index)| {
+            let first = file_offset + self.chunk_offset(index) as u64;
+            let second = file_offset + self.chunk_offset(index + 1) as u64;
+            ReadBytesItem {
+                user_data: (position, index),
+                range: first..second + chunk_read_len,
+                align: 1,
+            }
+        });
+        Ok(storage.read_bytes_iter(items, Random)?.map(move |result| {
+            let ((position, index), chunk) = result?;
+            // `chunk` starts at `index`'s chunk, so locate `index + 1` in it.
+            let second = self.chunk_offset(index + 1) - self.chunk_offset(index);
+            let range = Range {
+                start: self.decode_chunk(index, &chunk),
+                end: self.decode_chunk(index + 1, &chunk[second..]),
+            };
+            Ok((position, range))
+        }))
+    }
+
+    /// Byte offset of the chunk containing the value at `index`.
+    #[inline]
+    fn chunk_offset(self, index: usize) -> usize {
+        (index >> self.params.chunk_len_log2) * self.chunk_size_bytes
+    }
+
+    /// Decode the value at `index` from `chunk`.
+    ///
+    /// The `chunk` must hold at least `chunk_size_bytes + TAIL_SIZE` bytes.
+    /// The `index` must be less than [`Self::decompressed_len()`].
+    #[inline]
+    fn decode_chunk(self, index: usize, chunk: &[u8]) -> u64 {
+        let word = |offset: usize| u64::from_le_bytes(*chunk[offset..].first_chunk().unwrap());
+        let base = word(0) & self.base_mask;
+        if let Some(delta_index) = (index & self.chunk_len_mask).checked_sub(1) {
+            let bits =
+                self.params.base_bits as usize + delta_index * self.params.delta_bits as usize;
+            let delta =
+                (word(bits / u8::BITS as usize) >> (bits % u8::BITS as usize)) & self.delta_mask;
+            base + delta
+        } else {
+            base
+        }
     }
 }
 
@@ -311,19 +339,46 @@ mod tests {
     use rand::{RngExt, SeedableRng};
 
     use super::*;
+    use crate::universal_io::{MmapFs, OpenOptions, UniversalReadFs as _};
 
     #[test]
     fn test_compress_decompress() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let file = file.path();
+
         for values in test_sequences() {
-            for parameters in Parameters::try_all(&values) {
-                let compressed = compress_with_parameters(&values, parameters);
-                let (decompressor, bytes) = Reader::new(parameters, &compressed).unwrap();
-                assert!(bytes.is_empty());
-                assert_eq!(decompressor.len(), values.len());
-                for (i, &value) in values.iter().enumerate() {
-                    assert_eq!(decompressor.get(i), Some(value));
+            for params in Parameters::try_all(&values) {
+                let reader = params.validate().unwrap();
+                let compressed = compress_with_parameters(&values, params);
+                assert_eq!(reader.decompressed_len(), values.len());
+                assert_eq!(params.compressed_size_bytes(), Some(compressed.len()));
+
+                let expected = values
+                    .windows(2)
+                    .map(|pair| Range::from(pair[0]..pair[1]))
+                    .collect::<Vec<_>>();
+                let oob = values.len().saturating_sub(1); // the last value starts no pair
+
+                // SliceReader::read_pair
+                let slice_reader = reader.slice_reader(&compressed).unwrap();
+                for (index, &expected) in expected.iter().enumerate() {
+                    assert_eq!(slice_reader.read_pair(index), Some(expected));
                 }
-                assert_eq!(decompressor.get(values.len()), None);
+                assert_eq!(slice_reader.read_pair(oob), None);
+
+                // Reader::read_pairs_iter
+                let unrelated_data = [0xAA; 3]; // for `file_offset` testing
+                fs_err::write(file, [&unrelated_data[..], &compressed].concat()).unwrap();
+                let storage = MmapFs.open(file, OpenOptions::new_for_test(), ()).unwrap();
+                let offset = unrelated_data.len() as u64;
+                let indices = (0..expected.len()).collect::<Vec<_>>();
+                let mut out = vec![Range::from(1234..12345); expected.len()];
+                for result in reader.read_pairs_iter(&storage, offset, &indices).unwrap() {
+                    let (position, range) = result.unwrap();
+                    out[position] = range;
+                }
+                assert_eq!(out, expected);
+                assert!(reader.read_pairs_iter(&storage, offset, &[oob]).is_err());
             }
         }
     }

--- a/lib/common/common/src/bitpacking_ordered.rs
+++ b/lib/common/common/src/bitpacking_ordered.rs
@@ -39,7 +39,6 @@
 //! - `bitpad` is a bit padding (0..7 bits) so the chunk is byte-aligned.
 
 use std::ops::RangeInclusive;
-use std::range::Range;
 
 use thiserror::Error;
 use zerocopy::little_endian::U64;
@@ -115,10 +114,10 @@ pub struct SliceReader<'a> {
 }
 
 impl<'a> SliceReader<'a> {
-    /// Read `value[index]..value[index + 1]`. `index + 1` should be less than
-    /// [`Reader::decompressed_len()`].
+    /// Read `value[index]` and `value[index + 1]`. `index + 1` should be less
+    /// than [`Reader::decompressed_len()`].
     #[inline]
-    pub fn read_pair(&self, index: usize) -> Option<Range<u64>> {
+    pub fn read_pair(&self, index: usize) -> Option<(u64, u64)> {
         // Each pair needs `index + 1`, so the last value is not a valid index.
         if index >= self.reader.decompressed_len().saturating_sub(1) {
             return None;
@@ -132,7 +131,7 @@ impl<'a> SliceReader<'a> {
             let chunk = &self.data[self.reader.chunk_offset(end_index)..];
             self.reader.decode_chunk(end_index, chunk)
         };
-        Some(Range { start, end })
+        Some((start, end))
     }
 }
 
@@ -257,8 +256,8 @@ impl Reader {
         storage: &'a S,
         file_offset: u64,
         indices: &'a [usize],
-    ) -> UioResult<impl Iterator<Item = UioResult<(usize, Range<u64>)>> + 'a> {
-        // Each range needs `index + 1`, so the last value is not a valid index.
+    ) -> UioResult<impl Iterator<Item = UioResult<(usize, (u64, u64))>> + 'a> {
+        // Each pair needs `index + 1`, so the last value is not a valid index.
         let max_index = self.decompressed_len().saturating_sub(1);
         if let Some(&index) = indices.iter().find(|&&index| index >= max_index) {
             return Err(UniversalIoError::OutOfBounds {
@@ -268,7 +267,7 @@ impl Reader {
             });
         }
 
-        // One read per range, from `index`'s chunk through the end of what
+        // One read per pair, from `index`'s chunk through the end of what
         // `index + 1` needs. Both values share a chunk unless `index` ends one.
         let chunk_read_len = (self.chunk_size_bytes + TAIL_SIZE) as u64;
         let items = indices.iter().enumerate().map(move |(position, &index)| {
@@ -284,11 +283,9 @@ impl Reader {
             let ((position, index), chunk) = result?;
             // `chunk` starts at `index`'s chunk, so locate `index + 1` in it.
             let second = self.chunk_offset(index + 1) - self.chunk_offset(index);
-            let range = Range {
-                start: self.decode_chunk(index, &chunk),
-                end: self.decode_chunk(index + 1, &chunk[second..]),
-            };
-            Ok((position, range))
+            let start = self.decode_chunk(index, &chunk);
+            let end = self.decode_chunk(index + 1, &chunk[second..]);
+            Ok((position, (start, end)))
         }))
     }
 
@@ -335,6 +332,7 @@ pub fn gen_test_sequence(rng: &mut impl rand::Rng, max_delta: u64, len: usize) -
 mod tests {
     use std::iter::{once, once_with};
 
+    use itertools::Itertools;
     use rand::rngs::StdRng;
     use rand::{RngExt, SeedableRng};
 
@@ -353,10 +351,7 @@ mod tests {
                 assert_eq!(reader.decompressed_len(), values.len());
                 assert_eq!(params.compressed_size_bytes(), Some(compressed.len()));
 
-                let expected = values
-                    .windows(2)
-                    .map(|pair| Range::from(pair[0]..pair[1]))
-                    .collect::<Vec<_>>();
+                let expected = values.iter().copied().tuple_windows().collect::<Vec<_>>();
                 let oob = values.len().saturating_sub(1); // the last value starts no pair
 
                 // SliceReader::read_pair
@@ -372,10 +367,10 @@ mod tests {
                 let storage = MmapFs.open(file, OpenOptions::new_for_test(), ()).unwrap();
                 let offset = unrelated_data.len() as u64;
                 let indices = (0..expected.len()).collect::<Vec<_>>();
-                let mut out = vec![Range::from(1234..12345); expected.len()];
+                let mut out = vec![(1234, 12345); expected.len()];
                 for result in reader.read_pairs_iter(&storage, offset, &indices).unwrap() {
-                    let (position, range) = result.unwrap();
-                    out[position] = range;
+                    let (position, pair) = result.unwrap();
+                    out[position] = pair;
                 }
                 assert_eq!(out, expected);
                 assert!(reader.read_pairs_iter(&storage, offset, &[oob]).is_err());

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use atomicwrites::Error as AtomicIoError;
 use blobstore::error::BlobstoreError;
+use common::bitpacking_ordered::DecompressionError;
 use common::mmap::Error as MmapError;
 use common::universal_io::{IsNotFound, UniversalIoError};
 use rayon::ThreadPoolBuildError;
@@ -225,6 +226,12 @@ pub struct SegmentFailedState {
 impl From<ThreadPoolBuildError> for OperationError {
     fn from(error: ThreadPoolBuildError) -> Self {
         Self::service_error(error.to_string())
+    }
+}
+
+impl From<DecompressionError> for OperationError {
+    fn from(err: DecompressionError) -> Self {
+        Self::service_error(err.to_string())
     }
 }
 

--- a/lib/segment/src/index/hnsw_index/graph_links/view.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/view.rs
@@ -70,7 +70,7 @@ pub(super) enum CompressionInfo<'a> {
         /// Where
         /// 1. `c` are compressed links (i.e. a compressed form of `Vec<u32>`).
         neighbors: &'a [u8],
-        offsets: bitpacking_ordered::Reader<'a>,
+        offsets: bitpacking_ordered::SliceReader<'a>,
         hnsw_m: HnswM,
         bits_per_unsorted: u8,
     },
@@ -96,7 +96,7 @@ pub(super) enum CompressionInfo<'a> {
         /// 6. `_` is a padding to make the next base vector aligned.
         ///    Only present on level 0, omitted on higher levels.
         neighbors: &'a [u8],
-        offsets: bitpacking_ordered::Reader<'a>,
+        offsets: bitpacking_ordered::SliceReader<'a>,
         hnsw_m: HnswM,
         bits_per_unsorted: u8,
         base_vector_layout: Layout,
@@ -145,10 +145,7 @@ impl GraphLinksView<'_> {
         )?;
         let (reindex, data) = get_slice::<PointOffsetType>(data, header.point_count.get())?;
         let (neighbors, data) = get_slice::<u8>(data, header.total_neighbors_bytes.get())?;
-        let (offsets, _bytes) = bitpacking_ordered::Reader::new(header.offsets_parameters, data)
-            .map_err(|e| {
-                OperationError::service_error(format!("Can't create decompressor: {e}"))
-            })?;
+        let offsets = header.offsets_parameters.validate()?.slice_reader(data)?;
         Ok(GraphLinksView {
             reindex,
             compression: CompressionInfo::Compressed {
@@ -187,10 +184,7 @@ impl GraphLinksView<'_> {
             (pos.next_multiple_of(alignment) - pos) as u64
         })?;
         let (neighbors, data) = get_slice::<u8>(data, header.total_neighbors_bytes.get())?;
-        let (offsets, _bytes) = bitpacking_ordered::Reader::new(header.offsets_parameters, data)
-            .map_err(|e| {
-                OperationError::service_error(format!("Can't create decompressor: {e}"))
-            })?;
+        let offsets = header.offsets_parameters.validate()?.slice_reader(data)?;
         Ok(GraphLinksView {
             reindex,
             compression: CompressionInfo::CompressedWithVectors {
@@ -231,7 +225,7 @@ impl GraphLinksView<'_> {
                 offsets[idx].get() == offsets[idx + 1].get()
             }
             CompressionInfo::Compressed { ref offsets, .. } => {
-                offsets.get(idx + 1).unwrap() == offsets.get(idx).unwrap()
+                offsets.read_pair(idx).unwrap().is_empty()
             }
             CompressionInfo::CompressedWithVectors { .. } => {
                 // Not intended to be used outside of tests.
@@ -253,10 +247,9 @@ impl GraphLinksView<'_> {
                 ref hnsw_m,
                 bits_per_unsorted,
             } => {
-                let neighbors_range =
-                    offsets.get(idx).unwrap() as usize..offsets.get(idx + 1).unwrap() as usize;
+                let range = offsets.read_pair(idx).unwrap();
                 Either::Right(iterate_packed_links(
-                    &neighbors[neighbors_range],
+                    &neighbors[range.start as usize..range.end as usize],
                     bits_per_unsorted,
                     hnsw_m.level_m(level),
                 ))
@@ -301,8 +294,8 @@ impl GraphLinksView<'_> {
                 link_vector_size,
                 link_vector_alignment,
             } => {
-                let start = offsets.get(idx).unwrap() as usize;
-                let end = offsets.get(idx + 1).unwrap() as usize;
+                let range = offsets.read_pair(idx).unwrap();
+                let (start, end) = (range.start as usize, range.end as usize);
 
                 common::mmap::advice::will_need_multiple_pages(&neighbors[start..end]);
 
@@ -402,6 +395,6 @@ fn get_slice<T: FromBytes + Immutable>(data: &[u8], length: u64) -> OperationRes
     <[T]>::ref_from_prefix_with_elems(data, length as usize).map_err(|_| error_unsufficent_size())
 }
 
-fn error_unsufficent_size() -> OperationError {
+pub(super) fn error_unsufficent_size() -> OperationError {
     OperationError::service_error("Unsufficent file size for GraphLinks file")
 }

--- a/lib/segment/src/index/hnsw_index/graph_links/view.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/view.rs
@@ -225,7 +225,8 @@ impl GraphLinksView<'_> {
                 offsets[idx].get() == offsets[idx + 1].get()
             }
             CompressionInfo::Compressed { ref offsets, .. } => {
-                offsets.read_pair(idx).unwrap().is_empty()
+                let (start, end) = offsets.read_pair(idx).unwrap();
+                start == end
             }
             CompressionInfo::CompressedWithVectors { .. } => {
                 // Not intended to be used outside of tests.
@@ -247,9 +248,9 @@ impl GraphLinksView<'_> {
                 ref hnsw_m,
                 bits_per_unsorted,
             } => {
-                let range = offsets.read_pair(idx).unwrap();
+                let (start, end) = offsets.read_pair(idx).unwrap();
                 Either::Right(iterate_packed_links(
-                    &neighbors[range.start as usize..range.end as usize],
+                    &neighbors[start as usize..end as usize],
                     bits_per_unsorted,
                     hnsw_m.level_m(level),
                 ))
@@ -294,8 +295,8 @@ impl GraphLinksView<'_> {
                 link_vector_size,
                 link_vector_alignment,
             } => {
-                let range = offsets.read_pair(idx).unwrap();
-                let (start, end) = (range.start as usize, range.end as usize);
+                let (start, end) = offsets.read_pair(idx).unwrap();
+                let (start, end) = (start as usize, end as usize);
 
                 common::mmap::advice::will_need_multiple_pages(&neighbors[start..end]);
 

--- a/lib/segment/src/index/hnsw_index/graph_links/view.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/view.rs
@@ -120,7 +120,7 @@ impl GraphLinksView<'_> {
 
     fn load_plain(data: &[u8]) -> OperationResult<GraphLinksView<'_>> {
         let (header, data) =
-            HeaderPlain::ref_from_prefix(data).map_err(|_| error_unsufficent_size())?;
+            HeaderPlain::ref_from_prefix(data).map_err(|_| error_insufficient_size())?;
         let (level_offsets, data) =
             read_level_offsets(data, header.levels_count, header.total_offset_count)?;
         let (reindex, data) = get_slice::<PointOffsetType>(data, header.point_count)?;
@@ -136,7 +136,7 @@ impl GraphLinksView<'_> {
 
     fn load_compressed(data: &[u8]) -> OperationResult<GraphLinksView<'_>> {
         let (header, data) =
-            HeaderCompressed::ref_from_prefix(data).map_err(|_| error_unsufficent_size())?;
+            HeaderCompressed::ref_from_prefix(data).map_err(|_| error_insufficient_size())?;
         debug_assert_eq!(header.version.get(), HEADER_VERSION_COMPRESSED);
         let (level_offsets, data) = read_level_offsets(
             data,
@@ -166,7 +166,7 @@ impl GraphLinksView<'_> {
         let total_len = data.len();
 
         let (header, data) = HeaderCompressedWithVectors::ref_from_prefix(data)
-            .map_err(|_| error_unsufficent_size())?;
+            .map_err(|_| error_insufficient_size())?;
         debug_assert_eq!(header.version.get(), HEADER_VERSION_COMPRESSED_WITH_VECTORS);
 
         let base_vector_layout = header.base_vector_layout.try_into_layout()?;
@@ -393,9 +393,9 @@ fn read_level_offsets(
 }
 
 fn get_slice<T: FromBytes + Immutable>(data: &[u8], length: u64) -> OperationResult<(&[T], &[u8])> {
-    <[T]>::ref_from_prefix_with_elems(data, length as usize).map_err(|_| error_unsufficent_size())
+    <[T]>::ref_from_prefix_with_elems(data, length as usize).map_err(|_| error_insufficient_size())
 }
 
-pub(super) fn error_unsufficent_size() -> OperationError {
-    OperationError::service_error("Unsufficent file size for GraphLinks file")
+fn error_insufficient_size() -> OperationError {
+    OperationError::service_error("Insufficient file size for GraphLinks file")
 }


### PR DESCRIPTION
Preparation for #10010.

`bitpacking_ordered` is used to store file offsets in the HNSW graph file.
This PR adapts `bitpacking_ordered::Reader` so it can be both used in in-memory HNSW and UIO.

Before this PR we had this `bitpacking_ordered::Reader`:
```rust
// Holds `compressed: &'a [u8]` and compression parameters.
struct Reader<'a> { … }

impl Reader {
    // Get single value.
    // Uses unsafe inside to avoid excessive boundary checks.
    fn get(self, &index) -> usize;
}
```

After this PR:
```rust
// Holds only compression parameters, agnostic to the storage.
struct Reader { … }

// Behaves like the old `Reader`.
struct SliceReader<'a>(Reader, &'a [u8]);

impl SliceReader {
    // Used instead of old Reader::get().
    // Now returns a pair of values. No unsafe.
    fn read_pair(self, &index) -> Range<usize>;
}

impl Reader {
    pub fn read_pairs_iter(
        &self,
        s: &impl UniversalRead,
        indices: &[usize],
    ) -> UioResult<impl Iterator<…>>;
}
```

Notes:
- Removing `unsafe` from `Reader::get()` costs us ~60% of its performance on `bitpacking` micro-benchmarks.
- New interface returns pairs, not single values. (`get` -> `read_pair`)
  When using it for file offsets, we want to read pairs anyway.
  Specialized `read_pair` instead of two calls to `get()` reclaims a bit of performance back (so, only ~30% slower).
- But given that `bitpacking_ordered` is not the hottest part of HNSW search, the observable slowdown is ~0.5% in the worst case (on vector-db-benchmark).
- OTOH, after removing `unsafe`, the code can be less paranoid about safety invariants (search for `safety` or `#[deny` in the old code).
- `SliceReader` is integrated into HNSW search. The UIO version is not used yet.