### PR TITLE
Bump dev version to 1.19.1-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "api"
-version = "1.18.3-dev"
+version = "1.19.1-dev"
 dependencies = [
  "ahash",
  "chrono",
@@ -5902,7 +5902,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.18.3-dev"
+version = "1.19.1-dev"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.18.3-dev"
+version = "1.19.1-dev"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.18.3-dev"
+version = "1.19.1-dev"
 authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -7,7 +7,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.18.3-dev";
+pub const QDRANT_VERSION_STRING: &str = "1.19.1-dev";
 
 /// Current Qdrant semver version
 pub static QDRANT_VERSION: LazyLock<Version> =


### PR DESCRIPTION
Bump the dev version after the [Qdrant 1.19.0](https://github.com/qdrant/qdrant/releases/tag/v1.19.0) release.

Follows the pattern of <https://github.com/qdrant/qdrant/pull/9292>