### PR TITLE
Add writer for stored bitmask type

### DIFF
--- a/lib/common/common/src/stored_bitmask/format.rs
+++ b/lib/common/common/src/stored_bitmask/format.rs
@@ -10,6 +10,9 @@ pub(super) const MAGIC: [u8; 4] = *b"QBMK";
 pub(super) const VERSION: u32 = 1;
 pub(super) const HEADER_SIZE: usize = size_of::<BitmaskHeader>();
 
+/// Maximum logical length: every bit position must be representable as `u32`.
+pub(super) const MAX_LOGICAL_LEN: u64 = 1 << 32;
+
 /// How the payload following the header encodes the mask.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(super) enum Encoding {

--- a/lib/common/common/src/stored_bitmask/mod.rs
+++ b/lib/common/common/src/stored_bitmask/mod.rs
@@ -4,15 +4,20 @@
 //! or raw dense bits when that is smaller — the file is never larger than
 //! the dense representation.
 //!
-//! There is no in-place mutation: [`save_bitmask`] replaces the file
-//! atomically, so an open always sees a consistent snapshot.
+//! The file is never mutated in place: every save ([`save_bitmask`] or
+//! [`MutableStoredBitmask::save`]) rewrites and replaces it atomically, so
+//! an open always sees a consistent snapshot. [`MutableStoredBitmask`] is
+//! the mutable in-RAM handle: it materializes the mask at open, collects
+//! changes, and skips the rewrite when nothing changed.
 
 mod format;
+mod mutable;
 mod read;
 #[cfg(test)]
 mod tests;
 mod write;
 
 pub use format::BitmaskContent;
+pub use mutable::MutableStoredBitmask;
 pub use read::StoredBitmask;
 pub use write::save_bitmask;

