### PR TITLE
Fix restoring custom-sharded snapshot for new collections

### DIFF
--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -34,6 +34,11 @@ struct SnapshotShardKeyMappingEntry {
     shard_ids: HashSet<ShardId>,
 }
 
+struct SnapshotShardKeyPlan {
+    shard_key: ShardKey,
+    placement: Vec<Vec<PeerId>>,
+}
+
 async fn snapshot_shard_placement(
     snapshot_collection_dir: &std::path::Path,
     shard_ids: &[ShardId],
@@ -64,6 +69,46 @@ async fn snapshot_shard_placement(
     }
 
     Ok(placement)
+}
+
+async fn snapshot_shard_key_plan(
+    snapshot_collection_dir: &std::path::Path,
+) -> Result<Vec<SnapshotShardKeyPlan>, StorageError> {
+    let snapshot_mapping_path = snapshot_collection_dir.join(SHARD_KEY_MAPPING_FILE);
+    if !snapshot_mapping_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let snapshot_shard_mapping: Vec<SnapshotShardKeyMappingEntry> =
+        read_json(&snapshot_mapping_path)?;
+
+    let mut shard_keys: Vec<_> = snapshot_shard_mapping
+        .iter()
+        .map(|entry| {
+            let shard_key = entry.key.clone();
+            let mut shard_ids = entry.shard_ids.iter().copied().collect::<Vec<_>>();
+            shard_ids.sort_unstable();
+            (shard_key, shard_ids)
+        })
+        .collect();
+    shard_keys.sort_by_key(|(_, shard_ids)| shard_ids.first().copied().unwrap_or(0));
+
+    let mut plans = Vec::with_capacity(shard_keys.len());
+    for (shard_key, shard_ids) in shard_keys {
+        if shard_ids.is_empty() {
+            return Err(StorageError::service_error(format!(
+                "Snapshot shard mapping for key {shard_key} has no shard ids",
+            )));
+        }
+
+        let placement = snapshot_shard_placement(snapshot_collection_dir, &shard_ids).await?;
+        plans.push(SnapshotShardKeyPlan {
+            shard_key,
+            placement,
+        });
+    }
+
+    Ok(plans)
 }
 
 pub async fn activate_shard(
@@ -221,12 +266,10 @@ async fn _do_recover_from_snapshot(
 
     let schema = payload_schema.read().schema.clone();
 
-    let mut collection_was_created = false;
     let collection = match toc.get_collection(&collection_pass).await.ok() {
         Some(collection) => collection,
         None => {
             log::debug!("Collection {collection_pass} does not exist, creating it");
-            collection_was_created = true;
             let operation =
                 CollectionMetaOperations::CreateCollection(CreateCollectionOperation::new(
                     collection_pass.to_string(),
@@ -258,48 +301,39 @@ async fn _do_recover_from_snapshot(
 
     let mut state = collection.state().await;
 
-    // `CreateCollection` with custom sharding starts with empty shard distribution. For fresh
-    // collections this leaves `state.shards` empty, so the restore loop below would skip all
-    // snapshot shards. Materialize custom shard keys from snapshot metadata first.
-    if collection_was_created
-        && state.shards.is_empty()
-        && snapshot_config.params.sharding_method.unwrap_or_default() == ShardingMethod::Custom
-    {
-        let snapshot_mapping_path = tmp_collection_dir.path().join(SHARD_KEY_MAPPING_FILE);
-        if snapshot_mapping_path.exists() {
-            let snapshot_shard_mapping: Vec<SnapshotShardKeyMappingEntry> =
-                read_json(&snapshot_mapping_path)?;
+    // For custom sharding, initialize or reconcile shard keys from snapshot metadata.
+    // The whole plan is validated first (mapping + placements), then missing keys are created.
+    if snapshot_config.params.sharding_method.unwrap_or_default() == ShardingMethod::Custom {
+        let shard_key_plan = snapshot_shard_key_plan(tmp_collection_dir.path()).await?;
+        let snapshot_keys: HashSet<_> = shard_key_plan
+            .iter()
+            .map(|plan| plan.shard_key.clone())
+            .collect();
+        let existing_keys: HashSet<_> = state.shards_key_mapping.keys().cloned().collect();
 
-            let mut shard_keys: Vec<_> = snapshot_shard_mapping
-                .iter()
-                .map(|entry| {
-                    let shard_key = entry.key.clone();
-                    let shard_ids = &entry.shard_ids;
-                    let mut shard_ids = shard_ids.iter().copied().collect::<Vec<_>>();
-                    shard_ids.sort_unstable();
-                    (shard_key, shard_ids)
-                })
-                .collect();
-            shard_keys.sort_by_key(|(_, shard_ids)| shard_ids.first().copied().unwrap_or(0));
+        let unexpected_keys: Vec<_> = existing_keys.difference(&snapshot_keys).cloned().collect();
+        if !unexpected_keys.is_empty() {
+            return Err(StorageError::bad_input(format!(
+                "Snapshot is not compatible with existing collection: extra custom shard keys in target collection: {unexpected_keys:?}",
+            )));
+        }
 
-            for (shard_key, shard_ids) in shard_keys {
-                if shard_ids.is_empty() {
-                    continue;
-                }
+        let missing_keys = shard_key_plan
+            .into_iter()
+            .filter(|plan| !existing_keys.contains(&plan.shard_key))
+            .collect::<Vec<_>>();
 
-                let placement =
-                    snapshot_shard_placement(tmp_collection_dir.path(), &shard_ids).await?;
-                let consensus_op = CollectionMetaOperations::CreateShardKey(CreateShardKey {
-                    collection_name: collection_pass.to_string(),
-                    shard_key,
-                    placement,
-                    initial_state: None,
-                });
+        for plan in missing_keys {
+            let consensus_op = CollectionMetaOperations::CreateShardKey(CreateShardKey {
+                collection_name: collection_pass.to_string(),
+                shard_key: plan.shard_key,
+                placement: plan.placement,
+                initial_state: None,
+            });
 
-                dispatcher
-                    .submit_collection_meta_op(consensus_op, auth.clone(), None)
-                    .await?;
-            }
+            dispatcher
+                .submit_collection_meta_op(consensus_op, auth.clone(), None)
+                .await?;
         }
 
         state = collection.state().await;

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -1,29 +1,70 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use collection::collection::Collection;
 use collection::collection::payload_index_schema::PayloadIndexSchema;
 use collection::common::sha_256::hashes_equal;
-use collection::config::CollectionConfigInternal;
+use collection::config::{CollectionConfigInternal, ShardingMethod};
 use collection::operations::snapshot_ops::{SnapshotPriority, SnapshotRecover};
 use collection::operations::verification::new_unchecked_verification_pass;
 use collection::shards::check_shard_path;
 use collection::shards::replica_set::replica_set_state::{
-    MANUAL_RECOVERY_SHARD_STATE_VERSION, ReplicaState,
+    MANUAL_RECOVERY_SHARD_STATE_VERSION, ReplicaSetState, ReplicaState,
 };
 use collection::shards::shard::{PeerId, ShardId};
+use collection::shards::shard_holder::SHARD_KEY_MAPPING_FILE;
+use common::fs::read_json;
 use common::save_on_disk::SaveOnDisk;
 use fs_err::tokio as tokio_fs;
+use segment::types::ShardKey;
 use shard::files::PAYLOAD_INDEX_CONFIG_FILE;
 use shard::snapshots::snapshot_manifest::RecoveryType;
 
 use crate::content_manager::collection_meta_ops::{
-    CollectionMetaOperations, CreateCollectionOperation, CreatePayloadIndex,
+    CollectionMetaOperations, CreateCollectionOperation, CreatePayloadIndex, CreateShardKey,
 };
 use crate::content_manager::snapshots::download::download_snapshot;
 use crate::content_manager::snapshots::download_result::DownloadResult;
 use crate::dispatcher::Dispatcher;
 use crate::rbac::{AccessRequirements, Auth, CollectionPass};
 use crate::{StorageError, TableOfContent};
+
+#[derive(serde::Deserialize)]
+struct SnapshotShardKeyMappingEntry {
+    key: ShardKey,
+    shard_ids: HashSet<ShardId>,
+}
+
+async fn snapshot_shard_placement(
+    snapshot_collection_dir: &std::path::Path,
+    shard_ids: &[ShardId],
+) -> Result<Vec<Vec<PeerId>>, StorageError> {
+    let mut placement = Vec::with_capacity(shard_ids.len());
+
+    for shard_id in shard_ids {
+        let shard_path = check_shard_path(snapshot_collection_dir, *shard_id).await?;
+        let replica_state_path = shard_path.join("replica_state.json");
+
+        let replica_state: SaveOnDisk<ReplicaSetState> =
+            SaveOnDisk::load_or_init_default(&replica_state_path).map_err(|err| {
+                StorageError::service_error(format!(
+                    "Failed to load snapshot replica state from {}: {err}",
+                    replica_state_path.display(),
+                ))
+            })?;
+        let mut replicas: Vec<_> = replica_state.read().peers().keys().copied().collect();
+        replicas.sort_unstable();
+
+        if replicas.is_empty() {
+            return Err(StorageError::service_error(format!(
+                "Snapshot shard {shard_id} has no replicas in replica_state.json",
+            )));
+        }
+
+        placement.push(replicas);
+    }
+
+    Ok(placement)
+}
 
 pub async fn activate_shard(
     toc: &TableOfContent,
@@ -180,10 +221,12 @@ async fn _do_recover_from_snapshot(
 
     let schema = payload_schema.read().schema.clone();
 
+    let mut collection_was_created = false;
     let collection = match toc.get_collection(&collection_pass).await.ok() {
         Some(collection) => collection,
         None => {
             log::debug!("Collection {collection_pass} does not exist, creating it");
+            collection_was_created = true;
             let operation =
                 CollectionMetaOperations::CreateCollection(CreateCollectionOperation::new(
                     collection_pass.to_string(),
@@ -213,7 +256,54 @@ async fn _do_recover_from_snapshot(
         }
     };
 
-    let state = collection.state().await;
+    let mut state = collection.state().await;
+
+    // `CreateCollection` with custom sharding starts with empty shard distribution. For fresh
+    // collections this leaves `state.shards` empty, so the restore loop below would skip all
+    // snapshot shards. Materialize custom shard keys from snapshot metadata first.
+    if collection_was_created
+        && state.shards.is_empty()
+        && snapshot_config.params.sharding_method.unwrap_or_default() == ShardingMethod::Custom
+    {
+        let snapshot_mapping_path = tmp_collection_dir.path().join(SHARD_KEY_MAPPING_FILE);
+        if snapshot_mapping_path.exists() {
+            let snapshot_shard_mapping: Vec<SnapshotShardKeyMappingEntry> =
+                read_json(&snapshot_mapping_path)?;
+
+            let mut shard_keys: Vec<_> = snapshot_shard_mapping
+                .iter()
+                .map(|entry| {
+                    let shard_key = entry.key.clone();
+                    let shard_ids = &entry.shard_ids;
+                    let mut shard_ids = shard_ids.iter().copied().collect::<Vec<_>>();
+                    shard_ids.sort_unstable();
+                    (shard_key, shard_ids)
+                })
+                .collect();
+            shard_keys.sort_by_key(|(_, shard_ids)| shard_ids.first().copied().unwrap_or(0));
+
+            for (shard_key, shard_ids) in shard_keys {
+                if shard_ids.is_empty() {
+                    continue;
+                }
+
+                let placement =
+                    snapshot_shard_placement(tmp_collection_dir.path(), &shard_ids).await?;
+                let consensus_op = CollectionMetaOperations::CreateShardKey(CreateShardKey {
+                    collection_name: collection_pass.to_string(),
+                    shard_key,
+                    placement,
+                    initial_state: None,
+                });
+
+                dispatcher
+                    .submit_collection_meta_op(consensus_op, auth.clone(), None)
+                    .await?;
+            }
+        }
+
+        state = collection.state().await;
+    }
 
     // Check config compatibility
     // Check vectors config

--- a/tests/consensus_tests/test_snapshot_upload.py
+++ b/tests/consensus_tests/test_snapshot_upload.py
@@ -12,9 +12,9 @@ N_SHARDS = 3
 COLLECTION_NAME = "test_collection"
 
 
-def create_snapshot(peer_api_uri):
+def create_snapshot(peer_api_uri, collection_name=COLLECTION_NAME):
     r = requests.post(
-        f"{peer_api_uri}/collections/{COLLECTION_NAME}/snapshots")
+        f"{peer_api_uri}/collections/{collection_name}/snapshots")
     assert_http_ok(r)
     return r.json()["result"]["name"]
 
@@ -25,24 +25,24 @@ def get_peer_id(peer_api_uri):
     return r.json()["result"]["peer_id"]
 
 
-def get_local_shards(peer_api_uri):
-    r = requests.get(f"{peer_api_uri}/collections/{COLLECTION_NAME}/cluster")
+def get_local_shards(peer_api_uri, collection_name=COLLECTION_NAME):
+    r = requests.get(f"{peer_api_uri}/collections/{collection_name}/cluster")
     assert_http_ok(r)
     return r.json()["result"]["local_shards"]
 
 
-def get_remote_shards(peer_api_uri):
-    r = requests.get(f"{peer_api_uri}/collections/{COLLECTION_NAME}/cluster")
+def get_remote_shards(peer_api_uri, collection_name=COLLECTION_NAME):
+    r = requests.get(f"{peer_api_uri}/collections/{collection_name}/cluster")
     assert_http_ok(r)
     return r.json()["result"]["remote_shards"]
 
 
-def upload_snapshot(peer_api_uri, snapshot_path):
+def upload_snapshot(peer_api_uri, snapshot_path, collection_name=COLLECTION_NAME):
     with open(snapshot_path, "rb") as f:
         print(f"uploading {snapshot_path} to {peer_api_uri}")
         snapshot_file = {"snapshot": f}
         r = requests.post(
-            f"{peer_api_uri}/collections/{COLLECTION_NAME}/snapshots/upload",
+            f"{peer_api_uri}/collections/{collection_name}/snapshots/upload",
             files=snapshot_file,
         )
         assert_http_ok(r)
@@ -181,3 +181,73 @@ def recover_from_uploaded_snapshot(tmp_path: pathlib.Path, n_replicas):
     assert replicas_per_shard == {
         shard_id: n_replicas for shard_id in range(N_SHARDS)
     }
+
+
+def test_upload_snapshot_custom_sharding_into_new_collection(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    source_collection = "test_custom_snapshot_source"
+    target_collection = "test_custom_snapshot_restore"
+
+    peer_api_uris, peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 1)
+    peer_api_uri = peer_api_uris[0]
+
+    create_collection(
+        peer_api_uri,
+        collection=source_collection,
+        shard_number=1,
+        replication_factor=1,
+        sharding_method="custom",
+        sparse_vectors=False,
+    )
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=source_collection,
+        peer_api_uris=peer_api_uris,
+    )
+
+    create_shard_key(
+        "1",
+        peer_api_uri,
+        collection=source_collection,
+        shard_number=1,
+        replication_factor=1,
+    )
+    create_shard_key(
+        "2",
+        peer_api_uri,
+        collection=source_collection,
+        shard_number=1,
+        replication_factor=1,
+    )
+
+    upsert_random_points(
+        peer_api_uri,
+        num=20,
+        collection_name=source_collection,
+        with_sparse_vector=False,
+        shard_key="1",
+    )
+
+    source_count = get_collection_point_count(
+        peer_api_uri,
+        source_collection,
+        exact=True,
+    )
+    assert source_count == 20
+
+    snapshot_name = create_snapshot(peer_api_uri, source_collection)
+    snapshot_path = Path(peer_dirs[0]) / "snapshots" / source_collection / snapshot_name
+    assert snapshot_path.exists()
+
+    upload_snapshot(peer_api_uri, snapshot_path, target_collection)
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=target_collection,
+        peer_api_uris=peer_api_uris,
+    )
+
+    restored_count = get_collection_point_count(
+        peer_api_uri,
+        target_collection,
+        exact=True,
+    )
+    assert restored_count == source_count


### PR DESCRIPTION
Closes #10135 

## Summary
- Fix snapshot upload recovery for fresh custom-sharded collections where restore created collection metadata but skipped shard data restore.
- During recovery, when the target collection is newly created and has `sharding_method=custom` with empty shard state, bootstrap shard keys from snapshot metadata before shard restore.
- Reconstruct shard placement from snapshot `replica_state.json`, submit `CreateShardKey` ops, refresh state, then proceed with normal shard recovery loop.

## Root Cause
- `CreateCollection` with custom sharding starts with empty shard distribution.
- Snapshot recovery iterated `state.shards`; for a newly created custom-sharded target, this list was empty, so no shards were restored.
- Result: collection config existed, but points were missing.

## Test plan
- [x] `cargo check -p storage`
- [x] Repro original bug:
  - create custom-sharded `test` collection
  - create shard keys
  - insert points
  - create and download snapshot
  - restore via `POST /collections/test-restore/snapshots/upload?wait=true&priority=snapshot`
  - verify `test-restore` has expected point count/scroll results
- [x] Verify same flow from Web UI restore path
- [x] Regression sanity:
  - restore to existing collection still works
  - auto-sharded snapshot restore behavior unchanged

## Notes
- This change is scoped to snapshot recovery path in `lib/storage/src/content_manager/snapshots/recover.rs`.
- No API contract changes.