### PR TITLE
Batched deletion checks in full-scan/exact search (10-35% faster Turbo4)

### DIFF
--- a/lib/common/common/src/bitmap_scan.rs
+++ b/lib/common/common/src/bitmap_scan.rs
@@ -1,0 +1,148 @@
+use bitvec::field::BitField as _;
+
+use crate::bitvec::BitSlice;
+use crate::types::PointOffsetType;
+
+/// Cursor over the ids in `0..point_count` whose bit is unset in all `N`
+/// flagged bitmaps, yielded in ascending order in caller-buffer-sized chunks.
+/// Bits past the end of a bitmap read as unflagged, matching the
+/// `get_bit(id).unwrap_or(false)` convention of per-id bit checks. A mask
+/// whose absent bits must count as flagged cannot rely on this — bound
+/// `point_count` by that mask's length instead.
+pub struct BatchedBitmapScan<'a, const N: usize> {
+    masks: [&'a BitSlice; N],
+    point_count: usize,
+    /// Start of the next unread 64-id block; always a multiple of 64.
+    start: usize,
+}
+
+impl<'a, const N: usize> BatchedBitmapScan<'a, N> {
+    pub fn new(point_count: usize, masks: [&'a BitSlice; N]) -> Self {
+        Self {
+            masks,
+            point_count,
+            start: 0,
+        }
+    }
+
+    /// Fill `buf` with the next unflagged ids, in ascending order. Returns the
+    /// count written; 0 means the scan is exhausted. `buf.len()` must be at
+    /// least 64 so a whole 64-id block always fits into an empty buffer.
+    pub fn next_chunk(&mut self, buf: &mut [PointOffsetType]) -> usize {
+        debug_assert!(buf.len() >= 64);
+        let mut n = 0;
+        while self.start < self.point_count {
+            let start = self.start;
+
+            // Bit `i` set → id `start + i` is a candidate: unflagged in every mask.
+            let mut flagged = 0u64;
+            for mask in self.masks {
+                flagged |= bitmap_word(mask, start);
+            }
+            let mut candidates = !flagged;
+
+            // Zero the bits past the scan range in the final block.
+            let block_len = self.point_count - start;
+            if block_len < 64 {
+                candidates &= (1u64 << block_len) - 1;
+            }
+            if candidates == 0 {
+                self.start += 64;
+                continue;
+            }
+
+            // Return the chunk once this block's ids no longer fit; the block
+            // stays unread and is re-harvested on the next call.
+            if n + candidates.count_ones() as usize > buf.len() {
+                break;
+            }
+            self.start += 64;
+
+            let base = start as PointOffsetType;
+            if candidates == u64::MAX {
+                // Fully flag-free block — the common case.
+                for (i, slot) in buf[n..n + 64].iter_mut().enumerate() {
+                    *slot = base + i as PointOffsetType;
+                }
+                n += 64;
+            } else {
+                // One iteration per set bit, in ascending order:
+                // `trailing_zeros` locates the lowest set bit (the next
+                // candidate's offset in the block), `candidates - 1` &-ed
+                // into the mask clears exactly that bit.
+                while candidates != 0 {
+                    buf[n] = base + candidates.trailing_zeros() as PointOffsetType;
+                    n += 1;
+                    candidates &= candidates - 1;
+                }
+            }
+        }
+        n
+    }
+}
+
+/// The 64-bit word of `bitmap` covering positions `start..start + 64`.
+/// Positions past the end of the slice read as 0 (not flagged).
+#[inline]
+fn bitmap_word(bitmap: &BitSlice, start: usize) -> u64 {
+    let end = (start + 64).min(bitmap.len());
+    if start >= end {
+        return 0;
+    }
+    bitmap[start..end].load_le::<u64>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bitvec::{BitSliceExt as _, BitVec};
+
+    /// `BatchedBitmapScan::next_chunk` must reproduce a per-id `get_bit` scan of the
+    /// same masks: ascending ids, no duplicates across calls, including a word
+    /// split across two calls, a fully-flagged word, a fully-live word (fast
+    /// path), masks shorter than the scan range, and a tail block.
+    #[test]
+    fn batched_bitmap_scan_chunks_match_per_id_reference() {
+        const POINT_COUNT: usize = 300;
+
+        // Word 0 (ids 0..64): every 3rd id flagged -> 42 candidates.
+        // Word 1 (ids 64..128): fully live -> u64::MAX fast path.
+        // Word 2 (ids 128..192): fully flagged by mask_b -> skipped block.
+        // Word 3 (ids 192..256): fully live (both masks end before it).
+        // Word 4 (ids 256..300): tail block of 44.
+        let mut mask_a = BitVec::repeat(false, 64);
+        for i in (0..64).step_by(3) {
+            mask_a.set(i, true);
+        }
+        let mut mask_b = BitVec::repeat(false, 200);
+        for i in 128..192 {
+            mask_b.set(i, true);
+        }
+
+        let reference: Vec<PointOffsetType> = (0..POINT_COUNT as PointOffsetType)
+            .filter(|&id| {
+                !mask_a.get_bit(id as usize).unwrap_or(false)
+                    && !mask_b.get_bit(id as usize).unwrap_or(false)
+            })
+            .collect();
+
+        let mut scan =
+            BatchedBitmapScan::new(POINT_COUNT, [mask_a.as_bitslice(), mask_b.as_bitslice()]);
+        let mut buf = [0; 64];
+        let mut harvested = Vec::new();
+        let mut chunk_sizes = Vec::new();
+        loop {
+            let n = scan.next_chunk(&mut buf);
+            if n == 0 {
+                break;
+            }
+            chunk_sizes.push(n);
+            harvested.extend_from_slice(&buf[..n]);
+        }
+
+        assert_eq!(harvested, reference);
+        // Word 1 (64 candidates) must not fit behind word 0's 42 -> it is
+        // deferred to the second call; every fully-live word fills one chunk.
+        assert_eq!(chunk_sizes, vec![42, 64, 64, 44]);
+    }
+}

--- a/lib/common/common/src/bitmap_scan.rs
+++ b/lib/common/common/src/bitmap_scan.rs
@@ -14,6 +14,10 @@ pub struct BatchedBitmapScan<'a, const N: usize> {
     point_count: usize,
     /// Start of the next unread 64-id block; always a multiple of 64.
     start: usize,
+    /// Candidate word that did not fit into the previous `next_chunk` buffer,
+    /// carried over so the masks are read once per block; 0 = none pending.
+    pending: u64,
+    pending_base: PointOffsetType,
 }
 
 impl<'a, const N: usize> BatchedBitmapScan<'a, N> {
@@ -22,17 +26,32 @@ impl<'a, const N: usize> BatchedBitmapScan<'a, N> {
             masks,
             point_count,
             start: 0,
+            pending: 0,
+            pending_base: 0,
         }
     }
 
     /// Fill `buf` with the next unflagged ids, in ascending order. Returns the
     /// count written; 0 means the scan is exhausted. `buf.len()` must be at
     /// least 64 so a whole 64-id block always fits into an empty buffer.