--- a/lib/common/common/src/stored_bitmask/mutable.rs
+++ b/lib/common/common/src/stored_bitmask/mutable.rs
@@ -1,0 +1,171 @@
+use std::path::Path;
+
+use roaring::RoaringBitmap;
+
+use super::format::MAX_LOGICAL_LEN;
+use super::read::StoredBitmask;
+use super::write::bitmask_file_bytes;
+use crate::universal_io::{OpenOptions, UioResult, UniversalReadFs, UniversalWriteFileOps};
+
+/// Mutable in-RAM handle over a bitmask persisted by [`save_bitmask`].
+///
+/// [`Self::open`] materializes the whole mask into a bitmap of the set
+/// positions and drops the file handle; reads and mutations then operate on
+/// RAM only. Changes are tracked per position, and [`Self::save`] rewrites
+/// the whole file atomically — or skips the write entirely when the mask has
+/// not effectively changed since it was opened or last saved.
+///
+/// Not a concurrency primitive: mutations and saves take `&mut self`, and
+/// there is no interior locking. Sharing and flush orchestration belong to a
+/// wrapper.
+///
+/// [`save_bitmask`]: super::save_bitmask
+#[derive(Debug)]
+pub struct MutableStoredBitmask {
+    /// Number of logical flags (bits) in the mask.
+    logical_len: u64,
+    /// Authoritative set positions. Invariant: every position is below
+    /// `logical_len`.
+    ones: RoaringBitmap,
+    /// Positions whose current value differs from the last persisted
+    /// snapshot; empty right after [`Self::open`] and [`Self::save`].
+    changed: RoaringBitmap,
+    /// `logical_len` of the last persisted snapshot; `None` when the mask
+    /// has never been persisted (fresh [`Self::new`]).
+    persisted_len: Option<u64>,
+}
+
+impl MutableStoredBitmask {
+    /// Fresh all-zeros mask of `logical_len` bits, not persisted anywhere
+    /// yet: the first [`Self::save`] writes the file even with no set bits.
+    ///
+    /// # Panics
+    ///
+    /// If `logical_len` exceeds the `u32` position space.
+    pub fn new(logical_len: u64) -> Self {
+        assert!(
+            logical_len <= MAX_LOGICAL_LEN,
+            "bitmask of {logical_len} bits exceeds the u32 position space",
+        );
+        Self {
+            logical_len,
+            ones: RoaringBitmap::new(),
+            changed: RoaringBitmap::new(),
+            persisted_len: None,
+        }
+    }
+
+    /// Open a persisted bitmask and materialize it into RAM; the file handle
+    /// is dropped before returning. The result starts clean.
+    ///
+    /// A missing file is an error; compose with
+    /// [`ok_not_found`](crate::universal_io::OkNotFound::ok_not_found) and
+    /// [`Self::new`] to start from an empty mask instead.
+    ///
+    /// The mask is read once, whole: pass a non-writeable, sequential
+    /// [`OpenOptions`] with blocking populate.
+    pub fn open<Fs: UniversalReadFs>(
+        fs: &Fs,
+        path: impl AsRef<Path>,
+        options: OpenOptions,
+        extra: Fs::OpenExtra,
+    ) -> UioResult<Self> {
+        let stored = StoredBitmask::<Fs::File>::open(fs, path, options, extra)?;
+        Ok(Self {
+            logical_len: stored.bit_len(),
+            ones: stored.read_ones()?,
+            changed: RoaringBitmap::new(),
+            persisted_len: Some(stored.bit_len()),
+        })
+    }
+
+    /// Number of logical flags (bits) in the mask.
+    pub fn bit_len(&self) -> u64 {
+        self.logical_len
+    }
+
+    /// Number of set bits.
+    pub fn count_ones(&self) -> u64 {
+        self.ones.len()
+    }
+
+    /// The set positions; everything else in `0..bit_len` is unset.
+    pub fn ones(&self) -> &RoaringBitmap {
+        &self.ones
+    }
+
+    /// Value of the bit at `index`; `false` at and beyond [`Self::bit_len`].
+    pub fn get(&self, index: u32) -> bool {
+        self.ones.contains(index)
+    }
+
+    /// Set the bit at `index`, returning its previous value.
+    ///
+    /// # Panics
+    ///
+    /// If `index` is at or beyond [`Self::bit_len`].
+    pub fn set(&mut self, index: u32, value: bool) -> bool {
+        assert!(
+            u64::from(index) < self.logical_len,
+            "position {index} beyond bitmask of {} bits",
+            self.logical_len,
+        );
+        let previous = if value {
+            !self.ones.insert(index)
+        } else {
+            self.ones.remove(index)
+        };
+        if previous != value {
+            // Toggle divergence: flipping a bit a second time lands it back
+            // on its persisted value, so the change cancels out.
+            if !self.changed.remove(index) {
+                self.changed.insert(index);
+            }
+        }
+        previous
+    }
+
+    /// Grow the mask to `new_len` bits; the new bits are unset. Passing the
+    /// current length is a no-op.
+    ///
+    /// # Panics
+    ///
+    /// If `new_len` would shrink the mask or exceeds the `u32` position
+    /// space.
+    pub fn set_len(&mut self, new_len: u64) {
+        assert!(
+            new_len >= self.logical_len,
+            "cannot shrink bitmask of {} bits to {new_len}",
+            self.logical_len,
+        );
+        assert!(
+            new_len <= MAX_LOGICAL_LEN,
+            "bitmask of {new_len} bits exceeds the u32 position space",
+        );
+        self.logical_len = new_len;
+    }
+
+    /// Whether the in-RAM state differs from the last persisted snapshot.
+    pub fn is_dirty(&self) -> bool {
+        self.persisted_len != Some(self.logical_len) || !self.changed.is_empty()
+    }
+
+    /// Persist the mask at `path` in one atomic whole-file write, or skip
+    /// the write entirely when nothing changed since the mask was opened or
+    /// last saved.
+    ///
+    /// A failed save leaves the mask dirty, so a later retry writes again.
+    pub fn save(&mut self, fs: &impl UniversalWriteFileOps, path: &Path) -> UioResult<()> {
+        if !self.is_dirty() {
+            return Ok(());
+        }
+
+        // The encoder consumes its bitmap; this handle keeps its own.
+        let bytes = bitmask_file_bytes(self.logical_len, self.ones.clone())?;
+        fs.atomic_save(path, &bytes)?;
+
+        self.changed.clear();
+        self.persisted_len = Some(self.logical_len);
+        Ok(())
+    }
+}

