### PR TITLE
[UpdateOnly] implement the appendable vector storages

### DIFF
--- a/lib/segment/src/common/flags/update_only_stored_flags.rs
+++ b/lib/segment/src/common/flags/update_only_stored_flags.rs
@@ -3,7 +3,9 @@ use std::path::{Path, PathBuf};
 use common::bitvec::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::{OkNotFound as _, UniversalAppend, UniversalWriteFileOps as _};
+use common::universal_io::{
+    OkNotFound as _, UniversalAppend, UniversalReadFileOps as _, UniversalWriteFileOps as _,
+};
 
 use super::dynamic_stored_flags::{DynamicFlagsStatus, FLAGS_FILE, file_size_for, status_file};
 use super::in_memory_bitvec_flags::InMemoryBitvecFlags;
@@ -32,6 +34,18 @@ impl<S: UniversalAppend + 'static> UpdateOnlyStoredFlags<S> {
     /// directory that holds none yet opens empty; nothing is created until the
     /// first [`flush`](Self::flush).
     pub fn open(fs: S::Fs, directory: &Path) -> OperationResult<Self> {
+        // Materialize the directory on the first open rather than on the first
+        // flag. Storages use it as the marker that they exist at all — the
+        // sparse one takes its absence for "not created yet" and starts over —
+        // so a batch that flags nothing must still leave it behind.
+        if !fs.exists(&status_file(directory))? {
+            fs.create_dir(directory)?;
+            fs.atomic_save(
+                &status_file(directory),
+                bytemuck::bytes_of(&DynamicFlagsStatus::new(0)),
+            )?;
+        }
+
         let flags = InMemoryBitvecFlags::open::<S>(&fs, directory)
             .ok_not_found()?
             .map(InMemoryBitvecFlags::into_bitvec)

--- a/lib/segment/src/common/flags/update_only_stored_flags.rs
+++ b/lib/segment/src/common/flags/update_only_stored_flags.rs
@@ -31,8 +31,8 @@ pub struct UpdateOnlyStoredFlags<S: UniversalAppend + 'static> {
 
 impl<S: UniversalAppend + 'static> UpdateOnlyStoredFlags<S> {
     /// Read the flags at `directory` into memory, ready to be extended. A
-    /// directory that holds none yet opens empty; nothing is created until the
-    /// first [`flush`](Self::flush).
+    /// directory that holds none yet opens empty, and is created — status file
+    /// included — right away.
     pub fn open(fs: S::Fs, directory: &Path) -> OperationResult<Self> {
         // Materialize the directory on the first open rather than on the first
         // flag. Storages use it as the marker that they exist at all — the

--- a/lib/segment/src/vector_storage/chunked_vectors/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/update_only/mod.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap::AdviceSetting;
 use common::universal_io::{
-    OpenOptions, Populate, UniversalAppend, UniversalReadFileOps, UniversalReadFs, UniversalWrite,
+    OpenOptions, Populate, UniversalAppend, UniversalReadFileOps, UniversalReadFs,
     UniversalWriteFileOps,
 };
 
@@ -46,7 +46,7 @@ fn append_options() -> OpenOptions {
 impl<T, S> UpdateOnlyChunkedVectors<T, S>
 where
     T: bytemuck::Pod + Send,
-    S: UniversalAppend + UniversalWrite + 'static,
+    S: UniversalAppend + 'static,
 {
     /// Open a chunked-vectors directory for appending, creating it if missing.
     pub fn open(fs: S::Fs, directory: &Path, dim: usize) -> OperationResult<Self> {

--- a/lib/segment/src/vector_storage/chunked_vectors/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/update_only/mod.rs
@@ -24,7 +24,6 @@ use crate::vector_storage::chunked_vectors::config::{
 /// touched chunks, appends, and persists the vector count, so a batch is
 /// durable when it returns and there is nothing to flush.
 #[derive(Debug)]
-#[cfg_attr(not(test), expect(dead_code))]
 pub struct UpdateOnlyChunkedVectors<T, S: UniversalAppend> {
     directory: PathBuf,
     config: ChunkedVectorsConfig,
@@ -42,7 +41,6 @@ fn append_options() -> OpenOptions {
     }
 }
 
-#[cfg_attr(not(test), expect(dead_code))]
 impl<T, S> UpdateOnlyChunkedVectors<T, S>
 where
     T: bytemuck::Pod + Send,

--- a/lib/segment/src/vector_storage/chunked_vectors/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/update_only/mod.rs
@@ -15,7 +15,7 @@ use crate::common::operation_error::{OperationError, OperationResult};
 use crate::vector_storage::VectorOffsetType;
 use crate::vector_storage::chunked_vectors::chunks::{chunk_name, list_chunk_files};
 use crate::vector_storage::chunked_vectors::config::{
-    ChunkedVectorsConfig, Status, ensure_config, status_file,
+    ChunkedVectorsConfig, Status, ensure_config, read_status_len, status_file,
 };
 
 /// Short-lived append-only writer for chunked vectors storage.
@@ -65,6 +65,24 @@ where
             fs,
             _t: PhantomData,
         })
+    }
+
+    /// The vector count the directory records, read from storage every time so
+    /// that it reflects what a previous writer left rather than anything this
+    /// handle remembers.
+    ///
+    /// Needed where a storage's rows are not indexed by point slot — the
+    /// multivector ones — so a batch knows where the row space ends.
+    pub fn stored_len(&self) -> OperationResult<usize> {
+        read_status_len(&self.fs, &status_file(&self.directory))
+    }
+
+    /// How many more vectors fit in the chunk that `key` falls in.
+    ///
+    /// A vector never straddles a chunk, so a caller placing a run of rows has
+    /// to skip to the next chunk when the run does not fit in this one.
+    pub fn remaining_chunk_keys(&self, key: usize) -> usize {
+        self.config.remaining_chunk_capacity(key)
     }
 
     /// Replace the stored vector count.

--- a/lib/segment/src/vector_storage/dense/mod.rs
+++ b/lib/segment/src/vector_storage/dense/mod.rs
@@ -3,4 +3,5 @@ pub mod dense_vector_storage;
 pub mod empty_dense_vector_storage;
 pub mod immutable_dense_vectors;
 pub mod read_only;
+pub mod update_only;
 pub mod volatile_dense_vector_storage;

--- a/lib/segment/src/vector_storage/dense/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/dense/update_only/mod.rs
@@ -1,0 +1,117 @@
+#[cfg(test)]
+mod tests;
+
+use std::borrow::Cow;
+use std::path::Path;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalAppend;
+
+use super::appendable_dense_vector_storage::{DELETED_DIR_PATH, VECTORS_DIR_PATH};
+use crate::common::flags::update_only_stored_flags::UpdateOnlyStoredFlags;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::data_types::vectors::VectorElementType;
+use crate::vector_storage::VectorOffsetType;
+use crate::vector_storage::chunked_vectors::update_only::UpdateOnlyChunkedVectors;
+use crate::vector_storage::update_only::VectorToStore;
+
+/// Writes what [`AppendableMmapDenseVectorStorage`] persists: the vectors, and
+/// the flags marking which slots hold no vector of their own.
+///
+/// [`AppendableMmapDenseVectorStorage`]: super::appendable_dense_vector_storage::AppendableMmapDenseVectorStorage
+pub struct UpdateOnlyDenseVectorStorage<T: PrimitiveVectorElement, S: UniversalAppend + 'static> {
+    vectors: UpdateOnlyChunkedVectors<T, S>,
+    deleted: UpdateOnlyStoredFlags<S>,
+    dim: usize,
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static> UpdateOnlyDenseVectorStorage<T, S> {
+    /// Open the storage at `path` for appending, creating it if it is not there
+    /// yet.
+    pub fn open(fs: S::Fs, path: &Path, dim: usize) -> OperationResult<Self> {
+        Ok(Self {
+            vectors: UpdateOnlyChunkedVectors::open(fs.clone(), &path.join(VECTORS_DIR_PATH), dim)?,
+            deleted: UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIR_PATH))?,
+            dim,
+        })
+    }
+
+    /// Append one vector per point of a batch, starting at `start_slot`, and
+    /// persist them.
+    ///
+    /// Slots are consecutive from `start_slot`: every point of the batch takes
+    /// one, whether or not it has a vector here. `start_slot` must be the slot
+    /// this storage ends at, since the vectors are stored positionally.
+    pub fn append_many<'a>(
+        &mut self,
+        start_slot: PointOffsetType,
+        vectors: impl IntoIterator<Item = VectorToStore<'a>>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        // Decoded whole rather than streamed: a chunk append takes the run as
+        // one slice-of-slices, and the borrow of a decoded vector cannot
+        // outlive the conversion that produced it.
+        let mut run: Vec<Vec<T>> = Vec::new();
+        let mut missing = Vec::new();
+
+        for (offset, vector) in vectors.into_iter().enumerate() {
+            let elements = match vector {
+                VectorToStore::Decoded(vector) => {
+                    let vector: &[VectorElementType] = vector.try_into()?;
+                    T::slice_from_float_cow(Cow::Borrowed(vector)).into_owned()
+                }
+                VectorToStore::Raw(bytes) => self.decode_raw(bytes)?,
+                VectorToStore::Missing => {
+                    // A placeholder keeps the slot numbering aligned with the id
+                    // tracker; the flag is what says there is no vector here.
+                    missing.push(start_slot + offset as PointOffsetType);
+                    vec![T::default(); self.dim]
+                }
+            };
+
+            if elements.len() != self.dim {
+                return Err(OperationError::WrongVectorDimension {
+                    expected_dim: self.dim,
+                    received_dim: elements.len(),
+                });
+            }
+            run.push(elements);
+        }
+
+        self.vectors.append_many(
+            start_slot as VectorOffsetType,
+            run.iter().map(Vec::as_slice),
+            hw_counter,
+        )?;
+
+        // Only the missing ones are flagged. A slot this writer has not flagged
+        // reads as not deleted, and the mask is explicitly allowed to be shorter
+        // than the vector count — so a batch where every point has a vector
+        // rewrites no mask at all.
+        for slot in missing {
+            self.deleted.set(slot, true);
+        }
+
+        self.deleted.flush(hw_counter)
+    }
+
+    /// Storage-native bytes are a packed `[T]` of exactly one vector, the form
+    /// [`with_dense_bytes_opt`][1] hands out.
+    ///
+    /// [1]: crate::vector_storage::DenseVectorStorageRead::with_dense_bytes_opt
+    fn decode_raw(&self, bytes: &[u8]) -> OperationResult<Vec<T>> {
+        let expected_size = self.dim * size_of::<T>();
+        if bytes.len() != expected_size {
+            // `MalformedVectorBlob`, not a service error: a blob that reached
+            // the WAL is skipped on replay rather than crash-looping recovery.
+            return Err(OperationError::malformed_vector_blob(format!(
+                "Malformed dense vector blob of {} bytes, expected {expected_size}",
+                bytes.len(),
+            )));
+        }
+
+        Ok(bytemuck::allocation::pod_collect_to_vec(bytes))
+    }
+}

