### PR TITLE
fix: use exact index count for numeric range cardinality estimation

### DIFF
--- a/lib/segment/src/index/field_index/numeric_index/query.rs
+++ b/lib/segment/src/index/field_index/numeric_index/query.rs
@@ -36,10 +36,17 @@ use crate::types::{
     RangeInterface, UuidIntType, ValueVariants,
 };
 
-/// Histogram-driven cardinality estimation for a range condition.
+/// Cardinality estimation for a range condition.
+///
+/// Counts the `(value, point)` pairs in the range directly from the index
+/// (an `O(log n)` boundary search on the immutable / mmap variants) instead
+/// of extrapolating from the histogram. A single-value-per-point field gets
+/// an exact count; a multi-value field gets the histogram-independent
+/// estimate from [`estimate_multi_value_selection_cardinality`].
 pub(super) fn range_cardinality<T, I>(
     index: &I,
     range: &RangeInterface,
+    hw_counter: &HardwareCounterCell,
 ) -> OperationResult<CardinalityEstimation>
 where
     T: Encodable + Numericable + StoredValue + Send + Sync + Default,
@@ -57,43 +64,32 @@ where
         }
     };
 
-    let lbound = if let Some(lte) = range.lte {
-        Included(lte)
-    } else if let Some(lt) = range.lt {
-        Excluded(lt)
-    } else {
-        Unbounded
-    };
+    let (start_bound, end_bound) = range.as_index_key_bounds();
 
-    let gbound = if let Some(gte) = range.gte {
-        Included(gte)
-    } else if let Some(gt) = range.gt {
-        Excluded(gt)
-    } else {
-        Unbounded
-    };
-
-    let histogram_estimation = index.get_histogram().estimate(gbound, lbound);
-    let min_estimation = histogram_estimation.0;
-    let max_estimation = histogram_estimation.2;
+    // `map.range` panics when the start bound is greater than the end bound;
+    // an inverted range matches no points.
+    if !check_boundaries(&start_bound, &end_bound) {
+        return Ok(CardinalityEstimation::exact(0));
+    }
 
     let total_values = index.total_unique_values_count()?;
-    // Note: max_values_per_point is never zero here because we check it above
-    let expected_min = max(
-        min_estimation / max_values_per_point,
-        max(
-            min(1, min_estimation),
-            min_estimation.saturating_sub(total_values - index.get_points_count()),
-        ),
-    );
-    let expected_max = min(index.get_points_count(), max_estimation);
 
