### PR TITLE
Add UpdateOnlyDiskIdTracker, the delete-only writer

### DIFF
--- a/lib/segment/src/id_tracker/disk_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/mod.rs
@@ -2,12 +2,17 @@
 //! [on-disk format](on_disk_format)), so resident memory does not scale with
 //! point count. The mapping is immutable once written.
 //!
-//! Two trackers share the [`reader`] core:
+//! [`DiskIdTracker`] and [`ReadOnlyDiskIdTracker`] share the [`reader`] core:
 //!
 //! - [`DiskIdTracker`] — writable but deletion-only (non-appendable, R6);
-//!   `deleted` and `versions` are resident and mutated in place.
+//!   `deleted` and `versions` are resident and mutated in place. Also builds
+//!   the segment (the mapping plus the initial `deleted`/`versions` state).
 //! - [`ReadOnlyDiskIdTracker`] — fully read-only; picks up external deletions
 //!   via live-reload.
+//! - [`UpdateOnlyDiskIdTracker`](update_only::UpdateOnlyDiskIdTracker) — a
+//!   narrower writer over an already-built segment: no mapping lookup, no
+//!   read surface, just batch-marking internal offsets deleted, persisted via
+//!   whole-file rewrites so it only needs an append-only backend.
 
 mod id_tracker;
 mod id_tracker_read;
@@ -16,6 +21,7 @@ pub mod mappings;
 pub mod on_disk_format;
 pub mod read_only;
 mod reader;
+pub mod update_only;
 
 #[cfg(test)]
 mod tests;