+    ///
+    /// Inlined so the cursor state stays in registers across a caller's
+    /// chunk loop; with dense bitmaps this is called once per 64 ids.
+    #[inline(always)]
     pub fn next_chunk(&mut self, buf: &mut [PointOffsetType]) -> usize {
         debug_assert!(buf.len() >= 64);
         let mut n = 0;
+
+        // Word carried over because it did not fit into the previous buffer;
+        // an empty buffer always has room for a whole word.
+        if self.pending != 0 {
+            n = expand_word(self.pending, self.pending_base, buf, 0);
+            self.pending = 0;
+        }
+
         while self.start < self.point_count {
             let start = self.start;
+            self.start += 64;
 
             // Bit `i` set → id `start + i` is a candidate: unflagged in every mask.
             let mut flagged = 0u64;
@@ -47,35 +66,46 @@ impl<'a, const N: usize> BatchedBitmapScan<'a, N> {
                 candidates &= (1u64 << block_len) - 1;
             }
             if candidates == 0 {
-                self.start += 64;
                 continue;
             }
 
-            // Return the chunk once this block's ids no longer fit; the block
-            // stays unread and is re-harvested on the next call.
+            // Return the chunk once this block's ids no longer fit; the word
+            // is stashed for the next call rather than re-read from the masks.
             if n + candidates.count_ones() as usize > buf.len() {
+                self.pending = candidates;
+                self.pending_base = start as PointOffsetType;
                 break;
             }
-            self.start += 64;
 
-            let base = start as PointOffsetType;
-            if candidates == u64::MAX {
-                // Fully flag-free block — the common case.
-                for (i, slot) in buf[n..n + 64].iter_mut().enumerate() {
-                    *slot = base + i as PointOffsetType;
-                }
-                n += 64;
-            } else {
-                // One iteration per set bit, in ascending order:
-                // `trailing_zeros` locates the lowest set bit (the next
-                // candidate's offset in the block), `candidates - 1` &-ed
-                // into the mask clears exactly that bit.
-                while candidates != 0 {
-                    buf[n] = base + candidates.trailing_zeros() as PointOffsetType;
-                    n += 1;
-                    candidates &= candidates - 1;
-                }
-            }
+            n = expand_word(candidates, start as PointOffsetType, buf, n);
+        }
+        n
+    }
+}
+
+/// Append the ids of the set bits of `candidates` (offset by `base`) to
+/// `buf[n..]`; returns the new fill count. Caller guarantees the bits fit.
+#[inline(always)]
+fn expand_word(
+    mut candidates: u64,
+    base: PointOffsetType,
+    buf: &mut [PointOffsetType],
+    mut n: usize,
+) -> usize {
+    if candidates == u64::MAX {
+        // Fully flag-free block — the common case.
+        for (i, slot) in buf[n..n + 64].iter_mut().enumerate() {
+            *slot = base + i as PointOffsetType;
+        }
+        n + 64
+    } else {
+        // One iteration per set bit, in ascending order: `trailing_zeros`
+        // locates the lowest set bit (the next candidate's offset in the
+        // block), `candidates - 1` &-ed into the mask clears exactly that bit.
+        while candidates != 0 {
+            buf[n] = base + candidates.trailing_zeros() as PointOffsetType;
+            n += 1;
+            candidates &= candidates - 1;
         }
         n
     }

--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod aligned_buf;
 #[cfg(feature = "testing")]
 pub mod bench_cache;
 pub mod binary_search;
+pub mod bitmap_scan;
 pub mod bitpacking;
 pub mod bitpacking_links;
 pub mod bitpacking_ordered;

--- a/lib/segment/src/id_tracker/disk_id_tracker/mappings.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/mappings.rs
@@ -108,6 +108,10 @@ impl<'a, S: UniversalRead> DiskMappingsRef<'a, S> {
         self.deleted
     }
 
+    pub fn total_point_count(self) -> usize {
+        self.reader.total_point_count() as usize
+    }
+
     pub fn iter_external(self) -> impl Iterator<Item = PointIdType> + 'a {
         self.reader
             .iter_from(None)

--- a/lib/segment/src/id_tracker/id_tracker_base/point_mappings_ref.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/point_mappings_ref.rs
@@ -181,6 +181,20 @@ impl<'a, S: UniversalRead> PointMappingsRefEnum<'a, S> {
         }
     }
 
