### PR TITLE
perf(common): add zero copy fast path for multi-block disk cache hits

### DIFF
--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -90,5 +90,9 @@ name = "atomic_stop"
 harness = false
 
 [[bench]]
+name = "disk_cache"
+harness = false
+
+[[bench]]
 name = "universal_io"
 harness = false

--- a/lib/common/common/benches/disk_cache.rs
+++ b/lib/common/common/benches/disk_cache.rs
@@ -1,0 +1,64 @@
+use std::hint::black_box;
+use std::io::Write as _;
+use std::path::PathBuf;
+
+use common::bench_cache::{build_once, cache_path};
+use common::universal_io::disk_cache::{CacheController, CachedSlice};
+use criterion::{Criterion, criterion_group, criterion_main};
+use fs_err as fs;
+
+const FILE_SIZE_BYTES: u64 = 10 * 1024 * 1024; // 10mb file
+
+fn benches(c: &mut Criterion) {
+    let (cache_file, data_file) = make_cache_and_file();
+
+    let controller = CacheController::new(&cache_file, FILE_SIZE_BYTES).unwrap();
+    let slice = CachedSlice::open(&controller, &data_file).unwrap();
+
+    // warm up the cache so blocks are continuously loaded into the mmap
+    let _ = slice
+        .get_range_bytes(0..FILE_SIZE_BYTES as usize, 8)
+        .unwrap();
+
+    let mut group = c.benchmark_group("disk_cache");
+
+    // Bench single block fast path
+    group.bench_function("single_block_hit", |b| {
+        b.iter(|| {
+            // Read 4kb from inside the first block
+            let data = slice.get_range_bytes(100..4196, 8).unwrap();
+            black_box(data);
+        })
+    });
+
+    // Bench multi-block contiguous fast path
+    group.bench_function("multi_block_contiguous_hit", |b| {
+        b.iter(|| {
+            // Read 4 blocks across boundaries
+            // since they are contiguous, it avoids allocating and copying
+            let data = slice.get_range_bytes(100..60 * 1024 + 100, 8).unwrap();
+            black_box(data);
+        })
+    });
+}
+
+fn make_cache_and_file() -> (PathBuf, PathBuf) {
+    let dir = build_once(cache_path!("disk_cache_bench"), |path| {
+        fs::create_dir_all(path).unwrap();
+
+        let mut file = fs::File::create(path.join("cold.bin")).unwrap();
+        let buffer = vec![42u8; FILE_SIZE_BYTES as usize];
+        file.write_all(&buffer).unwrap();
+        file.flush().unwrap();
+    });
+
+    (dir.join("cache.bin"), dir.join("cold.bin"))
+}
+
+criterion_group! {
+    name = bench_group;
+    config = Criterion::default();
+    targets = benches
+}
+
+criterion_main!(bench_group);

--- a/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
+++ b/lib/common/common/src/universal_io/disk_cache/cached_slice.rs
@@ -66,9 +66,18 @@ impl CachedSlice {
             return Ok(ACow::Borrowed(&[]));
         }
 
+        // fast path: all required blocks are already in cache and allocated consecutively.
+        // Return a single borrowed slice without allocating.
+        if let Some(contiguous_slice) = self
+            .controller
+            .get_contiguous_from_cache(self.blocks_for(range.clone()))
+        {
+            return Ok(ACow::Borrowed(contiguous_slice));
+        }
+
         let mut blocks_iter = self.blocks_for(range.clone());
 