--- a/lib/common/common/src/stored_bitmask/mutable.rs
+++ b/lib/common/common/src/stored_bitmask/mutable.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::path::Path;
 
 use roaring::RoaringBitmap;
@@ -155,8 +156,9 @@ impl MutableStoredBitmask {
             return Ok(());
         }
 
-        // The encoder consumes its bitmap; this handle keeps its own.
-        let bytes = bitmask_file_bytes(self.logical_len, self.ones.clone())?;
+        // Run-optimize in place so the encoder can serialize a borrow.
+        self.ones.optimize();
+        let bytes = bitmask_file_bytes(self.logical_len, Cow::Borrowed(&self.ones))?;
         fs.atomic_save(path, &bytes)?;
 
         self.changed = false;

--- a/lib/common/common/src/stored_bitmask/mutable.rs
+++ b/lib/common/common/src/stored_bitmask/mutable.rs
@@ -27,9 +27,8 @@ pub struct MutableStoredBitmask {
     /// Authoritative set positions. Invariant: every position is below
     /// `logical_len`.
     ones: RoaringBitmap,
-    /// Positions whose current value differs from the last persisted
-    /// snapshot; empty right after [`Self::open`] and [`Self::save`].
-    changed: RoaringBitmap,
+    /// Whether this structures has any in-memory changes that are not yet persisted.
+    changed: bool,
     /// `logical_len` of the last persisted snapshot; `None` when the mask
     /// has never been persisted (fresh [`Self::new`]).
     persisted_len: Option<u64>,
@@ -50,7 +49,7 @@ impl MutableStoredBitmask {
         Self {
             logical_len,
             ones: RoaringBitmap::new(),
-            changed: RoaringBitmap::new(),
+            changed: false,
             persisted_len: None,
         }
     }
@@ -74,7 +73,7 @@ impl MutableStoredBitmask {
         Ok(Self {
             logical_len: stored.bit_len(),
             ones: stored.read_ones()?,
-            changed: RoaringBitmap::new(),
+            changed: false,
             persisted_len: Some(stored.bit_len()),
         })
     }
@@ -116,11 +115,7 @@ impl MutableStoredBitmask {
             self.ones.remove(index)
         };
         if previous != value {
-            // Toggle divergence: flipping a bit a second time lands it back
-            // on its persisted value, so the change cancels out.
-            if !self.changed.remove(index) {
-                self.changed.insert(index);
-            }
+            self.changed = true;
         }
         previous
     }
