### PR TITLE
optimizations for Filtered-block HNSW

### DIFF
--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -114,6 +114,24 @@ pub trait EncodedVectors: Sized {
         bytes: &[u8],
         hw_counter: &HardwareCounterCell,
     ) -> f32;
+
+    /// Score two stored vectors given their encoded bytes, applying the same
+    /// symmetric kernel [`Self::score_internal`] applies to the bytes it
+    /// fetches by id - given the same bytes, the scores must be bitwise
+    /// identical.
+    ///
+    /// `None` means this encoder exposes no byte-level symmetric scoring and
+    /// the caller must score by id instead. That is the default; encoders
+    /// whose symmetric kernel already reduces to a pair of byte slices can
+    /// opt in.
+    fn score_internal_bytes(
+        &self,
+        _a: &[u8],
+        _b: &[u8],
+        _hw_counter: &HardwareCounterCell,
+    ) -> Option<f32> {
+        None
+    }
 }
 
 impl DistanceType {

--- a/lib/quantization/src/encoded_vectors_tq.rs
+++ b/lib/quantization/src/encoded_vectors_tq.rs
@@ -513,4 +513,19 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
             score
         }
     }
+
+    fn score_internal_bytes(
+        &self,
+        a: &[u8],
+        b: &[u8],
+        hw_counter: &HardwareCounterCell,
+    ) -> Option<f32> {
+        hw_counter.cpu_counter().incr_delta(a.len() + b.len());
+        let score = self.quantizer.score_symmetric(a, b);
+        Some(if self.metadata.vector_parameters.invert {
+            -score
+        } else {
+            score
+        })
+    }
 }

--- a/lib/segment/src/index/hnsw_index/entry_points.rs
+++ b/lib/segment/src/index/hnsw_index/entry_points.rs
@@ -43,6 +43,17 @@ impl EntryPoints {
         // Do not merge `extra_entry_points` to prevent duplications
     }
 
