### PR TITLE
[Raw payloads]: read payload as stored bytes in retrieve_raw

### DIFF
--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -25,7 +25,7 @@ use segment::index::query_optimization::rescore_formula::parsed_formula::{
     DatetimeExpression, DecayKind, ParsedExpression, ParsedFormula,
 };
 use segment::types::{
-    DateTimePayloadType, FloatPayloadType, RawPayload, RawPayloadEncoding, VectorStorageDatatype,
+    DateTimePayloadType, FloatPayloadType, RawPayload, VectorStorageDatatype,
     default_quantization_ignore_value,
 };
 use segment::vector_storage::query::{self as segment_query, NaiveFeedbackCoefficients};
@@ -3705,14 +3705,6 @@ impl From<Modifier> for grpc::Modifier {
     }
 }
 
-impl From<grpc::RawPayloadEncoding> for RawPayloadEncoding {
-    fn from(value: grpc::RawPayloadEncoding) -> Self {
-        match value {
-            grpc::RawPayloadEncoding::JsonBytes => RawPayloadEncoding::JsonBytes,
-        }
-    }
-}
-
 impl TryFrom<grpc::RawPayload> for RawPayload {
     type Error = Status;
 
@@ -3722,15 +3714,12 @@ impl TryFrom<grpc::RawPayload> for RawPayload {
             encoding,
         } = value;
 
-        // A number no variant maps to comes from a node that encodes payloads in
-        // a way this one does not know, which must not be read as the default.
         let encoding = grpc::RawPayloadEncoding::try_from(encoding)
             .map_err(|_| Status::invalid_argument("Unknown raw payload encoding"))?;
 
-        Ok(Self {
-            payload_bytes,
-            encoding: RawPayloadEncoding::from(encoding),
-        })
+        match encoding {
+            grpc::RawPayloadEncoding::JsonBytes => Ok(Self { payload_bytes }),
+        }
     }
 }
 

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -25,7 +25,8 @@ use segment::index::query_optimization::rescore_formula::parsed_formula::{
     DatetimeExpression, DecayKind, ParsedExpression, ParsedFormula,
 };
 use segment::types::{
-    DateTimePayloadType, FloatPayloadType, VectorStorageDatatype, default_quantization_ignore_value,
+    DateTimePayloadType, FloatPayloadType, RawPayload, RawPayloadEncoding, VectorStorageDatatype,
+    default_quantization_ignore_value,
 };
 use segment::vector_storage::query::{self as segment_query, NaiveFeedbackCoefficients};
 use sparse::common::sparse_vector::validate_sparse_vector_impl;
@@ -3701,6 +3702,35 @@ impl From<Modifier> for grpc::Modifier {
             Modifier::None => grpc::Modifier::None,
             Modifier::Idf => grpc::Modifier::Idf,
         }
+    }
+}
+
+impl From<grpc::RawPayloadEncoding> for RawPayloadEncoding {
+    fn from(value: grpc::RawPayloadEncoding) -> Self {
+        match value {
+            grpc::RawPayloadEncoding::JsonBytes => RawPayloadEncoding::JsonBytes,
+        }
+    }
+}
+
+impl TryFrom<grpc::RawPayload> for RawPayload {
+    type Error = Status;
+
+    fn try_from(value: grpc::RawPayload) -> Result<Self, Self::Error> {
+        let grpc::RawPayload {
+            payload_bytes,
+            encoding,
+        } = value;
+
+        // A number no variant maps to comes from a node that encodes payloads in
+        // a way this one does not know, which must not be read as the default.
+        let encoding = grpc::RawPayloadEncoding::try_from(encoding)
+            .map_err(|_| Status::invalid_argument("Unknown raw payload encoding"))?;
+
+        Ok(Self {
+            payload_bytes,
+            encoding: RawPayloadEncoding::from(encoding),
+        })
     }
 }
 

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -12,7 +12,7 @@ use ordered_float::Float;
 use segment::common::operation_error::OperationError;
 use segment::data_types::modifier::Modifier;
 use segment::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use segment::data_types::segment_record::SegmentRecordRaw;
