### PR TITLE
[CachedFs] Unchanged file open is no-op

### DIFF
--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -52,7 +52,7 @@ pub struct CachedFs<Fs: UniversalReadFs> {
     files_info: Option<HashMap<PathBuf, FileInfo>>,
     /// Previous listing snapshot.
     previous_files_info: Option<HashMap<PathBuf, FileInfo>>,
-    files_prefetched: Arc<Mutex<HashMap<PathBuf, UioResult<Fs::File>>>>,
+    files_prefetched: Arc<Mutex<HashMap<PathBuf, Option<Fs::File>>>>,
 }
 
 /// Manual impl: `derive(Clone)` would add a spurious `Fs::File: Clone`
@@ -197,8 +197,8 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
             open_extra = open_extra.with_known_len(info.size);
         }
 
-        let file = self.fs.open(path, open_options, open_extra);
-        files_prefetched.insert(path.to_path_buf(), file);
+        let file = self.fs.open(path, open_options, open_extra)?;
+        files_prefetched.insert(path.to_path_buf(), Some(file));
 
         Ok(())
     }
@@ -219,13 +219,7 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
         if let Some((previous, current)) = self.previous_file_info(path).zip(self.file_info(path))
             && previous == current
         {
-            files_prefetched.insert(
-                path.to_path_buf(),
-                Err(UniversalIoError::UnchangedOpen {
-                    path: path.to_path_buf(),
-                    since: previous.last_modified,
-                }),
-            );
+            files_prefetched.insert(path.to_path_buf(), None);
             return Ok(());
         }
 
@@ -312,7 +306,13 @@ impl<Fs: UniversalReadFs> UniversalReadFs for CachedFs<Fs> {
         }
 
         if let Some(file) = self.files_prefetched.lock().remove(path) {
-            return file;
+            return match file {
+                Some(file) => Ok(file),
+                None => Err(UniversalIoError::UnchangedOpen {
+                    path: path.to_owned(),
+                    since: self.file_info(path).and_then(|info| info.last_modified),
+                }),
+            };
         }
 
         // With a snapshot, unlisted paths fail locally — probing for

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -12,12 +12,27 @@ use crate::universal_io::{
     UniversalReadFileOps, UniversalReadFs,
 };
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct FileInfo {
     /// Length in bytes of the entire file
     pub size: u64,
     /// Last modification time, when the listing backend exposes one
     pub last_modified: Option<std::time::SystemTime>,
+}
+
+impl FileInfo {
+    /// Return true if both `FileInfo` have all data and it's equal.
+    pub fn full_eq(&self, other: &FileInfo) -> bool {
+        let Self {
+            size,
+            last_modified,
+        } = self;
+
+        size == &other.size
+            && last_modified
+                .zip(other.last_modified)
+                .is_some_and(|(this, other)| this == other)
+    }
 }
 
 /// Read-only filesystem wrapper that snapshots the file listing and serves
@@ -218,10 +233,11 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
                 return Ok(());
             }
 