+    /// Word-scan form of [`Self::iter_internal`]: it yields an id iff the id
+    /// is below the returned cutoff (the mapping's total point count) and its
+    /// bit is unset in the returned deleted bitslice. Unlike
+    /// [`Self::visible_scan_masks`], no deferred or shadowed-active filtering
+    /// applies.
+    pub fn internal_scan_masks(self) -> (Option<PointOffsetType>, &'a BitSlice) {
+        let total = match self {
+            PointMappingsRefEnum::Plain(m) => m.total_point_count(),
+            PointMappingsRefEnum::Compressed(m) => m.total_point_count(),
+            PointMappingsRefEnum::Disk(m) => m.total_point_count(),
+        };
+        (Some(total as PointOffsetType), self.deleted())
+    }
+
     /// Iterate starting from a given ID, with deferred filtering selected by
     /// `deferred_behavior`. See [`PointMappings::iter_from_with_behavior`] for
     /// the per-mode contract. Compressed mappings ignore the parameter (they

--- a/lib/segment/src/id_tracker/id_tracker_base/point_mappings_ref.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/point_mappings_ref.rs
@@ -162,6 +162,25 @@ impl<'a, S: UniversalRead> PointMappingsRefEnum<'a, S> {
         }
     }
 
+    /// Word-scan form of [`Self::filter_deferred_and_deleted`] with
+    /// [`DeferredBehavior::VisibleOnly`], for full-range scans.  Returns
+    /// `(cutoff, mapping_deleted, shadowed)`: a point is visible iff its id
+    /// is below the cutoff (when `Some`) and its bit is unset in both
+    /// bitslices.  Callers OR the bitslices into a word-level liveness
+    /// harvest (see `BatchFilteredSearcher::peek_top_visible`) instead of
+    /// filtering ids one at a time.
+    ///
+    /// Branches mirror [`Self::filter_deferred_and_deleted`]: without a
+    /// deferred cutoff the shadowed-actives bitslice applies (it is empty
+    /// unless deferred mutations exist); with a cutoff only the deleted
+    /// bitslice and the cutoff itself apply.
+    pub fn visible_scan_masks(self) -> (Option<PointOffsetType>, &'a BitSlice, &'a BitSlice) {
+        match DeferredBehavior::VisibleOnly.apply(self.deferred_internal_id()) {
+            None => (None, self.deleted(), self.shadowed()),
+            Some(cutoff) => (Some(cutoff), self.deleted(), BitSlice::empty()),
+        }
+    }
+
     /// Iterate starting from a given ID, with deferred filtering selected by
     /// `deferred_behavior`. See [`PointMappings::iter_from_with_behavior`] for
     /// the per-mode contract. Compressed mappings ignore the parameter (they

--- a/lib/segment/src/id_tracker/point_mappings.rs
+++ b/lib/segment/src/id_tracker/point_mappings.rs
@@ -967,6 +967,42 @@ mod set_link_shadow_tests {
         assert_eq!(include_all, vec![3, 7, 8]);
     }
 
+    /// `internal_scan_masks` must describe exactly the ids `iter_internal`
+    /// yields: below the total-count cutoff and unset in the deleted
+    /// bitslice, with no deferred or shadowed filtering — the shadowed
+    /// active, its deferred head, and never-linked holes all behave the same
+    /// through both forms.
+    #[test]
+    fn internal_scan_masks_match_iter_internal() {
+        use common::bitvec::BitSliceExt as _;
+
+        use crate::id_tracker::PointMappingsRefEnum;
+
+        // Cutoff = 5: ext 7 has a shadowed active (2) plus a deferred head
+        // (7), ext 9 is deferred-only (8), ext 10 is dropped (tombstoned 4),
+        // and slots 0, 1, 5, 6 are never-linked holes.
+        let mut m = fresh_mapping(Some(5));
+        m.set_link(ext(7), 2);
+        m.set_link(ext(7), 7);
+        m.set_link(ext(8), 3);
+        m.set_link(ext(9), 8);
+        m.set_link(ext(10), 4);
+        m.drop(ext(10));
+
+        let r = PointMappingsRefEnum::<common::universal_io::MmapFile>::Plain(&m);
+        let (cutoff, mapping_deleted) = r.internal_scan_masks();
+
+        let cutoff = cutoff.expect("internal scan is bounded by the mapping length");
+        let from_masks: Vec<PointOffsetType> = (0..cutoff)
+            .filter(|&id| !mapping_deleted.get_bit(id as usize).unwrap_or(false))
+            .collect();
+        let reference: Vec<PointOffsetType> = r.iter_internal().collect();
+        assert_eq!(from_masks, reference);
+        // Both the shadowed active and its deferred head are in the scan.
+        assert!(reference.contains(&2));
+        assert!(reference.contains(&7));
+    }
+
     #[test]
     fn drop_clears_both_tracks_and_shadow() {
         let mut m = fresh_mapping(Some(5));

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
@@ -207,22 +207,68 @@ where
             .collect()
     }
 
