### PR TITLE
fix: count explicit null payload value as one value in values_count filters

### DIFF
--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -479,6 +479,55 @@ mod tests {
     }
 
     #[test]
+    fn test_value_count_explicit_null_is_one_value() {
+        // An explicit JSON `null` is a stored, non-array value. According to
+        // the documented contract for `values_count` ("if stored value is not
+        // an array, the amount of values is assumed to be 1") it must count
+        // as a single value, not as zero. Regression for
+        // https://github.com/qdrant/qdrant/issues/10113.
+        let key = JsonPath::new("state");
+
+        let field_condition = |values_count: ValuesCount| FieldCondition {
+            r#match: None,
+            range: None,
+            geo_radius: None,
+            geo_bounding_box: None,
+            geo_polygon: None,
+            values_count: Some(values_count),
+            key: key.clone(),
+            is_empty: None,
+            is_null: None,
+        };
+
+        let gte_one = field_condition(ValuesCount {
+            lt: None,
+            gt: None,
+            gte: Some(1),
+            lte: None,
+        });
+        // Explicit `null` has one value, so `gte: 1` must match.
+        assert!(gte_one.check(&json!(null)));
+
+        let lt_one = field_condition(ValuesCount {
+            lt: Some(1),
+            gt: None,
+            gte: None,
+            lte: None,
+        });
+        // One value is not `< 1`, so `lt: 1` must not match.
+        assert!(!lt_one.check(&json!(null)));
+
+        let gte_two = field_condition(ValuesCount {
+            lt: None,
+            gt: None,
+            gte: Some(2),
+            lte: None,
+        });
+        // One value is not `>= 2`, so `gte: 2` must not match.
+        assert!(!gte_two.check(&json!(null)));
+    }
+
+    #[test]
     fn test_value_checker_for_null_or_empty() {
         let array = json!([]);
         let array_with_null = json!([null]);

--- a/lib/segment/src/payload_storage/query_checker.rs
+++ b/lib/segment/src/payload_storage/query_checker.rs
@@ -500,6 +500,57 @@ mod tests {
             )));
         assert!(payload_checker.check(0, &few_value_count_condition));
 
+        // An explicit `null` is a stored, non-array value, so it counts as one
+        // value. Regression for https://github.com/qdrant/qdrant/issues/10113.
+        let null_field_has_one_value =
+            Filter::new_must(Condition::Field(FieldCondition::new_values_count(
+                JsonPath::new("packaging"),
+                ValuesCount {
+                    lt: None,
+                    gt: None,
+                    gte: Some(1),
+                    lte: None,
+                },
+            )));
+        assert!(payload_checker.check(0, &null_field_has_one_value));
+
+        let null_field_has_lt_one_value =
+            Filter::new_must(Condition::Field(FieldCondition::new_values_count(
+                JsonPath::new("packaging"),
+                ValuesCount {
+                    lt: Some(1),
+                    gt: None,
+                    gte: None,
+                    lte: None,
+                },
+            )));
+        assert!(!payload_checker.check(0, &null_field_has_lt_one_value));
+
+        // A genuinely missing field must still count as zero values.
+        let missing_field_has_lt_one_value =
+            Filter::new_must(Condition::Field(FieldCondition::new_values_count(
+                JsonPath::new("something_new"),
+                ValuesCount {
+                    lt: Some(1),
+                    gt: None,
+                    gte: None,
+                    lte: None,
+                },
+            )));
+        assert!(payload_checker.check(0, &missing_field_has_lt_one_value));
+
+        let missing_field_has_one_value =
+            Filter::new_must(Condition::Field(FieldCondition::new_values_count(
+                JsonPath::new("something_new"),
+                ValuesCount {
+                    lt: None,
+                    gt: None,
+                    gte: Some(1),
+                    lte: None,
+                },
+            )));
+        assert!(!payload_checker.check(0, &missing_field_has_one_value));
+
         let in_berlin = Condition::Field(FieldCondition::new_geo_bounding_box(
             JsonPath::new("location"),
             GeoBoundingBox {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -3392,7 +3392,12 @@ impl ValuesCount {
 
     pub fn check_count_from(&self, value: &Value) -> bool {
         let count = match value {
-            Value::Null => 0,
+            // An explicit `null` is a stored, non-array value. It must be
+            // counted as a single value, consistent with the documented rule
+            // "if stored value is not an array, the amount of values is
+            // assumed to be 1". A *missing* field is handled separately via
+            // `check_empty` -> `check_count(0)`.
+            Value::Null => 1,
             Value::Array(array) => array.len(),
             Value::Bool(_) | Value::Number(_) | Value::String(_) | Value::Object(_) => 1,
         };


### PR DESCRIPTION
### Problem

`values_count` filters miscount an explicit JSON `null`. When a payload field
exists with the value `null` (e.g. `{"state": null}`), a `values_count` with
`gte: 1` excludes the point, treating the field as having **zero** values.
A missing field and a field explicitly storing `null` are different states:
the `is_null` condition already distinguishes them end-to-end.

This contradicts the documented `values_count` contract: "if stored value is
not an array, the amount of values is assumed to be 1". An explicit `null` is
a stored, non-array value, so it should count as one value. Note the
inconsistency is scalar-only: `[null]` (an array containing null) already
counts as one value via the array length.

### Root cause

`ValuesCount::check_count_from` in `lib/segment/src/types.rs` mapped
`Value::Null => 0`. A genuinely missing field is handled separately by
`check_field_condition` via `check_empty() -> check_count(0)`, so treating an
explicit `null` as `1` does not change missing-field semantics (those remain
covered by the existing `test_value_count_missing_field` regression for
qdrant/qdrant#9586).

### Changes

- `lib/segment/src/types.rs`: `Value::Null => 1` in `check_count_from`, with a
  comment explaining the stored-value semantics.
- `lib/segment/src/payload_storage/condition_checker.rs`: new unit test
  `test_value_count_explicit_null_is_one_value` (`gte: 1` matches,
  `lt: 1` / `gte: 2` don't).
- `lib/segment/src/payload_storage/query_checker.rs`: end-to-end assertions
  through `SimpleConditionChecker` + real in-memory payload storage:
  - explicit `null` field satisfies `gte: 1` and fails `lt: 1`;
  - a genuinely missing field still satisfies `lt: 1` and fails `gte: 1`.

### Validation

- `cargo test -p segment --lib payload_storage::` — all pass, including the
  pre-existing `test_value_count_missing_field` and
  `test_value_checker_for_null_or_empty`.

### Consistency note

`is_empty` currently treats an explicit `null` as empty (`Value::Null =>
is_empty` in `check_is_empty`). This change does not touch that path; it only
aligns `values_count` with its own documented contract. If maintainers would
prefer `null` to mean "no value" uniformly (i.e. keep `values_count` at 0 and
change `is_empty` docs/behavior instead), happy to rework — but as filed, the
`values_count` documentation explicitly promises "if stored value is not an
array, the amount of values is assumed to be 1", and an explicit `null` is a
stored, non-array value.

Fixes #10113

---

### AI disclosure (per docs/CONTRIBUTING.md)

This PR was developed with the assistance of an AI coding agent. The change
and its regression tests are:

- [AI] fix: count an explicit `null` payload value as one value in
  `values_count` filters
- [manual] PR validation and final review

Initial prompt used: "Fix qdrant #10113: `values_count` treats an explicit
JSON `null` as zero values, but a stored non-array value should count as 1 per
the documented contract; missing fields must still count as 0."
