### PR TITLE
Add /profiler/consensus_lag to measure apply lag between peers

### DIFF
--- a/lib/api/src/grpc/proto/qdrant_internal_service.proto
+++ b/lib/api/src/grpc/proto/qdrant_internal_service.proto
@@ -23,6 +23,10 @@ service QdrantInternal {
 
   // Get how much of its resource quota this peer is using
   rpc GetQuotaUsage(GetQuotaUsageRequest) returns (GetQuotaUsageResponse) {}
+
+  // Get the log of recently applied consensus entries from this peer
+  rpc GetConsensusAppliedLog(GetConsensusAppliedLogRequest)
+      returns (GetConsensusAppliedLogResponse) {}
 }
 
 message GetConsensusCommitRequest {}
@@ -46,6 +50,28 @@ message WaitOnConsensusCommitRequest {
 message WaitOnConsensusCommitResponse {
   // False if commit/term is diverged and never reached or if timed out.
   bool ok = 1;
+}
+
+message GetConsensusAppliedLogRequest {}
+
+message AppliedConsensusEntry {
+  // Raft log index of the entry
+  uint64 index = 1;
+  // Raft term the entry was proposed in
+  uint64 term = 2;
+  // Wall clock when the entry finished applying, milliseconds since the Unix epoch
+  uint64 applied_at_ms = 3;
+  // How long this single entry took to apply, in milliseconds
+  uint64 took_ms = 4;
+}
+
+message GetConsensusAppliedLogResponse {
+  // Recently applied entries, oldest first
+  repeated AppliedConsensusEntry entries = 1;
+  // Wall clock on the responding peer, milliseconds since the Unix epoch
+  uint64 now_ms = 2;
+  // Entries committed but not yet applied on the responding peer
+  uint64 pending_operations = 3;
 }
 
 message GetAuditLogRequest {

--- a/lib/api/src/grpc/proto/qdrant_internal_service.proto
+++ b/lib/api/src/grpc/proto/qdrant_internal_service.proto
@@ -72,6 +72,8 @@ message GetConsensusAppliedLogResponse {
   uint64 now_ms = 2;
   // Entries committed but not yet applied on the responding peer
   uint64 pending_operations = 3;
+  // Highest entry index the responding peer has applied, from its consensus state
+  optional uint64 last_applied_index = 4;
 }
 
 message GetAuditLogRequest {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -13828,6 +13828,9 @@ pub struct GetConsensusAppliedLogResponse {
     /// Entries committed but not yet applied on the responding peer
     #[prost(uint64, tag = "3")]
     pub pending_operations: u64,
+    /// Highest entry index the responding peer has applied, from its consensus state
+    #[prost(uint64, optional, tag = "4")]
+    pub last_applied_index: ::core::option::Option<u64>,
 }
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -13798,6 +13798,38 @@ pub struct WaitOnConsensusCommitResponse {
     pub ok: bool,
 }
 #[derive(serde::Serialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetConsensusAppliedLogRequest {}
+#[derive(serde::Serialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AppliedConsensusEntry {
+    /// Raft log index of the entry
+    #[prost(uint64, tag = "1")]
+    pub index: u64,
+    /// Raft term the entry was proposed in
+    #[prost(uint64, tag = "2")]
+    pub term: u64,
+    /// Wall clock when the entry finished applying, milliseconds since the Unix epoch
+    #[prost(uint64, tag = "3")]
+    pub applied_at_ms: u64,
+    /// How long this single entry took to apply, in milliseconds
+    #[prost(uint64, tag = "4")]
+    pub took_ms: u64,
+}
+#[derive(serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetConsensusAppliedLogResponse {
+    /// Recently applied entries, oldest first
+    #[prost(message, repeated, tag = "1")]
+    pub entries: ::prost::alloc::vec::Vec<AppliedConsensusEntry>,
+    /// Wall clock on the responding peer, milliseconds since the Unix epoch
+    #[prost(uint64, tag = "2")]
+    pub now_ms: u64,
+    /// Entries committed but not yet applied on the responding peer
+    #[prost(uint64, tag = "3")]
+    pub pending_operations: u64,
+}
+#[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetAuditLogRequest {
     /// ISO-8601 start time (inclusive), omit for no lower bound
@@ -14041,6 +14073,33 @@ pub mod qdrant_internal_client {
                 .insert(GrpcMethod::new("qdrant.QdrantInternal", "GetQuotaUsage"));
             self.inner.unary(req, path, codec).await
         }
+        /// Get the log of recently applied consensus entries from this peer
+        pub async fn get_consensus_applied_log(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetConsensusAppliedLogRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetConsensusAppliedLogResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/qdrant.QdrantInternal/GetConsensusAppliedLog",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new("qdrant.QdrantInternal", "GetConsensusAppliedLog"),
+                );
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -14094,6 +14153,14 @@ pub mod qdrant_internal_server {
             request: tonic::Request<super::GetQuotaUsageRequest>,
         ) -> std::result::Result<
             tonic::Response<super::GetQuotaUsageResponse>,
+            tonic::Status,
+        >;
+        /// Get the log of recently applied consensus entries from this peer
+        async fn get_consensus_applied_log(
+            &self,
+            request: tonic::Request<super::GetConsensusAppliedLogRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetConsensusAppliedLogResponse>,
             tonic::Status,
         >;
     }
@@ -14389,6 +14456,55 @@ pub mod qdrant_internal_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = GetQuotaUsageSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/qdrant.QdrantInternal/GetConsensusAppliedLog" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetConsensusAppliedLogSvc<T: QdrantInternal>(pub Arc<T>);
+                    impl<
+                        T: QdrantInternal,
+                    > tonic::server::UnaryService<super::GetConsensusAppliedLogRequest>
+                    for GetConsensusAppliedLogSvc<T> {
+                        type Response = super::GetConsensusAppliedLogResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetConsensusAppliedLogRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as QdrantInternal>::get_consensus_applied_log(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetConsensusAppliedLogSvc(inner);
                         let codec = tonic_prost::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/lib/storage/src/content_manager/consensus/applied_log.rs
+++ b/lib/storage/src/content_manager/consensus/applied_log.rs
@@ -1,0 +1,99 @@
+//! Diagnostic record of the consensus entries this peer has applied.
+//!
+//! Consensus never reads this back: it exists so peers can be compared against each other by
+//! `/profiler/consensus_lag`, which lines up the entry indices they have in common. Kept in
+//! memory rather than alongside the persisted consensus state, which is rewritten on every
+//! applied entry.
+
+use std::collections::VecDeque;
+use std::time::{Duration, SystemTime};
+
+use parking_lot::Mutex;
+use raft::eraftpb::Entry as RaftEntry;
+use serde::Serialize;
+
+/// How many recently applied consensus entries each peer remembers.
+///
+/// Only bounds memory. A peer further behind than this many entries can still be placed by
+/// index, but not timed, because no entry it applied is still remembered elsewhere.
+pub const APPLIED_LOG_SIZE: usize = 32;
+
+/// A consensus entry this peer has finished applying.
+///
+/// Timestamps come from this peer's own wall clock, so comparing them against another peer's
+/// includes whatever clock skew exists between the two machines.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct AppliedEntry {
+    /// Raft log index of the entry.
+    pub index: u64,
+    /// Raft term the entry was proposed in.
+    pub term: u64,
+    /// Wall clock when the entry finished applying, milliseconds since the Unix epoch.
+    pub applied_at_ms: u64,
+    /// How long this single entry took to apply.
+    pub took_ms: u64,
+}
+
+/// Snapshot of a peer's applied-entry log, as served to `/profiler/consensus_lag`.
+#[derive(Debug, Clone, Serialize)]
+pub struct AppliedLog {
+    /// Recently applied entries, oldest first, at most [`APPLIED_LOG_SIZE`] of them.
+    pub entries: Vec<AppliedEntry>,
+    /// Wall clock on this peer when the log was read, milliseconds since the Unix epoch.
+    ///
+    /// Lets a reader age the newest entry against the clock that stamped it, rather than its own.
+    pub now_ms: u64,
+    /// Entries committed but not yet applied on this peer.
+    pub pending_operations: usize,
+}
+
+/// Ring of the entries this peer applied most recently, oldest first.
+pub struct AppliedEntryRing(Mutex<VecDeque<AppliedEntry>>);
+
+impl Default for AppliedEntryRing {
+    fn default() -> Self {
+        Self(Mutex::new(VecDeque::with_capacity(APPLIED_LOG_SIZE)))
+    }
+}
+
+impl AppliedEntryRing {
+    /// Record that `entry` finished applying, evicting the oldest entry once the ring is full.
+    pub fn record(&self, entry: &RaftEntry, took: Duration) {
+        let applied = AppliedEntry {
+            index: entry.index,
+            term: entry.term,
+            applied_at_ms: now_ms(),
+            took_ms: took.as_millis() as u64,
+        };
+
+        let mut entries = self.0.lock();
+        while entries.len() >= APPLIED_LOG_SIZE {
+            entries.pop_front();
+        }
+        entries.push_back(applied);
+    }
+
+    /// Snapshot the ring for a lag report.
+    ///
+    /// The ring is empty until this peer applies its first entry after startup, so a freshly
+    /// restarted peer reports nothing regardless of how far it has caught up.
+    ///
+    /// `pending_operations` is supplied by the caller: the ring records completed entries and
+    /// has no view of the apply queue behind them.
+    pub fn snapshot(&self, pending_operations: usize) -> AppliedLog {
+        let entries = self.0.lock().iter().copied().collect();
+
+        AppliedLog {
+            entries,
+            now_ms: now_ms(),
+            pending_operations,
+        }
+    }
+}
+
+/// Current wall clock in milliseconds since the Unix epoch, saturating at 0 before it.
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_or(0, |since_epoch| since_epoch.as_millis() as u64)
+}

--- a/lib/storage/src/content_manager/consensus/applied_log.rs
+++ b/lib/storage/src/content_manager/consensus/applied_log.rs
@@ -45,6 +45,9 @@ pub struct AppliedLog {
     pub now_ms: u64,
     /// Entries committed but not yet applied on this peer.
     pub pending_operations: usize,
+    /// Highest entry index this peer has applied, from the consensus state rather than the
+    /// entries above, which cover only this process. `None` if it has never applied one.
+    pub last_applied_index: Option<u64>,
 }
 
 /// Ring of the entries this peer applied most recently, oldest first.
@@ -76,17 +79,21 @@ impl AppliedEntryRing {
     /// Snapshot the ring for a lag report.
     ///
     /// The ring is empty until this peer applies its first entry after startup, so a freshly
-    /// restarted peer reports nothing regardless of how far it has caught up.
-    ///
-    /// `pending_operations` is supplied by the caller: the ring records completed entries and
-    /// has no view of the apply queue behind them.
-    pub fn snapshot(&self, pending_operations: usize) -> AppliedLog {
+    /// restarted peer has nothing to time, however far it has caught up. Both `pending_operations`
+    /// and `last_applied_index` are supplied by the caller from the consensus state, which knows
+    /// where the peer stands whether or not this process applied anything.
+    pub fn snapshot(
+        &self,
+        pending_operations: usize,
+        last_applied_index: Option<u64>,
+    ) -> AppliedLog {
         let entries = self.0.lock().iter().copied().collect();
 
         AppliedLog {
             entries,
             now_ms: now_ms(),
             pending_operations,
+            last_applied_index,
         }
     }
 }

--- a/lib/storage/src/content_manager/consensus/mod.rs
+++ b/lib/storage/src/content_manager/consensus/mod.rs
@@ -1,3 +1,4 @@
+pub mod applied_log;
 pub mod consensus_wal;
 pub mod entry_queue;
 pub mod operation_sender;

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -1,5 +1,5 @@
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::error::Error;
 use std::fmt::Display;
 use std::future::Future;
@@ -7,7 +7,7 @@ use std::ops::Deref;
 use std::path::Path;
 use std::str;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::{Context, anyhow};
 use chrono::Utc;
@@ -50,6 +50,49 @@ pub mod prelude {
 
 /// Allow us updating our peer metadata once every 60 seconds
 const CONSENSUS_PEER_METADATA_UPDATE_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How many recently applied consensus entries each peer remembers for lag diagnostics.
+///
+/// Only bounds memory: the log is read by `/profiler/consensus_lag`, which compares peers on the
+/// entry indices they have in common. A peer further behind than this many entries can still be
+/// placed by index, but not timed.
+pub const APPLIED_LOG_SIZE: usize = 32;
+
+/// A consensus entry this peer has finished applying.
+///
+/// Timestamps come from this peer's own wall clock, so comparing them against another peer's
+/// includes whatever clock skew exists between the two machines.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct AppliedEntry {
+    /// Raft log index of the entry.
+    pub index: u64,
+    /// Raft term the entry was proposed in.
+    pub term: u64,
+    /// Wall clock when the entry finished applying, milliseconds since the Unix epoch.
+    pub applied_at_ms: u64,
+    /// How long this single entry took to apply.
+    pub took_ms: u64,
+}
+
+/// Snapshot of a peer's applied-entry log, as served to `/profiler/consensus_lag`.
+#[derive(Debug, Clone, Serialize)]
+pub struct AppliedLog {
+    /// Recently applied entries, oldest first, at most [`APPLIED_LOG_SIZE`] of them.
+    pub entries: Vec<AppliedEntry>,
+    /// Wall clock on this peer when the log was read, milliseconds since the Unix epoch.
+    ///
+    /// Lets a reader age the newest entry against the clock that stamped it, rather than its own.
+    pub now_ms: u64,
+    /// Entries committed but not yet applied on this peer.
+    pub pending_operations: usize,
+}
+
+/// Current wall clock in milliseconds since the Unix epoch, saturating at 0 before it.
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_or(0, |since_epoch| since_epoch.as_millis() as u64)
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SnapshotData {
@@ -107,6 +150,9 @@ pub struct ConsensusManager<C: CollectionContainer> {
     message_send_failures: RwLock<HashMap<String, MessageSendErrors>>,
     /// Last time we attempted to update the peer metadata
     next_peer_metadata_update_attempt: Mutex<Instant>,
+    /// Ring of the last [`APPLIED_LOG_SIZE`] applied entries, oldest first.
+    /// Diagnostics only: nothing in consensus reads it back.
+    applied_log: Mutex<VecDeque<AppliedEntry>>,
 }
 
 impl<C: CollectionContainer> ConsensusManager<C> {
@@ -150,7 +196,41 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             }),
             message_send_failures: Default::default(),
             next_peer_metadata_update_attempt: Mutex::new(Instant::now()),
+            applied_log: Mutex::new(VecDeque::with_capacity(APPLIED_LOG_SIZE)),
         })