+    /// Same as [`Self::merge_from_other`], for entry points recorded in the
+    /// local id space of a subgraph. `to_global` maps them back.
+    pub fn merge_translated(&mut self, other: EntryPoints, to_global: &[PointOffsetType]) {
+        self.entry_points
+            .extend(other.entry_points.into_iter().map(|entry| EntryPoint {
+                point_id: to_global[entry.point_id as usize],
+                level: entry.level,
+            }));
+        // Do not merge `extra_entry_points` to prevent duplications
+    }
+
     pub fn new_point<F>(
         &mut self,
         new_point: PointOffsetType,

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -93,6 +93,55 @@ impl GraphLayersBase for GraphLayersBuilder {
 /// Budget of how many checks have to be done at minimum to consider subgraph-connectivity approximation correct.
 const SUBGRAPH_CONNECTIVITY_SEARCH_BUDGET: usize = 64;
 
+/// Samples how many edges to drop before the next kept one, when every edge is
+/// dropped independently with probability `q`.
+#[derive(Clone, Copy)]
+struct DropGapSampler {
+    q: f32,
+    /// `1 / ln(q)`, hoisted so sampling multiplies instead of dividing. Only
+    /// meaningful for `0 < q < 1`, which is the only case that reads it.
+    inv_ln_q: f64,
+}
+
+impl DropGapSampler {
+    fn new(q: f32) -> Self {
+        Self {
+            q,
+            inv_ln_q: f64::from(q).ln().recip(),
+        }
+    }
+
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> usize {
+        if self.q <= 0.0 {
+            // Every edge is kept.
+            return 0;
+        }
+        if self.q >= 1.0 {
+            // No edge is kept: a gap this large steps past any link slice.
+            // Not reachable from the build call site, but `subgraph_connectivity`
+            // is a public method.
+            return usize::MAX;
+        }
+        // `u` must land in `(0, 1]`, `ln(0)` is -inf. `random` yields `[0, 1)`.
+        Self::gap_from_uniform(1.0 - rng.random::<f64>(), self.inv_ln_q)
+    }
+
+    /// `floor(ln(u) / ln(q))`, the inverse CDF of `Geometric(1 - q)`.
+    ///
+    /// Split out from [`Self::sample`] so the boundary values of `u` can be
+    /// injected by tests. Saturates rather than wrapping: `u = 1` gives 0, and
+    /// a small `u` under a `q` near 1 gives a gap that outgrows `usize` and is
+    /// clamped to `usize::MAX`, past the end of any link slice.
+    fn gap_from_uniform(u: f64, inv_ln_q: f64) -> usize {
+        let gap = u.ln() * inv_ln_q;
+        if gap >= usize::MAX as f64 {
+            usize::MAX
+        } else {
+            gap.floor() as usize
+        }
+    }
+}
+
 impl GraphLayersBuilder {
     pub fn get_entry_points(&self) -> MutexGuard<'_, EntryPoints> {
         self.entry_points.lock()
@@ -146,6 +195,8 @@ impl GraphLayersBuilder {
         });
         let entry_layer = self.get_point_level(entry_point);
 
+        let drop_gap = DropGapSampler::new(q);
+
         let mut queue: Vec<u32> = vec![];
 
         // Amount of points reached when searching the graph.
@@ -170,15 +221,14 @@ impl GraphLayersBuilder {
                 // Do BFS through all points on the current layer.
                 while let Some(current_point) = queue.pop() {
                     let links = self.links_layers[current_point as usize][current_layer].read();
+                    let links = links.links();
 
-                    for link in links.iter() {
-                        spent_budget += 1;
+                    // The budget counts enumerated edges, dropped ones included.
+                    spent_budget += links.len();
 
-                        // Flip a coin to decide if the edge is removed or not
-                        let coin_flip = rng.random_range(0.0..1.0);
-                        if coin_flip < q {
-                            continue;
-                        }
+                    let mut i = drop_gap.sample(rng);
+                    while i < links.len() {
+                        let link = links[i];
 
                         let is_selected = point_selection.get_bit(link as usize).unwrap_or(false);
                         let is_visited = visited.get_bit(link as usize).unwrap_or(false);
@@ -189,6 +239,8 @@ impl GraphLayersBuilder {
                             queue.push(link);
                             previous_visited_points.push(link);
                         }
+
+                        i = i.saturating_add(1).saturating_add(drop_gap.sample(rng));
                     }
                 }
             }
@@ -360,6 +412,13 @@ impl GraphLayersBuilder {
                     current_layers.push(other_links);
                 } else {
                     let other_links = other_links.into_inner();
+                    if other_links.links().is_empty() {
+                        // Nothing to append, and seeding the visited list is
+                        // side-effect-free. Skipping avoids taking the write
+                        // lock for the vast majority of points, as a payload
+                        // block only touches a small subset of the segment.
+                        continue;
+                    }
                     visited_list.next_iteration();
                     let mut current_links = current_layers[level].write();
                     current_links.iter().for_each(|x| {
@@ -378,6 +437,61 @@ impl GraphLayersBuilder {
         self.entry_points
             .lock()
             .merge_from_other(other.entry_points.into_inner());
+    }
+
+    /// Merge a payload-block subgraph that was built in its own id space.
+    /// `to_global` maps every point of `block` to its segment-wide id
+    pub fn merge_block(&self, block: GraphLayersBuilder, to_global: &[PointOffsetType]) -> usize {
+        debug_assert_eq!(block.links_layers.len(), to_global.len());
+        #[cfg(debug_assertions)]
+        {
+            // Two local ids mapping to the same point would silently corrupt
+            // the merged links, so make sure the block is a set.
+            let unique: std::collections::HashSet<_> = to_global.iter().copied().collect();
+            debug_assert_eq!(
+                unique.len(),
+                to_global.len(),
+                "payload block points must be unique",
+            );
+            debug_assert!(
+                to_global
+                    .iter()
+                    .all(|&global| (global as usize) < self.links_layers.len()),
+                "payload block points must exist in the target graph",
+            );
+        }
+
+        let mut links_added = 0;
+        for (local_id, levels) in block.links_layers.into_iter().enumerate() {
+            debug_assert_eq!(levels.len(), 1, "payload block points only have level 0");
+            let global_id = to_global[local_id] as usize;
+
+            for (level, block_links) in levels.into_iter().enumerate() {
+                let block_links = block_links.into_inner();
+                if block_links.links().is_empty() {
+                    continue;
+                }
+
+                // Seeding the dedup and appending must not be interleaved with
+                // another block merging into the same point.
+                let mut current_links = self.links_layers[global_id][level].write();
+                for &local_link in block_links.links() {
+                    let global_link = to_global[local_link as usize];
+                    // Containers hold a couple of `m0` links at most, so a scan
+                    // is cheaper than seeding a segment-sized visited list.
+                    if !current_links.links().contains(&global_link) {
+                        current_links.push(global_link);
+                        links_added += 1;
+                    }
+                }
+            }
+        }
+
+        self.entry_points
+            .lock()
+            .merge_translated(block.entry_points.into_inner(), to_global);
+
+        links_added
     }
 
     fn num_points(&self) -> usize {
@@ -575,6 +689,20 @@ impl GraphLayersBuilder {
                 links.connect(point_id, nearest_point.idx, level_m, scorer);
             }
         }
+    }
+
+    /// Every link container, per point and per level.
+    #[cfg(test)]
+    pub(crate) fn links_snapshot(&self) -> Vec<Vec<Vec<PointOffsetType>>> {
+        self.links_layers
+            .iter()
+            .map(|levels| {
+                levels
+                    .iter()
+                    .map(|links| links.read().links().to_vec())
+                    .collect()
+            })
+            .collect()
     }
 
     /// This function returns average number of links per node in HNSW graph
@@ -952,6 +1080,467 @@ mod tests {
             .sum();
         let avg_connectivity = total_edges as f64 / NUM_VECTORS as f64;
         eprintln!("avg_connectivity = {avg_connectivity:#?}");
+    }
+
+    /// Reference implementation of [`GraphLayersBuilder::subgraph_connectivity`]
+    /// that flips an independent coin for every enumerated edge, as the
+    /// production code did before the geometric skip sampler was introduced.
+    fn subgraph_connectivity_per_edge_coin<R: Rng + ?Sized>(
+        builder: &GraphLayersBuilder,
+        rng: &mut R,
+        points: &[PointOffsetType],
+        q: f32,
+    ) -> f32 {
+        if points.is_empty() {
+            return 1.0;
+        }
+
+        let max_point_id = *points.iter().max().unwrap();
+
+        let mut visited: BitVec = BitVec::repeat(false, max_point_id as usize + 1);
+        let mut point_selection: BitVec = BitVec::repeat(false, max_point_id as usize + 1);
+
+        for point_id in points {
+            point_selection.set(*point_id as usize, true);
+        }
+
+        let entry_point = builder
+            .entry_points
+            .lock()
+            .get_random_entry_point(rng, |point_id| {
+                point_selection.get_bit(point_id as usize).unwrap_or(false)
+            })
+            .map(|ep| ep.point_id);
+
+        let entry_point = entry_point.unwrap_or_else(|| {
+            points
+                .iter()
+                .max_by_key(|point_id| builder.links_layers[**point_id as usize].len())
+                .cloned()
+                .unwrap()
+        });
+        let entry_layer = builder.get_point_level(entry_point);
+
+        let mut queue: Vec<u32> = vec![];
+        let mut reached_points = 1;
+        let mut spent_budget = 0;
+
+        loop {
+            let budget_before_iteration = spent_budget;
+            visited.set(entry_point as usize, true);
+
+            let mut previous_visited_points = vec![entry_point];
+
+            for current_layer in (0..=entry_layer).rev() {
+                queue.extend_from_slice(&previous_visited_points);
+
+                while let Some(current_point) = queue.pop() {
+                    let links = builder.links_layers[current_point as usize][current_layer].read();
+
+                    for link in links.iter() {
+                        spent_budget += 1;
+
+                        let coin_flip = rng.random_range(0.0..1.0);
+                        if coin_flip < q {
+                            continue;
+                        }
+
+                        let is_selected = point_selection.get_bit(link as usize).unwrap_or(false);
+                        let is_visited = visited.get_bit(link as usize).unwrap_or(false);
+
+                        if !is_visited && is_selected {
+                            visited.set(link as usize, true);
+                            reached_points += 1;
+                            queue.push(link);
+                            previous_visited_points.push(link);
+                        }
+                    }
+                }
+            }
+
+            if spent_budget > SUBGRAPH_CONNECTIVITY_SEARCH_BUDGET
+                || spent_budget == budget_before_iteration
+            {
+                break;
+            }
+
+            queue.clear();
+            reached_points = 1;
+            visited.fill(false);
+        }
+
+        reached_points as f32 / points.len() as f32
+    }
+
+    /// The gap sampler must keep edges at rate `1 - q`.
+    #[test]
+    fn test_drop_gap_sampler_keep_rate() {
+        const KEPT_SAMPLES: usize = 1_000_000;
+
+        let mut rng = SmallRng::seed_from_u64(0xC0FFEE);
+        for q in [0.5f32, 0.9, 0.95] {
+            let sampler = DropGapSampler::new(q);
+
+            // Each draw stands for `gap` dropped edges plus one kept edge.
+            let mut enumerated = 0usize;
+            for _ in 0..KEPT_SAMPLES {
+                enumerated += sampler.sample(&mut rng) + 1;
+            }
+
+            let keep_rate = KEPT_SAMPLES as f64 / enumerated as f64;
+            let expected = 1.0 - f64::from(q);
+            assert!(
+                (keep_rate - expected).abs() < 0.005,
+                "q={q}: keep rate {keep_rate} too far from {expected}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_drop_gap_sampler_degenerate_probabilities() {
+        let mut rng = SmallRng::seed_from_u64(1);
+        for _ in 0..100 {
+            assert_eq!(DropGapSampler::new(0.0).sample(&mut rng), 0);
+            assert_eq!(DropGapSampler::new(-1.0).sample(&mut rng), 0);
+            assert_eq!(DropGapSampler::new(1.0).sample(&mut rng), usize::MAX);
+            assert_eq!(DropGapSampler::new(2.0).sample(&mut rng), usize::MAX);
+        }
+    }
+
+    /// The gap must stay finite and in range at both ends of `u`, for every
+    /// `q` the sampler can be handed.
+    #[test]
+    fn test_drop_gap_sampler_uniform_boundaries() {
+        // `random::<f64>()` has 53 bits of resolution, so `1.0 - u` spans
+        // `[2^-53, 1.0]`.
+        let u_min = 2.0f64.powi(-53);
+
+        // Both ends of the `q` range that reaches the sampling branch, plus the
+        // closest `f32` below 1.
+        for q in [
+            f32::MIN_POSITIVE,
+            0.5,
+            0.999_999_9,
+            1.0 - f32::EPSILON / 2.0,
+        ] {
+            assert!(q > 0.0 && q < 1.0, "q={q} must reach the sampling branch");
+            let inv_ln_q = f64::from(q).ln().recip();
+
+            assert_eq!(
+                DropGapSampler::gap_from_uniform(1.0, inv_ln_q),
+                0,
+                "q={q}: u=1 must keep the very next edge",
+            );
+            let gap = DropGapSampler::gap_from_uniform(u_min, inv_ln_q);
+            assert!(gap < usize::MAX, "q={q}: u={u_min} gave a saturated gap");
+        }
+
+        // On a 64-bit `usize` no `f32` value of `q` can overflow the cast, but a
+        // 32-bit one can, so the guard has to hold rather than wrap.
+        assert_eq!(
+            DropGapSampler::gap_from_uniform(u_min, -1e300),
+            usize::MAX,
+            "an overflowing gap must saturate",
+        );
+    }
+
+    /// The skip sampler must estimate the same connectivity as a per-edge coin.
+    #[test]
+    fn test_subgraph_connectivity_matches_per_edge_coin() {
+        const NUM_VECTORS: usize = 500;
+        const DIM: usize = 8;
+        const RUNS: usize = 200;
+
+        let mut rng = SmallRng::seed_from_u64(42);
+        let (_vector_holder, builder) =
+            create_graph_layer(NUM_VECTORS, DIM, true, false, Distance::Cosine, &mut rng);
+
+        let points: Vec<PointOffsetType> = (0..NUM_VECTORS as PointOffsetType).collect();
+        let mut means = Vec::new();
+
+        for q in [0.5f32, 0.75, 0.875] {
+            let mut rng = SmallRng::seed_from_u64(7);
+            let mean: f64 = (0..RUNS)
+                .map(|_| f64::from(builder.subgraph_connectivity(&mut rng, &points, q)))
+                .sum::<f64>()
+                / RUNS as f64;
+
+            let mut rng = SmallRng::seed_from_u64(7);
+            let reference_mean: f64 = (0..RUNS)
+                .map(|_| {
+                    f64::from(subgraph_connectivity_per_edge_coin(
+                        &builder, &mut rng, &points, q,
+                    ))
+                })
+                .sum::<f64>()
+                / RUNS as f64;
+
+            eprintln!("q={q}: mean={mean} reference_mean={reference_mean}");
+            assert!(
+                (mean - reference_mean).abs() < 0.02,
+                "q={q}: mean connectivity {mean} vs reference {reference_mean}",
+            );
+            means.push(mean);
+        }
+
+        // Sanity check that the estimate actually responds to `q`, otherwise
+        // the comparison above could pass on two degenerate implementations.
+        assert!(
+            means.windows(2).all(|w| w[0] > w[1] + 0.05),
+            "connectivity estimate should fall as more edges are dropped: {means:?}",
+        );
+    }
+
+    /// Merging a builder whose containers are all empty must leave the target
+    /// untouched, link-for-link and in the same order.
+    #[test]
+    fn test_merge_from_other_empty_is_noop() {
+        let distance = Distance::Cosine;
+        let num_vectors = 200;
+        let dim = 8;
+
+        let mut rng = SmallRng::seed_from_u64(42);
+        let (_vector_holder, mut graph_layers_builder) =
+            create_graph_layer(num_vectors, dim, true, false, distance, &mut rng);
+
+        let before = graph_layers_builder.links_snapshot();
+        let entry_points_before = format!("{:?}", *graph_layers_builder.entry_points.lock());
+
+        let empty =
+            GraphLayersBuilder::new_with_params(num_vectors, HnswM::new2(M), 16, 1, true, false);
+        graph_layers_builder.merge_from_other(empty);
+
+        assert_eq!(before, graph_layers_builder.links_snapshot());
+        assert_eq!(
+            entry_points_before,
+            format!("{:?}", *graph_layers_builder.entry_points.lock()),
+        );
+    }
+
+    /// Merging a block built in its own id space must land exactly where the
+    /// legacy segment-sized block lands, links and entry points alike.
+    #[test]
+    fn test_merge_block_matches_merge_from_other() {
+        use rand::seq::SliceRandom as _;
+
+        const NUM_VECTORS: usize = 200;
+        const BLOCK_SIZE: usize = 40;
+        const DIM: usize = 8;
+
+        let mut target_legacy = create_graph_layer(
+            NUM_VECTORS,
+            DIM,
+            true,
+            false,
+            Distance::Cosine,
+            &mut SmallRng::seed_from_u64(42),
+        )
+        .1;
+        let target_compact = create_graph_layer(
+            NUM_VECTORS,
+            DIM,
+            true,
+            false,
+            Distance::Cosine,
+            &mut SmallRng::seed_from_u64(42),
+        )
+        .1;
+        assert_eq!(
+            target_legacy.links_snapshot(),
+            target_compact.links_snapshot(),
+        );
+
+        let mut rng = SmallRng::seed_from_u64(7);
+
+        // The block is a scattered subset of the segment, so local and global
+        // ids share no ordering.
+        let mut to_global: Vec<PointOffsetType> = (0..NUM_VECTORS as PointOffsetType).collect();
+        to_global.shuffle(&mut rng);
+        to_global.truncate(BLOCK_SIZE);
+
+        let legacy_block =
+            GraphLayersBuilder::new_with_params(NUM_VECTORS, HnswM::new2(M), 16, 1, true, false);
+        let compact_block =
+            GraphLayersBuilder::new_with_params(BLOCK_SIZE, HnswM::new2(M), 16, 1, true, false);
+
+        for local_id in 0..BLOCK_SIZE {
+            // Repeats are intentional: both merges have to dedup them.
+            for _ in 0..rng.random_range(0..8) {
+                let local_link = rng.random_range(0..BLOCK_SIZE);
+                legacy_block.links_layers[to_global[local_id] as usize][0]
+                    .write()
+                    .push(to_global[local_link]);
+                compact_block.links_layers[local_id][0]
+                    .write()
+                    .push(local_link as PointOffsetType);
+            }
+
+            // The production checker accepts the same points on both sides, so
+            // mirror it through the id map here too.
+            legacy_block
+                .entry_points
+                .lock()
+                .new_point(to_global[local_id], 0, |point_id| {
+                    point_id.is_multiple_of(3)
+                });
+            compact_block.entry_points.lock().new_point(
+                local_id as PointOffsetType,
+                0,
+                |point_id| to_global[point_id as usize].is_multiple_of(3),
+            );
+        }
+
+        target_legacy.merge_from_other(legacy_block);
+        target_compact.merge_block(compact_block, &to_global);
+
+        assert_eq!(
+            target_legacy.links_snapshot(),
+            target_compact.links_snapshot(),
+        );
+        assert_eq!(
+            format!("{:?}", *target_legacy.get_entry_points()),
+            format!("{:?}", *target_compact.get_entry_points()),
+        );
+    }
+
+    /// Build `count` synthetic blocks over overlapping subsets of a segment of
+    /// `num_vectors` points. Returns each block's builder with its id map.
+    fn random_blocks<R: Rng + ?Sized>(
+        rng: &mut R,
+        num_vectors: usize,
+        block_size: usize,
+        count: usize,
+    ) -> Vec<(GraphLayersBuilder, Vec<PointOffsetType>)> {
+        use rand::seq::SliceRandom as _;
+
+        (0..count)
+            .map(|_| {
+                let mut to_global: Vec<PointOffsetType> =
+                    (0..num_vectors as PointOffsetType).collect();
+                to_global.shuffle(rng);
+                to_global.truncate(block_size);
+
+                let block = GraphLayersBuilder::new_with_params(
+                    block_size,
+                    HnswM::new2(M),
+                    16,
+                    1,
+                    true,
+                    false,
+                );
+                for local_id in 0..block_size {
+                    for _ in 0..rng.random_range(0..8) {
+                        let local_link = rng.random_range(0..block_size) as PointOffsetType;
+                        block.links_layers[local_id][0].write().push(local_link);
+                    }
+                    block
+                        .entry_points
+                        .lock()
+                        .new_point(local_id as PointOffsetType, 0, |_| true);
+                }
+
+                (block, to_global)
+            })
+            .collect()
+    }
+
+    /// Blocks merged concurrently may end up ordered differently inside a
+    /// container, but the set of links must be exactly the sequential one:
+    /// nothing lost, nothing duplicated.
+    #[test]
+    fn test_merge_block_concurrent_matches_sequential() {
+        use rayon::prelude::*;
+
+        const NUM_VECTORS: usize = 120;
+        const BLOCK_SIZE: usize = 100;
+        const BLOCKS: usize = 64;
+        const DIM: usize = 8;
+        const ITERATIONS: usize = 20;
+
+        // Blocks cover almost the whole segment, so nearly every container is
+        // written by nearly every merge and the per-point lock is the only thing
+        // keeping them consistent.
+        let mut rng = SmallRng::seed_from_u64(11);
+        let blocks = random_blocks(&mut rng, NUM_VECTORS, BLOCK_SIZE, BLOCKS);
+
+        let sequential = create_graph_layer(
+            NUM_VECTORS,
+            DIM,
+            true,
+            false,
+            Distance::Cosine,
+            &mut SmallRng::seed_from_u64(42),
+        )
+        .1;
+        for (block, to_global) in &blocks {
+            let copy = clone_block(block);
+            sequential.merge_block(copy, to_global);
+        }
+        let expected = sorted_links(&sequential.links_snapshot());
+
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .unwrap();
+
+        for iteration in 0..ITERATIONS {
+            let concurrent = create_graph_layer(
+                NUM_VECTORS,
+                DIM,
+                true,
+                false,
+                Distance::Cosine,
+                &mut SmallRng::seed_from_u64(42),
+            )
+            .1;
+
+            pool.install(|| {
+                blocks.par_iter().for_each(|(block, to_global)| {
+                    concurrent.merge_block(clone_block(block), to_global);
+                });
+            });
+
+            assert_eq!(
+                sorted_links(&concurrent.links_snapshot()),
+                expected,
+                "iteration {iteration}: concurrent merge changed the link sets",
+            );
+        }
+    }
+
+    /// `merge_block` consumes the block, so each run needs its own copy.
+    fn clone_block(block: &GraphLayersBuilder) -> GraphLayersBuilder {
+        let copy = GraphLayersBuilder::new_with_params(
+            block.links_layers.len(),
+            block.hnsw_m,
+            block.ef_construct,
+            1,
+            block.use_heuristic,
+            false,
+        );
+        for (levels, copy_levels) in block.links_layers.iter().zip(&copy.links_layers) {
+            for (links, copy_links) in levels.iter().zip(copy_levels) {
+                copy_links.write().fill_from(links.read().iter());
+            }
+        }
+        *copy.entry_points.lock() = block.entry_points.lock().clone();
+        copy
+    }
+
+    fn sorted_links(links: &[Vec<Vec<PointOffsetType>>]) -> Vec<Vec<Vec<PointOffsetType>>> {
+        links
+            .iter()
+            .map(|levels| {
+                levels
+                    .iter()
+                    .map(|container| {
+                        let mut container = container.clone();
+                        container.sort_unstable();
+                        container
+                    })
+                    .collect()
+            })
+            .collect()
     }
 
     /// Regression test: `subgraph_connectivity` must not hang when the chosen

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -17,6 +17,8 @@ use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 
 mod build;
+#[cfg(test)]
+pub(crate) use build::HnswBuildDebugOptions;
 #[cfg(feature = "gpu")]
 mod gpu_build;
 mod old_index;

--- a/lib/segment/src/index/hnsw_index/hnsw/build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/build.rs
@@ -1,8 +1,11 @@
+use std::cmp::Reverse;
 use std::ops::Deref as _;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::thread;
 
-use common::bitvec::{BitSliceExt as _, BitVec};
+use common::bitvec::{BitSlice, BitSliceExt as _, BitVec};
+use common::condition_checker::ConditionChecker as _;
 use common::counter::hardware_counter::HardwareCounterCell;
 #[cfg(target_os = "linux")]
 use common::cpu::linux_low_thread_priority;
@@ -10,7 +13,9 @@ use common::progress_tracker::ProgressTracker;
 use common::types::{DeferredBehavior, PointOffsetType};
 use fs_err as fs;
 use log::{debug, trace};
-use rand::Rng;
+use parking_lot::Mutex;
+use rand::rngs::SmallRng;
+use rand::{Rng, RngExt, SeedableRng};
 use rayon::ThreadPool;
 use rayon::prelude::*;
 
@@ -38,7 +43,9 @@ use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
 use crate::index::hnsw_index::graph_layers_healer::GraphLayersHealer;
 use crate::index::hnsw_index::graph_links::{GraphLinksFormatParam, StorageGraphLinksVectors};
-use crate::index::hnsw_index::point_scorer::FilteredScorer;
+use crate::index::hnsw_index::point_scorer::{
+    BlockVectors, FilteredScorer, MAX_BLOCK_GATHER_BYTES, MIN_BLOCK_GATHER_BYTES,
+};
 use crate::index::query_optimization::optimized_filter::OptimizedFilter;
 use crate::index::struct_payload_index::StructPayloadIndex;
 use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
@@ -47,12 +54,58 @@ use crate::segment_constructor::VectorIndexBuildArgs;
 use crate::types::Condition::Field;
 use crate::types::{FieldCondition, Filter};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
-use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
+use crate::vector_storage::{NotDeletedChecker, VectorStorageEnum, VectorStorageRead};
+
+/// Blocks below this cardinality are cheap enough that giving each one a whole
+/// thread beats splitting every one of them across the pool, whose serial
+/// insertion prefix does not amortize on a short run.
+const DEFAULT_LARGE_BLOCK_THRESHOLD: usize = 32_768;
+
+/// Knobs that let tests reach into the payload-block stage of the build.
+#[derive(Default)]
+pub(crate) struct HnswBuildDebugOptions<'a> {
+    /// Build payload block subgraphs with the legacy segment-sized builder,
+    /// so its output can be compared against the compact one.
+    pub force_legacy_payload_blocks: bool,
+    /// Incremented once per payload block that is actually built.
+    pub blocks_built: Option<&'a AtomicUsize>,
+    /// Incremented once per payload block the connectivity shortcut skips.
+    pub blocks_skipped_by_connectivity: Option<&'a AtomicUsize>,
+    /// Incremented once per block routed through the large-block path, which
+    /// spreads a single block's insertion run over the whole pool.
+    pub large_blocks_built: Option<&'a AtomicUsize>,
+    /// Incremented once per built block whose vectors were copied into a
+    /// block-local buffer for scoring.
+    pub blocks_gathered: Option<&'a AtomicUsize>,
+    /// Incremented once per block handed over by the unified cross-field queue,
+    /// and never by the legacy per-field path.
+    ///
+    /// Without it the queue's tests would pass just as well against a build that
+    /// silently fell back to the legacy path, since the two agree on everything
+    /// else those tests can see.
+    pub blocks_via_queue: Option<&'a AtomicUsize>,
+    /// Collects the block index each block is filtered under, in call order.
+    /// Both build paths have to number a field's blocks the same way.
+    pub block_indices: Option<&'a Mutex<Vec<usize>>>,
+    /// Overrides [`DEFAULT_LARGE_BLOCK_THRESHOLD`], which is far above any
+    /// cardinality a test fixture can reach.
+    pub large_block_threshold: Option<usize>,
+    /// Called with the finished graph, before it is serialized.
+    pub inspect_builder: Option<&'a dyn Fn(&GraphLayersBuilder)>,
+}
 
 impl HNSWIndex {
     pub fn build<R: Rng + ?Sized>(
         open_args: HnswIndexOpenArgs<'_>,
         build_args: VectorIndexBuildArgs<'_, R>,
+    ) -> OperationResult<Self> {
+        Self::build_with_debug_options(open_args, build_args, HnswBuildDebugOptions::default())
+    }
+
+    pub(crate) fn build_with_debug_options<R: Rng + ?Sized>(
+        open_args: HnswIndexOpenArgs<'_>,
+        build_args: VectorIndexBuildArgs<'_, R>,
+        debug_options: HnswBuildDebugOptions<'_>,
     ) -> OperationResult<Self> {
         if HnswGraphConfig::get_config_path(open_args.path).exists()
             || GraphLayers::get_path(open_args.path).exists()
@@ -387,11 +440,23 @@ impl HNSWIndex {
             let percolation = 1. - 2. / (average_links_per_0_level_int as f32);
 
             let required_connectivity = if average_links_per_0_level_int >= 4 {
-                let global_graph_connectivity = [
-                    graph_layers_builder.subgraph_connectivity(rng, &all_points, percolation),
-                    graph_layers_builder.subgraph_connectivity(rng, &all_points, percolation),
-                    graph_layers_builder.subgraph_connectivity(rng, &all_points, percolation),
-                ];
+                // Each sample walks the whole segment, so run them concurrently.
+                // Seeds are drawn up front to keep the parent RNG stream
+                // independent of the scheduling order.
+                let seeds: [u64; 3] = std::array::from_fn(|_| rng.random());
+                let global_graph_connectivity = pool.install(|| {
+                    seeds
+                        .into_par_iter()
+                        .map(|seed| {
+                            let mut rng = SmallRng::seed_from_u64(seed);
+                            graph_layers_builder.subgraph_connectivity(
+                                &mut rng,
+                                &all_points,
+                                percolation,
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                });
 
                 debug!("graph connectivity: {global_graph_connectivity:?} @ {percolation}");
 
@@ -412,9 +477,6 @@ impl HNSWIndex {
                 BitVec::repeat(false, total_vector_count)
             };
 
-            let visited_pool = VisitedPool::new();
-            let mut block_filter_list = visited_pool.get(total_vector_count);
-
             #[cfg(feature = "gpu")]
             let mut gpu_insert_context = if let Some(gpu_vectors) = gpu_vectors.as_ref() {
                 Some(GpuInsertContext::new(
@@ -431,103 +493,267 @@ impl HNSWIndex {
             #[cfg(not(feature = "gpu"))]
             let mut gpu_insert_context = None;
 
-            for (index_pos, (field_progress, field)) in indexed_fields.into_iter().enumerate() {
-                field_progress.start();
+            // The compact path builds each block in its own id space, so it
+            // does not pay for a segment-sized builder per block. It cannot
+            // serve the two callers that need segment-wide ids: `m == 0` counts
+            // indexed vectors into a segment-sized bitset, and the GPU builder
+            // is welded to a segment-sized `GraphLayersBuilder`.
+            let use_compact_blocks = config.m > 0
+                && gpu_insert_context.is_none()
+                && !debug_options.force_legacy_payload_blocks;
 
-                debug!("building additional index for field {field}");
+            let visited_pool = VisitedPool::new();
+            let mut block_filter_list =
+                (!use_compact_blocks).then(|| visited_pool.get(total_vector_count));
 
-                let is_tenant = payload_index_ref.is_tenant(&field);
+            let large_block_threshold = debug_options
+                .large_block_threshold
+                .unwrap_or(DEFAULT_LARGE_BLOCK_THRESHOLD);
 
-                // It is expected, that graph will become disconnected less than
-                // $1/m$ points left.
-                // So blocks larger than $1/m$ are not needed.
-                // We add multiplier for the extra safety.
-                const PERCOLATION_MULTIPLIER: usize = 4;
-                let max_block_size = if config.m > 0 {
-                    total_vector_count / average_links_per_0_level_int * PERCOLATION_MULTIPLIER
-                } else {
-                    usize::MAX
+            // Block-level parallelism needs threads to spare, and keeping the
+            // single-threaded build sequential keeps it reproducible.
+            let parallel_blocks = use_compact_blocks && pool.current_num_threads() > 1;
+
+            // It is expected, that graph will become disconnected less than
+            // $1/m$ points left.
+            // So blocks larger than $1/m$ are not needed.
+            // We add multiplier for the extra safety.
+            const PERCOLATION_MULTIPLIER: usize = 4;
+            let max_block_size = if config.m > 0 {
+                total_vector_count / average_links_per_0_level_int * PERCOLATION_MULTIPLIER
+            } else {
+                usize::MAX
+            };
+
+            // The cap is per block and the small-block drain runs one block per
+            // thread, so without dividing it out the transient total would be
+            // the pool size times the cap.
+            let gather_budget = if parallel_blocks {
+                (MAX_BLOCK_GATHER_BYTES / pool.current_num_threads().max(1))
+                    .max(MIN_BLOCK_GATHER_BYTES)
+            } else {
+                MAX_BLOCK_GATHER_BYTES
+            };
+            let gather_declined = AtomicUsize::new(0);
+
+            if use_compact_blocks {
+                let block_builder = BlockBuilder {
+                    vector_storage: &vector_storage_ref,
+                    quantized_vectors: &quantized_vectors_ref,
+                    graph: &graph_layers_builder,
+                    vec_deleted: deleted_bitslice,
+                    point_deleted: id_tracker_ref.deleted_point_bitslice(),
+                    payload_m,
+                    ef_construct: config.ef_construct,
+                    gather_budget,
+                    blocks_gathered: debug_options.blocks_gathered,
+                    gather_declined: &gather_declined,
+                    stopped,
                 };
 
-                let counter = field_progress.track_progress(None);
-
-                let mut process_block = |payload_block: PayloadBlockCondition| {
-                    check_process_stopped(stopped)?;
-
-                    if payload_block.cardinality > max_block_size {
-                        return Ok(());
+                // The witness that the queue actually ran: the legacy per-field
+                // path never touches it.
+                let count_queued = || {
+                    if let Some(blocks_via_queue) = debug_options.blocks_via_queue {
+                        blocks_via_queue.fetch_add(1, Ordering::Relaxed);
                     }
+                };
 
-                    let points_to_index = condition_points(
-                        payload_block.condition,
-                        &payload_index_ref,
-                        &vector_storage_ref,
-                        stopped,
-                    )?;
+                // Per-field state a block needs, in the field order below.
+                let mut field_filters: Vec<(BlockFilter, Arc<AtomicU64>)> = Vec::new();
+                // `(field position, block index within that field, block)`.
+                let mut block_queue: Vec<(usize, usize, PayloadBlockCondition)> = Vec::new();
 
-                    // This is a heuristic to skip building graph for mostly deleted blocks.
-                    // It might be, that majority of points do not actually have vectors
-                    // (vectors marked as deleted), so we can avoid building graph for such blocks.
-                    //
-                    // FYI: query heuristic does account
-                    // for deleted vectors via [`adjust_to_available_vectors`]
-                    const DELETED_POINTS_FACTOR: usize = 4; // allow block to have up to 75% of deleted points and still be indexed
+                // Every field's blocks go into one queue, so the parallel run
+                // drains once for the whole segment instead of once per field.
+                for (index_pos, (field_progress, field)) in indexed_fields.iter().enumerate() {
+                    field_progress.start();
 
-                    if points_to_index.len() <= full_scan_threshold / DELETED_POINTS_FACTOR {
-                        return Ok(());
-                    }
+                    // Drawn per field: one base shared across fields would give
+                    // field `i`'s block `j` and field `k`'s block `j` the same
+                    // seed, correlating their connectivity estimates. Drawn up
+                    // front so the seeds do not depend on scheduling order.
+                    let block_seed_base: u64 = rng.random();
 
-                    if !is_tenant
-                        && index_pos > 0
-                        && let Some(required_connectivity) = required_connectivity
-                    {
-                        // Always build for tenants
-                        let graph_connectivity = graph_layers_builder.subgraph_connectivity(
-                            rng,
-                            &points_to_index,
+                    debug!("building additional index for field {field}");
+
+                    let is_tenant = payload_index_ref.is_tenant(field);
+                    let counter = field_progress.track_progress(None);
+
+                    let before = block_queue.len();
+                    payload_index_ref.with_view(|v| {
+                        v.for_each_payload_block(field, full_scan_threshold, &mut |block| {
+                            block_queue.push((index_pos, block_queue.len() - before, block));
+                            Ok(())
+                        })
+                    })?;
+
+                    field_filters.push((
+                        BlockFilter {
+                            field,
+                            payload_index: &payload_index_ref,
+                            vector_storage: &vector_storage_ref,
+                            stopped,
+                            full_scan_threshold,
+                            max_block_size,
+                            check_connectivity: !is_tenant && index_pos > 0,
+                            required_connectivity,
                             percolation,
+                            block_seed_base,
+                            blocks_built: debug_options.blocks_built,
+                            blocks_skipped_by_connectivity: debug_options
+                                .blocks_skipped_by_connectivity,
+                            block_indices: debug_options.block_indices,
+                        },
+                        counter,
+                    ));
+                }
+
+                let build_queued = |(field_pos, block_index, block): (
+                    usize,
+                    usize,
+                    PayloadBlockCondition,
+                )|
+                 -> OperationResult<()> {
+                    count_queued();
+                    let (filter, counter) = &field_filters[field_pos];
+                    block_builder.build(filter, block_index, block, counter, None)
+                };
+
+                if parallel_blocks {
+                    let (mut small, large): (Vec<_>, Vec<_>) = block_queue
+                        .into_iter()
+                        .partition(|(_, _, block)| block.cardinality < large_block_threshold);
+
+                    // One large block at a time, spread over the whole pool.
+                    for (field_pos, block_index, block) in large {
+                        if let Some(large_blocks_built) = debug_options.large_blocks_built {
+                            large_blocks_built.fetch_add(1, Ordering::Relaxed);
+                        }
+                        count_queued();
+                        let (filter, counter) = &field_filters[field_pos];
+                        block_builder.build(filter, block_index, block, counter, Some(&pool))?;
+                    }
+
+                    // Longest first, so the run does not end up waiting on a
+                    // straggler that happened to be scheduled last.
+                    small.sort_unstable_by_key(|(_, _, block)| Reverse(block.cardinality));
+                    pool.install(|| small.into_par_iter().try_for_each(build_queued))?;
+                } else {
+                    // Same order the legacy per-field path uses, since the queue
+                    // is fields in order and blocks in generation order.
+                    for (field_pos, block_index, block) in block_queue {
+                        count_queued();
+                        let (filter, counter) = &field_filters[field_pos];
+                        block_builder.build(filter, block_index, block, counter, Some(&pool))?;
+                    }
+                }
+
+                drop(field_filters);
+            } else {
+                for (index_pos, (field_progress, field)) in indexed_fields.iter().enumerate() {
+                    field_progress.start();
+
+                    let block_seed_base: u64 = rng.random();
+
+                    debug!("building additional index for field {field}");
+
+                    let is_tenant = payload_index_ref.is_tenant(field);
+
+                    let counter = field_progress.track_progress(None);
+                    let counter = counter.deref();
+
+                    // Numbered the same way the compact path numbers the blocks
+                    // it collects, so for a given block both paths seed the
+                    // connectivity shortcut with the same index and reach the
+                    // same skip decision.
+                    let block_filter = BlockFilter {
+                        field,
+                        payload_index: &payload_index_ref,
+                        vector_storage: &vector_storage_ref,
+                        stopped,
+                        full_scan_threshold,
+                        max_block_size,
+                        check_connectivity: !is_tenant && index_pos > 0,
+                        required_connectivity,
+                        percolation,
+                        block_seed_base,
+                        blocks_built: debug_options.blocks_built,
+                        blocks_skipped_by_connectivity: debug_options
+                            .blocks_skipped_by_connectivity,
+                        block_indices: debug_options.block_indices,
+                    };
+
+                    // Which *field* comes first is still up to `indexed_fields`,
+                    // which hands back a `HashMap`.
+                    let mut next_block_index = 0;
+
+                    let mut process_block = |payload_block: PayloadBlockCondition| {
+                        let block_index = next_block_index;
+                        next_block_index += 1;
+
+                        let cardinality = payload_block.cardinality;
+                        let Some(points_to_index) = block_filter.points(
+                            &graph_layers_builder,
+                            block_index,
+                            payload_block,
+                        )?
+                        else {
+                            return Ok(());
+                        };
+                        let block_points = points_to_index.len();
+
+                        // ToDo: reuse graph layer for same payload
+                        let mut additional_graph = GraphLayersBuilder::new_with_params(
+                            total_vector_count,
+                            payload_m,
+                            config.ef_construct,
+                            1,
+                            HNSW_USE_HEURISTIC,
+                            false,
                         );
 
-                        if graph_connectivity >= required_connectivity {
-                            trace!(
-                                "skip building additional HNSW links for {field}, connectivity {graph_connectivity:.4} >= {required_connectivity:.4}"
-                            );
-                            return Ok(());
-                        }
-                        trace!("graph connectivity: {graph_connectivity} for {field}");
-                    }
+                        build_filtered_graph(
+                            id_tracker_ref.deref(),
+                            &vector_storage_ref,
+                            &quantized_vectors_ref,
+                            &mut gpu_insert_context,
+                            &payload_index_ref,
+                            &pool,
+                            stopped,
+                            &mut additional_graph,
+                            points_to_index,
+                            block_filter_list.as_mut().unwrap(),
+                            &mut indexed_vectors_set,
+                            counter,
+                        )?;
+                        graph_layers_builder.merge_from_other(additional_graph);
 
-                    // ToDo: reuse graph layer for same payload
-                    let mut additional_graph = GraphLayersBuilder::new_with_params(
-                        total_vector_count,
-                        payload_m,
-                        config.ef_construct,
-                        1,
-                        HNSW_USE_HEURISTIC,
-                        false,
-                    );
+                        debug!(
+                            "payload block {field} [{cardinality}]: built {block_points} points (legacy)"
+                        );
+                        Ok(())
+                    };
 
-                    build_filtered_graph(
-                        id_tracker_ref.deref(),
+                    payload_index_ref.with_view(|v| {
+                        v.for_each_payload_block(field, full_scan_threshold, &mut process_block)
+                    })?;
+                }
+            }
+
+            // A build where the block-local copy never engaged looks, from the
+            // outside, exactly like one where it did. Say so once, at info, so
+            // the no-op is visible without per-block debug logging.
+            let declined = gather_declined.load(Ordering::Relaxed);
+            if declined > 0 {
+                log::info!(
+                    "payload-block vector gather declined for {declined} block(s): {}",
+                    BlockVectors::gather_constraints(
                         &vector_storage_ref,
-                        &quantized_vectors_ref,
-                        &mut gpu_insert_context,
-                        &payload_index_ref,
-                        &pool,
-                        stopped,
-                        &mut additional_graph,
-                        points_to_index,
-                        &mut block_filter_list,
-                        &mut indexed_vectors_set,
-                        &counter,
-                    )?;
-                    graph_layers_builder.merge_from_other(additional_graph);
-                    Ok(())
-                };
-
-                payload_index_ref.with_view(|v| {
-                    v.for_each_payload_block(&field, full_scan_threshold, &mut process_block)
-                })?;
+                        quantized_vectors_ref.as_ref(),
+                        gather_budget,
+                    ),
+                );
             }
 
             let indexed_payload_vectors = indexed_vectors_set.count_ones();
@@ -560,6 +786,10 @@ impl HNSWIndex {
             Some(v) => GraphLinksFormatParam::CompressedWithVectors(v),
             None => GraphLinksFormatParam::Compressed,
         };
+
+        if let Some(inspect_builder) = debug_options.inspect_builder {
+            inspect_builder(&graph_layers_builder);
+        }
 
         let graph: GraphLayers =
             graph_layers_builder.into_graph_layers(path, format_param, is_on_disk)?;
@@ -623,6 +853,302 @@ fn condition_points(
         .filter(|&point_id| !deleted_bitslice.get_bit(point_id as usize).unwrap_or(false))
         .collect())
     })
+}
+
+/// Decides which payload blocks of one field are worth indexing.
+struct BlockFilter<'a> {
+    field: &'a JsonPath,
+    payload_index: &'a StructPayloadIndex,
+    vector_storage: &'a VectorStorageEnum,
+    stopped: &'a AtomicBool,
+    full_scan_threshold: usize,
+    max_block_size: usize,
+    /// Whether the connectivity shortcut applies to this field at all.
+    check_connectivity: bool,
+    required_connectivity: Option<f32>,
+    percolation: f32,
+    block_seed_base: u64,
+    blocks_built: Option<&'a AtomicUsize>,
+    blocks_skipped_by_connectivity: Option<&'a AtomicUsize>,
+    block_indices: Option<&'a Mutex<Vec<usize>>>,
+}
+
+impl BlockFilter<'_> {
+    /// Points of `payload_block` worth indexing, or `None` if it is skipped.
+    ///
+    /// `block_index` is the block's position in its field's generation order.
+    /// It seeds the connectivity shortcut, so both build paths have to number
+    /// the blocks of a field the same way to reach the same skip decisions.
+    fn points(
+        &self,
+        graph: &GraphLayersBuilder,
+        block_index: usize,
+        payload_block: PayloadBlockCondition,
+    ) -> OperationResult<Option<Vec<PointOffsetType>>> {
+        check_process_stopped(self.stopped)?;
+
+        if let Some(block_indices) = self.block_indices {
+            block_indices.lock().push(block_index);
+        }
+
+        let field = self.field;
+        let cardinality = payload_block.cardinality;
+        if cardinality > self.max_block_size {
+            debug!(
+                "payload block {field} [{cardinality}]: skip, over {}",
+                self.max_block_size,
+            );
+            return Ok(None);
+        }
+
+        let points_to_index = condition_points(
+            payload_block.condition,
+            self.payload_index,
+            self.vector_storage,
+            self.stopped,
+        )?;
+
+        // This is a heuristic to skip building graph for mostly deleted blocks.
+        // It might be, that majority of points do not actually have vectors
+        // (vectors marked as deleted), so we can avoid building graph for such blocks.
+        //
+        // FYI: query heuristic does account
+        // for deleted vectors via [`adjust_to_available_vectors`]
+        const DELETED_POINTS_FACTOR: usize = 4; // allow block to have up to 75% of deleted points and still be indexed
+
+        if points_to_index.len() <= self.full_scan_threshold / DELETED_POINTS_FACTOR {
+            debug!(
+                "payload block {field} [{cardinality}]: skip, only {} live points",
+                points_to_index.len(),
+            );
+            return Ok(None);
+        }
+
+        if self.check_connectivity
+            && let Some(required_connectivity) = self.required_connectivity
+        {
+            // Seeded per block, so the estimate does not depend on how the
+            // blocks of this field were scheduled.
+            let mut block_rng = SmallRng::seed_from_u64(self.block_seed_base ^ block_index as u64);
+            let graph_connectivity =
+                graph.subgraph_connectivity(&mut block_rng, &points_to_index, self.percolation);
+
+            if graph_connectivity >= required_connectivity {
+                trace!(
+                    "skip building additional HNSW links for {field}, connectivity {graph_connectivity:.4} >= {required_connectivity:.4}"
+                );
+                debug!(
+                    "payload block {field} [{cardinality}]: skip, connectivity {graph_connectivity:.4} >= {required_connectivity:.4}"
+                );
+                if let Some(blocks_skipped) = self.blocks_skipped_by_connectivity {
+                    blocks_skipped.fetch_add(1, Ordering::Relaxed);
+                }
+                return Ok(None);
+            }
+            trace!("graph connectivity: {graph_connectivity} for {field}");
+        }
+
+        if let Some(blocks_built) = self.blocks_built {
+            blocks_built.fetch_add(1, Ordering::Relaxed);
+        }
+
+        Ok(Some(points_to_index))
+    }
+}
+
+/// Builds one payload block's subgraph and merges it into the main graph.
+struct BlockBuilder<'a> {
+    vector_storage: &'a VectorStorageEnum,
+    quantized_vectors: &'a Option<QuantizedVectors>,
+    graph: &'a GraphLayersBuilder,
+    vec_deleted: &'a BitSlice,
+    point_deleted: &'a BitSlice,
+    payload_m: HnswM,
+    ef_construct: usize,
+    /// Per-block ceiling on the vector copy for blocks built concurrently,
+    /// already divided down by how many can be in flight at once. Blocks that
+    /// run exclusively use [`MAX_BLOCK_GATHER_BYTES`] instead.
+    gather_budget: usize,
+    blocks_gathered: Option<&'a AtomicUsize>,
+    /// Blocks the copy was wanted for but declined, reported once per build.
+    gather_declined: &'a AtomicUsize,
+    stopped: &'a AtomicBool,
+}
+
+impl BlockBuilder<'_> {
+    /// Build `payload_block` and merge it, unless `filter` skips it.
+    fn build(
+        &self,
+        filter: &BlockFilter,
+        block_index: usize,
+        payload_block: PayloadBlockCondition,
+        counter: &AtomicU64,
+        insert_pool: Option<&ThreadPool>,
+    ) -> OperationResult<()> {
+        let field = filter.field;
+        let cardinality = payload_block.cardinality;
+        let Some(points_to_index) = filter.points(self.graph, block_index, payload_block)? else {
+            return Ok(());
+        };
+
+        let block_deleted =
+            block_deleted_flags(&points_to_index, self.vec_deleted, self.point_deleted);
+
+        // Copied once per block and shared by every insertion in it, so the copy
+        // costs one pass over the block against the many searches that read it.
+        //
+        // A block that has the pool to itself also has the memory cap to
+        // itself: no other block is gathering while it builds, so the divided
+        // concurrent budget would decline it for a transient that cannot occur.
+        let gather_budget = if insert_pool.is_some() {
+            MAX_BLOCK_GATHER_BYTES
+        } else {
+            self.gather_budget
+        };
+        let block_vectors = BlockVectors::try_gather(
+            &points_to_index,
+            self.vector_storage,
+            self.quantized_vectors.as_ref(),
+            gather_budget,
+        );
+
+        if block_vectors.is_some() {
+            if let Some(blocks_gathered) = self.blocks_gathered {
+                blocks_gathered.fetch_add(1, Ordering::Relaxed);
+            }
+        } else {
+            self.gather_declined.fetch_add(1, Ordering::Relaxed);
+        }
+
+        let block_graph = build_filtered_graph_compact(
+            self.vector_storage,
+            self.quantized_vectors,
+            block_vectors.as_ref(),
+            insert_pool,
+            self.stopped,
+            self.payload_m,
+            self.ef_construct,
+            &points_to_index,
+            &block_deleted,
+            counter,
+        )?;
+
+        let links_added = self.graph.merge_block(block_graph, &points_to_index);
+
+        debug!(
+            "payload block {field} [{cardinality}]: built {} points, {links_added} links, \
+             gathered={}",
+            points_to_index.len(),
+            block_vectors.is_some(),
+        );
+        Ok(())
+    }
+}
+
+/// Per-block deletion flags, indexed by the local id of a block point.
+fn block_deleted_flags(
+    points_to_index: &[PointOffsetType],
+    vec_deleted: &BitSlice,
+    point_deleted: &BitSlice,
+) -> BitVec {
+    let not_deleted = NotDeletedChecker {
+        point_deleted,
+        vec_deleted,
+    };
+    let mut block_deleted = BitVec::repeat(false, points_to_index.len());
+    for (local_id, &global_id) in points_to_index.iter().enumerate() {
+        if !not_deleted.check_infallible(global_id) {
+            block_deleted.set(local_id, true);
+        }
+    }
+    debug_assert_eq!(
+        block_deleted.count_ones(),
+        0,
+        "payload blocks are expected to hold only live points",
+    );
+    block_deleted
+}
+
+/// Build the subgraph of a payload block in its own id space.
+///
+/// Points are numbered `0..points_to_index.len()`, in `points_to_index` order,
+/// which keeps the builder proportional to the block instead of to the whole
+/// segment. Every candidate reachable in such a graph is a block member by
+/// construction, so unlike [`build_filtered_graph`] this needs no filter
+/// context to keep the search inside the block.
+///
+/// Passing no `pool` inserts every point on the calling thread.
+#[allow(clippy::too_many_arguments)]
+fn build_filtered_graph_compact(
+    vector_storage: &VectorStorageEnum,
+    quantized_vectors: &Option<QuantizedVectors>,
+    block_vectors: Option<&BlockVectors>,
+    pool: Option<&ThreadPool>,
+    stopped: &AtomicBool,
+    hnsw_m: HnswM,
+    ef_construct: usize,
+    points_to_index: &[PointOffsetType],
+    block_deleted: &BitSlice,
+    counter: &AtomicU64,
+) -> OperationResult<GraphLayersBuilder> {
+    let block_graph = GraphLayersBuilder::new_with_params(
+        points_to_index.len(),
+        hnsw_m,
+        ef_construct,
+        1,
+        HNSW_USE_HEURISTIC,
+        false,
+    );
+
+    let insert_point = |local_id: PointOffsetType| {
+        check_process_stopped(stopped)?;
+
+        // This hardware counter can be discarded, since it is only used for internal operations
+        let internal_hardware_counter = HardwareCounterCell::disposable();
+
+        let points_scorer = FilteredScorer::new_block_scorer(
+            points_to_index[local_id as usize],
+            points_to_index,
+            vector_storage,
+            quantized_vectors.as_ref(),
+            block_vectors,
+            block_deleted,
+            internal_hardware_counter,
+        )?;
+
+        block_graph.link_new_point(local_id, points_scorer);
+
+        counter.fetch_add(1, Ordering::Relaxed);
+
+        Ok::<_, OperationError>(())
+    };
+
+    let block_len = points_to_index.len() as PointOffsetType;
+    let first_points = block_len.min(SINGLE_THREADED_HNSW_BUILD_THRESHOLD as PointOffsetType);
+
+    // First index points in single thread so ensure warm start for parallel indexing process
+    for local_id in 0..first_points {
+        insert_point(local_id)?;
+    }
+    // Once initial structure is built, index remaining points in parallel
+    // So that each thread will insert points in different parts of the graph,
+    // it is less likely that they will compete for the same locks
+    match pool {
+        Some(pool) if block_len > first_points => {
+            pool.install(|| {
+                (first_points..block_len)
+                    .into_par_iter()
+                    .try_for_each(insert_point)
+            })?;
+        }
+        _ => {
+            for local_id in first_points..block_len {
+                insert_point(local_id)?;
+            }
+        }
+    }
+
+    Ok(block_graph)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -12,12 +12,141 @@ use crate::common::operation_error::{OperationError, OperationResult, check_proc
 use crate::data_types::vectors::QueryVector;
 use crate::index::query_optimization::optimized_filter::OptimizedFilter;
 use crate::vector_storage::common::VECTOR_READ_BATCH_SIZE;
-use crate::vector_storage::quantized::quantized_query_scorer::InternalScorerUnsupported;
-use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
-use crate::vector_storage::query_scorer::QueryScorerBytes;
-use crate::vector_storage::{NotDeletedChecker, RawScorer, RawScorerBuilder, VectorStorageRead};
 #[cfg(feature = "testing")]
-use crate::vector_storage::{VectorStorageEnum, new_raw_scorer};
+use crate::vector_storage::new_raw_scorer;
+use crate::vector_storage::quantized::quantized_query_scorer::InternalScorerUnsupported;
+use crate::vector_storage::quantized::quantized_vectors::{QuantizedVectors, QuantizedVectorsRead};
+use crate::vector_storage::query_scorer::QueryScorerBytes;
+use crate::vector_storage::{
+    NotDeletedChecker, RawScorer, RawScorerBuilder, VectorStorageEnum, VectorStorageRead,
+};
+
+/// The encoded vectors of one payload block, copied into a single buffer, where
+/// the copy holds the *exact* bytes the scorer would otherwise have read.
+pub struct BlockVectors {
+    /// One encoded vector per block point, in local id order, spaced
+    /// `stride` bytes apart.
+    data: Vec<u64>,
+    stride: usize,
+    len: usize,
+}
+
+/// Largest block buffer worth copying, when one block is built at a time.
+pub const MAX_BLOCK_GATHER_BYTES: usize = 32 * 1024 * 1024;
+
+/// Floor for the per-block cap once it has been divided by the number of blocks
+/// in flight.
+pub const MIN_BLOCK_GATHER_BYTES: usize = 8 * 1024 * 1024;
+
+/// Alignment the gather buffer can guarantee, from its `u64` backing store.
+const GATHER_ALIGN: usize = align_of::<u64>();
+
+impl BlockVectors {
+    /// Copy the encoded vectors of `points` into one contiguous buffer.
+    ///
+    /// Returns `None` - meaning "score against the global storage instead" -
+    /// when this storage exposes no fixed-layout byte view (sparse and
+    /// multivector storages), when the layout needs more alignment than the
+    /// buffer provides or a stride that is not a whole number of alignment
+    /// units, or when the copy would exceed `max_bytes`.
+    pub fn try_gather(
+        points: &[PointOffsetType],
+        vectors: &VectorStorageEnum,
+        quantized_vectors: Option<&QuantizedVectors>,
+        max_bytes: usize,
+    ) -> Option<Self> {
+        let layout = match quantized_vectors {
+            Some(quantized) => quantized.get_quantized_vector_layout().ok()?,
+            None => vectors.get_vector_layout().ok()?,
+        };
+        // A stride that is not a multiple of the alignment would leave every
+        // other vector in the buffer misaligned. No current layout has one -
+        // encoders that read plain bytes declare alignment 1 - so this guards
+        // future encoders, not a reachable case.
+        let stride = layout.size();
+        if stride == 0 || layout.align() > GATHER_ALIGN || !stride.is_multiple_of(layout.align()) {
+            return None;
+        }
+
+        let total = stride.checked_mul(points.len())?;
+        if total == 0 || total > max_bytes {
+            return None;
+        }
+
+        let mut data = vec![0u64; total.div_ceil(size_of::<u64>())];
+        let bytes: &mut [u8] = bytemuck::cast_slice_mut(&mut data);
+
+        for (local, &global) in points.iter().enumerate() {
+            let dst = &mut bytes[local * stride..local * stride + stride];
+            let copied = match quantized_vectors {
+                Some(quantized) => {
+                    let src = quantized.get_quantized_vector(global);
+                    (src.len() == stride).then(|| dst.copy_from_slice(&src))
+                }
+                None => vectors
+                    .with_vector_bytes_opt::<Random, _>(global, |src| {
+                        (src.len() == stride).then(|| dst.copy_from_slice(src))
+                    })
+                    .ok()
+                    .flatten()
+                    .flatten(),
+            };
+            // A short or missing vector means the layout does not describe this
+            // storage after all. Score against the storage rather than guess.
+            copied?;
+        }
+
+        Some(BlockVectors {
+            data,
+            stride,
+            len: points.len(),
+        })
+    }
+
+    pub fn gather_constraints(
+        vectors: &VectorStorageEnum,
+        quantized_vectors: Option<&QuantizedVectors>,
+        max_bytes: usize,
+    ) -> String {
+        let layout = match quantized_vectors {
+            Some(quantized) => quantized.get_quantized_vector_layout(),
+            None => vectors.get_vector_layout(),
+        };
+        match layout {
+            Err(err) => format!("storage exposes no fixed-layout byte view ({err})"),
+            Ok(layout) if layout.align() > GATHER_ALIGN => format!(
+                "vector alignment {} exceeds the buffer's {GATHER_ALIGN} bytes",
+                layout.align(),
+            ),
+            Ok(layout) if !layout.size().is_multiple_of(layout.align().max(1)) => format!(
+                "stride {} B is not a multiple of the vector alignment {} B",
+                layout.size(),
+                layout.align(),
+            ),
+            Ok(layout) => format!(
+                "stride {} B against a {} MiB per-block cap, so blocks over ~{} points",
+                layout.size(),
+                max_bytes / (1024 * 1024),
+                max_bytes / layout.size().max(1),
+            ),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Encoded bytes of the block point with local id `local_id`.
+    #[inline]
+    fn get(&self, local_id: PointOffsetType) -> &[u8] {
+        // The slice op alone would not always catch an out-of-range id: the
+        // buffer rounds up to whole `u64`s, and an id just past the end can
+        // land in that slack and read pad bytes instead of panicking.
+        debug_assert!((local_id as usize) < self.len);
+        let start = self.stride * local_id as usize;
+        &bytemuck::cast_slice::<u64, u8>(&self.data)[start..start + self.stride]
+    }
+}
 
 /// Scorers composition:
 ///
@@ -192,6 +321,81 @@ impl<'a> FilteredScorer<'a> {
         V: VectorStorageRead + RawScorerBuilder,
         Q: QuantizedVectorsRead,
     {
+        let raw_scorer =
+            Self::internal_raw_scorer(point_id, vectors, quantized_vectors, hardware_counter)?;
+        Ok(FilteredScorer {
+            raw_scorer,
+            filters: ScorerFilters::new(filter_context, vectors.not_deleted_checker(point_deleted)),
+            scores_buffer: Vec::new(),
+        })
+    }
+
+    /// Score a payload-block subgraph whose points are numbered `0..to_global.len()`.
+    /// `to_global` maps every block point back to its segment-wide id, and `block_deleted`
+    /// holds one flag per block point.
+    pub fn new_block_scorer(
+        global_point_id: PointOffsetType,
+        to_global: &'a [PointOffsetType],
+        vectors: &'a VectorStorageEnum,
+        quantized_vectors: Option<&'a QuantizedVectors>,
+        block_vectors: Option<&'a BlockVectors>,
+        block_deleted: &'a BitSlice,
+        hardware_counter: HardwareCounterCell,
+    ) -> OperationResult<Self> {
+        // One entry per block point, in `to_global`'s local order - a shorter
+        // slice would make the filters treat valid block points as deleted.
+        debug_assert_eq!(block_deleted.len(), to_global.len());
+        // A mismatched copy is a caller bug, not a decline: in release it
+        // falls back to the remapped path below, silently but correctly.
+        debug_assert!(
+            block_vectors.is_none_or(|block| block.len() == to_global.len()),
+            "gathered buffer does not match the block it is scored for",
+        );
+
+        let inner = Self::internal_raw_scorer(
+            global_point_id,
+            vectors,
+            quantized_vectors,
+            hardware_counter,
+        )?;
+
+        let usable = block_vectors
+            .filter(|block| block.len() == to_global.len())
+            .filter(|_| inner.scorer_bytes().is_some());
+
+        let raw_scorer: Box<dyn RawScorer + 'a> = match usable {
+            Some(block) => Box::new(GatherRawScorer {
+                inner,
+                to_global,
+                block,
+            }),
+            None => Box::new(RemappedRawScorer { inner, to_global }),
+        };
+
+        Ok(FilteredScorer {
+            raw_scorer,
+            filters: ScorerFilters::new(
+                None,
+                NotDeletedChecker {
+                    point_deleted: block_deleted,
+                    vec_deleted: block_deleted,
+                },
+            ),
+            scores_buffer: Vec::new(),
+        })
+    }
+
+    /// Raw scorer that scores against the vector stored under `point_id`.
+    fn internal_raw_scorer<V, Q>(
+        point_id: PointOffsetType,
+        vectors: &'a V,
+        quantized_vectors: Option<&'a Q>,
+        hardware_counter: HardwareCounterCell,
+    ) -> OperationResult<Box<dyn RawScorer + 'a>>
+    where
+        V: VectorStorageRead + RawScorerBuilder,
+        Q: QuantizedVectorsRead,
+    {
         // This is a fallback function, which is used if quantized vector storage
         // is not capable of reconstructing the query vector.
         let original_query_fn = || {
@@ -199,22 +403,17 @@ impl<'a> FilteredScorer<'a> {
             let query: QueryVector = query.as_vec_ref().into();
             query
         };
-        let raw_scorer = match quantized_vectors {
+        match quantized_vectors {
             Some(quantized_vectors) => quantized_vectors
                 .raw_internal_scorer(point_id, hardware_counter)
                 .or_else(|InternalScorerUnsupported(hardware_counter)| {
                     quantized_vectors.raw_scorer(original_query_fn(), hardware_counter)
-                })?,
+                }),
             None => {
                 let query = original_query_fn();
-                vectors.build_raw_scorer(query, hardware_counter)?
+                vectors.build_raw_scorer(query, hardware_counter)
             }
-        };
-        Ok(FilteredScorer {
-            raw_scorer,
-            filters: ScorerFilters::new(filter_context, vectors.not_deleted_checker(point_deleted)),
-            scores_buffer: Vec::new(),
-        })
+        }
     }
 
     /// Create a new filtered scorer for testing purposes.
@@ -300,6 +499,103 @@ impl<'a> FilteredScorer<'a> {
 
     pub fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
         self.raw_scorer.score_internal(point_a, point_b)
+    }
+}
+
+/// Drives a scorer built over segment-wide ids with the local ids of a
+/// payload-block subgraph.
+struct RemappedRawScorer<'a> {
+    inner: Box<dyn RawScorer + 'a>,
+    to_global: &'a [PointOffsetType],
+}
+
+/// Score block points through a scorer built over segment-wide ids, translating
+/// local ids to global ones as it goes.
+fn remapped_score_points(
+    inner: &dyn RawScorer,
+    to_global: &[PointOffsetType],
+    points: &[PointOffsetType],
+    scores: &mut [ScoreType],
+) {
+    debug_assert_eq!(points.len(), scores.len());
+    let mut translated = [0; VECTOR_READ_BATCH_SIZE];
+    for (points, scores) in points
+        .chunks(VECTOR_READ_BATCH_SIZE)
+        .zip(scores.chunks_mut(VECTOR_READ_BATCH_SIZE))
+    {
+        let translated = &mut translated[..points.len()];
+        for (global, &local) in translated.iter_mut().zip(points) {
+            *global = to_global[local as usize];
+        }
+        inner.score_points(translated, scores);
+    }
+}
+
+impl RawScorer for RemappedRawScorer<'_> {
+    fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoreType]) {
+        remapped_score_points(self.inner.as_ref(), self.to_global, points, scores);
+    }
+
+    fn score_point(&self, point: PointOffsetType) -> ScoreType {
+        self.inner.score_point(self.to_global[point as usize])
+    }
+
+    fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
+        self.inner.score_internal(
+            self.to_global[point_a as usize],
+            self.to_global[point_b as usize],
+        )
+    }
+
+    fn scorer_bytes(&self) -> Option<&dyn QueryScorerBytes> {
+        None
+    }
+}
+
+/// Scores candidates against a copy of the block's vectors instead of the
+/// segment-wide storage.
+struct GatherRawScorer<'a> {
+    inner: Box<dyn RawScorer + 'a>,
+    to_global: &'a [PointOffsetType],
+    block: &'a BlockVectors,
+}
+
+impl RawScorer for GatherRawScorer<'_> {
+    fn score_points(&self, points: &[PointOffsetType], scores: &mut [ScoreType]) {
+        debug_assert_eq!(points.len(), scores.len());
+        let Some(bytes_scorer) = self.inner.scorer_bytes() else {
+            // Ruled out when this scorer was built. Score against the storage
+            // rather than report something else.
+            debug_assert!(false, "gather scorer built over a scorer without bytes");
+            return remapped_score_points(self.inner.as_ref(), self.to_global, points, scores);
+        };
+        for (&local, score) in points.iter().zip(scores.iter_mut()) {
+            *score = bytes_scorer.score_bytes(self.block.get(local));
+        }
+    }
+
+    fn score_point(&self, point: PointOffsetType) -> ScoreType {
+        match self.inner.scorer_bytes() {
+            Some(bytes_scorer) => bytes_scorer.score_bytes(self.block.get(point)),
+            None => self.inner.score_point(self.to_global[point as usize]),
+        }
+    }
+
+    fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
+        if let Some(bytes_scorer) = self.inner.scorer_bytes()
+            && let Some(score) =
+                bytes_scorer.score_internal_bytes(self.block.get(point_a), self.block.get(point_b))
+        {
+            return score;
+        }
+        self.inner.score_internal(
+            self.to_global[point_a as usize],
+            self.to_global[point_b as usize],
+        )
+    }
+
+    fn scorer_bytes(&self) -> Option<&dyn QueryScorerBytes> {
+        None
     }
 }
 
@@ -469,5 +765,195 @@ impl<'a> BatchFilteredSearcher<'a> {
             .map(|BatchSearch { pq, .. }| pq.into_sorted_vec())
             .collect();
         Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Config structs keep their deprecated placement fields until 2.0; a
+    // struct literal has to name them either way.
+    #![allow(deprecated)]
+
+    use common::bitvec::BitVec;
+    use rand::SeedableRng as _;
+    use rand::rngs::StdRng;
+
+    use super::*;
+    use crate::data_types::vectors::{VectorElementType, VectorRef};
+    use crate::fixtures::index_fixtures::random_vector;
+    use crate::types::{
+        Distance, QuantizationConfig, TurboQuantBitSize, TurboQuantQuantizationConfig,
+        TurboQuantization,
+    };
+    use crate::vector_storage::VectorStorage;
+    use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
+    use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsStorageType;
+
+    /// A dense storage with TurboQuant 4-bit quantization over it. At `dim`
+    /// values not covered by [`TurboQuantizer::padded_dim`]'s packing, the
+    /// quantized stride is not a whole number of alignment units, which is
+    /// exactly the case the gather buffer's padded stride exists for.
+    fn tq_fixture(
+        dim: usize,
+        num_vectors: usize,
+    ) -> (VectorStorageEnum, QuantizedVectors, tempfile::TempDir) {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut storage = new_volatile_dense_vector_storage(dim, Distance::Dot);
+        let hw_counter = HardwareCounterCell::new();
+        for offset in 0..num_vectors as PointOffsetType {
+            let vector =
+                Distance::Dot.preprocess_vector::<VectorElementType>(random_vector(&mut rng, dim));
+            storage
+                .insert_vector(offset, VectorRef::from(&vector), &hw_counter)
+                .unwrap();
+        }
+
+        let config = QuantizationConfig::Turbo(TurboQuantization {
+            turbo: TurboQuantQuantizationConfig {
+                always_ram: Some(true),
+                memory: None,
+                bits: Some(TurboQuantBitSize::Bits4),
+            },
+        });
+        let dir = tempfile::tempdir().unwrap();
+        let quantized = QuantizedVectors::create(
+            &storage,
+            &config,
+            QuantizedVectorsStorageType::Immutable,
+            dir.path(),
+            1,
+            &AtomicBool::new(false),
+        )
+        .unwrap();
+        (storage, quantized, dir)
+    }
+
+    #[test]
+    fn gather_packs_odd_stride_tightly() {
+        // 10 dims at 4 bits pack into 5 bytes of codes plus a 4-byte extras
+        // trailer: a 9-byte stride. TurboQuant declares byte alignment, so
+        // the buffer packs vectors back to back at exactly that stride.
+        let (storage, quantized, _dir) = tq_fixture(10, 64);
+        let layout = quantized.get_quantized_vector_layout().unwrap();
+        assert_ne!(
+            layout.size() % 8,
+            0,
+            "fixture no longer produces an odd stride; pick a dim that does",
+        );
+
+        // Every other point, so local and global ids differ.
+        let points: Vec<PointOffsetType> = (0..64).step_by(2).collect();
+        let block =
+            BlockVectors::try_gather(&points, &storage, Some(&quantized), MAX_BLOCK_GATHER_BYTES)
+                .expect("a byte-aligned odd stride must gather");
+
+        assert_eq!(block.stride, layout.size());
+        for (local, &global) in points.iter().enumerate() {
+            assert_eq!(
+                block.get(local as PointOffsetType),
+                &*quantized.get_quantized_vector(global),
+                "gathered bytes of local {local} differ from storage",
+            );
+        }
+    }
+
+    #[test]
+    fn gather_scores_match_storage() {
+        let (storage, quantized, _dir) = tq_fixture(10, 64);
+
+        // The gather only engages when the inner scorer scores raw bytes; if
+        // TurboQuant ever stops offering that, the equality below would just
+        // compare the fallback path against itself. Same for the symmetric
+        // kernel and the internal-scoring comparison.
+        let inner = FilteredScorer::internal_raw_scorer(
+            0,
+            &storage,
+            Some(&quantized),
+            HardwareCounterCell::new(),
+        )
+        .unwrap();
+        let inner_bytes = inner
+            .scorer_bytes()
+            .expect("TQ scorer lost its byte entry point; this test no longer covers the gather");
+
+        let points: Vec<PointOffsetType> = (1..64).step_by(3).collect();
+        let block =
+            BlockVectors::try_gather(&points, &storage, Some(&quantized), MAX_BLOCK_GATHER_BYTES)
+                .unwrap();
+
+        assert!(
+            inner_bytes
+                .score_internal_bytes(block.get(0), block.get(1))
+                .is_some(),
+            "TQ scorer lost its symmetric byte kernel; the internal-scoring \
+             comparison below no longer covers the gathered path",
+        );
+
+        let block_deleted = BitVec::repeat(false, points.len());
+        let scorer = |block_vectors| {
+            FilteredScorer::new_block_scorer(
+                points[0],
+                &points,
+                &storage,
+                Some(&quantized),
+                block_vectors,
+                &block_deleted,
+                HardwareCounterCell::new(),
+            )
+            .unwrap()
+        };
+        let gathered = scorer(Some(&block));
+        let ungathered = scorer(None);
+
+        for local in 0..points.len() as PointOffsetType {
+            assert_eq!(
+                gathered.score_point(local).to_bits(),
+                ungathered.score_point(local).to_bits(),
+                "scores diverge at local {local}",
+            );
+        }
+
+        for a in 0..points.len() as PointOffsetType {
+            for b in 0..points.len() as PointOffsetType {
+                assert_eq!(
+                    gathered.score_internal(a, b).to_bits(),
+                    ungathered.score_internal(a, b).to_bits(),
+                    "internal scores diverge from storage at locals {a}, {b}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn gather_dense_bytes_match_storage() {
+        // f32 dense: stride dim * 4 with 4-byte alignment.
+        let mut rng = StdRng::seed_from_u64(42);
+        let dim = 8;
+        let mut storage = new_volatile_dense_vector_storage(dim, Distance::Dot);
+        let hw_counter = HardwareCounterCell::new();
+        for offset in 0..32 {
+            let vector = random_vector(&mut rng, dim);
+            storage
+                .insert_vector(offset, VectorRef::from(&vector), &hw_counter)
+                .unwrap();
+        }
+
+        let points: Vec<PointOffsetType> = (0..32).step_by(2).collect();
+        let block = BlockVectors::try_gather(&points, &storage, None, MAX_BLOCK_GATHER_BYTES)
+            .expect("aligned dense storage must gather");
+
+        assert_eq!(block.stride, dim * size_of::<f32>());
+        for (local, &global) in points.iter().enumerate() {
+            let matches = storage
+                .with_vector_bytes_opt::<Random, _>(global, |src| {
+                    src == block.get(local as PointOffsetType)
+                })
+                .unwrap()
+                .unwrap();
+            assert!(
+                matches,
+                "gathered bytes of local {local} differ from storage"
+            );
+        }
     }
 }

--- a/lib/segment/src/index/hnsw_index/tests/mod.rs
+++ b/lib/segment/src/index/hnsw_index/tests/mod.rs
@@ -1,5 +1,6 @@
 mod test_compact_graph_layer;
 mod test_graph_connectivity;
+mod test_payload_block_build;
 
 use common::types::PointOffsetType;
 use rand::Rng;

--- a/lib/segment/src/index/hnsw_index/tests/test_payload_block_build.rs
+++ b/lib/segment/src/index/hnsw_index/tests/test_payload_block_build.rs
@@ -1,0 +1,866 @@
+// Config structs keep their deprecated placement fields until 2.0; a struct
+// literal has to name them either way.
+#![allow(deprecated)]
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
+
+use atomic_refcell::AtomicRefCell;
+use common::budget::ResourcePermit;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::FeatureFlags;
+use common::progress_tracker::ProgressTracker;
+use common::types::PointOffsetType;
+use parking_lot::Mutex;
+use rand::SeedableRng;
+use rand::prelude::StdRng;
+use rstest::rstest;
+use tempfile::Builder;
+
+use crate::data_types::vectors::{DEFAULT_VECTOR_NAME, only_default_vector};
+use crate::entry::entry_point::SegmentEntry;
+use crate::fixtures::index_fixtures::random_vector;
+use crate::id_tracker::IdTracker;
+use crate::index::PayloadIndex;
+use crate::index::hnsw_index::get_num_indexing_threads;
+use crate::index::hnsw_index::hnsw::{HNSWIndex, HnswBuildDebugOptions, HnswIndexOpenArgs};
+use crate::json_path::JsonPath;
+use crate::payload_json;
+use crate::segment::Segment;
+use crate::segment_constructor::VectorIndexBuildArgs;
+use crate::segment_constructor::simple_segment_constructor::build_simple_segment;
+use crate::types::{
+    Distance, HnswConfig, HnswGlobalConfig, PayloadSchemaType, QuantizationConfig, SeqNumberType,
+    TurboQuantBitSize, TurboQuantQuantizationConfig, TurboQuantization,
+};
+use crate::vector_storage::quantized::quantized_vectors::{
+    QuantizedVectors, QuantizedVectorsStorageType,
+};
+
+const DIM: usize = 8;
+const NUM_VECTORS: u64 = 2_000;
+/// Distinct payload values. Every value covers 250 points of the fixture,
+/// enough for the block it generates to clear `full_scan_threshold`.
+const NUM_VALUES: u64 = 8;
+const SEED: u64 = 42;
+
+const KEYWORD_KEY: &str = "tenant";
+const KEYWORD_TWIN_KEY: &str = "tenant_twin";
+const INT_KEY: &str = "bucket";
+
+#[derive(Clone, Copy, Debug)]
+pub(super) enum FixtureField {
+    Keyword,
+    Integer,
+    /// Two keyword fields holding the same values.
+    TwinKeyword,
+    /// Two keyword fields holding the same values, over vectors that cluster
+    /// tightly per value. Each value's block is then already well connected in
+    /// the main graph, which is what makes the connectivity shortcut skip it.
+    ClusteredTwinKeyword,
+    /// One keyword field whose values differ enough in cardinality to fall on
+    /// both sides of a lowered large-block threshold.
+    SkewedKeyword,
+    /// One keyword field, with some points dropped from the ID tracker while
+    /// their vectors stay live in vector storage. Those points leave both the
+    /// main graph and the payload blocks, so blocks end up smaller than their
+    /// payload cardinality.
+    KeywordWithStalePoints,
+}
+
+/// How a [`FixtureField`] lays out its payload and vectors.
+struct FixtureSpec {
+    keys: &'static [(&'static str, PayloadSchemaType)],
+    /// Points per value. Sums to `NUM_VECTORS`, and every entry has to stay
+    /// above the block-generation threshold or it produces no block at all.
+    value_sizes: Vec<u64>,
+    /// Draw each value's points around a per-value centroid.
+    clustered: bool,
+    /// Drop every Nth point from the ID tracker after indexing.
+    drop_every: Option<u64>,
+}
+
+impl FixtureField {
+    fn spec(self) -> FixtureSpec {
+        const KEYWORD: PayloadSchemaType = PayloadSchemaType::Keyword;
+        let uniform = vec![NUM_VECTORS / NUM_VALUES; NUM_VALUES as usize];
+
+        let (keys, value_sizes, clustered, drop_every): (&[_], _, _, _) = match self {
+            // Keyword values produce one block each.
+            FixtureField::Keyword => (&[(KEYWORD_KEY, KEYWORD)], uniform, false, None),
+            // Integer values produce overlapping range blocks, as they do for
+            // the numeric fields that dominate this stage in production.
+            FixtureField::Integer => (
+                &[(INT_KEY, PayloadSchemaType::Integer)],
+                uniform,
+                false,
+                None,
+            ),
+            FixtureField::TwinKeyword => (
+                &[(KEYWORD_KEY, KEYWORD), (KEYWORD_TWIN_KEY, KEYWORD)],
+                uniform,
+                false,
+                None,
+            ),
+            FixtureField::ClusteredTwinKeyword => (
+                &[(KEYWORD_KEY, KEYWORD), (KEYWORD_TWIN_KEY, KEYWORD)],
+                uniform,
+                true,
+                None,
+            ),
+            // Sums to NUM_VECTORS, straddles a threshold of 256, and stays
+            // under the percolation ceiling of `total / avg_links * 4`.
+            FixtureField::SkewedKeyword => (
+                &[(KEYWORD_KEY, KEYWORD)],
+                vec![450, 400, 350, 300, 250, 150, 100],
+                false,
+                None,
+            ),
+            FixtureField::KeywordWithStalePoints => {
+                (&[(KEYWORD_KEY, KEYWORD)], uniform, false, Some(9))
+            }
+        };
+
+        debug_assert_eq!(value_sizes.iter().sum::<u64>(), NUM_VECTORS);
+        FixtureSpec {
+            keys,
+            value_sizes,
+            clustered,
+            drop_every,
+        }
+    }
+
+    fn is_keyword(self) -> bool {
+        !matches!(self, FixtureField::Integer)
+    }
+}
+
+/// Value assigned to each point, indexed by internal offset.
+///
+/// Points are upserted in id order into a fresh segment, so external ids and
+/// internal offsets coincide and this doubles as the block membership map.
+fn value_assignment(spec: &FixtureSpec) -> Vec<u64> {
+    let mut values = Vec::with_capacity(NUM_VECTORS as usize);
+    for (value, &size) in spec.value_sizes.iter().enumerate() {
+        values.extend(std::iter::repeat_n(value as u64, size as usize));
+    }
+    values
+}
+
+/// The blocks a keyword fixture generates, as internal point offsets.
+fn value_blocks(field: FixtureField) -> Vec<Vec<PointOffsetType>> {
+    assert!(field.is_keyword(), "range blocks are not one per value");
+    let spec = field.spec();
+    let values = value_assignment(&spec);
+
+    (0..spec.value_sizes.len() as u64)
+        .map(|value| {
+            values
+                .iter()
+                .enumerate()
+                .filter(|&(_, &v)| v == value)
+                .map(|(point, _)| point as PointOffsetType)
+                .collect()
+        })
+        .collect()
+}
+
+/// Every link container of the final graph, per point and per level, plus the
+/// entry point list. Compared verbatim, so any reordering shows up.
+type GraphSnapshot = (Vec<Vec<Vec<PointOffsetType>>>, String);
+
+/// A fixture segment with one or two indexed payload fields.
+///
+/// Only the single-field cases are comparable across builds. `indexed_fields`
+/// hands back a `HashMap`, so which field is indexed first - and therefore the
+/// order in which their links are merged - varies from build to build. Giving
+/// two fields identical values does not rescue it either: each field's index
+/// carries its own value map, so the two fields generate their blocks in
+/// different orders and are not interchangeable.
+///
+/// The two-field cases are therefore only used by tests that look at a single
+/// build, where they buy coverage of a multi-field segment and of the
+/// connectivity shortcut, which only runs from the second field on.
+fn build_fixture_segment(dir: &Path, field: FixtureField) -> Segment {
+    let mut rng = StdRng::seed_from_u64(SEED);
+    let hw_counter = HardwareCounterCell::new();
+
+    let spec = field.spec();
+    let values = value_assignment(&spec);
+
+    // Tight enough that a value's points are each other's nearest neighbours,
+    // so the main graph links them to one another and barely to anything else.
+    const CLUSTER_NOISE: f32 = 0.02;
+    let centroids: Vec<Vec<f32>> = (0..spec.value_sizes.len())
+        .map(|_| random_vector(&mut rng, DIM))
+        .collect();
+
+    let mut segment = build_simple_segment(dir, DIM, Distance::Cosine).unwrap();
+    for n in 0..NUM_VECTORS {
+        let value = values[n as usize];
+        let vector = if spec.clustered {
+            let noise = random_vector(&mut rng, DIM);
+            centroids[value as usize]
+                .iter()
+                .zip(&noise)
+                .map(|(centroid, noise)| centroid + CLUSTER_NOISE * noise)
+                .collect()
+        } else {
+            random_vector(&mut rng, DIM)
+        };
+
+        let payload = if field.is_keyword() {
+            let mut payload = payload_json! {};
+            for &(key, _) in spec.keys {
+                payload
+                    .0
+                    .insert(key.to_owned(), format!("tenant-{value}").into());
+            }
+            payload
+        } else {
+            payload_json! {INT_KEY: value as i64}
+        };
+
+        segment
+            .upsert_point(
+                n as SeqNumberType,
+                n.into(),
+                only_default_vector(&vector),
+                &hw_counter,
+            )
+            .unwrap();
+        segment
+            .set_full_payload(n as SeqNumberType, n.into(), &payload, &hw_counter)
+            .unwrap();
+    }
+
+    for &(key, schema) in spec.keys {
+        segment
+            .payload_index
+            .borrow_mut()
+            .set_indexed(&JsonPath::new(key), schema, &hw_counter)
+            .unwrap();
+    }
+
+    if let Some(drop_every) = spec.drop_every {
+        // Drops the ID tracker mapping and nothing else: the vector stays live
+        // in vector storage and the payload index keeps the point, so the point
+        // still turns up as a block member while counting as deleted. That is
+        // exactly the state `block_deleted_flags` exists to describe.
+        //
+        // `Segment::delete_point` would not do: it also clears the payload row,
+        // which would take the point out of its block entirely.
+        let mut id_tracker = segment.id_tracker.borrow_mut();
+        for n in (0..NUM_VECTORS).step_by(drop_every as usize) {
+            id_tracker.drop(n.into()).unwrap();
+        }
+    }
+
+    segment
+}
+
+fn hnsw_config(threads: usize) -> HnswConfig {
+    HnswConfig {
+        m: 8,
+        ef_construct: 16,
+        // In KB. Vectors are 8 `f32`s, so this lands far below the per-value
+        // cardinality of the fixture and every value produces a block.
+        full_scan_threshold: 1,
+        max_indexing_threads: threads,
+        on_disk: Some(false),
+        memory: None,
+        payload_m: None,
+        inline_storage: None,
+    }
+}
+
+/// What the payload-block stage did during one build.
+#[derive(Debug, Default)]
+struct BlockStats {
+    built: usize,
+    skipped_by_connectivity: usize,
+    large: usize,
+    /// Blocks whose vectors were copied into a block-local scoring buffer.
+    gathered: usize,
+    /// Blocks handed over by the unified cross-field queue. Zero on the
+    /// legacy path, which is what makes it a witness that the queue ran.
+    via_queue: usize,
+    /// Block index each block was filtered under, in call order.
+    indices: Vec<usize>,
+}
+
+/// Non-default knobs for one build. `None` leaves the production default.
+#[derive(Clone, Copy, Default)]
+struct BuildOverrides {
+    force_legacy_payload_blocks: bool,
+    large_block_threshold: Option<usize>,
+    /// Build over TurboQuant 4-bit quantized vectors instead of the raw dense
+    /// storage - the production configuration of the block gather.
+    quantize: bool,
+}
+
+/// Build an HNSW index over `segment` and snapshot the graph before it is
+/// serialized.
+fn build_and_snapshot(
+    segment: &Segment,
+    force_legacy_payload_blocks: bool,
+    threads: usize,
+) -> (GraphSnapshot, BlockStats) {
+    build_and_snapshot_opts(
+        segment,
+        threads,
+        BuildOverrides {
+            force_legacy_payload_blocks,
+            ..Default::default()
+        },
+    )
+}
+
+fn build_and_snapshot_with(
+    segment: &Segment,
+    force_legacy_payload_blocks: bool,
+    threads: usize,
+    large_block_threshold: Option<usize>,
+) -> (GraphSnapshot, BlockStats) {
+    build_and_snapshot_opts(
+        segment,
+        threads,
+        BuildOverrides {
+            force_legacy_payload_blocks,
+            large_block_threshold,
+            ..Default::default()
+        },
+    )
+}
+
+fn build_and_snapshot_opts(
+    segment: &Segment,
+    threads: usize,
+    overrides: BuildOverrides,
+) -> (GraphSnapshot, BlockStats) {
+    let BuildOverrides {
+        force_legacy_payload_blocks,
+        large_block_threshold,
+        quantize,
+    } = overrides;
+
+    let stopped = AtomicBool::new(false);
+    let hnsw_dir = Builder::new().prefix("hnsw_dir").tempdir().unwrap();
+    let mut rng = StdRng::seed_from_u64(SEED);
+
+    let quantized_vectors = if quantize {
+        let config = QuantizationConfig::Turbo(TurboQuantization {
+            turbo: TurboQuantQuantizationConfig {
+                always_ram: Some(true),
+                memory: None,
+                bits: Some(TurboQuantBitSize::Bits4),
+            },
+        });
+        let storage = segment.vector_data[DEFAULT_VECTOR_NAME]
+            .vector_storage
+            .borrow();
+        let quantized = QuantizedVectors::create(
+            &storage,
+            &config,
+            QuantizedVectorsStorageType::Immutable,
+            hnsw_dir.path(),
+            1,
+            &stopped,
+        )
+        .unwrap();
+        Arc::new(AtomicRefCell::new(Some(quantized)))
+    } else {
+        Default::default()
+    };
+
+    let snapshot = Mutex::new(None);
+    let blocks_built = AtomicUsize::new(0);
+    let blocks_skipped = AtomicUsize::new(0);
+    let large_blocks = AtomicUsize::new(0);
+    let blocks_gathered = AtomicUsize::new(0);
+    let blocks_via_queue = AtomicUsize::new(0);
+    let block_indices = Mutex::new(Vec::new());
+
+    let hnsw_config = hnsw_config(threads);
+    let permit_cpu_count = get_num_indexing_threads(hnsw_config.max_indexing_threads);
+    let permit = Arc::new(ResourcePermit::dummy(permit_cpu_count as u32));
+
+    HNSWIndex::build_with_debug_options(
+        HnswIndexOpenArgs {
+            path: hnsw_dir.path(),
+            id_tracker: segment.id_tracker.clone(),
+            vector_storage: segment.vector_data[DEFAULT_VECTOR_NAME]
+                .vector_storage
+                .clone(),
+            quantized_vectors,
+            payload_index: segment.payload_index.clone(),
+            hnsw_config,
+        },
+        VectorIndexBuildArgs {
+            permit,
+            old_indices: &[],
+            gpu_device: None,
+            rng: &mut rng,
+            stopped: &stopped,
+            hnsw_global_config: &HnswGlobalConfig::default(),
+            feature_flags: FeatureFlags::default(),
+            progress: ProgressTracker::new_for_test(),
+        },
+        HnswBuildDebugOptions {
+            force_legacy_payload_blocks,
+            blocks_built: Some(&blocks_built),
+            blocks_skipped_by_connectivity: Some(&blocks_skipped),
+            large_blocks_built: Some(&large_blocks),
+            blocks_gathered: Some(&blocks_gathered),
+            blocks_via_queue: Some(&blocks_via_queue),
+            block_indices: Some(&block_indices),
+            large_block_threshold,
+            inspect_builder: Some(&|builder| {
+                *snapshot.lock() = Some((
+                    builder.links_snapshot(),
+                    format!("{:?}", *builder.get_entry_points()),
+                ));
+            }),
+        },
+    )
+    .unwrap();
+
+    let stats = BlockStats {
+        built: blocks_built.into_inner(),
+        skipped_by_connectivity: blocks_skipped.into_inner(),
+        large: large_blocks.into_inner(),
+        gathered: blocks_gathered.into_inner(),
+        via_queue: blocks_via_queue.into_inner(),
+        indices: block_indices.into_inner(),
+    };
+    (
+        snapshot.into_inner().expect("builder was never inspected"),
+        stats,
+    )
+}
+
+/// The compact per-block builder must produce exactly the graph the legacy
+/// segment-sized builder produces, link for link and in the same order.
+///
+/// The comparison covers everything the compact path does differently: blocks
+/// are drained through the unified cross-field queue - serially in the order
+/// the legacy path visits them - and each block is scored against a copy of
+/// its own vectors. The copy holds the same encoded bytes and is scored
+/// through the same `score_bytes` entry point, so the scores are bitwise equal
+/// and the links must come out link for link and in the same order. These
+/// cases run without quantized vectors, so what they pin down is the
+/// unquantized dense path; the quantized path production uses is pinned the
+/// same way by [`test_compact_payload_blocks_match_legacy_quantized`].
+///
+/// Single-field fixtures only: see [`build_fixture_segment`] for why anything
+/// with two indexed fields cannot be compared across builds.
+/// The `stale_points` case covers a segment carrying ID-tracker-deleted points
+/// whose vectors are still live. It does *not* reach `block_deleted_flags`:
+/// `iter_filtered_points` drops those points before they can become block
+/// members, so the flags come out all-false either way. See that function for
+/// why they are still derived.
+#[rstest]
+#[case::keyword(FixtureField::Keyword)]
+#[case::integer(FixtureField::Integer)]
+#[case::stale_points(FixtureField::KeywordWithStalePoints)]
+fn test_compact_payload_blocks_match_legacy(#[case] field: FixtureField) {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let segment = build_fixture_segment(dir.path(), field);
+
+    let (legacy, legacy_stats) = build_and_snapshot(&segment, true, 1);
+    let (compact, compact_stats) = build_and_snapshot(&segment, false, 1);
+
+    assert!(
+        legacy_stats.built >= 5,
+        "fixture is vacuous, only {} payload blocks were built",
+        legacy_stats.built,
+    );
+    assert_eq!(legacy_stats.built, compact_stats.built);
+
+    // Without these the comparison below would pass just as well against a
+    // compact build that quietly skipped the queue or the vector copy, and
+    // would then prove nothing about either.
+    assert_eq!(legacy_stats.gathered, 0);
+    assert_eq!(legacy_stats.via_queue, 0);
+    assert_eq!(
+        compact_stats.gathered, compact_stats.built,
+        "gather did not engage: {compact_stats:?}",
+    );
+    assert_eq!(
+        compact_stats.via_queue,
+        compact_stats.indices.len(),
+        "the compact build did not take every block off the queue: {compact_stats:?}",
+    );
+
+    // Both paths must number a field's blocks the same way, or they seed the
+    // connectivity shortcut differently and can skip different blocks. Single
+    // field here, so the numbering is simply generation order.
+    let expected_indices: Vec<usize> = (0..legacy_stats.indices.len()).collect();
+    assert_eq!(legacy_stats.indices, expected_indices);
+    assert_eq!(compact_stats.indices, expected_indices);
+
+    let (legacy_links, legacy_entry_points) = legacy;
+    let (compact_links, compact_entry_points) = compact;
+
+    assert_eq!(legacy_links.len(), compact_links.len());
+    for (point_id, (legacy, compact)) in legacy_links.iter().zip(&compact_links).enumerate() {
+        assert_eq!(
+            legacy, compact,
+            "links of point {point_id} differ between the legacy and compact block builders",
+        );
+    }
+    assert_eq!(legacy_entry_points, compact_entry_points);
+}
+
+/// [`test_compact_payload_blocks_match_legacy`], on the quantized path
+/// production actually uses (TurboQuant 4-bit). Here the block-local copy also
+/// serves the link-selection heuristic's stored-vs-stored scoring
+/// (`score_internal_bytes`): same bytes, same kernels, bitwise-equal scores,
+/// so the graphs must still be byte-identical.
+///
+/// TQ is the only encoder whose symmetric kernel the copy can serve, so this
+/// is the one build-level fixture where `score_internal_bytes` changes which
+/// code runs rather than falling back - engagement of the bytes kernel itself
+/// is pinned by the unit tests next to `BlockVectors`.
+#[rstest]
+#[case::keyword(FixtureField::Keyword)]
+#[case::integer(FixtureField::Integer)]
+fn test_compact_payload_blocks_match_legacy_quantized(#[case] field: FixtureField) {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let segment = build_fixture_segment(dir.path(), field);
+
+    let arm = |force_legacy_payload_blocks| BuildOverrides {
+        force_legacy_payload_blocks,
+        quantize: true,
+        ..Default::default()
+    };
+
+    let ((legacy_links, legacy_entries), legacy_stats) =
+        build_and_snapshot_opts(&segment, 1, arm(true));
+    let ((compact_links, compact_entries), compact_stats) =
+        build_and_snapshot_opts(&segment, 1, arm(false));
+
+    assert!(
+        legacy_stats.built >= 5,
+        "fixture is vacuous, only {} payload blocks were built",
+        legacy_stats.built,
+    );
+    assert_eq!(legacy_stats.built, compact_stats.built);
+    assert_eq!(legacy_stats.gathered, 0);
+    // Without this the comparison below would pass on two identical
+    // un-gathered builds and prove nothing.
+    assert_eq!(
+        compact_stats.gathered, compact_stats.built,
+        "gather did not engage: {compact_stats:?}",
+    );
+
+    // And without this, `quantize: true` silently building over raw vectors
+    // would prove the wrong path. Quantized scores differ from raw scores, so
+    // an identical graph means quantization never engaged.
+    let ((raw_links, _), _) = build_and_snapshot(&segment, false, 1);
+    assert_ne!(
+        raw_links, compact_links,
+        "quantized build produced the raw build's graph; quantization did not engage",
+    );
+
+    for (point_id, (legacy, compact)) in legacy_links.iter().zip(&compact_links).enumerate() {
+        assert_eq!(
+            legacy, compact,
+            "links of point {point_id} differ between the legacy and compact block builders",
+        );
+    }
+    assert_eq!(legacy_entries, compact_entries);
+}
+
+/// With more than one field the unified queue is the point of the change, so the
+/// numbering it hands blocks over under has to survive it.
+///
+/// Serially the queue is still fields in order and blocks in generation order -
+/// the order the legacy path visits them - so every block is filtered under the
+/// same index either way. That is the property under test, and it holds for both
+/// cases. (The single-field equality tests above already compare the graphs
+/// themselves; two-field fixtures cannot be, per [`build_fixture_segment`].)
+///
+/// The connectivity shortcut's *verdicts* are a different matter, and
+/// `compare_verdicts` is what says so. `indexed_fields` hands back a `HashMap`,
+/// so which twin field is visited first varies between the two builds this
+/// compares - see [`build_fixture_segment`]. `check_connectivity` only applies
+/// from the second field on, so a flipped order points the shortcut at the other
+/// field, and any borderline verdict flips with it. The uniform case has
+/// essentially nothing to skip so its counts match regardless; the clustered case
+/// exists precisely to make the shortcut fire, so its counts are not comparable
+/// across builds and only the numbering is checked. Pinning the field order would
+/// mean fighting the `HashMap`, which is not what this test is for -
+/// `test_connectivity_shortcut_skips_well_connected_blocks` covers the predicate
+/// itself from a single build.
+#[rstest]
+#[case::twin_keyword(FixtureField::TwinKeyword, true)]
+#[case::clustered_twin_keyword(FixtureField::ClusteredTwinKeyword, false)]
+fn test_unified_block_queue_census_matches_legacy(
+    #[case] field: FixtureField,
+    #[case] compare_verdicts: bool,
+) {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let segment = build_fixture_segment(dir.path(), field);
+
+    let (_, legacy_stats) = build_and_snapshot(&segment, true, 1);
+    let ((unified_links, _), unified_stats) = build_and_snapshot(&segment, false, 1);
+
+    assert!(
+        legacy_stats.built >= 5,
+        "fixture is vacuous: {legacy_stats:?}",
+    );
+    if compare_verdicts {
+        assert_eq!(
+            legacy_stats.built, unified_stats.built,
+            "a different set of blocks was built: {legacy_stats:?} vs {unified_stats:?}",
+        );
+        assert_eq!(
+            legacy_stats.skipped_by_connectivity, unified_stats.skipped_by_connectivity,
+            "the connectivity shortcut reached different verdicts: \
+             {legacy_stats:?} vs {unified_stats:?}",
+        );
+    }
+    assert_eq!(
+        legacy_stats.indices, unified_stats.indices,
+        "blocks were numbered differently: {legacy_stats:?} vs {unified_stats:?}",
+    );
+
+    // Without this the whole test would pass against a build that quietly fell
+    // back to the legacy per-field path.
+    assert_eq!(
+        legacy_stats.via_queue, 0,
+        "the legacy build went through the unified queue: {legacy_stats:?}",
+    );
+    assert_eq!(
+        unified_stats.via_queue,
+        unified_stats.indices.len(),
+        "the unified build did not take every block off the queue: {unified_stats:?}",
+    );
+
+    assert_links_are_sane(&unified_links);
+}
+
+/// The compact path must leave the graph usable: no duplicate links, no links
+/// to points outside the segment, no self-links.
+#[rstest]
+#[case::keyword(FixtureField::Keyword)]
+#[case::integer(FixtureField::Integer)]
+#[case::twin_keyword(FixtureField::TwinKeyword)]
+#[case::stale_points(FixtureField::KeywordWithStalePoints)]
+fn test_compact_payload_blocks_structural_invariants(#[case] field: FixtureField) {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let segment = build_fixture_segment(dir.path(), field);
+
+    let ((links, _), stats) = build_and_snapshot(&segment, false, 1);
+    assert!(stats.built >= 5);
+
+    assert_links_are_sane(&links);
+}
+
+/// The connectivity shortcut has to actually skip blocks somewhere in the
+/// suite, otherwise nothing pins down its predicate.
+///
+/// Clustered vectors are what make that happen: each value's points are one
+/// another's nearest neighbours, so the main graph already connects them and a
+/// block's own connectivity estimate lands above the whole-graph estimate the
+/// threshold is drawn from. The count is totalled across fields because which
+/// of the twin fields is visited first is not deterministic.
+#[test]
+fn test_connectivity_shortcut_skips_well_connected_blocks() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let segment = build_fixture_segment(dir.path(), FixtureField::ClusteredTwinKeyword);
+
+    let ((links, _), stats) = build_and_snapshot(&segment, false, 1);
+
+    assert!(
+        stats.skipped_by_connectivity >= 4,
+        "connectivity shortcut skipped only {} blocks, so its predicate is untested: {stats:?}",
+        stats.skipped_by_connectivity,
+    );
+    assert!(
+        stats.built >= 5,
+        "fixture skipped everything, so nothing was built: {stats:?}",
+    );
+    assert_links_are_sane(&links);
+}
+
+/// Fraction of `points` that fall in the largest connected component of the
+/// level-0 graph restricted to `points`.
+fn largest_component_fraction(
+    links: &[Vec<Vec<PointOffsetType>>],
+    points: &[PointOffsetType],
+) -> f64 {
+    fn find(parent: &mut [usize], mut x: usize) -> usize {
+        while parent[x] != x {
+            parent[x] = parent[parent[x]];
+            x = parent[x];
+        }
+        x
+    }
+
+    let local: HashMap<PointOffsetType, usize> = points.iter().copied().zip(0..).collect();
+    let mut parent: Vec<usize> = (0..points.len()).collect();
+
+    for (&global, &from) in &local {
+        for &link in &links[global as usize][0] {
+            if let Some(&to) = local.get(&link) {
+                let (from, to) = (find(&mut parent, from), find(&mut parent, to));
+                if from != to {
+                    parent[from] = to;
+                }
+            }
+        }
+    }
+
+    let mut sizes: HashMap<usize, usize> = HashMap::new();
+    for point in 0..points.len() {
+        *sizes.entry(find(&mut parent, point)).or_default() += 1;
+    }
+    sizes.values().copied().max().unwrap_or(0) as f64 / points.len() as f64
+}
+
+/// Building payload blocks concurrently must leave every block as connected as
+/// the sequential build leaves it, and must not corrupt any link container.
+///
+/// The two builds are not compared link for link: the main graph is itself
+/// built in parallel, so a multi-threaded build differs from a single-threaded
+/// one before the payload stage even starts. `merge_block` is pinned down
+/// exactly by `test_merge_block_concurrent_matches_sequential` instead.
+///
+/// The fixture's block cardinalities straddle `LARGE_BLOCK_THRESHOLD`, lowered
+/// here from its production value, so the run exercises both halves of the
+/// partition: large blocks handed the whole pool one at a time, small blocks
+/// each running as one task of a parallel batch.
+#[rstest]
+#[case::uniform(FixtureField::Keyword, None)]
+#[case::mixed_block_sizes(FixtureField::SkewedKeyword, Some(256))]
+fn test_parallel_payload_blocks_stay_connected(
+    #[case] field: FixtureField,
+    #[case] large_block_threshold: Option<usize>,
+) {
+    const ITERATIONS: usize = 10;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let segment = build_fixture_segment(dir.path(), field);
+    let blocks = value_blocks(field);
+
+    let ((sequential, _), sequential_stats) =
+        build_and_snapshot_with(&segment, false, 1, large_block_threshold);
+    assert!(
+        sequential_stats.built >= 5,
+        "fixture is vacuous, only {} payload blocks were built",
+        sequential_stats.built,
+    );
+
+    let sequential_fractions: Vec<f64> = blocks
+        .iter()
+        .map(|points| largest_component_fraction(&sequential, points))
+        .collect();
+    assert!(
+        sequential_fractions.iter().all(|&fraction| fraction > 0.9),
+        "sequential build left blocks fragmented: {sequential_fractions:?}",
+    );
+
+    for iteration in 0..ITERATIONS {
+        let ((parallel, _), parallel_stats) =
+            build_and_snapshot_with(&segment, false, 4, large_block_threshold);
+        assert_eq!(
+            parallel_stats.built, sequential_stats.built,
+            "iteration {iteration}: a different set of blocks was built",
+        );
+
+        if large_block_threshold.is_some() {
+            assert!(
+                parallel_stats.large > 0 && parallel_stats.large < parallel_stats.built,
+                "iteration {iteration}: expected the run to use both sides of the block \
+                 partition, got {parallel_stats:?}",
+            );
+        }
+
+        assert_links_are_sane(&parallel);
+
+        for (value, (points, sequential)) in blocks.iter().zip(&sequential_fractions).enumerate() {
+            let fraction = largest_component_fraction(&parallel, points);
+            assert!(
+                fraction >= sequential - 0.01,
+                "iteration {iteration}, block {value}: connectivity {fraction} below the \
+                 sequential build's {sequential}",
+            );
+        }
+    }
+}
+
+/// Draining every field's blocks through one parallel scope must leave the graph
+/// intact and must still filter each block exactly once, under its own field's
+/// numbering.
+///
+/// Unlike the serial case this is not a census-equality check. The connectivity
+/// shortcut reads the graph as it stands when a block is filtered, and
+/// interleaving the fields changes how much of an earlier field has merged by
+/// then - so a block can be skipped by one schedule and built by another. That
+/// was already true between blocks of one field on the parallel path; the
+/// unified queue extends it across fields. What is pinned down here is what does
+/// not move: every block is still filtered once, under the same index.
+#[rstest]
+#[case::twin_keyword(FixtureField::TwinKeyword)]
+#[case::clustered_twin_keyword(FixtureField::ClusteredTwinKeyword)]
+fn test_unified_block_queue_parallel_stays_sane(#[case] field: FixtureField) {
+    const ITERATIONS: usize = 6;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let segment = build_fixture_segment(dir.path(), field);
+
+    let (_, serial_stats) = build_and_snapshot(&segment, false, 1);
+    assert!(
+        serial_stats.built >= 5,
+        "fixture is vacuous: {serial_stats:?}"
+    );
+
+    let mut expected_indices = serial_stats.indices.clone();
+    expected_indices.sort_unstable();
+
+    for iteration in 0..ITERATIONS {
+        let ((links, _), stats) = build_and_snapshot(&segment, false, 4);
+
+        assert_links_are_sane(&links);
+
+        let mut indices = stats.indices.clone();
+        indices.sort_unstable();
+        assert_eq!(
+            indices, expected_indices,
+            "iteration {iteration}: blocks were filtered a different number of times, \
+             or under different indices: {stats:?}",
+        );
+        assert!(
+            stats.built > 0,
+            "iteration {iteration}: nothing was built: {stats:?}",
+        );
+    }
+}
+
+pub(super) fn assert_links_are_sane(links: &[Vec<Vec<PointOffsetType>>]) {
+    for (point_id, levels) in links.iter().enumerate() {
+        for (level, container) in levels.iter().enumerate() {
+            let mut seen = container.clone();
+            seen.sort_unstable();
+            let before = seen.len();
+            seen.dedup();
+            assert_eq!(
+                before,
+                seen.len(),
+                "point {point_id} level {level} has duplicate links",
+            );
+            assert!(
+                container.iter().all(|&link| (link as usize) < links.len()),
+                "point {point_id} level {level} links outside the segment",
+            );
+            assert!(
+                container.iter().all(|&link| link as usize != point_id),
+                "point {point_id} level {level} links to itself",
+            );
+        }
+    }
+}

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -110,4 +110,9 @@ where
         self.quantized_data
             .score_bytes(enabled, &self.query, bytes, &self.hardware_counter)
     }
+
+    fn score_internal_bytes(&self, a: &[u8], b: &[u8]) -> Option<ScoreType> {
+        self.quantized_data
+            .score_internal_bytes(a, b, &self.hardware_counter)
+    }
 }

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -31,6 +31,14 @@ pub trait QueryScorer {
 
     type SupportsBytes: TBool;
     fn score_bytes(&self, _: Self::SupportsBytes, bytes: &[u8]) -> ScoreType;
+
+    /// Score two stored vectors given their encoded bytes, bitwise identical
+    /// to [`Self::score_internal`] on the same bytes. `None` - the default -
+    /// means the underlying scorer has no byte-level symmetric kernel and the
+    /// caller must score by id instead.
+    fn score_internal_bytes(&self, _a: &[u8], _b: &[u8]) -> Option<ScoreType> {
+        None
+    }
 }
 
 pub fn default_score_stored_batch<Q: QueryScorer + ?Sized>(
@@ -47,6 +55,11 @@ pub fn default_score_stored_batch<Q: QueryScorer + ?Sized>(
 
 pub trait QueryScorerBytes {
     fn score_bytes(&self, bytes: &[u8]) -> ScoreType;
+
+    /// See [`QueryScorer::score_internal_bytes`].
+    fn score_internal_bytes(&self, _a: &[u8], _b: &[u8]) -> Option<ScoreType> {
+        None
+    }
 }
 
 #[derive(TransparentWrapper)]
@@ -64,6 +77,10 @@ impl<TQueryScorer: QueryScorer> QueryScorerBytesImpl<TQueryScorer> {
 impl<TQueryScorer: QueryScorer> QueryScorerBytes for QueryScorerBytesImpl<TQueryScorer> {
     fn score_bytes(&self, bytes: &[u8]) -> ScoreType {
         self.0.get().score_bytes(self.0.is_some(), bytes)
+    }
+
+    fn score_internal_bytes(&self, a: &[u8], b: &[u8]) -> Option<ScoreType> {
+        self.0.get().score_internal_bytes(a, b)
     }
 }
 

--- a/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
+++ b/lib/segment/tests/integration/multivector_filtrable_hnsw_test.rs
@@ -39,7 +39,7 @@ use tempfile::Builder;
 #[case::recobestscore_eq(QueryVariant::RecoBestScore, 1, 64, 5)]
 #[case::recobestscore_multi(QueryVariant::RecoBestScore, 2, 64, 10)]
 #[case::recosumscores_eq(QueryVariant::RecoSumScores, 1, 64, 5)]
-#[case::recosumscores_multi(QueryVariant::RecoSumScores, 2, 64, 10)]
+#[case::recosumscores_multi(QueryVariant::RecoSumScores, 2, 64, 15)]
 fn test_multi_filterable_hnsw(
     #[case] query_variant: QueryVariant,
     #[case] max_num_vector_per_points: usize,
@@ -161,6 +161,11 @@ fn test_multi_filterable_hnsw(
         },
     )
     .unwrap();
+
+    // Queries get their own RNG stream. Sharing one with the build ties which
+    // queries are asked to how many draws the build happens to consume, so any
+    // change to build-internal sampling silently re-rolls the measurement.
+    let mut rng = StdRng::seed_from_u64(43);
 
     let top = 3;
     let mut hits = 0;


### PR DESCRIPTION
### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

## Improvements to Payload-HNSW Construction

**TLDR:** The current payload-HNSW construction path underutilizes CPU resources, performs many unnecessary no-op operations, misses opportunities for block-level cache locality, and uses an inefficient sampling method for its shortcut heuristic. This pull request introduces adaptive parallelism to fully utilize the configured HNSW threads, builds a lightweight block-level global-to-local ID lookup table to eliminate unnecessary no-ops, replaces per-edge sampling with a more efficient but statistically equivalent method, and adds block-level caching to reduce random memory access during HNSW construction. Testing on a 102 core machine showed that this reduced indexing time for a large segment with multiple payload indicies from 12265.2s to 2278.2s (5.38x faster), and extensive local testing showed that filtered recall remains statistically equivalent before and after these changes. 



## What Qdrant Currently Does

Qdrant’s payload indexes emit blocks of points corresponding to conditions over each indexed payload field. For example, one block for `color = "red"` and another for `color = "green"`. For blocks that fall within the qualifying size range and are not deemed sufficiently connected by the percolation-based shortcut, Qdrant constructs a temporary block-level HNSW over only the points in that block. The edges from this temporary graph are then merged into the main segment-level HNSW, after which the block-level graph is discarded.

The logical flow is: 

For each qualifying payload block, Qdrant:

1. Takes only the points matching that block.
2. Builds a temporary, level-0 HNSW over those points.
3. Copies the temporary HNSW’s edges into the main segment-level HNSW.
4. Discards the temporary graph.




### Inefficiencies  
1. Payload HNSWs are constructed one field at a time and, within each field, one block at a time. This leads to substantial CPU underutilization when processing small blocks. During construction of a small block-level HNSW, insertion threads frequently contend for node locks, causing the build to behave effectively as a single-threaded process. In testing, a payload-HNSW build configured with a 16-thread pool utilized only 1–5 cores, despite being able to use up to 16.
2. Block-level HNSW construction uses segment-global IDs to size `GraphLayersBuilder`, causing `links_layers` to allocate one Vec and RwLock for every point in the segment. Similarly, `merge_from_other` iterated over the entire segment-sized builder, even though only a block-sized subset of points could contain edges. As a result, most entries were empty and most merge checks were unnecessary.
3. During block-level HNSW construction, inserting a point required fetching each existing vector in the block from the segment to compute similarity scores. A similar pattern occurred during merging and any pruning triggered by newly added edges. Together, these operations caused repeated random accesses across the segment’s vector data.
4. The shortcut heuristic tries to estimate whether a block is already connected enough to skip a block-level HNSW by running a small randomized BF. During the process, it does a coin-flip on each edge it encounters to determine if it is should be taken. 

### Optimizations

1. Exploiting parallelism and avoiding tail-latency
    - Adaptive parallelism based on block size: small blocks do not benefit from multithreaded insertion because lock contention limits parallelism. Based on local testing, blocks smaller than 32,768 points are built using single-threaded insertion. However, multiple eligible block-level HNSWs can be constructed concurrently, avoiding contention within each builder while still utilizing the configured thread pool. In testing, this approach allowed construction to use the expected 16 cores. For blocks larger than approximately 32K points, lock contention is significantly lower and multithreaded insertion provides a clear benefit. These blocks may therefore use all 16 threads, with only one large block constructed at a time.
    - Size-aware scheduling: to reduce tail latency caused by an uneven mix of large and small blocks, the construction queue is sorted across fields by block size. Large blocks are processed first, allowing all 16 threads to be allocated to each block. The remaining small blocks are then constructed concurrently across the thread pool. This ordering improves overall utilization and minimizes the long tail at the end of construction.
2. Instead of a segment-sized builder addressed by global point ids, each block is built in a local id space of size `len(block)` with a small lookup table used to translate between global IDs and local IDs. This reduces the `GraphLayersBuilder` to the size of the block. When merging the segment-level HNSW with the block-level HNSW, only edges belonging to the block are considered, eliminating unnecessary no-ops.
3. Block-HNSW vectors are copied into a contiguous per-block memory buffer. This improves locality, increases the likelihood that the working set remains in the L2 or L3 cache, and reduces random memory accesses. To cap memory overhead, each block buffer is capped at 32 MB / `num_indexing_threads`, with a minimum capacity of 8 MB. With 16 indexing threads, the maximum additional memory usage is bounded at 128 MB. Blocks that do not fit within this limit fall back to the original access path. 
    - To support unusually sized vectors in the per-block memory buffer, the gather function can add padding to ensure proper byte alignment. Most vectors are already byte-aligned, so this change does not affect the common case, but it allows the optimization to be applied more broadly. Even when padding is required, the final output remains byte-identical to the unbuffered path.
    -  While query-to-stored-vector scoring can use the buffer through an existing byte-level interface, stored-to-stored scoring follows a separate path through `score_internal`, which previously had no byte-level entry point. As a result, the link-selection heuristic's comparisons still accessed global memory even in buffered blocks. To support buffered stored-to-stored scoring, this PR adds a  `score_internal_bytes` trait method to `EncodedVectors`, defaulting to `None`. When byte-level scoring is unavailable — or the block's buffer was not allocated — the block scorer falls back to the existing id-based path, incurring global memory access. We added an override to `score_internal_bytes` for TurboQuant; it applies the same symmetric kernel to the same encoded bytes the id-based path would fetch, so scores are bitwise identical, which the equality tests enforce at the graph level.
  
4. In place of the per-edge sampler for the heuristic, I implemented a new `DropGapSampler`, which draws Geometric(1−q) distributed gaps.  Each gap "skips the next `gap` edges" — which generates the same random process (each edge retained independently with probability p) using ~n/(p·n+1) fewer RNG draws.



### Misc

**Minor Test change:** `multivector_filtrable_hnsw_test.rs`. This test previously drew its 100 recall queries from the same seeded RNG the build had been consuming, so the identity of the query set depended on how many random draws the build performed internally. This PR changes that draw count by design (the gap sampler consumes ~one draw per kept edge instead of one per enumerated edge, and block scheduling draws per-field seed bases up front), which would have silently re-rolled the query set and made the recall score move for reasons unrelated to graph quality. The test now gives queries their own fixed-seed RNG, so it always asks the same questions regardless of build-internal sampling — any future change to the builder included. On this pinned query set the graph scores 87/100, so the RecoSumScores miss budget is raised from 10 to 15; to confirm this is recalibration rather than a masked regression, I ran the unmodified pre-change code against the same pinned queries and it also scores exactly 87/100. The old budget of 10 only held because the previous shared-stream queries happened to be an easier sample.

**Recall Testing:** 
Using Claude, I carried out the following recall analysis. Below is Claude Fable’s summary of its findings:

> Two complementary arguments cover the two ways this series could affect recall. First, for the serial path, no statistical argument is needed: the test suite proves the new builder produces byte-identical graphs to the old one—using order-sensitive comparisons of every point’s link list and the entry points across keyword, numeric-range, and deleted-point fixtures, both unquantized and with TurboQuant 4-bit. Therefore, any recall effect can arise only from the two places where behavior legitimately differs: merge arrival order under block-level parallelism and the connectivity shortcut’s sampling, which preserves the same distribution but uses a different RNG stream.
>
> Those two effects were measured empirically on real data rather than synthetic fixtures. Segments were built from the FineWeb corpus using 768-dimensional text embeddings at scales of 218,000 and 1 million points, with `m=48`, `ef_construct=256`, TurboQuant 4-bit, one indexed keyword payload field, and two indexed numeric payload fields. The overlapping range blocks generated by the numeric fields dominate this build stage.
>
> Because HNSW construction is nondeterministic, each arm—before and after the changes—was built several times using distinct entropy seeds to first establish the within-arm noise floor. Cross-arm differences were then evaluated against a two-standard-deviation band of that run-to-run variation, using the mean recall of each build pair as the unit of analysis. Recall was measured against exact-search ground truth for both filtered queries—the workload this stage is intended to support—and unfiltered queries at two operating points: top-100 with `ef=128` and top-10 with `ef=64`.
>
> Across 26 before-and-after build pairs, with three seeded builds per arm, filtered recall was statistically equivalent in every pair. Unfiltered recall changed by −0.02 percentage points at top-100/`ef=128` and −0.09 percentage points at top-10/`ef=64`, compared with a within-arm noise floor of ±0.11–0.13 percentage points. These differences were therefore indistinguishable from normal build-to-build variation.
>
> Relative to the pre-series baseline, the full series improved recall by approximately 0.25–0.28 percentage points. An early sample with only three observations showed a −0.8 percentage-point deficit at top-10/`ef=64`, but this result did not replicate across additional seed runs and converged to −0.09 percentage points at the larger sample size, indicating that the initial result was seed noise.
>
> An additional study covering 11 build pairs isolated the block-buffer scoring optimization. It measured recall differences of −0.01 percentage points and +0.00 percentage points at the two operating points, respectively, both well within the observed noise bands.
