### PR TITLE
fix(segment): make IsNullCondition consistent for arrays

### DIFF
--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -26,10 +26,14 @@ pub fn check_is_empty<'a>(values: impl IntoIterator<Item = &'a Value>) -> bool {
 }
 
 pub fn check_is_null<'a>(values: impl IntoIterator<Item = &'a Value>) -> bool {
-    values.into_iter().any(|x| x.is_null())
-    // { "a": [ { "b": null }, { "b": 1 } ] } => true
-    // { "a": [ { "b": 1 }, { "b": null } ] } => true
-    // { "a": [ { "b": 1 }, { "b": 2 } ] } => false
+    values.into_iter().any(|value| match value {
+        Value::Array(values) => values.iter().any(|value| value.is_null()),
+        Value::Null => true,
+        Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Object(_) => false,
+    })
+    // { "a": [null, 1] } => true
+    // { "a": [1, null] } => true
+    // { "a": [1, 2] } => false
 }
 
 pub fn rev_range(a: usize, b: usize) -> impl Iterator<Item = usize> {

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -359,7 +359,8 @@ mod tests {
             "shipped_at": "2020-02-15T00:00:00Z",
             "parts": [],
             "packaging": null,
-            "not_null": [null],
+            "not_null": [true],
+            "null_array": [null, 1],
         };
 
         let hw_counter = HardwareCounterCell::new();
@@ -444,6 +445,13 @@ mod tests {
             },
         }));
         assert!(!payload_checker.check(0, &is_null_condition));
+
+        let is_null_condition = Filter::new_must(Condition::IsNull(IsNullCondition {
+            is_null: PayloadField {
+                key: JsonPath::new("null_array"),
+            },
+        }));
+        assert!(payload_checker.check(0, &is_null_condition));
 
         let match_red = Condition::Field(FieldCondition::new_match(
             JsonPath::new("color"),


### PR DESCRIPTION
## Summary

- Make the unindexed IsNullCondition path inspect array elements for null values.
- Add regression coverage for an unindexed [null, 1] payload.

Closes #10096

## Validation

- cargo test -p segment --lib payload_storage::query_checker::tests::test_condition_checker
- cargo clippy -p segment --lib --tests
- git diff --check

cargo +nightly fmt --all -- --check could not be completed in this Windows environment because rustup stalled while invoking the installed nightly toolchain. The stable formatter also reports an existing upstream formatting difference in lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs; no unrelated file was changed.

## AI disclosure

This patch was prepared with AI assistance. Initial prompt: implement qdrant/qdrant#10096, keep the change focused on the unindexed IsNullCondition array behavior, and add a deterministic Rust regression test.