+    }
+
+    /// Record that `entry` finished applying, evicting the oldest entry once the ring is full.
+    fn record_applied_entry(&self, entry: &RaftEntry, took: Duration) {
+        let applied = AppliedEntry {
+            index: entry.index,
+            term: entry.term,
+            applied_at_ms: now_ms(),
+            took_ms: took.as_millis() as u64,
+        };
+
+        let mut applied_log = self.applied_log.lock();
+        while applied_log.len() >= APPLIED_LOG_SIZE {
+            applied_log.pop_front();
+        }
+        applied_log.push_back(applied);
+    }
+
+    /// Snapshot of the recently applied entries on this peer, oldest first.
+    ///
+    /// The log is empty until this peer applies its first entry after startup, so a freshly
+    /// restarted peer reports nothing regardless of how far it has caught up.
+    pub fn applied_log(&self) -> AppliedLog {
+        // Taken one at a time: the apply loop touches both, and holding the ring lock across
+        // the persistent one would be the only place the two ever nest.
+        let entries = self.applied_log.lock().iter().copied().collect();
+        let pending_operations = self.persistent.read().unapplied_entities_count();
+
+        AppliedLog {
+            entries,
+            now_ms: now_ms(),
+            pending_operations,
+        }
     }
 
     pub fn report_snapshot(
@@ -361,6 +441,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
                 .lock()
                 .entry(entry_index)
                 .context(format!("Failed to get entry at index {entry_index}"))?;
+            let apply_started = Instant::now();
             let stop_consensus: bool = if entry.data.is_empty() {
                 // Empty entry, when the peer becomes Leader it will send an empty entry.
                 false
@@ -413,6 +494,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
                 .write()
                 .entry_applied()
                 .context("Failed to save new state of applied entries queue")?;
+            self.record_applied_entry(&entry, apply_started.elapsed());
         }
         Ok(false) // do not stop consensus
     }

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -1,5 +1,5 @@
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt::Display;
 use std::future::Future;