-            // Check if contents changed
-            if let Some((previous, current)) =
-                self.previous_file_info(path).zip(self.file_info(path))
-                && previous == current
+            // Check if their file info is complete and didn't change.
+            if self
+                .previous_file_info(path)
+                .zip(self.file_info(path))
+                .is_some_and(|(previous, current)| previous.full_eq(current))
             {
                 files_prefetched.insert(path.to_path_buf(), None);
                 return Ok(());

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -147,6 +147,7 @@ impl<Fs: UniversalReadFs> CachedFs<Fs> {
 }
 
 impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
+    /// Take a LIST snapshot of the filesystem and replace existing cached data.
     fn cache_file_info(&mut self) -> UioResult<()> {
         // List all files
         let list = self.fs.list_files(&self.prefix_path)?;
@@ -169,6 +170,7 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
             .collect();
 
         self.previous_files_info = self.files_info.replace(files_info);
+        self.files_prefetched.lock().clear();
 
         Ok(())
     }

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -209,18 +209,21 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
         open_arguments: Option<OpenOptions>,
         open_extra: Option<Fs::OpenExtra>,
     ) -> UioResult<()> {
-        let mut files_prefetched = self.files_prefetched.lock();
-
-        if files_prefetched.contains_key(path) {
-            return Ok(());
-        }
-
-        // Check if contents changed
-        if let Some((previous, current)) = self.previous_file_info(path).zip(self.file_info(path))
-            && previous == current
         {
-            files_prefetched.insert(path.to_path_buf(), None);
-            return Ok(());
+            let mut files_prefetched = self.files_prefetched.lock();
+
+            if files_prefetched.contains_key(path) {
+                return Ok(());
+            }
+
+            // Check if contents changed
+            if let Some((previous, current)) =
+                self.previous_file_info(path).zip(self.file_info(path))
+                && previous == current
+            {
+                files_prefetched.insert(path.to_path_buf(), None);
+                return Ok(());
+            }
         }
 
         // Otherwise schedule normally

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -168,7 +168,7 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
             )
             .collect();
 
-        self.previous_files_info = std::mem::replace(&mut self.files_info, Some(files_info));
+        self.previous_files_info = self.files_info.replace(files_info);
 
         Ok(())
     }
@@ -216,17 +216,17 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
         }
 
         // Check if contents changed
-        if let Some((previous, current)) = self.previous_file_info(path).zip(self.file_info(path)) {
-            if previous == current {
-                files_prefetched.insert(
-                    path.to_path_buf(),
-                    Err(UniversalIoError::UnchangedOpen {
-                        path: path.to_path_buf(),
-                        since: previous.last_modified,
-                    }),
-                );
-                return Ok(());
-            }
+        if let Some((previous, current)) = self.previous_file_info(path).zip(self.file_info(path))
+            && previous == current
+        {
+            files_prefetched.insert(
+                path.to_path_buf(),
+                Err(UniversalIoError::UnchangedOpen {
+                    path: path.to_path_buf(),
+                    since: previous.last_modified,
+                }),
+            );
+            return Ok(());
         }
 
         // Otherwise schedule normally

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -12,7 +12,7 @@ use crate::universal_io::{
     UniversalReadFileOps, UniversalReadFs,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct FileInfo {
     /// Length in bytes of the entire file
     pub size: u64,
@@ -50,7 +50,9 @@ pub struct CachedFs<Fs: UniversalReadFs> {
     /// `None` until [`CachedFs::cache_file_info`] takes the listing
     /// snapshot; the wrapper forwards to `fs` until then.
     files_info: Option<HashMap<PathBuf, FileInfo>>,
-    files_prefetched: Arc<Mutex<HashMap<PathBuf, Fs::File>>>,
+    /// Previous listing snapshot.
+    previous_files_info: Option<HashMap<PathBuf, FileInfo>>,
+    files_prefetched: Arc<Mutex<HashMap<PathBuf, UioResult<Fs::File>>>>,
 }
 
 /// Manual impl: `derive(Clone)` would add a spurious `Fs::File: Clone`
@@ -62,12 +64,14 @@ impl<Fs: UniversalReadFs> Clone for CachedFs<Fs> {
             fs,
             prefix_path,
             files_info,
+            previous_files_info,
             files_prefetched,
         } = self;
         Self {
             fs: fs.clone(),
             prefix_path: prefix_path.clone(),
             files_info: files_info.clone(),
+            previous_files_info: previous_files_info.clone(),
             files_prefetched: files_prefetched.clone(),
         }
     }
@@ -79,6 +83,7 @@ impl<Fs: UniversalReadFs> CachedFs<Fs> {
             fs,
             prefix_path: prefix_path.to_path_buf(),
             files_info: None,
+            previous_files_info: None,
             files_prefetched: Arc::new(Mutex::new(HashMap::new())),
         })
     }
