### PR TITLE
cargo +nightly fmt

### DIFF
--- a/lib/common/common/benches/mmap_hashmap.rs
+++ b/lib/common/common/benches/mmap_hashmap.rs
@@ -14,12 +14,12 @@ const LIMIT_MEMORY_ENV: &str = "LIMIT_MEMORY";
 const LIMIT_MEMORY_ENV_INTERNAL: &str = "_LIMIT_MEMORY_INTERNAL";
 
 type Backend = cfg_select! {
-    target_os = "linux" => { common::universal_io::IoUringFile }
-    _ => { common::universal_io::MmapFile }
+    target_os = "linux" => common::universal_io::IoUringFile,
+    _ => common::universal_io::MmapFile,
 };
 type BackendFs = cfg_select! {
-    target_os = "linux" => { common::universal_io::IoUringFs }
-    _ => { common::universal_io::MmapFs }
+    target_os = "linux" => common::universal_io::IoUringFs,
+    _ => common::universal_io::MmapFs,
 };
 
 fn bench_mmap_hashmap(c: &mut Criterion) {

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -400,23 +400,24 @@ impl MmapFile {
                 let remap_options = memmap2::RemapOptions::new().may_move(true);
                 unsafe {
                     mmap.remap(new_len, remap_options)?;
-                    mmap_seq.as_mut().map(|m| m.remap(new_len, remap_options)).transpose()?;
+                    mmap_seq
+                        .as_mut()
+                        .map(|m| m.remap(new_len, remap_options))
+                        .transpose()?;
                 };
 
                 // Whether or not `remap` moved the memory region let's update the pointers
                 let ptr = SendSyncPtr(mmap.as_mut_ptr());
-                let ptr_seq = mmap_seq.as_ref().map(|m| SendSyncPtr(m.as_mut_ptr())).unwrap_or(ptr);
+                let ptr_seq = mmap_seq
+                    .as_ref()
+                    .map(|m| SendSyncPtr(m.as_mut_ptr()))
+                    .unwrap_or(ptr);
                 let len = new_len;
             }
             // otherwise, let's open again
             _ => {
                 let _ = new_len; // suppress unused variable lint.
-                *mmap = open_mmap(
-                    self.path.as_ref(),
-                    self.writeable,
-                    populate,
-                    self.advice,
-                )?;
+                *mmap = open_mmap(self.path.as_ref(), self.writeable, populate, self.advice)?;
                 let ptr = SendSyncPtr(mmap.as_mut_ptr());
 
                 let ptr_seq;


### PR DESCRIPTION
Good news: the recent nightly rustfmt [can now format `cfg_select!`](https://www.github.com/rust-lang/rust/pull/154202)
Bad news: [CI is broken](https://github.com/qdrant/qdrant/actions/runs/30678828938/job/91311504767).