### PR TITLE
Move deferred iter into PointMappings and don't walk over visible points

### DIFF
--- a/lib/segment/src/id_tracker/id_tracker_base/point_mappings_ref.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/point_mappings_ref.rs
@@ -96,6 +96,15 @@ impl<'a, S: UniversalRead> PointMappingsRefEnum<'a, S> {
         }
     }
 
+    /// Iterate over the internal IDs at or above the mapping's deferred
+    /// threshold, excluding soft-deleted points — the tail complement of
+    /// [`Self::iter_internal_visible`]. Empty when the mapping has no deferred threshold.
+    pub fn iter_deferred(self) -> impl Iterator<Item = PointOffsetType> + 'a {
+        let (total, deleted) = self.internal_scan_masks();
+        let start = self.deferred_internal_id().unwrap_or(total);
+        (start..total).filter(move |&id| !deleted.get_bit(id as usize).unwrap_or(false))
+    }
+
     /// Iterate over all internal IDs, with deferred filtering selected by
     /// `deferred_behavior`. See [`PointMappings::iter_internal_with_behavior`]
     /// for the per-mode contract.
@@ -181,18 +190,17 @@ impl<'a, S: UniversalRead> PointMappingsRefEnum<'a, S> {
         }
     }
 
-    /// Word-scan form of [`Self::iter_internal`]: it yields an id iff the id
-    /// is below the returned cutoff (the mapping's total point count) and its
-    /// bit is unset in the returned deleted bitslice. Unlike
-    /// [`Self::visible_scan_masks`], no deferred or shadowed-active filtering
-    /// applies.
-    pub fn internal_scan_masks(self) -> (Option<PointOffsetType>, &'a BitSlice) {
+    /// Mask form of [`Self::iter_internal`]: an id is in the iteration iff it
+    /// is below the returned total point count and unset in the deleted
+    /// bitslice. Unlike [`Self::visible_scan_masks`], no deferred or
+    /// shadowed-active filtering applies.
+    pub fn internal_scan_masks(self) -> (PointOffsetType, &'a BitSlice) {
         let total = match self {
             PointMappingsRefEnum::Plain(m) => m.total_point_count(),
             PointMappingsRefEnum::Compressed(m) => m.total_point_count(),
             PointMappingsRefEnum::Disk(m) => m.total_point_count(),
         };
-        (Some(total as PointOffsetType), self.deleted())
+        (total as PointOffsetType, self.deleted())
     }
 
     /// Iterate starting from a given ID, with deferred filtering selected by

--- a/lib/segment/src/id_tracker/point_mappings.rs
+++ b/lib/segment/src/id_tracker/point_mappings.rs
@@ -992,7 +992,6 @@ mod set_link_shadow_tests {
         let r = PointMappingsRefEnum::<common::universal_io::MmapFile>::Plain(&m);
         let (cutoff, mapping_deleted) = r.internal_scan_masks();
 
-        let cutoff = cutoff.expect("internal scan is bounded by the mapping length");
         let from_masks: Vec<PointOffsetType> = (0..cutoff)
             .filter(|&id| !mapping_deleted.get_bit(id as usize).unwrap_or(false))
             .collect();

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
@@ -256,9 +256,10 @@ where
         // Scan candidates by combining the deletion bitmaps word by word
         // instead of feeding `iter_internal()` into `peek_top_iter` — the
         // per-id enumeration dominates unfiltered full scans.
-        let (cutoff, mapping_deleted) = self.id_tracker.point_mappings().internal_scan_masks();
+        let (total_points, mapping_deleted) =
+            self.id_tracker.point_mappings().internal_scan_masks();
         let search_results = batch_filtered_searcher.peek_top_visible(
-            cutoff,
+            Some(total_points),
             mapping_deleted,
             BitSlice::empty(),
             &is_stopped,

--- a/lib/segment/src/segment/read_view/deferred.rs
+++ b/lib/segment/src/segment/read_view/deferred.rs
@@ -51,17 +51,13 @@ where
     }
 
     pub fn deferred_point_ids(&self) -> Vec<PointIdType> {
-        let Some(deferred_from) = self.deferred_internal_id() else {
-            return vec![];
-        };
         if self.deferred_point_count() == 0 {
             return vec![];
         }
 
-        let mappings = self.id_tracker.point_mappings();
-        mappings
-            .iter_internal()
-            .skip_while(|&internal_id| internal_id < deferred_from)
+        self.id_tracker
+            .point_mappings()
+            .iter_deferred()
             .filter_map(|internal_id| self.id_tracker.external_id(internal_id))
             .collect()
     }


### PR DESCRIPTION
Minor code improvement, potentially slightly improving performance.
However, the **main goal is improving on code quality**, not performance.

### The "issue"
```rust
let mappings = self.id_tracker.point_mappings();
mappings
  .iter_internal() // <- Bitmap check for each point, including non deferred which we skip below.
  .skip_while(|&internal_id| internal_id < deferred_from) // **Skips** all the normal points we performed deletion checks for
  .filter_map(|internal_id| self.id_tracker.external_id(internal_id))
  .collect()
```


### The Improvement
The new code doesn't iterate over visible points anymore. Additionally, we don't need to craft the iterator manually since `PointMappingsRefEnum` now provides the iterator.

```rust
pub fn iter_deferred(self) -> impl Iterator<Item = PointOffsetType> + 'a {
    let (total, deleted) = self.internal_scan_masks();
    let start = self.deferred_internal_id().unwrap_or(total);
    (start..total).filter(move |&id| !deleted.get_bit(id as usize).unwrap_or(false)) // <- Skip all visible points and *then* check for deletion.

// [...]

// Original path is much cleaner now
 self.id_tracker
        .point_mappings()
        .iter_deferred()
        // same as above
        .filter_map(|internal_id| self.id_tracker.external_id(internal_id))
        .collect()
}
```

To further improve on code quality, the logic for iterating over deferred points has moved to `PointMappingsRefEnum`.