@@ -96,6 +101,11 @@ impl<Fs: UniversalReadFs> CachedFs<Fs> {
     /// File info from the snapshot; `None` before [`CachedFs::cache_file_info`].
     pub fn file_info(&self, path: &Path) -> Option<&FileInfo> {
         self.files_info.as_ref()?.get(path)
+    }
+
+    /// Previous file info from the snapshot; `None` before [`CachedFs::cache_file_info`] is called twice.
+    pub fn previous_file_info(&self, path: &Path) -> Option<&FileInfo> {
+        self.previous_files_info.as_ref()?.get(path)
     }
 
     /// Files matching `prefix_path` in the snapshot; empty before
@@ -158,7 +168,7 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
             )
             .collect();
 
-        self.files_info = Some(files_info);
+        self.previous_files_info = std::mem::replace(&mut self.files_info, Some(files_info));
 
         Ok(())
     }
@@ -187,10 +197,40 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
             open_extra = open_extra.with_known_len(info.size);
         }
 
-        let file = self.fs.open(path, open_options, open_extra)?;
+        let file = self.fs.open(path, open_options, open_extra);
         files_prefetched.insert(path.to_path_buf(), file);
 
         Ok(())
+    }
+
+    fn reschedule_prefetch(
+        &self,
+        path: &Path,
+        open_arguments: Option<OpenOptions>,
+        open_extra: Option<Fs::OpenExtra>,
+    ) -> UioResult<()> {
+        let mut files_prefetched = self.files_prefetched.lock();
+
+        if files_prefetched.contains_key(path) {
+            return Ok(());
+        }
+
+        // Check if contents changed
+        if let Some((previous, current)) = self.previous_file_info(path).zip(self.file_info(path)) {
+            if previous == current {
+                files_prefetched.insert(
+                    path.to_path_buf(),
+                    Err(UniversalIoError::UnchangedOpen {
+                        path: path.to_path_buf(),
+                        since: previous.last_modified,
+                    }),
+                );
+                return Ok(());
+            }
+        }
+
+        // Otherwise schedule normally
+        self.schedule_prefetch(path, open_arguments, open_extra)
     }
 
     fn cached_file_info(&self, path: &Path) -> Option<FileInfo> {
@@ -235,12 +275,14 @@ impl<Fs: UniversalReadFs> Debug for CachedFs<Fs> {
             fs,
             prefix_path,
             files_info,
+            previous_files_info,
             files_prefetched,
         } = self;
         f.debug_struct("CachedReadFs")
             .field("fs", fs)
             .field("prefix_path", prefix_path)
             .field("files_info", files_info)
+            .field("previous_files_info", previous_files_info)
             .field("files_prefetched", &*files_prefetched.lock())
             .finish()
     }
@@ -270,7 +312,7 @@ impl<Fs: UniversalReadFs> UniversalReadFs for CachedFs<Fs> {
         }
 
         if let Some(file) = self.files_prefetched.lock().remove(path) {
-            return Ok(file);
+            return file;
         }
 
         // With a snapshot, unlisted paths fail locally — probing for