@@ -147,7 +142,7 @@ impl MutableStoredBitmask {
 
     /// Whether the in-RAM state differs from the last persisted snapshot.
     pub fn is_dirty(&self) -> bool {
-        self.persisted_len != Some(self.logical_len) || !self.changed.is_empty()
+        self.changed || self.persisted_len != Some(self.logical_len)
     }
 
     /// Persist the mask at `path` in one atomic whole-file write, or skip
@@ -164,7 +159,7 @@ impl MutableStoredBitmask {
         let bytes = bitmask_file_bytes(self.logical_len, self.ones.clone())?;
         fs.atomic_save(path, &bytes)?;
 
-        self.changed.clear();
+        self.changed = false;
         self.persisted_len = Some(self.logical_len);
         Ok(())
     }

--- a/lib/common/common/src/stored_bitmask/read.rs
+++ b/lib/common/common/src/stored_bitmask/read.rs
@@ -4,7 +4,9 @@ use std::path::Path;
 
 use roaring::RoaringBitmap;
 
-use super::format::{BitmaskContent, BitmaskHeader, Encoding, HEADER_SIZE, MAGIC, VERSION};
+use super::format::{
+    BitmaskContent, BitmaskHeader, Encoding, HEADER_SIZE, MAGIC, MAX_LOGICAL_LEN, VERSION,
+};
 use crate::bitvec::{BitSlice, BitVec};
 use crate::generic_consts::Sequential;
 use crate::universal_io::{
@@ -83,7 +85,7 @@ impl<S: UniversalRead> StoredBitmask<S> {
         };
         // Mirrors the write-side validation; also keeps every position
         // representable as `u32` for [`Self::read_ones`].
-        if header.logical_len > u64::from(u32::MAX) + 1 {
+        if header.logical_len > MAX_LOGICAL_LEN {
             return Err(invalid_data(
                 path,
                 format_args!(

--- a/lib/common/common/src/stored_bitmask/tests.rs
+++ b/lib/common/common/src/stored_bitmask/tests.rs
@@ -231,3 +231,257 @@ fn rejects_foreign_files() {
         StoredBitmask::<MmapFile>::open(&MmapFs, &path, OpenOptions::new_for_test(), ()).is_err()
     );
 }
+
+mod mutable {
+    use super::*;
+    use crate::stored_bitmask::MutableStoredBitmask;
+    use crate::universal_io::{IsNotFound, OkNotFound};
+
+    fn open_mutable(path: &Path) -> MutableStoredBitmask {
+        MutableStoredBitmask::open(&MmapFs, path, OpenOptions::new_for_test(), ()).unwrap()
+    }
+
+    #[test]
+    fn new_starts_dirty_and_first_save_creates_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("mask.bin");
+
+        let mut mask = MutableStoredBitmask::new(100);
+        assert!(mask.is_dirty());
+        mask.save(&MmapFs, &path).unwrap();
+        assert!(!mask.is_dirty());
+
+        assert_bits(&open(&path), 100, &RoaringBitmap::new());
+        let reopened = open_mutable(&path);
+        assert!(!reopened.is_dirty());
+        assert_eq!(reopened.bit_len(), 100);
+        assert_eq!(reopened.count_ones(), 0);
+    }
+
+    #[test]
+    fn open_is_clean_and_matches_persisted_content() {
+        // Same fixtures as `read_ones_normalizes_every_encoding`: one mask
+        // per stored encoding, plus an empty one.
+        let sparse = RoaringBitmap::from_sorted_iter([1u32, 7, 63, 64, 100_000]).unwrap();
+        let mut mostly_ones = RoaringBitmap::new();
+        mostly_ones.insert_range(0..1_000_000u32);
+        mostly_ones.remove(500);
+        let alternating =
+            RoaringBitmap::from_sorted_iter((0..100_000u32).filter(|i| i % 2 == 0)).unwrap();
+
+        for (len, ones) in [
+            (1_000_000u64, sparse),
+            (1_000_000, mostly_ones),
+            (100_000, alternating),
+            (12_345, RoaringBitmap::new()),
+        ] {
+            let dir = TempDir::new().unwrap();
+            let path = dir.path().join("mask.bin");
+            save_bitmask(&MmapFs, &path, len, ones.clone()).unwrap();
+
+            let mask = open_mutable(&path);
+            assert!(!mask.is_dirty());
+            assert_eq!(mask.bit_len(), len);
+            assert_eq!(mask.ones(), &ones);
+            assert_eq!(mask.count_ones(), ones.len());
+            assert_eq!(mask.get(0), ones.contains(0));
+            assert_eq!(mask.get(500), ones.contains(500));
+            assert!(!mask.get(len as u32)); // beyond the mask: never set
+        }
+    }
+
+    #[test]
+    fn open_missing_file_is_not_found() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("missing.bin");
+
+        let err = MutableStoredBitmask::open(&MmapFs, &path, OpenOptions::new_for_test(), ())
+            .unwrap_err();
+        assert!(err.is_not_found());
+
+        // The supported caller composition: fall back to an empty mask.
+        let mask = MutableStoredBitmask::open(&MmapFs, &path, OpenOptions::new_for_test(), ())
+            .ok_not_found()
+            .unwrap()
+            .unwrap_or_else(|| MutableStoredBitmask::new(100));
+        assert!(mask.is_dirty());
+        assert_eq!(mask.bit_len(), 100);
+    }
+
+    #[test]
+    fn set_returns_previous_value() {
+        let mut mask = MutableStoredBitmask::new(10);
+        assert!(!mask.set(3, true));
+        assert!(mask.set(3, true));
+        assert!(mask.get(3));
+        assert!(mask.set(3, false));
+        assert!(!mask.set(3, false));
+        assert!(!mask.get(3));
+        assert_eq!(mask.count_ones(), 0);
+    }
+
+    #[test]
+    fn noop_set_stays_clean() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("mask.bin");
+        let ones = RoaringBitmap::from_sorted_iter([20u32]).unwrap();
+        save_bitmask(&MmapFs, &path, 100, ones).unwrap();
+
+        let mut mask = open_mutable(&path);
+        assert!(mask.set(20, true));
+        assert!(!mask.set(30, false));
+        assert!(!mask.is_dirty());
+    }
+
+    #[test]
+    fn reverted_change_is_clean_again() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("mask.bin");
+        let ones = RoaringBitmap::from_sorted_iter([20u32]).unwrap();
+        save_bitmask(&MmapFs, &path, 100, ones).unwrap();
+
+        let mut mask = open_mutable(&path);
+        mask.set(20, false);
+        mask.set(30, true);
+        assert!(mask.is_dirty());
+        mask.set(20, true);
+        mask.set(30, false);
+        assert!(!mask.is_dirty());
+    }
+
+    #[test]
+    fn save_when_clean_skips_write() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("mask.bin");
+
+        let mut mask = MutableStoredBitmask::new(100);
+        mask.set(42, true);
+        mask.save(&MmapFs, &path).unwrap();
+
+        // A clean save must not touch storage: with the file deleted behind
+        // its back, only an actual write could bring it back.
+        fs_err::remove_file(&path).unwrap();
+        mask.save(&MmapFs, &path).unwrap();
+        assert!(!path.exists());
+
+        // The next effective change writes again — the whole mask, not a
+        // delta on the (gone) previous file.
+        mask.set(43, true);
+        mask.save(&MmapFs, &path).unwrap();
+        assert_bits(
+            &open(&path),
+            100,
+            &RoaringBitmap::from_sorted_iter([42u32, 43]).unwrap(),
+        );
+    }
+
+    #[test]
+    fn mutate_save_reopen_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("mask.bin");
+        let mut expected = RoaringBitmap::from_sorted_iter(0..50u32).unwrap();
+        save_bitmask(&MmapFs, &path, 200, expected.clone()).unwrap();
+
+        let mut mask = open_mutable(&path);
+        for (index, value) in [(10u32, false), (49, false), (50, true), (199, true)] {
+            mask.set(index, value);
+            if value {
+                expected.insert(index);
+            } else {
+                expected.remove(index);
+            }
+        }
+        mask.save(&MmapFs, &path).unwrap();
+        assert!(!mask.is_dirty());
+
+        assert_bits(&open(&path), 200, &expected);
+        assert_eq!(open_mutable(&path).ones(), &expected);
+    }
+
+    #[test]
+    fn encoding_transition_sparse_to_dense() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("mask.bin");
+        save_bitmask(
+            &MmapFs,
+            &path,
+            100_000,
+            RoaringBitmap::from_sorted_iter([3u32, 500]).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(open(&path).encoding, Encoding::RoaringOnes);
+
+        // Alternating bits are incompressible in both polarities.
+        let mut mask = open_mutable(&path);
+        for index in (0..100_000u32).step_by(2) {
+            mask.set(index, true);
+        }
+        mask.set(3, false);
+        mask.save(&MmapFs, &path).unwrap();
+
+        let reopened = open(&path);
+        assert_eq!(reopened.encoding, Encoding::Dense);
+        let expected =
+            RoaringBitmap::from_sorted_iter((0..100_000u32).filter(|i| i % 2 == 0)).unwrap();
+        assert_bits(&reopened, 100_000, &expected);
+    }
+
+    #[test]
+    fn set_len_grows_and_persists() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("mask.bin");
+        let ones = RoaringBitmap::from_sorted_iter([0u32, 99]).unwrap();
+        save_bitmask(&MmapFs, &path, 100, ones.clone()).unwrap();
+
+        let mut mask = open_mutable(&path);
+        mask.set_len(100); // equal length: still clean
+        assert!(!mask.is_dirty());
+
+        // Growth alone must persist: the length is part of the file.
+        mask.set_len(150);
+        assert!(mask.is_dirty());
+        mask.save(&MmapFs, &path).unwrap();
+
+        assert_bits(&open(&path), 150, &ones);
+        let mut reopened = open_mutable(&path);
+        assert!(!reopened.is_dirty());
+        assert!(!reopened.set(149, true)); // the grown range is writable
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot shrink")]
+    fn set_len_shrink_panics() {
+        MutableStoredBitmask::new(100).set_len(50);
+    }
+
+    #[test]
+    #[should_panic(expected = "beyond bitmask")]
+    fn set_out_of_bounds_panics() {
+        MutableStoredBitmask::new(10).set(10, true);
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds the u32 position space")]
+    fn len_beyond_u32_space_panics() {
+        MutableStoredBitmask::new((1 << 32) + 1);
+    }
+
+    #[test]
+    fn max_len_boundary() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("mask.bin");
+
+        // Sparse ones keep everything roaring-encoded: nothing here may
+        // materialize the 512 MiB dense form or the full complement.
+        let mut mask = MutableStoredBitmask::new(1 << 32);
+        assert!(!mask.set(u32::MAX, true));
+        assert!(mask.get(u32::MAX));
+        mask.save(&MmapFs, &path).unwrap();
+
+        let reopened = open_mutable(&path);
+        assert!(!reopened.is_dirty());
+        assert_eq!(reopened.bit_len(), 1 << 32);
+        assert_eq!(reopened.count_ones(), 1);
+        assert!(reopened.get(u32::MAX));
+    }
+}

