### PR TITLE
refactor: deduplicate memory placement validation

### DIFF
--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -188,16 +188,10 @@ impl PayloadStorageParams {
 /// Reject memory placements not supported by payload storage.
 /// `validator` unwraps `Option<Memory>` before calling, so we receive `&Memory`.
 fn validate_payload_storage_memory(memory: &Memory) -> Result<(), ValidationError> {
-    match memory {
-        Memory::Cold | Memory::Cached => Ok(()),
-        Memory::Pinned => {
-            let mut error = ValidationError::new("unsupported_memory_placement");
-            error.message = Some(std::borrow::Cow::from(
-                "`pinned` memory placement is not supported for payload storage",
-            ));
-            Err(error)
-        }
-    }
+    segment::types::validate_memory_placement(
+        memory,
+        "`pinned` memory placement is not supported for payload storage",
+    )
 }
 
 impl CollectionParams {

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -3,7 +3,6 @@
 #![allow(deprecated)]
 
 use std::backtrace::Backtrace;
-use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::error::Error as _;
 use std::fmt::{Debug, Write as _};
@@ -1398,7 +1397,7 @@ pub struct VectorParams {
     /// flag if both are set. `pinned` is not supported for dense vector storage.
     /// Default: `cached` (`cold` if `on_disk` is set to true).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[validate(custom(function = "validate_dense_vector_memory"))]
+    #[validate(custom(function = "segment::types::validate_dense_vector_memory"))]
     pub memory: Option<Memory>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1433,21 +1432,6 @@ fn validate_sparse_datatype(datatype: &Datatype) -> Result<(), ValidationError> 
         return Err(common::validation::sparse_turbo4_unsupported_error());
     }
     Ok(())
-}
-
-/// Reject memory placements not supported by dense vector storage.
-/// `validator` unwraps `Option<Memory>` before calling, so we receive `&Memory`.
-fn validate_dense_vector_memory(memory: &Memory) -> Result<(), ValidationError> {
-    match memory {
-        Memory::Cold | Memory::Cached => Ok(()),
-        Memory::Pinned => {
-            let mut error = ValidationError::new("unsupported_memory_placement");
-            error.message = Some(Cow::from(
-                "`pinned` memory placement is not supported for dense vector storage",
-            ));
-            Err(error)
-        }
-    }
 }
 
 /// Is considered empty if `None` or if diff has no field specified
@@ -1785,7 +1769,7 @@ pub struct VectorParamsDiff {
     /// Memory placement of the original vector storage. Overrides the deprecated `on_disk`
     /// flag if both are set. `pinned` is not supported for dense vector storage.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[validate(custom(function = "validate_dense_vector_memory"))]
+    #[validate(custom(function = "segment::types::validate_dense_vector_memory"))]
     pub memory: Option<Memory>,
 }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -761,19 +761,31 @@ pub struct VectorsConfigDefaults {
     pub memory: Option<Memory>,
 }
 
-/// Reject memory placements not supported by dense vector storage.
-/// `validator` unwraps `Option<Memory>` before calling, so we receive `&Memory`.
-fn validate_dense_vector_memory(memory: &Memory) -> Result<(), ValidationError> {
+/// Reject memory placements not supported by a storage kind.
+///
+/// `reason` becomes the message of the `unsupported_memory_placement` error, so each storage kind
+/// keeps its own user-facing wording while the error key and construction stay in one place.
+pub fn validate_memory_placement(
+    memory: &Memory,
+    reason: &'static str,
+) -> Result<(), ValidationError> {
     match memory {
         Memory::Cold | Memory::Cached => Ok(()),
         Memory::Pinned => {
             let mut error = ValidationError::new("unsupported_memory_placement");
-            error.message = Some(Cow::from(
-                "`pinned` memory placement is not supported for dense vector storage",
-            ));
+            error.message = Some(Cow::from(reason));
             Err(error)
         }
     }
+}
+
+/// Reject memory placements not supported by dense vector storage.
+/// `validator` unwraps `Option<Memory>` before calling, so we receive `&Memory`.
+pub fn validate_dense_vector_memory(memory: &Memory) -> Result<(), ValidationError> {
+    validate_memory_placement(
+        memory,
+        "`pinned` memory placement is not supported for dense vector storage",
+    )
 }
 
 /// Vector index configuration
@@ -4768,6 +4780,35 @@ mod tests {
             Some(Memory::Pinned)
         );
         assert_eq!(Memory::resolve(None, None), None);
+    }
+
+    #[test]
+    fn test_memory_placement_validation_rejects_pinned() {
+        // `Cold`/`Cached` are valid everywhere; `Pinned` is rejected with a shared
+        // error code and the storage-kind-specific message.
+        for placement in [Memory::Cold, Memory::Cached] {
+            assert!(validate_memory_placement(&placement, "storage").is_ok());
+            assert!(validate_dense_vector_memory(&placement).is_ok());
+        }
+
+        let dense_error = validate_dense_vector_memory(&Memory::Pinned)
+            .expect_err("Pinned must be rejected for dense vector storage");
+        assert_eq!(dense_error.code, "unsupported_memory_placement");
+        assert_eq!(
+            dense_error.message.as_deref(),
+            Some("`pinned` memory placement is not supported for dense vector storage"),
+        );
+
+        let payload_error = validate_memory_placement(
+            &Memory::Pinned,
+            "`pinned` memory placement is not supported for payload storage",
+        )
+        .expect_err("Pinned must be rejected for payload storage");
+        assert_eq!(payload_error.code, "unsupported_memory_placement");
+        assert_eq!(
+            payload_error.message.as_deref(),
+            Some("`pinned` memory placement is not supported for payload storage"),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`segment` and `collection` each reimplemented an identical validator that rejects `Memory::Pinned` for dense vector storage, duplicating the `unsupported_memory_placement` error key and its construction. The byte-identical copies can drift independently (error code or message diverging between crates) with no compile-time signal which might lead to a  inconsistent API errors.

## What

Consolidate the validation into `lib/segment/src/types.rs`, where `Memory` is defined:

- Add `validate_memory_placement(memory, reason)` to `segment::types` so the error key and construction live in a single place, while each storage kind keeps its own user-facing message.
- Point the `#[validate(custom(function = ...))]` attributes on `VectorParams` and `VectorParamsDiff` at `segment::types::validate_dense_vector_memory` directly, and delete the duplicated function in `lib/collection/src/operations/types.rs`.
- Reduce `validate_payload_storage_memory` in `lib/collection/src/config.rs` to a one-line delegation.
- Add `test_memory_placement_validation_rejects_pinned` in `segment::types` pinning the error code and messages.

Behavior is unchanged: same `unsupported_memory_placement` error code and identical messages as before.

## Verification

- `cargo check -p segment -p collection` — clean
- `cargo clippy -p segment -p collection --all-features` — clean
- `cargo +nightly fmt --all --check` — clean
- `cargo test -p segment --lib` — 981 passed
- `cargo test -p collection --lib` — 252 passed