--- a/lib/common/common/src/universal_io/error.rs
+++ b/lib/common/common/src/universal_io/error.rs
@@ -47,6 +47,7 @@ impl IsNotFound for UniversalIoError {
             | Self::OutOfBounds { .. }
             | Self::InvalidFileIndex { .. }
             | Self::Uninitialized { .. }
+            | Self::UnchangedOpen { .. }
             | Self::QueueIsFull
             | Self::AppendOffsetConflict { .. }
             | Self::S3(_)
@@ -80,6 +81,12 @@ pub enum UniversalIoError {
     /// `Io(NotFound)` so callers can match without relying on a specific io::ErrorKind.
     #[error("path {path} not found")]
     NotFound { path: PathBuf },
+
+    #[error("Did not open a new instance of {path} because it didn't change since {since:?}")]
+    UnchangedOpen {
+        path: PathBuf,
+        since: Option<std::time::SystemTime>,
+    },
 
     #[error("elements range {start}..{end} is out of bounds, file contains {elements} elements")]
     OutOfBounds {

--- a/lib/common/common/src/universal_io/error.rs
+++ b/lib/common/common/src/universal_io/error.rs
@@ -57,6 +57,42 @@ impl IsNotFound for UniversalIoError {
     }
 }
 
+pub trait OkUnchanged {
+    type Ok;
+    type Error;
+
+    fn ok_unchanged(self) -> Result<Option<Self::Ok>, Self::Error>;
+}
+
+impl<T> OkUnchanged for Result<T, UniversalIoError> {
+    type Ok = T;
+    type Error = UniversalIoError;
+
+    fn ok_unchanged(self) -> Result<Option<T>, UniversalIoError> {
+        match self {
+            Ok(t) => Ok(Some(t)),
+            Err(err) => match err {
+                UniversalIoError::UnchangedOpen { .. } => Ok(None),
+                err @ (UniversalIoError::Io(_)
+                | UniversalIoError::Mmap(_)
+                | UniversalIoError::Bincode(_)
+                | UniversalIoError::BytemuckCast(_)
+                | UniversalIoError::ZerocopySize(_)
+                | UniversalIoError::IoUringNotSupported(_)
+                | UniversalIoError::NotFound { .. }
+                | UniversalIoError::OutOfBounds { .. }
+                | UniversalIoError::InvalidFileIndex { .. }
+                | UniversalIoError::Uninitialized { .. }
+                | UniversalIoError::QueueIsFull
+                | UniversalIoError::AppendOffsetConflict { .. }
+                | UniversalIoError::S3(_)
+                | UniversalIoError::S3Config { .. }
+                | UniversalIoError::TaskPanicked(_)) => Err(err),
+            },
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum UniversalIoError {
     #[error(transparent)]

--- a/lib/common/common/src/universal_io/error.rs
+++ b/lib/common/common/src/universal_io/error.rs
@@ -71,24 +71,8 @@ impl<T> OkUnchanged for Result<T, UniversalIoError> {
     fn ok_unchanged(self) -> Result<Option<T>, UniversalIoError> {
         match self {
             Ok(t) => Ok(Some(t)),
-            Err(err) => match err {
-                UniversalIoError::UnchangedOpen { .. } => Ok(None),
-                err @ (UniversalIoError::Io(_)
-                | UniversalIoError::Mmap(_)
-                | UniversalIoError::Bincode(_)
-                | UniversalIoError::BytemuckCast(_)
-                | UniversalIoError::ZerocopySize(_)
-                | UniversalIoError::IoUringNotSupported(_)
-                | UniversalIoError::NotFound { .. }
-                | UniversalIoError::OutOfBounds { .. }
-                | UniversalIoError::InvalidFileIndex { .. }
-                | UniversalIoError::Uninitialized { .. }
-                | UniversalIoError::QueueIsFull
-                | UniversalIoError::AppendOffsetConflict { .. }
-                | UniversalIoError::S3(_)
-                | UniversalIoError::S3Config { .. }
-                | UniversalIoError::TaskPanicked(_)) => Err(err),
-            },
+            Err(UniversalIoError::UnchangedOpen { .. }) => Ok(None),
+            Err(err) => Err(err),
         }
     }
 }

--- a/lib/common/common/src/universal_io/error.rs
+++ b/lib/common/common/src/universal_io/error.rs
@@ -47,6 +47,7 @@ impl IsNotFound for UniversalIoError {
             | Self::OutOfBounds { .. }
             | Self::InvalidFileIndex { .. }
             | Self::Uninitialized { .. }
+            | Self::UnchangedOpen { .. }
             | Self::QueueIsFull
             | Self::AppendOffsetConflict { .. }
             | Self::S3(_)
@@ -80,6 +81,12 @@ pub enum UniversalIoError {
     /// `Io(NotFound)` so callers can match without relying on a specific io::ErrorKind.
     #[error("path {path} not found")]
     NotFound { path: PathBuf },
+
+    #[error("Did not open a new instance of {path} because it didn't change since {since:?}")]
+    UnchangedOpen {
+        path: PathBuf,
+        since: Option<std::time::SystemTime>,
+    },
 
     #[error("elements range {start}..{end} is out of bounds, file contains {elements} elements")]
     OutOfBounds {
@@ -131,6 +138,7 @@ impl UniversalIoError {
             | Self::QueueIsFull
             | Self::S3(_)
             | Self::S3Config { .. }
+            | Self::UnchangedOpen { .. }
             | Self::TaskPanicked(_) => false,
         }
     }

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -20,7 +20,7 @@ pub mod conformance;
 mod tests;
 
 pub use self::cached_fs::{CachedFs, CachedReadFsContext};
-pub use self::error::{IsNotFound, OkNotFound, UniversalIoError};
+pub use self::error::{IsNotFound, OkNotFound, OkUnchanged, UniversalIoError};
 #[cfg(target_os = "linux")]
 pub use self::io_uring::{IoUringFile, IoUringFs, IoUringOpenExtra, is_io_uring_supported};
 pub use self::mmap::{MmapFile, MmapFs};

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -23,7 +23,7 @@ pub mod conformance;
 mod tests;
 
 pub use self::cached_fs::{CachedFs, CachedReadFsContext};
-pub use self::error::{IsNotFound, OkNotFound, UniversalIoError};
+pub use self::error::{IsNotFound, OkNotFound, OkUnchanged, UniversalIoError};
 #[cfg(target_os = "linux")]
 pub use self::io_uring::{IoUringFile, IoUringFs, IoUringOpenExtra, is_io_uring_supported};
 pub use self::mmap::{MmapFile, MmapFs};

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -170,6 +170,19 @@ pub trait CachedReadFs: UniversalReadFs {
         open_extra: Option<Self::OpenExtra>,
     ) -> UioResult<()>;
 
+    /// Schedule a prefetch for a file that has been opened already.
+    ///
+    /// Checks if the modified time has changed since the last file listing snapshot.
+    ///
+    /// This will force `Self::open` to return `UnchangedOpen` error if the file
+    /// did not change its `FileInfo` in between snapshots.
+    fn reschedule_prefetch(
+        &self,
+        path: &Path,
+        open_arguments: Option<OpenOptions>,
+        open_extra: Option<Self::OpenExtra>,
+    ) -> UioResult<()>;
+
     /// Return the file info from the current snapshot.
     fn cached_file_info(&self, path: &Path) -> Option<FileInfo>;
 }

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -145,6 +145,19 @@ pub trait CachedReadFs: UniversalReadFs {
         open_extra: Option<Self::OpenExtra>,
     ) -> UioResult<()>;
 
+    /// Schedule a prefetch for a file that has been opened already.
+    ///
+    /// Checks if the modified time has changed since the last file listing snapshot.
+    ///
+    /// This will force `Self::open` to return `UnchangedOpen` error if the file
+    /// did not change its `FileInfo` in between snapshots.
+    fn reschedule_prefetch(
+        &self,
+        path: &Path,
+        open_arguments: Option<OpenOptions>,
+        open_extra: Option<Self::OpenExtra>,
+    ) -> UioResult<()>;
+
     /// Return the file info from the current snapshot.
     fn cached_file_info(&self, path: &Path) -> Option<FileInfo>;
 }

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -172,8 +172,6 @@ pub trait CachedReadFs: UniversalReadFs {
 
     /// Schedule a prefetch for a file that has been opened already.
     ///
-    /// Checks if the modified time has changed since the last file listing snapshot.
-    ///
     /// This will force `Self::open` to return `UnchangedOpen` error if the file
     /// did not change its `FileInfo` in between snapshots.
     fn reschedule_prefetch(

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -237,6 +237,7 @@ impl From<UniversalIoError> for OperationError {
             | UniversalIoError::OutOfBounds { .. }
             | UniversalIoError::InvalidFileIndex { .. }
             | UniversalIoError::Uninitialized { .. }
+            | UniversalIoError::UnchangedOpen { .. }
             | UniversalIoError::QueueIsFull
             | UniversalIoError::AppendOffsetConflict { .. }
             | UniversalIoError::S3(_)
@@ -361,6 +362,7 @@ impl From<BlobstoreError> for OperationError {
                 | UniversalIoError::OutOfBounds { .. }
                 | UniversalIoError::InvalidFileIndex { .. }
                 | UniversalIoError::Uninitialized { .. }
+                | UniversalIoError::UnchangedOpen { .. }
                 | UniversalIoError::QueueIsFull
                 | UniversalIoError::AppendOffsetConflict { .. }
                 | UniversalIoError::S3(_)

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -229,6 +229,9 @@ impl From<UniversalIoError> for OperationError {
             UniversalIoError::Mmap(err) => Self::from(err),
 
             UniversalIoError::NotFound { path } => Self::FileNotFound { path },
+            UniversalIoError::UnchangedOpen { .. } => Self::Cancelled {
+                description: err.to_string(),
+            },
 
             UniversalIoError::Bincode(_)
             | UniversalIoError::BytemuckCast(_)
@@ -237,7 +240,6 @@ impl From<UniversalIoError> for OperationError {
             | UniversalIoError::OutOfBounds { .. }
             | UniversalIoError::InvalidFileIndex { .. }
             | UniversalIoError::Uninitialized { .. }
-            | UniversalIoError::UnchangedOpen { .. }
             | UniversalIoError::QueueIsFull
             | UniversalIoError::AppendOffsetConflict { .. }
             | UniversalIoError::S3(_)

--- a/src/tonic/api/storage_read_api/helpers.rs
+++ b/src/tonic/api/storage_read_api/helpers.rs
@@ -262,6 +262,7 @@ pub fn io_error_to_status(e: UniversalIoError) -> Status {
         UniversalIoError::Uninitialized { description } => {
             Status::internal(format!("Uninitialized: {description}"))
         }
+        UniversalIoError::UnchangedOpen { .. } => Status::internal(e.to_string()),
         UniversalIoError::Bincode(e) => Status::internal(format!("Bincode error: {e}")),
         UniversalIoError::BytemuckCast(e) => Status::internal(format!("Bytemuck cast error: {e}")),
         UniversalIoError::ZerocopySize(e) => Status::internal(e),


### PR DESCRIPTION
This enables the interface of `CachedReadFs` + `UniversalRead` to avoid replacing and re-fetching a file that didn't really change on the remote. 

To achieve this, I added `CachedReadFs::reschedule_prefetch` that returns a new `UniversalIoError::UnchangedOpen` when a file kept the same size and modified time since last LIST operation. 

For the caller this will let it match on the error, so that additional work can be skipped.

Example usage:

```rust
impl<S: UniversalRead> LiveReload for MyType<S> {
    type File = S
    fn live_preload(&self, fs: &impl CachedReadFs<File = S>) -> OperationResult<()> {
	    fs.reschedule_prefetch(Self::deleted_path())

        Ok(())
    }
    
    fn live_reload(&mut self, fs: impl &UniversalReadFs<File = S>) -> OperationResult<()> {
        let Some(file) = fs.open(Self::deleted_path(), ...).ok_unchanged() else {
            // avoid work and return early
         }
            
	    self.deleted = file;
        Ok(())
    }
}
```