-    fn search_plain_iterator_batched(
+    pub(super) fn search_plain_batched(
         &self,
         query_vectors: &[&QueryVector],
-        points: impl Iterator<Item = PointOffsetType>,
+        filtered_points: impl Iterator<Item = PointOffsetType>,
         top: usize,
         params: Option<&SearchParams>,
         vector_query_context: &VectorQueryContext,
     ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        let is_stopped = vector_query_context.is_stopped();
+        let batch_filtered_searcher =
+            self.construct_plain_batch_searcher(query_vectors, top, params, vector_query_context)?;
+        let search_results = batch_filtered_searcher.peek_top_iter(filtered_points, &is_stopped)?;
+        self.postprocess_plain_batch(
+            search_results,
+            query_vectors,
+            top,
+            params,
+            vector_query_context,
+        )
+    }
+
+    pub(super) fn search_plain_unfiltered_batched(
+        &self,
+        query_vectors: &[&QueryVector],
+        top: usize,
+        params: Option<&SearchParams>,
+        vector_query_context: &VectorQueryContext,
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        let is_stopped = vector_query_context.is_stopped();
+        let batch_filtered_searcher =
+            self.construct_plain_batch_searcher(query_vectors, top, params, vector_query_context)?;
+        // Scan candidates by combining the deletion bitmaps word by word
+        // instead of feeding `iter_internal()` into `peek_top_iter` — the
+        // per-id enumeration dominates unfiltered full scans.
+        let (cutoff, mapping_deleted) = self.id_tracker.point_mappings().internal_scan_masks();
+        let search_results = batch_filtered_searcher.peek_top_visible(
+            cutoff,
+            mapping_deleted,
+            BitSlice::empty(),
+            &is_stopped,
+        )?;
+        self.postprocess_plain_batch(
+            search_results,
+            query_vectors,
+            top,
+            params,
+            vector_query_context,
+        )
+    }
+
+    fn construct_plain_batch_searcher<'b>(
+        &'b self,
+        query_vectors: &[&QueryVector],
+        top: usize,
+        params: Option<&SearchParams>,
+        vector_query_context: &'b VectorQueryContext<'b>,
+    ) -> OperationResult<BatchFilteredSearcher<'b>> {
         let deleted_points = vector_query_context
             .deleted_points()
             .unwrap_or_else(|| self.id_tracker.deleted_point_bitslice());
-
-        let is_stopped = vector_query_context.is_stopped();
         let oversampled_top = get_oversampled_top(self.quantized_vectors, params, top);