-    let estimation = estimate_multi_value_selection_cardinality(
-        index.get_points_count(),
-        total_values,
-        histogram_estimation.1,
-    )
-    .round() as usize;
+    hw_counter
+        .payload_index_io_read_counter()
+        // Two binary searches (lower and upper bound) in mmap and immutable storage.
+        .incr_delta(2 * ((total_values as f32).log2().ceil() as usize));
+
+    let range_size = index.values_range_size(start_bound, end_bound, hw_counter)?;
+    let points_count = index.get_points_count();
+
+    // At least `ceil(range_size / max_values_per_point)` distinct points are
+    // needed to cover the matched pairs, at most one point per pair.
+    let expected_min = range_size.div_ceil(max_values_per_point);
+    let expected_max = min(range_size, points_count);
+
+    let estimation =
+        estimate_multi_value_selection_cardinality(points_count, total_values, range_size).round()
+            as usize;
 
     Ok(CardinalityEstimation {
         primary_clauses: vec![],
@@ -212,7 +208,7 @@ where
         .range
         .as_ref()
         .map(|range| {
-            let mut cardinality = range_cardinality(index, range)?;
+            let mut cardinality = range_cardinality(index, range, hw_counter)?;
             cardinality
                 .primary_clauses
                 .push(PrimaryCondition::Condition(Box::new(condition.clone())));
@@ -233,6 +229,7 @@ where
     I: NumericIndexRead<T>,
 {
     let collect_blocks = || -> OperationResult<Vec<PayloadBlockCondition>> {
+        let hw_counter = HardwareCounterCell::new();
         let mut lower_bound = Unbounded;
         let mut pre_lower_bound: Option<Bound<T>> = None;
         let mut payload_conditions = Vec::new();
@@ -265,7 +262,8 @@ where
                         Excluded(_) | Unbounded => None,
                     },
                 };
-                let cardinality = range_cardinality(index, &RangeInterface::Float(range))?;
+                let cardinality =
+                    range_cardinality(index, &RangeInterface::Float(range), &hw_counter)?;
                 let condition = PayloadBlockCondition {
                     condition: FieldCondition::new_range(key.clone(), range),
                     cardinality: cardinality.exp,

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -160,8 +160,12 @@ fn cardinality_request(
         lte: query.lte.map(OrderedFloat::from),
     };
 
-    let estimation =
-        query::range_cardinality(index.inner(), &RangeInterface::Float(ordered_range)).unwrap();
+    let estimation = query::range_cardinality(
+        index.inner(),
+        &RangeInterface::Float(ordered_range),
+        &hw_counter,
+    )
+    .unwrap();
 
     let result = index
         .inner()
@@ -276,6 +280,72 @@ fn test_cardinality_exp(#[case] index_type: IndexType) {
         },
         HwMeasurementAcc::new(),
     );
+}
+
+/// Regression test for #10124: `count exact=false` on a numeric `range`
+/// filter must not extrapolate from the histogram. On a single-value field
+/// the estimator has to be exact, including for clustered value
+/// distributions where the histogram's uniform-in-bucket interpolation is
+/// systematically wrong.
+#[rstest]
+#[case(IndexType::MutableGridstore)]
+#[case(IndexType::Mmap)]
+#[case(IndexType::RamMmap)]
+fn test_range_cardinality_single_value_exact(#[case] index_type: IndexType) {
+    let mut rng = StdRng::seed_from_u64(7);
+    let (_temp_dir, mut builder) = get_index_builder(index_type);
+    let hw_counter = HardwareCounterCell::new();
+
+    // Values clustered in two narrow bands far apart. The histogram's linear
+    // interpolation inside each bucket is badly wrong for such a
+    // distribution, so the exact index count is the only reliable answer.
+    for i in 0..1000 {
+        let value = if rng.random_bool(0.5) {
+            10i64 + i64::from(rng.random_range(0..10)) // band [10, 20)
+        } else {
+            500i64 + i64::from(rng.random_range(0..10)) // band [500, 510)
+        };
+        builder
+            .add_point(i as PointOffsetType, &[&Value::from(value)], &hw_counter)
+            .unwrap();
+    }
+    let index = builder.finalize().unwrap();
+
+    let cases = [
+        (10.0, 20.0),
+        (500.0, 510.0),
+        (0.0, 30.0),
+        (490.0, 520.0),
+        (0.0, 1000.0),
+        (100.0, 400.0), // empty range in the gap between the bands
+    ];
+    for (gte, lt) in cases {
+        let range = Range {
+            lt: Some(OrderedFloat(lt)),
+            gt: None,
+            gte: Some(OrderedFloat(gte)),
+            lte: None,
+        };
+        let estimation =
+            query::range_cardinality(index.inner(), &RangeInterface::Float(range), &hw_counter)
+                .unwrap();
+        let exact = index
+            .inner()
+            .filter(
+                &FieldCondition::new_range(JsonPath::new("unused"), range),
+                &hw_counter,
+            )
+            .unwrap()
+            .unwrap()
+            .count();
+
+        assert_eq!(
+            estimation.exp, exact,
+            "range [{gte}, {lt}) estimate must match the exact filtered count"
+        );
+        assert_eq!(estimation.min, exact, "range [{gte}, {lt}) min");
+        assert_eq!(estimation.max, exact, "range [{gte}, {lt}) max");
+    }
 }
 
 #[rstest]
@@ -1071,9 +1141,12 @@ fn test_block_index_fallback_equivalence() {
         queries
             .iter()
             .map(|query| {
-                let estimation =
-                    query::range_cardinality(index.inner(), &RangeInterface::Float(*query))
-                        .unwrap();
+                let estimation = query::range_cardinality(
+                    index.inner(),
+                    &RangeInterface::Float(*query),
+                    &hw_counter,
+                )
+                .unwrap();
                 let points = index
                     .inner()
                     .filter(


### PR DESCRIPTION
### Problem

`POST /collections/{c}/points/count` with `exact=false` on an `integer` or `datetime` indexed field filtered by `range` returns counts that are wrong by a bidirectional 5-10% at steady state (after indexing completes). `exact=true` always returns the correct count.

Root cause: `range_cardinality` in `lib/segment/src/index/field_index/numeric_index/query.rs` extrapolates the number of matching values from the histogram, assuming values are spread uniformly inside each histogram bucket. With clustered value distributions that assumption is systematically wrong, so the estimate is biased in either direction depending on which bins the query range falls into. The histogram interpolation cannot be fixed reliably by recalibrating bin sizes, because the error depends on the actual data distribution inside each bucket.

### Solution

Count the `(value, point)` pairs in the requested range directly from the index via `NumericIndexRead::values_range_size`. On the immutable and mmap variants this is an `O(log n)` boundary search; the mutable variant falls back to the trait default that counts the range iterator. The exact value count is then converted to a point count with the existing `estimate_multi_value_selection_cardinality`:

- single-value-per-point fields (the common case, and the one in the report) get an exact count;
- multi-value fields get an unbiased estimate instead of the histogram's biased one.

The histogram is no longer consulted for range cardinality. It stays for payload-block generation (`get_range_by_size`) and telemetry.

Changes:

- `lib/segment/src/index/field_index/numeric_index/query.rs`
  - `range_cardinality` now takes a `hw_counter` and counts via `values_range_size`, with the same two-binary-search IO accounting as `estimate_points`.
  - An inverted (empty) range now short-circuits to an exact zero through `check_boundaries`, mirroring `filter`, instead of relying on the histogram.
  - `min`/`max` bounds are now tight: at least `range_size / max_values_per_point` distinct points, at most `min(range_size, points_count)`.
- `lib/segment/src/index/field_index/numeric_index/tests.rs`
  - New regression test `test_range_cardinality_single_value_exact`: feeds a clustered two-band distribution (the exact shape that makes the histogram's uniform-in-bucket interpolation wrong, reproducing the report's error pattern) and asserts `min == exp == max` equals the exact filtered count for several ranges across all three index variants (`MutableGridstore`, `Mmap`, `RamMmap`).

### Validation

- `cargo check -p segment --tests`
- `test_range_cardinality_single_value_exact`, `test_cardinality_exp`, `test_payload_blocks`, `test_block_index_fallback_equivalence` and the rest of the numeric-index test module pass for all index variants.

Fixes #10124

---

### AI disclosure (per docs/CONTRIBUTING.md)

This PR was developed with the assistance of an AI coding agent. The change and its regression test are:

- [AI] fix: use exact index count for numeric range cardinality estimation
- [manual] PR validation and final review

Initial prompt used: "Fix qdrant #10124: make `count exact=false` for numeric/datetime `range` filters return accurate counts at steady state by routing range-conditional cardinality through the numeric index's exact value count (`values_range_size`) instead of the histogram estimator, and add a regression test that reproduces the reported bias."
