### PR TITLE
[UpdateOnly] append_many is offset-aware; drop UniversalWrite bound

### DIFF
--- a/lib/segment/src/vector_storage/chunked_vectors/test_utils.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/test_utils.rs
@@ -4,20 +4,30 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::universal_io::MmapFile;
 
 use super::update_only::UpdateOnlyChunkedVectors;
+use crate::vector_storage::VectorOffsetType;
 
 pub(super) fn make_vec(seed: usize, dim: usize) -> Vec<f32> {
     (0..dim).map(|i| (seed * dim + i) as f32).collect()
 }
 
-/// Append one durable batch of `make_vec(seed)` vectors through the writer.
+/// Append one durable batch of `make_vec(seed)` vectors through the writer,
+/// each at the offset equal to its own seed — the seed range doubles as the
+/// batch's target [`VectorOffsetType`] range.
 pub(super) fn append_range(
     writer: &mut UpdateOnlyChunkedVectors<f32, MmapFile>,
     seeds: std::ops::Range<usize>,
     dim: usize,
     hw: &HardwareCounterCell,
 ) {
-    let batch: Vec<Vec<f32>> = seeds.map(|seed| make_vec(seed, dim)).collect();
+    let batch: Vec<(VectorOffsetType, Vec<f32>)> = seeds
+        .map(|seed| (seed as VectorOffsetType, make_vec(seed, dim)))
+        .collect();
     writer
-        .append_many(batch.iter().map(|vector| vector.as_slice()), hw)
+        .append_many(
+            batch
+                .iter()
+                .map(|(offset, vector)| (*offset, vector.as_slice())),
+            hw,
+        )
         .unwrap();
 }

--- a/lib/segment/src/vector_storage/chunked_vectors/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/update_only/mod.rs
@@ -7,14 +7,15 @@ use std::path::{Path, PathBuf};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap::AdviceSetting;
 use common::universal_io::{
-    OpenOptions, Populate, StoredStruct, UniversalAppend, UniversalReadFileOps, UniversalReadFs,
-    UniversalWrite, UniversalWriteFileOps,
+    OpenOptions, Populate, UniversalAppend, UniversalReadFileOps, UniversalReadFs,
+    UniversalWriteFileOps,
 };
 
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::vector_storage::VectorOffsetType;
 use crate::vector_storage::chunked_vectors::chunks::{chunk_name, list_chunk_files};
 use crate::vector_storage::chunked_vectors::config::{
-    ChunkedVectorsConfig, Status, ensure_config, status_file,
+    ChunkedVectorsConfig, Status, ensure_config, read_status_len, status_file,
 };
 
 /// Short-lived append-only writer for chunked vectors storage.