--- a/lib/common/common/src/stored_bitmask/tests.rs
+++ b/lib/common/common/src/stored_bitmask/tests.rs
@@ -334,22 +334,6 @@ mod mutable {
     }
 
     #[test]
-    fn reverted_change_is_clean_again() {
-        let dir = TempDir::new().unwrap();
-        let path = dir.path().join("mask.bin");
-        let ones = RoaringBitmap::from_sorted_iter([20u32]).unwrap();
-        save_bitmask(&MmapFs, &path, 100, ones).unwrap();
-
-        let mut mask = open_mutable(&path);
-        mask.set(20, false);
-        mask.set(30, true);
-        assert!(mask.is_dirty());
-        mask.set(20, true);
-        mask.set(30, false);
-        assert!(!mask.is_dirty());
-    }
-
-    #[test]
     fn save_when_clean_skips_write() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("mask.bin");

--- a/lib/common/common/src/stored_bitmask/write.rs
+++ b/lib/common/common/src/stored_bitmask/write.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::io;
 use std::path::Path;
 
@@ -17,17 +18,25 @@ pub fn save_bitmask(
     logical_len: u64,
     ones: RoaringBitmap,
 ) -> UioResult<()> {
-    let bytes = bitmask_file_bytes(logical_len, ones)?;
+    let bytes = bitmask_file_bytes(logical_len, Cow::Owned(ones))?;
     fs.atomic_save(path, &bytes)
 }
 
 /// Encode a bitmask of `logical_len` bits whose set positions are `ones` into
 /// the complete file image: header plus the cheapest payload encoding.
