### PR TITLE
chore(deps): drop dead dependencies in edge-path crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7448,7 +7448,6 @@ dependencies = [
  "criterion",
  "fnv",
  "fs-err",
- "fs4 1.1.0",
  "indexmap 2.14.0",
  "itertools 0.15.0",
  "log",

--- a/lib/blobstore/Cargo.toml
+++ b/lib/blobstore/Cargo.toml
@@ -28,12 +28,12 @@ strum = { workspace = true }
 bitvec = { workspace = true }
 itertools = { workspace = true }
 zerocopy = { workspace = true }
-dataset = { path = "../common/dataset" }
 common = { path = "../common/common" }
 
 [dev-dependencies]
 criterion = { workspace = true }
 csv = "1.4.0"
+dataset = { path = "../common/dataset" }
 fs-err = { workspace = true, features = ["debug"] }
 rstest = { workspace = true }
 proptest = { workspace = true }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -39,6 +39,7 @@ anyhow = { workspace = true }
 object_store = { workspace = true }
 bytes = { workspace = true }
 tokio = { workspace = true }
+tap = { workspace = true }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 pprof = { workspace = true }
@@ -91,7 +92,6 @@ siphasher = "1.0.3"
 smallvec = { workspace = true }
 strum = { workspace = true }
 byteorder = { workspace = true }
-tap = { workspace = true }
 zerocopy = { workspace = true }
 vaporetto = { version = "0.6.5" }
 rust-stemmers = { package = "qdrant-rust-stemmers", version = "1.2.2" }

--- a/lib/shard/Cargo.toml
+++ b/lib/shard/Cargo.toml
@@ -45,7 +45,6 @@ uuid = { workspace = true }
 validator = { workspace = true }
 serde_json = { workspace = true }
 fs-err = { workspace = true }
-fs4 = { workspace = true }
 tempfile = { workspace = true }
 
 

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -26,7 +26,6 @@ memmap2 = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tempfile = { workspace = true }
 ordered-float = { workspace = true }
 rand = { workspace = true }
 validator = { workspace = true }
@@ -43,6 +42,7 @@ fs-err = { workspace = true, features = ["debug"] }
 indicatif = { workspace = true }
 sha2 = { workspace = true }
 sparse = { path = ".", features = ["testing"] }
+tempfile = { workspace = true }
 zerocopy = { workspace = true }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]


### PR DESCRIPTION
## Summary

Follow-up to #10069 (*Make `tonic` optional in shard*): that PR removed the tonic → axum stack from edge builds, but the `edge` dependency graph still carried several dependencies that are dead weight for the embedded `qdrant-edge` use case. This PR removes them.

### Changes

- **`lib/blobstore/Cargo.toml`** — move `dataset` from `[dependencies]` to `[dev-dependencies]`. `dataset` is used **only** in `src/blobstore/tests.rs` (`#[cfg(test)]`) and `benches/real_data_bench.rs`. As a hard dependency it pulled `dataset → reqwest → hyper / hyper-util / tower / tower-http / h2 / rustls / aws-lc-rs` into **every** build (edge, edge-ffi, edge-python wheel, and the server). Sibling crates `segment` and `sparse` already keep `dataset` in `[dev-dependencies]`.
- **`lib/shard/Cargo.toml`** — remove unused `fs4` (zero references anywhere in the crate).
- **`lib/segment/Cargo.toml`** — move `tap` from `[dependencies]` to `[dev-dependencies]`. It is used only in `tests/integration/hnsw_incremental_build.rs` and `benches/hnsw_incremental_build.rs`.
- **`lib/sparse/Cargo.toml`** — move `tempfile` from `[dependencies]` to `[dev-dependencies]`. All usage is under `#[cfg(test)]`-gated modules.

## Verification

- `cargo check -p edge`, `-p qdrant-edge-ffi`, `-p qdrant-edge-py`, `-p storage` — all pass
- `cargo check -p shard --no-default-features` — passes (edge mode)
- `cargo test -p blobstore` — 151 passed
- `cargo test -p sparse` — 156 passed
- `cargo test -p segment --lib` — 980 passed
- `cargo test -p segment --test integration hnsw_incremental_build` — passed (`tap` consumer)
- `cargo check -p segment --benches` — passes (`tap` consumer)
- `cargo clippy -p blobstore -p sparse -p segment -p shard` — no warnings
- `cargo tree -p edge -e no-dev -i dataset` — not found (previously: `dataset → reqwest` root)
- `cargo tree -p edge -e no-dev -i reqwest` — single root remaining: `object_store ← io_bridge_object_store ← segment` (tracked separately)

### Pre-existing failure, unrelated to this PR

`cargo test -p shard` has one failing test: `quota::manager::enforce::tests::limits_only_apply_while_the_quota_is_enabled` (`unwrap_err()` on an `Ok` value). It fails identically on clean `dev` without these changes.

## AI disclosure

Prepared with assistance from an AI coding agent. Analysis and verification were human-reviewed.