-
-        let batch_filtered_searcher = construct_batch_searcher(
+        construct_batch_searcher(
             query_vectors,
             self.vector_storage,
             self.quantized_vectors,
@@ -231,8 +277,17 @@ where
             params,
             vector_query_context.hardware_counter(),
             None,
-        )?;
-        let mut search_results = batch_filtered_searcher.peek_top_iter(points, &is_stopped)?;
+        )
+    }
+
+    fn postprocess_plain_batch(
+        &self,
+        mut search_results: Vec<Vec<ScoredPointOffset>>,
+        query_vectors: &[&QueryVector],
+        top: usize,
+        params: Option<&SearchParams>,
+        vector_query_context: &VectorQueryContext,
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
         for (search_result, query_vector) in search_results.iter_mut().zip(query_vectors) {
             *search_result = postprocess_search_result(
                 std::mem::take(search_result),
@@ -246,34 +301,6 @@ where
             )?;
         }
         Ok(search_results)
-    }
-
-    pub(super) fn search_plain_batched(
-        &self,
-        vectors: &[&QueryVector],
-        filtered_points: impl Iterator<Item = PointOffsetType>,
-        top: usize,
-        params: Option<&SearchParams>,
-        vector_query_context: &VectorQueryContext,
-    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
-        self.search_plain_iterator_batched(
-            vectors,
-            filtered_points,
-            top,
-            params,
-            vector_query_context,
-        )
-    }
-
-    pub(super) fn search_plain_unfiltered_batched(
-        &self,
-        vectors: &[&QueryVector],
-        top: usize,
-        params: Option<&SearchParams>,
-        vector_query_context: &VectorQueryContext,
-    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
-        let ids_iterator = self.id_tracker.point_mappings().iter_internal();
-        self.search_plain_iterator_batched(vectors, ids_iterator, top, params, vector_query_context)
     }
 
     pub(super) fn search_vectors_plain(

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::AtomicBool;
 
+use bitvec::field::BitField as _;
 use common::bitvec::BitSlice;
 use common::condition_checker::{CheckItem, ConditionChecker, Rest, Select};
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -419,6 +420,114 @@ impl<'a> BatchFilteredSearcher<'a> {
         self.peek_top_iter(iter, is_stopped)
     }
 
+    /// Full-scan counterpart of [`Self::peek_top_iter`]: scores every point
+    /// that is not flagged in the deletion bitmaps, is below `cutoff` (when
+    /// `Some`), and is not flagged in `mapping_deleted` / `shadowed`.
+    ///
+    /// Equivalent to feeding `peek_top_iter` the composition of
+    /// [`Self::iter_not_deleted`] with
+    /// `PointMappingsRefEnum::filter_deferred_and_deleted` — callers obtain
+    /// `cutoff`, `mapping_deleted`, and `shadowed` from
+    /// `PointMappingsRefEnum::visible_scan_masks`.  Instead of walking
+    /// `iter_zeros()` bit by bit and re-checking every id against the same
+    /// bitmaps, this combines all bitmaps one 64-bit word at a time and
+    /// extracts candidate ids with `trailing_zeros`, which is where full
+    /// scans over mostly-live segments spend their enumeration time.
+    pub fn peek_top_visible(
+        self,
+        cutoff: Option<PointOffsetType>,
+        mapping_deleted: &BitSlice,
+        shadowed: &BitSlice,
+        is_stopped: &AtomicBool,
+    ) -> OperationResult<Vec<Vec<ScoredPointOffset>>> {
+        // A whole harvested 64-point block must fit into one scoring chunk.
+        const { assert!(VECTOR_READ_BATCH_SIZE >= 64) };
+
+        let Self {
+            mut scorer_batch,
+            filters,
+        } = self;
+
+        // Number of leading point ids to scan. Points without an explicit
+        // `point_deleted` flag count as deleted (see [`NotDeletedChecker`]),
+        // so that bitmap's length bounds the scan; the deferred cutoff
+        // tightens the bound further.
+        let mut point_count = filters.deleted.point_deleted.len();
+        if let Some(cutoff) = cutoff {
+            point_count = point_count.min(cutoff as usize);
+        }
+
+        let mut chunk = [0; VECTOR_READ_BATCH_SIZE];
+        let mut scores_buffer = [0.0; VECTOR_READ_BATCH_SIZE];
+        // Number of candidate ids accumulated in `chunk` (`chunk[..chunk_size]` is the filled prefix); reset on every flush to the scorers.
+        let mut chunk_size = 0;
+
+        // Process points in blocks of 64 — one word from each bitmap.
+        for start in (0..point_count).step_by(64) {
+            // Bit `i` set → point `start + i` is a candidate: not flagged in
+            // any deletion bitmap, not mapping-deleted, not shadowed.
+            let mut candidates = !(bitmap_word(filters.deleted.point_deleted, start)
+                | bitmap_word(filters.deleted.vec_deleted, start)
+                | bitmap_word(mapping_deleted, start)
+                | bitmap_word(shadowed, start));
+
+            // Zero the bits past the scan range in the final block.
+            let block_len = point_count - start;
+            if block_len < 64 {
+                candidates &= (1u64 << block_len) - 1;
+            }
+            if candidates == 0 {
+                continue;
+            }
+
+            // If this block's candidates would overflow the `chunk` buffer, score the ids accumulated so far to make room.
+            if chunk_size + candidates.count_ones() as usize > VECTOR_READ_BATCH_SIZE {
+                check_process_stopped(is_stopped)?;
+                score_chunk(
+                    &filters,
+                    &mut scorer_batch,
+                    &mut chunk[..chunk_size],
+                    &mut scores_buffer,
+                )?;
+                chunk_size = 0;
+            }
+
+            let base = start as PointOffsetType;
+            if candidates == u64::MAX && false {
+                // Fully live block — the common no-deletions case.
+                for (i, slot) in chunk[chunk_size..chunk_size + 64].iter_mut().enumerate() {
+                    *slot = base + i as PointOffsetType;
+                }
+                chunk_size += 64;
+            } else {
+                // One iteration per set bit, in ascending order:
+                // `trailing_zeros` locates the lowest set bit (the next candidate's offset in the block), `candidates - 1` &-ed
+                // into the mask clears exactly that bit.
+                while candidates != 0 {
+                    chunk[chunk_size] = base + candidates.trailing_zeros() as PointOffsetType;
+                    chunk_size += 1;
+                    candidates &= candidates - 1;
+                }
+            }
+        }
+
+        if chunk_size > 0 {
+            check_process_stopped(is_stopped)?;
+            score_chunk(
+                &filters,
+                &mut scorer_batch,
+                &mut chunk[..chunk_size],
+                &mut scores_buffer,
+            )?;
+        }
+
+        let results = scorer_batch
+            .into_iter()
+            .map(|BatchSearch { pq, .. }| pq.into_sorted_vec())
+            .collect();
+        Ok(results)
+    }
+
     /// This function expects deferred points to be already filtered from the iterator.
     pub fn peek_top_iter(
         mut self,
@@ -469,5 +578,175 @@ impl<'a> BatchFilteredSearcher<'a> {
             .map(|BatchSearch { pq, .. }| pq.into_sorted_vec())
             .collect();
         Ok(results)
+    }
+}
+
+/// The 64-bit word of `bitmap` covering positions `start..start + 64`.
+/// Positions past the end of the slice read as 0 (not flagged), matching the
+/// `get_bit(id).unwrap_or(false)` convention of the per-id checks.
+#[inline]
+fn bitmap_word(bitmap: &BitSlice, start: usize) -> u64 {
+    let end = (start + 64).min(bitmap.len());
+    if start >= end {
+        return 0;
+    }
+    bitmap[start..end].load_le::<u64>()
+}
+
+/// Score one harvested chunk against every scorer and push into its queue.
+/// Applies `filter_context` if present; the deletion bitmaps were already folded into the harvest masks by the caller.
+fn score_chunk(
+    filters: &ScorerFilters<'_>,
+    scorer_batch: &mut [BatchSearch<'_>],
+    chunk: &mut [PointOffsetType],
+    scores_buffer: &mut [ScoreType; VECTOR_READ_BATCH_SIZE],
+) -> OperationResult<()> {
+    let n = match &filters.filter_context {
+        Some(f) => f.check_batched(chunk, Select::Matches, Rest::Discard)?,
+        None => chunk.len(),
+    };
+    let chunk = &chunk[..n];
+    if chunk.is_empty() {
+        return Ok(());
+    }
+    for BatchSearch { raw_scorer, pq } in scorer_batch {
+        raw_scorer.score_points(chunk, &mut scores_buffer[..chunk.len()]);
+        for i in 0..chunk.len() {
+            pq.push(ScoredPointOffset {
+                idx: chunk[i],
+                score: scores_buffer[i],
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use common::bitvec::{BitSliceExt as _, BitVec};
+    use rand::rngs::StdRng;
+    use rand::{RngExt, SeedableRng};
+
+    use super::*;
+    use crate::types::Distance;
+    use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
+    use crate::vector_storage::{DEFAULT_STOPPED, VectorStorage as _};
+
+    fn random_mask(rng: &mut StdRng, len: usize, rate: f64) -> BitVec {
+        let mut mask = BitVec::repeat(false, len);
+        for i in 0..len {
+            if rng.random_bool(rate) {
+                mask.set(i, true);
+            }
+        }
+        mask
+    }
+
+    /// [`BatchFilteredSearcher::peek_top_visible`] must reproduce the iterator
+    /// path exactly for every combination of deletion bitmaps (including
+    /// lengths that are not word multiples and differ from the point count),
+    /// extra masks, and deferred cutoff.
+    #[test]
+    fn peek_top_visible_matches_iter_reference() {
+        const TOTAL: usize = 300;
+        const DIM: usize = 4;
+        const TOP: usize = 20;
+
+        let mut rng = StdRng::seed_from_u64(42);
+        let hw_counter = HardwareCounterCell::new();
+
+        let mut storage = new_volatile_dense_vector_storage(DIM, Distance::Dot);
+        for i in 0..TOTAL {
+            let vector: Vec<f32> = (0..DIM).map(|_| rng.random_range(-1.0..1.0)).collect();
+            storage
+                .insert_vector(i as PointOffsetType, vector.as_slice().into(), &hw_counter)
+                .unwrap();
+        }
+        for i in 0..TOTAL {
+            if rng.random_bool(0.15) {
+                storage.delete_vector(i as PointOffsetType).unwrap();
+            }
+        }
+
+        let queries: Vec<QueryVector> = (0..2)
+            .map(|_| {
+                let v: Vec<f32> = (0..DIM).map(|_| rng.random_range(-1.0..1.0)).collect();
+                v.as_slice().into()
+            })
+            .collect();
+
+        let empty = BitVec::new();
+        let all_live = BitVec::repeat(false, TOTAL);
+        let mut dead_prefix = BitVec::repeat(false, TOTAL);
+        for i in 0..200 {
+            dead_prefix.set(i, true);
+        }
+
+        // (point_deleted, mapping_deleted, shadowed, cutoff)
+        let cases: Vec<(BitVec, BitVec, BitVec, Option<PointOffsetType>)> = vec![
+            // All alive, no extra bitmaps, no cutoff — the fully-live block
+            // fast path.
+            (all_live.clone(), empty.clone(), empty.clone(), None),
+            // Empty point_deleted bitmap: everything counts as deleted.
+            (BitVec::new(), empty.clone(), empty.clone(), None),
+            // Random deletions everywhere; extra bitmaps shorter and longer
+            // than the point count.
+            (
+                random_mask(&mut rng, TOTAL, 0.3),
+                random_mask(&mut rng, 100, 0.5),
+                random_mask(&mut rng, 400, 0.2),
+                None,
+            ),
+            // point_deleted shorter than the storage: tail points excluded.
+            (
+                random_mask(&mut rng, 250, 0.1),
+                empty.clone(),
+                empty.clone(),
+                None,
+            ),
+            // Deferred cutoff mid-word, at zero, and beyond the range.
+            (
+                random_mask(&mut rng, TOTAL, 0.2),
+                random_mask(&mut rng, TOTAL, 0.1),
+                empty.clone(),
+                Some(150),
+            ),
+            (all_live.clone(), empty.clone(), empty.clone(), Some(0)),
+            (all_live.clone(), empty.clone(), empty.clone(), Some(1000)),
+            // Exactly one word.
+            (
+                random_mask(&mut rng, 64, 0.4),
+                empty.clone(),
+                empty.clone(),
+                None,
+            ),
+            // Long fully-dead stretch before the live region.
+            (dead_prefix, empty.clone(), empty.clone(), None),
+        ];
+
+        for (case_idx, (point_deleted, mapping_deleted, shadowed, cutoff)) in
+            cases.iter().enumerate()
+        {
+            let visible =
+                BatchFilteredSearcher::new_for_test(&queries, &storage, point_deleted, TOP)
+                    .peek_top_visible(*cutoff, mapping_deleted, shadowed, &DEFAULT_STOPPED)
+                    .unwrap();
+
+            // Reference: the same visibility predicate applied id by id
+            // through the iterator path (`peek_top_iter` re-checks the
+            // deletion bitmaps itself via `check_vector`).
+            let bound = cutoff.map_or(usize::MAX, |c| c as usize);
+            let ids = (0..TOTAL as PointOffsetType).filter(|&id| {
+                (id as usize) < bound
+                    && !mapping_deleted.get_bit(id as usize).unwrap_or(false)
+                    && !shadowed.get_bit(id as usize).unwrap_or(false)
+            });
+            let reference =
+                BatchFilteredSearcher::new_for_test(&queries, &storage, point_deleted, TOP)
+                    .peek_top_iter(ids, &DEFAULT_STOPPED)
+                    .unwrap();
+
+            assert_eq!(visible, reference, "case {case_idx}");
+        }
     }
 }

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -493,7 +493,7 @@ impl<'a> BatchFilteredSearcher<'a> {
             }
 
             let base = start as PointOffsetType;
-            if candidates == u64::MAX && false {
+            if candidates == u64::MAX {
                 // Fully live block — the common no-deletions case.
                 for (i, slot) in chunk[chunk_size..chunk_size + 64].iter_mut().enumerate() {
                     *slot = base + i as PointOffsetType;

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::AtomicBool;
 
-use bitvec::field::BitField as _;
+use common::bitmap_scan::BatchedBitmapScan;
 use common::bitvec::BitSlice;
 use common::condition_checker::{CheckItem, ConditionChecker, Rest, Select};
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -420,19 +420,12 @@ impl<'a> BatchFilteredSearcher<'a> {
         self.peek_top_iter(iter, is_stopped)
     }
 
-    /// Full-scan counterpart of [`Self::peek_top_iter`]: scores every point
-    /// that is not flagged in the deletion bitmaps, is below `cutoff` (when
-    /// `Some`), and is not flagged in `mapping_deleted` / `shadowed`.
-    ///
-    /// Equivalent to feeding `peek_top_iter` the composition of
-    /// [`Self::iter_not_deleted`] with
-    /// `PointMappingsRefEnum::filter_deferred_and_deleted` — callers obtain
-    /// `cutoff`, `mapping_deleted`, and `shadowed` from
-    /// `PointMappingsRefEnum::visible_scan_masks`.  Instead of walking
-    /// `iter_zeros()` bit by bit and re-checking every id against the same
-    /// bitmaps, this combines all bitmaps one 64-bit word at a time and
-    /// extracts candidate ids with `trailing_zeros`, which is where full
-    /// scans over mostly-live segments spend their enumeration time.
+    /// Full-scan counterpart of [`Self::peek_top_iter`]: scores every point that
+    /// is unflagged in the deletion bitmaps and in `mapping_deleted` / `shadowed`,
+    /// and below `cutoff` (when `Some`). Callers obtain those three arguments from
+    /// `PointMappingsRefEnum::visible_scan_masks`; the word-wise harvest via
+    /// [`BatchedBitmapScan`] is what makes this beat the per-id iterator path on
+    /// full scans over mostly-live segments.
     pub fn peek_top_visible(
         self,
         cutoff: Option<PointOffsetType>,
@@ -448,75 +441,35 @@ impl<'a> BatchFilteredSearcher<'a> {
             filters,
         } = self;
 
-        // Number of leading point ids to scan. Points without an explicit
-        // `point_deleted` flag count as deleted (see [`NotDeletedChecker`]),
-        // so that bitmap's length bounds the scan; the deferred cutoff
-        // tightens the bound further.
+        // Ignore points without an entry in `point_deleted` (absent entries count as
+        // deleted, see `NotDeletedChecker`) and points at or above the deferred cutoff.
         let mut point_count = filters.deleted.point_deleted.len();
         if let Some(cutoff) = cutoff {
             point_count = point_count.min(cutoff as usize);
         }
 
+        let mut scan = BatchedBitmapScan::new(
+            point_count,
+            [
+                filters.deleted.point_deleted,
+                filters.deleted.vec_deleted,
+                mapping_deleted,
+                shadowed,
+            ],
+        );
+
         let mut chunk = [0; VECTOR_READ_BATCH_SIZE];
         let mut scores_buffer = [0.0; VECTOR_READ_BATCH_SIZE];
-        // Number of candidate ids accumulated in `chunk` (`chunk[..chunk_size]` is the filled prefix); reset on every flush to the scorers.
-        let mut chunk_size = 0;
-
-        // Process points in blocks of 64 — one word from each bitmap.
-        for start in (0..point_count).step_by(64) {
-            // Bit `i` set → point `start + i` is a candidate: not flagged in
-            // any deletion bitmap, not mapping-deleted, not shadowed.
-            let mut candidates = !(bitmap_word(filters.deleted.point_deleted, start)
-                | bitmap_word(filters.deleted.vec_deleted, start)
-                | bitmap_word(mapping_deleted, start)
-                | bitmap_word(shadowed, start));
-
-            // Zero the bits past the scan range in the final block.
-            let block_len = point_count - start;
-            if block_len < 64 {
-                candidates &= (1u64 << block_len) - 1;
+        loop {
+            let n = scan.next_chunk(&mut chunk);
+            if n == 0 {
+                break;
             }
-            if candidates == 0 {
-                continue;
-            }
-
-            // If this block's candidates would overflow the `chunk` buffer, score the ids accumulated so far to make room.
-            if chunk_size + candidates.count_ones() as usize > VECTOR_READ_BATCH_SIZE {
-                check_process_stopped(is_stopped)?;
-                score_chunk(
-                    &filters,
-                    &mut scorer_batch,
-                    &mut chunk[..chunk_size],
-                    &mut scores_buffer,
-                )?;
-                chunk_size = 0;
-            }
-
-            let base = start as PointOffsetType;
-            if candidates == u64::MAX {
-                // Fully live block — the common no-deletions case.
-                for (i, slot) in chunk[chunk_size..chunk_size + 64].iter_mut().enumerate() {
-                    *slot = base + i as PointOffsetType;
-                }
-                chunk_size += 64;
-            } else {
-                // One iteration per set bit, in ascending order:
-                // `trailing_zeros` locates the lowest set bit (the next candidate's offset in the block), `candidates - 1` &-ed
-                // into the mask clears exactly that bit.
-                while candidates != 0 {
-                    chunk[chunk_size] = base + candidates.trailing_zeros() as PointOffsetType;
-                    chunk_size += 1;
-                    candidates &= candidates - 1;
-                }
-            }
-        }
-
-        if chunk_size > 0 {
             check_process_stopped(is_stopped)?;
             score_chunk(
                 &filters,
                 &mut scorer_batch,
-                &mut chunk[..chunk_size],
+                &mut chunk[..n],
                 &mut scores_buffer,
             )?;
         }
@@ -579,18 +532,6 @@ impl<'a> BatchFilteredSearcher<'a> {
             .collect();
         Ok(results)
     }
-}
-
-/// The 64-bit word of `bitmap` covering positions `start..start + 64`.
-/// Positions past the end of the slice read as 0 (not flagged), matching the
-/// `get_bit(id).unwrap_or(false)` convention of the per-id checks.
-#[inline]
-fn bitmap_word(bitmap: &BitSlice, start: usize) -> u64 {
-    let end = (start + 64).min(bitmap.len());
-    if start >= end {
-        return 0;
-    }
-    bitmap[start..end].load_le::<u64>()
 }
 
 /// Score one harvested chunk against every scorer and push into its queue.

--- a/lib/segment/src/index/plain_vector_index/read_view/search.rs
+++ b/lib/segment/src/index/plain_vector_index/read_view/search.rs
@@ -1,5 +1,5 @@
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::{DeferredBehavior, ScoredPointOffset};
+use common::types::ScoredPointOffset;
 
 use super::PlainVectorIndexReadView;
 use crate::common::BYTES_IN_KB;
@@ -108,14 +108,9 @@ where
                 batch_searcher.peek_top_iter(filtered_ids_vec.iter().copied(), &is_stopped)?
             }
             None => {
-                let iter = self
-                    .id_tracker
-                    .point_mappings()
-                    .filter_deferred_and_deleted(
-                        batch_searcher.iter_not_deleted(),
-                        DeferredBehavior::VisibleOnly,
-                    );
-                batch_searcher.peek_top_iter(iter, &is_stopped)?
+                let (cutoff, mapping_deleted, shadowed) =
+                    self.id_tracker.point_mappings().visible_scan_masks();
+                batch_searcher.peek_top_visible(cutoff, mapping_deleted, shadowed, &is_stopped)?
             }
         };
 

--- a/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/search.rs
+++ b/lib/segment/src/index/sparse_index/sparse_vector_index/read_view/search.rs
@@ -1,6 +1,6 @@
 use common::condition_checker::ConditionChecker;
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::types::{DeferredBehavior, PointOffsetType, ScoredPointOffset, TelemetryDetail};
+use common::types::{PointOffsetType, ScoredPointOffset, TelemetryDetail};
 use itertools::Itertools;
 use sparse::common::sparse_vector::SparseVector;
 use sparse::index::inverted_index::InvertedIndex;
@@ -136,14 +136,9 @@ where
                 searcher.peek_top_iter(filtered_points, &is_stopped)?
             }
             None => {
-                let iter = self
-                    .id_tracker
-                    .point_mappings()
-                    .filter_deferred_and_deleted(
-                        searcher.iter_not_deleted(),
-                        DeferredBehavior::VisibleOnly,
-                    );
-                searcher.peek_top_iter(iter, &is_stopped)?
+                let (cutoff, mapping_deleted, shadowed) =
+                    self.id_tracker.point_mappings().visible_scan_masks();
+                searcher.peek_top_visible(cutoff, mapping_deleted, shadowed, &is_stopped)?
             }
         };
         let res = results.pop().expect("single element results");


### PR DESCRIPTION
**Disclaimer: The code in this PR is a **proof of concept** and this PR is in first place meant for discussion.**

This PR optimizes deletion-checks in **full scan search**. HNSW search is untouched.
As the results show below, this *significantly* improves QPS and execution-time for `Turbo4`, but also other datatypes such as the default f32 datatype (the changes aren't datatype dependent).

The fix works better for TurboQuant, as it has 8x the throughput thanks to its compression.

# Benchmarks
Benchmarks use bfb, exact search for 10k queries against a collection with 100k points. Averaged over 2 runs. Cold queries.

## QPS
Median QPS for each f32 and Turbo4.
These results show that on Turbo4 this PR achieves up to 35% more QPS for `exact search`.

Furthermore it compares Turbo4 vs f32 (Turbo4 is on avg **3x faster**), serving as an initial benchmark for the new Turbo4 datatype (see more below).

No regression at larger dimensions, since this fix is **completely dimension independent**. The reason larger dimensions have less improvement is because the scoring math is dominating at higher dimensionality.

<img width="1200" height="750" alt="bench_qps" src="https://github.com/user-attachments/assets/d1f8dacb-bd39-44c9-82be-adcf56d0bc9f" />

X axis log scaled. Orange is `turbo4`, blue is `f32`. The light lines are this PR, the dark ones are `dev`.
The `-0.7%` for f32 on 4096 dimensions are noise. More runs will most likely diverge to a slight improvement since the 
changes are not dim dependent.

## Median Server time
Median Server time for each f32 and Turbo4. X and Y axis log scaled.

<img width="1200" height="960" alt="bench_server_time_turbo4" src="https://github.com/user-attachments/assets/5c23c71a-7ff0-485b-8d93-9830895eb073" />

<img width="1200" height="960" alt="bench_server_time_f32" src="https://github.com/user-attachments/assets/95857db4-af23-4c45-8d07-97d88e11f3d8" />

## Turbo4 vs F32
QPS difference between f32 and turbo4 per dimension (measured on PR).

| dim | 128 | 256 | 512 | 768 | 1024 | 2048 | 4096 |
|---|---|---|---|---|---|---|---|
| turbo4 vs f32 | 1.56× | 2.08× | 2.66× | 2.99× | 3.26× | 3.66× | 4.29× |


# The Issue + Fix
As shown in the perf samples below, checking for deleted points takes up a lot of time.
Since turbo4 has higher throughput, the scoring part takes less time and the check for point deletion has a larger impact.
<img width="3369" height="917" alt="image" src="https://github.com/user-attachments/assets/8b30cac0-b20c-44cb-8b50-1b57baa6bee7" />

The fix aims at reducing how often we access the deletion bitmaps during a full scan.
Before, every point got checked against the same bitmaps several times: [here](https://github.com/qdrant/qdrant/blob/f44ae2939d324e02fa92697b2fc0452bd467a566/lib/segment/src/index/plain_vector_index/read_view/search.rs?plain=1#L111-L117) we walk `point_deleted` bit by bit with `iter_zeros()` just to produce candidate ids, and [here](https://github.com/qdrant/qdrant/blob/efa1d744d7b4203242fae9634284d7418c0a1f39/lib/segment/src/vector_storage/raw_scorer.rs?plain=1#L597-L602) we then check the same bitmap again (plus `vec_deleted`) for every id the iterator just gave us. On top of that comes an atomic stop-flag check for every single point. In the perf result these spots added up to about 33% of the search CPU.

The issue with `iter_zeros()`: it is built to skip long runs of ones, but our bitmaps are **almost all zeros** (nothing deleted). So it ends up yielding 0, 1, 2, 3, ... with the full iterator machinery running per bit, and it re-reads the same underlying integer up to *64 times*.

The proof of concept code reads all bitmaps into one u64 at a time, ORs them together and handles 64 points in one step. Deletion and stop checks happen once per block instead of once per point, and there is a shortcut for blocks where nothing is deleted. 

Perf result with the fix applied:

<img width="2041" height="720" alt="image" src="https://github.com/user-attachments/assets/93529549-75a0-4d05-af5d-0a66483b4d12" />
As we can see, scoring now takes up a much bigger share of the CPU time. Its absolute cost didn't change, the overhead around it is just gone. The actual scoring math is now the main bottleneck, which is where we want to be.