### PR TITLE
[UpdateOnly] wire every component into the appendable segment

### DIFF
--- a/lib/edge/src/read_only/tests.rs
+++ b/lib/edge/src/read_only/tests.rs
@@ -26,7 +26,7 @@ use crate::read_only::{
 use crate::read_view::EdgeShardRead;
 use crate::{CountRequest, EdgeConfig, EdgeShard, RetrieveRequestBuilder, ScrollRequestBuilder};
 
-const VECTOR_NAME: &str = "edge-ro-test-vector";
+pub(crate) const VECTOR_NAME: &str = "edge-ro-test-vector";
 
 pub(crate) fn test_config() -> EdgeConfig {
     EdgeConfig {
@@ -53,7 +53,7 @@ pub(crate) fn test_config() -> EdgeConfig {
     }
 }
 
-fn point(id: u64) -> PointStructPersisted {
+pub(crate) fn point(id: u64) -> PointStructPersisted {
     PointStructPersisted {
         id: ExtendedPointId::NumId(id),
         vector: VectorStructPersisted::from(VectorStructInternal::Named(HashMap::from([(
@@ -113,7 +113,7 @@ pub(crate) fn scrolled_ids(follower: &ReadOnlyEdgeShard<MmapFile>) -> Vec<Extend
 }
 
 /// Assert each id is retrievable from the follower with its expected vector `[id as f32]`.
-fn assert_follower_vectors(follower: &ReadOnlyEdgeShard<MmapFile>, ids: &[u64]) {
+pub(crate) fn assert_follower_vectors(follower: &ReadOnlyEdgeShard<MmapFile>, ids: &[u64]) {
     let point_ids = ids
         .iter()
         .map(|id| ExtendedPointId::NumId(*id))

--- a/lib/edge/src/update_only/apply.rs
+++ b/lib/edge/src/update_only/apply.rs
@@ -199,7 +199,12 @@ fn open_writer<S: UniversalAppend + UniversalWrite + 'static>(
 ) -> OperationResult<UpdateOnlySegmentEnum<S>> {
     let segment = segments.get(uuid)?.read();
 
-    UpdateOnlySegmentEnum::open(fs, &segment.segment_path, segment.writer_state())
+    UpdateOnlySegmentEnum::open(
+        fs,
+        &segment.segment_path,
+        &segment.segment_config,
+        segment.writer_state(),
+    )
 }
 
 /// Locate every point the batch touches: every slot it occupies, with the

--- a/lib/edge/src/update_only/tests.rs
+++ b/lib/edge/src/update_only/tests.rs
@@ -1,19 +1,31 @@
 //! End-to-end checks of the writer against a shard directory a leader
 //! [`EdgeShard`] built.
 //!
-//! Only deletes can run the whole way through today: storing points still
-//! needs the append-only vector, payload and index storages.
+//! Every phase runs for real: the points are located and resolved through the
+//! `LookupSegment`s, a writer resumes the write target from what that read
+//! saw, and what it appends is verified through an ordinary follower opened
+//! afterwards.
 
-use common::universal_io::MmapFile;
-use segment::types::{ExtendedPointId, SeqNumberType};
+use std::path::Path;
+
+use common::universal_io::{MmapFile, MmapFs};
+use segment::payload_json;
+use segment::payload_storage::update_only::UpdateOnlyPayloadStorage;
+use segment::types::{ExtendedPointId, SeqNumberType, WithPayloadInterface, WithVector};
+use shard::files::SEGMENTS_PATH;
 use shard::operations::CollectionUpdateOperations;
 use shard::operations::CollectionUpdateOperations::PointOperation;
-use shard::operations::point_ops::PointOperations::DeletePoints;
+use shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
+use shard::operations::point_ops::PointOperations::{DeletePoints, UpsertPoints};
+use shard::operations::point_ops::PointStructPersisted;
 use tempfile::TempDir;
 
-use crate::EdgeShard;
-use crate::read_only::tests::{exact_count, open_follower, scrolled_ids, test_config, upsert};
+use crate::read_only::tests::{
+    assert_follower_vectors, exact_count, open_follower, point, scrolled_ids, test_config, upsert,
+};
+use crate::read_view::EdgeShardRead as _;
 use crate::update_only::UpdateOnlyEdgeShard;
+use crate::{EdgeShard, RetrieveRequestBuilder};
 
 /// A flushed shard directory holding points 1 to 10, with the leader that
 /// wrote it closed — a writer opens a directory, not a running shard.
@@ -84,4 +96,156 @@ fn replayed_delete_batch_is_a_no_op() {
 
     let follower = open_follower(dir.path());
     assert_eq!(exact_count(&follower), 9);
+}
+
+/// The leader writes its payload storage in mutable (Gridstore) mode, which an
+/// append-only writer refuses to append to. Recreate each segment's payload
+/// storage empty in append-only mode — the fixture points carry no payloads,
+/// so nothing is lost. Stands in for creating segments with append-only
+/// components from the start, which nothing does yet.
+fn recreate_payload_storages_append_only(shard_dir: &Path) {
+    for segment in fs_err::read_dir(shard_dir.join(SEGMENTS_PATH)).unwrap() {
+        let segment_path = segment.unwrap().path();
+        let payload_storage = segment_path.join("payload_storage");
+        if payload_storage.is_dir() {
+            fs_err::remove_dir_all(&payload_storage).unwrap();
+            // Opening the writer creates the storage in append-only mode.
+            UpdateOnlyPayloadStorage::<MmapFile>::open(MmapFs, &segment_path).unwrap();
+        }
+    }
+}
+
+fn store_batch(
+    op_num: SeqNumberType,
+    points: Vec<PointStructPersisted>,
+) -> [(SeqNumberType, CollectionUpdateOperations); 1] {
+    [(op_num, PointOperation(UpsertPoints(PointsList(points))))]
+}
+
+/// A batch of stores against the appendable segment: a new point (with a
+/// payload) and a rewrite of an existing one, appended by the writer and read
+/// back through an ordinary follower.
+#[test]
+fn store_batch_appends_points_end_to_end() {
+    let dir = leader_with_ten_points("edge-update-store");
+    recreate_payload_storages_append_only(dir.path());
+
+    let new_point = PointStructPersisted {
+        payload: Some(payload_json! { "kind": "fresh" }),
+        ..point(11)
+    };
+    // The rewrite must win over the old copy, so give it a vector the fixture
+    // would never produce.
+    let rewritten = PointStructPersisted {
+        vector: point(50).vector,
+        ..point(5)
+    };
+
+    let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+    let outcome = writer
+        .apply_batch(store_batch(100, vec![new_point, rewritten]))
+        .unwrap();
+
+    assert_eq!(outcome.stored, 2);
+    assert_eq!(outcome.deleted, 0);
+    assert_eq!(outcome.skipped, 0);
+    assert_eq!(outcome.missing, 0);
+
+    let follower = open_follower(dir.path());
+    assert_eq!(exact_count(&follower), 11);
+    assert_eq!(
+        scrolled_ids(&follower),
+        (1..=11).map(ExtendedPointId::NumId).collect::<Vec<_>>(),
+    );
+
+    // The untouched points read back unchanged...
+    assert_follower_vectors(&follower, &[1, 2, 3, 4, 6, 7, 8, 9, 10]);
+
+    // ...the rewritten one serves the batch's vector, not the old copy's, and
+    // the new one carries its payload.
+    let results = follower
+        .retrieve(
+            RetrieveRequestBuilder::new(vec![
+                ExtendedPointId::NumId(5),
+                ExtendedPointId::NumId(11),
+            ])
+            .with_payload(WithPayloadInterface::Bool(true))
+            .with_vector(WithVector::Bool(true))
+            .build(),
+        )
+        .unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(
+        results[0].vector,
+        Some(point(50).vector.try_into().unwrap())
+    );
+    assert_eq!(results[1].payload, Some(payload_json! { "kind": "fresh" }),);
+}
+
+/// A retried store batch — a fresh writer over the same directory — is a
+/// no-op: every point already carries the batch's version, which only a
+/// published versions array can tell it.
+#[test]
+fn replayed_store_batch_is_a_no_op() {
+    let dir = leader_with_ten_points("edge-update-store-replay");
+    recreate_payload_storages_append_only(dir.path());
+
+    let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+    let batch = || store_batch(100, vec![point(11)]);
+    assert_eq!(writer.apply_batch(batch()).unwrap().stored, 1);
+
+    let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+    let replayed = writer.apply_batch(batch()).unwrap();
+    assert_eq!(replayed.stored, 0);
+    assert_eq!(replayed.skipped, 1);
+
+    let follower = open_follower(dir.path());
+    assert_eq!(exact_count(&follower), 11);
+}
+
+/// A second batch through a fresh writer resumes every component where the
+/// first ended: the mappings log, the vector chunks and the payload pages all
+/// carry on rather than starting over — and a store and a delete land in one
+/// batch through one writer.
+#[test]
+fn second_batch_resumes_where_the_first_ended() {
+    let dir = leader_with_ten_points("edge-update-store-resume");
+    recreate_payload_storages_append_only(dir.path());
+
+    let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+    assert_eq!(
+        writer
+            .apply_batch(store_batch(100, vec![point(11)]))
+            .unwrap()
+            .stored,
+        1,
+    );
+
+    let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+    let second = writer
+        .apply_batch([
+            (
+                101,
+                PointOperation(UpsertPoints(PointsList(vec![point(12)]))),
+            ),
+            (
+                102,
+                PointOperation(DeletePoints {
+                    ids: vec![ExtendedPointId::NumId(2)],
+                }),
+            ),
+        ])
+        .unwrap();
+    assert_eq!(second.stored, 1);
+    assert_eq!(second.deleted, 1);
+
+    let follower = open_follower(dir.path());
+    assert_eq!(exact_count(&follower), 11);
+    assert_eq!(
+        scrolled_ids(&follower),
+        [1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+            .map(ExtendedPointId::NumId)
+            .to_vec(),
+    );
+    assert_follower_vectors(&follower, &[11, 12]);
 }

--- a/lib/edge/src/update_only/tests.rs
+++ b/lib/edge/src/update_only/tests.rs
@@ -6,26 +6,16 @@
 //! saw, and what it appends is verified through an ordinary follower opened
 //! afterwards.
 
-use std::path::Path;
-
-use common::universal_io::{MmapFile, MmapFs};
-use segment::payload_json;
-use segment::payload_storage::update_only::UpdateOnlyPayloadStorage;
-use segment::types::{ExtendedPointId, SeqNumberType, WithPayloadInterface, WithVector};
-use shard::files::SEGMENTS_PATH;
+use common::universal_io::MmapFile;
+use segment::types::{ExtendedPointId, SeqNumberType};
 use shard::operations::CollectionUpdateOperations;
 use shard::operations::CollectionUpdateOperations::PointOperation;
-use shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
-use shard::operations::point_ops::PointOperations::{DeletePoints, UpsertPoints};
-use shard::operations::point_ops::PointStructPersisted;
+use shard::operations::point_ops::PointOperations::DeletePoints;
 use tempfile::TempDir;
 
-use crate::read_only::tests::{
-    assert_follower_vectors, exact_count, open_follower, point, scrolled_ids, test_config, upsert,
-};
-use crate::read_view::EdgeShardRead as _;
+use crate::EdgeShard;
+use crate::read_only::tests::{exact_count, open_follower, scrolled_ids, test_config, upsert};
 use crate::update_only::UpdateOnlyEdgeShard;
-use crate::{EdgeShard, RetrieveRequestBuilder};
 
 /// A flushed shard directory holding points 1 to 10, with the leader that
 /// wrote it closed — a writer opens a directory, not a running shard.
@@ -98,154 +88,179 @@ fn replayed_delete_batch_is_a_no_op() {
     assert_eq!(exact_count(&follower), 9);
 }
 
-/// The leader writes its payload storage in mutable (Gridstore) mode, which an
-/// append-only writer refuses to append to. Recreate each segment's payload
-/// storage empty in append-only mode — the fixture points carry no payloads,
-/// so nothing is lost. Stands in for creating segments with append-only
-/// components from the start, which nothing does yet.
-fn recreate_payload_storages_append_only(shard_dir: &Path) {
-    for segment in fs_err::read_dir(shard_dir.join(SEGMENTS_PATH)).unwrap() {
-        let segment_path = segment.unwrap().path();
-        let payload_storage = segment_path.join("payload_storage");
-        if payload_storage.is_dir() {
-            fs_err::remove_dir_all(&payload_storage).unwrap();
-            // Opening the writer creates the storage in append-only mode.
-            UpdateOnlyPayloadStorage::<MmapFile>::open(MmapFs, &segment_path).unwrap();
+/// The store tests cannot run on Windows: the leader's writable storage
+/// preallocates chunk files, the append-only writer cuts them back to end at
+/// the data (its append offset is a compare-and-swap token), and Windows
+/// refuses to replace a file while the writer's own `LookupSegment`s hold it
+/// memory-mapped. The production target is object storage, where neither
+/// preallocation nor mmap exists.
+#[cfg(not(windows))]
+mod store {
+    use std::path::Path;
+
+    use common::universal_io::MmapFs;
+    use segment::payload_json;
+    use segment::payload_storage::update_only::UpdateOnlyPayloadStorage;
+    use segment::types::{WithPayloadInterface, WithVector};
+    use shard::files::SEGMENTS_PATH;
+    use shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
+    use shard::operations::point_ops::PointOperations::UpsertPoints;
+    use shard::operations::point_ops::PointStructPersisted;
+
+    use super::*;
+    use crate::RetrieveRequestBuilder;
+    use crate::read_only::tests::{assert_follower_vectors, point};
+    use crate::read_view::EdgeShardRead as _;
+
+    /// The leader writes its payload storage in mutable (Gridstore) mode, which an
+    /// append-only writer refuses to append to. Recreate each segment's payload
+    /// storage empty in append-only mode — the fixture points carry no payloads,
+    /// so nothing is lost. Stands in for creating segments with append-only
+    /// components from the start, which nothing does yet.
+    fn recreate_payload_storages_append_only(shard_dir: &Path) {
+        for segment in fs_err::read_dir(shard_dir.join(SEGMENTS_PATH)).unwrap() {
+            let segment_path = segment.unwrap().path();
+            let payload_storage = segment_path.join("payload_storage");
+            if payload_storage.is_dir() {
+                fs_err::remove_dir_all(&payload_storage).unwrap();
+                // Opening the writer creates the storage in append-only mode.
+                UpdateOnlyPayloadStorage::<MmapFile>::open(MmapFs, &segment_path).unwrap();
+            }
         }
     }
-}
 
-fn store_batch(
-    op_num: SeqNumberType,
-    points: Vec<PointStructPersisted>,
-) -> [(SeqNumberType, CollectionUpdateOperations); 1] {
-    [(op_num, PointOperation(UpsertPoints(PointsList(points))))]
-}
+    fn store_batch(
+        op_num: SeqNumberType,
+        points: Vec<PointStructPersisted>,
+    ) -> [(SeqNumberType, CollectionUpdateOperations); 1] {
+        [(op_num, PointOperation(UpsertPoints(PointsList(points))))]
+    }
 
-/// A batch of stores against the appendable segment: a new point (with a
-/// payload) and a rewrite of an existing one, appended by the writer and read
-/// back through an ordinary follower.
-#[test]
-fn store_batch_appends_points_end_to_end() {
-    let dir = leader_with_ten_points("edge-update-store");
-    recreate_payload_storages_append_only(dir.path());
+    /// A batch of stores against the appendable segment: a new point (with a
+    /// payload) and a rewrite of an existing one, appended by the writer and read
+    /// back through an ordinary follower.
+    #[test]
+    fn store_batch_appends_points_end_to_end() {
+        let dir = leader_with_ten_points("edge-update-store");
+        recreate_payload_storages_append_only(dir.path());
 
-    let new_point = PointStructPersisted {
-        payload: Some(payload_json! { "kind": "fresh" }),
-        ..point(11)
-    };
-    // The rewrite must win over the old copy, so give it a vector the fixture
-    // would never produce.
-    let rewritten = PointStructPersisted {
-        vector: point(50).vector,
-        ..point(5)
-    };
+        let new_point = PointStructPersisted {
+            payload: Some(payload_json! { "kind": "fresh" }),
+            ..point(11)
+        };
+        // The rewrite must win over the old copy, so give it a vector the fixture
+        // would never produce.
+        let rewritten = PointStructPersisted {
+            vector: point(50).vector,
+            ..point(5)
+        };
 
-    let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
-    let outcome = writer
-        .apply_batch(store_batch(100, vec![new_point, rewritten]))
-        .unwrap();
+        let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+        let outcome = writer
+            .apply_batch(store_batch(100, vec![new_point, rewritten]))
+            .unwrap();
 
-    assert_eq!(outcome.stored, 2);
-    assert_eq!(outcome.deleted, 0);
-    assert_eq!(outcome.skipped, 0);
-    assert_eq!(outcome.missing, 0);
+        assert_eq!(outcome.stored, 2);
+        assert_eq!(outcome.deleted, 0);
+        assert_eq!(outcome.skipped, 0);
+        assert_eq!(outcome.missing, 0);
 
-    let follower = open_follower(dir.path());
-    assert_eq!(exact_count(&follower), 11);
-    assert_eq!(
-        scrolled_ids(&follower),
-        (1..=11).map(ExtendedPointId::NumId).collect::<Vec<_>>(),
-    );
+        let follower = open_follower(dir.path());
+        assert_eq!(exact_count(&follower), 11);
+        assert_eq!(
+            scrolled_ids(&follower),
+            (1..=11).map(ExtendedPointId::NumId).collect::<Vec<_>>(),
+        );
 
-    // The untouched points read back unchanged...
-    assert_follower_vectors(&follower, &[1, 2, 3, 4, 6, 7, 8, 9, 10]);
+        // The untouched points read back unchanged...
+        assert_follower_vectors(&follower, &[1, 2, 3, 4, 6, 7, 8, 9, 10]);
 
-    // ...the rewritten one serves the batch's vector, not the old copy's, and
-    // the new one carries its payload.
-    let results = follower
-        .retrieve(
-            RetrieveRequestBuilder::new(vec![
-                ExtendedPointId::NumId(5),
-                ExtendedPointId::NumId(11),
+        // ...the rewritten one serves the batch's vector, not the old copy's, and
+        // the new one carries its payload.
+        let results = follower
+            .retrieve(
+                RetrieveRequestBuilder::new(vec![
+                    ExtendedPointId::NumId(5),
+                    ExtendedPointId::NumId(11),
+                ])
+                .with_payload(WithPayloadInterface::Bool(true))
+                .with_vector(WithVector::Bool(true))
+                .build(),
+            )
+            .unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0].vector,
+            Some(point(50).vector.try_into().unwrap())
+        );
+        assert_eq!(results[1].payload, Some(payload_json! { "kind": "fresh" }),);
+    }
+
+    /// A retried store batch — a fresh writer over the same directory — is a
+    /// no-op: every point already carries the batch's version, which only a
+    /// published versions array can tell it.
+    #[test]
+    fn replayed_store_batch_is_a_no_op() {
+        let dir = leader_with_ten_points("edge-update-store-replay");
+        recreate_payload_storages_append_only(dir.path());
+
+        let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+        let batch = || store_batch(100, vec![point(11)]);
+        assert_eq!(writer.apply_batch(batch()).unwrap().stored, 1);
+
+        let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+        let replayed = writer.apply_batch(batch()).unwrap();
+        assert_eq!(replayed.stored, 0);
+        assert_eq!(replayed.skipped, 1);
+
+        let follower = open_follower(dir.path());
+        assert_eq!(exact_count(&follower), 11);
+    }
+
+    /// A second batch through a fresh writer resumes every component where the
+    /// first ended: the mappings log, the vector chunks and the payload pages all
+    /// carry on rather than starting over — and a store and a delete land in one
+    /// batch through one writer.
+    #[test]
+    fn second_batch_resumes_where_the_first_ended() {
+        let dir = leader_with_ten_points("edge-update-store-resume");
+        recreate_payload_storages_append_only(dir.path());
+
+        let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+        assert_eq!(
+            writer
+                .apply_batch(store_batch(100, vec![point(11)]))
+                .unwrap()
+                .stored,
+            1,
+        );
+
+        let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+        let second = writer
+            .apply_batch([
+                (
+                    101,
+                    PointOperation(UpsertPoints(PointsList(vec![point(12)]))),
+                ),
+                (
+                    102,
+                    PointOperation(DeletePoints {
+                        ids: vec![ExtendedPointId::NumId(2)],
+                    }),
+                ),
             ])
-            .with_payload(WithPayloadInterface::Bool(true))
-            .with_vector(WithVector::Bool(true))
-            .build(),
-        )
-        .unwrap();
-    assert_eq!(results.len(), 2);
-    assert_eq!(
-        results[0].vector,
-        Some(point(50).vector.try_into().unwrap())
-    );
-    assert_eq!(results[1].payload, Some(payload_json! { "kind": "fresh" }),);
-}
+            .unwrap();
+        assert_eq!(second.stored, 1);
+        assert_eq!(second.deleted, 1);
 
-/// A retried store batch — a fresh writer over the same directory — is a
-/// no-op: every point already carries the batch's version, which only a
-/// published versions array can tell it.
-#[test]
-fn replayed_store_batch_is_a_no_op() {
-    let dir = leader_with_ten_points("edge-update-store-replay");
-    recreate_payload_storages_append_only(dir.path());
-
-    let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
-    let batch = || store_batch(100, vec![point(11)]);
-    assert_eq!(writer.apply_batch(batch()).unwrap().stored, 1);
-
-    let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
-    let replayed = writer.apply_batch(batch()).unwrap();
-    assert_eq!(replayed.stored, 0);
-    assert_eq!(replayed.skipped, 1);
-
-    let follower = open_follower(dir.path());
-    assert_eq!(exact_count(&follower), 11);
-}
-
-/// A second batch through a fresh writer resumes every component where the
-/// first ended: the mappings log, the vector chunks and the payload pages all
-/// carry on rather than starting over — and a store and a delete land in one
-/// batch through one writer.
-#[test]
-fn second_batch_resumes_where_the_first_ended() {
-    let dir = leader_with_ten_points("edge-update-store-resume");
-    recreate_payload_storages_append_only(dir.path());
-
-    let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
-    assert_eq!(
-        writer
-            .apply_batch(store_batch(100, vec![point(11)]))
-            .unwrap()
-            .stored,
-        1,
-    );
-
-    let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
-    let second = writer
-        .apply_batch([
-            (
-                101,
-                PointOperation(UpsertPoints(PointsList(vec![point(12)]))),
-            ),
-            (
-                102,
-                PointOperation(DeletePoints {
-                    ids: vec![ExtendedPointId::NumId(2)],
-                }),
-            ),
-        ])
-        .unwrap();
-    assert_eq!(second.stored, 1);
-    assert_eq!(second.deleted, 1);
-
-    let follower = open_follower(dir.path());
-    assert_eq!(exact_count(&follower), 11);
-    assert_eq!(
-        scrolled_ids(&follower),
-        [1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-            .map(ExtendedPointId::NumId)
-            .to_vec(),
-    );
-    assert_follower_vectors(&follower, &[11, 12]);
+        let follower = open_follower(dir.path());
+        assert_eq!(exact_count(&follower), 11);
+        assert_eq!(
+            scrolled_ids(&follower),
+            [1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+                .map(ExtendedPointId::NumId)
+                .to_vec(),
+        );
+        assert_follower_vectors(&follower, &[11, 12]);
+    }
 }

--- a/lib/segment/src/segment/update_only/appendable/mod.rs
+++ b/lib/segment/src/segment/update_only/appendable/mod.rs
@@ -1,8 +1,9 @@
 //! The write phase for the appendable segment: the one segment of a shard a
 //! batch appends its points to.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
+use ahash::AHashSet;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalAppend;
@@ -10,13 +11,67 @@ use common::universal_io::UniversalAppend;
 use super::AppendableIdTrackerState;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::fully_qualified_point::FullyQualifiedPoint;
-use crate::id_tracker::mutable_id_tracker::update_only::UpdateOnlyAppendableIdTracker;
-use crate::types::PointIdType;
+use crate::id_tracker::mutable_id_tracker::update_only::{
+    MappingOperation, UpdateOnlyAppendableIdTracker,
+};
+use crate::index::struct_payload_index::update_only::UpdateOnlyStructPayloadIndex;
+use crate::payload_storage::update_only::UpdateOnlyPayloadStorage;
+use crate::segment_constructor::get_vector_storage_path;
+use crate::types::{PointIdType, SegmentConfig, SeqNumberType, VectorNameBuf};
+use crate::vector_storage::update_only::{UpdateOnlyVectorStorage, VectorToStore};
 
 /// A segment open for appends: the write target. Every point a batch stores
 /// lands here, in a fresh slot — nothing is ever rewritten in place.
 pub struct AppendableSegment<S: UniversalAppend + 'static> {
     id_tracker: UpdateOnlyAppendableIdTracker<S>,
+    /// What [`store_components`](Self::store_components) opens with.
+    fs: S::Fs,
+    segment_path: PathBuf,
+    config: SegmentConfig,
+    /// The components a stored point's data goes into, opened on the first
+    /// [`store_points`](Self::store_points). A batch that only deletes writes
+    /// nothing but the mappings log, so it never pays for these opens.
+    store: Option<StoreComponents<S>>,
+    /// External ids this writer has stored, so that
+    /// [`tombstone_points`](Self::tombstone_points) never retires a point this
+    /// very batch wrote.
+    stored_ids: AHashSet<PointIdType>,
+}
+
+/// Everywhere a stored point's data goes. The mappings log that publishes the
+/// point is not here: it belongs to the segment itself, since deletes need it
+/// too.
+struct StoreComponents<S: UniversalAppend + 'static> {
+    payload_storage: UpdateOnlyPayloadStorage<S>,
+    payload_indexes: UpdateOnlyStructPayloadIndex<S>,
+    /// One writer per named vector, dense and sparse alike.
+    vector_storages: Vec<(VectorNameBuf, UpdateOnlyVectorStorage<S>)>,
+}
+
+impl<S: UniversalAppend + 'static> StoreComponents<S> {
+    fn open(fs: &S::Fs, segment_path: &Path, config: &SegmentConfig) -> OperationResult<Self> {
+        let payload_storage = UpdateOnlyPayloadStorage::open(fs.clone(), segment_path)?;
+        let payload_indexes = UpdateOnlyStructPayloadIndex::open(fs.clone(), segment_path)?;
+
+        let mut vector_storages =
+            Vec::with_capacity(config.vector_data.len() + config.sparse_vector_data.len());
+        for (vector_name, vector_config) in &config.vector_data {
+            let path = get_vector_storage_path(segment_path, vector_name);
+            let storage = UpdateOnlyVectorStorage::open(fs.clone(), &path, vector_config)?;
+            vector_storages.push((vector_name.clone(), storage));
+        }
+        for vector_name in config.sparse_vector_data.keys() {
+            let path = get_vector_storage_path(segment_path, vector_name);
+            let storage = UpdateOnlyVectorStorage::open_sparse(fs.clone(), &path)?;
+            vector_storages.push((vector_name.clone(), storage));
+        }
+
+        Ok(Self {
+            payload_storage,
+            payload_indexes,
+            vector_storages,
+        })
+    }
 }
 
 impl<S: UniversalAppend + 'static> AppendableSegment<S> {
@@ -29,6 +84,7 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
     pub fn open(
         fs: S::Fs,
         segment_path: &Path,
+        config: &SegmentConfig,
         state: AppendableIdTrackerState,
     ) -> OperationResult<Self> {
         let AppendableIdTrackerState {
@@ -38,48 +94,126 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
         } = state;
 
         let id_tracker = UpdateOnlyAppendableIdTracker::new(
-            fs,
+            fs.clone(),
             segment_path,
             max_claimed_internal_id,
             pending_inserts,
             mappings_end,
         )?;
 
-        Ok(Self { id_tracker })
+        Ok(Self {
+            id_tracker,
+            fs,
+            segment_path: segment_path.to_path_buf(),
+            config: config.clone(),
+            store: None,
+            stored_ids: AHashSet::new(),
+        })
+    }
+
+    fn store_components(&mut self) -> OperationResult<&mut StoreComponents<S>> {
+        if self.store.is_none() {
+            self.store = Some(StoreComponents::open(
+                &self.fs,
+                &self.segment_path,
+                &self.config,
+            )?);
+        }
+        Ok(self.store.as_mut().expect("just opened"))
     }
 
     /// Append `points` to this segment, each into a fresh slot, and repoint
     /// the id tracker at those slots. A point that already exists here is
     /// never rewritten in place: it is written anew, and the mappings log
     /// retires its previous slot on its own.
+    ///
+    /// The order of writes is what makes a crash safe anywhere in between:
+    /// the slots are claimed first, every component then writes its data at
+    /// them, and only after all of that do the versions cover them — the step
+    /// that makes the points visible to readers. A batch cut short leaves
+    /// claimed, unpublished slots, which the next writer to open this segment
+    /// retires.
     pub fn store_points(
         &mut self,
         points: &[FullyQualifiedPoint],
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
-        let _ = (points, hw_counter);
-        // The id tracker half is ready (`insert_operations` +
-        // `set_internal_versions`); what is missing is everywhere the point's
-        // data goes.
-        //
-        // Keep the ids `insert_operations` returns when writing this: with
-        // them, `tombstone_points` can refuse to retire a point this batch
-        // stored, and the caller stops having to know not to ask.
-        todo!("needs the append-only vector storages, payload storage and field indexes")
+        if points.is_empty() {
+            return Ok(());
+        }
+
+        let operations: Vec<MappingOperation> = points
+            .iter()
+            .map(|point| MappingOperation::Insert(point.id))
+            .collect();
+        let inserted = self.id_tracker.insert_operations(&operations)?;
+        let (_, start_slot) = *inserted.first().expect("one slot per insert");
+
+        let store = self.store_components()?;
+
+        // Each named vector, from whichever half of the point holds it: the
+        // batch's own decoded vectors win over the bytes carried from the
+        // point's previous slot, and a name in neither still takes its slot —
+        // the storage records it as a vector the point does not have.
+        for (vector_name, storage) in &mut store.vector_storages {
+            let vectors = points.iter().map(|point| {
+                if let Some(vector) = point.updated_vectors.get(vector_name) {
+                    VectorToStore::Decoded(vector)
+                } else if let Some((_, bytes)) = point
+                    .stored_vectors
+                    .iter()
+                    .find(|(name, _)| name == vector_name)
+                {
+                    VectorToStore::Raw(bytes)
+                } else {
+                    VectorToStore::Missing
+                }
+            });
+            storage.append_many(start_slot, vectors, hw_counter)?;
+        }
+
+        let slot_payloads = || {
+            inserted
+                .iter()
+                .zip(points)
+                .map(|((_, slot), point)| (*slot, &point.payload))
+        };
+        store
+            .payload_storage
+            .append_many(slot_payloads(), hw_counter)?;
+        store
+            .payload_indexes
+            .append_many(slot_payloads(), hw_counter)?;
+
+        // Publish: covering the slots with their versions is what makes the
+        // points visible, so everything above must already be durable.
+        let slots: Vec<PointOffsetType> = inserted.iter().map(|(_, slot)| *slot).collect();
+        let versions: Vec<SeqNumberType> = points.iter().map(|point| point.version).collect();
+        self.id_tracker.set_internal_versions(&slots, &versions)?;
+
+        self.stored_ids.extend(points.iter().map(|point| point.id));
+
+        Ok(())
     }
 
     /// Retire the given points, addressed by their external ids — the slots
     /// they occupy play no part here, since a retired mapping is what makes a
     /// point unreachable. The data on those slots is left where it is.
     ///
-    /// Only call this for points the batch *deletes*. A point the batch stores
-    /// again needs no retirement: its new mapping supersedes the old slot, and
-    /// a delete recorded afterwards would retire the new slot along with it.
+    /// A point this writer has stored is skipped rather than retired: its new
+    /// mapping already supersedes every old slot, and a delete recorded on top
+    /// would take the new slot with it. The caller can hand over every slot a
+    /// stored point used to occupy without holding that rule itself.
     pub fn tombstone_points(
         &mut self,
         points: &[(PointIdType, PointOffsetType)],
     ) -> OperationResult<()> {
-        self.id_tracker
-            .delete_points(points.iter().map(|(point_id, _internal_id)| *point_id))
+        let stored_ids = &self.stored_ids;
+        self.id_tracker.delete_points(
+            points
+                .iter()
+                .map(|(point_id, _internal_id)| *point_id)
+                .filter(|point_id| !stored_ids.contains(point_id)),
+        )
     }
 }

--- a/lib/segment/src/segment/update_only/appendable/mod.rs
+++ b/lib/segment/src/segment/update_only/appendable/mod.rs
@@ -3,7 +3,6 @@
 
 use std::path::{Path, PathBuf};
 
-use ahash::AHashSet;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::UniversalAppend;
@@ -32,10 +31,6 @@ pub struct AppendableSegment<S: UniversalAppend + 'static> {
     /// [`store_points`](Self::store_points). A batch that only deletes writes
     /// nothing but the mappings log, so it never pays for these opens.
     store: Option<StoreComponents<S>>,
-    /// External ids this writer has stored, so that
-    /// [`tombstone_points`](Self::tombstone_points) never retires a point this
-    /// very batch wrote.
-    stored_ids: AHashSet<PointIdType>,
 }
 
 /// Everywhere a stored point's data goes. The mappings log that publishes the
@@ -107,7 +102,6 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
             segment_path: segment_path.to_path_buf(),
             config: config.clone(),
             store: None,
-            stored_ids: AHashSet::new(),
         })
     }
 
@@ -191,8 +185,6 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
         let versions: Vec<SeqNumberType> = points.iter().map(|point| point.version).collect();
         self.id_tracker.set_internal_versions(&slots, &versions)?;
 
-        self.stored_ids.extend(points.iter().map(|point| point.id));
-
         Ok(())
     }
 
@@ -200,20 +192,15 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
     /// they occupy play no part here, since a retired mapping is what makes a
     /// point unreachable. The data on those slots is left where it is.
     ///
-    /// A point this writer has stored is skipped rather than retired: its new
-    /// mapping already supersedes every old slot, and a delete recorded on top
-    /// would take the new slot with it. The caller can hand over every slot a
-    /// stored point used to occupy without holding that rule itself.
+    /// Only call this for points the batch *deletes*. A point the batch stores
+    /// again needs no retirement — its new mapping supersedes the old slot —
+    /// and asking for one here retires the point outright: a delete addresses
+    /// the external id, so it takes the fresh slot along with the stale one.
     pub fn tombstone_points(
         &mut self,
         points: &[(PointIdType, PointOffsetType)],
     ) -> OperationResult<()> {
-        let stored_ids = &self.stored_ids;
-        self.id_tracker.delete_points(
-            points
-                .iter()
-                .map(|(point_id, _internal_id)| *point_id)
-                .filter(|point_id| !stored_ids.contains(point_id)),
-        )
+        self.id_tracker
+            .delete_points(points.iter().map(|(point_id, _internal_id)| *point_id))
     }
 }

--- a/lib/segment/src/segment/update_only/appendable/mod.rs
+++ b/lib/segment/src/segment/update_only/appendable/mod.rs
@@ -1,6 +1,8 @@
 //! The write phase for the appendable segment: the one segment of a shard a
 //! batch appends its points to.
 
+use std::borrow::Cow;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -8,15 +10,23 @@ use common::types::PointOffsetType;
 use common::universal_io::UniversalAppend;
 
 use super::AppendableIdTrackerState;
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::fully_qualified_point::FullyQualifiedPoint;
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::data_types::vectors::{
+    VectorElementType, VectorElementTypeByte, VectorElementTypeHalf, VectorRef,
+};
 use crate::id_tracker::mutable_id_tracker::update_only::{
     MappingOperation, UpdateOnlyAppendableIdTracker,
 };
 use crate::index::struct_payload_index::update_only::UpdateOnlyStructPayloadIndex;
 use crate::payload_storage::update_only::UpdateOnlyPayloadStorage;
 use crate::segment_constructor::get_vector_storage_path;
-use crate::types::{PointIdType, SegmentConfig, SeqNumberType, VectorNameBuf};
+use crate::types::{
+    Distance, PointIdType, QuantizationConfig, SegmentConfig, SeqNumberType, VectorNameBuf,
+    VectorStorageDatatype,
+};
+use crate::vector_storage::quantized::update_only::UpdateOnlyQuantizedVectors;
 use crate::vector_storage::update_only::{UpdateOnlyVectorStorage, VectorToStore};
 
 /// A segment open for appends: the write target. Every point a batch stores
@@ -41,6 +51,13 @@ struct StoreComponents<S: UniversalAppend + 'static> {
     payload_indexes: UpdateOnlyStructPayloadIndex<S>,
     /// One writer per named vector, dense and sparse alike.
     vector_storages: Vec<(VectorNameBuf, UpdateOnlyVectorStorage<S>)>,
+    /// Quantized overlays, keyed by vector name — only for dense, non-multivector vectors
+    /// whose quantization method supports incremental appends (Binary/Turbo — see
+    /// `QuantizationConfig::supports_appendable`). A vector name with no entry here simply
+    /// has no live quantization (never configured, an unsupported method, or a multivector —
+    /// that support is a follow-up, needing its own append-only offsets storage): it stays
+    /// searchable exactly, through the raw storage alone, same as before this existed.
+    quantized_vectors: HashMap<VectorNameBuf, UpdateOnlyQuantizedVectors<S>>,
 }
 
 impl<S: UniversalAppend + 'static> StoreComponents<S> {
@@ -50,10 +67,22 @@ impl<S: UniversalAppend + 'static> StoreComponents<S> {
 
         let mut vector_storages =
             Vec::with_capacity(config.vector_data.len() + config.sparse_vector_data.len());
+        let mut quantized_vectors = HashMap::new();
         for (vector_name, vector_config) in &config.vector_data {
             let path = get_vector_storage_path(segment_path, vector_name);
             let storage = UpdateOnlyVectorStorage::open(fs.clone(), &path, vector_config)?;
             vector_storages.push((vector_name.clone(), storage));
+
+            // Turbo4-datatype vectors already store a compressed representation as their raw
+            // format; a `QuantizationConfig` overlay on top of that is not a combination the
+            // non-update-only path supports either, so it is out of scope here too.
+            let is_turbo4_datatype = vector_config.datatype == Some(VectorStorageDatatype::Turbo4);
+            if vector_config.multivector_config.is_none() && !is_turbo4_datatype {
+                let quantized = UpdateOnlyQuantizedVectors::open(fs.clone(), &path)?;
+                if let Some(quantized) = quantized {
+                    quantized_vectors.insert(vector_name.clone(), quantized);
+                }
+            }
         }
         for vector_name in config.sparse_vector_data.keys() {
             let path = get_vector_storage_path(segment_path, vector_name);
@@ -65,7 +94,55 @@ impl<S: UniversalAppend + 'static> StoreComponents<S> {
             payload_storage,
             payload_indexes,
             vector_storages,
+            quantized_vectors,
         })
+    }
+}
+
+/// Reconstruct the `f32` form of a vector stored as raw, storage-native bytes — carried over
+/// from a point's previous slot rather than freshly decoded — so it can be pushed through a
+/// quantized overlay the same way a freshly decoded vector is. Mirrors
+/// `QuantizedVectors::create_impl`'s use of `PrimitiveVectorElement::quantization_preprocess`
+/// for the same purpose on the non-update-only path.
+fn decode_raw_dense_vector(
+    datatype: VectorStorageDatatype,
+    quantization_config: &QuantizationConfig,
+    distance: Distance,
+    bytes: &[u8],
+) -> Vec<VectorElementType> {
+    match datatype {
+        VectorStorageDatatype::Float32 => {
+            let vector: &[VectorElementType] = bytemuck::cast_slice(bytes);
+            VectorElementType::quantization_preprocess(
+                quantization_config,
+                distance,
+                Cow::Borrowed(vector),
+            )
+            .into_owned()
+        }
+        VectorStorageDatatype::Uint8 => {
+            let vector: &[VectorElementTypeByte] = bytemuck::cast_slice(bytes);
+            VectorElementTypeByte::quantization_preprocess(
+                quantization_config,
+                distance,
+                Cow::Borrowed(vector),
+            )
+            .into_owned()
+        }
+        VectorStorageDatatype::Float16 => {
+            let vector: &[VectorElementTypeHalf] = bytemuck::cast_slice(bytes);
+            VectorElementTypeHalf::quantization_preprocess(
+                quantization_config,
+                distance,
+                Cow::Borrowed(vector),
+            )
+            .into_owned()
+        }
+        VectorStorageDatatype::Turbo4 => {
+            unreachable!(
+                "a Turbo4-datatype vector never has a quantized overlay open, see StoreComponents::open"
+            )
+        }
     }
 }
 
@@ -143,6 +220,21 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
         let inserted = self.id_tracker.insert_operations(&operations)?;
         let (_, start_slot) = *inserted.first().expect("one slot per insert");
 
+        // Distance/datatype per named vector, needed to decode a `VectorToStore::Raw` blob back
+        // to `f32` for its quantized overlay. Captured before `store_components()` borrows
+        // `self` mutably — `self.config` and `self.store` cannot both be borrowed through it.
+        let vector_metadata: HashMap<VectorNameBuf, (Distance, VectorStorageDatatype)> = self
+            .config
+            .vector_data
+            .iter()
+            .map(|(name, cfg)| {
+                (
+                    name.clone(),
+                    (cfg.distance, cfg.datatype.unwrap_or_default()),
+                )
+            })
+            .collect();
+
         let store = self.store_components()?;
 
         // Each named vector, from whichever half of the point holds it: the
@@ -164,6 +256,43 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
                 }
             });
             storage.append_many(start_slot, vectors, hw_counter)?;
