### PR TITLE
fix(edge): skip pool install for single search thread

### DIFF
--- a/lib/edge/src/read_view/mod.rs
+++ b/lib/edge/src/read_view/mod.rs
@@ -59,8 +59,12 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
         F: Fn(&H) -> OperationResult<R> + Send + Sync,
         R: Send,
     {
-        self.pool
-            .install(|| self.segments.par_iter().map(f).collect())
+        if self.pool.current_num_threads() <= 1 {
+            self.segments.iter().map(f).collect()
+        } else {
+            self.pool
+                .install(|| self.segments.par_iter().map(f).collect())
+        }
     }
 }
 


### PR DESCRIPTION
Skips pool install if search should be sequential. Without this, querying does not scale with global threads in the sequential case, which in some cases is the faster option.

Here's the scaling before:
```
max_search_thr    global_thr    single q/s     batch q/s  batch/single
             1    1           206           505          2.45
             1    2           243           520          2.14
             1    4           243           523          2.16
             1    8           242           526          2.17
             1   16           242           526          2.17
             1   20           243           524          2.15

            80    1           525          2106          4.01
            80    2           784          3333          4.25
            80    4          1080          4978          4.61
            80    8          1284          5756          4.48
            80   16          1368          6383          4.67
            80   20          1376          6302          4.58
```

and after the fix:
```
max_search_thr    global_thr    single q/s     batch q/s  batch/single
             1    1           240           493          2.06
             1    2           475           982          2.07
             1    4           971          1940          2.00
             1    8          1331          3795          2.85
             1   16          1421          4852          3.41
             1   20          1686          5903          3.50

            80    1           498          2147          4.31
            80    2           784          3405          4.34
            80    4          1080          4702          4.35
            80    8          1280          5788          4.52
            80   16          1365          6330          4.64
            80   20          1381          6339          4.59
```