### PR TITLE
Fix Turbo4 multivector panics and IO hardware counters

### DIFF
--- a/lib/segment/src/vector_storage/query_scorer/turbo_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/turbo_query_scorer.rs
@@ -66,6 +66,7 @@ impl<TStorage: TurboScoring> QueryScorer for TurboQueryScorer<'_, TStorage> {
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {
+        self.hardware_counter.vector_io_read().incr_delta(2);
         self.hardware_counter.cpu_counter().incr();
         self.storage.score_internal_encoded(point_a, point_b)
     }

--- a/lib/segment/src/vector_storage/tests/test_appendable_turbo_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_turbo_vector_storage.rs
@@ -1560,3 +1560,40 @@ fn batch_scoring_accumulates_same_hw_counters() {
         per_point_acc.get_vector_io_read(),
     );
 }
+
+#[test]
+fn score_internal_increments_hardware_counters() {
+    use common::counter::hardware_accumulator::HwMeasurementAcc;
+
+    use crate::vector_storage::query_scorer::QueryScorer;
+    use crate::vector_storage::query_scorer::turbo_query_scorer::TurboQueryScorer;
+
+    const DIM: usize = 128;
+    const COUNT: usize = 2;
+
+    let distance = Distance::Dot;
+    let inputs = make_vectors(DIM, COUNT, SEEDS[0]);
+
+    let dir = Builder::new()
+        .prefix("turbo_internal_hw")
+        .tempdir()
+        .unwrap();
+    build_single_file(dir.path(), &inputs, DIM, distance);
+    let storage =
+        open_turbo_vector_storage_with_uring(dir.path(), DIM, distance, false, false).unwrap();
+
+    let acc = HwMeasurementAcc::new();
+    {
+        let scorer = TurboQueryScorer::new(inputs[0].clone(), &storage, acc.get_counter_cell());
+        scorer.score_internal(0, 1);
+    }
+
+    // score_internal increments CPU by 1
+    assert_eq!(acc.get_cpu(), 1 * storage.quantized_vector_size());
+
+    // score_internal increments vector IO read by 2
+    assert_eq!(
+        acc.get_vector_io_read(),
+        2 * storage.quantized_vector_size()
+    );
+}

--- a/lib/segment/src/vector_storage/turbo/multi_turbo/appendable_mmap_multi_turbo_vector_storage.rs
+++ b/lib/segment/src/vector_storage/turbo/multi_turbo/appendable_mmap_multi_turbo_vector_storage.rs
@@ -241,13 +241,11 @@ impl AppendableMmapMultiTurboVectorStorage {
     }
 
     /// Decode the full multivector behind an offset record.
-    fn dequantize_multi(&self, offset: MultivectorMmapOffset) -> CowVector<'_> {
+    fn dequantize_multi(&self, offset: MultivectorMmapOffset) -> Option<CowVector<'_>> {
         let records = self
             .storage
-            .get_many::<Random>(offset.offset, offset.count as usize)
-            // SAFETY: `fresh_range_start` guarantees ranges never straddle across a boundary.
-            .expect("Multivector not found");
-        self.dequantize_records(&records)
+            .get_many::<Random>(offset.offset, offset.count as usize)?;
+        Some(self.dequantize_records(&records))
     }
 
     /// Decode concatenated encoded records (the
@@ -495,10 +493,13 @@ impl AppendableMmapMultiTurboVectorStorage {
             return ScoreType::NEG_INFINITY;
         };
 
-        let records = self
+        let Some(records) = self
             .storage
             .get_many::<Random>(offset.offset, offset.count as usize)
-            .expect("Multivector not found");
+        else {
+            log::error!("Multivector not found");
+            return ScoreType::NEG_INFINITY;
+        };
 
         hw_counter
             .cpu_counter()
@@ -525,15 +526,21 @@ impl AppendableMmapMultiTurboVectorStorage {
             return ScoreType::NEG_INFINITY;
         };
 
