### PR TITLE
fix(api): reject empty dense vectors in gRPC Vector::Dense validation

### DIFF
--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -10,6 +10,7 @@ use segment::data_types::index::validate_integer_index_params;
 use validator::{Validate, ValidationError, ValidationErrors};
 
 use super::qdrant as grpc;
+use crate::rest::schema::validate_non_empty_dense;
 
 const TIMESTAMP_MIN_SECONDS: i64 = -62_135_596_800; // 0001-01-01T00:00:00Z
 const TIMESTAMP_MAX_SECONDS: i64 = 253_402_300_799; // 9999-12-31T23:59:59Z
@@ -364,7 +365,7 @@ impl Validate for grpc::Vector {
 impl Validate for grpc::vector::Vector {
     fn validate(&self) -> Result<(), ValidationErrors> {
         match self {
-            grpc::vector::Vector::Dense(_dense) => Ok(()),
+            grpc::vector::Vector::Dense(dense) => validate_non_empty_dense(&dense.data),
             grpc::vector::Vector::Sparse(sparse) => sparse.validate(),
             grpc::vector::Vector::MultiDense(multi) => multi.validate(),
             grpc::vector::Vector::Document(_document) => Ok(()),
@@ -601,10 +602,25 @@ mod tests {
     use validator::Validate;
 
     use crate::grpc::qdrant::{
-        CreateCollection, CreateFieldIndexCollection, CreateVectorNameRequest,
+        CreateCollection, CreateFieldIndexCollection, CreateVectorNameRequest, DenseVector,
         DenseVectorCreationConfig, FieldCondition, GeoBoundingBox, GeoLineString, GeoPoint,
-        GeoPolygon, GeoRadius, SearchPoints, UpdateCollection, create_vector_name_request,
+        GeoPolygon, GeoRadius, SearchPoints, UpdateCollection, create_vector_name_request, vector,
     };
+
+    #[test]
+    fn test_dense_vector_rejects_empty_data() {
+        // A non-empty dense vector passes, consistent with sparse/multi-dense.
+        let valid = vector::Vector::Dense(DenseVector {
+            data: vec![1.0, 2.0, 3.0],
+        });
+        assert!(valid.validate().is_ok());
+
+        // An empty dense vector must be rejected the same way empty sparse and
+        // multi-dense vectors already are; otherwise it reaches storage code
+        // that assumes non-zero length (see qdrant/qdrant#9045, #7967).
+        let empty = vector::Vector::Dense(DenseVector { data: vec![] });
+        assert!(empty.validate().is_err());
+    }
 
     #[test]
     fn test_geo_field_condition_rejects_out_of_range_coordinates() {


### PR DESCRIPTION
### All Submissions:

* [x] My PR targets the `dev` branch.
* [x] Have you followed the guidelines in our [Contributing document](https://github.com/qdrant/qdrant/blob/dev/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

## What does this PR do?

`grpc::vector::Vector::Dense` was the only variant of the gRPC `Vector` oneof that skipped emptiness validation:

```rust
impl Validate for grpc::vector::Vector {
    fn validate(&self) -> Result<(), ValidationErrors> {
        match self {
            grpc::vector::Vector::Dense(_dense) => Ok(()),   // no check
            grpc::vector::Vector::Sparse(sparse) => sparse.validate(),
            grpc::vector::Vector::MultiDense(multi) => multi.validate(),
            ...
        }
    }
}
