### PR TITLE
fix: add `maximum: 65536` to `VectorParams.size` OpenAPI schema

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1372,6 +1372,7 @@ impl From<Datatype> for VectorStorageDatatype {
 pub struct VectorParams {
     /// Size of a vectors used
     #[validate(custom(function = "validate_nonzerou64_range_min_1_max_65536"))]
+    #[schemars(range(min = 1, max = 65536))]
     pub size: NonZeroU64,
     /// Type of distance function used for measuring distance between vectors
     pub distance: Distance,


### PR DESCRIPTION
## Problem

Fixes #9942.

`VectorParams.size` is validated at runtime against the range `[1, 65536]` via a custom validator (`validate_nonzerou64_range_min_1_max_65536`), but because this is a **custom** validator rather than a plain `#[validate(range(...)]`, schemars does not automatically emit `maximum: 65536` in the generated OpenAPI schema. The published `VectorParams.size` schema therefore declared only `minimum: 1`, while the runtime rejected values above 65 536 with HTTP 422 — a contract mismatch that affects clients and code-generators.

A sibling schema, `DenseVectorConfig.size`, already uses `#[validate(range(min = 1, max = 65536))]` which does produce `maximum: 65536` in the schema, so the bound is well-established in the codebase; it was simply missing from `VectorParams`.

## Solution

Add `#[schemars(range(min = 1, max = 65536))]` to `VectorParams.size`. This is the same annotation pattern already used in `lib/collection/src/operations/consistency_params.rs` (`#[schemars(range(min = 1))]`). No runtime behaviour changes — the existing `validate_nonzerou64_range_min_1_max_65536` validator is untouched.

## Change

```diff
 pub struct VectorParams {
     /// Size of a vectors used
     #[validate(custom(function = "validate_nonzerou64_range_min_1_max_65536"))]
+    #[schemars(range(min = 1, max = 65536))]
     pub size: NonZeroU64,
```

## AI Disclosure

- **[AI] fix:** initial identification of the missing `#[schemars(range(...)]` attribute and one-line edit to `lib/collection/src/operations/types.rs`.
- **[manual] review:** verified against `DenseVectorConfig.size` and `consistency_params.rs` usage; confirmed no runtime impact.

**Initial prompt:** "In qdrant/qdrant, issue #9942 reports that VectorParams.size is missing maximum: 65536 in the OpenAPI schema. The runtime enforces it via a custom validator. DenseVectorConfig.size uses #[validate(range(min = 1, max = 65536))] which auto-generates the schema constraint. Add the minimal schemars annotation to VectorParams.size to fix the schema mismatch."