-        let records_a = self
+        let Some(records_a) = self
             .storage
             .get_many::<Random>(offset_a.offset, offset_a.count as usize)
-            .expect("Multivector not found");
+        else {
+            log::error!("Multivector not found");
+            return ScoreType::NEG_INFINITY;
+        };
 
-        let records_b = self
+        let Some(records_b) = self
             .storage
             .get_many::<Random>(offset_b.offset, offset_b.count as usize)
-            .expect("Multivector not found");
+        else {
+            log::error!("Multivector not found");
+            return ScoreType::NEG_INFINITY;
+        };
 
         hw_counter
             .cpu_counter()
@@ -580,7 +587,7 @@ impl VectorStorageRead for AppendableMmapMultiTurboVectorStorage {
     }
 
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
-        Some(self.dequantize_multi(self.get_offset::<P>(key)?))
+        self.dequantize_multi(self.get_offset::<P>(key)?)
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
@@ -731,7 +738,7 @@ impl MultiTQVectorStorageRead for AppendableMmapMultiTurboVectorStorage {
             })
             // `get_many` is also `None` for a range across multiple chunks, but
             // `fresh_range_start` guarantees ranges never straddle a boundary.
-            .expect("Multivector not found")
+            .unwrap_or_default()
     }
 }
 
@@ -2045,5 +2052,46 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_corrupted_multivector_chunk_panics() {
+        let dir = Builder::new()
+            .prefix("turbo_multi_panic")
+            .tempdir()
+            .unwrap();
+        let dim = 128;
+        let distance = Distance::Cosine;
+        let multi_vector_config = MultiVectorConfig::default();
+        let mut storage = open_appendable_turbo_multi_vector_storage(
+            dir.path(),
+            dim,
+            distance,
+            multi_vector_config,
+            false,
+        )
+        .unwrap();
+
+        let hw_counter = HardwareCounterCell::new();
+        let vector = make_multi_vectors(dim, 1, 42).pop().unwrap();
+        storage
+            .insert_vector(0, VectorRef::from(&vector), &hw_counter)
+            .unwrap();
+
+        // simulate corruption: offset points out of bounds
+        let bad_offset = MultivectorMmapOffset {
+            offset: 1000000,
+            count: 4,
+            capacity: 4,
+        };
+        storage
+            .offsets
+            .insert(0, &[bad_offset], &hw_counter)
+            .unwrap();
+
+        // Missing data gracefully returns NEG_INFINITY instead of panicking.
+        let query = storage.preprocess_query(&make_multi_vectors(dim, 1, 43).pop().unwrap());
+        let score = storage.score_point_max_similarity(&query, 0, &hw_counter);
+        assert_eq!(score, f32::NEG_INFINITY);
     }
 }


### PR DESCRIPTION
### Problem
Scoring and retrieval methods in `AppendableMmapMultiTurboVectorStorage` used `.expect()` when fetching vector chunks, causing severe thread panics if the underlying storage was corrupted or offsets pointed out of bounds. This meant that a localized data corruption issue could unnecessarily take down the entire process instead of handling the missing data gracefully. Additionally, IO metrics were being undercounted during scoring due to a missing `vector_io_read` hardware counter increment in `TurboQueryScorer::score_internal`

### Solution
1. Replaced `.expect("Multivector not found")` with graceful fallbacks in `AppendableMmapMultiTurboVectorStorage` when handling corrupted or out of bounds offsets:
   - Scoring methods (`score_point_max_similarity`, `score_internal_max_similarity`) now log an error and return the lowest possible score instead of crashing
   - Read methods (`get_multi_tq`, `dequantize_multi`) return empty data if the chunk isn't found.
2. added the missing IO hardware counter increment (`vector_io_read` by 2) in `TurboQueryScorer::score_internal`
3. Added `test_corrupted_multivector_chunk_panics` to simulate missing data and verify the crash is fixed

