### PR TITLE
Detect container runtime beyond Docker in telemetry

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11903,6 +11903,7 @@
       "RunningEnvironmentTelemetry": {
         "type": "object",
         "required": [
+          "container_runtime",
           "cpu_flags",
           "is_docker"
         ],
@@ -11917,6 +11918,9 @@
           },
           "is_docker": {
             "type": "boolean"
+          },
+          "container_runtime": {
+            "$ref": "#/components/schemas/ContainerRuntime"
           },
           "cores": {
             "type": "integer",
@@ -11965,6 +11969,16 @@
             "nullable": true
           }
         }
+      },
+      "ContainerRuntime": {
+        "description": "Container runtime Qdrant is running under (`none` if bare metal).",
+        "type": "string",
+        "enum": [
+          "none",
+          "docker",
+          "kubernetes",
+          "other"
+        ]
       },
       "CpuEndian": {
         "type": "string",

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::LazyLock;
 
 use chrono::{DateTime, SubsecRound, Utc};
 use common::flags::FeatureFlags;
@@ -41,6 +42,9 @@ pub struct RunningEnvironmentTelemetry {
     #[anonymize(false)]
     distribution_version: Option<String>,
     is_docker: bool,
+    /// Container runtime Qdrant runs under (detects Kubernetes etc., unlike `is_docker`).
+    #[anonymize(false)]
+    container_runtime: ContainerRuntime,
     // Number of CPU cores Qdrant will use (accounting for cgroup/host limits)
     #[anonymize(false)]
     cores: Option<usize>,
@@ -228,10 +232,13 @@ fn get_system_data(storage_path: &Path) -> RunningEnvironmentTelemetry {
     #[cfg(not(feature = "gpu"))]
     let gpu_devices = None;
 
+    let container_runtime = *CONTAINER_RUNTIME;
+
     RunningEnvironmentTelemetry {
         distribution,
         distribution_version,
-        is_docker: cfg!(unix) && Path::new("/.dockerenv").exists(),
+        is_docker: container_runtime.is_docker(),
+        container_runtime,
         cores: Some(common::cpu::get_num_cpus()),
         cpu_cores_used: common::process_cpu_usage::process_cpu_usage_cores(),
         ram_size: Some((segment::utils::mem::total_memory_bytes() / 1024) as usize),
@@ -267,6 +274,59 @@ impl CpuEndian {
             CpuEndian::Other
         }
     }
+}
+
+/// Container runtime Qdrant is running under (`none` if bare metal).
+#[derive(Serialize, Clone, Copy, Debug, JsonSchema, Anonymize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContainerRuntime {
+    None,
+    Docker,
+    Kubernetes,
+    // Some other container (Podman, LXC, systemd-nspawn, plain containerd, …).
+    Other,
+}
+
+/// Detected once: the container runtime cannot change during the process's life.
+static CONTAINER_RUNTIME: LazyLock<ContainerRuntime> = LazyLock::new(ContainerRuntime::detect);
+
+impl ContainerRuntime {
+    /// Detect the runtime, most specific marker first.
+    pub fn detect() -> Self {
+        // k8s (containerd/CRI-O) writes no `/.dockerenv`; the injected env is the signal.
+        if std::env::var_os("KUBERNETES_SERVICE_HOST").is_some()
+            || Path::new("/var/run/secrets/kubernetes.io").exists()
+        {
+            return ContainerRuntime::Kubernetes;
+        }
+        if Path::new("/.dockerenv").exists() {
+            return ContainerRuntime::Docker;
+        }
+        // Podman, LXC/nspawn, or an unlabeled container image (overlay root).
+        if Path::new("/run/.containerenv").exists()
+            || Path::new("/run/systemd/container").exists()
+            || has_overlay_root()
+        {
+            return ContainerRuntime::Other;
+        }
+        ContainerRuntime::None
+    }
+
+    fn is_docker(self) -> bool {
+        matches!(self, ContainerRuntime::Docker)
+    }
+}
+
+fn has_overlay_root() -> bool {
+    // /proc/mounts columns: device mountpoint fstype opts …
+    let Ok(mounts) = fs_err::read_to_string("/proc/mounts") else {
+        return false;
+    };
+    mounts.lines().any(|line| {
+        let mut cols = line.split_whitespace();
+        let (_device, mountpoint, fstype) = (cols.next(), cols.next(), cols.next());
+        mountpoint == Some("/") && fstype == Some("overlay")
+    })
 }
 
 #[derive(Serialize, Clone, Debug, JsonSchema, Anonymize)]


### PR DESCRIPTION
## Motivation

`is_docker` is just `Path::new("/.dockerenv").exists()` — a marker only the Docker daemon writes. Kubernetes (containerd/CRI-O), Podman, etc. don't, so every Qdrant Cloud pod reports `is_docker: false` and looks identical to bare metal in telemetry.

## Fix

Add a `container_runtime` field detected from well-known markers:

- `kubernetes` — `KUBERNETES_SERVICE_HOST` / the serviceaccount mount
- `docker` — `/.dockerenv`
- `other` — any other container marker (`/run/.containerenv`, `/run/systemd/container`, overlay root fs)
- `none` — bare metal / VM

## Key decisions

- **Only `docker` and `kubernetes` are enumerated** — they're the deployment modes that matter for Qdrant. Podman/LXC/etc. fold into `other`; if that bucket ever looks big in telemetry, we split it then.
- **`is_docker` is kept, now derived** (`== docker`), so existing consumers don't break.
- **Detected once** (`LazyLock`) — the runtime can't change while the process runs.

## Gotchas

- `KUBERNETES_SERVICE_HOST` can be turned off per-pod; reliable on Qdrant Cloud.
- The overlay-root fallback is a strong signal but not 100% (unusual storage drivers).
