### PR TITLE
fix(segment): keep OnDiskMapIndex values_count deletion-aware

### DIFF
--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/lifecycle.rs
@@ -230,7 +230,7 @@ where
                 // `storage.remove_point` marks the point as deleted; it is
                 // per-point (idempotent in `idx`), so it only needs to run once
                 // rather than once per removed value.
-                self.storage.remove_point(idx);
+                self.storage.remove_point(idx)?;
                 self.indexed_points = self.indexed_points.saturating_sub(1);
             }
             self.values_count = self.values_count.saturating_sub(removed_values_count);

--- a/lib/segment/src/index/field_index/map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/lifecycle.rs
@@ -97,10 +97,7 @@ where
         match self {
             MapIndex::Mutable(index) => index.remove_point(id),
             MapIndex::Immutable(index) => index.remove_point(id),
-            MapIndex::OnDisk(index) => {
-                index.remove_point(id);
-                Ok(())
-            }
+            MapIndex::OnDisk(index) => index.remove_point(id),
         }
     }
 

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
@@ -122,6 +122,17 @@ where
             &mut deleted,
         )?;
 
+        // `config.total_key_value_pairs` counts every point, including ones
+        // already deleted at build/open time. Subtract their contributions so
+        // `total_key_value_pairs` stays consistent with `get_indexed_points()`
+        // (both used together to derive average values-per-point elsewhere).
+        let mut total_key_value_pairs = config.total_key_value_pairs;
+        for idx in deleted.iter_ones() {
+            if let Some(count) = point_to_values.get_values_count(idx as PointOffsetType)? {
+                total_key_value_pairs = total_key_value_pairs.saturating_sub(count);
+            }
+        }
+
         Ok(Some(Self {
             path: path.to_path_buf(),
             storage: Storage {
@@ -130,7 +141,7 @@ where
                 deleted: DeletedBitVec::new(deleted),
                 prefix_index,
             },
-            total_key_value_pairs: config.total_key_value_pairs,
+            total_key_value_pairs,
             compact_deleted_mask,
         }))
     }
@@ -139,8 +150,13 @@ where
     ///
     /// Not persisted: on reopen, deletions must be re-supplied via the
     /// `deleted_points` argument to [`Self::open`].