before fix (multivector panic):
```bash
shruti@DESKTOP-QR46EJI:~/qdrant$ RUST_BACKTRACE=1 cargo test -p segment test_corrupted_multivector_chunk_panics -- --nocapture
   Compiling segment v0.6.0 (/home/shruti/qdrant/lib/segment)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 4m 13s
     Running unittests src/lib.rs (target/debug/deps/segment-35b55b8a06d60259)

running 1 test

thread 'vector_storage::turbo::multi_turbo::appendable_mmap_multi_turbo_vector_storage::tests::test_corrupted_multivector_chunk_panics' (182378) panicked at lib/segment/src/vector_storage/turbo/multi_turbo/appendable_mmap_multi_turbo_vector_storage.rs:501:14:
Multivector not found
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/panicking.rs:80:14
   2: core::panicking::panic_display::<&str>
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/panicking.rs:259:5
   3: core::option::expect_failed
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/option.rs:2257:5
   4: <core::option::Option<alloc::borrow::Cow<[u8]>>>::expect
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/option.rs:968:21
   5: score_point_max_similarity
             at ./src/vector_storage/turbo/multi_turbo/appendable_mmap_multi_turbo_vector_storage.rs:501:14
   6: test_corrupted_multivector_chunk_panics
             at ./src/vector_storage/turbo/multi_turbo/appendable_mmap_multi_turbo_vector_storage.rs:2086:17
   7: segment::vector_storage::turbo::multi_turbo::appendable_mmap_multi_turbo_vector_storage::tests::test_corrupted_multivector_chunk_panics::{closure#0}
             at ./src/vector_storage/turbo/multi_turbo/appendable_mmap_multi_turbo_vector_storage.rs:2050:49
   8: <segment::vector_storage::turbo::multi_turbo::appendable_mmap_multi_turbo_vector_storage::tests::test_corrupted_multivector_chunk_panics::{closure#0} as core::ops::function::FnOnce<()>>::call_once
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/ops/function.rs:250:5
   9: <fn() -> core::result::Result<(), alloc::string::String> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
test vector_storage::turbo::multi_turbo::appendable_mmap_multi_turbo_vector_storage::tests::test_corrupted_multivector_chunk_panics ... FAILED

failures:

failures:
    vector_storage::turbo::multi_turbo::appendable_mmap_multi_turbo_vector_storage::tests::test_corrupted_multivector_chunk_panics

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 980 filtered out; finished in 1.17s

error: test failed, to rerun pass `-p segment --lib`
```

before fix (hardware counter):

```bash
running 1 test
test vector_storage::tests::test_appendable_turbo_vector_storage::score_internal_increments_hardware_counters ... FAILED

failures:

---- vector_storage::tests::test_appendable_turbo_vector_storage::score_internal_increments_hardware_counters stdout ----

thread 'vector_storage::tests::test_appendable_turbo_vector_storage::score_internal_increments_hardware_counters' (192565) panicked at lib/segment/src/vector_storage/tests/test_appendable_turbo_vector_storage.rs:1596:5:
assertion `left == right` failed
  left: 0
 right: 136
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/panicking.rs:80:14
   2: core::panicking::assert_failed_inner
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/panicking.rs:439:17
   3: core::panicking::assert_failed::<usize, usize>
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/panicking.rs:394:5
   4: score_internal_increments_hardware_counters
             at ./src/vector_storage/tests/test_appendable_turbo_vector_storage.rs:1596:5
   5: segment::vector_storage::tests::test_appendable_turbo_vector_storage::score_internal_increments_hardware_counters::{closure#0}
             at ./src/vector_storage/tests/test_appendable_turbo_vector_storage.rs:1565:49
   6: <segment::vector_storage::tests::test_appendable_turbo_vector_storage::score_internal_increments_hardware_counters::{closure#0} as core::ops::function::FnOnce<()>>::call_once
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/ops/function.rs:250:5
   7: <fn() -> core::result::Result<(), alloc::string::String> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    vector_storage::tests::test_appendable_turbo_vector_storage::score_internal_increments_hardware_counters

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 981 filtered out; finished in 0.71s

error: test failed, to rerun pass `-p segment --lib`
```