### PR TITLE
[UpdateOnly] implement `UpdateOnlyPayloadStorage`

### DIFF
--- a/lib/blobstore/src/blobstore/logstore/mod.rs
+++ b/lib/blobstore/src/blobstore/logstore/mod.rs
@@ -142,23 +142,17 @@ where
     }
 
     /// Opens an existing append-only storage, or initializes a new one, creating `base_path` if
-    /// it is not there yet.
+    /// it is not there yet. Depends on the existence of the config file, like
+    /// [`Blobstore::open_or_create`](super::Blobstore::open_or_create).
     ///
-    /// Which one it is depends on the existence of the config file, like
-    /// [`Blobstore::open_or_create`](super::Blobstore::open_or_create). An existing storage keeps
-    /// the config it was created with and `config_if_create` is ignored — the persisted
-    /// compression setting is what the value data in the pages is encoded with.
-    ///
-    /// A storage created in mutable mode is rejected rather than opened: the two modes persist
-    /// incompatible file formats.
+    /// In case of opening, it ignores the `config_if_create` parameter. A storage created in
+    /// mutable mode is rejected, the two modes persist incompatible file formats.
     pub fn open_or_create(
         fs: S::Fs,
         base_path: PathBuf,
         config_if_create: LogstoreConfig,
         populate: Populate,
     ) -> Result<Self> {
-        // Read the config rather than probe for it first: an absent one is what says there is no
-        // storage here yet, and asking twice costs a second round-trip on a remote backend.
         match super::reader::read_config(&fs, &base_path).ok_not_found()? {
             Some(StorageConfig::AppendOnly(config)) => Self::open(fs, base_path, config, populate),
             Some(StorageConfig::Mutable(_)) => Err(BlobstoreError::unsupported_operation(format!(

--- a/lib/blobstore/src/blobstore/logstore/mod.rs
+++ b/lib/blobstore/src/blobstore/logstore/mod.rs
@@ -15,7 +15,7 @@ use common::counter::referenced_counter::HwMetricRefCounter;
 use common::generic_consts::{AccessPattern, Sequential};
 use common::is_alive_lock::IsAliveLock;
 use common::universal_io::{
-    Populate, UniversalAppend, UniversalRead, UniversalWriteFileOps, UserData,
+    OkNotFound as _, Populate, UniversalAppend, UniversalRead, UniversalWriteFileOps, UserData,
 };
 use page::AppendOnlyPages;
 use parking_lot::RwLock;
@@ -141,6 +141,37 @@ where
         })
     }
 
+    /// Opens an existing append-only storage, or initializes a new one, creating `base_path` if
+    /// it is not there yet.
+    ///
+    /// Which one it is depends on the existence of the config file, like
+    /// [`Blobstore::open_or_create`](super::Blobstore::open_or_create). An existing storage keeps
+    /// the config it was created with and `config_if_create` is ignored — the persisted
+    /// compression setting is what the value data in the pages is encoded with.
+    ///
+    /// A storage created in mutable mode is rejected rather than opened: the two modes persist
+    /// incompatible file formats.
+    pub fn open_or_create(
+        fs: S::Fs,
+        base_path: PathBuf,
+        config_if_create: LogstoreConfig,
+        populate: Populate,
+    ) -> Result<Self> {
+        // Read the config rather than probe for it first: an absent one is what says there is no
+        // storage here yet, and asking twice costs a second round-trip on a remote backend.
+        match super::reader::read_config(&fs, &base_path).ok_not_found()? {
+            Some(StorageConfig::AppendOnly(config)) => Self::open(fs, base_path, config, populate),
+            Some(StorageConfig::Mutable(_)) => Err(BlobstoreError::unsupported_operation(format!(
+                "storage at {} was created in mutable mode, it cannot be opened append-only",
+                base_path.display(),
+            ))),
+            None => {
+                fs.create_dir(&base_path)?;
+                Self::new(fs, base_path, config_if_create)
+            }
+        }
+    }
+
     /// Open an existing storage at the given path, with the already read config.
     pub(super) fn open(
         fs: S::Fs,
@@ -182,7 +213,7 @@ where
     /// rejected, the storage is append-only.
     ///
     /// Always returns false on success, as values can never be updated.
-    pub(super) fn put_value(
+    pub fn put_value(
         &mut self,
         point_offset: PointOffset,
         value: &V,
@@ -431,7 +462,7 @@ impl<V, S: UniversalAppend + 'static> Logstore<V, S> {
     /// and syncs them, then does the same for the pending mappings in the tracker file. This
     /// order guarantees that a mapping on disk never points at value data that is not durable
     /// yet.
-    pub(super) fn flusher(&self) -> Flusher {
+    pub fn flusher(&self) -> Flusher {
         // Only values and mappings put up to this point are persisted, puts made during the
         // flush stay buffered for the next flush. The two watermarks are consistent with each
         // other: puts take &mut self, so no put can happen between capturing them.

--- a/lib/blobstore/src/blobstore/mod.rs
+++ b/lib/blobstore/src/blobstore/mod.rs
@@ -17,7 +17,7 @@ use common::universal_io::{
     UniversalWriteFileOps, UserData,
 };
 use gridstore::Gridstore;
-use logstore::Logstore;
+pub use logstore::Logstore;
 pub use reader::BlobstoreReader;
 use reader::CONFIG_FILENAME;
 pub use view::BlobstoreView;

--- a/lib/blobstore/src/lib.rs
+++ b/lib/blobstore/src/lib.rs
@@ -6,6 +6,10 @@ pub mod fixtures;
 mod tracker;
 
 pub use blob::Blob;
+// The append-only variant, exported because `Blobstore` cannot be named on a backend that only
+// appends: its type is bound at `UniversalWrite + UniversalAppend` for the sake of the other
+// variant. Its cross-crate surface is open, put and flush, nothing more.
+pub use blobstore::Logstore;
 // The bitmask belongs to the Gridstore variant, it is only public for the benchmarks
 pub use blobstore::gridstore::bitmask;
 pub use blobstore::{Blobstore, BlobstoreReader, BlobstoreView};

--- a/lib/blobstore/src/lib.rs
+++ b/lib/blobstore/src/lib.rs
@@ -6,9 +6,8 @@ pub mod fixtures;
 mod tracker;
 
 pub use blob::Blob;
-// The append-only variant, exported because `Blobstore` cannot be named on a backend that only
-// appends: its type is bound at `UniversalWrite + UniversalAppend` for the sake of the other
-// variant. Its cross-crate surface is open, put and flush, nothing more.
+// The append-only variant, it is public for backends that only append, which cannot name
+// `Blobstore` as it is bound at `UniversalWrite + UniversalAppend`
 pub use blobstore::Logstore;
 // The bitmask belongs to the Gridstore variant, it is only public for the benchmarks
 pub use blobstore::gridstore::bitmask;

--- a/lib/segment/src/payload_storage/mod.rs
+++ b/lib/segment/src/payload_storage/mod.rs
@@ -11,5 +11,6 @@ pub mod query_checker;
 pub mod read_only;
 #[cfg(test)]
 mod tests;
+pub mod update_only;
 
 pub use payload_storage_base::*;

--- a/lib/segment/src/payload_storage/update_only/mod.rs
+++ b/lib/segment/src/payload_storage/update_only/mod.rs
@@ -54,9 +54,8 @@ impl<S: UniversalAppend + 'static> UpdateOnlyPayloadStorage<S> {
     ///
     /// The slots must come in increasing order and must all be above every slot
     /// this storage already holds a payload for: it is append-only, so a slot
-    /// that was written cannot be written again. Slots skipped in between —
-    /// those of another segment's points, or of points this call has nothing to
-    /// store for — stay empty for good.
+    /// that was written cannot be written again. Slots skipped in between stay
+    /// empty for good.
     ///
     /// A point with an empty payload is not stored at all, its slot is skipped:
     /// an unwritten slot already reads back as an empty payload.

--- a/lib/segment/src/payload_storage/update_only/mod.rs
+++ b/lib/segment/src/payload_storage/update_only/mod.rs
@@ -1,0 +1,91 @@
+#[cfg(test)]
+mod tests;
+
+use std::path::Path;
+
+use blobstore::Logstore;
+use blobstore::config::LogstoreConfig;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::{Populate, UniversalAppend};
+
+use crate::common::operation_error::OperationResult;
+use crate::payload_storage::payload_storage_impl::storage_dir;
+use crate::types::Payload;
+
+/// The write half of the payload storage for an update-only segment: a
+/// short-lived writer opened for one batch and dropped with it.
+///
+/// Backed by a [`Logstore`], the append-only mode of the same storage
+/// [`PayloadStorageImpl`][1] uses, so a slot's payload is written once and
+/// never rewritten. [`append_many`](Self::append_many) flushes what it wrote,
+/// so a batch is durable when it returns and there is nothing to flush across
+/// calls.
+///
+/// [1]: crate::payload_storage::payload_storage_impl::PayloadStorageImpl
+pub struct UpdateOnlyPayloadStorage<S: UniversalAppend + 'static> {
+    storage: Logstore<Payload, S>,
+}
+
+impl<S: UniversalAppend + 'static> UpdateOnlyPayloadStorage<S> {
+    /// Open the payload storage of the segment at `segment_path` for appending,
+    /// creating it if the segment has none yet — the append-only counterpart of
+    /// [`PayloadStorageImpl::open_or_create`][1].
+    ///
+    /// A segment whose payload storage was created in mutable mode is rejected:
+    /// its file format is not one this writer can append to.
+    ///
+    /// [1]: crate::payload_storage::payload_storage_impl::PayloadStorageImpl::open_or_create
+    pub fn open(fs: S::Fs, segment_path: &Path) -> OperationResult<Self> {
+        let storage = Logstore::open_or_create(
+            fs,
+            storage_dir(segment_path),
+            LogstoreConfig::DEFAULT,
+            // Appends never read back, and on a remote backend populating would
+            // fetch every page of the storage per batch.
+            Populate::No,
+        )?;
+
+        Ok(Self { storage })
+    }
+
+    /// Store one payload per point of a batch, each at the slot the ID tracker
+    /// claimed for it, and persist them.
+    ///
+    /// The slots must come in increasing order and must all be above every slot
+    /// this storage already holds a payload for: it is append-only, so a slot
+    /// that was written cannot be written again. Slots skipped in between —
+    /// those of another segment's points, or of points this call has nothing to
+    /// store for — stay empty for good.
+    ///
+    /// A point with an empty payload is not stored at all, its slot is skipped:
+    /// an unwritten slot already reads back as an empty payload.
+    pub fn append_many<'a>(
+        &mut self,
+        payloads: impl IntoIterator<Item = (PointOffsetType, &'a Payload)>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let mut stored_any = false;
+        for (internal_id, payload) in payloads {
+            if payload.is_empty() {
+                continue;
+            }
+
+            self.storage.put_value(
+                internal_id,
+                payload,
+                hw_counter.ref_payload_io_write_counter(),
+            )?;
+            stored_any = true;
+        }
+
+        // Puts only buffer, the flush is what makes them durable. A batch that
+        // stored nothing skips it: the flush writes nothing, but still syncs
+        // every page file of the storage.
+        if stored_any {
+            self.storage.flusher()()?;
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/payload_storage/update_only/tests.rs
+++ b/lib/segment/src/payload_storage/update_only/tests.rs
@@ -20,9 +20,8 @@ fn payload(n: u64) -> Payload {
     payload_json! { "n": n, "text": format!("payload {n}") }
 }
 
-/// Read the segment's payload storage back through the read-only side, over the
-/// write-enforced backend, so what the writer produced is checked against a
-/// reader that cannot have written any of it.
+/// Read the segment's payload storage back through the read-only side, over a
+/// backend that cannot write.
 fn read_back(
     segment_path: &Path,
     slots: impl IntoIterator<Item = PointOffsetType>,
@@ -40,7 +39,7 @@ fn read_back(
 }
 
 /// A batch is durable once `append_many` returns, and a second writer resumes
-/// where the first one left off — the state lives in the files, not the writer.
+/// where the first one left off.
 #[test]
 fn batches_are_durable_and_resume() {
     let dir = TempDir::with_prefix("update_only_payload").unwrap();
@@ -74,7 +73,7 @@ fn batches_are_durable_and_resume() {
     );
 }
 
-/// Slots with an empty payload are not written at all, and read back empty —
+/// Slots with an empty payload are not written at all, and read back empty,
 /// including a gap the batch skips entirely.
 #[test]
 fn empty_payloads_and_gaps_read_back_empty() {
@@ -105,8 +104,7 @@ fn empty_payloads_and_gaps_read_back_empty() {
 }
 
 /// A slot far above everything the storage holds is written where it belongs,
-/// including on a storage that holds nothing at all — the case of a segment
-/// whose points had no payloads until now.
+/// including on a storage that holds nothing at all.
 #[test]
 fn first_payload_may_land_on_a_high_slot() {
     let dir = TempDir::with_prefix("update_only_payload").unwrap();
@@ -149,8 +147,7 @@ fn rewriting_a_slot_is_rejected() {
     assert!(writer.append_many([(0, &payload(0))], &hw_counter).is_err());
 }
 
-/// A payload storage created in mutable mode is not something this writer can
-/// append to, and is refused rather than opened.
+/// A payload storage created in mutable mode is refused rather than opened.
 #[test]
 fn mutable_storage_is_refused() {
     let dir = TempDir::with_prefix("update_only_payload").unwrap();

--- a/lib/segment/src/payload_storage/update_only/tests.rs
+++ b/lib/segment/src/payload_storage/update_only/tests.rs
@@ -1,0 +1,163 @@
+use std::path::Path;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::{
+    MmapFile, MmapFs, Populate, ReadOnly, UniversalRead, UniversalReadFileOps as _,
+};
+use tempfile::TempDir;
+
+use super::UpdateOnlyPayloadStorage;
+use crate::payload_json;
+use crate::payload_storage::PayloadStorageRead as _;
+use crate::payload_storage::payload_storage_impl::PayloadStorageImpl;
+use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
+use crate::types::Payload;
+
+type Writer = UpdateOnlyPayloadStorage<MmapFile>;
+
+fn payload(n: u64) -> Payload {
+    payload_json! { "n": n, "text": format!("payload {n}") }
+}
+
+/// Read the segment's payload storage back through the read-only side, over the
+/// write-enforced backend, so what the writer produced is checked against a
+/// reader that cannot have written any of it.
+fn read_back(
+    segment_path: &Path,
+    slots: impl IntoIterator<Item = PointOffsetType>,
+) -> Vec<Payload> {
+    type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
+    let fs = RoFs::from_context(Default::default()).unwrap();
+    let storage: ReadOnlyPayloadStorage<ReadOnly<MmapFile>> =
+        ReadOnlyPayloadStorage::open(&fs, segment_path.to_path_buf(), Populate::No).unwrap();
+
+    let hw_counter = HardwareCounterCell::new();
+    slots
+        .into_iter()
+        .map(|slot| storage.get(slot, &hw_counter).unwrap())
+        .collect()
+}
+
+/// A batch is durable once `append_many` returns, and a second writer resumes
+/// where the first one left off — the state lives in the files, not the writer.
+#[test]
+fn batches_are_durable_and_resume() {
+    let dir = TempDir::with_prefix("update_only_payload").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let first: Vec<Payload> = (0..3).map(payload).collect();
+    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    writer
+        .append_many(
+            first.iter().enumerate().map(|(i, p)| (i as u32, p)),
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    assert_eq!(read_back(dir.path(), 0..3), first);
+
+    let second: Vec<Payload> = (10..13).map(payload).collect();
+    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    writer
+        .append_many(
+            second.iter().enumerate().map(|(i, p)| (i as u32 + 3, p)),
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    assert_eq!(
+        read_back(dir.path(), 0..6),
+        first.iter().chain(&second).cloned().collect::<Vec<_>>(),
+    );
+}
+
+/// Slots with an empty payload are not written at all, and read back empty —
+/// including a gap the batch skips entirely.
+#[test]
+fn empty_payloads_and_gaps_read_back_empty() {
+    let dir = TempDir::with_prefix("update_only_payload").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let empty = Payload::default();
+    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    writer
+        .append_many(
+            [(0, &payload(0)), (1, &empty), (4, &payload(4))],
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    assert_eq!(
+        read_back(dir.path(), 0..6),
+        vec![
+            payload(0),
+            empty.clone(),
+            empty.clone(),
+            empty.clone(),
+            payload(4),
+            empty,
+        ],
+    );
+}
+
+/// A slot far above everything the storage holds is written where it belongs,
+/// including on a storage that holds nothing at all — the case of a segment
+/// whose points had no payloads until now.
+#[test]
+fn first_payload_may_land_on_a_high_slot() {
+    let dir = TempDir::with_prefix("update_only_payload").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    writer
+        .append_many([(1_000, &payload(1_000))], &hw_counter)
+        .unwrap();
+    drop(writer);
+
+    assert_eq!(
+        read_back(dir.path(), [0, 999, 1_000]),
+        vec![Payload::default(), Payload::default(), payload(1_000),]
+    );
+}
+
+/// The storage is append-only: a slot it already holds a payload for cannot be
+/// written a second time, whether within one batch or by a later writer.
+#[test]
+fn rewriting_a_slot_is_rejected() {
+    let dir = TempDir::with_prefix("update_only_payload").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    writer
+        .append_many([(0, &payload(0)), (1, &payload(1))], &hw_counter)
+        .unwrap();
+
+    // Out of order within a batch
+    assert!(
+        writer
+            .append_many([(3, &payload(3)), (2, &payload(2))], &hw_counter)
+            .is_err(),
+    );
+    drop(writer);
+
+    // And a slot a previous writer already used
+    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    assert!(writer.append_many([(0, &payload(0))], &hw_counter).is_err());
+}
+
+/// A payload storage created in mutable mode is not something this writer can
+/// append to, and is refused rather than opened.
+#[test]
+fn mutable_storage_is_refused() {
+    let dir = TempDir::with_prefix("update_only_payload").unwrap();
+
+    let storage: PayloadStorageImpl =
+        PayloadStorageImpl::open_or_create(dir.path().to_path_buf(), false).unwrap();
+    drop(storage);
+
+    assert!(Writer::open(MmapFs, dir.path()).is_err());
+}


### PR DESCRIPTION
The payload write half for the update-only segment writer, alongside `UpdateOnlyChunkedVectors` (#10114) and `UpdateOnlyAppendableIdTracker` (#10093): a short-lived storage opened for one batch and dropped with it, over a backend that only appends.

## What it does

Backed by a `Logstore` — the append-only mode of the same storage the writable `PayloadStorageImpl` uses — so a slot's payload is written once and never rewritten.

`append_many` takes one payload per point, at the slot the ID tracker claimed for it, and flushes. A batch is durable when the call returns; nothing is buffered across calls.

- **Puts only buffer.** The flush is what touches the files: one append per touched page file plus one to the tracker, regardless of batch size. Verified under `strace` — 3 payloads go out as one 96-byte page write and one 48-byte tracker write, and a 1000-slot gap backfill is a single 16016-byte tracker write, not 1001.
- **Empty payloads are skipped**, since an unwritten slot already reads back as an empty payload. So are gaps between slots, which the tracker materializes as unmapped entries.
- **Slots must increase.** A slot the storage already holds a payload for is rejected rather than rewritten.

## Why `Logstore` is exported

`Blobstore`'s type is bound at `UniversalWrite + UniversalAppend` for the sake of its `Gridstore` variant, so it cannot be named on a backend that only appends — which is exactly the backend this writer targets. `Logstore` therefore leaves the facade, annotated at the export. Its cross-crate surface is `open_or_create`, `put_value` and `flusher`, nothing more; everything else stays `pub(super)`.

The new `Logstore::open_or_create` mirrors `Blobstore::open_or_create` and rejects a payload storage created in mutable mode rather than opening it.

## Not in this PR

Not wired into `AppendableSegment` yet — `store_points` stays `todo!()` until the vector storages and field indexes exist, as with `UpdateOnlyChunkedVectors`.

Four per-open costs in `Logstore` are worth a follow-up before this path carries real batch traffic, since a per-batch writer turns them from once-per-segment-load into once-per-batch: `AppendOnlyPages::open` discards the sizes `list_files` already returned and re-`len()`s each page (N metadata round trips), every page file is opened though only the last is appended to, `flusher()` syncs all pages rather than the written ones, and `validate_consistency` re-reads the trailing 256 mappings each time. All pre-existing, and fixing them touches the mutable users too.

## Tests

5 new tests in `payload_storage::update_only`: durability and resume across writers, empty payloads and gaps, a first payload landing on a high slot, append-only rejection, and mutable-mode refusal. `-p blobstore` (151) and `-p segment --lib payload_storage` (22) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)