+
+            // The quantized overlay, if this vector has one, must keep its row count in exact
+            // lockstep with the raw storage above: every point takes a row here too — a
+            // decoded/carried-over vector encoded for real, a missing one as an all-zero
+            // placeholder — so row `k` always means the same point in both. Skipping a row for
+            // a `Raw`/`Missing` point here would silently misalign every later lookup, scoring
+            // one point's vector against another's quantized copy.
+            if let Some(quantized) = store.quantized_vectors.get_mut(vector_name) {
+                let quantization_config = quantized.quantization_config().clone();
+                let &(distance, datatype) = vector_metadata.get(vector_name).expect(
+                    "a quantized overlay only exists for a name present in config.vector_data",
+                );
+                for (offset, point) in points.iter().enumerate() {
+                    let id = start_slot + offset as PointOffsetType;
+                    if let Some(vector) = point.updated_vectors.get(vector_name) {
+                        let VectorRef::Dense(dense) = vector else {
+                            return Err(OperationError::WrongMulti);
+                        };
+                        quantized.upsert_vector(id, VectorRef::Dense(dense), hw_counter)?;
+                    } else if let Some((_, bytes)) = point
+                        .stored_vectors
+                        .iter()
+                        .find(|(name, _)| name == vector_name)
+                    {
+                        let decoded = decode_raw_dense_vector(
+                            datatype,
+                            &quantization_config,
+                            distance,
+                            bytes,
+                        );
+                        quantized.upsert_vector(id, VectorRef::Dense(&decoded), hw_counter)?;
+                    } else {
+                        let placeholder = vec![0.0 as VectorElementType; quantized.dim()];
+                        quantized.upsert_vector(id, VectorRef::Dense(&placeholder), hw_counter)?;
+                    }
+                }
+            }
         }
 
         let slot_payloads = || {

--- a/lib/segment/src/segment/update_only/segment_enum.rs
+++ b/lib/segment/src/segment/update_only/segment_enum.rs
@@ -8,12 +8,12 @@ use common::universal_io::{UniversalAppend, UniversalWrite};
 
 use super::{AppendableIdTrackerState, AppendableSegment, DeleteOnlySegment};
 use crate::common::operation_error::OperationResult;
-use crate::types::PointIdType;
+use crate::types::{PointIdType, SegmentConfig};
 
 /// A segment opened for writing: appendable, or accepting deletes only.
 pub enum UpdateOnlySegmentEnum<S: UniversalAppend + UniversalWrite + 'static> {
     DeleteOnly(DeleteOnlySegment<S>),
-    Appendable(AppendableSegment<S>),
+    Appendable(Box<AppendableSegment<S>>),
 }
 
 impl<S: UniversalAppend + UniversalWrite + 'static> UpdateOnlySegmentEnum<S> {