@@ -7,7 +7,7 @@ use std::ops::Deref;
 use std::path::Path;
 use std::str;
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, anyhow};
 use chrono::Utc;
@@ -32,6 +32,7 @@ use super::CollectionContainer;
 use super::alias_mapping::AliasMapping;
 use super::consensus_ops::{ConsensusOperations, SnapshotStatus};
 use super::errors::StorageError;
+use crate::content_manager::consensus::applied_log::{AppliedEntryRing, AppliedLog};
 use crate::content_manager::consensus::consensus_wal::ConsensusOpWal;
 use crate::content_manager::consensus::entry_queue::EntryId;
 use crate::content_manager::consensus::operation_sender::OperationSender;
@@ -50,49 +51,6 @@ pub mod prelude {
 
 /// Allow us updating our peer metadata once every 60 seconds
 const CONSENSUS_PEER_METADATA_UPDATE_INTERVAL: Duration = Duration::from_secs(60);
-
-/// How many recently applied consensus entries each peer remembers for lag diagnostics.
-///
-/// Only bounds memory: the log is read by `/profiler/consensus_lag`, which compares peers on the
-/// entry indices they have in common. A peer further behind than this many entries can still be
-/// placed by index, but not timed.
-pub const APPLIED_LOG_SIZE: usize = 32;
-
-/// A consensus entry this peer has finished applying.
-///
-/// Timestamps come from this peer's own wall clock, so comparing them against another peer's
-/// includes whatever clock skew exists between the two machines.
-#[derive(Debug, Clone, Copy, Serialize)]
-pub struct AppliedEntry {
-    /// Raft log index of the entry.
-    pub index: u64,
-    /// Raft term the entry was proposed in.
-    pub term: u64,
-    /// Wall clock when the entry finished applying, milliseconds since the Unix epoch.
-    pub applied_at_ms: u64,
-    /// How long this single entry took to apply.
-    pub took_ms: u64,
-}
-
-/// Snapshot of a peer's applied-entry log, as served to `/profiler/consensus_lag`.
-#[derive(Debug, Clone, Serialize)]
-pub struct AppliedLog {
-    /// Recently applied entries, oldest first, at most [`APPLIED_LOG_SIZE`] of them.
-    pub entries: Vec<AppliedEntry>,
-    /// Wall clock on this peer when the log was read, milliseconds since the Unix epoch.
-    ///
-    /// Lets a reader age the newest entry against the clock that stamped it, rather than its own.
-    pub now_ms: u64,
-    /// Entries committed but not yet applied on this peer.
-    pub pending_operations: usize,
-}
-
-/// Current wall clock in milliseconds since the Unix epoch, saturating at 0 before it.
-fn now_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map_or(0, |since_epoch| since_epoch.as_millis() as u64)
-}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SnapshotData {
@@ -150,9 +108,8 @@ pub struct ConsensusManager<C: CollectionContainer> {
     message_send_failures: RwLock<HashMap<String, MessageSendErrors>>,
     /// Last time we attempted to update the peer metadata
     next_peer_metadata_update_attempt: Mutex<Instant>,
-    /// Ring of the last [`APPLIED_LOG_SIZE`] applied entries, oldest first.
-    /// Diagnostics only: nothing in consensus reads it back.
-    applied_log: Mutex<VecDeque<AppliedEntry>>,
+    /// Recently applied entries, for `/profiler/consensus_lag`. Diagnostics only.
+    applied_log: AppliedEntryRing,
 }
 
 impl<C: CollectionContainer> ConsensusManager<C> {
@@ -196,41 +153,15 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             }),
             message_send_failures: Default::default(),
             next_peer_metadata_update_attempt: Mutex::new(Instant::now()),
-            applied_log: Mutex::new(VecDeque::with_capacity(APPLIED_LOG_SIZE)),
+            applied_log: Default::default(),
         })
     }
 
-    /// Record that `entry` finished applying, evicting the oldest entry once the ring is full.
-    fn record_applied_entry(&self, entry: &RaftEntry, took: Duration) {
-        let applied = AppliedEntry {
-            index: entry.index,
-            term: entry.term,
-            applied_at_ms: now_ms(),
-            took_ms: took.as_millis() as u64,
-        };
-
-        let mut applied_log = self.applied_log.lock();
-        while applied_log.len() >= APPLIED_LOG_SIZE {
-            applied_log.pop_front();
-        }
-        applied_log.push_back(applied);
-    }
-
     /// Snapshot of the recently applied entries on this peer, oldest first.
