### PR TITLE
Add Kdrant to the community client list

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Qdrant offers the following client libraries to help you integrate it into your 
   - [.NET/C# client](https://github.com/qdrant/qdrant-dotnet)
   - [Java client](https://github.com/qdrant/java-client)
 - Community:
+  - [Kotlin](https://github.com/NaCode-Studios/Kdrant)
   - [PHP](https://github.com/hkulekci/qdrant-php)
 
 ### Qdrant Edge


### PR DESCRIPTION
Kdrant is a Kotlin client for Qdrant, Apache-2.0, published on Maven Central under
`io.github.nacode-studios`. This adds one line to the community list.

It speaks to Qdrant over the REST API by default, with an optional gRPC engine behind the same
interface. Both engines are held to one behavioural test suite that runs against a real Qdrant in
CI, against `v1.18.2` and `latest`, and the REST request bodies are validated against Qdrant's own
OpenAPI document.

- Repository: https://github.com/NaCode-Studios/Kdrant
- Documentation: https://nacode-studios.github.io/Kdrant/
- Maven Central: https://central.sonatype.com/artifact/io.github.nacode-studios/kdrant-core

Targeted at `dev`, per CONTRIBUTING.md. Happy to move this entry, reword it, or drop it if the
community list has criteria I have missed.
