### PR TITLE
fix(shard): gate tonic behind the api feature for edge builds

### DIFF
--- a/lib/edge/ffi/Cargo.toml
+++ b/lib/edge/ffi/Cargo.toml
@@ -40,9 +40,10 @@ edge = { path = ".." }
 segment = { path = "../../segment", default-features = false }
 # default-features = false drops shard's `default = ["api"]` (the gRPC/prost
 # `api` types crate), which the FFI never uses — matching the `edge` and
-# `edge-python` siblings. (Note: `tonic`/`tokio` are still pulled in via
-# non-optional deps of `shard`/`common`, so this trims the `api`/prost crate,
-# not the whole server stack.)
+# `edge-python` siblings. `tonic` is optional in `shard` and enabled only by
+# that feature, so the gRPC/router stack (tonic/axum) is trimmed as well.
+# `tokio` remains: `common` uses it for snapshot tar extraction and budget
+# semaphores.
 shard = { path = "../../shard", default-features = false }
 sparse = { path = "../../sparse" }
 

--- a/lib/shard/Cargo.toml
+++ b/lib/shard/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [features]
 default = ["api"]
+api = ["dep:api", "dep:tonic"]
 testing = []
 staging = []
 
@@ -39,7 +40,7 @@ serde_cbor = { workspace = true }
 smallvec = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
-tonic = { workspace = true }
+tonic = { workspace = true, optional = true }
 uuid = { workspace = true }
 validator = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary

Closes #10068  

Follow-up to #8284: `api` was made optional for edge, but `tonic` remained a non-optional sibling dependency of `shard` even though every use is already behind `#[cfg(feature = "api")]`.

This change makes `tonic` optional and enables it only via:

```toml
api = ["dep:api", "dep:tonic"]
```

Edge (`default-features = false`) and amalgamation then drop `tonic` → `axum` → … Server defaults are unchanged.

## Changes

- `lib/shard/Cargo.toml` — `tonic` optional; wired into the `api` feature
- `lib/edge/ffi/Cargo.toml` — comment updated (tonic is now trimmed when `api` is off)

## Non-goals

- Does not remove `tokio` (used by edge/common).
- Does not claim full removal of `hyper` / `tower` (still possible via object-store / reqwest).

## Verification

- [x] `cargo check -p shard`
- [x] `cargo check -p shard --no-default-features`
- [x] `cargo check -p edge` / `-p qdrant-edge-ffi` / edge-python
- [x] `cargo check -p collection`
- [x] `cargo tree -p edge -i tonic` — gone
- [x] `cargo tree -p edge -i axum` — gone
- [x] amalgamation — no `tonic` / `axum` in generated `Cargo.toml`

## AI disclosure

Prepared with assistance from an AI coding agent. Analysis and verification were human-reviewed.