-    ///
-    /// The log is empty until this peer applies its first entry after startup, so a freshly
-    /// restarted peer reports nothing regardless of how far it has caught up.
     pub fn applied_log(&self) -> AppliedLog {
-        // Taken one at a time: the apply loop touches both, and holding the ring lock across
-        // the persistent one would be the only place the two ever nest.
-        let entries = self.applied_log.lock().iter().copied().collect();
+        // Read the apply queue before taking the ring, so the two locks never nest.
         let pending_operations = self.persistent.read().unapplied_entities_count();
-
-        AppliedLog {
-            entries,
-            now_ms: now_ms(),
-            pending_operations,
-        }
+        self.applied_log.snapshot(pending_operations)
     }
 
     pub fn report_snapshot(
@@ -494,7 +425,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
                 .write()
                 .entry_applied()
                 .context("Failed to save new state of applied entries queue")?;
-            self.record_applied_entry(&entry, apply_started.elapsed());
+            self.applied_log.record(&entry, apply_started.elapsed());
         }
         Ok(false) // do not stop consensus
     }

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -160,8 +160,15 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     /// Snapshot of the recently applied entries on this peer, oldest first.
     pub fn applied_log(&self) -> AppliedLog {
         // Read the apply queue before taking the ring, so the two locks never nest.
-        let pending_operations = self.persistent.read().unapplied_entities_count();
-        self.applied_log.snapshot(pending_operations)
+        let (pending_operations, last_applied_index) = {
+            let persistent = self.persistent.read();
+            (
+                persistent.unapplied_entities_count(),
+                persistent.last_applied_entry(),
+            )
+        };
+        self.applied_log
+            .snapshot(pending_operations, last_applied_index)
     }
 
     pub fn report_snapshot(

--- a/src/actix/api/profiler_api.rs
+++ b/src/actix/api/profiler_api.rs
@@ -1,13 +1,20 @@
+use std::time::Duration;
+
 use actix_web::{Responder, get, web};
 use actix_web_validator::Query;
+use api::grpc::transport_channel_pool::DEFAULT_GRPC_TIMEOUT;
+use collection::operations::verification::new_unchecked_verification_pass;
 use collection::profiling::interface::get_requests_profile_log;
 use collection::profiling::slow_requests_log::LogEntry;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use storage::content_manager::errors::StorageError;
+use storage::dispatcher::Dispatcher;
 use storage::rbac::AccessRequirements;
 use validator::Validate;
 
 use crate::actix::auth::ActixAuth;
+use crate::common::consensus_lag::collect_consensus_lag;
 
 #[derive(Deserialize, Validate)]
 struct LogParams {
@@ -42,6 +49,45 @@ async fn get_slow_requests(ActixAuth(auth): ActixAuth, params: Query<LogParams>)
     .await
 }
 
+#[derive(Deserialize, Validate)]
+struct ConsensusLagParams {
+    /// Timeout in seconds for reaching each peer
+    #[validate(range(min = 1))]
+    timeout: Option<u64>,
+}
+
+#[get("/profiler/consensus_lag")]
+async fn get_consensus_lag(
+    dispatcher: web::Data<Dispatcher>,
+    ActixAuth(auth): ActixAuth,
+    params: Query<ConsensusLagParams>,
+) -> impl Responder {
+    crate::actix::helpers::time(async move {
+        auth.check_global_access(AccessRequirements::new().manage(), "get_consensus_lag")?;
+
+        let consensus_state = dispatcher.consensus_state().ok_or_else(|| {
+            StorageError::bad_request("Consensus lag is only available in distributed mode")
+        })?;
+
+        // Not a collection level request.
+        let pass = new_unchecked_verification_pass();
+        let toc = dispatcher.toc(&auth, &pass);
+
+        let ConsensusLagParams { timeout } = params.into_inner();
+        let timeout = Duration::from_secs(timeout.unwrap_or(DEFAULT_GRPC_TIMEOUT.as_secs()));
+
+        collect_consensus_lag(
+            consensus_state,
+            toc.get_channel_service(),
+            toc.this_peer_id,
+            timeout,
+        )
+        .await
+    })
+    .await
+}
+
 pub fn config_profiler_api(cfg: &mut web::ServiceConfig) {
     cfg.service(get_slow_requests);
+    cfg.service(get_consensus_lag);
 }

--- a/src/common/consensus_lag.rs
+++ b/src/common/consensus_lag.rs
@@ -21,7 +21,8 @@ use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use serde::Serialize;
 use shard::PeerId;
-use storage::content_manager::consensus_manager::{AppliedEntry, AppliedLog, ConsensusStateRef};
+use storage::content_manager::consensus::applied_log::{AppliedEntry, AppliedLog};
+use storage::content_manager::consensus_manager::ConsensusStateRef;
 use storage::content_manager::errors::StorageError;
 
 /// Range of entry indices a peer's log covers.
@@ -137,6 +138,40 @@ pub async fn collect_consensus_lag(
     unreachable_peers.sort_by_key(|peer| peer.peer_id);
 
     Ok(build_report(this_peer_id, &logs, unreachable_peers))
+}
+
+/// Serve this peer's log to another peer that is collecting a lag report.
+pub fn applied_log_to_grpc(log: AppliedLog) -> grpc::GetConsensusAppliedLogResponse {
+    let AppliedLog {
+        entries,
+        now_ms,
+        pending_operations,
+    } = log;
+
+    let entries = entries
+        .into_iter()
+        .map(|entry| {
+            let AppliedEntry {
+                index,
+                term,
+                applied_at_ms,
+                took_ms,
+            } = entry;
+
+            grpc::AppliedConsensusEntry {
+                index,
+                term,
+                applied_at_ms,
+                took_ms,
+            }
+        })
+        .collect();
+
+    grpc::GetConsensusAppliedLogResponse {
+        entries,
+        now_ms,
+        pending_operations: pending_operations as u64,
+    }
 }
 
 fn applied_log_from_grpc(response: grpc::GetConsensusAppliedLogResponse) -> AppliedLog {

--- a/src/common/consensus_lag.rs
+++ b/src/common/consensus_lag.rs
@@ -1,0 +1,296 @@
+//! Cross-peer view of how far behind each peer is at applying consensus entries.
+//!
+//! Every peer keeps a small ring of the entries it has applied, stamped with its own wall clock.
+//! Collecting those rings from the whole cluster and lining them up on the entry indices that
+//! appear in more than one of them gives the delay between peers for the same entry.
+//!
+//! Each entry is measured from whichever peer applied it first, so a lag is how long the others
+//! took to catch up on that entry and is never negative. Which peer is first can differ from entry
+//! to entry, so the baseline is per entry rather than a single chosen peer.
+//!
+//! Timestamps come from different machines, so the delays include whatever clock skew exists
+//! between them. A peer whose clock runs behind is first on every entry and reports no lag at all,
+//! pushing that skew into everyone else's numbers.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use api::grpc;
+use collection::shards::channel_service::ChannelService;
+use futures::StreamExt;
+use futures::stream::FuturesUnordered;
+use serde::Serialize;
+use shard::PeerId;
+use storage::content_manager::consensus_manager::{AppliedEntry, AppliedLog, ConsensusStateRef};
+use storage::content_manager::errors::StorageError;
+
+/// Range of entry indices a peer's log covers.
+#[derive(Debug, Serialize)]
+pub struct LogWindow {
+    pub first_index: u64,
+    pub last_index: u64,
+}
+
+/// How long a peer trailed the first peer to apply each entry, over the entries it shares.
+#[derive(Debug, Serialize)]
+pub struct LagStats {
+    pub avg_ms: u64,
+    pub min_ms: u64,
+    pub max_ms: u64,
+    /// Shared entry indices these numbers are drawn from.
+    pub samples: usize,
+}
+
+/// How one peer compares against the rest of the cluster.
+#[derive(Debug, Serialize)]
+pub struct PeerLag {
+    pub peer_id: PeerId,
+    /// Highest entry index this peer reported applying, absent when its log is empty.
+    pub last_applied_index: Option<u64>,
+    /// Term of that entry.
+    pub last_applied_term: Option<u64>,
+    /// Entries the most advanced peer has applied and this one has not.
+    pub behind_entries: Option<u64>,
+    /// Entries committed but not yet applied here.
+    pub pending_operations: u64,
+    /// Age of this peer's newest applied entry, measured against that peer's own clock, so it is
+    /// free of skew. Grows without bound while a peer is stuck part-way through applying an entry.
+    pub newest_applied_age_ms: Option<u64>,
+    /// How long this peer trailed the first peer to apply each shared entry.
+    /// Absent when no other peer still remembers any entry this one applied.
+    pub lag_ms: Option<LagStats>,
+    /// No entry this peer applied is still remembered by any other peer, so only the entry gap is
+    /// known, not the delay. Raise `APPLIED_LOG_SIZE` to measure lags this large.
+    pub beyond_window: bool,
+    /// Longest single entry apply within this peer's log.
+    pub slowest_apply_ms: Option<u64>,
+}
+
+/// A peer that did not answer.
+#[derive(Debug, Serialize)]
+pub struct UnreachablePeer {
+    pub peer_id: PeerId,
+    pub error: String,
+}
+
+/// Consensus apply lag across the cluster.
+#[derive(Debug, Serialize)]
+pub struct ConsensusLagReport {
+    /// Peer that has applied the furthest, which `behind_entries` counts back from.
+    pub most_advanced_peer: PeerId,
+    /// Index range that peer's log covers, absent when it has applied nothing yet.
+    pub applied_window: Option<LogWindow>,
+    /// Peer with the lowest average lag. Absent when no entry is held by more than one peer.
+    pub fastest_peer: Option<PeerId>,
+    /// One entry per peer that answered, including this one, ordered by peer id.
+    pub peers: Vec<PeerLag>,
+    /// Peers that failed to answer within the timeout.
+    pub unreachable_peers: Vec<UnreachablePeer>,
+}
+
+/// Collect the applied-entry log from every peer and compare them.
+///
+/// Peers that fail or time out are reported in `unreachable_peers` rather than failing the whole
+/// request; a partial answer is more useful than none when the point is to find a stuck peer.
+pub async fn collect_consensus_lag(
+    consensus_state: &ConsensusStateRef,
+    channel_service: &ChannelService,
+    this_peer_id: PeerId,
+    timeout: Duration,
+) -> Result<ConsensusLagReport, StorageError> {
+    let mut logs = HashMap::from([(this_peer_id, consensus_state.applied_log())]);
+    let mut unreachable_peers = Vec::new();
+
+    let mut requests = channel_service
+        .other_peers(this_peer_id)
+        .into_iter()
+        .map(|peer_id| async move {
+            let result = tokio::time::timeout(
+                timeout,
+                channel_service.with_qdrant_client(peer_id, |mut client| async move {
+                    client
+                        .get_consensus_applied_log(grpc::GetConsensusAppliedLogRequest {})
+                        .await
+                }),
+            )
+            .await;
+            (peer_id, result)
+        })
+        .collect::<FuturesUnordered<_>>();
+
+    while let Some((peer_id, result)) = requests.next().await {
+        match result {
+            Ok(Ok(response)) => {
+                logs.insert(peer_id, applied_log_from_grpc(response.into_inner()));
+            }
+            Ok(Err(err)) => unreachable_peers.push(UnreachablePeer {
+                peer_id,
+                error: err.to_string(),
+            }),
+            Err(_elapsed) => unreachable_peers.push(UnreachablePeer {
+                peer_id,
+                error: format!("timed out after {timeout:?}"),
+            }),
+        }
+    }
+
+    unreachable_peers.sort_by_key(|peer| peer.peer_id);
+
+    Ok(build_report(this_peer_id, &logs, unreachable_peers))
+}
+
+fn applied_log_from_grpc(response: grpc::GetConsensusAppliedLogResponse) -> AppliedLog {
+    let grpc::GetConsensusAppliedLogResponse {
+        entries,
+        now_ms,
+        pending_operations,
+    } = response;
+
+    let entries = entries
+        .into_iter()
+        .map(|entry| {
+            let grpc::AppliedConsensusEntry {
+                index,
+                term,
+                applied_at_ms,
+                took_ms,
+            } = entry;
+
+            AppliedEntry {
+                index,
+                term,
+                applied_at_ms,
+                took_ms,
+            }
+        })
+        .collect();
+
+    AppliedLog {
+        entries,
+        now_ms,
+        pending_operations: pending_operations as usize,
+    }
+}
+
+/// Measure every peer against the first peer to apply each entry.
+fn build_report(
+    this_peer_id: PeerId,
+    logs: &HashMap<PeerId, AppliedLog>,
+    unreachable_peers: Vec<UnreachablePeer>,
+) -> ConsensusLagReport {
+    // Ties go to the lowest peer id, so repeated calls against an idle cluster agree with
+    // each other instead of alternating between equally-advanced peers.
+    let most_advanced_peer = logs
+        .iter()
+        .filter_map(|(&peer_id, log)| Some((log.entries.last()?.index, peer_id)))
+        .max_by_key(|&(last_index, peer_id)| (last_index, std::cmp::Reverse(peer_id)))
+        .map_or(this_peer_id, |(_last_index, peer_id)| peer_id);
+
+    let applied_window = logs.get(&most_advanced_peer).and_then(|log| {
+        Some(LogWindow {
+            first_index: log.entries.first()?.index,
+            last_index: log.entries.last()?.index,
+        })
+    });
+
+    let baseline = Baseline::of(logs);
+
+    let mut peers: Vec<_> = logs
+        .iter()
+        .map(|(&peer_id, log)| peer_lag(peer_id, log, &baseline, applied_window.as_ref()))
+        .collect();
+    peers.sort_by_key(|peer| peer.peer_id);
+
+    // Ties go to the lowest peer id for the same reason as above.
+    let fastest_peer = peers
+        .iter()
+        .filter_map(|peer| Some((peer.lag_ms.as_ref()?.avg_ms, peer.peer_id)))
+        .min()
+        .map(|(_avg_ms, peer_id)| peer_id);
+
+    ConsensusLagReport {
+        most_advanced_peer,
+        applied_window,
+        fastest_peer,
+        peers,
+        unreachable_peers,
+    }
+}
+
+/// Earliest apply time per entry index, over the entries at least two peers still remember.
+///
+/// Entries only one peer has are left out: measuring a peer against itself would score a lag of
+/// zero and drag every average toward it.
+struct Baseline(HashMap<u64, u64>);
+
+impl Baseline {
+    fn of(logs: &HashMap<PeerId, AppliedLog>) -> Self {
+        let mut earliest_by_index: HashMap<u64, (u64, usize)> = HashMap::new();
+
+        for log in logs.values() {
+            for entry in &log.entries {
+                earliest_by_index
+                    .entry(entry.index)
+                    .and_modify(|(earliest_ms, holders)| {
+                        *earliest_ms = (*earliest_ms).min(entry.applied_at_ms);
+                        *holders += 1;
+                    })
+                    .or_insert((entry.applied_at_ms, 1));
+            }
+        }
+
+        earliest_by_index.retain(|_index, (_earliest_ms, holders)| *holders > 1);
+
+        Self(
+            earliest_by_index
+                .into_iter()
+                .map(|(index, (earliest_ms, _holders))| (index, earliest_ms))
+                .collect(),
+        )
+    }
+
+    /// How long after the first peer this one applied the entry, if it is shared at all.
+    fn lag_of(&self, entry: &AppliedEntry) -> Option<u64> {
+        Some(
+            entry
+                .applied_at_ms
+                .saturating_sub(*self.0.get(&entry.index)?),
+        )
+    }
+}
+
+fn peer_lag(
+    peer_id: PeerId,
+    log: &AppliedLog,
+    baseline: &Baseline,
+    applied_window: Option<&LogWindow>,
+) -> PeerLag {
+    let newest = log.entries.last();
+
+    let lags: Vec<u64> = log
+        .entries
+        .iter()
+        .filter_map(|entry| baseline.lag_of(entry))
+        .collect();
+
+    let lag_ms = (!lags.is_empty()).then(|| LagStats {
+        avg_ms: lags.iter().sum::<u64>() / lags.len() as u64,
+        min_ms: lags.iter().copied().min().unwrap_or_default(),
+        max_ms: lags.iter().copied().max().unwrap_or_default(),
+        samples: lags.len(),
+    });
+
+    PeerLag {
+        peer_id,
+        last_applied_index: newest.map(|entry| entry.index),
+        last_applied_term: newest.map(|entry| entry.term),
+        behind_entries: newest
+            .zip(applied_window)
+            .map(|(entry, window)| window.last_index.saturating_sub(entry.index)),
+        pending_operations: log.pending_operations as u64,
+        newest_applied_age_ms: newest.map(|entry| log.now_ms.saturating_sub(entry.applied_at_ms)),
+        lag_ms,
+        beyond_window: newest.is_some() && lags.is_empty(),
+        slowest_apply_ms: log.entries.iter().map(|entry| entry.took_ms).max(),
+    }
+}

--- a/src/common/consensus_lag.rs
+++ b/src/common/consensus_lag.rs
@@ -46,12 +46,13 @@ pub struct LagStats {
 #[derive(Debug, Serialize)]
 pub struct PeerLag {
     pub peer_id: PeerId,
-    /// Highest entry index this peer reported applying, absent when its log is empty.
+    /// Highest entry index this peer has applied, from its consensus state rather than its
+    /// ring, so a peer that has applied nothing since starting still reports where it stands.
     pub last_applied_index: Option<u64>,
-    /// Term of that entry.
+    /// Term of that entry, known only while the entry is still in this peer's ring.
     pub last_applied_term: Option<u64>,
     /// Entries the most advanced peer has applied and this one has not.
-    pub behind_entries: Option<u64>,
+    pub behind_entries: u64,
     /// Entries committed but not yet applied here.
     pub pending_operations: u64,
     /// Age of this peer's newest applied entry, measured against that peer's own clock, so it is
@@ -79,7 +80,8 @@ pub struct UnreachablePeer {
 pub struct ConsensusLagReport {
     /// Peer that has applied the furthest, which `behind_entries` counts back from.
     pub most_advanced_peer: PeerId,
-    /// Index range that peer's log covers, absent when it has applied nothing yet.
+    /// Index range the collected rings cover, which is what the lag figures are drawn from.
+    /// Absent when no peer has applied anything since it started.
     pub applied_window: Option<LogWindow>,
     /// Peer with the lowest average lag. Absent when no entry is held by more than one peer.
     pub fastest_peer: Option<PeerId>,
@@ -146,6 +148,7 @@ pub fn applied_log_to_grpc(log: AppliedLog) -> grpc::GetConsensusAppliedLogRespo
         entries,
         now_ms,
         pending_operations,
+        last_applied_index,
     } = log;
 
     let entries = entries
@@ -171,6 +174,7 @@ pub fn applied_log_to_grpc(log: AppliedLog) -> grpc::GetConsensusAppliedLogRespo
         entries,
         now_ms,
         pending_operations: pending_operations as u64,
+        last_applied_index,
     }
 }
 
@@ -179,6 +183,7 @@ fn applied_log_from_grpc(response: grpc::GetConsensusAppliedLogResponse) -> Appl
         entries,
         now_ms,
         pending_operations,
+        last_applied_index,
     } = response;
 
     let entries = entries
@@ -204,6 +209,7 @@ fn applied_log_from_grpc(response: grpc::GetConsensusAppliedLogResponse) -> Appl
         entries,
         now_ms,
         pending_operations: pending_operations as usize,
+        last_applied_index,
     }
 }
 