+use segment::data_types::segment_record::{RawPayloadFormat, SegmentRecordRaw};
 use segment::data_types::vectors::QueryVector;
 use segment::types::{
     Filter, Indexes, PointIdType, ScoredPoint, SearchParams, SegmentConfig, VectorName,
@@ -425,7 +425,7 @@ impl SegmentsSearcher {
     pub async fn retrieve_raw(
         segments: LockedSegmentHolder,
         points: &[PointIdType],
-        with_payload: &WithPayload,
+        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         runtime_handle: &AdaptiveSearchHandle,
         timeout: Duration,
@@ -436,14 +436,13 @@ impl SegmentsSearcher {
         let points = runtime_handle.spawn_blocking({
             let segments = segments.clone();
             let points = points.to_vec();
-            let with_payload = with_payload.clone();
             let with_vector = with_vector.clone();
             let is_stopped = stopping_guard.get_is_stopped();
             move || {
                 retrieve_raw_blocking(
                     segments,
                     &points,
-                    &with_payload,
+                    payload_format,
                     &with_vector,
                     timeout,
                     &is_stopped,

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -12,7 +12,7 @@ use ordered_float::Float;
 use segment::common::operation_error::OperationError;
 use segment::data_types::modifier::Modifier;
 use segment::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use segment::data_types::segment_record::{RawPayloadFormat, SegmentRecordRaw};
+use segment::data_types::segment_record::SegmentRecordRaw;
 use segment::data_types::vectors::QueryVector;
 use segment::types::{
     Filter, Indexes, PointIdType, ScoredPoint, SearchParams, SegmentConfig, VectorName,
@@ -425,7 +425,6 @@ impl SegmentsSearcher {
     pub async fn retrieve_raw(
         segments: LockedSegmentHolder,
         points: &[PointIdType],
-        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         runtime_handle: &AdaptiveSearchHandle,
         timeout: Duration,
@@ -442,7 +441,6 @@ impl SegmentsSearcher {
                 retrieve_raw_blocking(
                     segments,
                     &points,
-                    payload_format,
                     &with_vector,
                     timeout,
                     &is_stopped,

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -9,7 +9,6 @@ use common::tar_ext;
 use common::types::{DeferredBehavior, TelemetryDetail};
 use parking_lot::Mutex as ParkingMutex;
 use segment::data_types::facets::{FacetParams, FacetResponse};
-use segment::data_types::segment_record::RawPayloadFormat;
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{
     ExtendedPointId, Filter, PointIdType, ScoredPoint, SizeStats, SnapshotFormat, StrictModeConfig,
@@ -455,7 +454,6 @@ impl ForwardProxyShard {
             .local_scroll_by_id_raw(
                 offset,
                 limit,
-                RawPayloadFormat::Parsed,
                 &WithVector::Bool(true),
                 filter,
                 runtime_handle,
@@ -521,7 +519,6 @@ impl ForwardProxyShard {
             .wrapped_shard
             .retrieve_raw(
                 &ids,
-                RawPayloadFormat::Parsed,
                 &WithVector::Bool(true),
                 runtime_handle,
                 None,                           // No timeout

--- a/lib/collection/src/shards/forward_proxy_shard.rs
+++ b/lib/collection/src/shards/forward_proxy_shard.rs
@@ -9,6 +9,7 @@ use common::tar_ext;
 use common::types::{DeferredBehavior, TelemetryDetail};
 use parking_lot::Mutex as ParkingMutex;
 use segment::data_types::facets::{FacetParams, FacetResponse};
+use segment::data_types::segment_record::RawPayloadFormat;
 use segment::index::field_index::CardinalityEstimation;
 use segment::types::{
     ExtendedPointId, Filter, PointIdType, ScoredPoint, SizeStats, SnapshotFormat, StrictModeConfig,
@@ -454,7 +455,7 @@ impl ForwardProxyShard {
             .local_scroll_by_id_raw(
                 offset,
                 limit,
-                &WithPayloadInterface::Bool(true),
+                RawPayloadFormat::Parsed,
                 &WithVector::Bool(true),
                 filter,
                 runtime_handle,
@@ -520,7 +521,7 @@ impl ForwardProxyShard {
             .wrapped_shard
             .retrieve_raw(
                 &ids,
-                &WithPayload::from(true),
+                RawPayloadFormat::Parsed,
                 &WithVector::Bool(true),
                 runtime_handle,
                 None,                           // No timeout

--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -12,6 +12,7 @@ use rand::distr::weighted::WeightedIndex;
 use rand::rngs::StdRng;
 use segment::common::operation_error::OperationResult;
 use segment::data_types::order_by::{Direction, OrderBy};
+use segment::data_types::segment_record::RawPayloadFormat;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
 };
@@ -241,7 +242,7 @@ impl LocalShard {
         &self,
         offset: Option<ExtendedPointId>,
         limit: usize,
-        with_payload_interface: &WithPayloadInterface,
+        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         filter: Option<&Filter>,
         search_runtime_handle: &AdaptiveSearchHandle,
@@ -302,7 +303,6 @@ impl LocalShard {
             .into_iter()
             .process_results(|iter| iter.flatten().sorted().dedup().take(limit).collect_vec())?;
 
-        let with_payload = WithPayload::from(with_payload_interface);
         // update timeout
         let timeout = timeout.saturating_sub(start.elapsed());
         let mut records_map = tokio::time::timeout(
@@ -310,7 +310,7 @@ impl LocalShard {
             SegmentsSearcher::retrieve_raw(
                 segments,
                 &point_ids,
-                &with_payload,
+                payload_format,
                 with_vector,
                 search_runtime_handle,
                 timeout,
@@ -327,8 +327,8 @@ impl LocalShard {
             .iter()
             // Use remove to avoid cloning, we take each point ID only once
             .filter_map(|point_id| records_map.remove(point_id))
-            .map(PointStructRawPersisted::from)
-            .collect();
+            .map(PointStructRawPersisted::try_from)
+            .collect::<Result<_, _>>()?;
 
         Ok(ordered_records)
     }

--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -12,7 +12,6 @@ use rand::distr::weighted::WeightedIndex;
 use rand::rngs::StdRng;
 use segment::common::operation_error::OperationResult;
 use segment::data_types::order_by::{Direction, OrderBy};
-use segment::data_types::segment_record::RawPayloadFormat;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
 };
@@ -242,7 +241,6 @@ impl LocalShard {
         &self,
         offset: Option<ExtendedPointId>,
         limit: usize,
-        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         filter: Option<&Filter>,
         search_runtime_handle: &AdaptiveSearchHandle,
@@ -310,7 +308,6 @@ impl LocalShard {
             SegmentsSearcher::retrieve_raw(
                 segments,
                 &point_ids,
-                payload_format,
                 with_vector,
                 search_runtime_handle,
                 timeout,

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -6,6 +6,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::types::DeferredBehavior;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
+use segment::data_types::segment_record::RawPayloadFormat;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
 };
@@ -627,7 +628,7 @@ impl LocalShard {
     pub async fn retrieve_raw(
         &self,
         ids: &[ExtendedPointId],
-        with_payload: &WithPayload,
+        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         search_runtime_handle: &AdaptiveSearchHandle,
         timeout: Option<Duration>,
@@ -640,7 +641,7 @@ impl LocalShard {
             SegmentsSearcher::retrieve_raw(
                 self.segments.clone(),
                 ids,
-                with_payload,
+                payload_format,
                 with_vector,
                 search_runtime_handle,
                 timeout,
@@ -655,8 +656,8 @@ impl LocalShard {
             .iter()
             // Use remove to avoid cloning, we take each point ID only once
             .filter_map(|id| records_map.remove(id))
-            .map(PointStructRawPersisted::from)
-            .collect();
+            .map(PointStructRawPersisted::try_from)
+            .collect::<Result<_, _>>()?;
 
         Ok(ordered_records)
     }
@@ -668,7 +669,7 @@ impl LocalShard {
         &self,
         offset: Option<ExtendedPointId>,
         limit: usize,
-        with_payload_interface: &WithPayloadInterface,
+        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         filter: Option<&Filter>,
         search_runtime_handle: &AdaptiveSearchHandle,
@@ -680,7 +681,7 @@ impl LocalShard {
         self.internal_scroll_by_id_raw(
             offset,
             limit,
-            with_payload_interface,
+            payload_format,
             with_vector,
             filter,
             search_runtime_handle,

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -6,7 +6,6 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::types::DeferredBehavior;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
-use segment::data_types::segment_record::RawPayloadFormat;
 use segment::types::{
     ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
 };
@@ -624,11 +623,9 @@ impl LocalShard {
     /// Byte-blob analogue of [`ShardOperation::retrieve`] for an explicit id set:
     /// returns storage-native raw vector bytes for shard transfer. Preserves
     /// input id order and silently drops ids not found (like `retrieve`).
-    #[allow(clippy::too_many_arguments)]
     pub async fn retrieve_raw(
         &self,
         ids: &[ExtendedPointId],
-        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         search_runtime_handle: &AdaptiveSearchHandle,
         timeout: Option<Duration>,
@@ -641,7 +638,6 @@ impl LocalShard {
             SegmentsSearcher::retrieve_raw(
                 self.segments.clone(),
                 ids,
-                payload_format,
                 with_vector,
                 search_runtime_handle,
                 timeout,
@@ -669,7 +665,6 @@ impl LocalShard {
         &self,
         offset: Option<ExtendedPointId>,
         limit: usize,
-        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         filter: Option<&Filter>,
         search_runtime_handle: &AdaptiveSearchHandle,
@@ -681,7 +676,6 @@ impl LocalShard {
         self.internal_scroll_by_id_raw(
             offset,
             limit,
-            payload_format,
             with_vector,
             filter,
             search_runtime_handle,

--- a/lib/segment/src/data_types/segment_record.rs
+++ b/lib/segment/src/data_types/segment_record.rs
@@ -1,7 +1,7 @@
 use smallvec::SmallVec;
 
 use crate::data_types::vectors::VectorInternal;
-use crate::types::{Payload, PointIdType, VectorNameBuf};
+use crate::types::{MaybeRawPayload, Payload, PointIdType, VectorNameBuf};
 
 /// A point almost always has a single (default) named vector, so keep it inline
 /// to avoid a heap allocation on the common retrieve path.
@@ -17,9 +17,29 @@ pub struct SegmentRecord {
     pub payload: Option<Payload>,
 }
 
-/// Byte-blob analogue of [`SegmentRecord`].
+/// Byte-blob analogue of [`SegmentRecord`]: vectors as stored, so a reader that
+/// only relocates the point does not decode them.
 pub struct SegmentRecordRaw {
     pub id: PointIdType,
     pub vectors: Option<NamedVectorBytesOwned>,
-    pub payload: Option<Payload>,
+    /// The payload in the form [`RawPayloadFormat`] asked for, or parsed if the
+    /// storage could not answer with a blob — see [`MaybeRawPayload`].
+    pub payload: Option<MaybeRawPayload>,
+}
+
+/// What a raw retrieval should do about the payload.
+///
+/// The caller states what it wants; [`MaybeRawPayload`] states what it got,
+/// which can differ only in one direction: a storage that keeps payloads parsed
+/// cannot answer [`Self::Raw`] with a blob.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RawPayloadFormat {
+    /// Do not read the payload at all.
+    #[default]
+    NoPayload,
+    /// Read it parsed, as [`SegmentRecord`] carries it.
+    Parsed,
+    /// Read it as stored, sparing both a parse here and an encode wherever the
+    /// payload is going.
+    Raw,
 }

--- a/lib/segment/src/data_types/segment_record.rs
+++ b/lib/segment/src/data_types/segment_record.rs
@@ -22,7 +22,5 @@ pub struct SegmentRecord {
 pub struct SegmentRecordRaw {
     pub id: PointIdType,
     pub vectors: Option<NamedVectorBytesOwned>,
-    /// The payload as stored, sparing both a parse here and an encode wherever
-    /// it is going. `None` when the point has no payload stored.
     pub payload: Option<RawPayload>,
 }

--- a/lib/segment/src/data_types/segment_record.rs
+++ b/lib/segment/src/data_types/segment_record.rs
@@ -1,7 +1,7 @@
 use smallvec::SmallVec;
 
 use crate::data_types::vectors::VectorInternal;
-use crate::types::{MaybeRawPayload, Payload, PointIdType, VectorNameBuf};
+use crate::types::{Payload, PointIdType, RawPayload, VectorNameBuf};
 
 /// A point almost always has a single (default) named vector, so keep it inline
 /// to avoid a heap allocation on the common retrieve path.
@@ -17,29 +17,12 @@ pub struct SegmentRecord {
     pub payload: Option<Payload>,
 }
 
-/// Byte-blob analogue of [`SegmentRecord`]: vectors as stored, so a reader that
-/// only relocates the point does not decode them.
+/// Byte-blob analogue of [`SegmentRecord`]: vectors and payload as stored, so a
+/// reader that only relocates the point does not decode them.
 pub struct SegmentRecordRaw {
     pub id: PointIdType,
     pub vectors: Option<NamedVectorBytesOwned>,
-    /// The payload in the form [`RawPayloadFormat`] asked for, or parsed if the
-    /// storage could not answer with a blob — see [`MaybeRawPayload`].
-    pub payload: Option<MaybeRawPayload>,
-}
-
-/// What a raw retrieval should do about the payload.
-///
-/// The caller states what it wants; [`MaybeRawPayload`] states what it got,
-/// which can differ only in one direction: a storage that keeps payloads parsed
-/// cannot answer [`Self::Raw`] with a blob.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum RawPayloadFormat {
-    /// Do not read the payload at all.
-    #[default]
-    NoPayload,
-    /// Read it parsed, as [`SegmentRecord`] carries it.
-    Parsed,
-    /// Read it as stored, sparing both a parse here and an encode wherever the
-    /// payload is going.
-    Raw,
+    /// The payload as stored, sparing both a parse here and an encode wherever
+    /// it is going. `None` when the point has no payload stored.
+    pub payload: Option<RawPayload>,
 }

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -107,9 +107,6 @@ pub trait ReadSegmentEntry {
     /// a needless parse when relocating points (copy-on-write moves, shard
     /// transfer). A caller that needs the parsed payload decodes it itself.
     ///
-    /// The payload always comes along, and whole: keys cannot be selected out of
-    /// an opaque blob, which is `retrieve`'s business.
-    ///
     /// Like `retrieve`, may return fewer records than requested and in any order.
     fn retrieve_raw(
         &self,

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -15,7 +15,7 @@ use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use crate::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
+use crate::data_types::segment_record::{RawPayloadFormat, SegmentRecord, SegmentRecordRaw};
 use crate::data_types::vector_name_config::VectorNameConfig;
 use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::entry::snapshot_entry::SnapshotEntry;
@@ -102,15 +102,19 @@ pub trait ReadSegmentEntry {
         deferred_behavior: DeferredBehavior,
     ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecord>>;
 
-    /// Byte-blob analogue of [`ReadSegmentEntry::retrieve`]: returns vectors as
-    /// storage-native bytes ([`SegmentRecordRaw`]) to avoid a lossy round-trip
-    /// when relocating points (copy-on-write moves, shard transfer).
+    /// Byte-blob analogue of [`ReadSegmentEntry::retrieve`]: returns vectors and
+    /// payload as stored ([`SegmentRecordRaw`]), to avoid a lossy round-trip and
+    /// a needless parse when relocating points (copy-on-write moves, shard
+    /// transfer). The payload comes back in the form `payload_format` asks for,
+    /// and always whole: selecting keys needs the parsed form, which is
+    /// `retrieve`'s business.
     ///
     /// Like `retrieve`, may return fewer records than requested and in any order.
+    #[allow(clippy::too_many_arguments)]
     fn retrieve_raw(
         &self,
         point_ids: &[PointIdType],
-        with_payload: &WithPayload,
+        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         hw_counter: &HardwareCounterCell,
         is_stopped: &AtomicBool,

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -15,7 +15,7 @@ use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use crate::data_types::segment_record::{RawPayloadFormat, SegmentRecord, SegmentRecordRaw};
+use crate::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
 use crate::data_types::vector_name_config::VectorNameConfig;
 use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::entry::snapshot_entry::SnapshotEntry;
@@ -105,16 +105,15 @@ pub trait ReadSegmentEntry {
     /// Byte-blob analogue of [`ReadSegmentEntry::retrieve`]: returns vectors and
     /// payload as stored ([`SegmentRecordRaw`]), to avoid a lossy round-trip and
     /// a needless parse when relocating points (copy-on-write moves, shard
-    /// transfer). The payload comes back in the form `payload_format` asks for,
-    /// and always whole: selecting keys needs the parsed form, which is
-    /// `retrieve`'s business.
+    /// transfer). A caller that needs the parsed payload decodes it itself.
+    ///
+    /// The payload always comes along, and whole: keys cannot be selected out of
+    /// an opaque blob, which is `retrieve`'s business.
     ///
     /// Like `retrieve`, may return fewer records than requested and in any order.
-    #[allow(clippy::too_many_arguments)]
     fn retrieve_raw(
         &self,
         point_ids: &[PointIdType],
-        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         hw_counter: &HardwareCounterCell,
         is_stopped: &AtomicBool,

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -18,9 +18,7 @@ use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::index::query_optimization::optimized_filter::OptimizedFilter;
 use crate::json_path::JsonPath;
 use crate::telemetry::PayloadIndexTelemetry;
-use crate::types::{
-    Filter, MaybeRawPayloadRef, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef,
-};
+use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef};
 
 pub enum BuildIndexResult {
     /// Index was built
@@ -154,11 +152,11 @@ pub trait PayloadIndexRead {
     ) -> OperationResult<()>;
 
     /// Raw analogue of [`Self::read_payloads`], see
-    /// [`PayloadStorageRead::read_payloads_maybe_raw`](crate::payload_storage::PayloadStorageRead::read_payloads_maybe_raw).
-    fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+    /// [`PayloadStorageRead::read_payloads_raw`](crate::payload_storage::PayloadStorageRead::read_payloads_raw).
+    fn read_payloads_raw<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_ids: impl Iterator<Item = (U, PointOffsetType)>,
-        callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        callback: impl FnMut(U, Option<&[u8]>) -> OperationResult<()>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()>;
 }

--- a/lib/segment/src/index/payload_index_base.rs
+++ b/lib/segment/src/index/payload_index_base.rs
@@ -18,7 +18,9 @@ use crate::index::field_index::{CardinalityEstimation, PayloadBlockCondition};
 use crate::index::query_optimization::optimized_filter::OptimizedFilter;
 use crate::json_path::JsonPath;
 use crate::telemetry::PayloadIndexTelemetry;
-use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef};
+use crate::types::{
+    Filter, MaybeRawPayloadRef, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef,
+};
 
 pub enum BuildIndexResult {
     /// Index was built
@@ -148,6 +150,15 @@ pub trait PayloadIndexRead {
         &self,
         point_ids: impl Iterator<Item = (U, PointOffsetType)>,
         callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()>;
+
+    /// Raw analogue of [`Self::read_payloads`], see
+    /// [`PayloadStorageRead::read_payloads_maybe_raw`](crate::payload_storage::PayloadStorageRead::read_payloads_maybe_raw).
+    fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+        &self,
+        point_ids: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()>;
 }

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -30,7 +30,9 @@ use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
 use crate::json_path::JsonPath;
 use crate::payload_storage::query_checker::SimpleConditionChecker;
 use crate::telemetry::PayloadIndexTelemetry;
-use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef};
+use crate::types::{
+    Filter, MaybeRawPayloadRef, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef,
+};
 
 /// Implementation of `PayloadIndex` which does not really indexes anything.
 ///
@@ -173,6 +175,15 @@ impl PayloadIndexRead for PlainPayloadIndex {
         &self,
         _point_ids: impl Iterator<Item = (U, PointOffsetType)>,
         _callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        unimplemented!()
+    }
+
+    fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+        &self,
+        _point_ids: impl Iterator<Item = (U, PointOffsetType)>,
+        _callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         unimplemented!()

--- a/lib/segment/src/index/plain_payload_index.rs
+++ b/lib/segment/src/index/plain_payload_index.rs
@@ -30,9 +30,7 @@ use crate::index::{BuildIndexResult, PayloadIndex, PayloadIndexRead};
 use crate::json_path::JsonPath;
 use crate::payload_storage::query_checker::SimpleConditionChecker;
 use crate::telemetry::PayloadIndexTelemetry;
-use crate::types::{
-    Filter, MaybeRawPayloadRef, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef,
-};
+use crate::types::{Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef};
 
 /// Implementation of `PayloadIndex` which does not really indexes anything.
 ///
@@ -180,10 +178,10 @@ impl PayloadIndexRead for PlainPayloadIndex {
         unimplemented!()
     }
 
-    fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+    fn read_payloads_raw<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         _point_ids: impl Iterator<Item = (U, PointOffsetType)>,
-        _callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        _callback: impl FnMut(U, Option<&[u8]>) -> OperationResult<()>,
         _hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         unimplemented!()

--- a/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
@@ -27,7 +27,8 @@ use crate::json_path::JsonPath;
 use crate::payload_storage::PayloadStorageRead;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
-    Condition, Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef,
+    Condition, Filter, MaybeRawPayloadRef, Payload, PayloadFieldSchema, PayloadKeyType,
+    PayloadKeyTypeRef,
 };
 use crate::vector_storage::VectorStorageRead;
 
@@ -300,5 +301,16 @@ where
         self.payload
             .borrow()
             .read_payloads::<AP, _>(point_ids, callback, hw_counter)
+    }
+
+    fn read_payloads_maybe_raw<AP: AccessPattern, U: common::universal_io::UserData>(
+        &self,
+        point_ids: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.payload
+            .borrow()
+            .read_payloads_maybe_raw::<AP, _>(point_ids, callback, hw_counter)
     }
 }

--- a/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
+++ b/lib/segment/src/index/struct_payload_index/read_view/payload_index_read.rs
@@ -27,8 +27,7 @@ use crate::json_path::JsonPath;
 use crate::payload_storage::PayloadStorageRead;
 use crate::telemetry::PayloadIndexTelemetry;
 use crate::types::{
-    Condition, Filter, MaybeRawPayloadRef, Payload, PayloadFieldSchema, PayloadKeyType,
-    PayloadKeyTypeRef,
+    Condition, Filter, Payload, PayloadFieldSchema, PayloadKeyType, PayloadKeyTypeRef,
 };
 use crate::vector_storage::VectorStorageRead;
 
@@ -303,14 +302,14 @@ where
             .read_payloads::<AP, _>(point_ids, callback, hw_counter)
     }
 
-    fn read_payloads_maybe_raw<AP: AccessPattern, U: common::universal_io::UserData>(
+    fn read_payloads_raw<AP: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_ids: impl Iterator<Item = (U, PointOffsetType)>,
-        callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        callback: impl FnMut(U, Option<&[u8]>) -> OperationResult<()>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         self.payload
             .borrow()
-            .read_payloads_maybe_raw::<AP, _>(point_ids, callback, hw_counter)
+            .read_payloads_raw::<AP, _>(point_ids, callback, hw_counter)
     }
 }

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -80,8 +80,6 @@ impl PayloadStorageRead for InMemoryPayloadStorage {
         _hw_counter: &HardwareCounterCell, // No measurements for in memory storage
     ) -> OperationResult<()> {
         for (user_data, point_offset) in point_offsets {
-            // Payloads are kept parsed here, so there is no stored encoding to
-            // hand out: produce the one an on-disk storage would have written.
             let encoded = self.payload.get(&point_offset).map(Blob::to_bytes);
             callback(user_data, encoded.as_deref())?;
         }
@@ -255,8 +253,6 @@ mod tests {
         );
     }
 
-    /// This storage keeps payloads parsed, so a raw read has to produce the
-    /// encoding an on-disk storage would have written.
     #[test]
     fn test_read_payloads_raw_encodes_on_the_fly() {
         let mut storage = InMemoryPayloadStorage::default();

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -1,6 +1,7 @@
 use std::collections::hash_map::Entry;
 use std::path::PathBuf;
 
+use blobstore::Blob;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
@@ -11,7 +12,7 @@ use crate::common::operation_error::OperationResult;
 use crate::json_path::JsonPath;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use crate::payload_storage::{PayloadStorage, PayloadStorageRead};
-use crate::types::{MaybeRawPayloadRef, OwnedPayloadRef, Payload};
+use crate::types::{OwnedPayloadRef, Payload};
 
 impl PayloadStorageRead for InMemoryPayloadStorage {
     fn get(
@@ -72,17 +73,17 @@ impl PayloadStorageRead for InMemoryPayloadStorage {
         Ok(())
     }
 
-    fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+    fn read_payloads_raw<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
-        mut callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        mut callback: impl FnMut(U, Option<&[u8]>) -> OperationResult<()>,
         _hw_counter: &HardwareCounterCell, // No measurements for in memory storage
     ) -> OperationResult<()> {
         for (user_data, point_offset) in point_offsets {
-            // Payloads are kept parsed here, so hand them out as they are rather
-            // than encoding them for a reader that would only parse them back.
-            let payload = self.payload.get(&point_offset);
-            callback(user_data, payload.map(MaybeRawPayloadRef::Parsed))?;
+            // Payloads are kept parsed here, so there is no stored encoding to
+            // hand out: produce the one an on-disk storage would have written.
+            let encoded = self.payload.get(&point_offset).map(Blob::to_bytes);
+            callback(user_data, encoded.as_deref())?;
         }
 
         Ok(())
@@ -199,7 +200,7 @@ mod tests {
     use crate::common::utils::IndexesMap;
     use crate::fixtures::payload_context_fixture::create_id_tracker_fixture;
     use crate::payload_storage::query_checker::check_payload;
-    use crate::types::{Condition, FieldCondition, Filter, MaybeRawPayload, OwnedPayloadRef};
+    use crate::types::{Condition, FieldCondition, Filter, OwnedPayloadRef};
 
     #[test]
     fn test_condition_checking() {
@@ -254,10 +255,10 @@ mod tests {
         );
     }
 
-    /// This storage keeps payloads parsed, so a raw read gets them as they are
-    /// instead of an encoding produced only to be parsed straight back.
+    /// This storage keeps payloads parsed, so a raw read has to produce the
+    /// encoding an on-disk storage would have written.
     #[test]
-    fn test_read_payloads_maybe_raw_hands_out_parsed() {
+    fn test_read_payloads_raw_encodes_on_the_fly() {
         let mut storage = InMemoryPayloadStorage::default();
         let payload: Payload = serde_json::from_str(r#"{"name": "John Doe"}"#).unwrap();
 
@@ -266,10 +267,10 @@ mod tests {
 
         let mut read = Vec::new();
         storage
-            .read_payloads_maybe_raw::<common::generic_consts::Random, _>(
+            .read_payloads_raw::<common::generic_consts::Random, _>(
                 [((), 1), ((), 2)].into_iter(),
                 |(), payload| {
-                    read.push(payload.map(MaybeRawPayloadRef::to_owned));
+                    read.push(payload.map(<[u8]>::to_vec));
                     Ok(())
                 },
                 &hw_counter,
@@ -279,7 +280,7 @@ mod tests {
         assert_eq!(
             read,
             // Point 2 has no payload at all
-            [Some(MaybeRawPayload::Parsed(payload)), None],
+            [Some(payload.to_bytes()), None],
         );
     }
 

--- a/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/in_memory_payload_storage_impl.rs
@@ -11,7 +11,7 @@ use crate::common::operation_error::OperationResult;
 use crate::json_path::JsonPath;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use crate::payload_storage::{PayloadStorage, PayloadStorageRead};
-use crate::types::{OwnedPayloadRef, Payload};
+use crate::types::{MaybeRawPayloadRef, OwnedPayloadRef, Payload};
 
 impl PayloadStorageRead for InMemoryPayloadStorage {
     fn get(
@@ -67,6 +67,22 @@ impl PayloadStorageRead for InMemoryPayloadStorage {
         for (user_data, point_offset) in point_offsets {
             let payload = self.get(point_offset, hw_counter)?;
             callback(user_data, payload)?;
+        }
+
+        Ok(())
+    }
+
+    fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        _hw_counter: &HardwareCounterCell, // No measurements for in memory storage
+    ) -> OperationResult<()> {
+        for (user_data, point_offset) in point_offsets {
+            // Payloads are kept parsed here, so hand them out as they are rather
+            // than encoding them for a reader that would only parse them back.
+            let payload = self.payload.get(&point_offset);
+            callback(user_data, payload.map(MaybeRawPayloadRef::Parsed))?;
         }
 
         Ok(())
@@ -183,7 +199,7 @@ mod tests {
     use crate::common::utils::IndexesMap;
     use crate::fixtures::payload_context_fixture::create_id_tracker_fixture;
     use crate::payload_storage::query_checker::check_payload;
-    use crate::types::{Condition, FieldCondition, Filter, OwnedPayloadRef};
+    use crate::types::{Condition, FieldCondition, Filter, MaybeRawPayload, OwnedPayloadRef};
 
     #[test]
     fn test_condition_checking() {
@@ -235,6 +251,35 @@ mod tests {
             0,
             &IndexesMap::new(),
             &HardwareCounterCell::new(),
+        );
+    }
+
+    /// This storage keeps payloads parsed, so a raw read gets them as they are
+    /// instead of an encoding produced only to be parsed straight back.
+    #[test]
+    fn test_read_payloads_maybe_raw_hands_out_parsed() {
+        let mut storage = InMemoryPayloadStorage::default();
+        let payload: Payload = serde_json::from_str(r#"{"name": "John Doe"}"#).unwrap();
+
+        let hw_counter = HardwareCounterCell::new();
+        storage.set(1, &payload, &hw_counter).unwrap();
+
+        let mut read = Vec::new();
+        storage
+            .read_payloads_maybe_raw::<common::generic_consts::Random, _>(
+                [((), 1), ((), 2)].into_iter(),
+                |(), payload| {
+                    read.push(payload.map(MaybeRawPayloadRef::to_owned));
+                    Ok(())
+                },
+                &hw_counter,
+            )
+            .unwrap();
+
+        assert_eq!(
+            read,
+            // Point 2 has no payload at all
+            [Some(MaybeRawPayload::Parsed(payload)), None],
         );
     }
 

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::json_path::JsonPath;
-use crate::types::{IoBackend, OwnedPayloadRef, Payload};
+use crate::types::{IoBackend, MaybeRawPayloadRef, OwnedPayloadRef, Payload};
 
 /// Read-only trait for payload data storage.
 ///
@@ -46,6 +46,16 @@ pub trait PayloadStorageRead {
         &self,
         point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
         callback: impl FnMut(U, Payload) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()>;
+
+    /// Raw analogue of [`Self::read_payloads`]: hands the callback each payload
+    /// as stored, skipping the parse — or parsed, if this storage keeps no
+    /// encoded form. `None` for points that have no payload stored.
+    fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()>;
 

--- a/lib/segment/src/payload_storage/payload_storage_base.rs
+++ b/lib/segment/src/payload_storage/payload_storage_base.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use crate::common::Flusher;
 use crate::common::operation_error::OperationResult;
 use crate::json_path::JsonPath;
-use crate::types::{IoBackend, MaybeRawPayloadRef, OwnedPayloadRef, Payload};
+use crate::types::{IoBackend, OwnedPayloadRef, Payload};
 
 /// Read-only trait for payload data storage.
 ///
@@ -50,12 +50,12 @@ pub trait PayloadStorageRead {
     ) -> OperationResult<()>;
 
     /// Raw analogue of [`Self::read_payloads`]: hands the callback each payload
-    /// as stored, skipping the parse — or parsed, if this storage keeps no
-    /// encoded form. `None` for points that have no payload stored.
-    fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+    /// in its stored encoding, uncompressed, skipping the parse. `None` for
+    /// points that have no payload stored.
+    fn read_payloads_raw<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
-        callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        callback: impl FnMut(U, Option<&[u8]>) -> OperationResult<()>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()>;
 

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -14,7 +14,7 @@ use crate::json_path::JsonPath;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use crate::payload_storage::payload_storage_impl::PayloadStorageImpl;
 use crate::payload_storage::{PayloadStorage, PayloadStorageRead};
-use crate::types::{IoBackend, OwnedPayloadRef, Payload};
+use crate::types::{IoBackend, MaybeRawPayloadRef, OwnedPayloadRef, Payload};
 
 #[derive(Debug)]
 pub enum PayloadStorageEnum {
@@ -106,6 +106,28 @@ impl PayloadStorageRead for PayloadStorageEnum {
             #[cfg(target_os = "linux")]
             PayloadStorageEnum::IoUring(s) => {
                 s.read_payloads::<P, _>(point_offsets, callback, hw_counter)
+            }
+        }
+    }
+
+    fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            #[cfg(feature = "testing")]
+            PayloadStorageEnum::InMemory(s) => {
+                s.read_payloads_maybe_raw::<P, _>(point_offsets, callback, hw_counter)
+            }
+
+            PayloadStorageEnum::Mmap(s) => {
+                s.read_payloads_maybe_raw::<P, _>(point_offsets, callback, hw_counter)
+            }
+            #[cfg(target_os = "linux")]
+            PayloadStorageEnum::IoUring(s) => {
+                s.read_payloads_maybe_raw::<P, _>(point_offsets, callback, hw_counter)
             }
         }
     }

--- a/lib/segment/src/payload_storage/payload_storage_enum.rs
+++ b/lib/segment/src/payload_storage/payload_storage_enum.rs
@@ -14,7 +14,7 @@ use crate::json_path::JsonPath;
 use crate::payload_storage::in_memory_payload_storage::InMemoryPayloadStorage;
 use crate::payload_storage::payload_storage_impl::PayloadStorageImpl;
 use crate::payload_storage::{PayloadStorage, PayloadStorageRead};
-use crate::types::{IoBackend, MaybeRawPayloadRef, OwnedPayloadRef, Payload};
+use crate::types::{IoBackend, OwnedPayloadRef, Payload};
 
 #[derive(Debug)]
 pub enum PayloadStorageEnum {
@@ -110,24 +110,24 @@ impl PayloadStorageRead for PayloadStorageEnum {
         }
     }
 
-    fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+    fn read_payloads_raw<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
-        callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        callback: impl FnMut(U, Option<&[u8]>) -> OperationResult<()>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         match self {
             #[cfg(feature = "testing")]
             PayloadStorageEnum::InMemory(s) => {
-                s.read_payloads_maybe_raw::<P, _>(point_offsets, callback, hw_counter)
+                s.read_payloads_raw::<P, _>(point_offsets, callback, hw_counter)
             }
 
             PayloadStorageEnum::Mmap(s) => {
-                s.read_payloads_maybe_raw::<P, _>(point_offsets, callback, hw_counter)
+                s.read_payloads_raw::<P, _>(point_offsets, callback, hw_counter)
             }
             #[cfg(target_os = "linux")]
             PayloadStorageEnum::IoUring(s) => {
-                s.read_payloads_maybe_raw::<P, _>(point_offsets, callback, hw_counter)
+                s.read_payloads_raw::<P, _>(point_offsets, callback, hw_counter)
             }
         }
     }

--- a/lib/segment/src/payload_storage/payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/payload_storage_impl.rs
@@ -13,7 +13,7 @@ use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::json_path::JsonPath;
 use crate::payload_storage::{PayloadStorage, PayloadStorageRead};
-use crate::types::{OwnedPayloadRef, Payload, PayloadKeyTypeRef};
+use crate::types::{MaybeRawPayloadRef, OwnedPayloadRef, Payload, PayloadKeyTypeRef};
 
 const STORAGE_PATH: &str = "payload_storage";
 
@@ -140,6 +140,19 @@ where
                 let payload = payload.unwrap_or_default();
                 callback(user_data, payload)
             },
+            hw_counter.payload_io_read_counter(),
+        )
+    }
+
+    fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.storage.read_values_bytes::<P, _, _>(
+            point_offsets,
+            |user_data, _, bytes| callback(user_data, bytes.map(MaybeRawPayloadRef::Raw)),
             hw_counter.payload_io_read_counter(),
         )
     }

--- a/lib/segment/src/payload_storage/payload_storage_impl.rs
+++ b/lib/segment/src/payload_storage/payload_storage_impl.rs
@@ -13,7 +13,7 @@ use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::json_path::JsonPath;
 use crate::payload_storage::{PayloadStorage, PayloadStorageRead};
-use crate::types::{MaybeRawPayloadRef, OwnedPayloadRef, Payload, PayloadKeyTypeRef};
+use crate::types::{OwnedPayloadRef, Payload, PayloadKeyTypeRef};
 
 const STORAGE_PATH: &str = "payload_storage";
 
@@ -144,15 +144,15 @@ where
         )
     }
 
-    fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+    fn read_payloads_raw<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
-        mut callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        mut callback: impl FnMut(U, Option<&[u8]>) -> OperationResult<()>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         self.storage.read_values_bytes::<P, _, _>(
             point_offsets,
-            |user_data, _, bytes| callback(user_data, bytes.map(MaybeRawPayloadRef::Raw)),
+            |user_data, _, bytes| callback(user_data, bytes),
             hw_counter.payload_io_read_counter(),
         )
     }

--- a/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
+++ b/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
@@ -6,7 +6,7 @@ use common::universal_io::UniversalRead;
 use crate::common::operation_error::OperationResult;
 use crate::payload_storage::PayloadStorageRead;
 use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
-use crate::types::{IoBackend, MaybeRawPayloadRef, OwnedPayloadRef, Payload};
+use crate::types::{IoBackend, OwnedPayloadRef, Payload};
 
 impl<S: UniversalRead> PayloadStorageRead for ReadOnlyPayloadStorage<S> {
     fn io_backend(&self) -> Option<IoBackend> {
@@ -65,15 +65,15 @@ impl<S: UniversalRead> PayloadStorageRead for ReadOnlyPayloadStorage<S> {
         )
     }
 
-    fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+    fn read_payloads_raw<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
-        mut callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        mut callback: impl FnMut(U, Option<&[u8]>) -> OperationResult<()>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         self.storage.read_values_bytes::<P, _, _>(
             point_offsets,
-            |user_data, _, bytes| callback(user_data, bytes.map(MaybeRawPayloadRef::Raw)),
+            |user_data, _, bytes| callback(user_data, bytes),
             hw_counter.payload_io_read_counter(),
         )
     }

--- a/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
+++ b/lib/segment/src/payload_storage/read_only/payload_storage_read.rs
@@ -6,7 +6,7 @@ use common::universal_io::UniversalRead;
 use crate::common::operation_error::OperationResult;
 use crate::payload_storage::PayloadStorageRead;
 use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
-use crate::types::{IoBackend, OwnedPayloadRef, Payload};
+use crate::types::{IoBackend, MaybeRawPayloadRef, OwnedPayloadRef, Payload};
 
 impl<S: UniversalRead> PayloadStorageRead for ReadOnlyPayloadStorage<S> {
     fn io_backend(&self) -> Option<IoBackend> {
@@ -61,6 +61,19 @@ impl<S: UniversalRead> PayloadStorageRead for ReadOnlyPayloadStorage<S> {
                 let payload = payload.unwrap_or_default();
                 callback(user_data, payload)
             },
+            hw_counter.payload_io_read_counter(),
+        )
+    }
+
+    fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.storage.read_values_bytes::<P, _, _>(
+            point_offsets,
+            |user_data, _, bytes| callback(user_data, bytes.map(MaybeRawPayloadRef::Raw)),
             hw_counter.payload_io_read_counter(),
         )
     }

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -17,7 +17,7 @@ use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use crate::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
+use crate::data_types::segment_record::{RawPayloadFormat, SegmentRecord, SegmentRecordRaw};
 use crate::data_types::vector_name_config::VectorNameConfig;
 use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::entry::entry_point::{
@@ -153,7 +153,7 @@ impl ReadSegmentEntry for Segment {
     fn retrieve_raw(
         &self,
         point_ids: &[PointIdType],
-        with_payload: &WithPayload,
+        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         hw_counter: &HardwareCounterCell,
         is_stopped: &AtomicBool,
@@ -162,7 +162,7 @@ impl ReadSegmentEntry for Segment {
         self.with_view(|view| {
             view.retrieve_raw(
                 point_ids,
-                with_payload,
+                payload_format,
                 with_vector,
                 hw_counter,
                 is_stopped,

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -17,7 +17,7 @@ use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use crate::data_types::segment_record::{RawPayloadFormat, SegmentRecord, SegmentRecordRaw};
+use crate::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
 use crate::data_types::vector_name_config::VectorNameConfig;
 use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::entry::entry_point::{
@@ -153,7 +153,6 @@ impl ReadSegmentEntry for Segment {
     fn retrieve_raw(
         &self,
         point_ids: &[PointIdType],
-        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         hw_counter: &HardwareCounterCell,
         is_stopped: &AtomicBool,
@@ -162,7 +161,6 @@ impl ReadSegmentEntry for Segment {
         self.with_view(|view| {
             view.retrieve_raw(
                 point_ids,
-                payload_format,
                 with_vector,
                 hw_counter,
                 is_stopped,

--- a/lib/segment/src/segment/read_only/read_entry.rs
+++ b/lib/segment/src/segment/read_only/read_entry.rs
@@ -13,7 +13,7 @@ use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use crate::data_types::segment_record::{RawPayloadFormat, SegmentRecord, SegmentRecordRaw};
+use crate::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
 use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::entry::entry_point::ReadSegmentEntry;
 use crate::id_tracker::IdTrackerRead;
@@ -149,7 +149,6 @@ impl<S: UniversalReadExt + 'static> ReadSegmentEntry for ReadOnlySegment<S> {
     fn retrieve_raw(
         &self,
         point_ids: &[PointIdType],
-        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         hw_counter: &HardwareCounterCell,
         is_stopped: &AtomicBool,
@@ -158,7 +157,6 @@ impl<S: UniversalReadExt + 'static> ReadSegmentEntry for ReadOnlySegment<S> {
         self.with_view(|view| {
             view.retrieve_raw(
                 point_ids,
-                payload_format,
                 with_vector,
                 hw_counter,
                 is_stopped,

--- a/lib/segment/src/segment/read_only/read_entry.rs
+++ b/lib/segment/src/segment/read_only/read_entry.rs
@@ -13,7 +13,7 @@ use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::{OrderBy, OrderValue};
 use crate::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use crate::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
+use crate::data_types::segment_record::{RawPayloadFormat, SegmentRecord, SegmentRecordRaw};
 use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::entry::entry_point::ReadSegmentEntry;
 use crate::id_tracker::IdTrackerRead;
@@ -149,7 +149,7 @@ impl<S: UniversalReadExt + 'static> ReadSegmentEntry for ReadOnlySegment<S> {
     fn retrieve_raw(
         &self,
         point_ids: &[PointIdType],
-        with_payload: &WithPayload,
+        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         hw_counter: &HardwareCounterCell,
         is_stopped: &AtomicBool,
@@ -158,7 +158,7 @@ impl<S: UniversalReadExt + 'static> ReadSegmentEntry for ReadOnlySegment<S> {
         self.with_view(|view| {
             view.retrieve_raw(
                 point_ids,
-                with_payload,
+                payload_format,
                 with_vector,
                 hw_counter,
                 is_stopped,

--- a/lib/segment/src/segment/read_view/payload.rs
+++ b/lib/segment/src/segment/read_view/payload.rs
@@ -10,7 +10,7 @@ use crate::index::query_estimator::adjust_for_deferred_points;
 use crate::payload_storage::PayloadStorageRead;
 use crate::segment::read_view::SegmentReadView;
 use crate::segment::vector_data_read::VectorDataRead;
-use crate::types::{Filter, Payload, PointIdType};
+use crate::types::{Filter, MaybeRawPayloadRef, Payload, PointIdType};
 
 impl<'s, TIdT, TPI, TPS, TVD> SegmentReadView<'s, TIdT, TPI, TPS, TVD>
 where
@@ -27,6 +27,18 @@ where
     ) -> OperationResult<()> {
         self.payload_index
             .read_payloads::<P, _>(point_offsets, callback, hw_counter)
+    }
+
+    /// Raw analogue of [`Self::read_payloads`], see
+    /// [`PayloadStorageRead::read_payloads_maybe_raw`](crate::payload_storage::PayloadStorageRead::read_payloads_maybe_raw).
+    pub fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+        &self,
+        point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.payload_index
+            .read_payloads_maybe_raw::<P, _>(point_offsets, callback, hw_counter)
     }
 
     /// Retrieve payload by internal ID.

--- a/lib/segment/src/segment/read_view/payload.rs
+++ b/lib/segment/src/segment/read_view/payload.rs
@@ -10,7 +10,7 @@ use crate::index::query_estimator::adjust_for_deferred_points;
 use crate::payload_storage::PayloadStorageRead;
 use crate::segment::read_view::SegmentReadView;
 use crate::segment::vector_data_read::VectorDataRead;
-use crate::types::{Filter, MaybeRawPayloadRef, Payload, PointIdType};
+use crate::types::{Filter, Payload, PointIdType};
 
 impl<'s, TIdT, TPI, TPS, TVD> SegmentReadView<'s, TIdT, TPI, TPS, TVD>
 where
@@ -30,15 +30,15 @@ where
     }
 
     /// Raw analogue of [`Self::read_payloads`], see
-    /// [`PayloadStorageRead::read_payloads_maybe_raw`](crate::payload_storage::PayloadStorageRead::read_payloads_maybe_raw).
-    pub fn read_payloads_maybe_raw<P: AccessPattern, U: common::universal_io::UserData>(
+    /// [`PayloadStorageRead::read_payloads_raw`](crate::payload_storage::PayloadStorageRead::read_payloads_raw).
+    pub fn read_payloads_raw<P: AccessPattern, U: common::universal_io::UserData>(
         &self,
         point_offsets: impl Iterator<Item = (U, PointOffsetType)>,
-        callback: impl FnMut(U, Option<MaybeRawPayloadRef<'_>>) -> OperationResult<()>,
+        callback: impl FnMut(U, Option<&[u8]>) -> OperationResult<()>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         self.payload_index
-            .read_payloads_maybe_raw::<P, _>(point_offsets, callback, hw_counter)
+            .read_payloads_raw::<P, _>(point_offsets, callback, hw_counter)
     }
 
     /// Retrieve payload by internal ID.

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -12,7 +12,7 @@ use crate::common::{check_query_vectors, check_stopped};
 use crate::data_types::query_context::{
     IdfScopeStats, QueryContext, QueryIdfStats, SegmentQueryContext,
 };
-use crate::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
+use crate::data_types::segment_record::{RawPayloadFormat, SegmentRecord, SegmentRecordRaw};
 use crate::data_types::vectors::{QueryVector, VectorStructInternal};
 use crate::id_tracker::IdTrackerRead;
 use crate::index::{PayloadIndexRead, VectorIndexRead};
@@ -20,8 +20,8 @@ use crate::payload_storage::PayloadStorageRead;
 use crate::segment::read_view::SegmentReadView;
 use crate::segment::vector_data_read::VectorDataRead;
 use crate::types::{
-    ExtendedPointId, Filter, Payload, PointIdType, ScoredPoint, SearchParams, VectorName,
-    VectorNameBuf, WithPayload, WithVector,
+    ExtendedPointId, Filter, MaybeRawPayload, Payload, PointIdType, ScoredPoint, SearchParams,
+    VectorName, VectorNameBuf, WithPayload, WithVector,
 };
 
 impl<'s, TIdT, TPI, TPS, TVD> SegmentReadView<'s, TIdT, TPI, TPS, TVD>
@@ -98,12 +98,16 @@ where
     }
 
     /// Byte-blob analogue of [`Self::retrieve`]: vectors are read as
-    /// storage-native bytes (`Vec<u8>`) to avoid a lossy round-trip.
+    /// storage-native bytes (`Vec<u8>`) to avoid a lossy round-trip, and the
+    /// payload in the form `payload_format` asks for.
+    ///
+    /// The payload is always taken whole — selecting keys needs the parsed form,
+    /// so that is [`Self::retrieve`]'s business.
     /// The body mirrors [`Self::retrieve`] — keep the two in sync.
     pub fn retrieve_raw(
         &self,
         point_ids: &[PointIdType],
-        with_payload: &WithPayload,
+        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         hw_counter: &HardwareCounterCell,
         is_stopped: &AtomicBool,
@@ -148,13 +152,26 @@ where
             })?;
         }
 
-        let payloads = self.requested_payloads(
-            resolved_ids,
-            resolved_offsets,
-            with_payload,
-            is_stopped,
-            hw_counter,
-        )?;
+        let payloads = match payload_format {
+            RawPayloadFormat::NoPayload => Vec::new(),
+            RawPayloadFormat::Parsed => self
+                .requested_payloads(
+                    resolved_ids,
+                    resolved_offsets,
+                    &WithPayload::from(true),
+                    is_stopped,
+                    hw_counter,
+                )?
+                .into_iter()
+                .map(|(id, payload)| (id, MaybeRawPayload::Parsed(payload)))
+                .collect(),
+            RawPayloadFormat::Raw => self.requested_payloads_maybe_raw(
+                resolved_ids,
+                resolved_offsets,
+                is_stopped,
+                hw_counter,
+            )?,
+        };
         for (id, payload) in payloads {
             if let Some(record) = records.get_mut(&id) {
                 record.payload = Some(payload);
@@ -208,6 +225,37 @@ where
                 };
 
                 payloads.push((point_id, payload));
+
+                Ok(())
+            },
+            hw_counter,
+        )?;
+
+        Ok(payloads)
+    }
+
+    /// Raw analogue of [`Self::requested_payloads`]: reads each resolved point's
+    /// payload as stored, without parsing it. Points with no stored payload are
+    /// skipped, so a missing entry means "no payload" rather than "empty
+    /// payload".
+    fn requested_payloads_maybe_raw(
+        &self,
+        resolved_ids: Vec<ExtendedPointId>,
+        resolved_offsets: Vec<PointOffsetType>,
+        is_stopped: &AtomicBool,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<Vec<(ExtendedPointId, MaybeRawPayload)>> {
+        let mut payloads = Vec::with_capacity(resolved_ids.len());
+        let point_offsets = resolved_ids.into_iter().zip(resolved_offsets);
+
+        self.read_payloads_maybe_raw::<Random, _>(
+            point_offsets,
+            |point_id, payload| {
+                check_stopped(is_stopped)?;
+
+                if let Some(payload) = payload {
+                    payloads.push((point_id, payload.to_owned()));
+                }
 
                 Ok(())
             },
@@ -426,14 +474,15 @@ mod tests {
 
     use crate::common::operation_error::OperationError;
     use crate::data_types::named_vectors::NamedVectors;
+    use crate::data_types::segment_record::{RawPayloadFormat, SegmentRecordRaw};
     use crate::data_types::vectors::VectorInternal;
     use crate::entry::entry_point::{ReadSegmentEntry as _, SegmentEntry as _};
     use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
     use crate::segment::Segment;
     use crate::segment_constructor::build_segment;
     use crate::types::{
-        Distance, Indexes, Payload, SegmentConfig, SparseVectorDataConfig, SparseVectorStorageType,
-        VectorDataConfig, VectorStorageType, WithPayload, WithVector,
+        Distance, Indexes, MaybeRawPayload, Payload, SegmentConfig, SparseVectorDataConfig,
+        SparseVectorStorageType, VectorDataConfig, VectorStorageType, WithPayload, WithVector,
     };
     use crate::vector_storage::sparse::StoredSparseVector;
 
@@ -500,6 +549,20 @@ mod tests {
         (segment, payload)
     }
 
+    /// The payload of a raw record in parsed form, whichever representation it
+    /// carries. Empty and absent payloads both read as `None`: a point without
+    /// payload has nothing stored at all, while the parsed form reports it as
+    /// empty.
+    fn raw_record_payload(record: &SegmentRecordRaw) -> Option<Payload> {
+        let payload = record
+            .payload
+            .as_ref()?
+            .to_parsed()
+            .expect("stored blob must be valid json")
+            .into_owned();
+        (!payload.is_empty()).then_some(payload)
+    }
+
     /// [`SegmentReadView::retrieve`] and [`SegmentReadView::retrieve_raw`]
     /// have hand-duplicated bodies — this guards them against drifting apart:
     /// both must return the same records (ids, payloads, vector names), and
@@ -524,6 +587,7 @@ mod tests {
         #[case] with_vector: WithVector,
         #[case] expected_point1_vectors: usize,
         #[values(true, false)] payload_enabled: bool,
+        #[values(RawPayloadFormat::Parsed, RawPayloadFormat::Raw)] payload_format: RawPayloadFormat,
     ) {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let (segment, payload) = build_two_point_segment(dir.path());
@@ -534,6 +598,11 @@ mod tests {
         let with_payload = WithPayload {
             enable: payload_enabled,
             payload_selector: None,
+        };
+        let payload_format = if payload_enabled {
+            payload_format
+        } else {
+            RawPayloadFormat::NoPayload
         };
         // Expectation derived independently of the `needs_vectors` helper the
         // functions under test share.
@@ -556,7 +625,7 @@ mod tests {
         let raw_records = segment
             .retrieve_raw(
                 &point_ids,
-                &with_payload,
+                payload_format,
                 &with_vector,
                 &hw_counter,
                 &is_stopped,
@@ -576,14 +645,27 @@ mod tests {
         }
         if payload_enabled {
             assert_eq!(point1.payload.as_ref(), Some(&payload));
+            let raw_point1 = raw_records
+                .get(&1.into())
+                .expect("raw point 1 must be retrieved");
+            assert_eq!(raw_record_payload(raw_point1).as_ref(), Some(&payload));
+            assert_eq!(
+                matches!(raw_point1.payload, Some(MaybeRawPayload::Raw(_))),
+                payload_format == RawPayloadFormat::Raw,
+                "the requested format decides the representation",
+            );
         }
 
         for (id, record) in &records {
             let raw_record = raw_records.get(id).expect("raw record for the same id");
             assert_eq!(record.id, raw_record.id);
-            assert_eq!(record.payload, raw_record.payload);
+            assert_eq!(
+                record.payload.clone().filter(|payload| !payload.is_empty()),
+                raw_record_payload(raw_record),
+            );
             if !payload_enabled {
                 assert!(record.payload.is_none(), "payload was not requested");
+                assert!(raw_record.payload.is_none(), "payload was not requested");
             }
 
             if !vectors_requested {
@@ -652,7 +734,7 @@ mod tests {
         let raw_err = segment
             .retrieve_raw(
                 &point_ids,
-                &with_payload,
+                RawPayloadFormat::NoPayload,
                 &with_vector,
                 &hw_counter,
                 &is_stopped,
@@ -698,7 +780,7 @@ mod tests {
         let raw_records = segment
             .retrieve_raw(
                 &point_ids,
-                &with_payload,
+                RawPayloadFormat::NoPayload,
                 &with_vector,
                 &hw_counter,
                 &is_stopped,

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -101,11 +101,6 @@ where
     /// storage-native bytes to avoid a lossy round-trip of the former and a
     /// parse-then-encode round-trip of the latter. A caller that needs the
     /// parsed payload decodes it itself, see [`RawPayload::decode`].
-    ///
-    /// The payload always comes along, and whole: this reads points to relocate
-    /// them, and keys cannot be selected out of an opaque blob anyway — that is
-    /// [`Self::retrieve`]'s business.
-    /// The body mirrors [`Self::retrieve`] — keep the two in sync.
     pub fn retrieve_raw(
         &self,
         point_ids: &[PointIdType],

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -12,7 +12,7 @@ use crate::common::{check_query_vectors, check_stopped};
 use crate::data_types::query_context::{
     IdfScopeStats, QueryContext, QueryIdfStats, SegmentQueryContext,
 };
-use crate::data_types::segment_record::{RawPayloadFormat, SegmentRecord, SegmentRecordRaw};
+use crate::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
 use crate::data_types::vectors::{QueryVector, VectorStructInternal};
 use crate::id_tracker::IdTrackerRead;
 use crate::index::{PayloadIndexRead, VectorIndexRead};
@@ -20,7 +20,7 @@ use crate::payload_storage::PayloadStorageRead;
 use crate::segment::read_view::SegmentReadView;
 use crate::segment::vector_data_read::VectorDataRead;
 use crate::types::{
-    ExtendedPointId, Filter, MaybeRawPayload, Payload, PointIdType, ScoredPoint, SearchParams,
+    ExtendedPointId, Filter, Payload, PointIdType, RawPayload, ScoredPoint, SearchParams,
     VectorName, VectorNameBuf, WithPayload, WithVector,
 };
 
@@ -97,17 +97,18 @@ where
         Ok(records)
     }
 
-    /// Byte-blob analogue of [`Self::retrieve`]: vectors are read as
-    /// storage-native bytes (`Vec<u8>`) to avoid a lossy round-trip, and the
-    /// payload in the form `payload_format` asks for.
+    /// Byte-blob analogue of [`Self::retrieve`]: vectors and payload are read as
+    /// storage-native bytes to avoid a lossy round-trip of the former and a
+    /// parse-then-encode round-trip of the latter. A caller that needs the
+    /// parsed payload decodes it itself, see [`RawPayload::decode`].
     ///
-    /// The payload is always taken whole — selecting keys needs the parsed form,
-    /// so that is [`Self::retrieve`]'s business.
+    /// The payload always comes along, and whole: this reads points to relocate
+    /// them, and keys cannot be selected out of an opaque blob anyway — that is
+    /// [`Self::retrieve`]'s business.
     /// The body mirrors [`Self::retrieve`] — keep the two in sync.
     pub fn retrieve_raw(
         &self,
         point_ids: &[PointIdType],
-        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         hw_counter: &HardwareCounterCell,
         is_stopped: &AtomicBool,
@@ -152,26 +153,8 @@ where
             })?;
         }
 
-        let payloads = match payload_format {
-            RawPayloadFormat::NoPayload => Vec::new(),
-            RawPayloadFormat::Parsed => self
-                .requested_payloads(
-                    resolved_ids,
-                    resolved_offsets,
-                    &WithPayload::from(true),
-                    is_stopped,
-                    hw_counter,
-                )?
-                .into_iter()
-                .map(|(id, payload)| (id, MaybeRawPayload::Parsed(payload)))
-                .collect(),
-            RawPayloadFormat::Raw => self.requested_payloads_maybe_raw(
-                resolved_ids,
-                resolved_offsets,
-                is_stopped,
-                hw_counter,
-            )?,
-        };
+        let payloads =
+            self.requested_payloads_raw(resolved_ids, resolved_offsets, is_stopped, hw_counter)?;
         for (id, payload) in payloads {
             if let Some(record) = records.get_mut(&id) {
                 record.payload = Some(payload);
@@ -238,23 +221,23 @@ where
     /// payload as stored, without parsing it. Points with no stored payload are
     /// skipped, so a missing entry means "no payload" rather than "empty
     /// payload".
-    fn requested_payloads_maybe_raw(
+    fn requested_payloads_raw(
         &self,
         resolved_ids: Vec<ExtendedPointId>,
         resolved_offsets: Vec<PointOffsetType>,
         is_stopped: &AtomicBool,
         hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<Vec<(ExtendedPointId, MaybeRawPayload)>> {
+    ) -> OperationResult<Vec<(ExtendedPointId, RawPayload)>> {
         let mut payloads = Vec::with_capacity(resolved_ids.len());
         let point_offsets = resolved_ids.into_iter().zip(resolved_offsets);
 
-        self.read_payloads_maybe_raw::<Random, _>(
+        self.read_payloads_raw::<Random, _>(
             point_offsets,
-            |point_id, payload| {
+            |point_id, bytes| {
                 check_stopped(is_stopped)?;
 
-                if let Some(payload) = payload {
-                    payloads.push((point_id, payload.to_owned()));
+                if let Some(bytes) = bytes {
+                    payloads.push((point_id, RawPayload::from_storage_bytes(bytes.to_vec())));
                 }
 
                 Ok(())
@@ -466,6 +449,7 @@ mod tests {
     use std::path::Path;
     use std::sync::atomic::AtomicBool;
 
+    use blobstore::Blob as _;
     use common::counter::hardware_counter::HardwareCounterCell;
     use common::types::DeferredBehavior;
     use rstest::rstest;
@@ -474,15 +458,15 @@ mod tests {
 
     use crate::common::operation_error::OperationError;
     use crate::data_types::named_vectors::NamedVectors;
-    use crate::data_types::segment_record::{RawPayloadFormat, SegmentRecordRaw};
+    use crate::data_types::segment_record::SegmentRecordRaw;
     use crate::data_types::vectors::VectorInternal;
     use crate::entry::entry_point::{ReadSegmentEntry as _, SegmentEntry as _};
     use crate::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
     use crate::segment::Segment;
     use crate::segment_constructor::build_segment;
     use crate::types::{
-        Distance, Indexes, MaybeRawPayload, Payload, SegmentConfig, SparseVectorDataConfig,
-        SparseVectorStorageType, VectorDataConfig, VectorStorageType, WithPayload, WithVector,
+        Distance, Indexes, Payload, SegmentConfig, SparseVectorDataConfig, SparseVectorStorageType,
+        VectorDataConfig, VectorStorageType, WithPayload, WithVector,
     };
     use crate::vector_storage::sparse::StoredSparseVector;
 
@@ -557,9 +541,8 @@ mod tests {
         let payload = record
             .payload
             .as_ref()?
-            .to_parsed()
-            .expect("stored blob must be valid json")
-            .into_owned();
+            .decode()
+            .expect("stored blob must be valid json");
         (!payload.is_empty()).then_some(payload)
     }
 
@@ -567,9 +550,10 @@ mod tests {
     /// have hand-duplicated bodies — this guards them against drifting apart:
     /// both must return the same records (ids, payloads, vector names), and
     /// the raw storage-native bytes must decode to exactly the vectors
-    /// `retrieve` returns. Covers every `with_vector` shape crossed with
-    /// payload on/off; `expected_point1_vectors` pins how many vectors the
-    /// fully-vectored point must come back with.
+    /// `retrieve` returns. Covers every `with_vector` shape — the payload is not
+    /// optional on the raw side, so it is always requested from both;
+    /// `expected_point1_vectors` pins how many vectors the fully-vectored point
+    /// must come back with.
     #[rstest]
     #[case::all_vectors(WithVector::Bool(true), 2)]
     #[case::no_vectors(WithVector::Bool(false), 0)]
@@ -586,8 +570,6 @@ mod tests {
     fn test_retrieve_and_retrieve_raw_equivalence(
         #[case] with_vector: WithVector,
         #[case] expected_point1_vectors: usize,
-        #[values(true, false)] payload_enabled: bool,
-        #[values(RawPayloadFormat::Parsed, RawPayloadFormat::Raw)] payload_format: RawPayloadFormat,
     ) {
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let (segment, payload) = build_two_point_segment(dir.path());
@@ -595,15 +577,7 @@ mod tests {
 
         // Id 3 does not exist; both functions must skip it the same way.
         let point_ids = [1.into(), 2.into(), 3.into()];
-        let with_payload = WithPayload {
-            enable: payload_enabled,
-            payload_selector: None,
-        };
-        let payload_format = if payload_enabled {
-            payload_format
-        } else {
-            RawPayloadFormat::NoPayload
-        };
+        let with_payload = WithPayload::from(true);
         // Expectation derived independently of the `needs_vectors` helper the
         // functions under test share.
         let vectors_requested = match &with_vector {
@@ -625,7 +599,6 @@ mod tests {
         let raw_records = segment
             .retrieve_raw(
                 &point_ids,
-                payload_format,
                 &with_vector,
                 &hw_counter,
                 &is_stopped,
@@ -643,18 +616,16 @@ mod tests {
             let point1_vectors = point1.vectors.as_ref().expect("vectors requested");
             assert_eq!(point1_vectors.len(), expected_point1_vectors);
         }
-        if payload_enabled {
-            assert_eq!(point1.payload.as_ref(), Some(&payload));
-            let raw_point1 = raw_records
-                .get(&1.into())
-                .expect("raw point 1 must be retrieved");
-            assert_eq!(raw_record_payload(raw_point1).as_ref(), Some(&payload));
-            assert_eq!(
-                matches!(raw_point1.payload, Some(MaybeRawPayload::Raw(_))),
-                payload_format == RawPayloadFormat::Raw,
-                "the requested format decides the representation",
-            );
-        }
+        assert_eq!(point1.payload.as_ref(), Some(&payload));
+        let raw_point1 = raw_records
+            .get(&1.into())
+            .expect("raw point 1 must be retrieved");
+        assert_eq!(raw_record_payload(raw_point1).as_ref(), Some(&payload));
+        assert_eq!(
+            raw_point1.payload.as_ref().map(|raw| &raw.payload_bytes),
+            Some(&payload.to_bytes()),
+            "the blob must be the payload exactly as the storage keeps it",
+        );
 
         for (id, record) in &records {
             let raw_record = raw_records.get(id).expect("raw record for the same id");
@@ -663,10 +634,6 @@ mod tests {
                 record.payload.clone().filter(|payload| !payload.is_empty()),
                 raw_record_payload(raw_record),
             );
-            if !payload_enabled {
-                assert!(record.payload.is_none(), "payload was not requested");
-                assert!(raw_record.payload.is_none(), "payload was not requested");
-            }
 
             if !vectors_requested {
                 assert!(record.vectors.is_none(), "vectors were not requested");
@@ -734,7 +701,6 @@ mod tests {
         let raw_err = segment
             .retrieve_raw(
                 &point_ids,
-                RawPayloadFormat::NoPayload,
                 &with_vector,
                 &hw_counter,
                 &is_stopped,
@@ -780,7 +746,6 @@ mod tests {
         let raw_records = segment
             .retrieve_raw(
                 &point_ids,
-                RawPayloadFormat::NoPayload,
                 &with_vector,
                 &hw_counter,
                 &is_stopped,

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -27,6 +27,7 @@ use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::OrderBy;
 use crate::data_types::query_context::QueryContext;
+use crate::data_types::segment_record::RawPayloadFormat;
 use crate::data_types::vectors::{
     DEFAULT_VECTOR_NAME, MultiDenseVectorInternal, QueryVector, VectorInternal, VectorRef,
     only_default_multi_vector, only_default_vector,
@@ -682,7 +683,7 @@ fn test_retrieve_raw_dense_bytes() {
     let raw = segment
         .retrieve_raw(
             &[7.into()],
-            &WithPayload::default(),
+            RawPayloadFormat::NoPayload,
             &true.into(),
             &hw_counter,
             &is_stopped,
@@ -750,7 +751,7 @@ fn test_retrieve_raw_multivec_bytes() {
     let raw = segment
         .retrieve_raw(
             &[4.into()],
-            &WithPayload::default(),
+            RawPayloadFormat::NoPayload,
             &true.into(),
             &hw_counter,
             &is_stopped,
@@ -815,7 +816,7 @@ fn test_retrieve_raw_sparse_bytes() {
     let raw = segment
         .retrieve_raw(
             &[7.into()],
-            &WithPayload::default(),
+            RawPayloadFormat::NoPayload,
             &true.into(),
             &hw_counter,
             &is_stopped,
@@ -841,7 +842,7 @@ fn retrieve_raw_vector(segment: &Segment, point_id: PointIdType, name: &str) -> 
     let raw = segment
         .retrieve_raw(
             &[point_id],
-            &WithPayload::default(),
+            RawPayloadFormat::NoPayload,
             &true.into(),
             &hw_counter,
             &is_stopped,

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -27,7 +27,6 @@ use crate::data_types::facets::{FacetParams, FacetValue};
 use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::order_by::OrderBy;
 use crate::data_types::query_context::QueryContext;
-use crate::data_types::segment_record::RawPayloadFormat;
 use crate::data_types::vectors::{
     DEFAULT_VECTOR_NAME, MultiDenseVectorInternal, QueryVector, VectorInternal, VectorRef,
     only_default_multi_vector, only_default_vector,
@@ -683,7 +682,6 @@ fn test_retrieve_raw_dense_bytes() {
     let raw = segment
         .retrieve_raw(
             &[7.into()],
-            RawPayloadFormat::NoPayload,
             &true.into(),
             &hw_counter,
             &is_stopped,
@@ -751,7 +749,6 @@ fn test_retrieve_raw_multivec_bytes() {
     let raw = segment
         .retrieve_raw(
             &[4.into()],
-            RawPayloadFormat::NoPayload,
             &true.into(),
             &hw_counter,
             &is_stopped,
@@ -816,7 +813,6 @@ fn test_retrieve_raw_sparse_bytes() {
     let raw = segment
         .retrieve_raw(
             &[7.into()],
-            RawPayloadFormat::NoPayload,
             &true.into(),
             &hw_counter,
             &is_stopped,
@@ -842,7 +838,6 @@ fn retrieve_raw_vector(segment: &Segment, point_id: PointIdType, name: &str) -> 
     let raw = segment
         .retrieve_raw(
             &[point_id],
-            RawPayloadFormat::NoPayload,
             &true.into(),
             &hw_counter,
             &is_stopped,

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2942,6 +2942,102 @@ impl TryFrom<PayloadIndexInfo> for PayloadFieldSchema {
     }
 }
 
+/// Byte-blob analogue of [`Payload`]: the whole payload object as a single
+/// encoded blob, tagged with its encoding.
+///
+/// Read from storage by `retrieve_raw` and shipped to another node as-is, so
+/// neither side has to parse the payload on the way.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct RawPayload {
+    pub payload_bytes: Vec<u8>,
+    pub encoding: RawPayloadEncoding,
+}
+
+/// Encoding of a raw payload blob.
+///
+/// Internal counterpart of `api::grpc::qdrant::RawPayloadEncoding`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum RawPayloadEncoding {
+    /// serde_json encoding of the whole payload object, uncompressed,
+    /// exactly as stored in gridstore.
+    #[default]
+    JsonBytes,
+}
+
+impl RawPayload {
+    /// Wrap payload bytes read from storage, which are plain uncompressed
+    /// serde_json.
+    pub fn from_storage_bytes(payload_bytes: Vec<u8>) -> Self {
+        Self {
+            payload_bytes,
+            encoding: RawPayloadEncoding::JsonBytes,
+        }
+    }
+
+    /// Parse the blob into a [`Payload`].
+    pub fn decode(&self) -> OperationResult<Payload> {
+        match self.encoding {
+            RawPayloadEncoding::JsonBytes => {
+                serde_json::from_slice(&self.payload_bytes).map_err(|err| {
+                    OperationError::service_error(format!("Malformed raw payload blob: {err}"))
+                })
+            }
+        }
+    }
+}
+
+/// A payload as a raw read hands it out: as stored, or parsed where no stored
+/// form can be handed out.
+///
+/// A raw read prefers [`Self::Raw`], to spare both a parse here and an encode
+/// wherever the payload is going. It falls back to [`Self::Parsed`] when a
+/// blob cannot answer the request: a payload storage that keeps payloads
+/// parsed has no blob to hand out, and a payload selector cannot be applied to
+/// an opaque blob.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum MaybeRawPayload {
+    Raw(RawPayload),
+    Parsed(Payload),
+}
+
+impl MaybeRawPayload {
+    /// The payload in parsed form, decoding the blob if that is what it carries.
+    pub fn to_parsed(&self) -> OperationResult<Cow<'_, Payload>> {
+        match self {
+            Self::Raw(raw) => Ok(Cow::Owned(raw.decode()?)),
+            Self::Parsed(payload) => Ok(Cow::Borrowed(payload)),
+        }
+    }
+
+    /// Owned counterpart of [`Self::to_parsed`].
+    pub fn into_parsed(self) -> OperationResult<Payload> {
+        match self {
+            Self::Raw(raw) => raw.decode(),
+            Self::Parsed(payload) => Ok(payload),
+        }
+    }
+}
+
+/// Borrowed counterpart of [`MaybeRawPayload`], as a payload storage hands a
+/// payload to its reader.
+#[derive(Clone, Copy, Debug)]
+pub enum MaybeRawPayloadRef<'a> {
+    /// The payload in its stored encoding, uncompressed.
+    Raw(&'a [u8]),
+    Parsed(&'a Payload),
+}
+
+impl MaybeRawPayloadRef<'_> {
+    pub fn to_owned(self) -> MaybeRawPayload {
+        match self {
+            Self::Raw(bytes) => {
+                MaybeRawPayload::Raw(RawPayload::from_storage_bytes(bytes.to_vec()))
+            }
+            Self::Parsed(payload) => MaybeRawPayload::Parsed(payload.clone()),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Hash)]
 #[serde(untagged)]
 pub enum ValueVariants {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2950,39 +2950,20 @@ impl TryFrom<PayloadIndexInfo> for PayloadFieldSchema {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct RawPayload {
     pub payload_bytes: Vec<u8>,
-    pub encoding: RawPayloadEncoding,
-}
-
-/// Encoding of a raw payload blob.
-///
-/// Internal counterpart of `api::grpc::qdrant::RawPayloadEncoding`.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub enum RawPayloadEncoding {
-    /// serde_json encoding of the whole payload object, uncompressed,
-    /// exactly as stored in gridstore.
-    #[default]
-    JsonBytes,
 }
 
 impl RawPayload {
     /// Wrap payload bytes read from storage, which are plain uncompressed
     /// serde_json.
     pub fn from_storage_bytes(payload_bytes: Vec<u8>) -> Self {
-        Self {
-            payload_bytes,
-            encoding: RawPayloadEncoding::JsonBytes,
-        }
+        Self { payload_bytes }
     }
 
     /// Parse the blob into a [`Payload`].
     pub fn decode(&self) -> OperationResult<Payload> {
-        match self.encoding {
-            RawPayloadEncoding::JsonBytes => {
-                serde_json::from_slice(&self.payload_bytes).map_err(|err| {
-                    OperationError::service_error(format!("Malformed raw payload blob: {err}"))
-                })
-            }
-        }
+        serde_json::from_slice(&self.payload_bytes).map_err(|err| {
+            OperationError::service_error(format!("Malformed raw payload blob: {err}"))
+        })
     }
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2986,58 +2986,6 @@ impl RawPayload {
     }
 }
 
-/// A payload as a raw read hands it out: as stored, or parsed where no stored
-/// form can be handed out.
-///
-/// A raw read prefers [`Self::Raw`], to spare both a parse here and an encode
-/// wherever the payload is going. It falls back to [`Self::Parsed`] when a
-/// blob cannot answer the request: a payload storage that keeps payloads
-/// parsed has no blob to hand out, and a payload selector cannot be applied to
-/// an opaque blob.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub enum MaybeRawPayload {
-    Raw(RawPayload),
-    Parsed(Payload),
-}
-
-impl MaybeRawPayload {
-    /// The payload in parsed form, decoding the blob if that is what it carries.
-    pub fn to_parsed(&self) -> OperationResult<Cow<'_, Payload>> {
-        match self {
-            Self::Raw(raw) => Ok(Cow::Owned(raw.decode()?)),
-            Self::Parsed(payload) => Ok(Cow::Borrowed(payload)),
-        }
-    }
-
-    /// Owned counterpart of [`Self::to_parsed`].
-    pub fn into_parsed(self) -> OperationResult<Payload> {
-        match self {
-            Self::Raw(raw) => raw.decode(),
-            Self::Parsed(payload) => Ok(payload),
-        }
-    }
-}
-
-/// Borrowed counterpart of [`MaybeRawPayload`], as a payload storage hands a
-/// payload to its reader.
-#[derive(Clone, Copy, Debug)]
-pub enum MaybeRawPayloadRef<'a> {
-    /// The payload in its stored encoding, uncompressed.
-    Raw(&'a [u8]),
-    Parsed(&'a Payload),
-}
-
-impl MaybeRawPayloadRef<'_> {
-    pub fn to_owned(self) -> MaybeRawPayload {
-        match self {
-            Self::Raw(bytes) => {
-                MaybeRawPayload::Raw(RawPayload::from_storage_bytes(bytes.to_vec()))
-            }
-            Self::Parsed(payload) => MaybeRawPayload::Parsed(payload.clone()),
-        }
-    }
-}
-
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Hash)]
 #[serde(untagged)]
 pub enum ValueVariants {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2950,6 +2950,102 @@ impl TryFrom<PayloadIndexInfo> for PayloadFieldSchema {
     }
 }
 
+/// Byte-blob analogue of [`Payload`]: the whole payload object as a single
+/// encoded blob, tagged with its encoding.
+///
+/// Read from storage by `retrieve_raw` and shipped to another node as-is, so
+/// neither side has to parse the payload on the way.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct RawPayload {
+    pub payload_bytes: Vec<u8>,
+    pub encoding: RawPayloadEncoding,
+}
+
+/// Encoding of a raw payload blob.
+///
+/// Internal counterpart of `api::grpc::qdrant::RawPayloadEncoding`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum RawPayloadEncoding {
+    /// serde_json encoding of the whole payload object, uncompressed,
+    /// exactly as stored in gridstore.
+    #[default]
+    JsonBytes,
+}
+
+impl RawPayload {
+    /// Wrap payload bytes read from storage, which are plain uncompressed
+    /// serde_json.
+    pub fn from_storage_bytes(payload_bytes: Vec<u8>) -> Self {
+        Self {
+            payload_bytes,
+            encoding: RawPayloadEncoding::JsonBytes,
+        }
+    }
+
+    /// Parse the blob into a [`Payload`].
+    pub fn decode(&self) -> OperationResult<Payload> {
+        match self.encoding {
+            RawPayloadEncoding::JsonBytes => {
+                serde_json::from_slice(&self.payload_bytes).map_err(|err| {
+                    OperationError::service_error(format!("Malformed raw payload blob: {err}"))
+                })
+            }
+        }
+    }
+}
+
+/// A payload as a raw read hands it out: as stored, or parsed where no stored
+/// form can be handed out.
+///
+/// A raw read prefers [`Self::Raw`], to spare both a parse here and an encode
+/// wherever the payload is going. It falls back to [`Self::Parsed`] when a
+/// blob cannot answer the request: a payload storage that keeps payloads
+/// parsed has no blob to hand out, and a payload selector cannot be applied to
+/// an opaque blob.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum MaybeRawPayload {
+    Raw(RawPayload),
+    Parsed(Payload),
+}
+
+impl MaybeRawPayload {
+    /// The payload in parsed form, decoding the blob if that is what it carries.
+    pub fn to_parsed(&self) -> OperationResult<Cow<'_, Payload>> {
+        match self {
+            Self::Raw(raw) => Ok(Cow::Owned(raw.decode()?)),
+            Self::Parsed(payload) => Ok(Cow::Borrowed(payload)),
+        }
+    }
+
+    /// Owned counterpart of [`Self::to_parsed`].
+    pub fn into_parsed(self) -> OperationResult<Payload> {
+        match self {
+            Self::Raw(raw) => raw.decode(),
+            Self::Parsed(payload) => Ok(payload),
+        }
+    }
+}
+
+/// Borrowed counterpart of [`MaybeRawPayload`], as a payload storage hands a
+/// payload to its reader.
+#[derive(Clone, Copy, Debug)]
+pub enum MaybeRawPayloadRef<'a> {
+    /// The payload in its stored encoding, uncompressed.
+    Raw(&'a [u8]),
+    Parsed(&'a Payload),
+}
+
+impl MaybeRawPayloadRef<'_> {
+    pub fn to_owned(self) -> MaybeRawPayload {
+        match self {
+            Self::Raw(bytes) => {
+                MaybeRawPayload::Raw(RawPayload::from_storage_bytes(bytes.to_vec()))
+            }
+            Self::Parsed(payload) => MaybeRawPayload::Parsed(payload.clone()),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, JsonSchema, Clone, PartialEq, Eq, Hash)]
 #[serde(untagged)]
 pub enum ValueVariants {

--- a/lib/shard/src/operations/point_ops.rs
+++ b/lib/shard/src/operations/point_ops.rs
@@ -17,7 +17,7 @@ use segment::data_types::vectors::{
     BatchVectorStructInternal, DEFAULT_VECTOR_NAME, DenseVector, MultiDenseVector,
     MultiDenseVectorInternal, VectorInternal, VectorRef, VectorStructInternal,
 };
-use segment::types::{Filter, Payload, PointIdType, VectorNameBuf};
+use segment::types::{Filter, MaybeRawPayload, Payload, PointIdType, VectorNameBuf};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use sparse::common::types::{DimId, DimWeight};
@@ -435,23 +435,33 @@ mod raw_vectors_serde {
     }
 }
 
-impl From<SegmentRecordRaw> for PointStructRawPersisted {
-    fn from(record: SegmentRecordRaw) -> Self {
+impl TryFrom<SegmentRecordRaw> for PointStructRawPersisted {
+    type Error = OperationError;
+
+    /// A raw record carries the payload as stored, so it is decoded here — this
+    /// struct goes into the WAL, which holds parsed payloads.
+    fn try_from(record: SegmentRecordRaw) -> Result<Self, Self::Error> {
         let SegmentRecordRaw {
             id,
             vectors,
             payload,
         } = record;
 
-        Self {
+        Ok(Self {
             id,
             vectors: vectors.unwrap_or_default(),
-            payload,
-        }
+            payload: payload.map(MaybeRawPayload::into_parsed).transpose()?,
+        })
     }
 }
 
 impl PointStructRawPersisted {
+    /// Whether this point carries the data stored in `segment_record`.
+    ///
+    /// Vectors are compared as bytes, so logically equal vectors in a different
+    /// encoding count as unequal, which only costs a redundant upsert on sync.
+    /// Payloads are compared parsed, decoding the stored blob; a blob that does
+    /// not parse counts as unequal.
     pub fn is_equal_to(&self, segment_record: &SegmentRecordRaw) -> bool {
         let SegmentRecordRaw {
             id,
@@ -480,8 +490,13 @@ impl PointStructRawPersisted {
 
         // Check if payloads are equal, empty and non-existent payloads are considered equal
         let self_payload = self.payload.as_ref().filter(|p| !p.is_empty());
-        let segment_payload = payload.as_ref().filter(|p| !p.is_empty());
-        self_payload == segment_payload
+        let Ok(segment_payload) = payload.as_ref().map(MaybeRawPayload::to_parsed).transpose()
+        else {
+            // A blob that cannot be parsed is not the data this point carries
+            return false;
+        };
+        let segment_payload = segment_payload.filter(|payload| !payload.is_empty());
+        self_payload == segment_payload.as_deref()
     }
 }
 

--- a/lib/shard/src/operations/point_ops.rs
+++ b/lib/shard/src/operations/point_ops.rs
@@ -549,16 +549,16 @@ impl TryFrom<api::grpc::qdrant::PointStructRaw> for PointStructRawPersisted {
     }
 }
 
-/// Decodes the RawPayload according to its encoding.
+/// Decodes a raw payload received over the wire.
+///
+/// The blob is decoded by [`RawPayload::decode`], the one place that knows how
+/// each encoding is read; this only restates its errors as the bad input they
+/// are on this side.
 #[cfg(feature = "api")]
 fn decode_payload(raw_payload: api::grpc::RawPayload) -> Result<Payload, tonic::Status> {
-    match raw_payload.encoding() {
-        api::grpc::RawPayloadEncoding::JsonBytes => {
-            serde_json::from_slice(&raw_payload.payload_bytes).map_err(|err| {
-                tonic::Status::invalid_argument(format!("Malformed raw payload blob: {err}"))
-            })
-        }
-    }
+    RawPayload::try_from(raw_payload)?
+        .decode()
+        .map_err(|err| tonic::Status::invalid_argument(err.to_string()))
 }
 
 impl Debug for PointStructRawPersisted {
@@ -1219,5 +1219,48 @@ mod tests {
         };
         assert_eq!(named.keys().cloned().collect::<Vec<_>>(), vec!["a"]);
         assert_eq!(batch.ids.len(), 2);
+    }
+
+    /// A raw payload arriving over the wire is read by the same decoder as one
+    /// read from storage, and a blob that does not parse is reported as the bad
+    /// input it is.
+    #[cfg(feature = "api")]
+    #[test]
+    fn wire_raw_payload_is_decoded_by_the_shared_decoder() {
+        let expected: Payload = serde_json::from_str(r#"{"city": "Berlin", "count": 3}"#).unwrap();
+
+        let received = decode_payload(api::grpc::RawPayload {
+            payload_bytes: br#"{"city": "Berlin", "count": 3}"#.to_vec(),
+            encoding: api::grpc::RawPayloadEncoding::JsonBytes as i32,
+        })
+        .expect("a well-formed blob must decode");
+        assert_eq!(received, expected);
+
+        let err = decode_payload(api::grpc::RawPayload {
+            payload_bytes: b"not json".to_vec(),
+            encoding: api::grpc::RawPayloadEncoding::JsonBytes as i32,
+        })
+        .expect_err("a malformed blob must not decode");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    /// An encoding this node has no variant for comes from a node that writes
+    /// payloads some other way: it must be rejected rather than read as the
+    /// default encoding.
+    #[cfg(feature = "api")]
+    #[test]
+    fn wire_raw_payload_rejects_an_unknown_encoding() {
+        let err = decode_payload(api::grpc::RawPayload {
+            payload_bytes: br#"{"city": "Berlin"}"#.to_vec(),
+            encoding: 12345,
+        })
+        .expect_err("an unknown encoding must not decode");
+
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(
+            err.message().contains("Unknown raw payload encoding"),
+            "unexpected message: {}",
+            err.message(),
+        );
     }
 }

--- a/lib/shard/src/operations/point_ops.rs
+++ b/lib/shard/src/operations/point_ops.rs
@@ -3,8 +3,6 @@ use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 use std::mem;
 
-#[cfg(feature = "api")]
-use api::grpc::RawPayload;
 use common::validation::validate_multi_vector;
 use itertools::Itertools as _;
 use ordered_float::OrderedFloat;
@@ -17,7 +15,7 @@ use segment::data_types::vectors::{
     BatchVectorStructInternal, DEFAULT_VECTOR_NAME, DenseVector, MultiDenseVector,
     MultiDenseVectorInternal, VectorInternal, VectorRef, VectorStructInternal,
 };
-use segment::types::{Filter, MaybeRawPayload, Payload, PointIdType, VectorNameBuf};
+use segment::types::{Filter, Payload, PointIdType, RawPayload, VectorNameBuf};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use sparse::common::types::{DimId, DimWeight};
@@ -450,7 +448,7 @@ impl TryFrom<SegmentRecordRaw> for PointStructRawPersisted {
         Ok(Self {
             id,
             vectors: vectors.unwrap_or_default(),
-            payload: payload.map(MaybeRawPayload::into_parsed).transpose()?,
+            payload: payload.as_ref().map(RawPayload::decode).transpose()?,
         })
     }
 }
@@ -490,13 +488,12 @@ impl PointStructRawPersisted {
 
         // Check if payloads are equal, empty and non-existent payloads are considered equal
         let self_payload = self.payload.as_ref().filter(|p| !p.is_empty());
-        let Ok(segment_payload) = payload.as_ref().map(MaybeRawPayload::to_parsed).transpose()
-        else {
+        let Ok(segment_payload) = payload.as_ref().map(RawPayload::decode).transpose() else {
             // A blob that cannot be parsed is not the data this point carries
             return false;
         };
         let segment_payload = segment_payload.filter(|payload| !payload.is_empty());
-        self_payload == segment_payload.as_deref()
+        self_payload == segment_payload.as_ref()
     }
 }
 
@@ -554,7 +551,7 @@ impl TryFrom<api::grpc::qdrant::PointStructRaw> for PointStructRawPersisted {
 
 /// Decodes the RawPayload according to its encoding.
 #[cfg(feature = "api")]
-fn decode_payload(raw_payload: RawPayload) -> Result<Payload, tonic::Status> {
+fn decode_payload(raw_payload: api::grpc::RawPayload) -> Result<Payload, tonic::Status> {
     match raw_payload.encoding() {
         api::grpc::RawPayloadEncoding::JsonBytes => {
             serde_json::from_slice(&raw_payload.payload_bytes).map_err(|err| {

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -14,7 +14,7 @@ use segment::data_types::facets::{FacetParams, FacetValue};
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::order_by::OrderValue;
 use segment::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use segment::data_types::segment_record::{RawPayloadFormat, SegmentRecord, SegmentRecordRaw};
+use segment::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
 use segment::data_types::vector_name_config::VectorNameConfig;
 use segment::data_types::vectors::{QueryVector, VectorInternal};
 use segment::entry::StorageSegmentEntry;
@@ -375,7 +375,6 @@ impl ReadSegmentEntry for ProxySegment {
     fn retrieve_raw(
         &self,
         point_ids: &[PointIdType],
-        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         hw_counter: &HardwareCounterCell,
         is_stopped: &AtomicBool,
@@ -385,7 +384,6 @@ impl ReadSegmentEntry for ProxySegment {
             self.redact_and_filter_for_retrieve(with_vector, point_ids);
         self.wrapped_segment.get().read().retrieve_raw(
             &filtered_point_ids,
-            payload_format,
             with_vector.as_ref(),
             hw_counter,
             is_stopped,

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -14,7 +14,7 @@ use segment::data_types::facets::{FacetParams, FacetValue};
 use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::order_by::OrderValue;
 use segment::data_types::query_context::{FormulaContext, QueryContext, SegmentQueryContext};
-use segment::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
+use segment::data_types::segment_record::{RawPayloadFormat, SegmentRecord, SegmentRecordRaw};
 use segment::data_types::vector_name_config::VectorNameConfig;
 use segment::data_types::vectors::{QueryVector, VectorInternal};
 use segment::entry::StorageSegmentEntry;
@@ -375,7 +375,7 @@ impl ReadSegmentEntry for ProxySegment {
     fn retrieve_raw(
         &self,
         point_ids: &[PointIdType],
-        with_payload: &WithPayload,
+        payload_format: RawPayloadFormat,
         with_vector: &WithVector,
         hw_counter: &HardwareCounterCell,
         is_stopped: &AtomicBool,
@@ -385,7 +385,7 @@ impl ReadSegmentEntry for ProxySegment {
             self.redact_and_filter_for_retrieve(with_vector, point_ids);
         self.wrapped_segment.get().read().retrieve_raw(
             &filtered_point_ids,
-            with_payload,
+            payload_format,
             with_vector.as_ref(),
             hw_counter,
             is_stopped,

--- a/lib/shard/src/retrieve/retrieve_blocking.rs
+++ b/lib/shard/src/retrieve/retrieve_blocking.rs
@@ -8,7 +8,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::types::DeferredBehavior;
 use parking_lot::RwLock;
 use segment::common::operation_error::{OperationError, OperationResult};
-use segment::data_types::segment_record::{RawPayloadFormat, SegmentRecordRaw};
+use segment::data_types::segment_record::SegmentRecordRaw;
 use segment::entry::ReadSegmentEntry;
 use segment::types::{PointIdType, SeqNumberType, WithPayload, WithVector};
 
@@ -122,11 +122,9 @@ pub fn retrieve_over<R: ReadSegmentEntry + ?Sized>(
 /// storage-native bytes ([`SegmentRecordRaw`]) instead of decoded records, to
 /// avoid a lossy quantization round-trip when relocating points (shard
 /// transfer). Applies the same cross-segment version-dedup.
-#[allow(clippy::too_many_arguments)]
 pub fn retrieve_raw_blocking(
     segments: LockedSegmentHolder,
     points: &[PointIdType],
-    payload_format: RawPayloadFormat,
     with_vector: &WithVector,
     timeout: Duration,
     is_stopped: &AtomicBool,
@@ -146,7 +144,6 @@ pub fn retrieve_raw_blocking(
     retrieve_raw_over(
         segments,
         points,
-        payload_format,
         with_vector,
         is_stopped,
         hw_measurement_acc,
@@ -158,7 +155,6 @@ pub fn retrieve_raw_blocking(
 pub fn retrieve_raw_over<R: ReadSegmentEntry + ?Sized>(
     segments: Vec<Arc<RwLock<R>>>,
     points: &[PointIdType],
-    payload_format: RawPayloadFormat,
     with_vector: &WithVector,
     is_stopped: &AtomicBool,
     hw_measurement_acc: HwMeasurementAcc,
@@ -196,7 +192,6 @@ pub fn retrieve_raw_over<R: ReadSegmentEntry + ?Sized>(
 
             for (id, record) in segment.retrieve_raw(
                 &newer_version_points,
-                payload_format,
                 with_vector,
                 &hw_counter,
                 is_stopped,

--- a/lib/shard/src/retrieve/retrieve_blocking.rs
+++ b/lib/shard/src/retrieve/retrieve_blocking.rs
@@ -8,7 +8,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::types::DeferredBehavior;
 use parking_lot::RwLock;
 use segment::common::operation_error::{OperationError, OperationResult};
-use segment::data_types::segment_record::SegmentRecordRaw;
+use segment::data_types::segment_record::{RawPayloadFormat, SegmentRecordRaw};
 use segment::entry::ReadSegmentEntry;
 use segment::types::{PointIdType, SeqNumberType, WithPayload, WithVector};
 
@@ -126,7 +126,7 @@ pub fn retrieve_over<R: ReadSegmentEntry + ?Sized>(
 pub fn retrieve_raw_blocking(
     segments: LockedSegmentHolder,
     points: &[PointIdType],
-    with_payload: &WithPayload,
+    payload_format: RawPayloadFormat,
     with_vector: &WithVector,
     timeout: Duration,
     is_stopped: &AtomicBool,
@@ -146,7 +146,7 @@ pub fn retrieve_raw_blocking(
     retrieve_raw_over(
         segments,
         points,
-        with_payload,
+        payload_format,
         with_vector,
         is_stopped,
         hw_measurement_acc,
@@ -158,7 +158,7 @@ pub fn retrieve_raw_blocking(
 pub fn retrieve_raw_over<R: ReadSegmentEntry + ?Sized>(
     segments: Vec<Arc<RwLock<R>>>,
     points: &[PointIdType],
-    with_payload: &WithPayload,
+    payload_format: RawPayloadFormat,
     with_vector: &WithVector,
     is_stopped: &AtomicBool,
     hw_measurement_acc: HwMeasurementAcc,
@@ -196,7 +196,7 @@ pub fn retrieve_raw_over<R: ReadSegmentEntry + ?Sized>(
 
             for (id, record) in segment.retrieve_raw(
                 &newer_version_points,
-                with_payload,
+                payload_format,
                 with_vector,
                 &hw_counter,
                 is_stopped,

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -26,15 +26,14 @@ use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwL
 use rand::seq::IndexedRandom;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::data_types::named_vectors::NamedVectors;
-use segment::data_types::segment_record::RawPayloadFormat;
 use segment::entry::{
     NonAppendableSegmentEntry, ReadSegmentEntry, SegmentEntry, StorageSegmentEntry,
 };
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;
 use segment::types::{
-    ExtendedPointId, MaybeRawPayload, Payload, PointIdType, SegmentConfig, SeqNumberType,
-    VectorNameBuf, WithVector,
+    ExtendedPointId, Payload, PointIdType, RawPayload, SegmentConfig, SeqNumberType, VectorNameBuf,
+    WithVector,
 };
 use smallvec::SmallVec;
 
@@ -1046,9 +1045,6 @@ impl SegmentHolder {
                         let mut record = write_segment
                             .retrieve_raw(
                                 &[point_id],
-                                // The `SetPayload` callback below merges into the
-                                // parsed payload anyway
-                                RawPayloadFormat::Parsed,
                                 &WithVector::Bool(true),
                                 hw_counter,
                                 &stopped,
@@ -1064,8 +1060,8 @@ impl SegmentHolder {
                         // payload, so a stored blob is decoded here.
                         let mut payload = record
                             .payload
-                            .take()
-                            .map(MaybeRawPayload::into_parsed)
+                            .as_ref()
+                            .map(RawPayload::decode)
                             .transpose()?
                             .unwrap_or_default();
                         let mut updated_vectors = NamedVectors::default();

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -26,14 +26,15 @@ use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwL
 use rand::seq::IndexedRandom;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::data_types::named_vectors::NamedVectors;
+use segment::data_types::segment_record::RawPayloadFormat;
 use segment::entry::{
     NonAppendableSegmentEntry, ReadSegmentEntry, SegmentEntry, StorageSegmentEntry,
 };
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;
 use segment::types::{
-    ExtendedPointId, Payload, PointIdType, SegmentConfig, SeqNumberType, VectorNameBuf,
-    WithPayload, WithVector,
+    ExtendedPointId, MaybeRawPayload, Payload, PointIdType, SegmentConfig, SeqNumberType,
+    VectorNameBuf, WithVector,
 };
 use smallvec::SmallVec;
 
@@ -1045,10 +1046,9 @@ impl SegmentHolder {
                         let mut record = write_segment
                             .retrieve_raw(
                                 &[point_id],
-                                &WithPayload {
-                                    enable: true,
-                                    payload_selector: None,
-                                },
+                                // The `SetPayload` callback below merges into the
+                                // parsed payload anyway
+                                RawPayloadFormat::Parsed,
                                 &WithVector::Bool(true),
                                 hw_counter,
                                 &stopped,
@@ -1060,7 +1060,14 @@ impl SegmentHolder {
                             })?;
 
                         let mut raw_vectors = record.vectors.take().unwrap_or_default();
-                        let mut payload = record.payload.take().unwrap_or_default();
+                        // The `SetPayload` callback below merges into the parsed
+                        // payload, so a stored blob is decoded here.
+                        let mut payload = record
+                            .payload
+                            .take()
+                            .map(MaybeRawPayload::into_parsed)
+                            .transpose()?
+                            .unwrap_or_default();
                         let mut updated_vectors = NamedVectors::default();
 
                         point_cow_operation(

--- a/lib/shard/src/update/points/sync.rs
+++ b/lib/shard/src/update/points/sync.rs
@@ -6,7 +6,7 @@ use ahash::{AHashMap, AHashSet};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::DeferredBehavior;
 use segment::common::operation_error::OperationResult;
-use segment::data_types::segment_record::{RawPayloadFormat, SegmentRecord, SegmentRecordRaw};
+use segment::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
 use segment::entry::ReadSegmentEntry;
 use segment::types::{PointIdType, SeqNumberType, WithPayload, WithVector};
 
@@ -181,8 +181,6 @@ impl PointToSync for PointStructRawPersisted {
     ) -> OperationResult<AHashMap<PointIdType, SegmentRecordRaw>> {
         segment.retrieve_raw(
             ids,
-            // Compared against an incoming point, whose payload is parsed
-            RawPayloadFormat::Parsed,
             &WithVector::Bool(true),
             hw_counter,
             is_stopped,

--- a/lib/shard/src/update/points/sync.rs
+++ b/lib/shard/src/update/points/sync.rs
@@ -6,7 +6,7 @@ use ahash::{AHashMap, AHashSet};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::DeferredBehavior;
 use segment::common::operation_error::OperationResult;
-use segment::data_types::segment_record::{SegmentRecord, SegmentRecordRaw};
+use segment::data_types::segment_record::{RawPayloadFormat, SegmentRecord, SegmentRecordRaw};
 use segment::entry::ReadSegmentEntry;
 use segment::types::{PointIdType, SeqNumberType, WithPayload, WithVector};
 
@@ -181,7 +181,8 @@ impl PointToSync for PointStructRawPersisted {
     ) -> OperationResult<AHashMap<PointIdType, SegmentRecordRaw>> {
         segment.retrieve_raw(
             ids,
-            &WithPayload::from(true),
+            // Compared against an incoming point, whose payload is parsed
+            RawPayloadFormat::Parsed,
             &WithVector::Bool(true),
             hw_counter,
             is_stopped,

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -85,7 +85,7 @@ fn retrieve_raw_record(
     segment
         .retrieve_raw(
             &[point_id.into()],
-            &segment::types::WithPayload::from(true),
+            segment::data_types::segment_record::RawPayloadFormat::Parsed,
             &segment::types::WithVector::Bool(true),
             &hw_counter,
             &is_stopped,
@@ -93,6 +93,15 @@ fn retrieve_raw_record(
         )
         .unwrap()
         .remove(&point_id.into())
+}
+
+/// The payload a raw record carries, parsed; `None` when the point has none
+/// stored or stores an empty one.
+fn stored_payload(
+    record: &segment::data_types::segment_record::SegmentRecordRaw,
+) -> Option<segment::types::Payload> {
+    let payload = record.payload.as_ref()?.to_parsed().unwrap().into_owned();
+    (!payload.is_empty()).then_some(payload)
 }
 
 #[test]
@@ -146,9 +155,9 @@ fn test_upsert_points_raw_moves_point_from_non_appendable() {
     }
 
     let record = retrieve_raw_record(&holder, sid_app, 1).unwrap();
-    assert_eq!(record.payload, Some(payload));
+    assert_eq!(stored_payload(&record), Some(payload));
     let record = retrieve_raw_record(&holder, sid_app, 100).unwrap();
-    assert_eq!(record.payload.filter(|p| !p.is_empty()), None);
+    assert_eq!(stored_payload(&record), None);
 }
 
 #[test]
@@ -160,7 +169,8 @@ fn test_sync_points_raw() {
     let mut holder = SegmentHolder::default();
     let sid = holder.add_new(segment);
 
-    let point_2 = PointStructRawPersisted::from(retrieve_raw_record(&holder, sid, 2).unwrap());
+    let point_2 =
+        PointStructRawPersisted::try_from(retrieve_raw_record(&holder, sid, 2).unwrap()).unwrap();
     let point_2_version_before = holder
         .get(sid)
         .unwrap()
@@ -168,7 +178,8 @@ fn test_sync_points_raw() {
         .read()
         .point_version(2.into());
 
-    let mut point_3 = PointStructRawPersisted::from(retrieve_raw_record(&holder, sid, 3).unwrap());
+    let mut point_3 =
+        PointStructRawPersisted::try_from(retrieve_raw_record(&holder, sid, 3).unwrap()).unwrap();
     let changed_bytes: Vec<u8> = [9.0f32, 8.0, 7.0, 6.0]
         .iter()
         .flat_map(|v| v.to_le_bytes())

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -85,7 +85,6 @@ fn retrieve_raw_record(
     segment
         .retrieve_raw(
             &[point_id.into()],
-            segment::data_types::segment_record::RawPayloadFormat::Parsed,
             &segment::types::WithVector::Bool(true),
             &hw_counter,
             &is_stopped,
@@ -100,7 +99,7 @@ fn retrieve_raw_record(
 fn stored_payload(
     record: &segment::data_types::segment_record::SegmentRecordRaw,
 ) -> Option<segment::types::Payload> {
-    let payload = record.payload.as_ref()?.to_parsed().unwrap().into_owned();
+    let payload = record.payload.as_ref()?.decode().unwrap();
     (!payload.is_empty()).then_some(payload)
 }
 


### PR DESCRIPTION
This PR does a mechanical work to provide raw payload retrieve from segment entry.

The key idea: retrieve_raw has a flag, do we need raw or original payload. Result type SegmentRecordRaw has raw and normal payload like in grpc api.