@@ -23,12 +23,16 @@ impl<S: UniversalAppend + UniversalWrite + 'static> UpdateOnlySegmentEnum<S> {
     pub fn open(
         fs: &S::Fs,
         segment_path: &Path,
+        config: &SegmentConfig,
         id_tracker_state: Option<AppendableIdTrackerState>,
     ) -> OperationResult<Self> {
         Ok(match id_tracker_state {
-            Some(state) => {
-                Self::Appendable(AppendableSegment::open(fs.clone(), segment_path, state)?)
-            }
+            Some(state) => Self::Appendable(Box::new(AppendableSegment::open(
+                fs.clone(),
+                segment_path,
+                config,
+                state,
+            )?)),
             None => Self::DeleteOnly(DeleteOnlySegment::open(fs.clone(), segment_path)),
         })
     }

--- a/lib/segment/src/vector_storage/quantized/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/update_only/mod.rs
@@ -32,10 +32,6 @@
 //! [`EncodedStorage`]: quantization::EncodedStorage
 //! [`EncodedStorageWrite`]: quantization::EncodedStorageWrite
 
-// Not wired into a segment yet — that lands in a later PR in this stack, so nothing outside
-// this module's own tests constructs `UpdateOnlyQuantizedVectors` today.
-#![expect(dead_code)]
-
 #[cfg(test)]
 mod tests;
 