@@ -215,24 +221,28 @@ fn build_report(
 ) -> ConsensusLagReport {
     // Ties go to the lowest peer id, so repeated calls against an idle cluster agree with
     // each other instead of alternating between equally-advanced peers.
-    let most_advanced_peer = logs
+    let (frontier, most_advanced_peer) = logs
         .iter()
-        .filter_map(|(&peer_id, log)| Some((log.entries.last()?.index, peer_id)))
-        .max_by_key(|&(last_index, peer_id)| (last_index, std::cmp::Reverse(peer_id)))
-        .map_or(this_peer_id, |(_last_index, peer_id)| peer_id);
+        .map(|(&peer_id, log)| (log.last_applied_index.unwrap_or(0), peer_id))
+        .max_by_key(|&(applied_index, peer_id)| (applied_index, std::cmp::Reverse(peer_id)))
+        .unwrap_or((0, this_peer_id));
 
-    let applied_window = logs.get(&most_advanced_peer).and_then(|log| {
-        Some(LogWindow {
-            first_index: log.entries.first()?.index,
-            last_index: log.entries.last()?.index,
-        })
-    });
+    let first_index = logs.values().filter_map(|log| log.entries.first());
+    let last_index = logs.values().filter_map(|log| log.entries.last());
+    let applied_window = first_index
+        .map(|entry| entry.index)
+        .min()
+        .zip(last_index.map(|entry| entry.index).max())
+        .map(|(first_index, last_index)| LogWindow {
+            first_index,
+            last_index,
+        });
 
     let baseline = Baseline::of(logs);
 
     let mut peers: Vec<_> = logs
         .iter()
-        .map(|(&peer_id, log)| peer_lag(peer_id, log, &baseline, applied_window.as_ref()))
+        .map(|(&peer_id, log)| peer_lag(peer_id, log, &baseline, frontier))
         .collect();
     peers.sort_by_key(|peer| peer.peer_id);
 
@@ -294,12 +304,7 @@ impl Baseline {
     }
 }
 
