### PR TITLE
build: make io_bridge_object_store optional in segment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,6 +2284,7 @@ dependencies = [
  "log",
  "object_store",
  "rand 0.10.2",
+ "segment",
  "serde_json",
 ]
 
@@ -2301,6 +2302,7 @@ dependencies = [
  "log",
  "object_store",
  "rand 0.10.2",
+ "segment",
  "serde_json",
 ]
 

--- a/lib/edge/publish/amalgamate.py
+++ b/lib/edge/publish/amalgamate.py
@@ -197,13 +197,10 @@ def main() -> None:
         # otherwise cargo fmt will fail to resolve deleted module
         (r"^#\[cfg\(feature = \"gpu\"\)]\npub mod gpu;\n", ""),
     )
-    # io_bridge_object_store is a path dependency excluded from the amalgamation
-    # (the embedded edge build has no object storage), so drop the BlobFile
-    # UniversalReadExt impl that references it.
-    substitute(
-        AMALGAMATION / "src/segment/index/universal_io.rs",
-        (r"(?s)^#\[rustfmt::skip]\nimpl<A: io_bridge_object_store.*?\n\}\n", ""),
-    )
+    # The BlobFile UniversalReadExt impl that references io_bridge_object_store
+    # (a path dependency excluded from the amalgamation) is gated behind
+    # segment's `object-storage` feature, which the amalgamated crate never
+    # defines, so it compiles out without source stripping.
 
     # Ast-grep-based fixups.
     RULES_TEMPLATE = (Path(__file__).parent / "ast-grep-rules.yaml").read_text(

--- a/lib/edge/tools/shard_query/Cargo.toml
+++ b/lib/edge/tools/shard_query/Cargo.toml
@@ -14,6 +14,10 @@ path = "src/main.rs"
 [dependencies]
 edge = { path = "../.." }
 common = { path = "../../../common/common" }
+# The tools read shards through the object-store blob backend, which needs
+# segment's `UniversalReadExt for BlobFile` impl -- feature-gated so that
+# plain edge builds don't resolve the object-store stack.
+segment = { path = "../../../segment", default-features = false, features = ["object-storage"] }
 io_bridge_object_store = { path = "../../../common/io_bridge_object_store" }
 io_bridge_uio_grpc = { path = "../../../common/io_bridge_uio_grpc" }
 

--- a/lib/edge/tools/shard_update/Cargo.toml
+++ b/lib/edge/tools/shard_update/Cargo.toml
@@ -14,6 +14,10 @@ path = "src/main.rs"
 [dependencies]
 edge = { path = "../.." }
 common = { path = "../../../common/common" }
+# The tools read shards through the object-store blob backend, which needs
+# segment's `UniversalReadExt for BlobFile` impl -- feature-gated so that
+# plain edge builds don't resolve the object-store stack.
+segment = { path = "../../../segment", default-features = false, features = ["object-storage"] }
 io_bridge_object_store = { path = "../../../common/io_bridge_object_store" }
 
 fs-err = { workspace = true }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -15,6 +15,11 @@ workspace = true
 default = []
 testing = ["common/testing", "sparse/testing", "gpu/testing", "quantization/testing"]
 gpu = ["gpu/gpu"]
+# Read segment data through the `io_bridge_object_store` blob backend.
+# Only needed by consumers that actually read shards from object storage
+# (the edge CLI tools); keeping it off elsewhere keeps the object-store
+# stack (reqwest/hyper, cloud SDKs, aws-lc-sys) out of edge builds.
+object-storage = ["dep:io_bridge_object_store"]
 
 [build-dependencies]
 cc = { workspace = true }
@@ -45,7 +50,7 @@ tap = { workspace = true }
 pprof = { workspace = true }
 
 [dependencies]
-io_bridge_object_store = { path = "../common/io_bridge_object_store" }
+io_bridge_object_store = { path = "../common/io_bridge_object_store", optional = true }
 blink-alloc = { workspace = true }
 bytemuck = { workspace = true }
 data-encoding = { workspace = true }

--- a/lib/segment/src/index/universal_io.rs
+++ b/lib/segment/src/index/universal_io.rs
@@ -115,6 +115,7 @@ impl UniversalReadExt for ReadOnly<MmapFile> {
     fn condition_checker_numeric_uuid    <'a>(i: RangeCC<'a, Self, UuidIntType>)      -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }
 }
 
+#[cfg(feature = "object-storage")]
 #[rustfmt::skip]
 impl<A: io_bridge_object_store::AsyncRead + Clone> UniversalReadExt for io_bridge_object_store::BlobFile<A> {
     fn condition_checker_bool            <'a>(i: BoolCC<'a, Self>)                    -> EnumCC<'a> { EnumCC::Dyn(Box::new(i)) }

--- a/lib/segment/src/segment/read_only/tests.rs
+++ b/lib/segment/src/segment/read_only/tests.rs
@@ -271,6 +271,7 @@ fn read_only_segment_with_load_profile_matches_mutable() {
 ///
 /// Ignored by default; run with a server up:
 /// `S3_INTEGRATION_TEST=1 cargo test -p segment read_only_segment_over_s3 -- --ignored`
+#[cfg(feature = "object-storage")]
 #[test]
 #[ignore = "requires a running S3-compatible server (set S3_INTEGRATION_TEST=1)"]
 fn read_only_segment_over_s3() {


### PR DESCRIPTION
segment declared io_bridge_object_store as a non-optional dependency used by exactly one impl (UniversalReadExt for BlobFile in universal_io.rs), whose only consumers are the edge CLI tools. Every edge build (lib/edge, ffi, python, amalgamated qdrant-edge) therefore resolved the full object-store stack -- reqwest/hyper/tower, the AWS/GCP/Azure SDK crates, and the aws-lc-sys C/assembly build -- without using any of it. This is the remaining part of the non-goal noted in #10069.

Gate the dependency and the BlobFile impl (plus the S3 integration test) behind a new `object-storage` feature, enabled explicitly by edge-shard-query and edge-shard-update. The amalgamation no longer needs to strip the impl from the source: the amalgamated crate never defines the feature, so it compiles out.

Verified: `cargo tree -p edge -e no-dev -i object_store` (also reqwest, aws-lc-sys) no longer matches any package, while edge-shard-query still resolves object_store through its own dependency and the feature; `cargo check` passes for edge, both edge tools, and segment with and without the feature.

Fixes #10111

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [ ] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?