@@ -47,7 +43,6 @@ use common::universal_io::{UniversalAppend, UniversalReadFileOps as _, read_json
 use quantization::encoded_vectors_binary::EncodedVectorsBin;
 use quantization::encoded_vectors_tq::EncodedVectorsTQ;
 
-use crate::common::Flusher;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::vectors::VectorRef;
 use crate::types::QuantizationConfig;
@@ -68,6 +63,7 @@ enum UpdateOnlyQuantizedVectorStorage<S: UniversalAppend + 'static> {
 /// [`UpdateOnlyDenseVectorStorage`]: crate::vector_storage::dense::update_only::UpdateOnlyDenseVectorStorage
 pub struct UpdateOnlyQuantizedVectors<S: UniversalAppend + 'static> {
     storage: UpdateOnlyQuantizedVectorStorage<S>,
+    config: QuantizedVectorsConfig,
 }
 
 impl<S: UniversalAppend + 'static> UpdateOnlyQuantizedVectors<S> {
@@ -133,7 +129,22 @@ impl<S: UniversalAppend + 'static> UpdateOnlyQuantizedVectors<S> {
             }
         };
 
-        Ok(Self { storage })
+        Ok(Self { storage, config })
+    }
+
+    /// The quantization method actually persisted for this overlay — the source of truth for a
+    /// caller deciding how to reconstruct an `f32` vector from storage-native bytes carried over
+    /// from a point's previous slot, since a reopened overlay's config is read from disk, not
+    /// necessarily identical to whatever live config the caller has to hand.
+    pub fn quantization_config(&self) -> &QuantizationConfig {
+        &self.config.quantization_config
+    }
+
+    /// The dimensionality of the (dense, unrotated) vector this overlay quantizes — the length
+    /// a caller must give [`Self::upsert_vector`], including for a placeholder vector standing
+    /// in for a point with no vector under this name.
+    pub fn dim(&self) -> usize {
+        self.config.vector_parameters.dim
     }
 
     /// Encode and persist `vector` for `id`. `id` must be the current end of the overlay: like