-fn peer_lag(
-    peer_id: PeerId,
-    log: &AppliedLog,
-    baseline: &Baseline,
-    applied_window: Option<&LogWindow>,
-) -> PeerLag {
+fn peer_lag(peer_id: PeerId, log: &AppliedLog, baseline: &Baseline, frontier: u64) -> PeerLag {
     let newest = log.entries.last();
 
     let lags: Vec<u64> = log
@@ -317,15 +322,96 @@ fn peer_lag(
 
     PeerLag {
         peer_id,
-        last_applied_index: newest.map(|entry| entry.index),
-        last_applied_term: newest.map(|entry| entry.term),
-        behind_entries: newest
-            .zip(applied_window)
-            .map(|(entry, window)| window.last_index.saturating_sub(entry.index)),
+        last_applied_index: log.last_applied_index,
+        last_applied_term: newest
+            .filter(|entry| Some(entry.index) == log.last_applied_index)
+            .map(|entry| entry.term),
+        behind_entries: frontier.saturating_sub(log.last_applied_index.unwrap_or(0)),
         pending_operations: log.pending_operations as u64,
         newest_applied_age_ms: newest.map(|entry| log.now_ms.saturating_sub(entry.applied_at_ms)),
         lag_ms,
         beyond_window: newest.is_some() && lags.is_empty(),
         slowest_apply_ms: log.entries.iter().map(|entry| entry.took_ms).max(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A peer that applied `entries`, given as `(index, applied_at_ms)`, and stands at the
+    /// last of them unless `last_applied_index` says otherwise.
+    fn log(entries: &[(u64, u64)], last_applied_index: Option<u64>) -> AppliedLog {
+        AppliedLog {
+            entries: entries
+                .iter()
+                .map(|&(index, applied_at_ms)| AppliedEntry {
+                    index,
+                    term: 1,
+                    applied_at_ms,
+                    took_ms: 0,
+                })
+                .collect(),
+            now_ms: 1_000,
+            pending_operations: 0,
+            last_applied_index: last_applied_index.or(entries.last().map(|&(index, _)| index)),
+        }
+    }
+
+    fn peer(report: &ConsensusLagReport, peer_id: PeerId) -> &PeerLag {
+        report.peers.iter().find(|p| p.peer_id == peer_id).unwrap()
+    }
+
+    /// A peer that restarted caught up has an empty ring, and nothing to time, but its
+    /// position is still known.
+    #[test]
+    fn empty_ring_still_reports_position() {
+        let logs = HashMap::from([
+            (1, log(&[(11, 100), (12, 110)], None)),
+            (2, log(&[], Some(10))),
+        ]);
+
+        let report = build_report(1, &logs, vec![]);
+        let restarted = peer(&report, 2);
+
+        assert_eq!(restarted.last_applied_index, Some(10));
+        assert_eq!(restarted.behind_entries, 2);
+        assert!(restarted.last_applied_term.is_none());
+        assert!(restarted.lag_ms.is_none());
+        assert_eq!(report.most_advanced_peer, 1);
+    }
+
+    /// The peer that has applied the furthest can be one that has timed nothing, so the
+    /// others are counted back from its position rather than from any ring.
+    #[test]
+    fn peer_behind_an_empty_ring_is_still_behind() {
+        let logs = HashMap::from([
+            (1, log(&[(5, 100), (6, 110), (7, 120)], None)),
+            (2, log(&[], Some(9))),
+        ]);
+
+        let report = build_report(1, &logs, vec![]);
+
+        assert_eq!(report.most_advanced_peer, 2);
+        assert_eq!(peer(&report, 1).behind_entries, 2);
+        assert_eq!(peer(&report, 2).behind_entries, 0);
+    }
+
+    /// Lags are measured from whichever peer applied each entry first, over the entries
+    /// more than one peer still holds.
+    #[test]
+    fn lag_is_measured_against_the_first_peer_to_apply() {
+        let logs = HashMap::from([
+            (1, log(&[(1, 100), (2, 200)], None)),
+            (2, log(&[(1, 150), (2, 800)], None)),
+        ]);
+
+        let report = build_report(1, &logs, vec![]);
+        let window = report.applied_window.as_ref().unwrap();
+
+        assert_eq!((window.first_index, window.last_index), (1, 2));
+        assert_eq!(report.fastest_peer, Some(1));
+        assert_eq!(peer(&report, 2).lag_ms.as_ref().unwrap().max_ms, 600);
+        assert_eq!(peer(&report, 1).lag_ms.as_ref().unwrap().max_ms, 0);
     }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,6 +1,7 @@
 pub mod audit;
 pub mod auth;
 pub mod collections;
+pub mod consensus_lag;
 pub mod debugger;
 pub mod error_reporting;
 pub mod health;

--- a/src/tonic/api/qdrant_internal_api.rs
+++ b/src/tonic/api/qdrant_internal_api.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use api::grpc::qdrant_internal_server::QdrantInternal;
 use api::grpc::{
-    AppliedConsensusEntry, GetAuditLogRequest, GetAuditLogResponse, GetConsensusAppliedLogRequest,
+    GetAuditLogRequest, GetAuditLogResponse, GetConsensusAppliedLogRequest,
     GetConsensusAppliedLogResponse, GetConsensusCommitRequest, GetConsensusCommitResponse,
     GetQuotaUsageRequest, GetQuotaUsageResponse, GetTelemetryRequest, GetTelemetryResponse,
     PeerTelemetry, QuotaUsage, WaitOnConsensusCommitRequest, WaitOnConsensusCommitResponse,
@@ -13,12 +13,13 @@ use chrono::DateTime;
 use common::types::{DetailsLevel, TelemetryDetail};
 use storage::audit::AuditConfig;
 use storage::audit_reader::{AuditLogQuery, read_local_audit_logs};
-use storage::content_manager::consensus_manager::{AppliedEntry, AppliedLog, ConsensusStateRef};
+use storage::content_manager::consensus_manager::ConsensusStateRef;
 use storage::quota;
 use storage::rbac::AccessRequirements;
 use tokio::sync::Mutex;
 use tonic::{Request, Response, Status};
 
+use crate::common::consensus_lag::applied_log_to_grpc;
 use crate::common::telemetry::TelemetryCollector;
 use crate::settings::Settings;
 use crate::tonic::auth::extract_auth;
@@ -154,36 +155,9 @@ impl QdrantInternal for QdrantInternalService {
         &self,
         _: Request<GetConsensusAppliedLogRequest>,
     ) -> Result<Response<GetConsensusAppliedLogResponse>, Status> {
-        let AppliedLog {
-            entries,
-            now_ms,
-            pending_operations,
-        } = self.consensus_state.applied_log();
-
-        let entries = entries
-            .into_iter()
-            .map(|entry| {
-                let AppliedEntry {
-                    index,
-                    term,
-                    applied_at_ms,
-                    took_ms,
-                } = entry;
-
-                AppliedConsensusEntry {
-                    index,
-                    term,
-                    applied_at_ms,
-                    took_ms,
-                }
-            })
-            .collect();
-
-        Ok(Response::new(GetConsensusAppliedLogResponse {
-            entries,
-            now_ms,
-            pending_operations: pending_operations as u64,
-        }))
+        Ok(Response::new(applied_log_to_grpc(
+            self.consensus_state.applied_log(),
+        )))
     }
 
     async fn get_audit_log(

--- a/src/tonic/api/qdrant_internal_api.rs
+++ b/src/tonic/api/qdrant_internal_api.rs
@@ -4,7 +4,8 @@ use std::time::{Duration, Instant};
 
 use api::grpc::qdrant_internal_server::QdrantInternal;
 use api::grpc::{
-    GetAuditLogRequest, GetAuditLogResponse, GetConsensusCommitRequest, GetConsensusCommitResponse,
+    AppliedConsensusEntry, GetAuditLogRequest, GetAuditLogResponse, GetConsensusAppliedLogRequest,
+    GetConsensusAppliedLogResponse, GetConsensusCommitRequest, GetConsensusCommitResponse,
     GetQuotaUsageRequest, GetQuotaUsageResponse, GetTelemetryRequest, GetTelemetryResponse,
     PeerTelemetry, QuotaUsage, WaitOnConsensusCommitRequest, WaitOnConsensusCommitResponse,
 };
@@ -12,7 +13,7 @@ use chrono::DateTime;
 use common::types::{DetailsLevel, TelemetryDetail};
 use storage::audit::AuditConfig;
 use storage::audit_reader::{AuditLogQuery, read_local_audit_logs};
-use storage::content_manager::consensus_manager::ConsensusStateRef;
+use storage::content_manager::consensus_manager::{AppliedEntry, AppliedLog, ConsensusStateRef};
 use storage::quota;
 use storage::rbac::AccessRequirements;
 use tokio::sync::Mutex;
@@ -147,6 +148,42 @@ impl QdrantInternal for QdrantInternalService {
         };
 
         Ok(Response::new(response))
+    }
+
+    async fn get_consensus_applied_log(
+        &self,
+        _: Request<GetConsensusAppliedLogRequest>,
+    ) -> Result<Response<GetConsensusAppliedLogResponse>, Status> {
+        let AppliedLog {
+            entries,
+            now_ms,
+            pending_operations,
+        } = self.consensus_state.applied_log();
+
+        let entries = entries
+            .into_iter()
+            .map(|entry| {
+                let AppliedEntry {
+                    index,
+                    term,
+                    applied_at_ms,
+                    took_ms,
+                } = entry;
+
+                AppliedConsensusEntry {
+                    index,
+                    term,
+                    applied_at_ms,
+                    took_ms,
+                }
+            })
+            .collect();
+
+        Ok(Response::new(GetConsensusAppliedLogResponse {
+            entries,
+            now_ms,
+            pending_operations: pending_operations as u64,
+        }))
     }
 
     async fn get_audit_log(

--- a/tests/consensus_tests/test_consensus_lag.py
+++ b/tests/consensus_tests/test_consensus_lag.py
@@ -1,0 +1,116 @@
+"""`/profiler/consensus_lag` reports how far each peer trails at applying entries.
+
+Every peer keeps a ring of the entries it applied, stamped with its own clock. The
+endpoint collects those rings from the whole cluster and measures each entry from
+whichever peer applied it first, so a lag is never negative.
+
+Needs `--features staging` for `test_slow_down`.
+"""
+
+import json
+import pathlib
+
+from .fixtures import create_collection, upsert_random_points
+from .utils import *
+
+N_PEERS = 3
+COLLECTION_NAME = "test_collection"
+
+
+def get_lag(peer_api_uri):
+    r = requests.get(f"{peer_api_uri}/profiler/consensus_lag")
+    assert_http_ok(r)
+    return r.json()["result"]
+
+
+def test_consensus_lag_report(tmp_path: pathlib.Path):
+    """Every peer answers, and a settled cluster reports no peer behind."""
+    assert_project_root()
+    peer_api_uris, _, _ = start_cluster(tmp_path, N_PEERS)
+    create_collection(peer_api_uris[0], shard_number=2, replication_factor=2)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME, peer_api_uris=peer_api_uris
+    )
+    upsert_random_points(peer_api_uris[0], 100)
+
+    for uri in peer_api_uris:
+        report = get_lag(uri)
+        print(f"\n=== settled: {uri} ===\n{json.dumps(report, indent=2)}")
+
+        assert len(report["peers"]) == N_PEERS, report
+        assert report["unreachable_peers"] == [], report
+        assert report["applied_window"] is not None, report
+
+        most_advanced = report["most_advanced_peer"]
+        assert any(p["peer_id"] == most_advanced for p in report["peers"]), report
+
+        for peer in report["peers"]:
+            assert peer["last_applied_index"] is not None, peer
+            assert peer["behind_entries"] == 0, peer
+            assert not peer["beyond_window"], peer
+            assert peer["lag_ms"] is not None, peer
+            assert peer["lag_ms"]["samples"] > 0, peer
+            # Measured from the first peer to apply each entry, so never negative.
+            # `max_ms` can still run into seconds: that is the bootstrap, where
+            # late joiners replayed entries the first peer applied before they existed.
+            assert peer["lag_ms"]["min_ms"] >= 0, peer
+            assert peer["lag_ms"]["avg_ms"] >= 0, peer
+            assert peer["lag_ms"]["max_ms"] >= 0, peer
+            assert peer["newest_applied_age_ms"] < 60_000, peer
+
+        fastest_id = report["fastest_peer"]
+        fastest = next(p for p in report["peers"] if p["peer_id"] == fastest_id)
+        for peer in report["peers"]:
+            assert peer["lag_ms"]["avg_ms"] >= fastest["lag_ms"]["avg_ms"], (
+                fastest,
+                peer,
+            )
+
+
+def test_consensus_lag_frozen_peer(tmp_path: pathlib.Path):
+    """A peer whose apply loop is stalled must show up as behind."""
+    assert_project_root()
+    peer_api_uris, _, _ = start_cluster(tmp_path, N_PEERS)
+    create_collection(peer_api_uris[0], shard_number=1, replication_factor=2)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME, peer_api_uris=peer_api_uris
+    )
+
+    frozen_id = get_cluster_info(peer_api_uris[2])["peer_id"]
+    r = requests.post(
+        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster",
+        json={"test_slow_down": {"peer_id": frozen_id, "duration": 60.0}},
+    )
+    assert_http_ok(r)
+    time.sleep(1)
+
+    # Cluster metadata with `wait=false` is the cheapest consensus entry that does
+    # not block on the frozen peer. An operation that waits for cluster
+    # confirmation can outlast the freeze, leaving nothing to measure.
+    for i in range(5):
+        r = requests.put(
+            f"{peer_api_uris[0]}/cluster/metadata/keys/lag_probe_{i}?wait=false",
+            json=i,
+        )
+        assert_http_ok(r)
+    time.sleep(3)
+
+    report = get_lag(peer_api_uris[0])
+    print(f"\n=== frozen peer {frozen_id} ===\n{json.dumps(report, indent=2)}")
+
+    frozen = next(p for p in report["peers"] if p["peer_id"] == frozen_id)
+    healthy = [p for p in report["peers"] if p["peer_id"] != frozen_id]
+
+    assert frozen["behind_entries"] > 0, frozen
+    assert frozen["pending_operations"] > 0, frozen
+
+    for peer in healthy:
+        assert peer["behind_entries"] == 0, peer
+        assert peer["pending_operations"] == 0, peer
+        # The stall shows in the newest entry's age, not in `lag_ms`: everything
+        # the frozen peer did apply, it applied on time, so its overlap
+        # statistics stay healthy while it sits stuck part-way through an entry.
+        assert frozen["newest_applied_age_ms"] > peer["newest_applied_age_ms"], (
+            frozen,
+            peer,
+        )

--- a/tests/consensus_tests/test_consensus_lag.py
+++ b/tests/consensus_tests/test_consensus_lag.py
@@ -16,11 +16,40 @@ from .utils import *
 N_PEERS = 3
 COLLECTION_NAME = "test_collection"
 
+FREEZE_SEC = 15
+# Peers that join last replay the bootstrap entries, which leaves them lags of a few
+# seconds. The threshold has to clear those without reaching the freeze itself.
+STALL_THRESHOLD_MS = 10_000
+
 
 def get_lag(peer_api_uri):
     r = requests.get(f"{peer_api_uri}/profiler/consensus_lag")
     assert_http_ok(r)
     return r.json()["result"]
+
+
+def peer_lag(peer_api_uri, peer_id):
+    return next(p for p in get_lag(peer_api_uri)["peers"] if p["peer_id"] == peer_id)
+
+
+def freeze_peer(peer_api_uri, peer_id, seconds):
+    r = requests.post(
+        f"{peer_api_uri}/collections/{COLLECTION_NAME}/cluster",
+        json={"test_slow_down": {"peer_id": peer_id, "duration": seconds}},
+    )
+    assert_http_ok(r)
+
+
+def stall_visible(peer_api_uri, peer_id):
+    return peer_lag(peer_api_uri, peer_id)["behind_entries"] > 0
+
+
+def stall_recovered(peer_api_uri, peer_id):
+    return peer_lag(peer_api_uri, peer_id)["behind_entries"] == 0
+
+
+def all_caught_up(peer_api_uri):
+    return all(peer["behind_entries"] == 0 for peer in get_lag(peer_api_uri)["peers"])
 
 
 def test_consensus_lag_report(tmp_path: pathlib.Path):
@@ -34,6 +63,8 @@ def test_consensus_lag_report(tmp_path: pathlib.Path):
     upsert_random_points(peer_api_uris[0], 100)
 
     for uri in peer_api_uris:
+        # Nothing above waits on consensus, so a peer can still trail by an entry.
+        wait_for(all_caught_up, uri)
         report = get_lag(uri)
         print(f"\n=== settled: {uri} ===\n{json.dumps(report, indent=2)}")
 
@@ -77,11 +108,7 @@ def test_consensus_lag_frozen_peer(tmp_path: pathlib.Path):
     )
 
     frozen_id = get_cluster_info(peer_api_uris[2])["peer_id"]
-    r = requests.post(
-        f"{peer_api_uris[0]}/collections/{COLLECTION_NAME}/cluster",
-        json={"test_slow_down": {"peer_id": frozen_id, "duration": 60.0}},
-    )
-    assert_http_ok(r)
+    freeze_peer(peer_api_uris[0], frozen_id, 60.0)
     time.sleep(1)
 
     # Cluster metadata with `wait=false` is the cheapest consensus entry that does
@@ -114,3 +141,45 @@ def test_consensus_lag_frozen_peer(tmp_path: pathlib.Path):
             frozen,
             peer,
         )
+
+
+def test_consensus_lag_outlives_the_stall(tmp_path: pathlib.Path):
+    """A stall that has already ended is still in the report.
+
+    Every live signal - `behind_entries`, `pending_operations` - is clean again by the
+    time the peer catches up, so a poll landing after the stall would see nothing. The
+    entry the peer was stuck on stays in the window and keeps the delay measurable.
+    """
+    assert_project_root()
+    peer_api_uris, _, _ = start_cluster(tmp_path, N_PEERS)
+    create_collection(peer_api_uris[0], shard_number=1, replication_factor=2)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME, peer_api_uris=peer_api_uris
+    )
+
+    # The freeze runs inside applying the entry that carries it, so that entry is the
+    # one measured: the other peers apply it at once, the frozen peer FREEZE_SEC later.
+    frozen_id = get_cluster_info(peer_api_uris[2])["peer_id"]
+    freeze_peer(peer_api_uris[0], frozen_id, FREEZE_SEC)
+
+    wait_for(stall_visible, peer_api_uris[0], frozen_id)
+    wait_for(
+        stall_recovered,
+        peer_api_uris[0],
+        frozen_id,
+        wait_for_timeout=FREEZE_SEC + 30,
+    )
+
+    report = get_lag(peer_api_uris[0])
+    print(f"\n=== recovered peer {frozen_id} ===\n{json.dumps(report, indent=2)}")
+
+    frozen = next(p for p in report["peers"] if p["peer_id"] == frozen_id)
+    healthy = [p for p in report["peers"] if p["peer_id"] != frozen_id]
+
+    assert frozen["pending_operations"] == 0, frozen
+    assert frozen["slowest_apply_ms"] >= STALL_THRESHOLD_MS, frozen
+    assert frozen["lag_ms"]["max_ms"] >= STALL_THRESHOLD_MS, frozen
+
+    for peer in healthy:
+        assert peer["slowest_apply_ms"] < frozen["slowest_apply_ms"], (frozen, peer)
+        assert peer["lag_ms"]["max_ms"] < frozen["lag_ms"]["max_ms"], (frozen, peer)


### PR DESCRIPTION
## Problem

Raft commit index advances normally on a peer whose *apply* loop is stalled. So the signals we have today report a stuck peer as healthy:

- `raft_info.commit` is the committed index, not the applied one
- `all_nodes_have_same_commit` / `wait_for_same_commit` in the test utils compare that same committed index

Nothing exposes how long a peer has been behind at applying entries — which is exactly what shard transfer's `await_consensus_sync` barrier waits on before it destroys the forward proxy.

## What this adds

**A ring of applied entries per peer.** The last 32 entries, each with its raft index/term, the wall clock when it finished applying, and how long that apply took. In memory on `ConsensusManager`, recorded at the single apply-completion site. Not in `Persistent`, so the on-disk format is untouched.

**`GetConsensusAppliedLog`** on the existing `QdrantInternal` service.

**`GET /profiler/consensus_lag`** — collects the rings from every peer and lines them up on the entry indices they share.

```json
{
  "most_advanced_peer": 321257240296485,
  "applied_window": { "first_index": 1, "last_index": 18 },
  "fastest_peer": 321257240296485,
  "peers": [
    { "peer_id": 3177012143598871, "last_applied_index": 12,
      "behind_entries": 6, "pending_operations": 1,
      "newest_applied_age_ms": 4145,
      "lag_ms": { "avg_ms": 22, "min_ms": 0, "max_ms": 243, "samples": 12 },
      "beyond_window": false, "slowest_apply_ms": 506 }
  ],
  "unreachable_peers": []
}
```

## Design notes

**Lag is measured per entry, from whichever peer applied it first.** A single chosen reference peer doesn't guarantee non-negative lag — the earliest peer can differ from entry to entry, so any peer you pick can be beaten on some entry. A per-index minimum can't be.

**Entries only one peer still remembers are excluded** from the baseline, otherwise that peer would be measured against itself, score zero, and drag its own average down.

**A stalled peer keeps healthy lag statistics.** Everything it did apply, it applied on time — the sample above shows a frozen peer at `avg_ms: 22`. That's why `behind_entries` and `newest_applied_age_ms` sit alongside: they're what actually exposes the stall. `newest_applied_age_ms` is computed against the reporting peer's own clock, so it carries no skew.

**Unreachable peers are listed, not fatal.** A partial answer is more useful than none when the point is to find the peer that stopped answering.

**Clock skew** is not corrected for. Timestamps come from different machines, so the peer with the slowest clock is first on every entry and reports zero, pushing its skew into everyone else's numbers. On an NTP-synced cluster that is milliseconds against lags measured in seconds.

**Why a dedicated RPC** rather than the existing cluster-telemetry fan-out: that path needs `details_level >= 2`, which pulls full collection telemetry off every peer on each call, and it would put a 32-entry array into the struct that also feeds `/metrics` and anonymized telemetry uploads.

## API surface

Follows `/profiler/slow_requests`: `manage` access, and deliberately outside OpenAPI — so neither `EXPECTED_NUMBER_OF_APIS` nor the `ACTION_ACCESS` table applies.

## Testing

`tests/consensus_tests/test_consensus_lag.py`, needs `--features staging`:

- settled 3-peer cluster — every peer answers, nobody behind, all lags non-negative, `fastest_peer` has the lowest average
- one peer frozen with `test_slow_down` — shows `behind_entries > 0`, `pending_operations > 0`, and a newest-entry age above every healthy peer's

Both pass locally. `clippy --all-targets -D warnings` and `cargo +nightly fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)