### PR TITLE
fix: point-id payload updates across multiple shard keys.

### DIFF
--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -23,7 +23,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::TryStreamExt as _;
 use futures::stream::FuturesUnordered;
 use segment::data_types::facets::{FacetParams, FacetResponse};
-use segment::types::{ScoredPoint, ShardKey};
+use segment::types::{ScoredPoint, ShardKey, WithPayloadInterface};
 use shard::retrieve::record_internal::RecordInternal;
 use shard::scroll::ScrollRequestInternal;
 use shard::search::CoreSearchRequestBatch;
@@ -499,40 +499,54 @@ impl TableOfContent {
         // `Collection::update_from_client` is cancel safe, so this method is cancel safe.
 
         let mut operations_per_key = Vec::with_capacity(shard_keys.len());
-        let has_explicit_point_ids = operation.point_ids().is_some();
+        let explicit_point_ids = operation.point_ids().map(|point_ids| point_ids.to_vec());
 
-        {
-            let shards_holder = collection.shards_holder();
-            let shard_holder = shards_holder.read().await;
+        if let Some(point_ids) = explicit_point_ids {
+            let mut found_point_ids = HashSet::new();
+            let mut ids_per_key = Vec::with_capacity(shard_keys.len());
 
             for shard_key in &shard_keys {
-                let mut operation_for_key = operation.clone();
+                let records = collection
+                    .retrieve(
+                        PointRequestInternal {
+                            ids: point_ids.clone(),
+                            with_payload: Some(WithPayloadInterface::Bool(false)),
+                            with_vector: false.into(),
+                        },
+                        None,
+                        None,
+                        &ShardSelectorInternal::ShardKey(shard_key.clone()),
+                        timeout,
+                        hw_measurement_acc.clone(),
+                    )
+                    .await?;
 
-                if has_explicit_point_ids {
-                    let matching_ids: HashSet<_> = shard_holder
-                        .split_by_shard(operation.clone(), &Some(shard_key.clone()))?
-                        .into_iter()
-                        .filter_map(|(_, split_operation)| split_operation.point_ids())
-                        .flatten()
-                        .collect();
-
-                    operation_for_key.retain_point_ids(|point_id| matching_ids.contains(point_id));
-
-                    if operation_for_key
-                        .point_ids()
-                        .is_some_and(|point_ids| point_ids.is_empty())
-                    {
-                        continue;
-                    }
-                }
-
-                operations_per_key.push((shard_key.clone(), operation_for_key));
+                let key_point_ids: HashSet<_> =
+                    records.into_iter().map(|record| record.id).collect();
+                found_point_ids.extend(key_point_ids.iter().copied());
+                ids_per_key.push((shard_key.clone(), key_point_ids));
             }
-        }
 
-        // If no operation has relevant point IDs for the selected shard keys,
-        // preserve previous behavior and surface a point-not-found style error.
-        if operations_per_key.is_empty() {
+            if let Some(missed_point_id) = point_ids
+                .iter()
+                .copied()
+                .find(|point_id| !found_point_ids.contains(point_id))
+            {
+                return Err(CollectionError::PointNotFound { missed_point_id }.into());
+            }
+
+            for (shard_key, key_point_ids) in ids_per_key {
+                let mut operation_for_key = operation.clone();
+                operation_for_key.retain_point_ids(|point_id| key_point_ids.contains(point_id));
+                if operation_for_key
+                    .point_ids()
+                    .is_some_and(|point_ids| point_ids.is_empty())
+                {
+                    continue;
+                }
+                operations_per_key.push((shard_key, operation_for_key));
+            }
+        } else {
             operations_per_key = shard_keys
                 .iter()
                 .cloned()

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -499,7 +499,7 @@ impl TableOfContent {
         // `Collection::update_from_client` is cancel safe, so this method is cancel safe.
 
         let mut operations_per_key = Vec::with_capacity(shard_keys.len());
-        let explicit_point_ids = operation.point_ids().map(|point_ids| point_ids.clone());
+        let explicit_point_ids = operation.point_ids().clone();
         let can_create_points = operation.upsert_point_ids().is_some();
 
         if let Some(point_ids) = explicit_point_ids

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -499,10 +499,13 @@ impl TableOfContent {
         // `Collection::update_from_client` is cancel safe, so this method is cancel safe.
 
         let mut operations_per_key = Vec::with_capacity(shard_keys.len());
-        let explicit_point_ids = operation.point_ids().map(|point_ids| point_ids.to_vec());
+        let explicit_point_ids = operation.point_ids().map(|point_ids| point_ids.clone());
+        let can_create_points = operation.upsert_point_ids().is_some();
 
-        if let Some(point_ids) = explicit_point_ids {
-            let mut retrieve_requests: FuturesUnordered<_> = shard_keys
+        if let Some(point_ids) = explicit_point_ids
+            && !can_create_points
+        {
+            let retrieve_requests: FuturesUnordered<_> = shard_keys
                 .iter()
                 .cloned()
                 .map(|shard_key| {

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -23,7 +23,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use futures::TryStreamExt as _;
 use futures::stream::FuturesUnordered;
 use segment::data_types::facets::{FacetParams, FacetResponse};
-use segment::types::{ScoredPoint, ShardKey, WithPayloadInterface};
+use segment::types::{ScoredPoint, ShardKey, WithPayloadInterface, WithVector};
 use shard::retrieve::record_internal::RecordInternal;
 use shard::scroll::ScrollRequestInternal;
 use shard::search::CoreSearchRequestBatch;
@@ -502,30 +502,40 @@ impl TableOfContent {
         let explicit_point_ids = operation.point_ids().map(|point_ids| point_ids.to_vec());
 
         if let Some(point_ids) = explicit_point_ids {
-            let mut found_point_ids = HashSet::new();
-            let mut ids_per_key = Vec::with_capacity(shard_keys.len());
+            let mut retrieve_requests: FuturesUnordered<_> = shard_keys
+                .iter()
+                .cloned()
+                .map(|shard_key| {
+                    let point_ids = point_ids.clone();
+                    let hw_measurement_acc = hw_measurement_acc.clone();
+                    async move {
+                        let shard_selector = ShardSelectorInternal::ShardKey(shard_key.clone());
+                        let records = collection
+                            .retrieve(
+                                PointRequestInternal {
+                                    ids: point_ids,
+                                    with_payload: Some(WithPayloadInterface::Bool(false)),
+                                    with_vector: WithVector::from(false),
+                                },
+                                None,
+                                None,
+                                &shard_selector,
+                                timeout,
+                                hw_measurement_acc,
+                            )
+                            .await?;
+                        let key_point_ids: HashSet<_> =
+                            records.into_iter().map(|record| record.id).collect();
+                        StorageResult::Ok((shard_key, key_point_ids))
+                    }
+                })
+                .collect();
 
-            for shard_key in &shard_keys {
-                let records = collection
-                    .retrieve(
-                        PointRequestInternal {
-                            ids: point_ids.clone(),
-                            with_payload: Some(WithPayloadInterface::Bool(false)),
-                            with_vector: false.into(),
-                        },
-                        None,
-                        None,
-                        &ShardSelectorInternal::ShardKey(shard_key.clone()),
-                        timeout,
-                        hw_measurement_acc.clone(),
-                    )
-                    .await?;
-
-                let key_point_ids: HashSet<_> =
-                    records.into_iter().map(|record| record.id).collect();
-                found_point_ids.extend(key_point_ids.iter().copied());
-                ids_per_key.push((shard_key.clone(), key_point_ids));
-            }
+            let ids_per_key: Vec<_> = retrieve_requests.try_collect().await?;
+            let found_point_ids: HashSet<_> = ids_per_key
+                .iter()
+                .flat_map(|(_shard_key, key_point_ids)| key_point_ids.iter().copied())
+                .collect();
 
             if let Some(missed_point_id) = point_ids
                 .iter()

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::time::Duration;
 
 use collection::collection::Collection;
@@ -497,11 +498,53 @@ impl TableOfContent {
     ) -> StorageResult<UpdateResult> {
         // `Collection::update_from_client` is cancel safe, so this method is cancel safe.
 
-        let updates: FuturesUnordered<_> = shard_keys
+        let mut operations_per_key = Vec::with_capacity(shard_keys.len());
+        let has_explicit_point_ids = operation.point_ids().is_some();
+
+        {
+            let shards_holder = collection.shards_holder();
+            let shard_holder = shards_holder.read().await;
+
+            for shard_key in &shard_keys {
+                let mut operation_for_key = operation.clone();
+
+                if has_explicit_point_ids {
+                    let matching_ids: HashSet<_> = shard_holder
+                        .split_by_shard(operation.clone(), &Some(shard_key.clone()))?
+                        .into_iter()
+                        .filter_map(|(_, split_operation)| split_operation.point_ids())
+                        .flatten()
+                        .collect();
+
+                    operation_for_key.retain_point_ids(|point_id| matching_ids.contains(point_id));
+
+                    if operation_for_key
+                        .point_ids()
+                        .is_some_and(|point_ids| point_ids.is_empty())
+                    {
+                        continue;
+                    }
+                }
+
+                operations_per_key.push((shard_key.clone(), operation_for_key));
+            }
+        }
+
+        // If no operation has relevant point IDs for the selected shard keys,
+        // preserve previous behavior and surface a point-not-found style error.
+        if operations_per_key.is_empty() {
+            operations_per_key = shard_keys
+                .iter()
+                .cloned()
+                .map(|shard_key| (shard_key, operation.clone()))
+                .collect();
+        }
+
+        let updates: FuturesUnordered<_> = operations_per_key
             .into_iter()
-            .map(|shard_key| {
+            .map(|(shard_key, operation_for_key)| {
                 collection.update_from_client(
-                    operation.clone(),
+                    operation_for_key,
                     wait,
                     timeout,
                     ordering,

--- a/tests/openapi/test_shard_key.py
+++ b/tests/openapi/test_shard_key.py
@@ -35,6 +35,10 @@ def get_shard_keys(collection_name):
     return response
 
 
+@pytest.mark.skipif(
+    not os.getenv("QDRANT__CLUSTER__ENABLED"),
+    reason="only works in distributed mode"
+)
 def test_set_payload_with_multiple_shard_keys_and_point_ids(collection_name):
     create_shard_key("1", collection_name)
     create_shard_key("2", collection_name)

--- a/tests/openapi/test_shard_key.py
+++ b/tests/openapi/test_shard_key.py
@@ -35,6 +35,68 @@ def get_shard_keys(collection_name):
     return response
 
 
+def test_set_payload_with_multiple_shard_keys_and_point_ids(collection_name):
+    create_shard_key("1", collection_name)
+    create_shard_key("2", collection_name)
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={
+            "shard_key": "1",
+            "points": [
+                {"id": 9, "vector": [0.1, 0.2, 0.3, 0.4]},
+            ],
+        },
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={
+            "shard_key": "2",
+            "points": [
+                {"id": 101, "vector": [0.4, 0.3, 0.2, 0.1]},
+            ],
+        },
+    )
+    assert response.ok
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/payload",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        query_params={"wait": "true"},
+        body={
+            "payload": {"color": "black"},
+            "points": [9, 101],
+            "shard_key": ["1", "2"],
+        },
+    )
+    assert response.ok, response.json()
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/{id}",
+        method="GET",
+        path_params={"collection_name": collection_name, "id": 9},
+    )
+    assert response.ok
+    assert response.json()["result"]["payload"]["color"] == "black"
+
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/{id}",
+        method="GET",
+        path_params={"collection_name": collection_name, "id": 101},
+    )
+    assert response.ok
+    assert response.json()["result"]["payload"]["color"] == "black"
+
+
 @pytest.mark.skipif(
     not os.getenv("QDRANT__CLUSTER__ENABLED"),
     reason="only works in distributed mode"


### PR DESCRIPTION
Closes #10064 

## Summary
- Fix multi-`shard_key` write routing for point-ID-based updates (`set_payload`, `overwrite_payload`, and other point-ID operations) so each shard key only receives the subset of point IDs that belong to it.
- Prevent false `No point with id ... found` errors when a single request includes IDs that belong to different shard keys.
- Preserve existing behavior for requests where no point IDs map to selected shard keys by falling back to prior handling.
- Add a regression test for `set_payload` with `shard_key: ["1", "2"]` and mixed point IDs across those shard keys.

## Root Cause
`_update_shard_keys` replayed the full cloned operation for every shard key. For point-ID-based operations, each per-key execution could fail on IDs that belong to other keys, even if updates for local IDs already succeeded.

## Fix Details
- In `_update_shard_keys`, precompute per-key operation variants by:
  - splitting the operation by shard for each key,
  - collecting only matching point IDs,
  - filtering operation payload to those IDs via `retain_point_ids`.
- Skip per-key updates that end up with an empty point-ID set.
- Continue to use prior fallback behavior when no per-key operation remains.

## Tests
- Added: `test_set_payload_with_multiple_shard_keys_and_point_ids` in `tests/openapi/test_shard_key.py`
- Validates:
  - point `9` in shard key `"1"` and point `101` in shard key `"2"` both get updated by one request,
  - request succeeds without false not-found error.

## Verification
- `cargo test -p storage --lib point_ops --no-run`

## Example Scenario Fixed
Request:
```json
{
  "payload": {"color": "black"},
  "points": [9, 101],
  "shard_key": ["1", "2"]
}
```
Now updates both points successfully (instead of returning a false not-found while still partially applying updates).