@@ -155,13 +166,5 @@ impl<S: UniversalAppend + 'static> UpdateOnlyQuantizedVectors<S> {
                 Ok(q.upsert_vector(id, vector, hw_counter)?)
             }
         }
-    }
-
-    pub fn flusher(&self) -> Flusher {
-        let flusher = match &self.storage {
-            UpdateOnlyQuantizedVectorStorage::Binary(q) => q.flusher(),
-            UpdateOnlyQuantizedVectorStorage::Turbo(q) => q.flusher(),
-        };
-        Box::new(move || flusher().map_err(OperationError::from))
     }
 }

--- a/lib/segment/src/vector_storage/quantized/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/quantized/update_only/tests.rs
@@ -160,7 +160,10 @@ fn create_empty_overlay(
         .atomic_save(&QuantizedVectors::get_config_path(path), &bytes)
         .unwrap();
 
-    UpdateOnlyQuantizedVectors { storage }
+    UpdateOnlyQuantizedVectors {
+        storage,
+        config: overlay_config,
+    }
 }
 
 /// First writer: created fresh (as whatever builds a new segment would), writes half the batch,


### PR DESCRIPTION
Top of the stack: #10146 → #10147 → #10150 → #10151 → #10161 → this. Review those first; this PR's diff against its base is 4 commits (the fourth wires in #10161's quantized overlay).