@@ -22,12 +23,17 @@ use crate::vector_storage::chunked_vectors::config::{
 /// Holds no chunk handles: each [`append_many`](Self::append_many) opens the
 /// touched chunks, appends, and persists the vector count, so a batch is
 /// durable when it returns and there is nothing to flush.
+///
+/// Bounded on [`UniversalAppend`] alone, not [`UniversalWrite`](common::universal_io::UniversalWrite):
+/// the status file is small enough to go through `atomic_save`, like the
+/// config file, so this writer stays usable over append-only backends
+/// (object stores) that don't support random-offset writes.
 #[derive(Debug)]
 #[cfg_attr(not(test), expect(dead_code))]
-pub struct UpdateOnlyChunkedVectors<T, S: UniversalAppend + UniversalWrite> {
+pub struct UpdateOnlyChunkedVectors<T, S: UniversalAppend> {
     directory: PathBuf,
     config: ChunkedVectorsConfig,
-    status: StoredStruct<S, Status>,
+    status: Status,
     fs: S::Fs,
     _t: PhantomData<T>,
 }
@@ -46,37 +52,54 @@ fn append_options() -> OpenOptions {
 impl<T, S> UpdateOnlyChunkedVectors<T, S>
 where
     T: bytemuck::Pod + Send,
-    S: UniversalAppend + UniversalWrite + 'static,
+    S: UniversalAppend + 'static,
 {
     /// Open a chunked-vectors directory for appending, creating it if missing.
+    ///
+    /// Only reads the persisted vector count; on-disk chunk files are
+    /// reconciled against it lazily, in [`append_many`](Self::append_many),
+    /// once the caller's next batch reveals the offset it actually wants to
+    /// write at.
     pub fn open(fs: S::Fs, directory: &Path, dim: usize) -> OperationResult<Self> {
         let status_path = status_file(directory);
         // An absent status file marks the first open
         if !fs.exists(&status_path)? {
             fs.create_dir(directory)?;
-            fs.create(&status_path, size_of::<Status>())?;
+            fs.atomic_save(&status_path, bytemuck::bytes_of(&Status { len: 0 }))?;
         }
-        let status: StoredStruct<S, Status> =
-            StoredStruct::open(&fs, &status_path, append_options(), Default::default())?;
+        let status = Status {
+            len: read_status_len(&fs, &status_path)?,
+        };
         let config = ensure_config::<T, _>(&fs, directory, dim, false)?;
 
-        let writer = Self {
+        Ok(Self {
             directory: directory.to_owned(),
             config,
             status,
             fs,
             _t: PhantomData,
-        };
-        writer.ensure_chunk_lengths()?;
-        Ok(writer)
+        })
     }
 
-    /// Compare every chunk file's length against the stored vector count.
+    /// Make on-disk chunk files consistent with `target_len` before appending
+    /// at it.
     ///
-    /// Ensures every file is at the expected length by truncating or filling with zeroes.
-    fn ensure_chunk_lengths(&self) -> OperationResult<()> {
-        let total_bytes = self.status.len * self.config.dim * size_of::<T>();
-        let num_chunks = self.status.len.div_ceil(self.config.chunk_size_vectors);
+    /// `target_len` is the offset the caller is about to write its next
+    /// vector at, which may disagree with the persisted watermark
+    /// (`self.status.len`):
+    /// - equal: the ordinary case, nothing to grow or shrink; only a
+    ///   crashed writer's unacknowledged tail bytes need trimming.
+    /// - greater: the caller skipped a range (e.g. deleted points that never
+    ///   got a vector) — pad the gap with zeroes.
+    /// - less: the caller is replaying a range that was already durably
+    ///   appended — discard it, truncating chunks back down to `target_len`
+    ///   so it can be overwritten.
+    ///
+    /// Either way, every chunk file is left at the length `target_len`
+    /// implies, and anything entirely past it is removed.
+    fn reconcile_chunk_lengths(&self, target_len: usize) -> OperationResult<()> {
+        let total_bytes = target_len * self.config.dim * size_of::<T>();
+        let num_chunks = target_len.div_ceil(self.config.chunk_size_vectors);
 
         let mut listed = list_chunk_files(&self.fs, &self.directory)?;
 
@@ -107,10 +130,17 @@ where
                             // truncate
                             log::warn!("Expected smaller chunk, truncating chunk {chunk_id}");
                             let file = self.fs.open_append(&file_info.path, append_options())?;
-                            let content = file.read_whole::<u8>()?.into_owned();
+                            let content = file.read_whole::<u8>()?;
+                            let Some(truncated) = content.get(..expected as usize) else {
+                                return Err(OperationError::service_error(format!(
+                                    "Chunk {chunk_id} is {} bytes, shorter than the expected \
+                                     truncation length {expected}",
+                                    content.len(),
+                                )));
+                            };
+                            let truncated = truncated.to_vec();
                             drop(file);
-                            self.fs
-                                .atomic_save(&file_info.path, &content[..expected as usize])?;
+                            self.fs.atomic_save(&file_info.path, &truncated)?;
                         }
                     }
                 }
@@ -126,16 +156,16 @@ where
             }
         }
 
-        // Files past the watermark hold no acknowledged data; a non-empty one
-        // is an unacknowledged append from a crashed writer.
+        // Files past the boundary hold no data this writer should serve —
+        // either unacknowledged bytes from a crashed writer, an empty file
+        // left behind by `open_chunk_for_append`'s `create()` before the
+        // crash, or data being rolled back because `target_len` shrank.
         for (chunk_id, file) in listed {
-            if file.size > 0 {
-                log::warn!(
-                    "Chunk {chunk_id} past the stored vector count is not empty ({} bytes). Removing.",
-                    file.size,
-                );
-                self.fs.remove(&file.path)?;
-            }
+            log::warn!(
+                "Chunk {chunk_id} past the target vector count ({} bytes). Removing.",
+                file.size,
+            );
+            self.fs.remove(&file.path)?;
         }
 
         Ok(())
@@ -143,23 +173,45 @@ where
 
     /// Append a batch of vectors at the end of the storage, one file append
     /// per touched chunk, then persist the new vector count.
+    ///
+    /// `vectors` pairs each vector with the offset it belongs at. The stream
+    /// must be ordered and contiguous: offsets increase by exactly one from
+    /// entry to entry. The *first* offset is checked against the persisted
+    /// watermark to decide whether on-disk chunks need to grow or shrink
+    /// before this batch lands — see
+    /// [`reconcile_chunk_lengths`](Self::reconcile_chunk_lengths).
     pub fn append_many<'a>(
         &mut self,
-        vectors: impl IntoIterator<Item = &'a [T]>,
+        vectors: impl IntoIterator<Item = (VectorOffsetType, &'a [T])>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         let mut vectors = vectors.into_iter().peekable();
-        let mut len = self.status.len;
+        let Some((first_offset, _)) = vectors.peek().copied() else {
+            return Ok(());
+        };
+
+        self.reconcile_chunk_lengths(first_offset)?;
+        let mut len = first_offset;
 
         while vectors.peek().is_some() {
             let chunk_idx = self.config.get_chunk_index(len);
             let chunk_offset = self.config.get_chunk_offset(len);
             let capacity = self.config.remaining_chunk_capacity(len);
 
-            let batch: Vec<&[T]> = vectors.by_ref().take(capacity).collect();
-            for vector in &batch {
-                assert_eq!(vector.len(), self.config.dim, "Vector size mismatch");
-            }
+            let batch: Vec<&[T]> = vectors
+                .by_ref()
+                .take(capacity)
+                .enumerate()
+                .map(|(i, (offset, vector))| {
+                    assert_eq!(
+                        offset,
+                        len + i,
+                        "vector offsets must be contiguous, starting at {first_offset}"
+                    );
+                    assert_eq!(vector.len(), self.config.dim, "Vector size mismatch");
+                    vector
+                })
+                .collect();
             let batch_bytes = batch.len() * self.config.dim * size_of::<T>();
 
             let mut chunk = self.open_chunk_for_append(chunk_idx, chunk_offset == 0)?;
@@ -176,7 +228,10 @@ where
 
         // Persist the watermark only after the data landed
         self.status.len = len;
-        self.status.flusher()()?;
+        self.fs.atomic_save(
+            &status_file(&self.directory),
+            bytemuck::bytes_of(&self.status),
+        )?;
 
         Ok(())
     }

--- a/lib/segment/src/vector_storage/chunked_vectors/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/update_only/mod.rs
@@ -11,7 +11,7 @@ use common::universal_io::{
     UniversalWrite, UniversalWriteFileOps,
 };
 
-use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::operation_error::OperationResult;
 use crate::vector_storage::chunked_vectors::chunks::{chunk_name, list_chunk_files};
 use crate::vector_storage::chunked_vectors::config::{
     ChunkedVectorsConfig, Status, ensure_config, status_file,
@@ -67,17 +67,14 @@ where
             fs,
             _t: PhantomData,
         };
-        writer.check_chunk_lengths()?;
+        writer.ensure_chunk_lengths()?;
         Ok(writer)
     }
 
-    /// Compare every chunk file's length against the stored vector count,
-    /// without opening any chunk.
+    /// Compare every chunk file's length against the stored vector count.
     ///
-    /// Rejects mismatches in both directions: a shorter chunk lost
-    /// acknowledged data, a longer one holds unacknowledged appends from a
-    /// crashed writer, which we don't attempt to adopt for now.
-    fn check_chunk_lengths(&self) -> OperationResult<()> {
+    /// Ensures every file is at the expected length by truncating or filling with zeroes.
+    fn ensure_chunk_lengths(&self) -> OperationResult<()> {
         let total_bytes = self.status.len * self.config.dim * size_of::<T>();
         let num_chunks = self.status.len.div_ceil(self.config.chunk_size_vectors);
 
@@ -90,18 +87,41 @@ where
                 .min(total_bytes.saturating_sub(chunk_id * self.config.chunk_size_bytes))
                 as u64;
             match listed.remove(&chunk_id) {
-                Some(file) if file.size == expected => {}
-                Some(file) => {
-                    return Err(OperationError::inconsistent_storage(format!(
-                        "Chunk {chunk_id} length {} doesn't match the expected {expected}",
-                        file.size,
-                    )));
+                Some(file_info) => {
+                    match file_info.size.cmp(&expected) {
+                        std::cmp::Ordering::Equal => {
+                            // Ok
+                        }
+                        std::cmp::Ordering::Less => {
+                            // fill with zeroes
+                            log::warn!(
+                                "Expected larger chunk, filling chunk {chunk_id} with zeroes"
+                            );
+                            let data = vec![0u8; (expected - file_info.size) as usize];
+                            let mut file =
+                                self.fs.open_append(&file_info.path, append_options())?;
+                            file.append(file_info.size, &data)?;
+                            file.flusher()()?;
+                        }
+                        std::cmp::Ordering::Greater => {
+                            // truncate
+                            log::warn!("Expected smaller chunk, truncating chunk {chunk_id}");
+                            let file = self.fs.open_append(&file_info.path, append_options())?;
+                            let content = file.read_whole::<u8>()?.into_owned();
+                            drop(file);
+                            self.fs
+                                .atomic_save(&file_info.path, &content[..expected as usize])?;
+                        }
+                    }
                 }
                 None => {
-                    return Err(OperationError::inconsistent_storage(format!(
-                        "Missing chunk {chunk_id} in {}",
-                        self.directory.display(),
-                    )));
+                    // create and fill with zeroes
+                    log::warn!(
+                        "Expected non-existing chunk {chunk_id}, creating and filling with zeroes"
+                    );
+                    let mut file = self.open_chunk_for_append(chunk_id, true)?;
+                    file.append(0, &vec![0u8; expected as usize])?;
+                    file.flusher()()?;
                 }
             }
         }
@@ -110,10 +130,11 @@ where
         // is an unacknowledged append from a crashed writer.
         for (chunk_id, file) in listed {
             if file.size > 0 {
-                return Err(OperationError::inconsistent_storage(format!(
-                    "Chunk {chunk_id} past the stored vector count is not empty ({} bytes)",
+                log::warn!(
+                    "Chunk {chunk_id} past the stored vector count is not empty ({} bytes). Removing.",
                     file.size,
-                )));
+                );
+                self.fs.remove(&file.path)?;
             }
         }
 

--- a/lib/segment/src/vector_storage/chunked_vectors/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/update_only/tests.rs
@@ -120,11 +120,13 @@ fn directory_reads_congruently() {
     }
 }
 
-/// A preallocated (`ChunkedVectors`-written) directory is repaired on open:
-/// chunk files longer than the stored vector count implies are truncated back
-/// to the data, after which appends continue where the count left off.
+/// A preallocated (`ChunkedVectors`-written) directory has chunk files longer
+/// than the stored vector count implies. `open` no longer inspects chunk
+/// files at all, so it succeeds regardless; the next `append_many` call
+/// reconciles the oversized chunk down to the persisted watermark before
+/// appending, same as it would for a crashed writer's leftover bytes.
 #[test]
-fn repairs_preallocated_chunks() {
+fn repairs_preallocated_chunks_on_next_append() {
     let hw = HardwareCounterCell::disposable();
     let dir = Builder::new().prefix("chunked_prealloc").tempdir().unwrap();
 
@@ -140,23 +142,19 @@ fn repairs_preallocated_chunks() {
     plain.flusher()().unwrap();
     drop(plain);
 
-    let vector_bytes = (DIM * size_of::<f32>()) as u64;
-    let chunk = chunk_name(dir.path(), 0);
-    assert!(
-        fs_err::metadata(&chunk).unwrap().len() > vector_bytes,
-        "chunk must be preallocated past the single stored vector",
-    );
+    // The chunk file is preallocated to a full chunk, way past the single
+    // stored vector the status file reports.
+    let preallocated_size = fs_err::metadata(chunk_name(dir.path(), 0)).unwrap().len();
+    assert!(preallocated_size > (DIM * size_of::<f32>()) as u64);
 
     let mut writer =
         UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, dir.path(), DIM).unwrap();
-    assert_eq!(
-        fs_err::metadata(&chunk).unwrap().len(),
-        vector_bytes,
-        "chunk truncated back to the data",
-    );
+    append_range(&mut writer, 1..2, DIM, &hw);
 
-    // The stored vector survived the truncation, and appends continue after it
-    append_range(&mut writer, 1..3, DIM, &hw);
+    // The chunk shrank to exactly what the two vectors need — the
+    // preallocated tail is gone.
+    let repaired_size = fs_err::metadata(chunk_name(dir.path(), 0)).unwrap().len();
+    assert_eq!(repaired_size, (2 * DIM * size_of::<f32>()) as u64);
 
     let reader = ReadOnlyChunkedVectors::<f32, MmapFile>::open(
         &MmapFs,
@@ -166,10 +164,128 @@ fn repairs_preallocated_chunks() {
         Populate::No,
     )
     .unwrap();
-    assert_eq!(reader.len(), 3);
-    for key in 0..3 {
+    assert_eq!(reader.len(), 2);
+    for key in 0..2 {
         assert_eq!(
-            reader.get::<Random>(key).unwrap().as_ref(),
+            reader
+                .get::<Random>(key as VectorOffsetType)
+                .unwrap()
+                .as_ref(),
+            make_vec(key, DIM).as_slice(),
+        );
+    }
+}
+
+/// A batch whose first offset lands *behind* the persisted watermark is a
+/// replay of an already-applied range (e.g. a WAL resending a batch after a
+/// crash that happened before the outer commit pointer advanced, but after
+/// this writer's data was durable). `append_many` must shrink the chunk back
+/// to that offset and overwrite it, rather than blindly appending after the
+/// existing data and corrupting the offset-to-vector mapping.
+#[test]
+fn replaying_an_already_applied_range_overwrites_it() {
+    let hw = HardwareCounterCell::disposable();
+    let dir = Builder::new().prefix("chunked_replay").tempdir().unwrap();
+
+    let mut writer =
+        UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, dir.path(), DIM).unwrap();
+    append_range(&mut writer, 0..100, DIM, &hw);
+
+    // Replay offsets 50..100 with different vectors than landed the first
+    // time, so the overwrite is observable.
+    let replay: Vec<(VectorOffsetType, Vec<f32>)> = (50..100)
+        .map(|seed| (seed as VectorOffsetType, make_vec(seed + 1000, DIM)))
+        .collect();
+    writer
+        .append_many(
+            replay
+                .iter()
+                .map(|(offset, vector)| (*offset, vector.as_slice())),
+            &hw,
+        )
+        .unwrap();
+
+    let reader = ReadOnlyChunkedVectors::<f32, MmapFile>::open(
+        &MmapFs,
+        dir.path(),
+        DIM,
+        AdviceSetting::Global,
+        Populate::No,
+    )
+    .unwrap();
+    // Not doubled: the watermark lands back at 100, not 150.
+    assert_eq!(reader.len(), 100);
+    for key in 0..50 {
+        assert_eq!(
+            reader
+                .get::<Random>(key as VectorOffsetType)
+                .unwrap()
+                .as_ref(),
+            make_vec(key, DIM).as_slice(),
+            "untouched prefix should be unchanged",
+        );
+    }
+    for key in 50..100 {
+        assert_eq!(
+            reader
+                .get::<Random>(key as VectorOffsetType)
+                .unwrap()
+                .as_ref(),
+            make_vec(key + 1000, DIM).as_slice(),
+            "replayed range should reflect the newer batch",
+        );
+    }
+}
+
+/// A batch whose first offset lands *ahead* of the persisted watermark
+/// skips a range (e.g. points deleted before ever getting a vector).
+/// `append_many` pads the gap with zero vectors instead of shifting later
+/// offsets down to close it.
+#[test]
+fn extends_across_a_gap_with_zeroes() {
+    let hw = HardwareCounterCell::disposable();
+    let dir = Builder::new().prefix("chunked_gap").tempdir().unwrap();
+
+    let mut writer =
+        UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, dir.path(), DIM).unwrap();
+    append_range(&mut writer, 0..10, DIM, &hw);
+    // Offsets 10..15 are skipped; the next batch picks up at 15.
+    append_range(&mut writer, 15..20, DIM, &hw);
+
+    let reader = ReadOnlyChunkedVectors::<f32, MmapFile>::open(
+        &MmapFs,
+        dir.path(),
+        DIM,
+        AdviceSetting::Global,
+        Populate::No,
+    )
+    .unwrap();
+    assert_eq!(reader.len(), 20);
+    for key in 0..10 {
+        assert_eq!(
+            reader
+                .get::<Random>(key as VectorOffsetType)
+                .unwrap()
+                .as_ref(),
+            make_vec(key, DIM).as_slice(),
+        );
+    }
+    for key in 10..15 {
+        assert_eq!(
+            reader
+                .get::<Random>(key as VectorOffsetType)
+                .unwrap()
+                .as_ref(),
+            vec![0.0f32; DIM].as_slice(),
+            "skipped offset {key} should read back as zeroes",
+        );
+    }
+    for key in 15..20 {
+        assert_eq!(
+            reader
+                .get::<Random>(key as VectorOffsetType)
+                .unwrap()
+                .as_ref(),
             make_vec(key, DIM).as_slice(),
         );
     }

--- a/lib/segment/src/vector_storage/chunked_vectors/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/update_only/tests.rs
@@ -5,7 +5,6 @@ use common::universal_io::{MmapFile, MmapFs, Populate};
 use tempfile::{Builder, TempDir};
 
 use super::UpdateOnlyChunkedVectors;
-use crate::common::operation_error::OperationError;
 use crate::vector_storage::VectorOffsetType;
 use crate::vector_storage::chunked_vectors::ChunkedVectors;
 use crate::vector_storage::chunked_vectors::chunks::chunk_name;
@@ -121,11 +120,11 @@ fn directory_reads_congruently() {
     }
 }
 
-/// A preallocated (`ChunkedVectors`-written) directory is not appendable-to:
-/// its chunk files are longer than the stored vector count implies, which the
-/// update-only writer rejects instead of adopting.
+/// A preallocated (`ChunkedVectors`-written) directory is repaired on open:
+/// chunk files longer than the stored vector count implies are truncated back
+/// to the data, after which appends continue where the count left off.
 #[test]
-fn rejects_preallocated_chunks() {
+fn repairs_preallocated_chunks() {
     let hw = HardwareCounterCell::disposable();
     let dir = Builder::new().prefix("chunked_prealloc").tempdir().unwrap();
 
@@ -141,9 +140,37 @@ fn rejects_preallocated_chunks() {
     plain.flusher()().unwrap();
     drop(plain);
 
-    let err = UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, dir.path(), DIM).unwrap_err();
+    let vector_bytes = (DIM * size_of::<f32>()) as u64;
+    let chunk = chunk_name(dir.path(), 0);
     assert!(
-        matches!(err, OperationError::InconsistentStorage { description: _ }),
-        "{err}",
+        fs_err::metadata(&chunk).unwrap().len() > vector_bytes,
+        "chunk must be preallocated past the single stored vector",
     );
+
+    let mut writer =
+        UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, dir.path(), DIM).unwrap();
+    assert_eq!(
+        fs_err::metadata(&chunk).unwrap().len(),
+        vector_bytes,
+        "chunk truncated back to the data",
+    );
+
+    // The stored vector survived the truncation, and appends continue after it
+    append_range(&mut writer, 1..3, DIM, &hw);
+
+    let reader = ReadOnlyChunkedVectors::<f32, MmapFile>::open(
+        &MmapFs,
+        dir.path(),
+        DIM,
+        AdviceSetting::Global,
+        Populate::No,
+    )
+    .unwrap();
+    assert_eq!(reader.len(), 3);
+    for key in 0..3 {
+        assert_eq!(
+            reader.get::<Random>(key).unwrap().as_ref(),
+            make_vec(key, DIM).as_slice(),
+        );
+    }
 }


### PR DESCRIPTION
Follow-up to #10114, addressing @dancixx's review.

**`append_many` is now offset-aware.** It took bare vectors and always appended after `status.len`, with the chunk-length repair running once at `open()`, trusting the persisted watermark unconditionally — no way to tell a WAL replaying an already-applied batch (would double the data) from a batch skipping a range (would misalign everything after the gap).

`append_many` now takes `(VectorOffsetType, &[T])` pairs (ordered, contiguous) and does the repair itself, keyed off the batch's first offset:
- first offset == watermark: normal case, just trims a crashed writer's unacknowledged tail.
- first offset > watermark: a skipped range gets zero-filled.
- first offset < watermark: an already-applied range gets truncated and overwritten, not duplicated.

`open()` is now cheap — just reads the vector count.

**Status via `atomic_save`.** `S: UniversalAppend` already guarantees `atomic_save` through `S::Fs`, so swapped `StoredStruct<S, Status>` for a plain field + `atomic_save` and dropped the `UniversalWrite` bound, matching your suggestion.

**Also:** fixed the truncate-path panic on a content/listed-size mismatch (now an error), and stray chunk files past the watermark are removed unconditionally (previously skipped empty ones). Replaced the now-stale `rejects_preallocated_chunks` test and added coverage for the gap-fill / replay-overwrite paths.

Test plan: `cargo test -p segment --lib vector_storage::chunked_vectors` (10/10), `mold -run cargo clippy --workspace --all-targets` clean.