-    pub fn remove_point(&mut self, idx: PointOffsetType) {
-        self.storage.deleted.mark_deleted(idx);
+    pub fn remove_point(&mut self, idx: PointOffsetType) -> OperationResult<()> {
+        if self.storage.deleted.mark_deleted(idx)
+            && let Some(count) = self.storage.point_to_values.get_values_count(idx)?
+        {
+            self.total_key_value_pairs = self.total_key_value_pairs.saturating_sub(count);
+        }
+        Ok(())
     }
 
     pub fn files(&self) -> Vec<PathBuf> {

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/live_reload.rs
@@ -27,7 +27,7 @@ where
         // this UniversalMapIndex is not mutable.
         // We only patch in-memory deleted bitslice representation.
         for deleted_point in deleted_points {
-            self.remove_point(*deleted_point)
+            self.remove_point(*deleted_point)?;
         }
 
         Ok(())

--- a/lib/segment/src/index/field_index/map_index/tests.rs
+++ b/lib/segment/src/index/field_index/map_index/tests.rs
@@ -402,6 +402,72 @@ fn test_map_index_reload(#[case] index_type: IndexType) {
     assert_eq!(hits, vec![3, 4]);
 }
 
+/// Regression test: `get_values_count()` must stay consistent with
+/// `get_indexed_points()` as points are deleted, both for in-place deletion
+/// (`remove_point`) and across a reload with a pre-supplied `deleted_points`
+/// bitslice. On a single-valued field this ratio (`values_count /
+/// indexed_points`) feeds `combine_match_any_estimations`'s exclusivity
+/// weight — if it drifts away from 1 under deletions, `match_any` cardinality
+/// estimation silently degrades back towards the independence-OR
+/// under-count that this estimator exists to avoid.
+#[rstest]
+#[case(IndexType::MutableGridstore)]
+#[case(IndexType::Mmap)]
+#[case(IndexType::RamMmap)]
+fn test_map_index_values_count_consistent_after_deletion(#[case] index_type: IndexType) {
+    let temp_dir = Builder::new().prefix("store_dir").tempdir().unwrap();
+    // Single-valued: every point contributes exactly one value.
+    let data: Vec<Vec<IntPayloadType>> = vec![
+        vec![1], // id 0
+        vec![1], // id 1
+        vec![2], // id 2
+        vec![2], // id 3
+        vec![3], // id 4
+        vec![3], // id 5
+    ];
+
+    {
+        save_map_index::<IntPayloadType>(&data, temp_dir.path(), index_type, |v| (*v).into());
+        let mut index = load_map_index::<IntPayloadType>(&data, temp_dir.path(), index_type);
+        index.remove_point(1).unwrap();
+        index.remove_point(2).unwrap();
+        index.flusher()().unwrap();
+        assert_eq!(index.get_indexed_points(), 4);
+        assert_eq!(
+            index.get_values_count(),
+            index.get_indexed_points(),
+            "single-valued field must keep values_count == indexed_points after in-place deletion",
+        );
+        drop(index);
+    }
+
+    let deleted = deleted_with(&[1, 2]);
+    let new_index = match index_type {
+        IndexType::MutableGridstore => {
+            MapIndex::<IntPayloadType>::new_mutable(temp_dir.path().to_path_buf(), true, false)
+                .unwrap()
+                .unwrap()
+        }
+        IndexType::Mmap => {
+            MapIndex::<IntPayloadType>::new_immutable(temp_dir.path(), Memory::Cold, &deleted)
+                .unwrap()
+                .unwrap()
+        }
+        IndexType::RamMmap => {
+            MapIndex::<IntPayloadType>::new_immutable(temp_dir.path(), Memory::Pinned, &deleted)
+                .unwrap()
+                .unwrap()
+        }
+    };
+
+    assert_eq!(new_index.get_indexed_points(), 4);
+    assert_eq!(
+        new_index.get_values_count(),
+        new_index.get_indexed_points(),
+        "single-valued field must keep values_count == indexed_points after reload",
+    );
+}
+
 /// Regression test: when reloading an mmap map index with a `deleted_points`
 /// bitslice shorter than `point_to_values.len()`, missing entries must
 /// default to live, not deleted. Empty-payload bits from the on-disk


### PR DESCRIPTION
## Summary
- `OnDiskMapIndex::total_key_value_pairs` (backing `get_values_count()`) was computed once at build/open time and never adjusted for deletions, while `get_indexed_points()` already excludes deleted points (`point_to_values.len() - deleted.deleted_count()`).
- On a segment with soft-deleted points, this makes `values_count / indexed_points` (average values-per-point) drift upward even when the underlying data is unchanged — relevant to anything that uses these two counters together to characterize the field (e.g. cardinality estimation), since deletions accumulate routinely before optimization/vacuum.
- Fix: subtract deleted points' value counts once in `open()` (covers points already deleted at/before open) and incrementally in `remove_point()` (covers runtime deletions), mirroring how `ImmutableMapIndex` already keeps its own `values_count` field deletion-aware.
- `OnDiskMapIndex::remove_point` now returns `OperationResult<()>` (was infallible before) since it may need to read the point's value count; updated the two call sites (`MapIndex::remove_point` dispatcher, `OnDiskMapIndex`'s `LiveReload` impl) and `ImmutableMapIndex::remove_point`, which already propagates a `Result` and now checks the one it was previously discarding.

## Test plan
- [x] New regression test `test_map_index_values_count_consistent_after_deletion` (int map index, all three backends: mutable, mmap/on-disk, ram-mmap) asserting `get_values_count() == get_indexed_points()` on a single-valued field, both after in-place `remove_point` and after a reload with a pre-supplied `deleted_points` bitslice. Verified it fails on the on-disk (`Mmap`) case without this fix and passes with it.
- [x] `cargo test -p segment --lib map_index` — 42/42 passed
- [x] `cargo clippy -p segment --all-targets` — clean