`AppendableSegment::store_points` sheds its `todo!()` — the update-only segment now stores points for real, and the edge writer's upsert path runs the whole way through.

## The write order is the crash contract

1. **Claim**: the id tracker records one `Insert` per point, handing out consecutive fresh slots. Durable immediately, invisible to readers.
2. **Write**: every component puts its data at those slots — each named vector storage (dense, sparse, whatever the config declares), the payload storage, the payload indexes. Each is durable when its `append_many` returns.
3. **Publish**: `set_internal_versions` covers the slots — the one step that makes the points visible.

A crash anywhere in between leaves claimed, unpublished slots; the next writer to open the segment retires them (`retire_pending_inserts`). Nothing needs undoing, because nothing partial was ever visible.

Each vector comes from whichever half of `FullyQualifiedPoint` holds it: the batch's decoded vectors win over the storage-native bytes carried from the point's previous slot, and a name in neither still takes its slot as a vector the point does not have.

## Store components open lazily

Opened on the first `store_points`, not at segment open. Two reasons:

- A batch that only deletes writes nothing but the mappings log — it shouldn't pay for opening N storages (on a remote backend, N sets of round trips).
- Today's leaders create payload storages in **mutable** (Gridstore) mode, which the append-only writers refuse. Lazy opening keeps delete-only batches working against every segment that exists today; the pre-existing edge delete tests pass unchanged.

