### PR TITLE
Bump edge packages (Python + Rust + FFI) to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5986,7 +5986,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant-edge-ffi"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "edge",
@@ -6011,7 +6011,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant-edge-py"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "bytemuck",

--- a/lib/edge/ffi/Cargo.toml
+++ b/lib/edge/ffi/Cargo.toml
@@ -7,7 +7,7 @@ name = "qdrant-edge-ffi"
 # `lib/edge/VERSION` single-source-of-truth file and its CI `version-sync` check
 # (also covering the Gradle `VERSION_NAME` and Swift release tag) are introduced
 # with the Gradle/Swift packaging in those follow-up PRs.
-version = "0.7.2"
+version = "0.8.0"
 authors = ["Qdrant Team <info@qdrant.tech>"]
 license = "Apache-2.0"
 edition = "2024"

--- a/lib/edge/publish/amalgamate.py
+++ b/lib/edge/publish/amalgamate.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 import tomlkit
 
-VERSION = "0.7.2"
+VERSION = "0.8.0"
 
 # Assume this script is in <root>/lib/edge/publish/.
 REPO_ROOT = Path(__file__).parent.parent.parent.parent

--- a/lib/edge/publish/ast-grep-rules.yaml
+++ b/lib/edge/publish/ast-grep-rules.yaml
@@ -78,7 +78,7 @@ fix: ""
 # Inline package versions.
 # Why: these are significant for migration logic.
 # Before: `env!("CARGO_PKG_VERSION")`
-# After:  `"0.7.1"`
+# After:  `"0.8.0"`
 ---
 id: replace-pkg-version
 language: rust

--- a/lib/edge/python/Cargo.toml
+++ b/lib/edge/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant-edge-py"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["Qdrant Team <info@qdrant.tech>"]
 license = "Apache-2.0"
 edition = "2024"


### PR DESCRIPTION
Minor version bump of the edge packages from `0.7.2` to `0.8.0`, in preparation for publishing `qdrant-edge` to crates.io and `qdrant-edge-py` to PyPI.

## Changes

- `lib/edge/python/Cargo.toml`: `qdrant-edge-py` `0.7.2` → `0.8.0`
- `lib/edge/publish/amalgamate.py`: `VERSION` constant bumped (drives the `qdrant-edge` crates.io version)
- `lib/edge/ffi/Cargo.toml`: `qdrant-edge-ffi` bumped — this crate was added after the last bump (#9374) and its header comment asks for it to be kept equal to the other two by hand
- `lib/edge/publish/ast-grep-rules.yaml`: inline package version comment updated (it was stale at `0.7.1`)
- `Cargo.lock`: regenerated version entries

Follows the same pattern as #9252 / #9187.

## Verification

Ran `lib/edge/publish/amalgamate.py` locally — the generated `qdrant-edge` manifest reports `0.8.0` and `cargo check -p examples` passes against it.

## Follow-up (not part of this PR)

After merge, the release itself is two manual workflow dispatches on `dev`:

1. [Qdrant Edge Rust Release](https://github.com/qdrant/qdrant/actions/workflows/edge-rust-release.yml) with **Publish to crates.io = true**
2. [Qdrant Edge Release Build](https://github.com/qdrant/qdrant/actions/workflows/edge-py-release.yml) with **Publish to PyPI = true**

🤖 Generated with [Claude Code](https://claude.com/claude-code)