### PR TITLE
[UpdateOnly] implement `UpdateOnlyStructPayloadIndex`, the per-segment fan-out

### DIFF
--- a/lib/segment/src/index/struct_payload_index/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/mod.rs
@@ -7,6 +7,7 @@ pub use read_view::{IdsConditionChecker, StructPayloadIndexReadView};
 pub mod read_only;
 #[cfg(test)]
 mod tests;
+pub mod update_only;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/lib/segment/src/index/struct_payload_index/update_only/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/update_only/mod.rs
@@ -1,0 +1,112 @@
+//! The write half of a segment's payload indexes, for update-only segments.
+
+#[cfg(test)]
+mod tests;
+
+use std::path::Path;
+
+use ahash::AHashMap;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalAppend;
+
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::index::field_index::UpdateOnlyFieldIndex;
+use crate::index::payload_config::PayloadConfig;
+use crate::segment_constructor::get_payload_index_path;
+use crate::types::{Payload, PayloadContainer as _, PayloadKeyType};
+
+/// Every field index of one segment, open for one batch of updates and dropped
+/// with it — the update-only counterpart of [`ReadOnlyStructPayloadIndex`][1].
+///
+/// Holds no payload storage, no id tracker and no vector storages, unlike both
+/// the writable index and the read-only one. Those are there to answer queries
+/// and to resolve what an update means; by the time a batch reaches here it is
+/// resolved, and every point arrives with the payload it will be stored with.
+///
+/// [1]: crate::index::struct_payload_index::read_only::ReadOnlyStructPayloadIndex
+pub struct UpdateOnlyStructPayloadIndex<S: UniversalAppend + 'static> {
+    /// One writer per index of each indexed field, as the payload config
+    /// declares them.
+    field_indexes: AHashMap<PayloadKeyType, Vec<UpdateOnlyFieldIndex<S>>>,
+}
+
+impl<S: UniversalAppend + 'static> UpdateOnlyStructPayloadIndex<S> {
+    /// Open a writer for every index of every field the segment at
+    /// `segment_path` has indexed, creating storages the segment does not have
+    /// yet. A segment with no payload config has no indexed fields, and opens
+    /// with nothing.
+    ///
+    /// A field whose index types the config does not spell out is refused. That
+    /// is a config from before those types were recorded, which the writable
+    /// index repairs by deriving them from the schema on its next open — this
+    /// writer builds no indexes, so it cannot, and it must not carry on leaving
+    /// whatever is on disk to rot.
+    pub fn open(fs: S::Fs, segment_path: &Path) -> OperationResult<Self> {
+        let path = get_payload_index_path(segment_path);
+        let config = PayloadConfig::load_universal(&fs, &PayloadConfig::get_config_path(&path))?
+            .unwrap_or_default();
+
+        let mut field_indexes = AHashMap::with_capacity(config.indices.len());
+        for (field, indexed) in config.indices.iter() {
+            if indexed.types.is_empty() {
+                return Err(OperationError::service_error(format!(
+                    "Payload index of field {field} does not record which indexes it has; \
+                     open the segment for writing once to have them derived and stored",
+                )));
+            }
+
+            let indexes = indexed
+                .types
+                .iter()
+                .map(|index_type| {
+                    UpdateOnlyFieldIndex::open(
+                        fs.clone(),
+                        &path,
+                        field,
+                        &indexed.schema,
+                        index_type,
+                    )
+                })
+                .collect::<OperationResult<Vec<_>>>()?;
+
+            field_indexes.insert(field.clone(), indexes);
+        }
+
+        Ok(Self { field_indexes })
+    }
+
+    /// Index a batch of points, each at the slot the ID tracker claimed for it,
+    /// and persist every index that gained anything.
+    ///
+    /// The slots must come in increasing order and must all be above every slot
+    /// these indexes already cover: they are append-only, so a slot that was
+    /// indexed cannot be indexed again.
+    ///
+    /// Every field is offered every point, including the points whose payload
+    /// has nothing under that field. An index that stores values per point
+    /// stores none for those and leaves the slot empty; the null index records
+    /// that the point has no value there, which is exactly what it is for.
+    pub fn append_many<'a>(
+        &mut self,
+        points: impl IntoIterator<Item = (PointOffsetType, &'a Payload)>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        for (slot, payload) in points {
+            for (field, indexes) in &mut self.field_indexes {
+                let values = payload.get_value(field);
+                for index in indexes.iter_mut() {
+                    index.add_point(slot, &values, hw_counter)?;
+                }
+            }
+        }
+
+        // Once per index per batch: a flush is what reaches the files, and for
+        // the bitmask-backed indexes it rewrites a whole mask.
+        for index in self.field_indexes.values_mut().flatten() {
+            index.flush(hw_counter)?;
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/index/struct_payload_index/update_only/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/update_only/mod.rs
@@ -20,9 +20,8 @@ use crate::types::{Payload, PayloadContainer as _, PayloadKeyType};
 /// with it — the update-only counterpart of [`ReadOnlyStructPayloadIndex`][1].
 ///
 /// Holds no payload storage, no id tracker and no vector storages, unlike both
-/// the writable index and the read-only one. Those are there to answer queries
-/// and to resolve what an update means; by the time a batch reaches here it is
-/// resolved, and every point arrives with the payload it will be stored with.
+/// the writable index and the read-only one: by the time a batch reaches here
+/// every point arrives with the payload it will be stored with.
 ///
 /// [1]: crate::index::struct_payload_index::read_only::ReadOnlyStructPayloadIndex
 pub struct UpdateOnlyStructPayloadIndex<S: UniversalAppend + 'static> {
@@ -37,11 +36,10 @@ impl<S: UniversalAppend + 'static> UpdateOnlyStructPayloadIndex<S> {
     /// yet. A segment with no payload config has no indexed fields, and opens
     /// with nothing.
     ///
-    /// A field whose index types the config does not spell out is refused. That
-    /// is a config from before those types were recorded, which the writable
-    /// index repairs by deriving them from the schema on its next open — this
-    /// writer builds no indexes, so it cannot, and it must not carry on leaving
-    /// whatever is on disk to rot.
+    /// A field whose index types the config does not spell out is refused: that
+    /// is a config from before those types were recorded, which only the
+    /// writable index can repair, by deriving them from the schema on its next
+    /// open.
     pub fn open(fs: S::Fs, segment_path: &Path) -> OperationResult<Self> {
         let path = get_payload_index_path(segment_path);
         let config = PayloadConfig::load_universal(&fs, &PayloadConfig::get_config_path(&path))?
@@ -84,9 +82,9 @@ impl<S: UniversalAppend + 'static> UpdateOnlyStructPayloadIndex<S> {
     /// indexed cannot be indexed again.
     ///
     /// Every field is offered every point, including the points whose payload
-    /// has nothing under that field. An index that stores values per point
-    /// stores none for those and leaves the slot empty; the null index records
-    /// that the point has no value there, which is exactly what it is for.
+    /// has nothing under that field: an index that stores values per point
+    /// leaves the slot empty, the null index records that the point has no
+    /// value there.
     pub fn append_many<'a>(
         &mut self,
         points: impl IntoIterator<Item = (PointOffsetType, &'a Payload)>,
@@ -101,8 +99,8 @@ impl<S: UniversalAppend + 'static> UpdateOnlyStructPayloadIndex<S> {
             }
         }
 
-        // Once per index per batch: a flush is what reaches the files, and for
-        // the bitmask-backed indexes it rewrites a whole mask.
+        // Once per index per batch: for the bitmask-backed indexes a flush
+        // rewrites a whole mask
         for index in self.field_indexes.values_mut().flatten() {
             index.flush(hw_counter)?;
         }

--- a/lib/segment/src/index/struct_payload_index/update_only/tests.rs
+++ b/lib/segment/src/index/struct_payload_index/update_only/tests.rs
@@ -1,6 +1,5 @@
 //! Writes a batch through the whole fan-out, then reads each field index back
-//! through the ordinary appendable index that owns it — the same contract the
-//! per-index writers are tested against, one level up.
+//! through the ordinary appendable index that owns it.
 
 use std::path::Path;
 
@@ -36,9 +35,8 @@ fn index_type(index_type: PayloadIndexType) -> FullPayloadIndexType {
     }
 }
 
