### PR TITLE
Cache BitmaskGaps entirely in memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9947,3 +9947,7 @@ dependencies = [
  "syn 2.0.119",
  "winnow 0.7.15",
 ]
+
+[[patch.unused]]
+name = "boa_string"
+version = "1.0.0-dev"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9947,7 +9947,3 @@ dependencies = [
  "syn 2.0.119",
  "winnow 0.7.15",
 ]
-
-[[patch.unused]]
-name = "boa_string"
-version = "1.0.0-dev"

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
@@ -181,7 +181,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
     }
 
     pub fn trailing_free_blocks(&self) -> Result<u32> {
-        let slice = self.read_all()?;
+        let slice = self.read_all();
         Ok(slice
             .iter()
             .rev()
@@ -211,14 +211,14 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         Ok(())
     }
 
-    pub fn read_all(&self) -> Result<Cow<'_, [RegionGaps]>> {
-        Ok(Cow::Borrowed(&self.data))
+    pub fn read_all(&self) -> Cow<'_, [RegionGaps]> {
+        Cow::Borrowed(&self.data)
     }
 
     /// Find a gap in the bitmask that is large enough to fit `num_blocks` blocks.
     /// Returns the range of regions where the gap is.
     pub fn find_fitting_gap(&self, num_blocks: u32) -> Result<Option<Range<RegionId>>> {
-        let slice = self.read_all()?;
+        let slice = self.read_all();
 
         if slice.len() == 1 {
             return Ok(if slice[0].max as usize >= num_blocks as usize {
@@ -257,15 +257,15 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
 
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
-    pub fn populate(&self) -> Result<()> {
+    #[allow(clippy::unused_self)]
+    pub fn populate(&self) {
         // Data is always in RAM, no-op
-        Ok(())
     }
 
     /// Drop disk cache.
-    pub fn clear_cache(&self) -> Result<()> {
+    #[allow(clippy::unused_self)]
+    pub fn clear_cache(&self) {
         // Data is always in RAM, no-op
-        Ok(())
     }
 
     /// Find a gap in the bitmask that is large enough to fit `num_blocks` blocks, in a merged window of regions.

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
@@ -136,8 +136,10 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         let options = OpenOptions {
             writeable: true,
             need_sequential: false,
-            // Read the entire file upfront
-            populate: Populate::Blocking,
+            // No need to pre-fault the mmap: data is immediately copied into
+            // `self.data` via `read_whole()?.into_owned()`, and the mmap is
+            // thereafter used only as a write through store (never read again).
+            populate: Populate::No,
             advice: AdviceSetting::Advice(Advice::Normal),
         };
         let slice_store = TypedStorage::open(fs, &path, options, Default::default())?;
@@ -204,8 +206,8 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
 
     /// Get the RegionGaps at the specified index.
     #[cfg(test)]
-    pub fn get(&self, idx: usize) -> Result<Option<RegionGaps>> {
-        Ok(self.data.get(idx).copied())
+    pub fn get(&self, idx: usize) -> Option<RegionGaps> {
+        self.data.get(idx).copied()
     }
 
     /// Set the RegionGaps at the specified index.
@@ -673,7 +675,7 @@ mod tests {
                 BitmaskGaps::create(&MmapFs, dir_path, gaps.clone().into_iter(), config).unwrap();
             assert_eq!(region_gaps.len(), gaps.len());
             for (i, gap) in gaps.iter().enumerate() {
-                assert_eq!(region_gaps.get(i).unwrap(), Some(*gap));
+                assert_eq!(region_gaps.get(i), Some(*gap));
             }
         }
 
@@ -684,7 +686,7 @@ mod tests {
                 BitmaskGaps::open(&MmapFs, dir_path, config).unwrap();
             assert_eq!(region_gaps.len(), gaps.len());
             for (i, gap) in gaps.iter().enumerate() {
-                assert_eq!(region_gaps.get(i).unwrap(), Some(*gap));
+                assert_eq!(region_gaps.get(i), Some(*gap));
             }
         }
 
@@ -701,7 +703,7 @@ mod tests {
             region_gaps.extend(more_gaps.clone().into_iter()).unwrap();
             assert_eq!(region_gaps.len(), gaps.len() + more_gaps.len());
             for (i, gap) in gaps.iter().chain(more_gaps.iter()).enumerate() {
-                assert_eq!(region_gaps.get(i).unwrap(), Some(*gap));
+                assert_eq!(region_gaps.get(i), Some(*gap));
             }
         }
 
@@ -712,7 +714,7 @@ mod tests {
                 BitmaskGaps::open(&MmapFs, dir_path, config).unwrap();
             assert_eq!(region_gaps.len(), gaps.len() + more_gaps.len());
             for (i, gap) in gaps.iter().chain(more_gaps.iter()).enumerate() {
-                assert_eq!(region_gaps.get(i).unwrap(), Some(*gap));
+                assert_eq!(region_gaps.get(i), Some(*gap));
             }
         }
 
@@ -726,7 +728,7 @@ mod tests {
 
             // Set the gap and verify it's updated in memory
             region_gaps.set(update_idx, updated_gap).unwrap();
-            assert_eq!(region_gaps.get(update_idx).unwrap(), Some(updated_gap));
+            assert_eq!(region_gaps.get(update_idx), Some(updated_gap));
 
             // Verify out of bounds set fails properly
             let out_of_bounds_idx = region_gaps.len();
@@ -738,7 +740,7 @@ mod tests {
             let config = GridstoreConfig::DEFAULT;
             let region_gaps: MmapBitmaskGaps =
                 BitmaskGaps::open(&MmapFs, dir_path, config).unwrap();
-            assert_eq!(region_gaps.get(update_idx).unwrap(), Some(updated_gap));
+            assert_eq!(region_gaps.get(update_idx), Some(updated_gap));
         }
 
         // Clean up

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
@@ -83,6 +83,9 @@ fn gaps_file_path(dir: &Path) -> PathBuf {
 pub(super) struct BitmaskGaps<S> {
     path: PathBuf,
     config: GridstoreConfig,
+    /// Primary in-memory copy of all region gaps for fast lookup.
+    data: Vec<RegionGaps>,
+    /// Write through backing store. Only written to, reads go to `data`
     slice_store: TypedStorage<S, RegionGaps>,
 }
 
@@ -118,6 +121,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         Ok(Self {
             path,
             config,
+            data,
             slice_store,
         })
     }
@@ -127,14 +131,17 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         let options = OpenOptions {
             writeable: true,
             need_sequential: false,
-            populate: Populate::No,
+            // Read the entire file upfront
+            populate: Populate::Blocking,
             advice: AdviceSetting::Advice(Advice::Normal),
         };
         let slice_store = TypedStorage::open(fs, &path, options, Default::default())?;
+        let data = slice_store.read_whole()?.into_owned();
 
         Ok(Self {
             path,
             config,
+            data,
             slice_store,
         })
     }
@@ -154,7 +161,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         self.slice_store.flusher()()?;
 
         // reopen the file with a larger size
-        let prev_len = self.len()?;
+        let prev_len = self.len();
         let new_slice_len = prev_len + data.len();
         let new_length_in_bytes = new_slice_len * size_of::<RegionGaps>();
 
@@ -162,10 +169,13 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
 
         self.slice_store.reopen()?;
 
-        debug_assert_eq!(self.len()? - prev_len, data.len());
+        debug_assert_eq!(self.slice_store.len()? as usize - prev_len, data.len());
 
         let byte_offset = (prev_len * size_of::<RegionGaps>()) as u64;
         self.slice_store.write(byte_offset, &data)?;
+
+        // Keep in memory copy in sync
+        self.data.extend_from_slice(&data);
 
         Ok(())
     }
@@ -180,24 +190,29 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
             .sum())
     }
 
-    pub fn len(&self) -> Result<usize> {
-        Ok(self.slice_store.len()? as usize)
+    pub fn len(&self) -> usize {
+        self.data.len()
     }
 
     #[cfg(test)]
     pub fn get(&self, idx: usize) -> Result<Option<RegionGaps>> {
-        let slice = self.read_all()?;
-        Ok(slice.get(idx).copied())
+        Ok(self.data.get(idx).copied())
     }
 
     pub fn set(&mut self, idx: usize, value: RegionGaps) -> Result<()> {
+        if idx >= self.data.len() {
+            return Err(crate::error::BlobstoreError::ServiceError {
+                description: format!("Bitmask index {idx} out of bounds"),
+            });
+        }
         let byte_offset = (idx * size_of::<RegionGaps>()) as u64;
         self.slice_store.write(byte_offset, &[value])?;
+        self.data[idx] = value;
         Ok(())
     }
 
     pub fn read_all(&self) -> Result<Cow<'_, [RegionGaps]>> {
-        Ok(self.slice_store.read_whole()?)
+        Ok(Cow::Borrowed(&self.data))
     }
 
     /// Find a gap in the bitmask that is large enough to fit `num_blocks` blocks.
@@ -243,13 +258,13 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) -> Result<()> {
-        self.slice_store.populate()?;
+        // Data is always in RAM, no-op
         Ok(())
     }
 
     /// Drop disk cache.
     pub fn clear_cache(&self) -> Result<()> {
-        self.slice_store.clear_ram_cache()?;
+        // Data is always in RAM, no-op
         Ok(())
     }
 
@@ -383,8 +398,8 @@ mod tests {
 
             if let Some(range) = bitmask_gaps.find_fitting_gap(num_blocks).unwrap() {
                 // Range should be within bounds
-                prop_assert!(range.start <= bitmask_gaps.len().unwrap() as u32);
-                prop_assert!(range.end <= bitmask_gaps.len().unwrap() as u32);
+                prop_assert!(range.start <= bitmask_gaps.len() as u32);
+                prop_assert!(range.end <= bitmask_gaps.len() as u32);
                 prop_assert!(range.start <= range.end);
 
                 // check that range is as constrained as possible
@@ -430,7 +445,7 @@ mod tests {
         let config = GridstoreConfig::DEFAULT;
         let bitmask_gaps: MmapBitmaskGaps =
             BitmaskGaps::create(&MmapFs, temp_dir.path(), gaps.into_iter(), config).unwrap();
-        assert!(bitmask_gaps.len().unwrap() >= 3);
+        assert!(bitmask_gaps.len() >= 3);
 
         assert!(
             bitmask_gaps
@@ -681,7 +696,7 @@ mod tests {
             let config = GridstoreConfig::DEFAULT;
             let region_gaps: MmapBitmaskGaps =
                 BitmaskGaps::create(&MmapFs, dir_path, gaps.clone().into_iter(), config).unwrap();
-            assert_eq!(region_gaps.len().unwrap(), gaps.len());
+            assert_eq!(region_gaps.len(), gaps.len());
             for (i, gap) in gaps.iter().enumerate() {
                 assert_eq!(region_gaps.get(i).unwrap(), Some(*gap));
             }
@@ -692,7 +707,7 @@ mod tests {
             let config = GridstoreConfig::DEFAULT;
             let region_gaps: MmapBitmaskGaps =
                 BitmaskGaps::open(&MmapFs, dir_path, config).unwrap();
-            assert_eq!(region_gaps.len().unwrap(), gaps.len());
+            assert_eq!(region_gaps.len(), gaps.len());
             for (i, gap) in gaps.iter().enumerate() {
                 assert_eq!(region_gaps.get(i).unwrap(), Some(*gap));
             }
@@ -709,7 +724,7 @@ mod tests {
             let mut region_gaps: MmapBitmaskGaps =
                 BitmaskGaps::open(&MmapFs, dir_path, config).unwrap();
             region_gaps.extend(more_gaps.clone().into_iter()).unwrap();
-            assert_eq!(region_gaps.len().unwrap(), gaps.len() + more_gaps.len());
+            assert_eq!(region_gaps.len(), gaps.len() + more_gaps.len());
             for (i, gap) in gaps.iter().chain(more_gaps.iter()).enumerate() {
                 assert_eq!(region_gaps.get(i).unwrap(), Some(*gap));
             }
@@ -720,7 +735,7 @@ mod tests {
             let config = GridstoreConfig::DEFAULT;
             let region_gaps: MmapBitmaskGaps =
                 BitmaskGaps::open(&MmapFs, dir_path, config).unwrap();
-            assert_eq!(region_gaps.len().unwrap(), gaps.len() + more_gaps.len());
+            assert_eq!(region_gaps.len(), gaps.len() + more_gaps.len());
             for (i, gap) in gaps.iter().chain(more_gaps.iter()).enumerate() {
                 assert_eq!(region_gaps.get(i).unwrap(), Some(*gap));
             }

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
@@ -266,14 +266,13 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         self.find_merged_gap(&slice, window_size, num_blocks)
     }
 
-    /// Populate all pages in the mmap.
-    /// Block until all pages are populated.
+    /// No-op since gaps read from the in-memory data vector.
     #[allow(clippy::unused_self)]
     pub fn populate(&self) {
         // Data is always in RAM, no-op
     }
 
-    /// Drop disk cache.
+    /// No-op since gaps read from the in-memory data vector.
     #[allow(clippy::unused_self)]
     pub fn clear_cache(&self) {
         // Data is always in RAM, no-op
@@ -407,7 +406,7 @@ mod tests {
 
             let bitvec = regions_gaps_to_bitvec(&gaps, DEFAULT_REGION_SIZE_BLOCKS);
 
-            if let Some(range) = bitmask_gaps.find_fitting_gap(num_blocks).unwrap() {
+            if let Some(range) = bitmask_gaps.find_fitting_gap(num_blocks) {
                 // Range should be within bounds
                 prop_assert!(range.start <= bitmask_gaps.len() as u32);
                 prop_assert!(range.end <= bitmask_gaps.len() as u32);
@@ -461,7 +460,6 @@ mod tests {
         assert!(
             bitmask_gaps
                 .find_fitting_gap(large_value_blocks as u32)
-                .unwrap()
                 .is_some(),
         );
     }
@@ -488,17 +486,11 @@ mod tests {
         .unwrap();
 
         // Find space for blocks covering up to 2 regions
-        assert!(bitmask_gaps.find_fitting_gap(1).unwrap().is_some());
-        assert!(
-            bitmask_gaps
-                .find_fitting_gap(REGION_SIZE_BLOCKS)
-                .unwrap()
-                .is_some()
-        );
+        assert!(bitmask_gaps.find_fitting_gap(1).is_some());
+        assert!(bitmask_gaps.find_fitting_gap(REGION_SIZE_BLOCKS).is_some());
         assert!(
             bitmask_gaps
                 .find_fitting_gap(REGION_SIZE_BLOCKS * 2)
-                .unwrap()
                 .is_some(),
         );
 
@@ -506,13 +498,11 @@ mod tests {
         assert!(
             bitmask_gaps
                 .find_fitting_gap(REGION_SIZE_BLOCKS * 2 + 1)
-                .unwrap()
                 .is_some(),
         );
         assert!(
             bitmask_gaps
                 .find_fitting_gap(REGION_SIZE_BLOCKS * 3)
-                .unwrap()
                 .is_some(),
         );
 
@@ -520,7 +510,6 @@ mod tests {
         assert!(
             bitmask_gaps
                 .find_fitting_gap(REGION_SIZE_BLOCKS * 4)
-                .unwrap()
                 .is_none(),
         );
 
@@ -543,16 +532,10 @@ mod tests {
         .unwrap();
 
         // Find space for blocks covering up to 2 regions
-        assert!(
-            bitmask_gaps
-                .find_fitting_gap(REGION_SIZE_BLOCKS)
-                .unwrap()
-                .is_some()
-        );
+        assert!(bitmask_gaps.find_fitting_gap(REGION_SIZE_BLOCKS).is_some());
         assert!(
             bitmask_gaps
                 .find_fitting_gap(REGION_SIZE_BLOCKS * 2)
-                .unwrap()
                 .is_some(),
         );
 
@@ -560,13 +543,11 @@ mod tests {
         assert!(
             bitmask_gaps
                 .find_fitting_gap(REGION_SIZE_BLOCKS * 2 + 1)
-                .unwrap()
                 .is_some(),
         );
         assert!(
             bitmask_gaps
                 .find_fitting_gap((REGION_SIZE_BLOCKS * 2) + (REGION_SIZE_BLOCKS / 2))
-                .unwrap()
                 .is_some(),
         );
 
@@ -574,7 +555,6 @@ mod tests {
         assert!(
             bitmask_gaps
                 .find_fitting_gap((REGION_SIZE_BLOCKS * 2) + (REGION_SIZE_BLOCKS / 2) + 1)
-                .unwrap()
                 .is_none(),
         );
 
@@ -597,22 +577,15 @@ mod tests {
                 .unwrap();
 
         // Find space for blocks covering more than 1 to 1.5 regions
-        assert!(
-            bitmask_gaps
-                .find_fitting_gap(REGION_SIZE_BLOCKS)
-                .unwrap()
-                .is_some()
-        );
+        assert!(bitmask_gaps.find_fitting_gap(REGION_SIZE_BLOCKS).is_some());
         assert!(
             bitmask_gaps
                 .find_fitting_gap(REGION_SIZE_BLOCKS + 1)
-                .unwrap()
                 .is_some(),
         );
         assert!(
             bitmask_gaps
                 .find_fitting_gap(REGION_SIZE_BLOCKS + (REGION_SIZE_BLOCKS / 2))
-                .unwrap()
                 .is_some(),
         );
 
@@ -620,7 +593,6 @@ mod tests {
         assert!(
             bitmask_gaps
                 .find_fitting_gap(REGION_SIZE_BLOCKS + REGION_SIZE_BLOCKS / 2 + 1)
-                .unwrap()
                 .is_none(),
         );
     }
@@ -658,22 +630,15 @@ mod tests {
                 .unwrap();
 
         // Find space for blocks covering up to 1.5 region
-        assert!(
-            bitmask_gaps
-                .find_fitting_gap(REGION_SIZE_BLOCKS)
-                .unwrap()
-                .is_some()
-        );
+        assert!(bitmask_gaps.find_fitting_gap(REGION_SIZE_BLOCKS).is_some());
         assert!(
             bitmask_gaps
                 .find_fitting_gap(REGION_SIZE_BLOCKS + 1)
-                .unwrap()
                 .is_some(),
         );
         assert!(
             bitmask_gaps
                 .find_fitting_gap(REGION_SIZE_BLOCKS + REGION_SIZE_BLOCKS / 2)
-                .unwrap()
                 .is_some(),
         );
 
@@ -681,7 +646,6 @@ mod tests {
         assert!(
             bitmask_gaps
                 .find_fitting_gap(REGION_SIZE_BLOCKS + REGION_SIZE_BLOCKS / 2 + 1)
-                .unwrap()
                 .is_none(),
         );
     }
@@ -750,6 +714,31 @@ mod tests {
             for (i, gap) in gaps.iter().chain(more_gaps.iter()).enumerate() {
                 assert_eq!(region_gaps.get(i).unwrap(), Some(*gap));
             }
+        }
+
+        // Test updating an existing gap
+        let update_idx = 1;
+        let updated_gap = RegionGaps::new(100, 100, 100, region_size_blocks);
+        {
+            let config = GridstoreConfig::DEFAULT;
+            let mut region_gaps: MmapBitmaskGaps =
+                BitmaskGaps::open(&MmapFs, dir_path, config).unwrap();
+
+            // Set the gap and verify it's updated in memory
+            region_gaps.set(update_idx, updated_gap).unwrap();
+            assert_eq!(region_gaps.get(update_idx).unwrap(), Some(updated_gap));
+
+            // Verify out of bounds set fails properly
+            let out_of_bounds_idx = region_gaps.len();
+            assert!(region_gaps.set(out_of_bounds_idx, updated_gap).is_err());
+        }
+
+        // Reopen RegionGaps and verify the updated gap persisted
+        {
+            let config = GridstoreConfig::DEFAULT;
+            let region_gaps: MmapBitmaskGaps =
+                BitmaskGaps::open(&MmapFs, dir_path, config).unwrap();
+            assert_eq!(region_gaps.get(update_idx).unwrap(), Some(updated_gap));
         }
 
         // Clean up

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
@@ -19,6 +19,7 @@ pub struct RegionGaps {
 }
 
 impl RegionGaps {
+    /// Create a new RegionGaps instance
     pub fn new(
         leading: u16,
         trailing: u16,
@@ -53,6 +54,7 @@ impl RegionGaps {
         }
     }
 
+    /// Create a RegionGaps instance where all blocks are free.
     pub fn all_free(blocks: u16) -> Self {
         Self {
             max: blocks,
@@ -90,10 +92,12 @@ pub(super) struct BitmaskGaps<S> {
 }
 
 impl<S: UniversalWrite> BitmaskGaps<S> {
+    /// Return the path to the gaps file.
     pub fn path(&self) -> PathBuf {
         self.path.clone()
     }
 
+    /// Create a new BitmaskGaps file from an iterator of RegionGaps.
     pub fn create(
         fs: &S::Fs,
         dir: &Path,
@@ -126,6 +130,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         })
     }
 
+    /// Open an existing BitmaskGaps file.
     pub fn open(fs: &S::Fs, dir: &Path, config: GridstoreConfig) -> Result<Self> {
         let path = gaps_file_path(dir);
         let options = OpenOptions {
@@ -146,6 +151,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         })
     }
 
+    /// Return a flusher for the underlying slice store.
     pub fn flusher(&self) -> Flusher {
         self.slice_store.flusher()
     }
@@ -180,25 +186,29 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         Ok(())
     }
 
-    pub fn trailing_free_blocks(&self) -> Result<u32> {
+    /// Count the total number of trailing free blocks across all regions.
+    pub fn trailing_free_blocks(&self) -> u32 {
         let slice = self.read_all();
-        Ok(slice
+        slice
             .iter()
             .rev()
             .take_while_inclusive(|gap| gap.trailing == self.config.region_size_blocks as u16)
             .map(|gap| u32::from(gap.trailing))
-            .sum())
+            .sum()
     }
 
+    /// Return the number of regions in the bitmask gaps.
     pub fn len(&self) -> usize {
         self.data.len()
     }
 
+    /// Get the RegionGaps at the specified index.
     #[cfg(test)]
     pub fn get(&self, idx: usize) -> Result<Option<RegionGaps>> {
         Ok(self.data.get(idx).copied())
     }
 
+    /// Set the RegionGaps at the specified index.
     pub fn set(&mut self, idx: usize, value: RegionGaps) -> Result<()> {
         if idx >= self.data.len() {
             return Err(crate::error::BlobstoreError::ServiceError {
@@ -211,21 +221,22 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         Ok(())
     }
 
+    /// Read all RegionGaps from memory.
     pub fn read_all(&self) -> Cow<'_, [RegionGaps]> {
         Cow::Borrowed(&self.data)
     }
 
     /// Find a gap in the bitmask that is large enough to fit `num_blocks` blocks.
     /// Returns the range of regions where the gap is.
-    pub fn find_fitting_gap(&self, num_blocks: u32) -> Result<Option<Range<RegionId>>> {
+    pub fn find_fitting_gap(&self, num_blocks: u32) -> Option<Range<RegionId>> {
         let slice = self.read_all();
 
         if slice.len() == 1 {
-            return Ok(if slice[0].max as usize >= num_blocks as usize {
+            return if slice[0].max as usize >= num_blocks as usize {
                 Some(0..1)
             } else {
                 None
-            });
+            };
         }
 
         // try to find gap in the minimum regions needed
@@ -246,13 +257,13 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         };
 
         if fits_in_min_regions.is_some() {
-            return Ok(fits_in_min_regions);
+            return fits_in_min_regions;
         }
 
         // try to find gap by merging one more region (which is the maximum regions we may need for the value)
         let window_size = regions_needed + 1;
 
-        Ok(self.find_merged_gap(&slice, window_size, num_blocks))
+        self.find_merged_gap(&slice, window_size, num_blocks)
     }
 
     /// Populate all pages in the mmap.

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
@@ -213,7 +213,7 @@ impl<S: UniversalWrite> Bitmask<S> {
         let current_bit_len = self.bitslice.bit_len() as usize;
 
         // extend the region gaps
-        let current_total_regions = self.regions_gaps.len()?;
+        let current_total_regions = self.regions_gaps.len();
         let expected_total_full_regions =
             current_bit_len.div_euclid(self.config.region_size_blocks);
         debug_assert!(
@@ -226,7 +226,7 @@ impl<S: UniversalWrite> Bitmask<S> {
         self.regions_gaps.extend(new_gaps.into_iter())?;
 
         assert_eq!(
-            self.regions_gaps.len()? * self.config.region_size_blocks,
+            self.regions_gaps.len() * self.config.region_size_blocks,
             current_bit_len,
             "Bitmask length mismatch",
         );

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
@@ -169,7 +169,7 @@ impl<S: UniversalWrite> Bitmask<S> {
         let region_size_blocks = self.config.region_size_blocks;
         let block_size_bytes = self.config.block_size_bytes;
         let region_size_bytes = region_size_blocks * block_size_bytes;
-        let gaps = self.regions_gaps.read_all()?;
+        let gaps = self.regions_gaps.read_all();
         let all_bits = self.bitslice.read_all()?;
         for (gap_id, gap) in gaps.iter().enumerate() {
             // skip empty regions
@@ -558,14 +558,14 @@ impl<S: UniversalWrite> Bitmask<S> {
     /// Block until all pages are populated.
     pub fn populate(&self) -> Result<()> {
         self.bitslice.populate()?;
-        self.regions_gaps.populate()?;
+        self.regions_gaps.populate();
         Ok(())
     }
 
     /// Drop disk cache.
     pub fn clear_cache(&self) -> Result<()> {
         self.bitslice.clear_ram_cache()?;
-        self.regions_gaps.clear_cache()?;
+        self.regions_gaps.clear_cache();
         Ok(())
     }
 }

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
@@ -53,7 +53,7 @@ impl<S: UniversalWrite> Bitmask<S> {
 
     /// Calculate the amount of trailing free blocks in the bitmask.
     pub fn trailing_free_blocks(&self) -> Result<u32> {
-        let trailing_gap = self.regions_gaps.trailing_free_blocks()?;
+        let trailing_gap = self.regions_gaps.trailing_free_blocks();
         #[cfg(debug_assertions)]
         {
             let all_bits = self.bitslice.read_all()?;
@@ -253,7 +253,7 @@ impl<S: UniversalWrite> Bitmask<S> {
         &self,
         num_blocks: u32,
     ) -> Result<Option<(PageId, BlockOffset)>> {
-        let Some(region_id_range) = self.regions_gaps.find_fitting_gap(num_blocks)? else {
+        let Some(region_id_range) = self.regions_gaps.find_fitting_gap(num_blocks) else {
             return Ok(None);
         };
         let regions_start_offset = region_id_range.start as usize * self.config.region_size_blocks;


### PR DESCRIPTION
### Motivation

As discussed in #8501 ([comment](https://github.com/qdrant/qdrant/pull/8501#discussion_r3112989390)), `BitmaskGaps` reads from the mmap slice during every gap lookup. Since this structure is very small (e.g., ~16 KiB for 11M points), caching it completely in RAM avoids unnecessary I/O overhead without taking up too much memory.

### Solution
Optimize `BitmaskGaps` to strictly reside in RAM for the read path:
* `BitmaskGaps` now holds a `data: Vec<RegionGaps>` which serves as the source of truth for reads.
* The structure is loaded entirely into RAM upon `open()` via `slice_store.read_whole()`
* `find_fitting_gap` reads directly from the memory list, completely skipping the file layer when searching for gaps.
* Changes like `set` and `extend` update the memory and write to disk immediately, so no data is lost
* update `populate()` and `clear_cache()` as no-ops since the data is always loaded into RAM.

Related to #9496