-        // TODO(perf): if blocks are consecutive in the big cache file, we can still return without allocating.
+        // Single block fast path: avoids upfront allocation by exactly sizing `AVec` inside `on_miss`
         if blocks_iter.len() == 1 {
             let req = blocks_iter.next().expect("We just checked len() == 1");
             let result = self.controller.get_from_cache(req, |bytes| {
@@ -143,6 +152,10 @@ impl CachedSlice {
 
     pub fn len<T>(&self) -> usize {
         self.len_bytes / size_of::<T>()
+    }
+
+    pub fn is_empty<T>(&self) -> bool {
+        self.len::<T>() == 0
     }
 
     /// Returns the block descriptor for the provided bytes range.

--- a/lib/common/common/src/universal_io/disk_cache/controller.rs
+++ b/lib/common/common/src/universal_io/disk_cache/controller.rs
@@ -245,6 +245,42 @@ impl CacheController {
             GuardResult::Timeout => unreachable!("We didn't set a timeout"),
         }
     }
+
+    /// Fetch a contiguous slice for multiple block requests.
+    ///
+    /// Returns `Some(&[u8])` if all requested blocks are cached consecutively
+    pub(super) fn get_contiguous_from_cache(
+        &self,
+        mut reqs: impl Iterator<Item = BlockRequest>,
+    ) -> Option<&[u8]> {
+        let first_req = reqs.next()?;
+        let first_offset = self.cache.get(&first_req.key)?;
+
+        let mut total_len = first_req.range.len();
+        let mut expected_next_start = first_req.range.end;
+
+        for (i, req) in reqs.enumerate() {
+            // blocks must be logically contiguous to form a valid physical slice
+            if expected_next_start != BLOCK_SIZE || req.range.start != 0 {
+                return None;
+            }
+            expected_next_start = req.range.end;
+
+            let offset = self.cache.get(&req.key)?;
+            let expected_offset = first_offset.0.checked_add((i as u32) + 1)?;
+            if offset.0 != expected_offset {
+                return None;
+            }
+            total_len += req.range.len();
+        }
+
+        let range_start = first_offset.bytes() + first_req.range.start;
+        // SAFETY: blocks are verified to be physically consecutive and logically contiguous.
+        let slice = unsafe {
+            std::slice::from_raw_parts(self.cache_mmap.as_ptr().add(range_start), total_len)
+        };
+        Some(slice)
+    }
 }
 
 /// Result of a cache lookup.

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -17,8 +17,15 @@ mod pipeline;
 #[cfg(test)]
 mod tests;
 
+#[cfg(any(test, feature = "testing"))]
 pub use cached_slice::CachedSlice;
-use controller::{CacheController, CacheRead};
+#[cfg(not(any(test, feature = "testing")))]
+use cached_slice::CachedSlice;
+#[cfg(any(test, feature = "testing"))]
+pub use controller::CacheController;
+#[cfg(not(any(test, feature = "testing")))]
+use controller::CacheController;
+use controller::CacheRead;
 use pipeline::DiskCacheReadPipeline;
 
 use super::UniversalKind;

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -1,7 +1,10 @@
 mod cached_fs;
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(any(test, feature = "testing"))))]
 #[expect(dead_code, reason = "Not yet used")]
 mod disk_cache;
+
+#[cfg(all(not(target_os = "windows"), any(test, feature = "testing")))]
+pub mod disk_cache;
 mod error;
 #[cfg(target_os = "linux")]
 mod io_uring;


### PR DESCRIPTION
### Problem
Previously, when `get_range_bytes` needed to fetch data spanning multiple blocks, it always fell back to a slow path. It would allocate a new `AVec` on the heap and perform a separate memory copy (`extend_from_slice`) for every single block. This wasted CPU cycles and introduced unnecessary allocation latency on the hot read path.

### Solution
Optimized `get_range_bytes` by introducing a new zero copy fast path. It uses the new `get_contiguous_from_cache` method to verify if the requested blocks happen to be physically contiguous inside the cache mmap. If the blocks are already lined up perfectly next to each other, it bypasses the `AVec` allocation and memory copying entirely, safely returning a `ACow::Borrowed` slice over the data.

Added a new Criterion benchmark to measure multi-block reads. The results confirmed that bypassing the heap allocation and memory copying reduces read latency by **~94%**

<img width="600" height="350" alt="image" src="https://github.com/user-attachments/assets/7f81eadd-8811-412e-b623-fc79e64a85ed" />
