### PR TITLE
[UIO] Pin the append filesystem to its handle

### DIFF
--- a/lib/common/common/src/universal_io/traits/append.rs
+++ b/lib/common/common/src/universal_io/traits/append.rs
@@ -8,6 +8,13 @@ use crate::universal_io::{ByteOffset, UioResult};
 /// capabilities stay independent — a backend implements either, both, or
 /// neither.
 ///
+/// [`UniversalRead::Fs`] is pinned from both sides here: it opens `Self` for
+/// reading (`Fs::File = Self`) and hands `Self` out as its append handle
+/// (`Fs::AppendFile = Self`), so `S::Fs` is the file-creating, append-opening
+/// filesystem without a second associated type. As on the read side it is the
+/// canonical producer, not the only one — code that accepts any takes
+/// `&impl UniversalWriteFileOps<AppendFile = S>`.
+///
 /// # Contract
 ///
 /// - [`append`](Self::append) grows the file by writing the data at exactly
@@ -57,7 +64,9 @@ use crate::universal_io::{ByteOffset, UioResult};
 /// [`UniversalWrite::write`]: super::UniversalWrite::write
 /// [`len`]: UniversalRead::len
 /// [`reopen`]: UniversalRead::reopen
-pub trait UniversalAppend: UniversalRead<Fs: UniversalWriteFileOps> + UniversalFlush {
+pub trait UniversalAppend:
+    UniversalRead<Fs: UniversalWriteFileOps<AppendFile = Self>> + UniversalFlush
+{
     /// Atomically grow the file by appending `data` at exactly `offset`,
     /// which must equal the current end of file; rejected with
     /// [`AppendOffsetConflict`] otherwise.


### PR DESCRIPTION
Stacked on #10091 — review that one first; this PR's diff against it is one trait bound and the paragraph that explains it.

> **Update:** this PR previously also added `append_at_end`, an offset-less append. We decided against it: a caller that supplies no offset gets no compare-and-swap token, so a retry after an `Err` that had durably landed (a lost acknowledgement on a remote backend) appends the data twice. Callers pass the offset they expect, and get that check for free. Everything to do with `append_at_end` — the trait method, the per-backend implementations, the end-of-file tracking they needed, and their tests — is gone from this branch; only the filesystem pinning below remains. (The branch keeps its now-misleading name so the PR link survives.)

## The filesystem is now pinned to the handle

`UniversalRead::Fs` was reachable from an append handle and known to be a `UniversalWriteFileOps`, but not pinned: `fs.open_append(..)` on it returned some `Fs::AppendFile`, not the handle type the caller had in hand.

```rust
pub trait UniversalAppend:
    UniversalRead<Fs: UniversalWriteFileOps<AppendFile = Self>> + UniversalFlush
```

Every append handle's canonical filesystem already produced itself (`MmapFs → MmapFile`, `IoUringFs → IoUringFile`, `BlobFs<A> → BlobFile<A>`, the last guarded by the same `A: AsyncAppend` bound on both impls), so this only writes down what already held — it compiles workspace-wide unchanged.

What it buys: generic-over-`<S: UniversalAppend>` code reaches its file-creating, append-opening filesystem as `S::Fs`, with no second associated type and no `UniversalAppendFs`. Both forms now work, mirroring the read side exactly:

```rust
fn open_canonical<S: UniversalAppend>(fs: &S::Fs, path: &Path) -> UioResult<S>
fn open_via<S: UniversalAppend>(fs: &impl UniversalWriteFileOps<AppendFile = S>, ..) -> UioResult<S>
```

#10093 is the first caller: it holds an `S::Fs` and opens both of its files through it.

## Tests

None added — there is no behavior here to test. Verified locally: `cargo check --workspace --all-targets` and `clippy --workspace --all-targets` clean, `cargo test -p common universal_io` (112) green, nightly `fmt` clean.

## All Submissions:

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