--- a/lib/segment/src/vector_storage/dense/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/dense/update_only/tests.rs
@@ -1,0 +1,170 @@
+//! Writes through the update-only storage, then reads back through the
+//! ordinary appendable storage opened on the same directory.
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::Random;
+use common::mmap::AdviceSetting;
+use common::universal_io::{MmapFile, MmapFs};
+use tempfile::TempDir;
+
+use super::UpdateOnlyDenseVectorStorage;
+use crate::data_types::vectors::{VectorElementType, VectorRef};
+use crate::types::Distance;
+use crate::vector_storage::dense::appendable_dense_vector_storage::open_appendable_memmap_vector_storage_impl;
+use crate::vector_storage::update_only::VectorToStore;
+use crate::vector_storage::{DenseVectorStorageRead, VectorStorageRead};
+
+type Writer = UpdateOnlyDenseVectorStorage<VectorElementType, MmapFile>;
+
+const DIM: usize = 4;
+
+fn read_back(path: &std::path::Path) -> impl DenseVectorStorageRead<VectorElementType> + use<> {
+    open_appendable_memmap_vector_storage_impl::<VectorElementType>(
+        path,
+        DIM,
+        Distance::Dot,
+        AdviceSetting::Global,
+        false,
+    )
+    .unwrap()
+}
+
+/// A batch of decoded vectors lands where the appendable storage reads it.
+#[test]
+fn decoded_vectors_round_trip() {
+    let dir = TempDir::with_prefix("update_only_dense").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let vectors = [
+        vec![1.0, 2.0, 3.0, 4.0],
+        vec![5.0, 6.0, 7.0, 8.0],
+        vec![9.0, 10.0, 11.0, 12.0],
+    ];
+
+    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    writer
+        .append_many(
+            0,
+            vectors
+                .iter()
+                .map(|v| VectorToStore::Decoded(VectorRef::from(v.as_slice()))),
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    let storage = read_back(dir.path());
+    assert_eq!(storage.total_vector_count(), vectors.len());
+    for (slot, expected) in vectors.iter().enumerate() {
+        assert_eq!(
+            storage.get_dense::<Random>(slot as u32).as_ref(),
+            expected.as_slice(),
+        );
+        assert!(!storage.is_deleted_vector(slot as u32));
+    }
+}
+
+/// A point with no vector under this name still takes its slot, and reads back
+/// as deleted rather than as a zero vector.
+#[test]
+fn missing_vectors_take_their_slot_and_are_flagged() {
+    let dir = TempDir::with_prefix("update_only_dense").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let present = vec![1.0, 2.0, 3.0, 4.0];
+    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    writer
+        .append_many(
+            0,
+            [
+                VectorToStore::Decoded(VectorRef::from(present.as_slice())),
+                VectorToStore::Missing,
+                VectorToStore::Decoded(VectorRef::from(present.as_slice())),
+            ],
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    let storage = read_back(dir.path());
+    assert_eq!(
+        storage.total_vector_count(),
+        3,
+        "the missing vector still occupies slot 1",
+    );
+    assert!(!storage.is_deleted_vector(0));
+    assert!(storage.is_deleted_vector(1));
+    assert!(!storage.is_deleted_vector(2));
+}
+
+/// Storage-native bytes are appended verbatim, so a vector carried over from
+/// another slot needs no decode round-trip.
+#[test]
+fn raw_bytes_round_trip() {
+    let dir = TempDir::with_prefix("update_only_dense").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let vector: Vec<VectorElementType> = vec![1.5, 2.5, 3.5, 4.5];
+    let bytes = bytemuck::cast_slice(&vector).to_vec();
+
+    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    writer
+        .append_many(0, [VectorToStore::Raw(&bytes)], &hw_counter)
+        .unwrap();
+    drop(writer);
+
+    let storage = read_back(dir.path());
+    assert_eq!(storage.get_dense::<Random>(0).as_ref(), vector.as_slice());
+}
+
+/// A second writer resumes where the first left off.
+#[test]
+fn batches_resume() {
+    let dir = TempDir::with_prefix("update_only_dense").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let first = vec![1.0, 1.0, 1.0, 1.0];
+    let second = vec![2.0, 2.0, 2.0, 2.0];
+
+    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    writer
+        .append_many(
+            0,
+            [VectorToStore::Decoded(VectorRef::from(first.as_slice()))],
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    writer
+        .append_many(
+            1,
+            [VectorToStore::Decoded(VectorRef::from(second.as_slice()))],
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    let storage = read_back(dir.path());
+    assert_eq!(storage.total_vector_count(), 2);
+    assert_eq!(storage.get_dense::<Random>(0).as_ref(), first.as_slice());
+    assert_eq!(storage.get_dense::<Random>(1).as_ref(), second.as_slice());
+}
+
+/// A malformed raw blob is reported as such, so a bad blob that reached the WAL
+/// is skipped on replay instead of crash-looping recovery.
+#[test]
+fn malformed_raw_bytes_are_rejected() {
+    let dir = TempDir::with_prefix("update_only_dense").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    let err = writer
+        .append_many(0, [VectorToStore::Raw(&[1, 2, 3])], &hw_counter)
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("Malformed dense vector blob"),
+        "{err}"
+    );
+}

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -11,6 +11,7 @@ pub mod raw_scorer;
 pub mod read_only;
 pub mod sparse;
 pub mod turbo;
+pub mod update_only;
 mod vector_storage_base;
 pub mod volatile_chunked_vectors;
 

--- a/lib/segment/src/vector_storage/multi_dense/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/mod.rs
@@ -1,4 +1,5 @@
 pub mod appendable_mmap_multi_dense_vector_storage;
 mod buffered_offsets;
 pub mod read_only;
+pub mod update_only;
 pub mod volatile_multi_dense_vector_storage;

--- a/lib/segment/src/vector_storage/multi_dense/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/update_only/mod.rs
@@ -71,11 +71,12 @@ impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static>
         vectors: impl IntoIterator<Item = VectorToStore<'a>>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        // Rows are placed as we go, and a run that would straddle a chunk skips
-        // to the next one — so the rows of a batch are not necessarily one
-        // contiguous span. Each contiguous span is appended on its own; the gap
-        // a skip leaves is zero-filled by the append that follows it.
-        let mut spans: Vec<(usize, Vec<T>)> = Vec::new();
+        // Rows are placed as we go, and a run that would straddle a chunk
+        // skips to the next one — the rows of a batch are therefore not
+        // gapless. The gaps become explicit zero rows, so a single append
+        // lands every run exactly where its offset entry points.
+        let batch_start = self.next_row;
+        let mut rows: Vec<T> = Vec::new();
         let mut offsets = Vec::new();
         let mut missing = Vec::new();
 
@@ -94,30 +95,21 @@ impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static>
 
             let count = flattened.len() / self.dim;
             let row = self.place(count)?;
+            rows.resize(rows.len() + (row - self.next_row) * self.dim, T::default());
+            rows.extend_from_slice(&flattened);
             offsets.push(MultivectorMmapOffset {
                 offset: row as PointOffsetType,
                 count: count as PointOffsetType,
                 capacity: count as PointOffsetType,
             });
-
-            match spans.last_mut() {
-                // Contiguous with the span being built.
-                Some((start, rows)) if *start + rows.len() / self.dim == row => {
-                    rows.extend_from_slice(&flattened);
-                }
-                _ if flattened.is_empty() => {}
-                _ => spans.push((row, flattened)),
-            }
             self.next_row = row + count;
         }
 
-        for (start, rows) in &spans {
-            self.vectors.append_many(
-                *start as VectorOffsetType,
-                rows.chunks_exact(self.dim),
-                hw_counter,
-            )?;
-        }
+        self.vectors.append_many(
+            batch_start as VectorOffsetType,
+            rows.chunks_exact(self.dim),
+            hw_counter,
+        )?;
 
         self.offsets.append_many(
             start_slot as VectorOffsetType,

--- a/lib/segment/src/vector_storage/multi_dense/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/update_only/mod.rs
@@ -102,7 +102,7 @@ impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static>
 
             match spans.last_mut() {
                 // Contiguous with the span being built.
-                Some((start, rows)) if *start + rows.len() / self.dim.max(1) == row => {
+                Some((start, rows)) if *start + rows.len() / self.dim == row => {
                     rows.extend_from_slice(&flattened);
                 }
                 _ if flattened.is_empty() => {}

--- a/lib/segment/src/vector_storage/multi_dense/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/update_only/mod.rs
@@ -162,7 +162,7 @@ impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static>
     /// Storage-native bytes are the flattened inner vectors packed as `[T]`.
     fn flatten_raw(&self, bytes: &[u8]) -> OperationResult<Vec<T>> {
         let row_size = self.dim * size_of::<T>();
-        if bytes.len() % row_size != 0 {
+        if !bytes.len().is_multiple_of(row_size) {
             return Err(OperationError::malformed_vector_blob(format!(
                 "Malformed multi vector blob of {} bytes, not a whole number of {row_size}-byte \
                  inner vectors",

--- a/lib/segment/src/vector_storage/multi_dense/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/update_only/mod.rs
@@ -1,0 +1,174 @@
+#[cfg(test)]
+mod tests;
+
+use std::borrow::Cow;
+use std::path::Path;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalAppend;
+
+use super::appendable_mmap_multi_dense_vector_storage::{
+    DELETED_DIR_PATH, MultivectorMmapOffset, OFFSETS_DIR_PATH, VECTORS_DIR_PATH,
+};
+use crate::common::flags::update_only_stored_flags::UpdateOnlyStoredFlags;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::data_types::vectors::{TypedMultiDenseVectorRef, VectorElementType, VectorRef};
+use crate::vector_storage::VectorOffsetType;
+use crate::vector_storage::chunked_vectors::update_only::UpdateOnlyChunkedVectors;
+use crate::vector_storage::update_only::VectorToStore;
+
+/// Writes what [`AppendableMmapMultiDenseVectorStorage`] persists: the inner
+/// vectors flat, the per-point row ranges into them, and the deleted flags.
+///
+/// Unlike the single-vector storages, rows are not indexed by point slot — a
+/// point owns a run of them — so this writer tracks where the row space ends
+/// and places each point's run itself.
+///
+/// [`AppendableMmapMultiDenseVectorStorage`]: super::appendable_mmap_multi_dense_vector_storage::AppendableMmapMultiDenseVectorStorage
+pub struct UpdateOnlyMultiDenseVectorStorage<
+    T: PrimitiveVectorElement,
+    S: UniversalAppend + 'static,
+> {
+    /// Flat inner-vector space: one row per inner vector.
+    vectors: UpdateOnlyChunkedVectors<T, S>,
+    /// Maps each point slot to its row range.
+    offsets: UpdateOnlyChunkedVectors<MultivectorMmapOffset, S>,
+    deleted: UpdateOnlyStoredFlags<S>,
+    dim: usize,
+    /// One past the last row in use, carried across the batch.
+    next_row: usize,
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static>
+    UpdateOnlyMultiDenseVectorStorage<T, S>
+{
+    /// Open the storage at `path` for appending, creating it if it is not there
+    /// yet.
+    pub fn open(fs: S::Fs, path: &Path, dim: usize) -> OperationResult<Self> {
+        let vectors =
+            UpdateOnlyChunkedVectors::open(fs.clone(), &path.join(VECTORS_DIR_PATH), dim)?;
+        // One offset entry per point, so the "vector" is a single element.
+        let offsets = UpdateOnlyChunkedVectors::open(fs.clone(), &path.join(OFFSETS_DIR_PATH), 1)?;
+        let deleted = UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIR_PATH))?;
+        let next_row = vectors.stored_len()?;
+
+        Ok(Self {
+            vectors,
+            offsets,
+            deleted,
+            dim,
+            next_row,
+        })
+    }
+
+    /// Append one multi-vector per point of a batch, starting at `start_slot`,
+    /// and persist them.
+    pub fn append_many<'a>(
+        &mut self,
+        start_slot: PointOffsetType,
+        vectors: impl IntoIterator<Item = VectorToStore<'a>>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        // Rows are placed as we go, and a run that would straddle a chunk skips
+        // to the next one — so the rows of a batch are not necessarily one
+        // contiguous span. Each contiguous span is appended on its own; the gap
+        // a skip leaves is zero-filled by the append that follows it.
+        let mut spans: Vec<(usize, Vec<T>)> = Vec::new();
+        let mut offsets = Vec::new();
+        let mut missing = Vec::new();
+
+        for (offset, vector) in vectors.into_iter().enumerate() {
+            let flattened = match vector {
+                VectorToStore::Decoded(vector) => self.flatten_decoded(vector)?,
+                VectorToStore::Raw(bytes) => self.flatten_raw(bytes)?,
+                VectorToStore::Missing => {
+                    // A point with no multi-vector here owns no rows at all: the
+                    // offset entry is what says so, and unlike the single-vector
+                    // storages there is no slot in the row space to keep aligned.
+                    missing.push(start_slot + offset as PointOffsetType);
+                    Vec::new()
+                }
+            };
+
+            let count = flattened.len() / self.dim;
+            let row = self.place(count)?;
+            offsets.push(MultivectorMmapOffset {
+                offset: row as PointOffsetType,
+                count: count as PointOffsetType,
+                capacity: count as PointOffsetType,
+            });
+
+            match spans.last_mut() {
+                // Contiguous with the span being built.
+                Some((start, rows)) if *start + rows.len() / self.dim.max(1) == row => {
+                    rows.extend_from_slice(&flattened);
+                }
+                _ if flattened.is_empty() => {}
+                _ => spans.push((row, flattened)),
+            }
+            self.next_row = row + count;
+        }
+
+        for (start, rows) in &spans {
+            self.vectors.append_many(
+                *start as VectorOffsetType,
+                rows.chunks_exact(self.dim),
+                hw_counter,
+            )?;
+        }
+
+        self.offsets.append_many(
+            start_slot as VectorOffsetType,
+            offsets.iter().map(std::slice::from_ref),
+            hw_counter,
+        )?;
+
+        for slot in missing {
+            self.deleted.set(slot, true);
+        }
+
+        self.deleted.flush(hw_counter)
+    }
+
+    /// Where a run of `count` rows goes: at the end, or at the start of the next
+    /// chunk when it would otherwise straddle a chunk boundary.
+    fn place(&self, count: usize) -> OperationResult<usize> {
+        let remaining = self.vectors.remaining_chunk_keys(self.next_row);
+        if count > remaining {
+            let max = self.vectors.remaining_chunk_keys(0);
+            if count > max {
+                return Err(OperationError::service_error(format!(
+                    "Cannot insert a multi vector of {count} inner vectors, a chunk holds {max}",
+                )));
+            }
+            return Ok(self.next_row + remaining);
+        }
+        Ok(self.next_row)
+    }
+
+    fn flatten_decoded(&self, vector: VectorRef<'_>) -> OperationResult<Vec<T>> {
+        let multi = TypedMultiDenseVectorRef::<VectorElementType>::try_from(vector)?;
+        if multi.dim != self.dim {
+            return Err(OperationError::WrongVectorDimension {
+                expected_dim: self.dim,
+                received_dim: multi.dim,
+            });
+        }
+        Ok(T::slice_from_float_cow(Cow::Borrowed(multi.flattened_vectors)).into_owned())
+    }
+
+    /// Storage-native bytes are the flattened inner vectors packed as `[T]`.
+    fn flatten_raw(&self, bytes: &[u8]) -> OperationResult<Vec<T>> {
+        let row_size = self.dim * size_of::<T>();
+        if bytes.len() % row_size != 0 {
+            return Err(OperationError::malformed_vector_blob(format!(
+                "Malformed multi vector blob of {} bytes, not a whole number of {row_size}-byte \
+                 inner vectors",
+                bytes.len(),
+            )));
+        }
+        Ok(bytemuck::allocation::pod_collect_to_vec(bytes))
+    }
+}

--- a/lib/segment/src/vector_storage/multi_dense/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/multi_dense/update_only/tests.rs
@@ -8,9 +8,7 @@ use common::universal_io::{MmapFile, MmapFs};
 use tempfile::TempDir;
 
 use super::UpdateOnlyMultiDenseVectorStorage;
-use crate::data_types::vectors::{
-    MultiDenseVectorInternal, TypedMultiDenseVectorRef, VectorElementType, VectorRef,
-};
+use crate::data_types::vectors::{MultiDenseVectorInternal, VectorElementType, VectorRef};
 use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::open_appendable_memmap_multi_vector_storage;
 use crate::vector_storage::update_only::VectorToStore;
@@ -45,7 +43,7 @@ fn stored(storage: &crate::vector_storage::VectorStorageEnum, slot: u32) -> Vec<
         panic!("expected an appendable multi-dense storage");
     };
     let multi = storage.get_multi::<Random>(slot);
-    let multi = TypedMultiDenseVectorRef::from(multi.as_vec_ref());
+    let multi = multi.as_vec_ref();
     multi
         .flattened_vectors
         .chunks_exact(multi.dim)

--- a/lib/segment/src/vector_storage/multi_dense/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/multi_dense/update_only/tests.rs
@@ -1,0 +1,179 @@
+//! Writes through the update-only storage, then reads back through the
+//! ordinary appendable multi-vector storage opened on the same directory.
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::Random;
+use common::mmap::AdviceSetting;
+use common::universal_io::{MmapFile, MmapFs};
+use tempfile::TempDir;
+
+use super::UpdateOnlyMultiDenseVectorStorage;
+use crate::data_types::vectors::{
+    MultiDenseVectorInternal, TypedMultiDenseVectorRef, VectorElementType, VectorRef,
+};
+use crate::types::{Distance, MultiVectorConfig, VectorStorageDatatype};
+use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::open_appendable_memmap_multi_vector_storage;
+use crate::vector_storage::update_only::VectorToStore;
+use crate::vector_storage::{MultiVectorStorageRead, VectorStorageRead};
+
+type Writer = UpdateOnlyMultiDenseVectorStorage<VectorElementType, MmapFile>;
+
+const DIM: usize = 2;
+
+fn multi(rows: &[[VectorElementType; DIM]]) -> MultiDenseVectorInternal {
+    MultiDenseVectorInternal::new(rows.iter().flatten().copied().collect(), DIM)
+}
+
+/// Reopen through the writable storage the reader also uses, so the assertion
+/// runs against the real decode path rather than the raw files.
+fn read_back(path: &std::path::Path) -> crate::vector_storage::VectorStorageEnum {
+    open_appendable_memmap_multi_vector_storage(
+        VectorStorageDatatype::Float32,
+        path,
+        DIM,
+        Distance::Dot,
+        MultiVectorConfig::default(),
+        AdviceSetting::Global,
+        false,
+    )
+    .unwrap()
+}
+
+fn stored(storage: &crate::vector_storage::VectorStorageEnum, slot: u32) -> Vec<Vec<f32>> {
+    let crate::vector_storage::VectorStorageEnum::MultiDenseAppendableMemmap(storage) = storage
+    else {
+        panic!("expected an appendable multi-dense storage");
+    };
+    let multi = storage.get_multi::<Random>(slot);
+    let multi = TypedMultiDenseVectorRef::from(multi.as_vec_ref());
+    multi
+        .flattened_vectors
+        .chunks_exact(multi.dim)
+        .map(<[f32]>::to_vec)
+        .collect()
+}
+
+/// Each point owns a run of rows, and the runs land back to back.
+#[test]
+fn multi_vectors_round_trip() {
+    let dir = TempDir::with_prefix("update_only_multi").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let first = multi(&[[1.0, 2.0], [3.0, 4.0]]);
+    let second = multi(&[[5.0, 6.0]]);
+
+    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    writer
+        .append_many(
+            0,
+            [
+                VectorToStore::Decoded(VectorRef::from(&first)),
+                VectorToStore::Decoded(VectorRef::from(&second)),
+            ],
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    let storage = read_back(dir.path());
+    assert_eq!(stored(&storage, 0), vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
+    assert_eq!(stored(&storage, 1), vec![vec![5.0, 6.0]]);
+}
+
+/// A point with no multi-vector here owns no rows, and is flagged deleted; the
+/// point after it still reads back correctly.
+#[test]
+fn missing_multi_vectors_own_no_rows() {
+    let dir = TempDir::with_prefix("update_only_multi").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let present = multi(&[[1.0, 2.0]]);
+    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    writer
+        .append_many(
+            0,
+            [
+                VectorToStore::Missing,
+                VectorToStore::Decoded(VectorRef::from(&present)),
+            ],
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    let storage = read_back(dir.path());
+    let crate::vector_storage::VectorStorageEnum::MultiDenseAppendableMemmap(inner) = &storage
+    else {
+        panic!("expected an appendable multi-dense storage");
+    };
+    assert!(inner.is_deleted_vector(0));
+    assert!(!inner.is_deleted_vector(1));
+    assert_eq!(stored(&storage, 1), vec![vec![1.0, 2.0]]);
+}
+
+/// A second writer resumes at the row the first one left off at, rather than
+/// overwriting its rows.
+#[test]
+fn batches_resume_at_the_row_space_end() {
+    let dir = TempDir::with_prefix("update_only_multi").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let first = multi(&[[1.0, 1.0], [2.0, 2.0]]);
+    let second = multi(&[[3.0, 3.0]]);
+
+    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    writer
+        .append_many(
+            0,
+            [VectorToStore::Decoded(VectorRef::from(&first))],
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    writer
+        .append_many(
+            1,
+            [VectorToStore::Decoded(VectorRef::from(&second))],
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    let storage = read_back(dir.path());
+    assert_eq!(stored(&storage, 0), vec![vec![1.0, 1.0], vec![2.0, 2.0]]);
+    assert_eq!(
+        stored(&storage, 1),
+        vec![vec![3.0, 3.0]],
+        "the second batch must not have reused the first batch's rows",
+    );
+}
+
+/// Storage-native bytes are the flattened inner vectors; a blob that is not a
+/// whole number of them is reported as malformed.
+#[test]
+fn raw_multi_bytes_round_trip() {
+    let dir = TempDir::with_prefix("update_only_multi").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let flattened: Vec<VectorElementType> = vec![1.0, 2.0, 3.0, 4.0];
+    let bytes = bytemuck::cast_slice(&flattened).to_vec();
+
+    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    writer
+        .append_many(0, [VectorToStore::Raw(&bytes)], &hw_counter)
+        .unwrap();
+
+    let err = writer
+        .append_many(1, [VectorToStore::Raw(&bytes[..5])], &hw_counter)
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("Malformed multi vector blob"),
+        "{err}"
+    );
+    drop(writer);
+
+    let storage = read_back(dir.path());
+    assert_eq!(stored(&storage, 0), vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
+}

--- a/lib/segment/src/vector_storage/sparse/mod.rs
+++ b/lib/segment/src/vector_storage/sparse/mod.rs
@@ -2,6 +2,7 @@ pub mod empty_sparse_vector_storage;
 pub mod mmap_sparse_vector_storage;
 pub mod read_only;
 mod stored_sparse_vectors;
+pub mod update_only;
 pub mod volatile_sparse_vector_storage;
 
 pub(crate) use stored_sparse_vectors::StoredSparseVector;

--- a/lib/segment/src/vector_storage/sparse/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/sparse/update_only/mod.rs
@@ -1,0 +1,89 @@
+#[cfg(test)]
+mod tests;
+
+use std::path::Path;
+
+use blobstore::config::{Compression, DEFAULT_PAGE_SIZE_BYTES, LogstoreConfig};
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalAppend;
+use sparse::common::sparse_vector::SparseVector;
+
+use super::mmap_sparse_vector_storage::{DELETED_DIRNAME, STORAGE_DIRNAME};
+use super::stored_sparse_vectors::StoredSparseVector;
+use crate::common::flags::update_only_stored_flags::UpdateOnlyStoredFlags;
+use crate::common::operation_error::OperationResult;
+use crate::common::update_only_blobstore::UpdateOnlyBlobstore;
+use crate::vector_storage::update_only::VectorToStore;
+
+/// Storage layout for a sparse vector storage this writer creates.
+///
+/// Uncompressed, as the writable side is: the values are bitpacked already, and
+/// compressing them again costs CPU for nothing.
+const STORAGE_CONFIG: LogstoreConfig = LogstoreConfig {
+    page_capacity_bytes: DEFAULT_PAGE_SIZE_BYTES,
+    compression: Compression::None,
+};
+
+/// Writes what [`MmapSparseVectorStorage`] persists: the sparse vectors, and the
+/// flags marking which slots hold none.
+///
+/// [`MmapSparseVectorStorage`]: super::mmap_sparse_vector_storage::MmapSparseVectorStorage
+pub struct UpdateOnlySparseVectorStorage<S: UniversalAppend + 'static> {
+    storage: UpdateOnlyBlobstore<StoredSparseVector, S>,
+    deleted: UpdateOnlyStoredFlags<S>,
+}
+
+impl<S: UniversalAppend + 'static> UpdateOnlySparseVectorStorage<S> {
+    /// Open the storage at `path` for appending, creating it if it is not there
+    /// yet.
+    pub fn open(fs: S::Fs, path: &Path) -> OperationResult<Self> {
+        Ok(Self {
+            storage: UpdateOnlyBlobstore::open(
+                fs.clone(),
+                &path.join(STORAGE_DIRNAME),
+                STORAGE_CONFIG,
+            )?,
+            deleted: UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIRNAME))?,
+        })
+    }
+
+    /// Append one sparse vector per point of a batch, starting at `start_slot`,
+    /// and persist them.
+    ///
+    /// A point with no sparse vector here stores nothing — the storage is keyed
+    /// by slot, so an unwritten slot is already "no vector" — and is flagged
+    /// deleted, which is what the writable side records for it.
+    pub fn append_many<'a>(
+        &mut self,
+        start_slot: PointOffsetType,
+        vectors: impl IntoIterator<Item = VectorToStore<'a>>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        for (offset, vector) in vectors.into_iter().enumerate() {
+            let slot = start_slot + offset as PointOffsetType;
+            let stored = match vector {
+                VectorToStore::Decoded(vector) => {
+                    let vector: &SparseVector = vector.try_into()?;
+                    StoredSparseVector::from(vector)
+                }
+                // Validated, not trusted: these bytes may have come from a WAL
+                // written by another version. Re-encoding from the decoded
+                // vector is what the writable side does with them too.
+                VectorToStore::Raw(bytes) => {
+                    StoredSparseVector::from(&StoredSparseVector::decode_untrusted_bytes(bytes)?)
+                }
+                VectorToStore::Missing => {
+                    self.deleted.set(slot, true);
+                    continue;
+                }
+            };
+
+            self.storage
+                .put(slot, &stored, hw_counter.ref_vector_io_write_counter())?;
+        }
+
+        self.storage.flush()?;
+        self.deleted.flush(hw_counter)
+    }
+}

--- a/lib/segment/src/vector_storage/sparse/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/sparse/update_only/tests.rs
@@ -1,0 +1,86 @@
+//! Writes through the update-only storage, then reads back through the
+//! ordinary mmap sparse storage opened on the same directory.
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::Random;
+use common::universal_io::{MmapFile, MmapFs};
+use sparse::common::sparse_vector::SparseVector;
+use tempfile::TempDir;
+
+use super::UpdateOnlySparseVectorStorage;
+use crate::data_types::vectors::VectorRef;
+use crate::vector_storage::sparse::mmap_sparse_vector_storage::MmapSparseVectorStorage;
+use crate::vector_storage::update_only::VectorToStore;
+use crate::vector_storage::{SparseVectorStorageRead, VectorStorageRead};
+
+type Writer = UpdateOnlySparseVectorStorage<MmapFile>;
+
+fn sparse(indices: &[u32], values: &[f32]) -> SparseVector {
+    SparseVector::new(indices.to_vec(), values.to_vec()).unwrap()
+}
+
+/// Sparse vectors land where the mmap storage reads them, and a point without
+/// one is flagged rather than stored empty.
+#[test]
+fn sparse_vectors_round_trip() {
+    let dir = TempDir::with_prefix("update_only_sparse").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let first = sparse(&[1, 5], &[1.0, 2.0]);
+    let second = sparse(&[3], &[3.0]);
+
+    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    writer
+        .append_many(
+            0,
+            [
+                VectorToStore::Decoded(VectorRef::from(&first)),
+                VectorToStore::Missing,
+                VectorToStore::Decoded(VectorRef::from(&second)),
+            ],
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    let storage = MmapSparseVectorStorage::open_or_create(dir.path()).unwrap();
+    assert_eq!(storage.get_sparse::<Random>(0).unwrap(), first);
+    assert_eq!(storage.get_sparse::<Random>(2).unwrap(), second);
+    assert!(storage.is_deleted_vector(1));
+    assert!(!storage.is_deleted_vector(0));
+    assert!(!storage.is_deleted_vector(2));
+}
+
+/// A second writer appends above what the first left, rather than starting over.
+#[test]
+fn batches_resume() {
+    let dir = TempDir::with_prefix("update_only_sparse").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let first = sparse(&[1], &[1.0]);
+    let second = sparse(&[2], &[2.0]);
+
+    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    writer
+        .append_many(
+            0,
+            [VectorToStore::Decoded(VectorRef::from(&first))],
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    writer
+        .append_many(
+            1,
+            [VectorToStore::Decoded(VectorRef::from(&second))],
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    let storage = MmapSparseVectorStorage::open_or_create(dir.path()).unwrap();
+    assert_eq!(storage.get_sparse::<Random>(0).unwrap(), first);
+    assert_eq!(storage.get_sparse::<Random>(1).unwrap(), second);
+}

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -18,6 +18,7 @@ pub mod multi_turbo;
 pub mod read_only;
 pub(crate) mod shared;
 pub mod turbo_vector_storage;
+pub mod update_only;
 
 pub use self::appendable_turbo_vector_storage::{
     AppendableMmapTurboVectorStorage, open_appendable_turbo_vector_storage,

--- a/lib/segment/src/vector_storage/turbo/multi_turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/multi_turbo/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod appendable_mmap_multi_turbo_vector_storage;
 pub mod read_only;
+pub mod update_only;
 
 pub(crate) use self::appendable_mmap_multi_turbo_vector_storage::OFFSETS_DIR_PATH;
 pub use self::appendable_mmap_multi_turbo_vector_storage::{

--- a/lib/segment/src/vector_storage/turbo/multi_turbo/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/multi_turbo/update_only/mod.rs
@@ -73,9 +73,11 @@ impl<S: UniversalAppend + 'static> UpdateOnlyMultiTurboVectorStorage<S> {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         let encoded_size = self.quantizer.quantized_size();
-        // As in the plain multivector storage, a run that would straddle a chunk
-        // skips to the next one, so a batch's rows are not always one span.
-        let mut spans: Vec<(usize, Vec<u8>)> = Vec::new();
+        // As in the plain multivector storage, a run that would straddle a
+        // chunk skips to the next one; the gaps become explicit zero rows, so
+        // a single append lands every run where its offset entry points.
+        let batch_start = self.next_row;
+        let mut rows: Vec<u8> = Vec::new();
         let mut offsets = Vec::new();
         let mut missing = Vec::new();
 
@@ -91,29 +93,21 @@ impl<S: UniversalAppend + 'static> UpdateOnlyMultiTurboVectorStorage<S> {
 
             let count = encoded.len() / encoded_size;
             let row = self.place(count)?;
+            rows.resize(rows.len() + (row - self.next_row) * encoded_size, 0);
+            rows.extend_from_slice(&encoded);
             offsets.push(MultivectorMmapOffset {
                 offset: row as PointOffsetType,
                 count: count as PointOffsetType,
                 capacity: count as PointOffsetType,
             });
-
-            match spans.last_mut() {
-                Some((start, rows)) if *start + rows.len() / encoded_size == row => {
-                    rows.extend_from_slice(&encoded);
-                }
-                _ if encoded.is_empty() => {}
-                _ => spans.push((row, encoded)),
-            }
             self.next_row = row + count;
         }
 
-        for (start, rows) in &spans {
-            self.vectors.append_many(
-                *start as VectorOffsetType,
-                rows.chunks_exact(encoded_size),
-                hw_counter,
-            )?;
-        }
+        self.vectors.append_many(
+            batch_start as VectorOffsetType,
+            rows.chunks_exact(encoded_size),
+            hw_counter,
+        )?;
 
         self.offsets.append_many(
             start_slot as VectorOffsetType,

--- a/lib/segment/src/vector_storage/turbo/multi_turbo/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/multi_turbo/update_only/mod.rs
@@ -1,0 +1,181 @@
+use std::path::Path;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalAppend;
+use quantization::turboquant::quantization::TurboQuantizer;
+
+use super::super::shared::{self, DELETED_DIR_PATH, VECTORS_DIR_PATH};
+use super::appendable_mmap_multi_turbo_vector_storage::OFFSETS_DIR_PATH;
+use crate::common::flags::update_only_stored_flags::UpdateOnlyStoredFlags;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::data_types::vectors::{TypedMultiDenseVectorRef, VectorElementType, VectorRef};
+use crate::types::Distance;
+use crate::vector_storage::VectorOffsetType;
+use crate::vector_storage::chunked_vectors::update_only::UpdateOnlyChunkedVectors;
+use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_storage::MultivectorMmapOffset;
+use crate::vector_storage::update_only::VectorToStore;
+
+/// Writes what [`AppendableMmapMultiTurboVectorStorage`] persists: the encoded
+/// inner vectors flat, the per-point row ranges into them, and the deleted
+/// flags.
+///
+/// The multivector counterpart of [`UpdateOnlyTurboVectorStorage`][1]: it places
+/// runs of rows the way [`UpdateOnlyMultiDenseVectorStorage`][2] does, and
+/// encodes them the way the turbo writer does.
+///
+/// [`AppendableMmapMultiTurboVectorStorage`]: super::appendable_mmap_multi_turbo_vector_storage::AppendableMmapMultiTurboVectorStorage
+/// [1]: crate::vector_storage::turbo::update_only::UpdateOnlyTurboVectorStorage
+/// [2]: crate::vector_storage::multi_dense::update_only::UpdateOnlyMultiDenseVectorStorage
+pub struct UpdateOnlyMultiTurboVectorStorage<S: UniversalAppend + 'static> {
+    vectors: UpdateOnlyChunkedVectors<u8, S>,
+    offsets: UpdateOnlyChunkedVectors<MultivectorMmapOffset, S>,
+    deleted: UpdateOnlyStoredFlags<S>,
+    quantizer: TurboQuantizer,
+    quantization_buffer: Vec<f64>,
+    dim: usize,
+    /// One past the last row in use, carried across the batch.
+    next_row: usize,
+}
+
+impl<S: UniversalAppend + 'static> UpdateOnlyMultiTurboVectorStorage<S> {
+    /// Open the storage at `path` for appending, creating it if it is not there
+    /// yet.
+    pub fn open(fs: S::Fs, path: &Path, dim: usize, distance: Distance) -> OperationResult<Self> {
+        let quantizer = shared::build_quantizer(dim, distance);
+        let quantization_buffer = vec![0.0; quantizer.get_padded_dim()];
+        let vectors = UpdateOnlyChunkedVectors::open(
+            fs.clone(),
+            &path.join(VECTORS_DIR_PATH),
+            quantizer.quantized_size(),
+        )?;
+        let offsets = UpdateOnlyChunkedVectors::open(fs.clone(), &path.join(OFFSETS_DIR_PATH), 1)?;
+        let deleted = UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIR_PATH))?;
+        let next_row = vectors.stored_len()?;
+
+        Ok(Self {
+            vectors,
+            offsets,
+            deleted,
+            quantizer,
+            quantization_buffer,
+            dim,
+            next_row,
+        })
+    }
+
+    /// Append one encoded multi-vector per point of a batch, starting at
+    /// `start_slot`, and persist them.
+    pub fn append_many<'a>(
+        &mut self,
+        start_slot: PointOffsetType,
+        vectors: impl IntoIterator<Item = VectorToStore<'a>>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let encoded_size = self.quantizer.quantized_size();
+        // As in the plain multivector storage, a run that would straddle a chunk
+        // skips to the next one, so a batch's rows are not always one span.
+        let mut spans: Vec<(usize, Vec<u8>)> = Vec::new();
+        let mut offsets = Vec::new();
+        let mut missing = Vec::new();
+
+        for (offset, vector) in vectors.into_iter().enumerate() {
+            let encoded = match vector {
+                VectorToStore::Decoded(vector) => self.encode_decoded(vector)?,
+                VectorToStore::Raw(bytes) => self.encode_raw(bytes)?,
+                VectorToStore::Missing => {
+                    missing.push(start_slot + offset as PointOffsetType);
+                    Vec::new()
+                }
+            };
+
+            let count = encoded.len() / encoded_size;
+            let row = self.place(count)?;
+            offsets.push(MultivectorMmapOffset {
+                offset: row as PointOffsetType,
+                count: count as PointOffsetType,
+                capacity: count as PointOffsetType,
+            });
+
+            match spans.last_mut() {
+                Some((start, rows)) if *start + rows.len() / encoded_size == row => {
+                    rows.extend_from_slice(&encoded);
+                }
+                _ if encoded.is_empty() => {}
+                _ => spans.push((row, encoded)),
+            }
+            self.next_row = row + count;
+        }
+
+        for (start, rows) in &spans {
+            self.vectors.append_many(
+                *start as VectorOffsetType,
+                rows.chunks_exact(encoded_size),
+                hw_counter,
+            )?;
+        }
+
+        self.offsets.append_many(
+            start_slot as VectorOffsetType,
+            offsets.iter().map(std::slice::from_ref),
+            hw_counter,
+        )?;
+
+        for slot in missing {
+            self.deleted.set(slot, true);
+        }
+
+        self.deleted.flush(hw_counter)
+    }
+
+    /// Where a run of `count` rows goes: at the end, or at the start of the next
+    /// chunk when it would otherwise straddle a chunk boundary.
+    fn place(&self, count: usize) -> OperationResult<usize> {
+        let remaining = self.vectors.remaining_chunk_keys(self.next_row);
+        if count > remaining {
+            let max = self.vectors.remaining_chunk_keys(0);
+            if count > max {
+                return Err(OperationError::service_error(format!(
+                    "Cannot insert a multi vector of {count} inner vectors, a chunk holds {max}",
+                )));
+            }
+            return Ok(self.next_row + remaining);
+        }
+        Ok(self.next_row)
+    }
+
+    /// Encode every inner vector, back to back.
+    fn encode_decoded(&mut self, vector: VectorRef<'_>) -> OperationResult<Vec<u8>> {
+        let multi = TypedMultiDenseVectorRef::<VectorElementType>::try_from(vector)?;
+        if multi.dim != self.dim {
+            return Err(OperationError::WrongVectorDimension {
+                expected_dim: self.dim,
+                received_dim: multi.dim,
+            });
+        }
+
+        let mut encoded =
+            Vec::with_capacity(multi.vectors_count() * self.quantizer.quantized_size());
+        for inner in multi.flattened_vectors.chunks_exact(multi.dim) {
+            encoded.extend_from_slice(
+                &self
+                    .quantizer
+                    .quantize(inner, &mut self.quantization_buffer),
+            );
+        }
+        Ok(encoded)
+    }
+
+    /// Storage-native bytes are the encoded inner vectors, already packed.
+    fn encode_raw(&self, bytes: &[u8]) -> OperationResult<Vec<u8>> {
+        let encoded_size = self.quantizer.quantized_size();
+        if bytes.len() % encoded_size != 0 {
+            return Err(OperationError::malformed_vector_blob(format!(
+                "Malformed multi TQ blob of {} bytes, not a whole number of {encoded_size}-byte \
+                 encoded inner vectors",
+                bytes.len(),
+            )));
+        }
+        Ok(bytes.to_vec())
+    }
+}

--- a/lib/segment/src/vector_storage/turbo/multi_turbo/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/multi_turbo/update_only/mod.rs
@@ -169,7 +169,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyMultiTurboVectorStorage<S> {
     /// Storage-native bytes are the encoded inner vectors, already packed.
     fn encode_raw(&self, bytes: &[u8]) -> OperationResult<Vec<u8>> {
         let encoded_size = self.quantizer.quantized_size();
-        if bytes.len() % encoded_size != 0 {
+        if !bytes.len().is_multiple_of(encoded_size) {
             return Err(OperationError::malformed_vector_blob(format!(
                 "Malformed multi TQ blob of {} bytes, not a whole number of {encoded_size}-byte \
                  encoded inner vectors",

--- a/lib/segment/src/vector_storage/turbo/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/update_only/mod.rs
@@ -1,0 +1,112 @@
+#[cfg(test)]
+mod tests;
+
+use std::path::Path;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalAppend;
+use quantization::turboquant::quantization::TurboQuantizer;
+
+use super::shared::{self, DELETED_DIR_PATH, VECTORS_DIR_PATH};
+use crate::common::flags::update_only_stored_flags::UpdateOnlyStoredFlags;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::data_types::vectors::VectorElementType;
+use crate::types::Distance;
+use crate::vector_storage::VectorOffsetType;
+use crate::vector_storage::chunked_vectors::update_only::UpdateOnlyChunkedVectors;
+use crate::vector_storage::update_only::VectorToStore;
+
+/// Writes what [`AppendableMmapTurboVectorStorage`] persists: the encoded
+/// vectors, and the flags marking which slots hold none.
+///
+/// The quantizer is rebuilt from the dimension and distance rather than read
+/// back, exactly as the writable side builds it — it carries no learned state,
+/// so the two encode identically.
+///
+/// [`AppendableMmapTurboVectorStorage`]: super::appendable_turbo_vector_storage::AppendableMmapTurboVectorStorage
+pub struct UpdateOnlyTurboVectorStorage<S: UniversalAppend + 'static> {
+    vectors: UpdateOnlyChunkedVectors<u8, S>,
+    deleted: UpdateOnlyStoredFlags<S>,
+    quantizer: TurboQuantizer,
+    /// Scratch for the padded, rotated vector `quantize` writes through.
+    quantization_buffer: Vec<f64>,
+    dim: usize,
+}
+
+impl<S: UniversalAppend + 'static> UpdateOnlyTurboVectorStorage<S> {
+    /// Open the storage at `path` for appending, creating it if it is not there
+    /// yet.
+    pub fn open(fs: S::Fs, path: &Path, dim: usize, distance: Distance) -> OperationResult<Self> {
+        let quantizer = shared::build_quantizer(dim, distance);
+        let quantization_buffer = vec![0.0; quantizer.get_padded_dim()];
+        let vectors = UpdateOnlyChunkedVectors::open(
+            fs.clone(),
+            &path.join(VECTORS_DIR_PATH),
+            quantizer.quantized_size(),
+        )?;
+        let deleted = UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIR_PATH))?;
+
+        Ok(Self {
+            vectors,
+            deleted,
+            quantizer,
+            quantization_buffer,
+            dim,
+        })
+    }
+
+    /// Append one encoded vector per point of a batch, starting at `start_slot`,
+    /// and persist them.
+    ///
+    /// As in the plain dense storage, a point with no vector here still takes
+    /// its slot — holding an encoded zero vector — and is flagged deleted.
+    pub fn append_many<'a>(
+        &mut self,
+        start_slot: PointOffsetType,
+        vectors: impl IntoIterator<Item = VectorToStore<'a>>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let encoded_size = self.quantizer.quantized_size();
+        let mut run: Vec<Vec<u8>> = Vec::new();
+        let mut missing = Vec::new();
+
+        for (offset, vector) in vectors.into_iter().enumerate() {
+            let encoded = match vector {
+                VectorToStore::Decoded(vector) => {
+                    let dense: &[VectorElementType] = vector.try_into()?;
+                    self.quantizer
+                        .quantize(dense, &mut self.quantization_buffer)
+                }
+                VectorToStore::Raw(bytes) => {
+                    if bytes.len() != encoded_size {
+                        return Err(OperationError::malformed_vector_blob(format!(
+                            "Malformed dense TQ blob of {} bytes, expected {encoded_size}",
+                            bytes.len(),
+                        )));
+                    }
+                    bytes.to_vec()
+                }
+                VectorToStore::Missing => {
+                    missing.push(start_slot + offset as PointOffsetType);
+                    let zeros = vec![0.0; self.dim];
+                    self.quantizer
+                        .quantize(&zeros, &mut self.quantization_buffer)
+                }
+            };
+            run.push(encoded);
+        }
+
+        self.vectors.append_many(
+            start_slot as VectorOffsetType,
+            run.iter().map(Vec::as_slice),
+            hw_counter,
+        )?;
+
+        for slot in missing {
+            self.deleted.set(slot, true);
+        }
+
+        self.deleted.flush(hw_counter)
+    }
+}

--- a/lib/segment/src/vector_storage/turbo/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/turbo/update_only/tests.rs
@@ -1,0 +1,92 @@
+//! Writes through the update-only storage, then reads back through the ordinary
+//! appendable TurboQuant storage opened on the same directory.
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::universal_io::{MmapFile, MmapFs};
+use tempfile::TempDir;
+
+use super::UpdateOnlyTurboVectorStorage;
+use crate::data_types::vectors::{VectorElementType, VectorRef};
+use crate::types::Distance;
+use crate::vector_storage::VectorStorageRead;
+use crate::vector_storage::turbo::appendable_turbo_vector_storage::open_appendable_turbo_vector_storage;
+use crate::vector_storage::update_only::VectorToStore;
+
+type Writer = UpdateOnlyTurboVectorStorage<MmapFile>;
+
+const DIM: usize = 8;
+
+/// The encoding this writer produces is the one the storage reads: the encoded
+/// bytes match what the writable side stores for the same vector.
+#[test]
+fn encoded_vectors_match_the_writable_side() {
+    let vector: Vec<VectorElementType> = (0..DIM).map(|i| i as f32 + 0.5).collect();
+    let hw_counter = HardwareCounterCell::new();
+
+    // Written by the update-only writer.
+    let ours = TempDir::with_prefix("update_only_turbo").unwrap();
+    let mut writer = Writer::open(MmapFs, ours.path(), DIM, Distance::Dot).unwrap();
+    writer
+        .append_many(
+            0,
+            [
+                VectorToStore::Decoded(VectorRef::from(vector.as_slice())),
+                VectorToStore::Missing,
+            ],
+            &hw_counter,
+        )
+        .unwrap();
+    drop(writer);
+
+    // Written by the storage itself.
+    let theirs = TempDir::with_prefix("turbo_reference").unwrap();
+    let mut reference =
+        open_appendable_turbo_vector_storage(theirs.path(), DIM, Distance::Dot, false).unwrap();
+    {
+        use crate::vector_storage::VectorStorage as _;
+        reference
+            .insert_vector(0, VectorRef::from(vector.as_slice()), &hw_counter)
+            .unwrap();
+    }
+
+    let ours =
+        open_appendable_turbo_vector_storage(ours.path(), DIM, Distance::Dot, false).unwrap();
+    assert_eq!(
+        ours.get_quantized_vector(0),
+        reference.get_quantized_vector(0),
+        "the update-only writer must encode exactly as the storage does",
+    );
+
+    assert!(!ours.is_deleted_vector(0));
+    assert!(
+        ours.is_deleted_vector(1),
+        "the missing vector took its slot"
+    );
+}
+
+/// A second writer resumes above what the first left.
+#[test]
+fn batches_resume() {
+    let dir = TempDir::with_prefix("update_only_turbo").unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let vector: Vec<VectorElementType> = vec![1.0; DIM];
+
+    for slot in 0..2 {
+        let mut writer = Writer::open(MmapFs, dir.path(), DIM, Distance::Dot).unwrap();
+        writer
+            .append_many(
+                slot,
+                [VectorToStore::Decoded(VectorRef::from(vector.as_slice()))],
+                &hw_counter,
+            )
+            .unwrap();
+    }
+
+    let storage =
+        open_appendable_turbo_vector_storage(dir.path(), DIM, Distance::Dot, false).unwrap();
+    assert_eq!(storage.total_vector_count(), 2);
+    assert_eq!(
+        storage.get_quantized_vector(0),
+        storage.get_quantized_vector(1),
+    );
+}

--- a/lib/segment/src/vector_storage/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/update_only/mod.rs
@@ -10,7 +10,22 @@
 //! [`UpdateOnlyStoredFlags`]: crate::common::flags::update_only_stored_flags::UpdateOnlyStoredFlags
 //! [`UpdateOnlyBlobstore`]: crate::common::update_only_blobstore::UpdateOnlyBlobstore
 
-use crate::data_types::vectors::VectorRef;
+use std::path::Path;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalAppend;
+
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::data_types::vectors::{
+    VectorElementType, VectorElementTypeByte, VectorElementTypeHalf, VectorRef,
+};
+use crate::types::{VectorDataConfig, VectorStorageDatatype, VectorStorageType};
+use crate::vector_storage::dense::update_only::UpdateOnlyDenseVectorStorage;
+use crate::vector_storage::multi_dense::update_only::UpdateOnlyMultiDenseVectorStorage;
+use crate::vector_storage::sparse::update_only::UpdateOnlySparseVectorStorage;
+use crate::vector_storage::turbo::multi_turbo::update_only::UpdateOnlyMultiTurboVectorStorage;
+use crate::vector_storage::turbo::update_only::UpdateOnlyTurboVectorStorage;
 
 /// One point's vector for one named storage, as a batch supplies it.
 ///
@@ -37,4 +52,107 @@ pub enum VectorToStore<'a> {
     ///
     /// [1]: crate::index::plain_vector_index::PlainVectorIndex
     Missing,
+}
+
+/// The write half of one named vector storage, over the backend `S`.
+///
+/// Covers the appendable half of [`VectorStorageEnum`][1] — the storages an
+/// update-only segment can have. The immutable ones are built, not appended to,
+/// so they have no writer here.
+///
+/// [1]: crate::vector_storage::VectorStorageEnum
+pub enum UpdateOnlyVectorStorage<S: UniversalAppend + 'static> {
+    Dense(Box<UpdateOnlyDenseVectorStorage<VectorElementType, S>>),
+    DenseByte(Box<UpdateOnlyDenseVectorStorage<VectorElementTypeByte, S>>),
+    DenseHalf(Box<UpdateOnlyDenseVectorStorage<VectorElementTypeHalf, S>>),
+    MultiDense(Box<UpdateOnlyMultiDenseVectorStorage<VectorElementType, S>>),
+    MultiDenseByte(Box<UpdateOnlyMultiDenseVectorStorage<VectorElementTypeByte, S>>),
+    MultiDenseHalf(Box<UpdateOnlyMultiDenseVectorStorage<VectorElementTypeHalf, S>>),
+    Turbo(Box<UpdateOnlyTurboVectorStorage<S>>),
+    MultiTurbo(Box<UpdateOnlyMultiTurboVectorStorage<S>>),
+    Sparse(Box<UpdateOnlySparseVectorStorage<S>>),
+}
+
+impl<S: UniversalAppend + 'static> UpdateOnlyVectorStorage<S> {
+    /// Open the writer for the storage `config` describes at `path`, creating it
+    /// if it is not there yet.
+    ///
+    /// Fails for a storage type an update-only segment cannot have: the mmap
+    /// ones are immutable, built whole rather than appended to, and the empty
+    /// placeholder has no files at all.
+    pub fn open(fs: S::Fs, path: &Path, config: &VectorDataConfig) -> OperationResult<Self> {
+        match config.storage_type {
+            VectorStorageType::ChunkedMmap | VectorStorageType::InRamChunkedMmap => {}
+            storage_type @ (VectorStorageType::Mmap
+            | VectorStorageType::InRamMmap
+            | VectorStorageType::Memory
+            | VectorStorageType::Empty) => {
+                return Err(OperationError::service_error(format!(
+                    "Cannot open a {storage_type:?} vector storage for appending: it is not an \
+                     appendable storage type",
+                )));
+            }
+        }
+
+        let dim = config.size;
+        let datatype = config.datatype.unwrap_or_default();
+        let storage = match (config.multivector_config.is_some(), datatype) {
+            (false, VectorStorageDatatype::Float32) => {
+                Self::Dense(Box::new(UpdateOnlyDenseVectorStorage::open(fs, path, dim)?))
+            }
+            (false, VectorStorageDatatype::Uint8) => {
+                Self::DenseByte(Box::new(UpdateOnlyDenseVectorStorage::open(fs, path, dim)?))
+            }
+            (false, VectorStorageDatatype::Float16) => {
+                Self::DenseHalf(Box::new(UpdateOnlyDenseVectorStorage::open(fs, path, dim)?))
+            }
+            (false, VectorStorageDatatype::Turbo4) => Self::Turbo(Box::new(
+                UpdateOnlyTurboVectorStorage::open(fs, path, dim, config.distance)?,
+            )),
+            (true, VectorStorageDatatype::Float32) => Self::MultiDense(Box::new(
+                UpdateOnlyMultiDenseVectorStorage::open(fs, path, dim)?,
+            )),
+            (true, VectorStorageDatatype::Uint8) => Self::MultiDenseByte(Box::new(
+                UpdateOnlyMultiDenseVectorStorage::open(fs, path, dim)?,
+            )),
+            (true, VectorStorageDatatype::Float16) => Self::MultiDenseHalf(Box::new(
+                UpdateOnlyMultiDenseVectorStorage::open(fs, path, dim)?,
+            )),
+            (true, VectorStorageDatatype::Turbo4) => Self::MultiTurbo(Box::new(
+                UpdateOnlyMultiTurboVectorStorage::open(fs, path, dim, config.distance)?,
+            )),
+        };
+
+        Ok(storage)
+    }
+
+    /// Open the writer for a sparse vector storage at `path`. Sparse vectors
+    /// are configured separately from dense ones, so they do not go through
+    /// [`open`](Self::open).
+    pub fn open_sparse(fs: S::Fs, path: &Path) -> OperationResult<Self> {
+        Ok(Self::Sparse(Box::new(UpdateOnlySparseVectorStorage::open(
+            fs, path,
+        )?)))
+    }
+
+    /// Append one vector per point of a batch, starting at `start_slot`, and
+    /// persist them.
+    pub fn append_many<'a>(
+        &mut self,
+        start_slot: PointOffsetType,
+        vectors: impl IntoIterator<Item = VectorToStore<'a>>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            Self::Dense(s) => s.append_many(start_slot, vectors, hw_counter),
+            Self::DenseByte(s) => s.append_many(start_slot, vectors, hw_counter),
+            Self::DenseHalf(s) => s.append_many(start_slot, vectors, hw_counter),
+            Self::MultiDense(s) => s.append_many(start_slot, vectors, hw_counter),
+            Self::MultiDenseByte(s) => s.append_many(start_slot, vectors, hw_counter),
+            Self::MultiDenseHalf(s) => s.append_many(start_slot, vectors, hw_counter),
+            Self::Turbo(s) => s.append_many(start_slot, vectors, hw_counter),
+            Self::MultiTurbo(s) => s.append_many(start_slot, vectors, hw_counter),
+            Self::Sparse(s) => s.append_many(start_slot, vectors, hw_counter),
+        }
+    }
 }

--- a/lib/segment/src/vector_storage/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/update_only/mod.rs
@@ -1,0 +1,40 @@
+//! The write half of the appendable vector storages, for update-only segments.
+//!
+//! Each storage family decomposes into pieces that already append: the vectors
+//! themselves into [`UpdateOnlyChunkedVectors`], the deleted flags into
+//! [`UpdateOnlyStoredFlags`], the sparse values into [`UpdateOnlyBlobstore`].
+//! What these writers add is the layout — which directory holds what — and the
+//! rule that a point with no vector under a name still occupies its slot.
+//!
+//! [`UpdateOnlyChunkedVectors`]: crate::vector_storage::chunked_vectors::update_only::UpdateOnlyChunkedVectors
+//! [`UpdateOnlyStoredFlags`]: crate::common::flags::update_only_stored_flags::UpdateOnlyStoredFlags
+//! [`UpdateOnlyBlobstore`]: crate::common::update_only_blobstore::UpdateOnlyBlobstore
+
+use crate::data_types::vectors::VectorRef;
+
+/// One point's vector for one named storage, as a batch supplies it.
+///
+/// The two ways a vector arrives are the two halves of
+/// [`FullyQualifiedPoint`][1]: `updated_vectors`, decoded by the batch, and
+/// `stored_vectors`, carried over from the point's previous slot as
+/// storage-native bytes that never need decoding.
+///
+/// [1]: crate::data_types::fully_qualified_point::FullyQualifiedPoint
+pub enum VectorToStore<'a> {
+    /// Decoded by the batch.
+    Decoded(VectorRef<'a>),
+    /// Storage-native bytes, in the form [`retrieve_raw`][1] returns.
+    ///
+    /// [1]: crate::entry::entry_point::ReadSegmentEntry::retrieve_raw
+    Raw(&'a [u8]),
+    /// The point has no vector under this name.
+    ///
+    /// Its slot is still written — with a placeholder value — and flagged
+    /// deleted, because slots are shared across every named storage of the
+    /// segment: skipping one here would shift every later vector of this
+    /// storage against the id tracker. This is what the writable path does in
+    /// [`PlainVectorIndex::update_vector`][1].
+    ///
+    /// [1]: crate::index::plain_vector_index::PlainVectorIndex
+    Missing,
+}


### PR DESCRIPTION
Based on #10147 (for `UpdateOnlyStoredFlags` and `UpdateOnlyBlobstore`), and a **sibling** of #10150 rather than stacked on it — the two are independent.

The last missing component: with this, an update-only segment has writers for its id tracker, chunked vectors, payload storage, payload indexes and vector storages.

## No new low-level writers were needed

Every appendable vector storage decomposes into pieces that already append:

| storage | components |
|---|---|
| dense ×3 element types | `UpdateOnlyChunkedVectors<T>` + `UpdateOnlyStoredFlags` |
| multi-dense ×3 | + `UpdateOnlyChunkedVectors<MultivectorMmapOffset>` for the row ranges |
| turbo / multi-turbo | `UpdateOnlyChunkedVectors<u8>` (+ offsets) + flags |
| sparse | `UpdateOnlyBlobstore<StoredSparseVector>` + flags |

`BufferedOffsets` is `ChunkedVectors<MultivectorMmapOffset>` underneath and `QuantizedChunkedStorage` is `ChunkedVectors<u8>`, so what these writers add is the layout and the placement rules — not new file formats.

## The rules that matter

**A point with no vector under a name still takes its slot.** Slots are shared across every named storage of a segment, so skipping one would shift every later vector of that storage against the id tracker. The single-vector storages write a placeholder and flag the slot deleted, exactly as `plain_vector_index/lifecycle.rs:33-41` does; the multivector ones instead record an empty row range, since their offsets are what map slot to rows.

**The deleted mask is barely written.** The storages document that it "may be smaller than actual number of vectors. Must not depend on its length", and update-only never rewrites a slot — so only the missing vectors are flagged, and a batch where every point has a vector rewrites no mask at all.

**Multivector rows are placed, not indexed.** A point owns a run of rows, so the writer reads where the row space ends on open and places each run itself, skipping to the next chunk rather than straddling one. A batch's rows are therefore not always one span; each span is appended on its own and the gap a skip leaves is zero-filled by the append that follows.

**The turbo quantizer is rebuilt, not read back** — it carries no learned state, and the test asserts the encoded bytes match what the writable storage produces for the same vector.

## One prerequisite, one bug fixed

- `UpdateOnlyChunkedVectors` required `S: UniversalAppend + UniversalWrite`, excluding the object-store backend it exists for. Nothing in it needs random-offset writes. (First commit.)
- `UpdateOnlyStoredFlags::open` now materializes its directory instead of waiting for the first flag: storages use that directory as the marker that they exist, and `MmapSparseVectorStorage::open_or_create` takes its absence for "not created yet" and starts a fresh storage over the old one. Caught by the sparse resume test.

## Tests

13 round-trips, each writing through the update-only writer and reading back through the real appendable storage on the same directory — decoded vectors, storage-native bytes, missing vectors, malformed blobs, and resume across writers for every family. `-p segment --lib` 1024 passed, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)