-pub(super) fn bitmask_file_bytes(logical_len: u64, ones: RoaringBitmap) -> UioResult<Vec<u8>> {
+///
+/// A borrowed mask is serialized as-is; the caller run-optimizes it in place
+/// beforehand to keep this path clone-free.
+pub(super) fn bitmask_file_bytes(
+    logical_len: u64,
+    ones: Cow<'_, RoaringBitmap>,
+) -> UioResult<Vec<u8>> {
     validate(logical_len, &ones)?;
 
     let (polarity, mut minority) = minority_polarity(logical_len, ones);
-    minority.optimize();
+    if let Cow::Owned(minority) = &mut minority {
+        minority.optimize();
+    }
 
     let dense_bits_len = logical_len.div_ceil(u64::from(u8::BITS));
     if (minority.serialized_size() as u64) < dense_bits_len {
@@ -63,14 +72,17 @@ fn validate(logical_len: u64, ones: &RoaringBitmap) -> UioResult<()> {
 
 /// Reduce to whichever bit value is the minority: the set positions as-is, or
 /// their complement within `0..logical_len`.
-fn minority_polarity(logical_len: u64, ones: RoaringBitmap) -> (Encoding, RoaringBitmap) {
+fn minority_polarity(
+    logical_len: u64,
+    ones: Cow<'_, RoaringBitmap>,
+) -> (Encoding, Cow<'_, RoaringBitmap>) {
     if ones.len().saturating_mul(2) <= logical_len {
         (Encoding::RoaringOnes, ones)
     } else {
         let mut zeros = RoaringBitmap::new();
         zeros.insert_range(0..=(logical_len - 1) as u32);
-        zeros -= ones;
-        (Encoding::RoaringZeros, zeros)
+        zeros -= &*ones;
+        (Encoding::RoaringZeros, Cow::Owned(zeros))
     }
 }
 

--- a/lib/common/common/src/stored_bitmask/write.rs
+++ b/lib/common/common/src/stored_bitmask/write.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use roaring::RoaringBitmap;
 
-use super::format::{BitmaskHeader, Encoding, HEADER_SIZE};
+use super::format::{BitmaskHeader, Encoding, HEADER_SIZE, MAX_LOGICAL_LEN};
 use crate::universal_io::{UioResult, UniversalIoError, UniversalWriteFileOps};
 
 /// Atomically persist a bitmask of `logical_len` bits whose set positions are
@@ -17,21 +17,26 @@ pub fn save_bitmask(
     logical_len: u64,
     ones: RoaringBitmap,
 ) -> UioResult<()> {
+    let bytes = bitmask_file_bytes(logical_len, ones)?;
+    fs.atomic_save(path, &bytes)
+}
+
+/// Encode a bitmask of `logical_len` bits whose set positions are `ones` into
+/// the complete file image: header plus the cheapest payload encoding.
+pub(super) fn bitmask_file_bytes(logical_len: u64, ones: RoaringBitmap) -> UioResult<Vec<u8>> {
     validate(logical_len, &ones)?;
 
     let (polarity, mut minority) = minority_polarity(logical_len, ones);
     minority.optimize();
 
     let dense_payload_len = logical_len.div_ceil(u64::from(u8::BITS));
-    let bytes = if (minority.serialized_size() as u64) < dense_payload_len {
-        roaring_file_bytes(logical_len, polarity, &minority)?
+    if (minority.serialized_size() as u64) < dense_payload_len {
+        roaring_file_bytes(logical_len, polarity, &minority)
     } else {
         // Even the minority polarity does not compress below raw bits: store
         // them densely, so the compact format is never larger than the mask.
-        dense_file_bytes(logical_len, polarity, &minority)
-    };
-
-    fs.atomic_save(path, &bytes)
+        Ok(dense_file_bytes(logical_len, polarity, &minority))
+    }
 }
 
 fn validate(logical_len: u64, ones: &RoaringBitmap) -> UioResult<()> {
@@ -39,7 +44,7 @@ fn validate(logical_len: u64, ones: &RoaringBitmap) -> UioResult<()> {
         UniversalIoError::Io(io::Error::new(io::ErrorKind::InvalidInput, message))
     };
 
-    if logical_len > u64::from(u32::MAX) + 1 {
+    if logical_len > MAX_LOGICAL_LEN {
         return Err(invalid(format!(
             "bitmask of {logical_len} bits exceeds the u32 position space"
         )));

--- a/lib/common/common/src/stored_bitmask/write.rs
+++ b/lib/common/common/src/stored_bitmask/write.rs
@@ -29,8 +29,8 @@ pub(super) fn bitmask_file_bytes(logical_len: u64, ones: RoaringBitmap) -> UioRe
     let (polarity, mut minority) = minority_polarity(logical_len, ones);
     minority.optimize();
 
-    let dense_payload_len = logical_len.div_ceil(u64::from(u8::BITS));
-    if (minority.serialized_size() as u64) < dense_payload_len {
+    let dense_bits_len = logical_len.div_ceil(u64::from(u8::BITS));
+    if (minority.serialized_size() as u64) < dense_bits_len {
         roaring_file_bytes(logical_len, polarity, &minority)
     } else {
         // Even the minority polarity does not compress below raw bits: store


### PR DESCRIPTION
Adds a mutable structure to help modify stored (compact) bitmasks. The structure keeps track of changes bits in a roaring bitmap. When saved, the full bitmask is atomically rewritten on disk. On each save, the smallest storage format is automatically chosen.

This is the counter part of `StoredBitmask`.

Integrating this structure will be done in a separate PR. It'll be used specifically for serverless.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
