### PR TITLE
fix: make IsNullCondition treat array nulls like FieldCondition

### DIFF
--- a/lib/segment/src/common/utils.rs
+++ b/lib/segment/src/common/utils.rs
@@ -26,10 +26,18 @@ pub fn check_is_empty<'a>(values: impl IntoIterator<Item = &'a Value>) -> bool {
 }
 
 pub fn check_is_null<'a>(values: impl IntoIterator<Item = &'a Value>) -> bool {
-    values.into_iter().any(|x| x.is_null())
-    // { "a": [ { "b": null }, { "b": 1 } ] } => true
-    // { "a": [ { "b": 1 }, { "b": null } ] } => true
-    // { "a": [ { "b": 1 }, { "b": 2 } ] } => false
+    // Match FieldCondition / NullIndex semantics: a field is null if any
+    // top-level value is Null, or any array value contains a Null element.
+    // { "a": null } => true
+    // { "a": [null, 1] } => true
+    // { "a": [1, 2] } => false
+    // { "a": [ { "b": null }, { "b": 1 } ] } with key "a[].b" => true
+    //   (nested paths are flattened by get_value into separate values)
+    values.into_iter().any(|x| match x {
+        Value::Null => true,
+        Value::Array(arr) => arr.iter().any(Value::is_null),
+        Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Object(_) => false,
+    })
 }
 
 pub fn rev_range(a: usize, b: usize) -> impl Iterator<Item = usize> {
@@ -140,8 +148,29 @@ impl<T: JsonSchema> JsonSchema for MaybeOneOrMany<T> {
 mod tests {
     use schemars::{JsonSchema, schema_for};
     use serde::{Deserialize, Serialize};
+    use serde_json::json;
 
-    use crate::common::utils::MaybeOneOrMany;
+    use crate::common::utils::{MaybeOneOrMany, check_is_null};
+
+    #[test]
+    fn test_check_is_null_matches_array_containing_null() {
+        // Plain null
+        assert!(check_is_null([&json!(null)]));
+        // Array with only null — must match (parity with FieldCondition / NullIndex)
+        assert!(check_is_null([&json!([null])]));
+        // Array with null mixed with other values — the reported inconsistency case
+        assert!(check_is_null([&json!([null, "a"])]));
+        assert!(check_is_null([&json!(["a", null])]));
+        // Non-null values
+        assert!(!check_is_null([&json!("a")]));
+        assert!(!check_is_null([&json!(["a"])]));
+        assert!(!check_is_null([&json!([])]));
+        assert!(!check_is_null([&json!(1)]));
+        assert!(!check_is_null([&json!({"b": null})]));
+        // Multiple flattened values (as from nested path get_value)
+        assert!(check_is_null([&json!(1), &json!(null)]));
+        assert!(!check_is_null([&json!(1), &json!(2)]));
+    }
 
     #[test]
     fn test_deserialize_one_or_many() {

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -359,7 +359,8 @@ mod tests {
             "shipped_at": "2020-02-15T00:00:00Z",
             "parts": [],
             "packaging": null,
-            "not_null": [null],
+            "array_with_null": [null],
+            "array_with_null_and_value": [null, "a"],
         };
 
         let hw_counter = HardwareCounterCell::new();
@@ -405,7 +406,7 @@ mod tests {
 
         let is_empty_condition = Filter::new_must(Condition::IsEmpty(IsEmptyCondition {
             is_empty: PayloadField {
-                key: JsonPath::new("not_null"),
+                key: JsonPath::new("array_with_null"),
             },
         }));
         assert!(!payload_checker.check(0, &is_empty_condition));
@@ -438,12 +439,21 @@ mod tests {
         }));
         assert!(payload_checker.check(0, &is_null_condition));
 
+        // Arrays containing null must match IsNullCondition (parity with
+        // FieldCondition { is_null: true } and NullIndex / indexed filters).
         let is_null_condition = Filter::new_must(Condition::IsNull(IsNullCondition {
             is_null: PayloadField {
-                key: JsonPath::new("not_null"),
+                key: JsonPath::new("array_with_null"),
             },
         }));
-        assert!(!payload_checker.check(0, &is_null_condition));
+        assert!(payload_checker.check(0, &is_null_condition));
+
+        let is_null_condition = Filter::new_must(Condition::IsNull(IsNullCondition {
+            is_null: PayloadField {
+                key: JsonPath::new("array_with_null_and_value"),
+            },
+        }));
+        assert!(payload_checker.check(0, &is_null_condition));
 
         let match_red = Condition::Field(FieldCondition::new_match(
             JsonPath::new("color"),

--- a/tests/openapi/test_is_null_array_consistency.py
+++ b/tests/openapi/test_is_null_array_consistency.py
@@ -1,0 +1,102 @@
+"""Regression for https://github.com/qdrant/qdrant/issues/10096
+
+IsNullCondition (`{"is_null":{"key":...}}`) must match arrays containing null
+the same way as FieldCondition (`{"key":...,"is_null":true}`), whether or not
+the field is indexed.
+"""
+
+import pytest
+
+from .helpers.collection_setup import drop_collection
+from .helpers.helpers import request_with_validation
+
+POINTS = [
+    {"id": 1, "payload": {"s": [None, "a"]}, "vector": [0.2, 0.3]},
+    {"id": 2, "payload": {"s": None}, "vector": [0.2, 0.4]},
+    {"id": 3, "payload": {"s": ["a"]}, "vector": [0.1, 0.4]},
+    {"id": 4, "payload": {"s": [None]}, "vector": [0.1, 0.5]},
+]
+
+# Points whose payload field `s` contains a null (literal or inside an array).
+EXPECTED_NULL_IDS = {1, 2, 4}
+
+
+def _create_collection(name: str, with_keyword_index: bool):
+    drop_collection(collection_name=name)
+    response = request_with_validation(
+        api='/collections/{collection_name}',
+        method="PUT",
+        path_params={'collection_name': name},
+        body={
+            "vectors": {
+                "size": 2,
+                "distance": "Dot",
+            },
+        },
+    )
+    assert response.ok
+
+    if with_keyword_index:
+        response = request_with_validation(
+            api='/collections/{collection_name}/index',
+            method="PUT",
+            path_params={'collection_name': name},
+            query_params={'wait': 'true'},
+            body={
+                "field_name": "s",
+                "field_schema": "keyword",
+            },
+        )
+        assert response.ok
+
+    response = request_with_validation(
+        api='/collections/{collection_name}/points',
+        method="PUT",
+        path_params={'collection_name': name},
+        query_params={'wait': 'true'},
+        body={"points": POINTS},
+    )
+    assert response.ok
+
+
+def _scroll_ids(collection_name: str, filt: dict) -> set[int]:
+    response = request_with_validation(
+        api='/collections/{collection_name}/points/scroll',
+        method="POST",
+        path_params={'collection_name': collection_name},
+        body={
+            "filter": filt,
+            "limit": 100,
+            "with_payload": True,
+        },
+    )
+    assert response.ok
+    return {point['id'] for point in response.json()['result']['points']}
+
+
+@pytest.fixture(scope="module")
+def collections():
+    indexed = "test_is_null_array_indexed"
+    unindexed = "test_is_null_array_unindexed"
+    _create_collection(indexed, with_keyword_index=True)
+    _create_collection(unindexed, with_keyword_index=False)
+    yield indexed, unindexed
+    drop_collection(collection_name=indexed)
+    drop_collection(collection_name=unindexed)
+
+
+@pytest.mark.parametrize(
+    "filter_body",
+    [
+        {"must": [{"is_null": {"key": "s"}}]},
+        {"must": [{"key": "s", "is_null": True}]},
+    ],
+    ids=["IsNullCondition", "FieldCondition_is_null"],
+)
+def test_is_null_array_consistent_indexed_and_unindexed(collections, filter_body):
+    indexed, unindexed = collections
+    indexed_ids = _scroll_ids(indexed, filter_body)
+    unindexed_ids = _scroll_ids(unindexed, filter_body)
+    assert indexed_ids == EXPECTED_NULL_IDS
+    assert unindexed_ids == EXPECTED_NULL_IDS
+    assert indexed_ids == unindexed_ids


### PR DESCRIPTION
### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

---

Fixes #10096

### Summary

`Condition::IsNull` (`{"is_null":{"key":…}}`) on an **unindexed** field only matched a top-level JSON `null`. It did **not** match array values that contain `null` (e.g. `[null, "a"]` or `[null]`).

The other three combinations already matched those points:

- indexed + `IsNullCondition`
- indexed + `FieldCondition { is_null: true }`
- unindexed + `FieldCondition { is_null: true }`

### Cause

Unindexed `IsNullCondition` goes through `check_is_null` in `lib/segment/src/common/utils.rs`, which only did `Value::is_null()` on each value returned by `get_value`. For `"s": [null, "a"]`, that value is an **array**, so it never matched.

`FieldCondition` and `NullIndex` already treat “any array element is null” as null.

### Change

Update `check_is_null` so a value matches if it is `Null` **or** an array that contains a `Null` element — same rule as `FieldCondition` / `NullIndex`.

### Tests

- Unit coverage for `check_is_null` (including `[null, "a"]`)
- Updated `query_checker` assertions that previously expected `[null]` **not** to match `IsNullCondition`
- OpenAPI regression: `tests/openapi/test_is_null_array_consistency.py` (indexed vs unindexed, both filter forms)

### How to test

1. Reproduce with the HTTP script from #10096 (or the openapi test above).
2. Before the fix, unindexed `{"must":[{"is_null":{"key":"s"}}]}` returns only point `2`.
3. After the fix, all four scroll queries return points `1`, `2`, and `4`.

Local checks run:

- `cargo test -p segment --lib --features testing check_is_null`
- `cargo test -p segment --lib --features testing test_condition_checker`
- `cargo clippy -p segment --lib --features testing --no-deps -- -D warnings`
- Manual HTTP repro against a locally built `qdrant` binary