### PR TITLE
uio-grpc-client/build.rs: don't bump mtime every build

### DIFF
--- a/lib/uio-grpc-client/build.rs
+++ b/lib/uio-grpc-client/build.rs
@@ -11,7 +11,9 @@ fn main() -> std::io::Result<()> {
     // by git so that the crate also builds standalone (e.g. from crates.io).
     if source.exists() {
         println!("cargo:rerun-if-changed={}", source.display());
-        fs_err::copy(source, local)?;
+        if fs_err::read(source)? != fs_err::read(local).unwrap_or_default() {
+            fs_err::copy(source, local)?;
+        }
     }
 
     tonic_prost_build::configure()


### PR DESCRIPTION
Run this command twice:
```sh
cargo run -p edge-shard-query
cargo run -p edge-shard-query
```

Problem: it will build the binary in both cases, instead of using cached binary for second run.

This PR fixes that.