### PR TITLE
Optimization: Skipping items before pushing into PriorityQueue.

### DIFF
--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -92,3 +92,7 @@ harness = false
 [[bench]]
 name = "universal_io"
 harness = false
+
+[[bench]]
+name = "fixed_length_priority_queue"
+harness = false

--- a/lib/common/common/benches/fixed_length_priority_queue.rs
+++ b/lib/common/common/benches/fixed_length_priority_queue.rs
@@ -1,0 +1,64 @@
+use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
+use common::top_k::TopK;
+use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::rngs::StdRng;
+use rand::{RngExt as _, SeedableRng as _};
+
+/// Pushed points, and how many of them the structure keeps.
+const CASES: [(usize, usize); 9] = [
+    (32, 10),
+    (64, 10),
+    (128, 10),
+    (50_000, 10),
+    (50_000, 32),
+    (50_000, 64),
+    (50_000, 100),
+    (50_000, 1000),
+    (50_000, 10_000),
+];
+
+fn bench_push(c: &mut Criterion) {
+    let mut group = c.benchmark_group("top_of");
+
+    for (size, limit) in CASES {
+        let points = random_points(size);
+        let case = format!("{size}/top={limit}");
+        group.throughput(Throughput::Elements(size as u64));
+
+        group.bench_with_input(BenchmarkId::new("fpq_push", &case), &points, |b, points| {
+            b.iter(|| {
+                let mut pq = FixedLengthPriorityQueue::new(limit);
+                for &point in points {
+                    pq.push(point);
+                }
+                pq.into_sorted_vec()
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("top_k", &case), &points, |b, points| {
+            b.iter(|| {
+                let mut top = TopK::new(limit);
+                for &point in points {
+                    top.push(point);
+                }
+                top.into_vec()
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn random_points(size: usize) -> Vec<ScoredPointOffset> {
+    let mut rng = StdRng::seed_from_u64(42);
+    (0..size)
+        .map(|idx| ScoredPointOffset {
+            idx: idx as PointOffsetType,
+            score: rng.random::<ScoreType>(),
+        })
+        .collect()
+}
+
+criterion_group!(benches, bench_push);
+criterion_main!(benches);

--- a/lib/common/common/src/fixed_length_priority_queue.rs
+++ b/lib/common/common/src/fixed_length_priority_queue.rs
@@ -46,16 +46,26 @@ impl<T: Ord> FixedLengthPriorityQueue<T> {
     /// If the queue if full, replaces the smallest value and returns it.
     pub fn push(&mut self, value: T) -> Option<T> {
         if !self.is_full() {
-            self.heap.push(Reverse(value));
-            return None;
+            return self.fill(value);
         }
 
-        let mut x = self.heap.peek_mut().unwrap();
-        let mut value = Reverse(value);
-        if x.0 < value.0 {
-            std::mem::swap(&mut *x, &mut value);
+        // Reject without ever constructing the `PeekMut` guard, whose `Drop` sifts the heap.
+        if self.heap.peek().expect("full queue is not empty").0 >= value {
+            return Some(value);
         }
+
+        let mut x = self.heap.peek_mut().expect("full queue is not empty");
+        let mut value = Reverse(value);
+        std::mem::swap(&mut *x, &mut value);
         Some(value.0)
+    }
+
+    /// The `push` path taken only while the queue is not full yet, kept out of line so that
+    /// the hot rejection path does not carry its register pressure.
+    #[inline(never)]
+    fn fill(&mut self, value: T) -> Option<T> {
+        self.heap.push(Reverse(value));
+        None
     }
 
     /// Consumes the [`FixedLengthPriorityQueue`] and returns a vector

--- a/lib/common/common/src/top_k.rs
+++ b/lib/common/common/src/top_k.rs
@@ -1,31 +1,37 @@
-use std::cmp::Reverse;
-
-use ordered_float::Float;
-
 use crate::types::{ScoreType, ScoredPointOffset};
 
 /// Avoid excessive memory allocation and allocation failures on huge limits
 const LARGEST_REASONABLE_ALLOCATION_SIZE: usize = 1_048_576;
 
-/// TopK implementation following the median algorithm described in
-/// <https://quickwit.io/blog/top-k-complexity>.
-///
-/// Keeps the largest `k` ScoredPointOffset.
+/// The threshold for switching from a sorted buffer to a median-based algorithm.
+const SORTED_K: usize = 32;
+
 #[derive(Default)]
 pub struct TopK {
     k: usize,
-    elements: Vec<Reverse<ScoredPointOffset>>,
+    elements: Vec<ScoredPointOffset>,
     threshold: ScoreType,
 }
 
 impl TopK {
+    /// Panics if `k` is 0.
     pub fn new(k: usize) -> Self {
+        assert!(k > 0, "k must be greater than zero");
+        let capacity = match k < SORTED_K {
+            true => k,
+            false => k.saturating_mul(2).min(LARGEST_REASONABLE_ALLOCATION_SIZE),
+        };
         TopK {
+            threshold: ScoreType::NEG_INFINITY,
+            elements: Vec::with_capacity(capacity),
             k,
-            elements: Vec::with_capacity(
-                k.saturating_mul(2).min(LARGEST_REASONABLE_ALLOCATION_SIZE),
-            ),
-            threshold: ScoreType::min_value(),
+        }
+    }
+
+    #[inline]
+    pub fn push(&mut self, point: ScoredPointOffset) {
+        if point.score > self.threshold {
+            self.cold_insert(point);
         }
     }
 
@@ -37,43 +43,114 @@ impl TopK {
         self.elements.is_empty()
     }
 
-    /// Returns the minimum score of the top k elements.
+    /// Score of the worst point that can still be kept.
     ///
-    /// Updated every 2k elements.
-    /// Initially set to `ScoreType::MIN`.
+    /// For `k` more than [`SORTED_K`] refreshed every `k` accepted points.
     pub fn threshold(&self) -> ScoreType {
         self.threshold
     }
 
-    pub fn push(&mut self, element: ScoredPointOffset) {
-        if element.score > self.threshold {
-            self.elements.push(Reverse(element));
+    /// Descending by score.
+    pub fn into_vec(mut self) -> Vec<ScoredPointOffset> {
+        if self.k >= SORTED_K {
+            self.elements.sort_unstable_by(descending);
+            self.elements.truncate(self.k);
+        }
+        self.elements
+    }
+
+    #[inline(never)]
+    fn cold_insert(&mut self, point: ScoredPointOffset) {
+        if self.k < SORTED_K {
+            if self.elements.len() < self.k {
+                self.elements.push(point); // Placeholder, overwritten by the slide below.
+            }
+
+            let points = &mut self.elements;
+            let mut position = points.len() - 1;
+            while position > 0 && points[position - 1].score < point.score {
+                points[position] = points[position - 1];
+                position -= 1;
+            }
+            points[position] = point;
+
+            if let Some(worst) = points.get(self.k - 1) {
+                self.threshold = worst.score;
+            }
+        } else {
+            // median algorithm described in https://quickwit.io/blog/top-k-complexity.
+            self.elements.push(point);
             // check if full
             if self.elements.len() == self.k.saturating_mul(2) {
-                let (_, median_el, _) = self.elements.select_nth_unstable(self.k - 1);
-                self.threshold = median_el.0.score;
+                let (_, kth, _) = self.elements.select_nth_unstable_by(self.k - 1, descending);
+                self.threshold = kth.score;
                 self.elements.truncate(self.k);
             }
         }
     }
+}
 
-    pub fn into_vec(mut self) -> Vec<ScoredPointOffset> {
-        self.elements.sort_unstable();
-        self.elements.truncate(self.k);
-        self.elements.into_iter().map(|Reverse(x)| x).collect()
-    }
+#[inline(always)]
+fn descending(a: &ScoredPointOffset, b: &ScoredPointOffset) -> std::cmp::Ordering {
+    b.score.total_cmp(&a.score)
 }
 
 #[cfg(test)]
 mod test {
+    use rand::rngs::StdRng;
+    use rand::{RngExt as _, SeedableRng as _};
+
     use super::*;
+    use crate::fixed_length_priority_queue::FixedLengthPriorityQueue;
+
+    /// Both strategies must keep the same scores as the reference queue, minus the NaNs.
+    #[test]
+    fn test_against_priority_queue() {
+        let mut rng = StdRng::seed_from_u64(42);
+        // Few distinct scores, to run into ties at the rejection threshold.
+        let points = (0..1000)
+            .map(|idx| ScoredPointOffset {
+                idx,
+                score: match idx % 37 {
+                    0 => ScoreType::NAN,
+                    _ => rng.random_range(0..50) as ScoreType,
+                },
+            })
+            .collect::<Vec<_>>();
+
+        for k in [1, 2, 10, 31, 32, 33, 999, 1000, 2000] {
+            let mut reference = FixedLengthPriorityQueue::new(k);
+            let mut top_k = TopK::new(k);
+            for &point in &points {
+                if !point.score.is_nan() {
+                    reference.push(point);
+                }
+                top_k.push(point);
+            }
+
+            let scores = |points: Vec<ScoredPointOffset>| {
+                points
+                    .into_iter()
+                    .map(|point| point.score)
+                    .collect::<Vec<_>>()
+            };
+            assert_eq!(
+                scores(top_k.into_vec()),
+                scores(reference.into_sorted_vec()),
+                "k={k}",
+            );
+        }
+    }
 
     #[test]
-    fn empty_with_double_capacity() {
+    fn empty_capacity() {
         let top_k = TopK::new(3);
         assert_eq!(top_k.len(), 0);
-        assert_eq!(top_k.elements.capacity(), 2 * 3);
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.elements.capacity(), 3);
+        assert_eq!(top_k.threshold(), ScoreType::NEG_INFINITY);
+
+        // From `SORTED_K` on, the buffer holds twice as many points as it keeps.
+        assert_eq!(TopK::new(SORTED_K).elements.capacity(), 2 * SORTED_K);
     }
 
     #[test]
@@ -102,11 +179,11 @@ mod test {
     fn test_top_k_under() {
         let mut top_k = TopK::new(3);
         top_k.push(ScoredPointOffset { score: 1.0, idx: 1 });
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.threshold(), ScoreType::NEG_INFINITY);
         assert_eq!(top_k.len(), 1);
 
         top_k.push(ScoredPointOffset { score: 2.0, idx: 2 });
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.threshold(), ScoreType::NEG_INFINITY);
         assert_eq!(top_k.len(), 2);
 
         let res = top_k.into_vec();
@@ -120,19 +197,20 @@ mod test {
         let mut top_k = TopK::new(3);
         top_k.push(ScoredPointOffset { score: 1.0, idx: 1 });
         assert_eq!(top_k.len(), 1);
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.threshold(), ScoreType::NEG_INFINITY);
 
         top_k.push(ScoredPointOffset { score: 3.0, idx: 3 });
         assert_eq!(top_k.len(), 2);
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.threshold(), ScoreType::NEG_INFINITY);
 
+        // The third point fills the queue, from now on the worst one is the threshold.
         top_k.push(ScoredPointOffset { score: 2.0, idx: 2 });
         assert_eq!(top_k.len(), 3);
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.threshold(), 1.0);
 
         top_k.push(ScoredPointOffset { score: 4.0, idx: 4 });
-        assert_eq!(top_k.len(), 4);
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        assert_eq!(top_k.len(), 3);
+        assert_eq!(top_k.threshold(), 2.0);
 
         let res = top_k.into_vec();
         assert_eq!(res.len(), 3);
@@ -144,30 +222,22 @@ mod test {
     #[test]
     fn test_top_k_pruned() {
         let mut top_k = TopK::new(3);
-        top_k.push(ScoredPointOffset { score: 1.0, idx: 1 });
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
-        assert_eq!(top_k.len(), 1);
-
-        top_k.push(ScoredPointOffset { score: 4.0, idx: 4 });
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
-        assert_eq!(top_k.len(), 2);
-
-        top_k.push(ScoredPointOffset { score: 2.0, idx: 2 });
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        for (score, idx) in [(1.0, 1), (4.0, 4), (2.0, 2)] {
+            top_k.push(ScoredPointOffset { idx, score });
+        }
         assert_eq!(top_k.len(), 3);
+        assert_eq!(top_k.threshold(), 1.0);
 
+        // Every further point evicts the worst one and raises the threshold.
         top_k.push(ScoredPointOffset { score: 5.0, idx: 5 });
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
-        assert_eq!(top_k.len(), 4);
+        assert_eq!(top_k.threshold(), 2.0);
 
         top_k.push(ScoredPointOffset { score: 3.0, idx: 3 });
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
-        assert_eq!(top_k.len(), 5);
+        assert_eq!(top_k.threshold(), 3.0);
 
         top_k.push(ScoredPointOffset { score: 6.0, idx: 6 });
         assert_eq!(top_k.threshold(), 4.0);
         assert_eq!(top_k.len(), 3);
-        assert_eq!(top_k.elements.capacity(), 6);
 
         let res = top_k.into_vec();
         assert_eq!(res.len(), 3);
@@ -179,30 +249,18 @@ mod test {
     #[test]
     fn test_top_same_scores() {
         let mut top_k = TopK::new(3);
-        top_k.push(ScoredPointOffset { score: 1.0, idx: 1 });
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
-        assert_eq!(top_k.len(), 1);
-
-        top_k.push(ScoredPointOffset { score: 1.0, idx: 4 });
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
-        assert_eq!(top_k.len(), 2);
-
-        top_k.push(ScoredPointOffset { score: 2.0, idx: 2 });
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
+        for (score, idx) in [(1.0, 1), (1.0, 4), (2.0, 2)] {
+            top_k.push(ScoredPointOffset { idx, score });
+        }
         assert_eq!(top_k.len(), 3);
-
-        top_k.push(ScoredPointOffset { score: 1.0, idx: 5 });
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
-        assert_eq!(top_k.len(), 4);
-
-        top_k.push(ScoredPointOffset { score: 1.0, idx: 3 });
-        assert_eq!(top_k.threshold(), ScoreType::MIN);
-        assert_eq!(top_k.len(), 5);
-
-        top_k.push(ScoredPointOffset { score: 1.0, idx: 6 });
         assert_eq!(top_k.threshold(), 1.0);
-        assert_eq!(top_k.len(), 3);
-        assert_eq!(top_k.elements.capacity(), 6);
+
+        // A score equal to the threshold does not displace the points already kept.
+        for (score, idx) in [(1.0, 5), (1.0, 3), (1.0, 6)] {
+            top_k.push(ScoredPointOffset { idx, score });
+            assert_eq!(top_k.len(), 3);
+            assert_eq!(top_k.threshold(), 1.0);
+        }
 
         let res = top_k.into_vec();
         assert_eq!(res.len(), 3);

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -515,13 +515,7 @@ impl<'a> BatchFilteredSearcher<'a> {
             // Switching the loops improves batching performance, but slightly degrades single-query performance.
             for BatchSearch { raw_scorer, pq } in &mut self.scorer_batch {
                 raw_scorer.score_points(&chunk[..chunk_size], &mut scores_buffer[..chunk_size]);
-
-                for i in 0..chunk_size {
-                    pq.push(ScoredPointOffset {
-                        idx: chunk[i],
-                        score: scores_buffer[i],
-                    });
-                }
+                push_scored_chunk(pq, &chunk[..chunk_size], &scores_buffer[..chunk_size]);
             }
         }
 
@@ -552,14 +546,42 @@ fn score_chunk(
     }
     for BatchSearch { raw_scorer, pq } in scorer_batch {
         raw_scorer.score_points(chunk, &mut scores_buffer[..chunk.len()]);
-        for i in 0..chunk.len() {
-            pq.push(ScoredPointOffset {
-                idx: chunk[i],
-                score: scores_buffer[i],
-            });
-        }
+        push_scored_chunk(pq, chunk, &scores_buffer[..chunk.len()]);
     }
     Ok(())
+}
+
+/// Push one chunk of scored ids into `pq`, skipping scores that cannot enter
+/// the full queue.
+/// The outcome is identical to unconditionally pushing every entry.
+#[inline]
+fn push_scored_chunk(
+    pq: &mut FixedLengthPriorityQueue<ScoredPointOffset>,
+    ids: &[PointOffsetType],
+    scores: &[ScoreType],
+) {
+    // Score of the queue's current minimum
+    let mut threshold = pq
+        .is_full()
+        .then(|| pq.top().expect("full queue is not empty").score);
+
+    for (&idx, &score) in ids.iter().zip(scores) {
+        // A score at or below the minimum cannot displace anything — `push`
+        // would hand it back untouched (`ScoredPointOffset` orders by score
+        // alone; NaN falls through to `push`). Rejecting on this register-held
+        // f32 compare skips the call and its heap bookkeeping, and with
+        // `top` ≪ point count nearly every push in a full scan is a rejection.
+        if let Some(threshold) = threshold
+            && score <= threshold
+        {
+            continue;
+        }
+
+        pq.push(ScoredPointOffset { idx, score });
+        if pq.is_full() {
+            threshold = Some(pq.top().expect("full queue is not empty").score);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -688,6 +710,39 @@ mod tests {
                     .unwrap();
 
             assert_eq!(visible, reference, "case {case_idx}");
+        }
+    }
+
+    /// The threshold gate in [`push_scored_chunk`] must leave the queue in
+    /// exactly the state unconditional `push` calls produce — including a
+    /// not-yet-full queue and ties with the current minimum (a coarse score
+    /// grid forces both).
+    #[test]
+    fn push_scored_chunk_matches_plain_push() {
+        let mut rng = StdRng::seed_from_u64(7);
+        for top in [1, 3, 32] {
+            for len in [0usize, 1, 5, 64, 300] {
+                let ids: Vec<PointOffsetType> = (0..len as PointOffsetType).collect();
+                let scores: Vec<ScoreType> = (0..len)
+                    .map(|_| rng.random_range(0..8) as ScoreType)
+                    .collect();
+
+                let mut gated = FixedLengthPriorityQueue::new(top);
+                for (chunk_ids, chunk_scores) in ids.chunks(64).zip(scores.chunks(64)) {
+                    push_scored_chunk(&mut gated, chunk_ids, chunk_scores);
+                }
+
+                let mut plain = FixedLengthPriorityQueue::new(top);
+                for (&idx, &score) in ids.iter().zip(&scores) {
+                    plain.push(ScoredPointOffset { idx, score });
+                }
+
+                assert_eq!(
+                    gated.into_sorted_vec(),
+                    plain.into_sorted_vec(),
+                    "top {top}, len {len}"
+                );
+            }
         }
     }
 }

--- a/lib/segment/src/index/hnsw_index/point_scorer.rs
+++ b/lib/segment/src/index/hnsw_index/point_scorer.rs
@@ -4,8 +4,8 @@ use common::bitmap_scan::BatchedBitmapScan;
 use common::bitvec::BitSlice;
 use common::condition_checker::{CheckItem, ConditionChecker, Rest, Select};
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::generic_consts::Random;
+use common::top_k::TopK;
 use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
 use smallvec::SmallVec;
 
@@ -307,7 +307,7 @@ impl<'a> FilteredScorer<'a> {
 // We keep each scorer with its queue to reduce allocations and improve data locality.
 struct BatchSearch<'a> {
     raw_scorer: Box<dyn RawScorer + 'a>,
-    pq: FixedLengthPriorityQueue<ScoredPointOffset>,
+    top_k: TopK,
 }
 
 pub struct BatchFilteredSearcher<'a> {
@@ -343,8 +343,8 @@ impl<'a> BatchFilteredSearcher<'a> {
                     }
                     None => vectors.build_raw_scorer(query, hardware_counter),
                 };
-                let pq = FixedLengthPriorityQueue::new(top);
-                raw_scorer.map(|raw_scorer| BatchSearch { raw_scorer, pq })
+                let top_k = TopK::new(top);
+                raw_scorer.map(|raw_scorer| BatchSearch { raw_scorer, top_k })
             })
             .collect::<Result<_, _>>()?;
         let filters =
@@ -378,7 +378,7 @@ impl<'a> BatchFilteredSearcher<'a> {
                 .unwrap();
                 BatchSearch {
                     raw_scorer,
-                    pq: FixedLengthPriorityQueue::new(top),
+                    top_k: TopK::new(top),
                 }
             })
             .collect();
@@ -476,7 +476,7 @@ impl<'a> BatchFilteredSearcher<'a> {
 
         let results = scorer_batch
             .into_iter()
-            .map(|BatchSearch { pq, .. }| pq.into_sorted_vec())
+            .map(|BatchSearch { top_k, .. }| top_k.into_vec())
             .collect();
         Ok(results)
     }
@@ -513,16 +513,22 @@ impl<'a> BatchFilteredSearcher<'a> {
             }
 
             // Switching the loops improves batching performance, but slightly degrades single-query performance.
-            for BatchSearch { raw_scorer, pq } in &mut self.scorer_batch {
+            for BatchSearch { raw_scorer, top_k } in &mut self.scorer_batch {
                 raw_scorer.score_points(&chunk[..chunk_size], &mut scores_buffer[..chunk_size]);
-                push_scored_chunk(pq, &chunk[..chunk_size], &scores_buffer[..chunk_size]);
+
+                for i in 0..chunk_size {
+                    top_k.push(ScoredPointOffset {
+                        idx: chunk[i],
+                        score: scores_buffer[i],
+                    });
+                }
             }
         }
 
         let results = self
             .scorer_batch
             .into_iter()
-            .map(|BatchSearch { pq, .. }| pq.into_sorted_vec())
+            .map(|BatchSearch { top_k, .. }| top_k.into_vec())
             .collect();
         Ok(results)
     }
@@ -544,44 +550,16 @@ fn score_chunk(
     if chunk.is_empty() {
         return Ok(());
     }
-    for BatchSearch { raw_scorer, pq } in scorer_batch {
+    for BatchSearch { raw_scorer, top_k } in scorer_batch {
         raw_scorer.score_points(chunk, &mut scores_buffer[..chunk.len()]);
-        push_scored_chunk(pq, chunk, &scores_buffer[..chunk.len()]);
+        for i in 0..chunk.len() {
+            top_k.push(ScoredPointOffset {
+                idx: chunk[i],
+                score: scores_buffer[i],
+            });
+        }
     }
     Ok(())
-}
-
-/// Push one chunk of scored ids into `pq`, skipping scores that cannot enter
-/// the full queue.
-/// The outcome is identical to unconditionally pushing every entry.
-#[inline]
-fn push_scored_chunk(
-    pq: &mut FixedLengthPriorityQueue<ScoredPointOffset>,
-    ids: &[PointOffsetType],
-    scores: &[ScoreType],
-) {
-    // Score of the queue's current minimum
-    let mut threshold = pq
-        .is_full()
-        .then(|| pq.top().expect("full queue is not empty").score);
-
-    for (&idx, &score) in ids.iter().zip(scores) {
-        // A score at or below the minimum cannot displace anything — `push`
-        // would hand it back untouched (`ScoredPointOffset` orders by score
-        // alone; NaN falls through to `push`). Rejecting on this register-held
-        // f32 compare skips the call and its heap bookkeeping, and with
-        // `top` ≪ point count nearly every push in a full scan is a rejection.
-        if let Some(threshold) = threshold
-            && score <= threshold
-        {
-            continue;
-        }
-
-        pq.push(ScoredPointOffset { idx, score });
-        if pq.is_full() {
-            threshold = Some(pq.top().expect("full queue is not empty").score);
-        }
-    }
 }
 
 #[cfg(test)]
@@ -710,39 +688,6 @@ mod tests {
                     .unwrap();
 
             assert_eq!(visible, reference, "case {case_idx}");
-        }
-    }
-
-    /// The threshold gate in [`push_scored_chunk`] must leave the queue in
-    /// exactly the state unconditional `push` calls produce — including a
-    /// not-yet-full queue and ties with the current minimum (a coarse score
-    /// grid forces both).
-    #[test]
-    fn push_scored_chunk_matches_plain_push() {
-        let mut rng = StdRng::seed_from_u64(7);
-        for top in [1, 3, 32] {
-            for len in [0usize, 1, 5, 64, 300] {
-                let ids: Vec<PointOffsetType> = (0..len as PointOffsetType).collect();
-                let scores: Vec<ScoreType> = (0..len)
-                    .map(|_| rng.random_range(0..8) as ScoreType)
-                    .collect();
-
-                let mut gated = FixedLengthPriorityQueue::new(top);
-                for (chunk_ids, chunk_scores) in ids.chunks(64).zip(scores.chunks(64)) {
-                    push_scored_chunk(&mut gated, chunk_ids, chunk_scores);
-                }
-
-                let mut plain = FixedLengthPriorityQueue::new(top);
-                for (&idx, &score) in ids.iter().zip(&scores) {
-                    plain.push(ScoredPointOffset { idx, score });
-                }
-
-                assert_eq!(
-                    gated.into_sorted_vec(),
-                    plain.into_sorted_vec(),
-                    "top {top}, len {len}"
-                );
-            }
         }
     }
 }

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -702,8 +702,11 @@ mod tests {
             .exactly_one()
             .unwrap();
         assert_eq!(closest.len(), 2, "must have 2 vectors, 3 are deleted");
-        assert_eq!(closest[0].idx, 4);
-        assert_eq!(closest[1].idx, 0);
+        // Points 0 and 4 both score 1.0 against this query; order among equal
+        // scores is unspecified, so assert the set rather than positions.
+        let mut ids = closest.iter().map(|p| p.idx).collect::<Vec<_>>();
+        ids.sort_unstable();
+        assert_eq!(ids, [0, 4]);
 
         // Delete all
         storage.delete_vector(0 as PointOffsetType).unwrap();

--- a/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_dense_vector_storage.rs
@@ -109,8 +109,11 @@ fn do_test_delete_points(storage: &mut VectorStorageEnum) {
         .exactly_one()
         .unwrap();
     assert_eq!(closest.len(), 2, "must have 2 vectors, 3 are deleted");
-    assert_eq!(closest[0].idx, 4);
-    assert_eq!(closest[1].idx, 0);
+    // Points 0 and 4 both score 1.0 against this query; order among equal
+    // scores is unspecified, so assert the set rather than positions.
+    let mut ids = closest.iter().map(|p| p.idx).collect::<Vec<_>>();
+    ids.sort_unstable();
+    assert_eq!(ids, [0, 4]);
 
     // Delete all
     assert!(storage.delete_vector(0 as PointOffsetType).unwrap());


### PR DESCRIPTION
This PR optimizes priority queue's pushing logic for full-scan / exact search. (~HNSW search not affected~ For HNSW changes, see comments).

The `peek_mut()` function from `BinaryHeap` is not free, it runs a comparatively expensive operation when dropping the mutable guard it returns.

Before pushing a point-chunk into a full PriorityQueue, we can cheaply grab the smallest item from it and skip all candidates that don't meet that threshold. This skips `peek_mut()` entirely. 
Especially for the full-scan scenario, we're rejecting a lot of items, so this cheap prefilter reduces the overhead of the PriorityQueue noticeably.

## Benchmark results
Performance improvement for Turbo4 datatype across common dimensions. The PriorityQueue is not dependent on the dimensionality and therefore the performance improvement will converge against 0 instead of resulting in performance regression for very large dims.

<img width="1584" height="864" alt="bench_push_gate_exact" src="https://github.com/user-attachments/assets/56b1842b-6e2a-4381-82fb-12d70c2a86cc" />


#### Numbers in detail:
| dim | dev (median qps) | pr (median qps) | dev (median server time) | pr (median server time) | Δ qps |
|---|---|---|---|---|---|
| 128 | 165.7 | **194.1** | 23.58 ms | 19.85 ms | +17.1% |
| 256 | 127.4 | **146.7** | 30.67 ms | 26.59 ms | +15.2% |
| 512 | 94.8 | **102.8** | 41.79 ms | 38.31 ms | +8.4% |
| 768 | 73.8 | **78.0** | 53.93 ms | 50.67 ms | +5.8% |
| 1024 | 60.1 | **62.8** | 66.80 ms | 63.68 ms | +4.5% |
| 2048 | 33.9 | **34.8** | 118.87 ms | 120.89 ms | +2.4% |

### Chunk size
Below the benchmark results across different chunk-sizes for which the new helper method is being called with.

| chunk size | `push_scored_chunk()` (PR) | direct `pq.push()` (Dev) | speedup |
|---|---|---|---|
| 1 | **2.48 ns** | 5.19 ns | 2.1x | 
| 2 | **2.88 ns** | 9.47 ns | 3.3x | 
| 8 | **4.83 ns** | 32.9 ns | 6.8x | 
| 64 | **28.98 ns** | 257.1 ns | 8.9x | 

The greater the chunk size, the bigger the performance improvement. However, even on a chunk-size of `1` (worst case), this PR won't introduce any performance regression (PR is actually **2x faster**).

## HNSW
This fix is deliberately not implemented directly into `PriorityQueue::push()` because it only improves performance if there are a lot of *rejections*.
In HNSW search case, we reject not as nearly as much items as we do in full-scan.
Benchmarks showed a very small regression in the HNSW search case for some dims, so I decided to make it a helper function for full-scan only. 