-/// Declare `f` as a keyword index, plus the null index that complements every
-/// indexed field — the shape [`StructPayloadIndex::build_field_indexes`] leaves
-/// behind.
+/// Declare `f` with the given index types, the shape
+/// [`StructPayloadIndex::build_field_indexes`] leaves behind.
 fn write_config(segment_path: &Path, types: Vec<FullPayloadIndexType>) {
     let path = get_payload_index_path(segment_path);
     fs_err::create_dir_all(&path).unwrap();
@@ -70,8 +68,7 @@ fn batch_reaches_every_index_of_a_field() {
 
     let payloads: Vec<Payload> = vec![
         payload_json! { "f": "alpha" },
-        // No value under `f` at all — the keyword index stores nothing for it,
-        // the null index still has to record that.
+        // No value under `f` at all, only the null index records anything for it
         payload_json! { "other": 1 },
         payload_json! { "f": null },
     ];
@@ -177,8 +174,7 @@ fn segment_without_indexes_opens_empty() {
 }
 
 /// A config that does not say which indexes a field has is refused: this writer
-/// builds no indexes, so it cannot derive them the way the writable index does,
-/// and carrying on would leave whatever is on disk to rot.
+/// builds no indexes, so it cannot derive them the way the writable index does.
 #[test]
 fn undeclared_index_types_are_refused() {
     let dir = TempDir::with_prefix("update_only_struct_index").unwrap();

--- a/lib/segment/src/index/struct_payload_index/update_only/tests.rs
+++ b/lib/segment/src/index/struct_payload_index/update_only/tests.rs
@@ -1,0 +1,194 @@
+//! Writes a batch through the whole fan-out, then reads each field index back
+//! through the ordinary appendable index that owns it — the same contract the
+//! per-index writers are tested against, one level up.
+
+use std::path::Path;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::universal_io::{MmapFile, MmapFs};
+use tempfile::TempDir;
+
+use super::UpdateOnlyStructPayloadIndex;
+use crate::index::field_index::map_index::mutable_map_index::MutableMapIndex;
+use crate::index::field_index::map_index::read_ops::MapIndexRead as _;
+use crate::index::field_index::null_index::NullIndexRead as _;
+use crate::index::field_index::null_index::mutable_null_index::MutableNullIndex;
+use crate::index::payload_config::{
+    FullPayloadIndexType, IndexMutability, PayloadConfig, PayloadFieldSchemaWithIndexType,
+    PayloadIndexType, StorageType,
+};
+use crate::json_path::JsonPath;
+use crate::payload_json;
+use crate::segment_constructor::get_payload_index_path;
+use crate::types::{Payload, PayloadFieldSchema, PayloadSchemaType};
+
+type Index = UpdateOnlyStructPayloadIndex<MmapFile>;
+
+fn field() -> JsonPath {
+    JsonPath::new("f")
+}
+
+fn index_type(index_type: PayloadIndexType) -> FullPayloadIndexType {
+    FullPayloadIndexType {
+        index_type,
+        mutability: IndexMutability::Mutable,
+        storage_type: StorageType::Gridstore,
+    }
+}
+
+/// Declare `f` as a keyword index, plus the null index that complements every
+/// indexed field — the shape [`StructPayloadIndex::build_field_indexes`] leaves
+/// behind.
+fn write_config(segment_path: &Path, types: Vec<FullPayloadIndexType>) {
+    let path = get_payload_index_path(segment_path);
+    fs_err::create_dir_all(&path).unwrap();
+
+    let mut config = PayloadConfig::default();
+    config.indices.insert(
+        field(),
+        PayloadFieldSchemaWithIndexType::new(
+            PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword),
+            types,
+        ),
+    );
+    config.save(&PayloadConfig::get_config_path(&path)).unwrap();
+}
+
+/// A batch reaches every index of the field: the one that stores values, and
+/// the null index that records which points have any.
+#[test]
+fn batch_reaches_every_index_of_a_field() {
+    let dir = TempDir::with_prefix("update_only_struct_index").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    write_config(
+        dir.path(),
+        vec![
+            index_type(PayloadIndexType::KeywordIndex),
+            index_type(PayloadIndexType::NullIndex),
+        ],
+    );
+
+    let payloads: Vec<Payload> = vec![
+        payload_json! { "f": "alpha" },
+        // No value under `f` at all — the keyword index stores nothing for it,
+        // the null index still has to record that.
+        payload_json! { "other": 1 },
+        payload_json! { "f": null },
+    ];
+
+    let mut index = Index::open(MmapFs, dir.path()).unwrap();
+    index
+        .append_many(
+            payloads.iter().enumerate().map(|(i, p)| (i as u32, p)),
+            &hw_counter,
+        )
+        .unwrap();
+    drop(index);
+
+    let path = get_payload_index_path(dir.path());
+
+    let keyword = MutableMapIndex::<str>::open_gridstore(
+        PayloadIndexType::KeywordIndex.storage_dir(&path, &field()),
+        false,
+        false,
+    )
+    .unwrap()
+    .unwrap();
+    let values = |slot| {
+        keyword
+            .get_values(slot, &hw_counter)
+            .map(|values| values.map(String::from).collect::<Vec<_>>())
+    };
+    assert_eq!(values(0), Some(vec!["alpha".to_string()]));
+    assert_eq!(values(1), None);
+    assert_eq!(values(2), None);
+
+    let null = MutableNullIndex::open(
+        &PayloadIndexType::NullIndex.storage_dir(&path, &field()),
+        payloads.len(),
+        false,
+    )
+    .unwrap()
+    .unwrap();
+    assert!(!null.values_is_empty(0).unwrap());
+    assert!(null.values_is_empty(1).unwrap());
+    assert!(null.values_is_null(2).unwrap());
+}
+
+/// A second batch resumes where the first left off, for both the append-backed
+/// index and the mask-backed one.
+#[test]
+fn batches_resume() {
+    let dir = TempDir::with_prefix("update_only_struct_index").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    write_config(
+        dir.path(),
+        vec![
+            index_type(PayloadIndexType::KeywordIndex),
+            index_type(PayloadIndexType::NullIndex),
+        ],
+    );
+
+    for (slot, value) in [(0, "alpha"), (1, "beta")] {
+        let payload = payload_json! { "f": value };
+        let mut index = Index::open(MmapFs, dir.path()).unwrap();
+        index.append_many([(slot, &payload)], &hw_counter).unwrap();
+    }
+
+    let path = get_payload_index_path(dir.path());
+    let keyword = MutableMapIndex::<str>::open_gridstore(
+        PayloadIndexType::KeywordIndex.storage_dir(&path, &field()),
+        false,
+        false,
+    )
+    .unwrap()
+    .unwrap();
+
+    for (slot, expected) in [(0, "alpha"), (1, "beta")] {
+        assert_eq!(
+            keyword
+                .get_values(slot, &hw_counter)
+                .map(|values| values.map(String::from).collect::<Vec<_>>()),
+            Some(vec![expected.to_string()]),
+        );
+    }
+
+    let null = MutableNullIndex::open(
+        &PayloadIndexType::NullIndex.storage_dir(&path, &field()),
+        2,
+        false,
+    )
+    .unwrap()
+    .unwrap();
+    assert!(!null.values_is_empty(0).unwrap(), "first batch survived");
+    assert!(!null.values_is_empty(1).unwrap());
+}
+
+/// A segment that indexes nothing opens with nothing, and a batch through it is
+/// a no-op rather than an error.
+#[test]
+fn segment_without_indexes_opens_empty() {
+    let dir = TempDir::with_prefix("update_only_struct_index").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let payload = payload_json! { "f": "alpha" };
+    let mut index = Index::open(MmapFs, dir.path()).unwrap();
+    index.append_many([(0, &payload)], &hw_counter).unwrap();
+}
+
+/// A config that does not say which indexes a field has is refused: this writer
+/// builds no indexes, so it cannot derive them the way the writable index does,
+/// and carrying on would leave whatever is on disk to rot.
+#[test]
+fn undeclared_index_types_are_refused() {
+    let dir = TempDir::with_prefix("update_only_struct_index").unwrap();
+    write_config(dir.path(), vec![]);
+
+    let Err(err) = Index::open(MmapFs, dir.path()) else {
+        panic!("a field with no declared index types must be refused");
+    };
+    assert!(
+        format!("{err}").contains("does not record which indexes"),
+        "{err}"
+    );
+}


### PR DESCRIPTION
Stacked on #10147 (which is stacked on #10146) — review those first; this PR's diff against its base is the single new commit.

Every field index of one segment, opened for a batch and dropped with it — the update-only counterpart of `ReadOnlyStructPayloadIndex`, and the level `AppendableSegment` needs: hand it the points a batch stores and every index of every indexed field is left current.

## What it does

Reads which indexes a field has from the payload config, exactly as the read-only side does, and holds nothing else. No payload storage, no id tracker, no vector storages — those exist to answer queries and to work out what an update *means*, and by the time a batch reaches here that is settled: each point arrives with the payload it will be stored with.

```rust
let mut indexes = UpdateOnlyStructPayloadIndex::open(fs, segment_path)?;
indexes.append_many(points.iter().map(|p| (p.slot, &p.payload)), &hw_counter)?;
```

**Every field is offered every point**, including points whose payload holds nothing under it. An index that stores values per point stores none for those; the null index records that the point has no value there, which is the whole reason it exists. That is simpler than the writable path's add-or-remove split, which is only needed because a slot there may already hold something — here the slot is fresh.

One flush per index per batch, after all points, since for the bitmask-backed indexes a flush rewrites a whole mask.

## Refusal

A field whose index types the config does not spell out is rejected. That config predates those types being recorded, and `StructPayloadIndex::load_from_db` repairs it by deriving them from the schema on its next open. This writer builds no indexes, so it cannot — and carrying on would leave whatever is on disk to rot while queries still use it. Any segment opened for writing since 1.15 has them.

## Tests

4 cases: a batch reaching both indexes of a field (value index + null index, including a point with no value under the field and one with an explicit null), resume across batches for both the append-backed and the mask-backed index, a segment with no indexed fields, and the undeclared-types refusal. Read back through the real `MutableMapIndex` / `MutableNullIndex`.

`-p segment --lib` 1015 passed, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)