### PR TITLE
fix: count an explicit null payload value as 1 in values_count

### DIFF
--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -500,6 +500,33 @@ mod tests {
             )));
         assert!(payload_checker.check(0, &few_value_count_condition));
 
+        // An explicitly stored `null` is a non-array value, so its value count
+        // is 1 ("if stored value is not an array, the amount of values is
+        // assumed to be 1"), unlike an absent field, whose count is 0.
+        let null_value_count_condition =
+            Filter::new_must(Condition::Field(FieldCondition::new_values_count(
+                JsonPath::new("packaging"),
+                ValuesCount {
+                    lt: None,
+                    gt: None,
+                    gte: Some(1),
+                    lte: None,
+                },
+            )));
+        assert!(payload_checker.check(0, &null_value_count_condition));
+
+        let absent_value_count_condition =
+            Filter::new_must(Condition::Field(FieldCondition::new_values_count(
+                JsonPath::new("something_new"),
+                ValuesCount {
+                    lt: None,
+                    gt: None,
+                    gte: Some(1),
+                    lte: None,
+                },
+            )));
+        assert!(!payload_checker.check(0, &absent_value_count_condition));
+
         let in_berlin = Condition::Field(FieldCondition::new_geo_bounding_box(
             JsonPath::new("location"),
             GeoBoundingBox {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -3392,9 +3392,16 @@ impl ValuesCount {
 
     pub fn check_count_from(&self, value: &Value) -> bool {
         let count = match value {
-            Value::Null => 0,
+            // An explicit `null` is a stored non-array value, so it counts as 1
+            // per the documented contract ("if stored value is not an array, the
+            // amount of values is assumed to be 1"). Only an *absent* field has
+            // a count of 0, which is handled by `check_empty`, not here.
             Value::Array(array) => array.len(),
-            Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Object(_) => 1,
+            Value::Null
+            | Value::Bool(_)
+            | Value::Number(_)
+            | Value::String(_)
+            | Value::Object(_) => 1,
         };
 
         self.check_count(count)


### PR DESCRIPTION
check_count_from() treated an explicitly stored JSON null as zero values, so a values_count condition like {"gte": 1} excluded points whose payload contains the field with a null value. The documented contract says a stored non-array value counts as 1, and an explicit null is a stored value -- it is distinct from an absent field, which is the case check_empty() already handles (and which stays at 0).

Fixes #10113

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?