### PR TITLE
refactor(query): deduplicate rescoring helpers into shard

### DIFF
--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -2,17 +2,15 @@ use std::mem;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use ahash::AHashSet;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::types::DeferredBehavior;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use ordered_float::OrderedFloat;
 use parking_lot::Mutex;
-use segment::common::reciprocal_rank_fusion::rrf_scoring;
-use segment::common::score_fusion::{ScoreFusion, score_fusion};
-use segment::types::{Filter, HasIdCondition, ScoredPoint, WithPayloadInterface, WithVector};
+use segment::types::{ScoredPoint, WithPayloadInterface, WithVector};
 use shard::query::planned_query::RescoreStages;
+use shard::query::rescore::{filter_with_point_ids, fusion_rescore};
 use shard::search::CoreSearchRequestBatch;
 
 use super::LocalShard;
@@ -26,7 +24,7 @@ use crate::operations::universal_query::planned_query::{
     MergePlan, PlannedQuery, RescoreParams, RootPlan, Source,
 };
 use crate::operations::universal_query::shard_query::{
-    FusionInternal, MmrInternal, SampleInternal, ScoringQuery, ShardQueryResponse,
+    MmrInternal, SampleInternal, ScoringQuery, ShardQueryResponse,
 };
 
 pub enum FetchedSource {
@@ -300,15 +298,16 @@ impl LocalShard {
         } = rescore_params;
 
         match rescore {
-            ScoringQuery::Fusion(fusion) => Self::fusion_rescore(
+            ScoringQuery::Fusion(fusion) => fusion_rescore(
                 sources,
                 fusion,
                 score_threshold.map(OrderedFloat::into_inner),
                 limit,
-            ),
+            )
+            .map_err(Into::into),
             ScoringQuery::OrderBy(order_by) => {
                 // create single scroll request for rescoring query
-                let filter = filter_with_sources_ids(sources.into_iter());
+                let filter = filter_with_point_ids(&sources);
 
                 // Note: score_threshold is not used in this case, as all results will have same score,
                 // but different order_value
@@ -336,7 +335,7 @@ impl LocalShard {
             }
             ScoringQuery::Vector(query_enum) => {
                 // create single search request for rescoring query
-                let filter = filter_with_sources_ids(sources.into_iter());
+                let filter = filter_with_point_ids(&sources);
 
                 let search_request = CoreSearchRequest {
                     query: query_enum,
@@ -381,7 +380,7 @@ impl LocalShard {
             ScoringQuery::Sample(sample) => match sample {
                 SampleInternal::Random => {
                     // create single scroll request for rescoring query
-                    let filter = filter_with_sources_ids(sources.into_iter());
+                    let filter = filter_with_point_ids(&sources);
 
                     // Note: score_threshold is not used in this case, as all results will have same score and order_value
                     let scroll_request = QueryScrollRequestInternal {
@@ -419,35 +418,6 @@ impl LocalShard {
                 .await
             }
         }
-    }
-
-    fn fusion_rescore(
-        sources: Vec<Vec<ScoredPoint>>,
-        fusion: FusionInternal,
-        score_threshold: Option<f32>,
-        limit: usize,
-    ) -> CollectionResult<Vec<ScoredPoint>> {
-        let fused = match fusion {
-            FusionInternal::Rrf { k, ref weights } => {
-                let weights_slice = weights
-                    .as_ref()
-                    .map(|w| w.iter().map(|f| f.into_inner()).collect::<Vec<_>>());
-                rrf_scoring(sources, k, weights_slice.as_deref())?
-            }
-            FusionInternal::Dbsf => score_fusion(sources, ScoreFusion::dbsf()),
-        };
-
-        let top_fused: Vec<_> = if let Some(score_threshold) = score_threshold {
-            fused
-                .into_iter()
-                .take_while(|point| point.score >= score_threshold)
-                .take(limit)
-                .collect()
-        } else {
-            fused.into_iter().take(limit).collect()
-        };
-
-        Ok(top_fused)
     }
 
     /// Maximal Marginal Relevance rescoring
@@ -497,20 +467,4 @@ impl LocalShard {
 
         Ok(top_mmr)
     }
-}
-
-/// Extracts point ids from sources, and creates a filter to only include those ids.
-fn filter_with_sources_ids(sources: impl Iterator<Item = Vec<ScoredPoint>>) -> Filter {
-    let mut point_ids = AHashSet::new();
-
-    for source in sources {
-        for point in source.iter() {
-            point_ids.insert(point.id);
-        }
-    }
-
-    // create filter for target point ids
-    Filter::new_must(segment::types::Condition::HasId(HasIdCondition::from(
-        point_ids,
-    )))
 }

--- a/lib/edge/src/read_view/ops/query.rs
+++ b/lib/edge/src/read_view/ops/query.rs
@@ -2,21 +2,17 @@ use std::mem;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
-use ahash::AHashSet;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::types::{DeferredBehavior, ScoreType};
 use ordered_float::OrderedFloat;
 use segment::common::operation_error::{OperationError, OperationResult};
-use segment::common::reciprocal_rank_fusion::rrf_scoring;
-use segment::common::score_fusion::{ScoreFusion, score_fusion};
 use segment::data_types::query_context::FormulaContext;
 use segment::entry::ReadSegmentEntry;
 use segment::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
-use segment::types::{
-    Filter, HasIdCondition, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
-};
+use segment::types::{ScoredPoint, WithPayload, WithPayloadInterface, WithVector};
 use shard::query::mmr::mmr_from_points_with_vector;
 use shard::query::planned_query::*;
+use shard::query::rescore::{filter_with_point_ids, fusion_rescore};
 use shard::query::scroll::{QueryScrollRequestInternal, ScrollOrder};
 use shard::query::*;
 use shard::retrieve::retrieve_blocking::retrieve_over;
@@ -214,7 +210,7 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
 
         match rescore {
             ScoringQuery::Fusion(fusion) => {
-                let top_fused = Self::fusion_rescore(
+                let top_fused = fusion_rescore(
                     sources,
                     fusion,
                     score_threshold.map(OrderedFloat::into_inner),
@@ -225,7 +221,7 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
 
             ScoringQuery::OrderBy(order_by) => {
                 // create single scroll request for rescoring query
-                let filter = filter_by_point_ids(&sources);
+                let filter = filter_with_point_ids(&sources);
 
                 // Note: score_threshold is not used in this case, as all results will have same score,
                 // but different order_value
@@ -242,7 +238,7 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
 
             ScoringQuery::Vector(query_enum) => {
                 // create single search request for rescoring query
-                let filter = filter_by_point_ids(&sources);
+                let filter = filter_with_point_ids(&sources);
 
                 let search_request = CoreSearchRequest {
                     query: query_enum,
@@ -269,7 +265,7 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
             ScoringQuery::Sample(sample) => match sample {
                 SampleInternal::Random => {
                     // create single scroll request for rescoring query
-                    let filter = filter_by_point_ids(&sources);
+                    let filter = filter_with_point_ids(&sources);
 
                     // Note: score_threshold is not used in this case, as all results will have same score and order_value
                     let scroll_request = QueryScrollRequestInternal {
@@ -286,35 +282,6 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
 
             ScoringQuery::Mmr(mmr) => self.mmr_rescore(sources, mmr, limit, hw_counter_acc),
         }
-    }
-
-    fn fusion_rescore(
-        sources: Vec<Vec<ScoredPoint>>,
-        fusion: FusionInternal,
-        score_threshold: Option<f32>,
-        limit: usize,
-    ) -> OperationResult<Vec<ScoredPoint>> {
-        let fused = match fusion {
-            FusionInternal::Rrf { k, ref weights } => {
-                let weights_slice = weights
-                    .as_ref()
-                    .map(|w| w.iter().map(|f| f.into_inner()).collect::<Vec<_>>());
-                rrf_scoring(sources, k, weights_slice.as_deref())?
-            }
-            FusionInternal::Dbsf => score_fusion(sources, ScoreFusion::dbsf()),
-        };
-
-        let top_fused: Vec<_> = if let Some(score_threshold) = score_threshold {
-            fused
-                .into_iter()
-                .take_while(|point| point.score >= score_threshold)
-                .take(limit)
-                .collect()
-        } else {
-            fused.into_iter().take(limit).collect()
-        };
-
-        Ok(top_fused)
     }
 
     pub(crate) fn rescore_with_formula(
@@ -456,20 +423,11 @@ fn take_prefetched_source<T: Default>(items: &mut [T], index: usize) -> Operatio
     Ok(mem::take(source))
 }
 
-/// Extracts point ids from sources, and creates a filter to only include those ids.
-fn filter_by_point_ids(points: &[Vec<ScoredPoint>]) -> Filter {
-    let point_ids: AHashSet<_> = points.iter().flatten().map(|point| point.id).collect();
-
-    // create filter for target point ids
-    Filter::new_must(segment::types::Condition::HasId(HasIdCondition::from(
-        point_ids,
-    )))
-}
-
 #[cfg(test)]
 mod tests {
+    use ahash::AHashSet;
     use segment::data_types::vectors::{NamedQuery, VectorInternal};
-    use segment::types::{Condition, WithPayloadInterface};
+    use segment::types::{Condition, Filter, HasIdCondition, WithPayloadInterface};
     use shard::query::query_enum::QueryEnum;
 
     use super::*;

--- a/lib/shard/src/query/mod.rs
+++ b/lib/shard/src/query/mod.rs
@@ -4,6 +4,7 @@ pub mod formula;
 pub mod mmr;
 pub mod planned_query;
 pub mod query_enum;
+pub mod rescore;
 pub mod scroll;
 mod validation;
 

--- a/lib/shard/src/query/rescore.rs
+++ b/lib/shard/src/query/rescore.rs
@@ -65,7 +65,7 @@ mod tests {
 
     fn point(id: u64, score: f32) -> ScoredPoint {
         ScoredPoint {
-            id: id.into(),
+            id: PointIdType::from(id),
             version: 0,
             score,
             payload: None,

--- a/lib/shard/src/query/rescore.rs
+++ b/lib/shard/src/query/rescore.rs
@@ -1,0 +1,170 @@
+use ahash::AHashSet;
+use segment::common::operation_error::OperationResult;
+use segment::common::reciprocal_rank_fusion::rrf_scoring;
+use segment::common::score_fusion::{ScoreFusion, score_fusion};
+use segment::types::{Filter, HasIdCondition, ScoredPoint};
+
+use crate::query::FusionInternal;
+
+/// Fuses multiple sources of scored points with the given fusion method, applies
+/// the score threshold (if any) and returns the top `limit` results.
+pub fn fusion_rescore(
+    sources: Vec<Vec<ScoredPoint>>,
+    fusion: FusionInternal,
+    score_threshold: Option<f32>,
+    limit: usize,
+) -> OperationResult<Vec<ScoredPoint>> {
+    let fused = match fusion {
+        FusionInternal::Rrf { k, ref weights } => {
+            let weights_slice = weights
+                .as_ref()
+                .map(|w| w.iter().map(|f| f.into_inner()).collect::<Vec<_>>());
+            rrf_scoring(sources, k, weights_slice.as_deref())?
+        }
+        FusionInternal::Dbsf => score_fusion(sources, ScoreFusion::dbsf()),
+    };
+
+    let top_fused: Vec<_> = if let Some(score_threshold) = score_threshold {
+        fused
+            .into_iter()
+            .take_while(|point| point.score >= score_threshold)
+            .take(limit)
+            .collect()
+    } else {
+        fused.into_iter().take(limit).collect()
+    };
+
+    Ok(top_fused)
+}
+
+/// Extracts point ids from sources, and creates a filter to only include those ids.
+pub fn filter_with_point_ids<I>(sources: I) -> Filter
+where
+    I: IntoIterator,
+    I::Item: AsRef<[ScoredPoint]>,
+{
+    let mut point_ids = AHashSet::new();
+
+    for source in sources {
+        for point in source.as_ref() {
+            point_ids.insert(point.id);
+        }
+    }
+
+    // create filter for target point ids
+    Filter::new_must(segment::types::Condition::HasId(HasIdCondition::from(
+        point_ids,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use segment::types::{Condition, PointIdType, ScoredPoint};
+
+    use super::*;
+
+    fn point(id: u64, score: f32) -> ScoredPoint {
+        ScoredPoint {
+            id: id.into(),
+            version: 0,
+            score,
+            payload: None,
+            vector: None,
+            shard_key: None,
+            order_value: None,
+        }
+    }
+
+    fn sorted_num_ids(points: &[ScoredPoint]) -> Vec<u64> {
+        let mut ids: Vec<u64> = points
+            .iter()
+            .filter_map(|point| match point.id {
+                PointIdType::NumId(num) => Some(num),
+                PointIdType::Uuid(_) => None,
+            })
+            .collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    fn filter_num_ids(filter: &Filter) -> Vec<u64> {
+        let conditions = filter.must.as_ref().expect("filter must conditions");
+        let Condition::HasId(has_id) = &conditions[0] else {
+            panic!("expected HasId condition");
+        };
+        let mut ids: Vec<u64> = has_id
+            .has_id
+            .iter()
+            .filter_map(|id| match id {
+                PointIdType::NumId(num) => Some(*num),
+                PointIdType::Uuid(_) => None,
+            })
+            .collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    #[test]
+    fn fusion_rescore_rrf_combines_sources_and_limits() {
+        let sources = vec![
+            vec![point(1, 1.0), point(2, 0.9)],
+            vec![point(1, 1.0), point(3, 0.8)],
+        ];
+        let fusion = FusionInternal::Rrf {
+            k: 2,
+            weights: None,
+        };
+
+        // Point 1 appears in both sources, so it ranks first.
+        let top = fusion_rescore(sources.clone(), fusion.clone(), None, 1).unwrap();
+        assert_eq!(sorted_num_ids(&top), vec![1]);
+
+        // All points are returned when the limit is large enough.
+        let all = fusion_rescore(sources, fusion, None, 10).unwrap();
+        assert_eq!(sorted_num_ids(&all), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn fusion_rescore_rrf_applies_score_threshold() {
+        let sources = vec![
+            vec![point(1, 1.0), point(2, 0.9)],
+            vec![point(1, 1.0), point(3, 0.8)],
+        ];
+        let fusion = FusionInternal::Rrf {
+            k: 2,
+            weights: None,
+        };
+
+        // Only the point present in both sources passes the threshold.
+        let result = fusion_rescore(sources, fusion, Some(0.5), 10).unwrap();
+        assert_eq!(sorted_num_ids(&result), vec![1]);
+    }
+
+    #[test]
+    fn fusion_rescore_dbsf_fuses_all_points() {
+        let sources = vec![
+            vec![point(1, 2.0), point(2, 1.0)],
+            vec![point(2, 3.0), point(3, 0.5)],
+        ];
+
+        let result = fusion_rescore(sources, FusionInternal::Dbsf, None, 10).unwrap();
+        assert_eq!(sorted_num_ids(&result), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn filter_with_point_ids_empty_input_yields_empty_filter() {
+        let filter = filter_with_point_ids(Vec::<Vec<ScoredPoint>>::new());
+        assert!(filter_num_ids(&filter).is_empty());
+    }
+
+    #[test]
+    fn filter_with_point_ids_deduplicates_across_sources() {
+        let sources = vec![
+            vec![point(1, 1.0), point(2, 1.0)],
+            vec![point(2, 1.0), point(3, 1.0)],
+        ];
+
+        let filter = filter_with_point_ids(&sources);
+        assert_eq!(filter_num_ids(&filter), vec![1, 2, 3]);
+    }
+}

--- a/lib/shard/src/query/rescore.rs
+++ b/lib/shard/src/query/rescore.rs
@@ -60,12 +60,25 @@ where
 #[cfg(test)]
 mod tests {
     use segment::types::{Condition, PointIdType, ScoredPoint};
+    use uuid::Uuid;
 
     use super::*;
 
     fn point(id: u64, score: f32) -> ScoredPoint {
         ScoredPoint {
             id: PointIdType::from(id),
+            version: 0,
+            score,
+            payload: None,
+            vector: None,
+            shard_key: None,
+            order_value: None,
+        }
+    }
+
+    fn point_uuid(id: u128, score: f32) -> ScoredPoint {
+        ScoredPoint {
+            id: PointIdType::Uuid(Uuid::from_u128(id)),
             version: 0,
             score,
             payload: None,
@@ -104,6 +117,28 @@ mod tests {
         ids
     }
 
+    /// All ids (numeric and UUID) normalized to point-id string form, sorted.
+    fn sorted_id_strings<'a>(ids: impl Iterator<Item = &'a PointIdType>) -> Vec<String> {
+        let mut ids: Vec<String> = ids
+            .map(|id| match id {
+                PointIdType::NumId(num) => num.to_string(),
+                // `PointIdType` renders UUIDs hyphenated; `Uuid`'s own
+                // `Display` renders them without hyphens.
+                PointIdType::Uuid(uuid) => uuid.hyphenated().to_string(),
+            })
+            .collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    fn filter_with_point_ids_sorted(filter: &Filter) -> Vec<String> {
+        let conditions = filter.must.as_ref().expect("filter must conditions");
+        let Condition::HasId(has_id) = &conditions[0] else {
+            panic!("expected HasId condition");
+        };
+        sorted_id_strings(has_id.has_id.iter())
+    }
+
     #[test]
     fn fusion_rescore_rrf_combines_sources_and_limits() {
         let sources = vec![
@@ -122,6 +157,83 @@ mod tests {
         // All points are returned when the limit is large enough.
         let all = fusion_rescore(sources, fusion, None, 10).unwrap();
         assert_eq!(sorted_num_ids(&all), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn fusion_rescore_rrf_weights_change_ranking() {
+        use ordered_float::OrderedFloat;
+
+        // Source 0's only point must outrank source 1's top point: it wins on
+        // weight even though source 1 has more candidates.
+        let sources = vec![vec![point(3, 1.0)], vec![point(1, 1.0), point(2, 1.0)]];
+        let weighted = FusionInternal::Rrf {
+            k: 2,
+            weights: Some(vec![OrderedFloat(5.0), OrderedFloat(1.0)]),
+        };
+
+        let result = fusion_rescore(sources, weighted, None, 10).unwrap();
+        assert_eq!(
+            sorted_num_ids(&result),
+            vec![1, 2, 3],
+            "all points must survive weighted fusion"
+        );
+        assert_eq!(
+            result[0].id,
+            PointIdType::from(3),
+            "the heavier-weighted source's point must rank first",
+        );
+    }
+
+    #[test]
+    fn fusion_rescore_rrf_rejects_mismatched_weights() {
+        let sources = vec![vec![point(1, 1.0)], vec![point(2, 1.0)]];
+        let fusion = FusionInternal::Rrf {
+            k: 2,
+            weights: Some(vec![ordered_float::OrderedFloat(1.0)]),
+        };
+
+        let result = fusion_rescore(sources, fusion, None, 10);
+        assert!(
+            result.is_err(),
+            "weights must match the number of sources: {result:?}",
+        );
+    }
+
+    #[test]
+    fn fusion_rescore_preserves_uuid_ids() {
+        let uuid_a = 0x1234_5678_9abc_def0_u128;
+        let uuid_b = 0xfedc_ba98_7654_3210_u128;
+
+        let sources = vec![
+            vec![point_uuid(uuid_a, 1.0), point(7, 0.9)],
+            vec![point_uuid(uuid_b, 1.0), point(7, 0.8)],
+        ];
+
+        let result = fusion_rescore(
+            sources,
+            FusionInternal::Rrf {
+                k: 2,
+                weights: None,
+            },
+            None,
+            10,
+        )
+        .unwrap();
+        let ids = sorted_id_strings(result.iter().map(|point| &point.id));
+
+        assert_eq!(ids.len(), 3, "uuid ids must not be dropped: {ids:?}");
+        assert!(
+            ids.contains(&PointIdType::from(7).to_string()),
+            "mixed numeric id must survive fusion: {ids:?}",
+        );
+        assert!(
+            ids.contains(&PointIdType::Uuid(Uuid::from_u128(uuid_a)).to_string()),
+            "uuid_a must survive fusion: {ids:?}",
+        );
+        assert!(
+            ids.contains(&PointIdType::Uuid(Uuid::from_u128(uuid_b)).to_string()),
+            "uuid_b must survive fusion: {ids:?}",
+        );
     }
 
     #[test]
@@ -166,5 +278,30 @@ mod tests {
 
         let filter = filter_with_point_ids(&sources);
         assert_eq!(filter_num_ids(&filter), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn filter_with_point_ids_preserves_and_deduplicates_uuids() {
+        let uuid_a = 0x1234_5678_9abc_def0_u128;
+        let uuid_b = 0xfedc_ba98_7654_3210_u128;
+
+        // Numeric id 2 and uuid_a are each duplicated across sources.
+        let sources = vec![
+            vec![point(1, 1.0), point_uuid(uuid_a, 1.0)],
+            vec![point(2, 1.0), point_uuid(uuid_a, 1.0)],
+            vec![point_uuid(uuid_b, 1.0), point(2, 1.0)],
+        ];
+
+        let filter = filter_with_point_ids(&sources);
+        assert_eq!(
+            filter_with_point_ids_sorted(&filter),
+            vec![
+                Uuid::from_u128(uuid_a).hyphenated().to_string(),
+                Uuid::from_u128(uuid_b).hyphenated().to_string(),
+                PointIdType::from(1).to_string(),
+                PointIdType::from(2).to_string(),
+            ],
+            "uuids must be preserved and deduplicated alongside numeric ids",
+        );
     }
 }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -15,7 +15,7 @@ use collection::operations::conversions::sharding_method_from_proto;
 use collection::operations::types::{
     INSUFFICIENT_STORAGE_METADATA_KEY, SparseVectorsConfig, VectorsConfigDiff,
 };
-use segment::types::{StrictModeConfig, StrictModeMultivectorConfig, StrictModeSparseConfig};
+use segment::types::StrictModeConfig;
 use tonic::Status;
 use tonic::metadata::MetadataValue;
 
@@ -126,7 +126,7 @@ impl TryFrom<grpc::CreateCollection> for CollectionMetaOperations {
                 sharding_method: sharding_method
                     .map(sharding_method_from_proto)
                     .transpose()?,
-                strict_mode_config: strict_mode_config.map(strict_mode_from_api),
+                strict_mode_config: strict_mode_config.map(StrictModeConfig::from),
                 uuid: None,
                 metadata: if metadata.is_empty() {
                     None
@@ -136,55 +136,6 @@ impl TryFrom<grpc::CreateCollection> for CollectionMetaOperations {
             },
         )?;
         Ok(CollectionMetaOperations::CreateCollection(op))
-    }
-}
-
-pub fn strict_mode_from_api(value: grpc::StrictModeConfig) -> StrictModeConfig {
-    let grpc::StrictModeConfig {
-        enabled,
-        max_query_limit,
-        max_timeout,
-        unindexed_filtering_retrieve,
-        unindexed_filtering_update,
-        search_max_hnsw_ef,
-        search_allow_exact,
-        search_max_oversampling,
-        upsert_max_batchsize,
-        search_max_batchsize,
-        max_collection_vector_size_bytes,
-        read_rate_limit,
-        write_rate_limit,
-        max_collection_payload_size_bytes,
-        max_points_count,
-        filter_max_conditions,
-        condition_max_size,
-        multivector_config,
-        sparse_config,
-        max_payload_index_count,
-        max_resident_memory_percent,
-    } = value;
-    StrictModeConfig {
-        enabled,
-        max_query_limit: max_query_limit.map(|i| i as usize),
-        max_timeout: max_timeout.map(|i| i as usize),
-        unindexed_filtering_retrieve,
-        unindexed_filtering_update,
-        search_max_hnsw_ef: search_max_hnsw_ef.map(|i| i as usize),
-        search_allow_exact,
-        search_max_oversampling: search_max_oversampling.map(f64::from),
-        upsert_max_batchsize: upsert_max_batchsize.map(|i| i as usize),
-        search_max_batchsize: search_max_batchsize.map(|i| i as usize),
-        max_collection_vector_size_bytes: max_collection_vector_size_bytes.map(|i| i as usize),
-        read_rate_limit: read_rate_limit.map(|i| i as usize),
-        write_rate_limit: write_rate_limit.map(|i| i as usize),
-        max_collection_payload_size_bytes: max_collection_payload_size_bytes.map(|i| i as usize),
-        max_points_count: max_points_count.map(|i| i as usize),
-        filter_max_conditions: filter_max_conditions.map(|i| i as usize),
-        condition_max_size: condition_max_size.map(|i| i as usize),
-        multivector_config: multivector_config.map(StrictModeMultivectorConfig::from),
-        sparse_config: sparse_config.map(StrictModeSparseConfig::from),
-        max_payload_index_count: max_payload_index_count.map(|i| i as usize),
-        max_resident_memory_percent: max_resident_memory_percent.map(|i| i as u8),
     }
 }
 


### PR DESCRIPTION
## Summary

Three pieces of duplicated logic between `collection`, `edge`, and `storage` are unified:

1. **`strict_mode_from_api`** (`lib/storage/src/content_manager/conversions.rs`) was a 48-line free function byte-for-byte identical to the existing `impl From<grpc::StrictModeConfig> for segment::types::StrictModeConfig` in `lib/api/src/grpc/conversions.rs`. Deleted in favor of the existing `From` impl (`StrictModeConfig::from`).
2. **`fusion_rescore`** had the identical body in `lib/collection/src/shards/local_shard/query.rs` and `lib/edge/src/read_view/ops/query.rs`, differing only in error type. Moved to a shared `shard::query::rescore::fusion_rescore` returning `segment`'s `OperationResult`; `collection` converts via the existing `From<OperationError> for CollectionError`.
3. **`filter_with_sources_ids` / `filter_by_point_ids`** were the same helper (same logic, same doc comment) in `collection` and `edge`. Unified as a single generic `shard::query::rescore::filter_with_point_ids` — the `I: IntoIterator, I::Item: AsRef<[ScoredPoint]>` bound keeps the caller syntax identical in both crates.

## Changes

- `lib/shard/src/query/rescore.rs` (new): shared `fusion_rescore` + `filter_with_point_ids` + unit tests
- `lib/shard/src/query/mod.rs`: register `pub mod rescore;`
- `lib/collection/src/shards/local_shard/query.rs`: use shared helpers, drop local duplicates
- `lib/edge/src/read_view/ops/query.rs`: use shared helpers, drop local duplicates
- `lib/storage/src/content_manager/conversions.rs`: drop `strict_mode_from_api`, use the existing `From` impl

## Verification

- `cargo check -p shard -p collection -p edge -p storage --all-targets` — clean, no warnings
- `cargo clippy` (same crates, `--all-targets`) — clean
- `cargo fmt --check` — clean
- `cargo test -p shard --lib query::rescore` — 5 new unit tests pass
- `cargo test -p edge` — 66 passed
- `cargo test -p collection --lib` — 253 passed
- `cargo test -p storage --lib` — 50 passed

Note: `cargo test -p shard --lib` has one pre-existing failure (`quota::manager::enforce::tests::limits_only_apply_while_the_quota_is_enabled`) that also fails on clean `dev` — unrelated to this PR.

## AI disclosure

Prepared with assistance from an AI coding agent. The initial prompt was: "Refactor duplicated query helpers between `collection` and `edge` into shared modules: (1) `StrictModeConfig` conversion in `storage` should reuse the existing `From` impl in `api`; (2) `fusion_rescore` and (3) `filter_with_sources_ids`/`filter_by_point_ids` should be shared via `lib/shard/src/query`. Add tests. Do not change behavior." Analysis and verification were human-reviewed.