--- a/lib/segment/src/id_tracker/disk_id_tracker/update_only/delete.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/update_only/delete.rs
@@ -1,0 +1,30 @@
+//! The one mutation this type offers: marking internal offsets deleted.
+
+use common::types::PointOffsetType;
+use common::universal_io::{UniversalAppend, UniversalWriteFileOps as _};
+
+use super::UpdateOnlyDiskIdTracker;
+use crate::common::operation_error::OperationResult;
+use crate::id_tracker::immutable_id_tracker::deleted_path;
+
+impl<S: UniversalAppend> UpdateOnlyDiskIdTracker<S> {
+    /// Mark every offset in `internal_ids` deleted and persist the whole
+    /// `deleted` file via `atomic_save`. Does not touch the `versions` file.
+    /// Offsets already deleted are handled without error.
+    pub fn delete_batch(&mut self, internal_ids: &[PointOffsetType]) -> OperationResult<()> {
+        if internal_ids.is_empty() {
+            return Ok(());
+        }
+
+        for &internal_id in internal_ids {
+            self.deleted.set(internal_id as usize, true);
+        }
+
+        self.fs.atomic_save(
+            &deleted_path(&self.path),
+            bytemuck::cast_slice(self.deleted.as_raw_slice()),
+        )?;
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/id_tracker/disk_id_tracker/update_only/lifecycle.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/update_only/lifecycle.rs
@@ -1,0 +1,41 @@
+//! Opening the append-only-backend delete writer over an existing
+//! [`DiskIdTracker`](super::super::DiskIdTracker) segment.
+
+use std::path::Path;
+
+use common::bitvec::BitVec;
+use common::mmap::AdviceSetting;
+use common::stored_bitslice::StoredBitSlice;
+use common::universal_io::{OpenOptions, Populate, UniversalAppend};
+
+use super::UpdateOnlyDiskIdTracker;
+use crate::common::operation_error::OperationResult;
+use crate::id_tracker::immutable_id_tracker::deleted_path;
+
+impl<S: UniversalAppend> UpdateOnlyDiskIdTracker<S> {
+    /// Open the `deleted` file of a segment already built by
+    /// [`DiskIdTracker`](super::super::DiskIdTracker); the mapping and
+    /// `versions` files are untouched by this type and stay on disk.
+    pub fn open(fs: &S::Fs, segment_path: &Path) -> OperationResult<Self> {
+        let open_options = OpenOptions {
+            writeable: false,
+            need_sequential: false,
+            populate: Populate::Blocking,
+            advice: AdviceSetting::Global,
+        };
+
+        let deleted_storage = StoredBitSlice::open(
+            fs,
+            deleted_path(segment_path),
+            open_options,
+            Default::default(),
+        )?;
+        let deleted: BitVec = deleted_storage.read_all()?.into_owned();
+
+        Ok(Self {
+            path: segment_path.to_path_buf(),
+            fs: fs.clone(),
+            deleted,
+        })
+    }
+}

--- a/lib/segment/src/id_tracker/disk_id_tracker/update_only/mod.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/update_only/mod.rs
@@ -1,0 +1,61 @@
+//! Delete-only writer for [`DiskIdTracker`](super::DiskIdTracker)'s `deleted`
+//! file, for backends that can only append, never seek-and-overwrite.
+//!
+//! `DiskIdTracker` builds the segment (the immutable mapping plus the initial
+//! `deleted`/`versions` state); this type only ever [`open`](Self::open)s an
+//! already-built segment and applies further deletions to it. Deleting a
+//! point in [`DiskIdTracker`] seeks and flips its bit in place, which needs
+//! random-offset writes ([`UniversalWrite`](common::universal_io::UniversalWrite));
+//! this type instead rewrites the file whole through
+//! [`UniversalWriteFileOps::atomic_save`](common::universal_io::UniversalWriteFileOps::atomic_save)
+//! on every [`delete_batch`](Self::delete_batch) call, which only needs
+//! [`UniversalAppend`] (append-only backends implement `atomic_save` too,
+//! e.g. as a full-object overwrite). The file stays byte-for-byte identical
+//! to [`DiskIdTracker`]'s format, so [`DiskIdTracker`]/[`ReadOnlyDiskIdTracker`](super::ReadOnlyDiskIdTracker)
+//! can open the result unchanged.
+//!
+//! It does not touch the `versions` file — deletion here is purely the
+//! `deleted` bit, not a version bump — nor is there a read surface (no
+//! [`IdTrackerRead`](crate::id_tracker::IdTrackerRead)) or mapping lookup:
+//! callers already know the internal offsets to delete, so nothing here needs
+//! the `i2e`/`e2i` mapping reader.
+//!
+//! Rewriting the whole file on every call is wasteful for a segment with
+//! frequent deletions; an incremental append-only delete log is a natural
+//! follow-up once that matters.
+
+mod delete;
+mod lifecycle;
+
+#[cfg(test)]
+mod tests;
+
+use std::path::PathBuf;
+
+use common::bitvec::BitVec;
+use common::universal_io::UniversalAppend;
+
+/// Delete-only, append-only-backend writer over an existing
+/// [`DiskIdTracker`](super::DiskIdTracker) segment. See the module docs.
+#[derive(Debug)]
+pub struct UpdateOnlyDiskIdTracker<S: UniversalAppend> {
+    path: PathBuf,
+    /// Filesystem handle, retained to run [`atomic_save`](common::universal_io::UniversalWriteFileOps::atomic_save)
+    /// from [`delete_batch`](Self::delete_batch).
+    fs: S::Fs,
+
+    /// Resident deleted set; rewritten whole on every [`delete_batch`](Self::delete_batch) call.
+    deleted: BitVec,
+}
+
+impl<S: UniversalAppend> UpdateOnlyDiskIdTracker<S> {
+    /// Approximate resident RAM: the deleted bitvec.
+    pub fn ram_usage_bytes(&self) -> usize {
+        let Self {
+            path: _,
+            fs: _,
+            deleted,
+        } = self;
+        deleted.capacity().div_ceil(u8::BITS as usize)
+    }
+}

--- a/lib/segment/src/id_tracker/disk_id_tracker/update_only/tests.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/update_only/tests.rs
@@ -1,0 +1,100 @@
+use common::types::DeferredBehavior;
+use common::universal_io::{MmapFile, MmapFs};
+use rand::SeedableRng as _;
+use rand::rngs::StdRng;
+use tempfile::Builder;
+
+use super::UpdateOnlyDiskIdTracker;
+use crate::id_tracker::IdTrackerRead;
+use crate::id_tracker::compressed::compressed_point_mappings::CompressedPointMappings;
+use crate::id_tracker::disk_id_tracker::{DiskIdTracker, ReadOnlyDiskIdTracker};
+use crate::id_tracker::in_memory_id_tracker::InMemoryIdTracker;
+use crate::types::{PointIdType, SeqNumberType};
+
+fn make_data(seed: u64) -> (Vec<SeqNumberType>, CompressedPointMappings) {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let in_memory = InMemoryIdTracker::random(&mut rng, 2_000, 1_700, 32);
+    let (versions, mappings) = in_memory.into_internal();
+    (versions, CompressedPointMappings::from_mappings(mappings))
+}
+
+/// Deletions applied through `UpdateOnlyDiskIdTracker` must be visible to
+/// `DiskIdTracker`/`ReadOnlyDiskIdTracker` reading the same path, and must not
+/// disturb points that were not deleted. Versions are left untouched.
+#[test]
+fn delete_batch_is_visible_to_disk_id_tracker_readers() {
+    let (versions, mappings) = make_data(1);
+    let dir = Builder::new().prefix("disk").tempdir().unwrap();
+    let disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
+
+    let live: Vec<(PointIdType, u32)> = disk.point_mappings().iter_from(None).collect();
+    let (to_delete, to_keep) = live.split_at(50);
+    let to_delete_offsets: Vec<u32> = to_delete.iter().map(|&(_, offset)| offset).collect();
+
+    let mut update_only = UpdateOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+    update_only.delete_batch(&to_delete_offsets).unwrap();
+
+    let reopened_disk = DiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+    let read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+
+    for (external_id, offset) in to_delete {
+        assert!(reopened_disk.is_deleted_point(*offset));
+        assert_eq!(
+            reopened_disk.internal_version(*offset),
+            Some(versions[*offset as usize]),
+            "delete_batch must not touch the version mapping",
+        );
+        assert_eq!(
+            reopened_disk.internal_id_with_behavior(*external_id, DeferredBehavior::VisibleOnly),
+            None,
+        );
+
+        assert!(read_only.is_deleted_point(*offset));
+        assert_eq!(
+            read_only.internal_id_with_behavior(*external_id, DeferredBehavior::VisibleOnly),
+            None,
+        );
+    }
+
+    // Untouched points must survive exactly as built.
+    for (external_id, offset) in to_keep {
+        assert!(!reopened_disk.is_deleted_point(*offset));
+        assert_eq!(
+            reopened_disk.internal_id_with_behavior(*external_id, DeferredBehavior::VisibleOnly),
+            Some(*offset),
+        );
+        assert!(!read_only.is_deleted_point(*offset));
+    }
+}
+
+#[test]
+fn delete_batch_is_idempotent() {
+    let (versions, mappings) = make_data(2);
+    let dir = Builder::new().prefix("disk").tempdir().unwrap();
+    let _disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
+
+    let mut update_only = UpdateOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+    update_only.delete_batch(&[3, 7, 7, 3]).unwrap();
+    update_only.delete_batch(&[7]).unwrap();
+
+    let read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+    assert!(read_only.is_deleted_point(3));
+    assert!(read_only.is_deleted_point(7));
+    assert_eq!(read_only.internal_version(3), Some(versions[3]));
+    assert_eq!(read_only.internal_version(7), Some(versions[7]));
+}
+
+#[test]
+fn empty_batch_is_a_noop() {
+    let (versions, mappings) = make_data(3);
+    let dir = Builder::new().prefix("disk").tempdir().unwrap();
+    let _disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
+
+    let before = fs_err::read(dir.path().join("id_tracker.deleted")).unwrap();
+
+    let mut update_only = UpdateOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+    update_only.delete_batch(&[]).unwrap();
+
+    let after = fs_err::read(dir.path().join("id_tracker.deleted")).unwrap();
+    assert_eq!(before, after, "empty batch must not touch the file");
+}

--- a/lib/segment/src/id_tracker/disk_id_tracker/update_only/tests.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/update_only/tests.rs
@@ -31,6 +31,9 @@ fn delete_batch_is_visible_to_disk_id_tracker_readers() {
     let (to_delete, to_keep) = live.split_at(50);
     let to_delete_offsets: Vec<u32> = to_delete.iter().map(|&(_, offset)| offset).collect();
 
+    // Windows cannot replace a file that is still memory-mapped.
+    drop(disk);
+
     let mut update_only = UpdateOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
     update_only.delete_batch(&to_delete_offsets).unwrap();
 
@@ -71,7 +74,9 @@ fn delete_batch_is_visible_to_disk_id_tracker_readers() {
 fn delete_batch_is_idempotent() {
     let (versions, mappings) = make_data(2);
     let dir = Builder::new().prefix("disk").tempdir().unwrap();
-    let _disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
+    let disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
+    // Windows cannot replace a file that is still memory-mapped.
+    drop(disk);
 
     let mut update_only = UpdateOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
     update_only.delete_batch(&[3, 7, 7, 3]).unwrap();
@@ -88,7 +93,7 @@ fn delete_batch_is_idempotent() {
 fn empty_batch_is_a_noop() {
     let (versions, mappings) = make_data(3);
     let dir = Builder::new().prefix("disk").tempdir().unwrap();
-    let _disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
+    DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
 
     let before = fs_err::read(dir.path().join("id_tracker.deleted")).unwrap();
 


### PR DESCRIPTION
## Summary
- `DiskIdTracker`'s `deleted` bitvec is mutated in place (flip an arbitrary bit at delete time), which needs random-offset writes (`UniversalWrite`) — unavailable on backends that can only append.
- `UpdateOnlyDiskIdTracker` opens an already-built `DiskIdTracker` segment and offers exactly one operation, `delete_batch`: mark a batch of internal offsets deleted and persist the whole `deleted` file via `UniversalWriteFileOps::atomic_save`, so it only needs `UniversalAppend`.
- The rewritten file stays byte-for-byte identical to `DiskIdTracker`'s own format, so `DiskIdTracker`/`ReadOnlyDiskIdTracker` can open the result unchanged — no reader-side changes needed.
- Deliberately narrow: no read surface (no `IdTrackerRead`), no mapping lookup, no `new`/`from_in_memory_tracker` (`DiskIdTracker` still owns building the segment), and it does not touch the `versions` file (no `DELETED_POINT_VERSION`-style crash-repair bookkeeping on this path).

Stacked on #10093.

## Test plan
- [x] `cargo test -p segment --lib id_tracker::disk_id_tracker` (14 tests, including 3 new ones covering delete visibility through `DiskIdTracker`/`ReadOnlyDiskIdTracker`, idempotency, and empty-batch no-op)
- [x] `mold -run cargo clippy -p segment --all-targets` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