## `tombstone_points` states its contract instead of guarding it

Only points the batch *deletes* go through it: a delete addresses the external id, so asking to retire a stored point's stale slot would take its fresh slot along with it. The caller in `apply_batch` already follows this (and must know it regardless — `preview` mirrors the same rule to count outcomes), so the writer carries no hidden stored-ids state; an earlier revision had one and it was removed as redundant.

`UpdateOnlySegmentEnum::open` now takes `&SegmentConfig`, which is where the writer learns which vector storages exist.

## End-to-end tests

Three new edge tests drive the full pipeline — located and resolved through the `LookupSegment`s, appended by the writer, verified through an ordinary follower:

- **store**: a new point with a payload plus a rewrite of an existing point with a changed vector; follower sees 11 points, the rewrite's new vector wins, the payload round-trips, the nine untouched points are byte-for-byte intact.
- **replay**: a fresh writer re-applying the same batch skips every point — which only works if the published versions round-trip through the read side.
- **resume**: a second writer stores and deletes through every component where the first left off.

One honest hack, marked as such: the leader writes its payload storage in mutable mode, so the tests recreate it empty in append-only mode (the fixture points carry no payloads — nothing is lost). It stands in for creating segments with append-only components from the start, which nothing does yet — that creation wiring is the next gap, not this PR's.

`-p segment --lib` 1028 passed, `-p edge --lib` 59 passed, workspace clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

