### PR TITLE
Fix flaky test_scale_down_revert_crash_orphans_resharding_state

### DIFF
--- a/tests/consensus_tests/test_resharding_down_revert_crash_orphans_state.py
+++ b/tests/consensus_tests/test_resharding_down_revert_crash_orphans_state.py
@@ -92,18 +92,34 @@ def test_scale_down_revert_crash_orphans_resharding_state(tmp_path: pathlib.Path
     )
 
     receiver_idx = peer_ids.index(receiver_peer)
-    victim_idx = next(i for i in range(3) if i != receiver_idx)
-    survivor_idx = next(i for i in range(3) if i not in (receiver_idx, victim_idx))
-    survivor_uri = peer_uris[survivor_idx]
-
-    # The staging crash fires on the peer whose working dir holds this marker.
-    (peer_dirs[victim_idx] / "crash_on_scale_down_revert").write_text("")
+    live_idxs = [i for i in range(3) if i != receiver_idx]
+    live_ids = {peer_ids[i] for i in live_idxs}
 
     # Kill the receiver; failing updates to its shard-0 replica make failure detection
     # propose SetReplicaState(Dead), whose gate aborts resharding on the live peers.
     receiver_proc = peer_procs[receiver_idx]
     processes.remove(receiver_proc)
     receiver_proc.kill()
+
+    # Crash the follower, never the leader, and wait out the election the receiver's
+    # death may have triggered first. The staging crash fires *inside* the apply of the
+    # `Dead` entry while raft messages leave through an async send queue, so a crashing
+    # leader takes the append carrying the new commit index down with it: the other live
+    # peer is left holding that entry appended but uncommitted, and as one voter out of
+    # three it can never commit it — so it would never abort, and the wait below would
+    # hang until the peers are restarted.
+    def leader_is_live_and_agreed() -> bool:
+        leaders = {get_leader(peer_uris[i]) for i in live_idxs}
+        return len(leaders) == 1 and leaders <= live_ids
+
+    wait_for(leader_is_live_and_agreed, wait_for_timeout=60)
+
+    survivor_idx = peer_ids.index(get_leader(peer_uris[live_idxs[0]]))
+    victim_idx = next(i for i in live_idxs if i != survivor_idx)
+    survivor_uri = peer_uris[survivor_idx]
+
+    # The staging crash fires on the peer whose working dir holds this marker.
+    (peer_dirs[victim_idx] / "crash_on_scale_down_revert").write_text("")
 
     stop = threading.Event()
 


### PR DESCRIPTION
## Problem

`test_scale_down_revert_crash_orphans_resharding_state` intermittently fails in CI with:

```
Exception: Timeout waiting for condition <lambda> to be satisfied in 30 seconds
```

That is the `wait_for(lambda: _resharding_ops(survivor_uri) == 0)` checkpoint, and once it goes wrong the surviving peer can never satisfy it.

The test picks the crashing peer positionally (`next(i for i in range(3) if i != receiver_idx)`), so it can be the raft leader. In the failing run the killed receiver *was* the term-1 leader, and the peer holding the crash marker won the term-2 election. From its log:

- `53.077` leader appends 26/27 = `SetShardReplicaState(..., Dead)` for the killed receiver
- `53.100` the other live peer acks index 27, still at commit 25
- `53.111435` the `bcast_append` carrying commit=27 is queued into the async raft message broker (`src/consensus.rs:1055` — mpsc → tokio task → gRPC)
- `53.116772` the apply of entry 26 reaches the staging hook and calls `std::process::exit(1)` (`lib/collection/src/collection/resharding.rs:396`), 5.3 ms later

The queued append never left the process. The surviving peer's last raft message is `MsgAppend{entries:[26,27], commit: 25}`; its persisted state stays at `commit: 25` with both entries in the log but uncommitted. As one voter out of three it cannot elect itself (terms 9→13 in the log, all failing), so entry 26 never commits, resharding is never aborted there, and the wait times out — the restart that would restore quorum only happens after it.

This is ordinary raft behaviour, not a product bug; it is only observable because the staging hook exits inside the apply, and everything converges once the peers restart.

## Fix

Pick the victim after the receiver is killed: wait for the two live peers to agree on a live leader, keep that leader as the survivor and crash the follower. The survivor then commits the abort entry with the victim's ack and applies it locally, so the checkpoint no longer depends on a commit index escaping a dying process. The wait also absorbs the election the receiver's death triggers.

## Test plan

- Fixed test: 5/5 local passes (26–34 s each).
- Mechanism check: a temporary copy forced to crash the *leader* still passed 5/5 locally (3× normal, 2× under 4× CPU oversubscription) — locally the append escapes 38–99 ms before the `exit(1)`, versus the 5.3 ms that lost in CI. That margin is why this shows up as a flake rather than a consistent failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)