### PR TITLE
Add edge-tool: CLI for creating, seeding, optimizing, and uploading local edge collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2305,6 +2305,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "edge-tool"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "edge",
+ "env_logger",
+ "fs-err",
+ "futures",
+ "io_bridge_object_store",
+ "log",
+ "object_store",
+ "rand 0.10.2",
+ "segment",
+ "serde_json",
+ "walkdir",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,6 +2310,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "common",
  "edge",
  "env_logger",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -362,6 +362,7 @@ members = [
     "lib/edge/python/codegen",
     "lib/edge/ffi",
     "lib/edge/ffi/bindgen",
+    "lib/edge/tools/edge_tool",
     "lib/edge/tools/shard_query",
     "lib/edge/tools/shard_update",
     "lib/blobstore",

--- a/lib/edge/tools/edge_tool/Cargo.toml
+++ b/lib/edge/tools/edge_tool/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "edge-tool"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "edge-tool"
+path = "src/main.rs"
+
+[dependencies]
+edge = { path = "../.." }
+segment = { path = "../../../segment", default-features = false }
+io_bridge_object_store = { path = "../../../common/io_bridge_object_store" }
+
+anyhow = { workspace = true }
+clap = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+rand = { workspace = true }
+serde_json = { workspace = true }
+fs-err = { workspace = true }
+object_store = { workspace = true }
+futures = { workspace = true }
+walkdir = { workspace = true }

--- a/lib/edge/tools/edge_tool/Cargo.toml
+++ b/lib/edge/tools/edge_tool/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 edge = { path = "../.." }
+common = { path = "../../../common/common" }
 segment = { path = "../../../segment", default-features = false }
 io_bridge_object_store = { path = "../../../common/io_bridge_object_store" }
 

--- a/lib/edge/tools/edge_tool/README.md
+++ b/lib/edge/tools/edge_tool/README.md
@@ -29,9 +29,10 @@ edge-tool create [OPTIONS] <PATH>
   image:512`. Repeatable.
 - `--distance <cosine|euclid|dot|manhattan>` — distance metric for every dense vector (default
   `cosine`).
-- `--sparse` — add a sparse vector named `sparse`.
-- `--sparse-name <NAME>` — add a named sparse vector. Repeatable for multiple sparse vectors;
-  combines with the bare `--sparse` flag.
+- `--sparse` — add a sparse vector. Bare `--sparse` creates one vector named `sparse`;
+  `--sparse=NAME` names it. The `=` is required — `--sparse NAME` (space-separated) is rejected,
+  since it would be ambiguous with the trailing `PATH` positional. Repeatable for multiple sparse
+  vectors.
 - `--quantization <PRESET>` — quantize every dense vector. One of `scalar`, `binary`,
   `product-x4`, `product-x8`, `product-x16`, `product-x32`, `product-x64`, `turbo1`, `turbo1.5`,
   `turbo2`, `turbo4`.

--- a/lib/edge/tools/edge_tool/README.md
+++ b/lib/edge/tools/edge_tool/README.md
@@ -39,6 +39,8 @@ edge-tool create [OPTIONS] <PATH>
 - `--payload-index NAME:TYPE` — create a payload index. `TYPE` is one of `keyword`, `integer`,
   `float`, `text`, `geo`. Comma-separated and/or repeatable, e.g. `--payload-index
   city:keyword,age:integer`.
+- `--indexing-threshold-kb <N>` — indexing threshold in KB: segments larger than this get an HNSW
+  index built for them by `optimize` (omit to use the built-in default).
 - `--on-disk-payload` — store payload on disk (mmap) instead of RAM.
 
 `PATH` must not already contain segment data.

--- a/lib/edge/tools/edge_tool/README.md
+++ b/lib/edge/tools/edge_tool/README.md
@@ -1,0 +1,113 @@
+# edge-tool
+
+Create, seed, optimize, and upload minimal local Qdrant edge collections — for benchmarking and
+manual testing of the edge write/read/optimize paths without a running Qdrant server.
+
+`create` and `upsert` write through [`edge::EdgeShard`](../../src/edge_shard/mod.rs) directly (the
+full read+write local shard, not the read-only or update-only edge variants used by
+`edge-shard-query`/`edge-shard-update`), so the resulting directory is a real, self-contained edge
+collection: readable by `edge-shard-query`, promotable to object storage with `upload`, or opened
+by a real Qdrant edge deployment.
+
+## Subcommands
+
+```sh
+cargo run -p edge-tool -- create --dense 1024 --sparse --quantization turbo4 ./collection
+cargo run -p edge-tool -- upsert -n 1000 ./collection
+cargo run -p edge-tool -- optimize ./collection
+cargo run -p edge-tool -- upload --bucket my-bucket ./collection my_collection/0
+```
+
+### `create` — build a minimal collection on disk
+
+```sh
+edge-tool create [OPTIONS] <PATH>
+```
+
+- `--dense <SIZE>` — add a dense vector. A single bare `--dense 1024` creates one vector named
+  `dense`; with more than one dense vector, every one must be named: `--dense text:768 --dense
+  image:512`. Repeatable.
+- `--distance <cosine|euclid|dot|manhattan>` — distance metric for every dense vector (default
+  `cosine`).
+- `--sparse [NAME]` — add a sparse vector. Bare `--sparse` creates one vector named `sparse`;
+  `--sparse NAME` names it. Repeatable for multiple sparse vectors.
+- `--quantization <PRESET>` — quantize every dense vector. One of `scalar`, `binary`,
+  `product-x4`, `product-x8`, `product-x16`, `product-x32`, `product-x64`, `turbo1`, `turbo1.5`,
+  `turbo2`, `turbo4`.
+- `--payload-index NAME:TYPE` — create a payload index. `TYPE` is one of `keyword`, `integer`,
+  `float`, `text`, `geo`. Comma-separated and/or repeatable, e.g. `--payload-index
+  city:keyword,age:integer`.
+- `--segments <N>` — target number of segments for the optimizer (omit to derive from CPU count).
+- `--on-disk-payload` — store payload on disk (mmap) instead of RAM.
+
+`PATH` must not already contain segment data.
+
+### `upsert` — seed the collection with random points
+
+```sh
+edge-tool upsert -n 1000 <PATH>
+```
+
+Generates `-n`/`--num` random points shaped to match the collection's *live* schema — every
+dense/sparse vector in its config, one random value per payload field currently indexed (read from
+`EdgeShard::info().payload_schema`, so it reflects reality even if the shard was not created by
+this tool). Point ids are sequential and default to starting at the collection's current
+(approximate) point count, so repeated `upsert` calls append rather than overwrite; override with
+`--start-id`. `--seed` controls the RNG (default `42`).
+
+### `optimize` — run the shard optimizers
+
+```sh
+edge-tool optimize <PATH>
+```
+
+Calls `EdgeShard::optimize()` once, which itself loops (merge/indexing/vacuum) until no further
+optimization plan is produced. Logs the segment/point counts before and after.
+
+### `upload` — push the collection to object storage
+
+```sh
+edge-tool upload [OPTIONS] <SOURCE> <DESTINATION>
+```
+
+Recursively uploads every file under the local `SOURCE` directory to `DESTINATION` (a key prefix
+inside the bucket, e.g. `my_collection/0`), preserving the relative directory structure — so the
+result is byte-for-byte the same layout `edge-shard-query`/`edge-shard-update` expect via
+`--prefix`. Every file is streamed through `object_store`'s multipart upload API (even small ones,
+as a single final part), so upload memory use stays bounded regardless of segment size.
+
+- `--aws` (default) — AWS S3 or an S3-compatible store (MinIO, RustFS, ...).
+- `--gcs` — Google Cloud Storage.
+- `--bucket` [`BLOB_BUCKET`] — required.
+- `--endpoint` [`S3_ENDPOINT`] — custom S3 endpoint (MinIO/RustFS/LocalStack; omit for real AWS).
+- `--region` [`S3_REGION`] — required for real AWS, optional for S3-compatible endpoints.
+- `--access-key` [`S3_ACCESS_KEY`] / `--secret-key` [`S3_SECRET_KEY`] — must be given together; if
+  both are omitted, the AWS default credential chain is used.
+- `--session-token` [`S3_SESSION_TOKEN`], `--s3-express` [`S3_EXPRESS`].
+- `--gcs-service-account-path` [`GCS_SERVICE_ACCOUNT_PATH`] / `--gcs-service-account-key`
+  [`GCS_SERVICE_ACCOUNT_KEY`] — GCS credentials; the path form takes precedence, ADC is used if
+  neither is set.
+- `--concurrency <N>` — files uploaded in parallel (default `8`).
+
+## Example — end to end against a local S3-compatible store
+
+Using [`../s3_proxy`](../s3_proxy) to serve a local directory as S3:
+
+```sh
+../s3_proxy/s3_proxy.sh up
+
+cargo run -p edge-tool -- create --dense 128 --sparse --quantization turbo4 \
+    --payload-index city:keyword,age:integer ./collection
+cargo run -p edge-tool -- upsert -n 1000 ./collection
+cargo run -p edge-tool -- optimize ./collection
+cargo run -p edge-tool -- upload \
+    --endpoint http://localhost:9000 --bucket test-bucket --region us-east-1 \
+    --access-key test --secret-key test \
+    ./collection my_collection/0
+
+# Read it back with no Qdrant server involved:
+cargo run -p edge-shard-query -- \
+    --backend aws --endpoint http://localhost:9000 --bucket test-bucket --region us-east-1 \
+    --access-key test --secret-key test --prefix my_collection/0 \
+    scroll --limit 10
+```

--- a/lib/edge/tools/edge_tool/README.md
+++ b/lib/edge/tools/edge_tool/README.md
@@ -29,8 +29,9 @@ edge-tool create [OPTIONS] <PATH>
   image:512`. Repeatable.
 - `--distance <cosine|euclid|dot|manhattan>` — distance metric for every dense vector (default
   `cosine`).
-- `--sparse [NAME]` — add a sparse vector. Bare `--sparse` creates one vector named `sparse`;
-  `--sparse NAME` names it. Repeatable for multiple sparse vectors.
+- `--sparse` — add a sparse vector named `sparse`.
+- `--sparse-name <NAME>` — add a named sparse vector. Repeatable for multiple sparse vectors;
+  combines with the bare `--sparse` flag.
 - `--quantization <PRESET>` — quantize every dense vector. One of `scalar`, `binary`,
   `product-x4`, `product-x8`, `product-x16`, `product-x32`, `product-x64`, `turbo1`, `turbo1.5`,
   `turbo2`, `turbo4`.

--- a/lib/edge/tools/edge_tool/README.md
+++ b/lib/edge/tools/edge_tool/README.md
@@ -79,6 +79,9 @@ result is byte-for-byte the same layout `edge-shard-query`/`edge-shard-update` e
 `--prefix`. Every file is streamed through `object_store`'s multipart upload API (even small ones,
 as a single final part), so upload memory use stays bounded regardless of segment size.
 
+- `--clean` — delete every existing object under `DESTINATION` before uploading, so a re-upload
+  doesn't leave stale files behind from a previous run with a different shape (e.g. a collection
+  re-created with a different segment UUID).
 - `--aws` (default) — AWS S3 or an S3-compatible store (MinIO, RustFS, ...).
 - `--gcs` — Google Cloud Storage.
 - `--bucket` [`BLOB_BUCKET`] — required.

--- a/lib/edge/tools/edge_tool/README.md
+++ b/lib/edge/tools/edge_tool/README.md
@@ -39,7 +39,6 @@ edge-tool create [OPTIONS] <PATH>
 - `--payload-index NAME:TYPE` — create a payload index. `TYPE` is one of `keyword`, `integer`,
   `float`, `text`, `geo`. Comma-separated and/or repeatable, e.g. `--payload-index
   city:keyword,age:integer`.
-- `--segments <N>` — target number of segments for the optimizer (omit to derive from CPU count).
 - `--on-disk-payload` — store payload on disk (mmap) instead of RAM.
 
 `PATH` must not already contain segment data.

--- a/lib/edge/tools/edge_tool/src/args.rs
+++ b/lib/edge/tools/edge_tool/src/args.rs
@@ -1,0 +1,182 @@
+//! CLI argument definitions.
+
+use std::path::PathBuf;
+
+use clap::{ArgAction, Args as ClapArgs, Parser, Subcommand, ValueEnum};
+use edge::Distance;
+
+use crate::quantization::QuantizationPreset;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "edge-tool",
+    about = "Create, seed, optimize, and upload minimal local Qdrant edge collections \
+             (for benchmarking and manual testing of the edge write/read/optimize paths)"
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Create a new minimal edge collection on local disk.
+    Create(CreateArgs),
+    /// Upsert randomly generated points into an existing local collection.
+    Upsert(UpsertArgs),
+    /// Run the shard optimizers (merge/indexing/vacuum) until idle.
+    Optimize(OptimizeArgs),
+    /// Upload a local collection directory to S3/GCS object storage.
+    Upload(UploadArgs),
+}
+
+#[derive(ClapArgs, Debug)]
+pub struct CreateArgs {
+    /// Directory to create the collection in. Must not already contain segment data.
+    pub path: PathBuf,
+
+    /// Add a dense vector. A single bare `--dense SIZE` creates one unnamed vector;
+    /// with more than one dense vector, every one must be named as `--dense NAME:SIZE`.
+    /// Repeatable.
+    #[arg(long = "dense", value_name = "SIZE|NAME:SIZE")]
+    pub dense: Vec<String>,
+
+    /// Distance metric applied to every dense vector.
+    #[arg(long, value_enum, default_value_t = DistanceArg::Cosine)]
+    pub distance: DistanceArg,
+
+    /// Add a sparse vector. Bare `--sparse` creates one unnamed sparse vector;
+    /// `--sparse NAME` names it. Repeatable for multiple sparse vectors.
+    #[arg(
+        long = "sparse",
+        value_name = "NAME",
+        num_args = 0..=1,
+        default_missing_value = "",
+        action = ArgAction::Append
+    )]
+    pub sparse: Vec<String>,
+
+    /// Quantize every dense vector with this preset.
+    #[arg(long, value_enum)]
+    pub quantization: Option<QuantizationPreset>,
+
+    /// Create a payload index: `NAME:TYPE`, where TYPE is one of keyword, integer,
+    /// float, text, geo. Comma-separated and/or repeatable.
+    #[arg(
+        long = "payload-index",
+        value_name = "NAME:TYPE",
+        value_delimiter = ','
+    )]
+    pub payload_index: Vec<String>,
+
+    /// Target number of segments for the optimizer (omit to derive from CPU count).
+    #[arg(long)]
+    pub segments: Option<usize>,
+
+    /// Store payload on disk (mmap) instead of RAM.
+    #[arg(long, default_value_t = false)]
+    pub on_disk_payload: bool,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum DistanceArg {
+    Cosine,
+    Euclid,
+    Dot,
+    Manhattan,
+}
+
+impl From<DistanceArg> for Distance {
+    fn from(value: DistanceArg) -> Self {
+        match value {
+            DistanceArg::Cosine => Distance::Cosine,
+            DistanceArg::Euclid => Distance::Euclid,
+            DistanceArg::Dot => Distance::Dot,
+            DistanceArg::Manhattan => Distance::Manhattan,
+        }
+    }
+}
+
+#[derive(ClapArgs, Debug)]
+pub struct UpsertArgs {
+    /// Path to an existing collection directory.
+    pub path: PathBuf,
+
+    /// Number of random points to upsert.
+    #[arg(short = 'n', long, default_value_t = 100)]
+    pub num: usize,
+
+    /// First point id to use. Defaults to the collection's current (approximate)
+    /// point count, so repeated `upsert` calls append rather than overwrite.
+    #[arg(long)]
+    pub start_id: Option<u64>,
+
+    /// RNG seed for the generated points.
+    #[arg(long, default_value_t = 42)]
+    pub seed: u64,
+}
+
+#[derive(ClapArgs, Debug)]
+pub struct OptimizeArgs {
+    /// Path to an existing collection directory.
+    pub path: PathBuf,
+}
+
+#[derive(ClapArgs, Debug)]
+pub struct UploadArgs {
+    /// Local collection directory to upload.
+    pub source: PathBuf,
+
+    /// Destination key prefix inside the bucket (e.g. `my_collection/0`).
+    pub destination: String,
+
+    /// Upload to AWS S3 or an S3-compatible store (MinIO, RustFS, ...). Default backend.
+    #[arg(long, conflicts_with = "gcs")]
+    pub aws: bool,
+
+    /// Upload to Google Cloud Storage.
+    #[arg(long)]
+    pub gcs: bool,
+
+    /// [AWS/GCS] Bucket name (without any scheme prefix).
+    #[arg(long, env = "BLOB_BUCKET")]
+    pub bucket: Option<String>,
+
+    /// [AWS] Custom S3 endpoint URL (MinIO / RustFS / LocalStack; omit for real AWS).
+    #[arg(long, env = "S3_ENDPOINT")]
+    pub endpoint: Option<String>,
+
+    /// [AWS] Region (e.g. `us-east-1`). Required for real AWS; optional otherwise.
+    #[arg(long, env = "S3_REGION")]
+    pub region: Option<String>,
+
+    /// [AWS] Access key id. If omitted, the AWS default credential chain is used.
+    #[arg(long, env = "S3_ACCESS_KEY")]
+    pub access_key: Option<String>,
+
+    /// [AWS] Secret access key. Required when `--access-key` is given.
+    #[arg(long, env = "S3_SECRET_KEY")]
+    pub secret_key: Option<String>,
+
+    /// [AWS] Optional session token for short-lived credentials.
+    #[arg(long, env = "S3_SESSION_TOKEN")]
+    pub session_token: Option<String>,
+
+    /// [AWS] Use S3 Express One Zone (directory buckets, named `*--x-s3`).
+    #[arg(long, env = "S3_EXPRESS")]
+    pub s3_express: bool,
+
+    /// [GCS] Path to a service-account JSON key file. Takes precedence over
+    /// `--gcs-service-account-key`; if neither is set, application default
+    /// credentials (ADC) are used.
+    #[arg(long, env = "GCS_SERVICE_ACCOUNT_PATH")]
+    pub gcs_service_account_path: Option<String>,
+
+    /// [GCS] Inline service-account JSON key contents (instead of a path).
+    #[arg(long, env = "GCS_SERVICE_ACCOUNT_KEY")]
+    pub gcs_service_account_key: Option<String>,
+
+    /// Number of files to upload concurrently.
+    #[arg(long, default_value_t = 8)]
+    pub concurrency: usize,
+}

--- a/lib/edge/tools/edge_tool/src/args.rs
+++ b/lib/edge/tools/edge_tool/src/args.rs
@@ -134,6 +134,12 @@ pub struct UploadArgs {
     /// Destination key prefix inside the bucket (e.g. `my_collection/0`).
     pub destination: String,
 
+    /// Delete every existing object under the destination prefix before uploading, so a
+    /// re-upload doesn't leave stale files behind from a previous run with a different
+    /// shape (e.g. different segment UUIDs).
+    #[arg(long, default_value_t = false)]
+    pub clean: bool,
+
     /// Upload to AWS S3 or an S3-compatible store (MinIO, RustFS, ...). Default backend.
     #[arg(long, conflicts_with = "gcs")]
     pub aws: bool,

--- a/lib/edge/tools/edge_tool/src/args.rs
+++ b/lib/edge/tools/edge_tool/src/args.rs
@@ -72,6 +72,11 @@ pub struct CreateArgs {
     )]
     pub payload_index: Vec<String>,
 
+    /// Indexing threshold in KB: segments larger than this get an HNSW index built
+    /// for them by `optimize`. Omit to use the built-in default.
+    #[arg(long)]
+    pub indexing_threshold_kb: Option<usize>,
+
     /// Store payload on disk (mmap) instead of RAM.
     #[arg(long, default_value_t = false)]
     pub on_disk_payload: bool,

--- a/lib/edge/tools/edge_tool/src/args.rs
+++ b/lib/edge/tools/edge_tool/src/args.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use clap::{Args as ClapArgs, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Args as ClapArgs, Parser, Subcommand, ValueEnum};
 use edge::Distance;
 
 use crate::quantization::QuantizationPreset;
@@ -45,14 +45,19 @@ pub struct CreateArgs {
     #[arg(long, value_enum, default_value_t = DistanceArg::Cosine)]
     pub distance: DistanceArg,
 
-    /// Add a sparse vector named `sparse`.
-    #[arg(long, default_value_t = false)]
-    pub sparse: bool,
-
-    /// Add a named sparse vector. Repeatable for multiple sparse vectors; combines
-    /// with the bare `--sparse` flag.
-    #[arg(long = "sparse-name", value_name = "NAME")]
-    pub sparse_name: Vec<String>,
+    /// Add a sparse vector. Bare `--sparse` creates one vector named `sparse`;
+    /// `--sparse=NAME` names it (the `=` is required — `--sparse NAME` is ambiguous
+    /// with the trailing PATH positional and is rejected). Repeatable for multiple
+    /// sparse vectors.
+    #[arg(
+        long = "sparse",
+        value_name = "NAME",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "",
+        action = ArgAction::Append
+    )]
+    pub sparse: Vec<String>,
 
     /// Quantize every dense vector with this preset.
     #[arg(long, value_enum)]

--- a/lib/edge/tools/edge_tool/src/args.rs
+++ b/lib/edge/tools/edge_tool/src/args.rs
@@ -72,10 +72,6 @@ pub struct CreateArgs {
     )]
     pub payload_index: Vec<String>,
 
-    /// Target number of segments for the optimizer (omit to derive from CPU count).
-    #[arg(long)]
-    pub segments: Option<usize>,
-
     /// Store payload on disk (mmap) instead of RAM.
     #[arg(long, default_value_t = false)]
     pub on_disk_payload: bool,

--- a/lib/edge/tools/edge_tool/src/args.rs
+++ b/lib/edge/tools/edge_tool/src/args.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use clap::{ArgAction, Args as ClapArgs, Parser, Subcommand, ValueEnum};
+use clap::{Args as ClapArgs, Parser, Subcommand, ValueEnum};
 use edge::Distance;
 
 use crate::quantization::QuantizationPreset;
@@ -45,16 +45,14 @@ pub struct CreateArgs {
     #[arg(long, value_enum, default_value_t = DistanceArg::Cosine)]
     pub distance: DistanceArg,
 
-    /// Add a sparse vector. Bare `--sparse` creates one unnamed sparse vector;
-    /// `--sparse NAME` names it. Repeatable for multiple sparse vectors.
-    #[arg(
-        long = "sparse",
-        value_name = "NAME",
-        num_args = 0..=1,
-        default_missing_value = "",
-        action = ArgAction::Append
-    )]
-    pub sparse: Vec<String>,
+    /// Add a sparse vector named `sparse`.
+    #[arg(long, default_value_t = false)]
+    pub sparse: bool,
+
+    /// Add a named sparse vector. Repeatable for multiple sparse vectors; combines
+    /// with the bare `--sparse` flag.
+    #[arg(long = "sparse-name", value_name = "NAME")]
+    pub sparse_name: Vec<String>,
 
     /// Quantize every dense vector with this preset.
     #[arg(long, value_enum)]

--- a/lib/edge/tools/edge_tool/src/create.rs
+++ b/lib/edge/tools/edge_tool/src/create.rs
@@ -2,8 +2,9 @@ use std::collections::HashSet;
 
 use anyhow::{Context, Result, anyhow, bail};
 use edge::{
-    CreateIndex, Distance, EdgeConfigBuilder, EdgeShard, EdgeSparseVectorParams, EdgeVectorParams,
-    FieldIndexOperations, JsonPath, PayloadFieldSchema, PayloadSchemaType, UpdateOperation,
+    CreateIndex, Distance, EdgeConfigBuilder, EdgeOptimizersConfig, EdgeShard,
+    EdgeSparseVectorParams, EdgeVectorParams, FieldIndexOperations, JsonPath, PayloadFieldSchema,
+    PayloadSchemaType, UpdateOperation,
 };
 
 use crate::args::CreateArgs;
@@ -43,6 +44,12 @@ pub fn run(args: CreateArgs) -> Result<()> {
     }
     if let Some(preset) = args.quantization {
         builder = builder.quantization_config(preset.to_config());
+    }
+    if let Some(indexing_threshold) = args.indexing_threshold_kb {
+        builder = builder.optimizers(EdgeOptimizersConfig {
+            indexing_threshold: Some(indexing_threshold),
+            ..Default::default()
+        });
     }
 
     fs_err::create_dir_all(&args.path)

--- a/lib/edge/tools/edge_tool/src/create.rs
+++ b/lib/edge/tools/edge_tool/src/create.rs
@@ -16,7 +16,7 @@ const DEFAULT_SPARSE_NAME: &str = "sparse";
 
 pub fn run(args: CreateArgs) -> Result<()> {
     let dense = parse_dense_specs(&args.dense)?;
-    let sparse = parse_sparse_specs(&args.sparse);
+    let sparse = parse_sparse_specs(args.sparse, &args.sparse_name);
     check_no_duplicate_names(&dense, &sparse)?;
     if dense.is_empty() && sparse.is_empty() {
         bail!("collection needs at least one vector: pass --dense <SIZE> and/or --sparse");
@@ -126,18 +126,12 @@ fn parse_dense_specs(specs: &[String]) -> Result<Vec<(String, usize)>> {
         .collect()
 }
 
-/// Parse `--sparse` specs: `default_missing_value = ""` turns a bare
-/// `--sparse` into [`DEFAULT_SPARSE_NAME`].
-fn parse_sparse_specs(specs: &[String]) -> Vec<String> {
-    specs
-        .iter()
-        .map(|name| {
-            if name.is_empty() {
-                DEFAULT_SPARSE_NAME.to_string()
-            } else {
-                name.trim().to_string()
-            }
-        })
+/// Combine the bare `--sparse` flag (named [`DEFAULT_SPARSE_NAME`]) with any
+/// `--sparse-name NAME` occurrences.
+fn parse_sparse_specs(bare: bool, named: &[String]) -> Vec<String> {
+    bare.then(|| DEFAULT_SPARSE_NAME.to_string())
+        .into_iter()
+        .chain(named.iter().map(|name| name.trim().to_string()))
         .collect()
 }
 

--- a/lib/edge/tools/edge_tool/src/create.rs
+++ b/lib/edge/tools/edge_tool/src/create.rs
@@ -2,9 +2,8 @@ use std::collections::HashSet;
 
 use anyhow::{Context, Result, anyhow, bail};
 use edge::{
-    CreateIndex, Distance, EdgeConfigBuilder, EdgeOptimizersConfig, EdgeShard,
-    EdgeSparseVectorParams, EdgeVectorParams, FieldIndexOperations, JsonPath, PayloadFieldSchema,
-    PayloadSchemaType, UpdateOperation,
+    CreateIndex, Distance, EdgeConfigBuilder, EdgeShard, EdgeSparseVectorParams, EdgeVectorParams,
+    FieldIndexOperations, JsonPath, PayloadFieldSchema, PayloadSchemaType, UpdateOperation,
 };
 
 use crate::args::CreateArgs;
@@ -44,12 +43,6 @@ pub fn run(args: CreateArgs) -> Result<()> {
     }
     if let Some(preset) = args.quantization {
         builder = builder.quantization_config(preset.to_config());
-    }
-    if let Some(segments) = args.segments {
-        builder = builder.optimizers(EdgeOptimizersConfig {
-            default_segment_number: Some(segments),
-            ..Default::default()
-        });
     }
 
     fs_err::create_dir_all(&args.path)

--- a/lib/edge/tools/edge_tool/src/create.rs
+++ b/lib/edge/tools/edge_tool/src/create.rs
@@ -1,0 +1,182 @@
+use std::collections::HashSet;
+
+use anyhow::{Context, Result, anyhow, bail};
+use edge::{
+    CreateIndex, Distance, EdgeConfigBuilder, EdgeOptimizersConfig, EdgeShard,
+    EdgeSparseVectorParams, EdgeVectorParams, FieldIndexOperations, JsonPath, PayloadFieldSchema,
+    PayloadSchemaType, UpdateOperation,
+};
+
+use crate::args::CreateArgs;
+
+/// Default name for a single, unnamed `--dense` vector.
+const DEFAULT_DENSE_NAME: &str = "dense";
+/// Default name for a single, unnamed `--sparse` vector.
+const DEFAULT_SPARSE_NAME: &str = "sparse";
+
+pub fn run(args: CreateArgs) -> Result<()> {
+    let dense = parse_dense_specs(&args.dense)?;
+    let sparse = parse_sparse_specs(&args.sparse);
+    check_no_duplicate_names(&dense, &sparse)?;
+    if dense.is_empty() && sparse.is_empty() {
+        bail!("collection needs at least one vector: pass --dense <SIZE> and/or --sparse");
+    }
+    let payload_index = parse_payload_index_specs(&args.payload_index)?;
+
+    let distance: Distance = args.distance.into();
+    let mut builder = EdgeConfigBuilder::new().on_disk_payload(args.on_disk_payload);
+    for (name, size) in &dense {
+        builder = builder.vector(
+            name.clone(),
+            EdgeVectorParams {
+                size: *size,
+                distance,
+                on_disk: None,
+                multivector_config: None,
+                datatype: None,
+                quantization_config: None,
+                hnsw_config: None,
+            },
+        );
+    }
+    for name in &sparse {
+        builder = builder.sparse_vector(name.clone(), EdgeSparseVectorParams::default());
+    }
+    if let Some(preset) = args.quantization {
+        builder = builder.quantization_config(preset.to_config());
+    }
+    if let Some(segments) = args.segments {
+        builder = builder.optimizers(EdgeOptimizersConfig {
+            default_segment_number: Some(segments),
+            ..Default::default()
+        });
+    }
+
+    fs_err::create_dir_all(&args.path)
+        .with_context(|| format!("failed to create directory {}", args.path.display()))?;
+    let shard = EdgeShard::new(&args.path, builder.build()).with_context(|| {
+        format!(
+            "failed to create edge collection at {}",
+            args.path.display()
+        )
+    })?;
+    log::info!(
+        "created edge collection at {}: {} dense vector(s) {:?}, {} sparse vector(s) {:?}",
+        args.path.display(),
+        dense.len(),
+        dense
+            .iter()
+            .map(|(name, size)| format!("{name:?}({size})"))
+            .collect::<Vec<_>>(),
+        sparse.len(),
+        sparse,
+    );
+
+    for (name, schema_type) in &payload_index {
+        let field_name: JsonPath = name
+            .parse()
+            .map_err(|()| anyhow!("invalid payload field name: {name:?}"))?;
+        shard
+            .update(UpdateOperation::FieldIndexOperation(
+                FieldIndexOperations::CreateIndex(CreateIndex {
+                    field_name,
+                    field_schema: Some(PayloadFieldSchema::FieldType(*schema_type)),
+                }),
+            ))
+            .with_context(|| format!("failed to create payload index on {name:?}"))?;
+        log::info!("created payload index: {name} ({schema_type:?})");
+    }
+
+    shard
+        .flush()
+        .context("failed to flush the new collection")?;
+    log::info!("collection ready at {}", args.path.display());
+    Ok(())
+}
+
+/// Parse `--dense` specs. A single bare `SIZE` names the vector
+/// [`DEFAULT_DENSE_NAME`]; with more than one `--dense`, every one must be
+/// `NAME:SIZE`.
+fn parse_dense_specs(specs: &[String]) -> Result<Vec<(String, usize)>> {
+    if let [size] = specs
+        && !size.contains(':')
+    {
+        let size: usize = size
+            .trim()
+            .parse()
+            .with_context(|| format!("invalid --dense size: {size:?}"))?;
+        return Ok(vec![(DEFAULT_DENSE_NAME.to_string(), size)]);
+    }
+
+    specs
+        .iter()
+        .map(|spec| {
+            let (name, size) = spec.split_once(':').ok_or_else(|| {
+                anyhow!(
+                    "multiple dense vectors require explicit names: use `--dense NAME:SIZE` \
+                     (got {spec:?})"
+                )
+            })?;
+            let size: usize = size
+                .trim()
+                .parse()
+                .with_context(|| format!("invalid dense vector size in {spec:?}"))?;
+            Ok((name.trim().to_string(), size))
+        })
+        .collect()
+}
+
+/// Parse `--sparse` specs: `default_missing_value = ""` turns a bare
+/// `--sparse` into [`DEFAULT_SPARSE_NAME`].
+fn parse_sparse_specs(specs: &[String]) -> Vec<String> {
+    specs
+        .iter()
+        .map(|name| {
+            if name.is_empty() {
+                DEFAULT_SPARSE_NAME.to_string()
+            } else {
+                name.trim().to_string()
+            }
+        })
+        .collect()
+}
+
+fn check_no_duplicate_names(dense: &[(String, usize)], sparse: &[String]) -> Result<()> {
+    let mut seen = HashSet::new();
+    for (name, _) in dense {
+        if !seen.insert(name.as_str()) {
+            bail!("duplicate vector name: {name:?}");
+        }
+    }
+    for name in sparse {
+        if !seen.insert(name.as_str()) {
+            bail!("duplicate vector name: {name:?}");
+        }
+    }
+    Ok(())
+}
+
+/// Parse `--payload-index` specs (`NAME:TYPE`), restricted to the types this
+/// tool knows how to generate random values for.
+fn parse_payload_index_specs(specs: &[String]) -> Result<Vec<(String, PayloadSchemaType)>> {
+    specs
+        .iter()
+        .map(|spec| {
+            let (name, kind) = spec.split_once(':').ok_or_else(|| {
+                anyhow!("--payload-index entries must be `NAME:TYPE` (got {spec:?})")
+            })?;
+            let schema_type = match kind.trim().to_ascii_lowercase().as_str() {
+                "keyword" => PayloadSchemaType::Keyword,
+                "integer" => PayloadSchemaType::Integer,
+                "float" => PayloadSchemaType::Float,
+                "text" => PayloadSchemaType::Text,
+                "geo" => PayloadSchemaType::Geo,
+                other => bail!(
+                    "unsupported payload index type {other:?} in {spec:?}; expected one of: \
+                     keyword, integer, float, text, geo"
+                ),
+            };
+            Ok((name.trim().to_string(), schema_type))
+        })
+        .collect()
+}

--- a/lib/edge/tools/edge_tool/src/create.rs
+++ b/lib/edge/tools/edge_tool/src/create.rs
@@ -16,7 +16,7 @@ const DEFAULT_SPARSE_NAME: &str = "sparse";
 
 pub fn run(args: CreateArgs) -> Result<()> {
     let dense = parse_dense_specs(&args.dense)?;
-    let sparse = parse_sparse_specs(args.sparse, &args.sparse_name);
+    let sparse = parse_sparse_specs(&args.sparse);
     check_no_duplicate_names(&dense, &sparse)?;
     if dense.is_empty() && sparse.is_empty() {
         bail!("collection needs at least one vector: pass --dense <SIZE> and/or --sparse");
@@ -126,12 +126,18 @@ fn parse_dense_specs(specs: &[String]) -> Result<Vec<(String, usize)>> {
         .collect()
 }
 
-/// Combine the bare `--sparse` flag (named [`DEFAULT_SPARSE_NAME`]) with any
-/// `--sparse-name NAME` occurrences.
-fn parse_sparse_specs(bare: bool, named: &[String]) -> Vec<String> {
-    bare.then(|| DEFAULT_SPARSE_NAME.to_string())
-        .into_iter()
-        .chain(named.iter().map(|name| name.trim().to_string()))
+/// Parse `--sparse` specs: `default_missing_value = ""` turns a bare
+/// `--sparse` into [`DEFAULT_SPARSE_NAME`]; `--sparse=NAME` names it.
+fn parse_sparse_specs(specs: &[String]) -> Vec<String> {
+    specs
+        .iter()
+        .map(|name| {
+            if name.is_empty() {
+                DEFAULT_SPARSE_NAME.to_string()
+            } else {
+                name.trim().to_string()
+            }
+        })
         .collect()
 }
 

--- a/lib/edge/tools/edge_tool/src/main.rs
+++ b/lib/edge/tools/edge_tool/src/main.rs
@@ -27,6 +27,15 @@ fn main() -> Result<()> {
         .format_timestamp_millis()
         .init();
 
+    // `serverless_compatible` is private on `FeatureFlags` — set only through deserialization,
+    // same as the main `qdrant` binary's config loader. Its `normalize()` cascades
+    // `write_segment_manifest`, `append_only_mutations`, `compact_bitmask` and
+    // `append_only_storages` on top.
+    let feature_flags: common::flags::FeatureFlags =
+        serde_json::from_value(serde_json::json!({ "serverless_compatible": true }))
+            .expect("serverless_compatible is a valid FeatureFlags field");
+    common::flags::init_feature_flags(feature_flags);
+
     let cli = Cli::parse();
 
     match cli.command {

--- a/lib/edge/tools/edge_tool/src/main.rs
+++ b/lib/edge/tools/edge_tool/src/main.rs
@@ -1,0 +1,38 @@
+//! `edge-tool` — create, seed, optimize, and upload minimal local Qdrant edge
+//! collections, for benchmarking and manual testing of the edge write/read/
+//! optimize paths without a running Qdrant server.
+//!
+//! ```sh
+//! cargo run -p edge-tool -- create --dense 1024 --sparse --quantization turbo4 ./collection
+//! cargo run -p edge-tool -- upsert -n 1000 ./collection
+//! cargo run -p edge-tool -- optimize ./collection
+//! cargo run -p edge-tool -- upload --bucket my-bucket ./collection my_collection/0
+//! ```
+
+mod args;
+mod create;
+mod optimize;
+mod points;
+mod quantization;
+mod upload;
+mod upsert;
+
+use anyhow::Result;
+use clap::Parser as _;
+
+use crate::args::{Cli, Command};
+
+fn main() -> Result<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format_timestamp_millis()
+        .init();
+
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::Create(args) => create::run(args),
+        Command::Upsert(args) => upsert::run(args),
+        Command::Optimize(args) => optimize::run(args),
+        Command::Upload(args) => upload::run(args),
+    }
+}

--- a/lib/edge/tools/edge_tool/src/optimize.rs
+++ b/lib/edge/tools/edge_tool/src/optimize.rs
@@ -1,0 +1,34 @@
+use anyhow::{Context, Result};
+use edge::EdgeShard;
+
+use crate::args::OptimizeArgs;
+
+pub fn run(args: OptimizeArgs) -> Result<()> {
+    let shard = EdgeShard::load(&args.path, None)
+        .with_context(|| format!("failed to open collection at {}", args.path.display()))?;
+
+    let before = shard.info().context("failed to read collection info")?;
+    log::info!(
+        "optimizing {}: {} segment(s), ~{} point(s) before",
+        args.path.display(),
+        before.segments_count,
+        before.points_count,
+    );
+
+    let optimized = shard.optimize().context("optimization failed")?;
+
+    let after = shard.info().context("failed to read collection info")?;
+    log::info!(
+        "optimization {}: {} segment(s), ~{} point(s) after",
+        if optimized {
+            "made progress"
+        } else {
+            "was a no-op (already optimal)"
+        },
+        after.segments_count,
+        after.points_count,
+    );
+
+    shard.flush().context("failed to flush the collection")?;
+    Ok(())
+}

--- a/lib/edge/tools/edge_tool/src/points.rs
+++ b/lib/edge/tools/edge_tool/src/points.rs
@@ -1,0 +1,114 @@
+//! Random point generation for `upsert`, shaped to match a collection's live
+//! schema: every dense/sparse vector the shard's config advertises, and one
+//! payload value per indexed payload field.
+
+use std::collections::HashMap;
+
+use edge::{
+    JsonPath, Payload, PayloadIndexInfo, PayloadSchemaType, PointId, PointStructPersisted,
+    SparseVector, VectorPersisted, VectorStructPersisted,
+};
+use rand::RngExt as _;
+use rand::rngs::StdRng;
+
+/// The shard's write-facing schema: every named vector a point must carry,
+/// and every payload field worth generating a value for.
+pub struct Schema {
+    pub dense: Vec<(String, usize)>,
+    pub sparse: Vec<String>,
+    pub payload: Vec<(String, PayloadSchemaType)>,
+}
+
+impl Schema {
+    pub fn new(
+        dense: HashMap<String, usize>,
+        sparse: impl IntoIterator<Item = String>,
+        payload_schema: &HashMap<JsonPath, PayloadIndexInfo>,
+    ) -> Self {
+        let mut dense: Vec<(String, usize)> = dense.into_iter().collect();
+        dense.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let mut sparse: Vec<String> = sparse.into_iter().collect();
+        sparse.sort();
+
+        let mut payload: Vec<(String, PayloadSchemaType)> = payload_schema
+            .iter()
+            .map(|(key, info)| (key.to_string(), info.data_type))
+            .collect();
+        payload.sort_by(|a, b| a.0.cmp(&b.0));
+
+        Self {
+            dense,
+            sparse,
+            payload,
+        }
+    }
+}
+
+const WORDS: &[&str] = &[
+    "amber", "basalt", "cobalt", "dune", "ember", "fjord", "garnet", "harbor",
+];
+
+/// One random point in the shape `schema` prescribes.
+pub fn random_point(id: PointId, schema: &Schema, rng: &mut StdRng) -> PointStructPersisted {
+    let mut vectors = HashMap::new();
+
+    for (name, size) in &schema.dense {
+        let dense: Vec<f32> = (0..*size).map(|_| rng.random_range(-1.0..1.0)).collect();
+        vectors.insert(name.clone(), VectorPersisted::Dense(dense));
+    }
+
+    for name in &schema.sparse {
+        // Cumulative random gaps: sorted, unique indices without a sampler.
+        let mut index = 0u32;
+        let mut indices = Vec::new();
+        let mut values = Vec::new();
+        for _ in 0..8 {
+            index += rng.random_range(1..1000);
+            indices.push(index);
+            values.push(rng.random_range(0.0..1.0));
+        }
+        vectors.insert(
+            name.clone(),
+            VectorPersisted::Sparse(SparseVector { indices, values }),
+        );
+    }
+
+    let mut payload = serde_json::Map::new();
+    for (field, schema_type) in &schema.payload {
+        payload.insert(field.clone(), random_payload_value(*schema_type, rng));
+    }
+
+    PointStructPersisted {
+        id,
+        vector: VectorStructPersisted::Named(vectors),
+        payload: Some(Payload::from(payload)),
+    }
+}
+
+fn random_payload_value(schema_type: PayloadSchemaType, rng: &mut StdRng) -> serde_json::Value {
+    let word = |rng: &mut StdRng| WORDS[rng.random_range(0..WORDS.len())].to_string();
+    match schema_type {
+        PayloadSchemaType::Keyword => word(rng).into(),
+        PayloadSchemaType::Integer => rng.random_range(0..1000).into(),
+        PayloadSchemaType::Float => rng.random_range(0.0..100.0).into(),
+        PayloadSchemaType::Bool => rng.random::<bool>().into(),
+        PayloadSchemaType::Geo => serde_json::json!({
+            "lon": rng.random_range(-180.0..180.0),
+            "lat": rng.random_range(-85.0..85.0),
+        }),
+        PayloadSchemaType::Text => format!("{} {} {}", word(rng), word(rng), word(rng)).into(),
+        PayloadSchemaType::Datetime => format!(
+            "2026-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+            rng.random_range(1..=12),
+            rng.random_range(1..=28),
+            rng.random_range(0..24),
+            rng.random_range(0..60),
+            rng.random_range(0..60),
+        )
+        .into(),
+        PayloadSchemaType::Uuid => edge::external::uuid::Uuid::from_u128(rng.random())
+            .to_string()
+            .into(),
+    }
+}

--- a/lib/edge/tools/edge_tool/src/quantization.rs
+++ b/lib/edge/tools/edge_tool/src/quantization.rs
@@ -1,0 +1,86 @@
+//! `--quantization` presets, mapped onto [`QuantizationConfig`].
+#![allow(
+    deprecated,
+    reason = "always_ram is deprecated but still constructible"
+)]
+
+use clap::ValueEnum;
+use edge::{
+    BinaryQuantizationConfig, CompressionRatio, ProductQuantizationConfig, QuantizationConfig,
+    ScalarQuantizationConfig, ScalarType,
+};
+use segment::types::{TurboQuantBitSize, TurboQuantQuantizationConfig, TurboQuantization};
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum QuantizationPreset {
+    #[value(name = "scalar")]
+    Scalar,
+    #[value(name = "binary")]
+    Binary,
+    #[value(name = "product-x4")]
+    ProductX4,
+    #[value(name = "product-x8")]
+    ProductX8,
+    #[value(name = "product-x16")]
+    ProductX16,
+    #[value(name = "product-x32")]
+    ProductX32,
+    #[value(name = "product-x64")]
+    ProductX64,
+    #[value(name = "turbo1")]
+    Turbo1,
+    #[value(name = "turbo1.5")]
+    Turbo1_5,
+    #[value(name = "turbo2")]
+    Turbo2,
+    #[value(name = "turbo4")]
+    Turbo4,
+}
+
+impl QuantizationPreset {
+    pub fn to_config(self) -> QuantizationConfig {
+        let product = |compression: CompressionRatio| -> QuantizationConfig {
+            ProductQuantizationConfig {
+                compression,
+                always_ram: None,
+                memory: None,
+            }
+            .into()
+        };
+        let turbo = |bits: TurboQuantBitSize| -> QuantizationConfig {
+            QuantizationConfig::Turbo(TurboQuantization {
+                turbo: TurboQuantQuantizationConfig {
+                    always_ram: None,
+                    memory: None,
+                    bits: Some(bits),
+                },
+            })
+        };
+
+        match self {
+            Self::Scalar => ScalarQuantizationConfig {
+                r#type: ScalarType::Int8,
+                quantile: Some(0.99),
+                always_ram: None,
+                memory: None,
+            }
+            .into(),
+            Self::Binary => BinaryQuantizationConfig {
+                always_ram: None,
+                memory: None,
+                encoding: None,
+                query_encoding: None,
+            }
+            .into(),
+            Self::ProductX4 => product(CompressionRatio::X4),
+            Self::ProductX8 => product(CompressionRatio::X8),
+            Self::ProductX16 => product(CompressionRatio::X16),
+            Self::ProductX32 => product(CompressionRatio::X32),
+            Self::ProductX64 => product(CompressionRatio::X64),
+            Self::Turbo1 => turbo(TurboQuantBitSize::Bits1),
+            Self::Turbo1_5 => turbo(TurboQuantBitSize::Bits1_5),
+            Self::Turbo2 => turbo(TurboQuantBitSize::Bits2),
+            Self::Turbo4 => turbo(TurboQuantBitSize::Bits4),
+        }
+    }
+}

--- a/lib/edge/tools/edge_tool/src/upload.rs
+++ b/lib/edge/tools/edge_tool/src/upload.rs
@@ -1,0 +1,192 @@
+//! Recursively upload a local collection directory to S3/GCS object storage.
+
+use std::io::{BufReader, Read as _};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, anyhow, bail};
+use futures::StreamExt as _;
+use io_bridge_object_store::backends::aws::{AwsConfig, AwsCredentials};
+use io_bridge_object_store::backends::gcp::{GcsConfig, GcsCredentials};
+use io_bridge_object_store::{BlobBackend, BridgeRuntime};
+use object_store::aws::AmazonS3;
+use object_store::gcp::GoogleCloudStorage;
+use object_store::{ObjectStore, ObjectStoreExt as _, WriteMultipart};
+use walkdir::WalkDir;
+
+use crate::args::UploadArgs;
+
+/// Chunk size for `WriteMultipart`: every non-final part must be at least
+/// 5 MiB on S3/GCS, so this stays comfortably above that.
+const MULTIPART_CHUNK_SIZE: usize = 8 * 1024 * 1024;
+
+pub fn run(args: UploadArgs) -> Result<()> {
+    if !args.source.is_dir() {
+        bail!("source {} is not a directory", args.source.display());
+    }
+
+    let files = collect_files(&args.source)?;
+    if files.is_empty() {
+        log::warn!("{} has no files to upload", args.source.display());
+        return Ok(());
+    }
+    log::info!(
+        "uploading {} file(s) from {} to {}",
+        files.len(),
+        args.source.display(),
+        args.destination,
+    );
+
+    let runtime = BridgeRuntime::new().context("failed to start the upload runtime")?;
+    let concurrency = args.concurrency.max(1);
+
+    if args.gcs {
+        let config = build_gcs_config(&args)?;
+        let store =
+            GoogleCloudStorage::build_store(&config).context("failed to build the GCS client")?;
+        runtime.block_on(upload_all(
+            &store,
+            &args.source,
+            &args.destination,
+            &files,
+            concurrency,
+        ))?;
+    } else {
+        let config = build_aws_config(&args)?;
+        let store = AmazonS3::build_store(&config).context("failed to build the S3 client")?;
+        runtime.block_on(upload_all(
+            &store,
+            &args.source,
+            &args.destination,
+            &files,
+            concurrency,
+        ))?;
+    }
+
+    log::info!("uploaded {} file(s) to {}", files.len(), args.destination);
+    Ok(())
+}
+
+fn collect_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for entry in WalkDir::new(root) {
+        let entry = entry.with_context(|| format!("failed to walk {}", root.display()))?;
+        if entry.file_type().is_file() {
+            files.push(entry.into_path());
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+async fn upload_all<O: ObjectStore>(
+    store: &O,
+    source: &Path,
+    destination: &str,
+    files: &[PathBuf],
+    concurrency: usize,
+) -> Result<()> {
+    futures::stream::iter(files)
+        .map(|file| upload_file(store, source, destination, file))
+        .buffer_unordered(concurrency)
+        .collect::<Vec<Result<()>>>()
+        .await
+        .into_iter()
+        .collect()
+}
+
+/// Stream a single local file into object storage as a multipart upload.
+/// Every file goes through the multipart path (even small ones, as a single
+/// final part) so there is one upload code path regardless of size.
+async fn upload_file<O: ObjectStore>(
+    store: &O,
+    source: &Path,
+    destination: &str,
+    file: &Path,
+) -> Result<()> {
+    let relative = file
+        .strip_prefix(source)
+        .with_context(|| format!("{} is not under {}", file.display(), source.display()))?;
+    let key = object_key(destination, relative)?;
+
+    let upload = store
+        .put_multipart(&key)
+        .await
+        .with_context(|| format!("failed to start upload of {}", file.display()))?;
+    let mut write = WriteMultipart::new_with_chunk_size(upload, MULTIPART_CHUNK_SIZE);
+
+    let handle =
+        fs_err::File::open(file).with_context(|| format!("failed to open {}", file.display()))?;
+    let mut reader = BufReader::new(handle);
+    let mut buffer = vec![0u8; MULTIPART_CHUNK_SIZE];
+    loop {
+        let bytes_read = reader
+            .read(&mut buffer)
+            .with_context(|| format!("failed to read {}", file.display()))?;
+        if bytes_read == 0 {
+            break;
+        }
+        // Sync but spawns an internal worker thread; `finish` waits for it.
+        write.write(&buffer[..bytes_read]);
+    }
+    write
+        .finish()
+        .await
+        .with_context(|| format!("failed to finish upload of {}", file.display()))?;
+
+    log::debug!("uploaded {} -> {key}", file.display());
+    Ok(())
+}
+
+fn object_key(destination: &str, relative: &Path) -> Result<object_store::path::Path> {
+    let relative = relative
+        .to_str()
+        .ok_or_else(|| anyhow!("non-UTF8 path: {}", relative.display()))?;
+    let destination = destination.trim_matches('/');
+    let key = if destination.is_empty() {
+        relative.to_string()
+    } else {
+        format!("{destination}/{relative}")
+    };
+    Ok(object_store::path::Path::from(key))
+}
+
+fn require_bucket(args: &UploadArgs) -> Result<String> {
+    args.bucket
+        .clone()
+        .ok_or_else(|| anyhow!("--bucket is required"))
+}
+
+fn build_aws_config(args: &UploadArgs) -> Result<AwsConfig> {
+    let credentials = match (&args.access_key, &args.secret_key) {
+        (Some(access_key_id), Some(secret_access_key)) => AwsCredentials::Static {
+            access_key_id: access_key_id.clone(),
+            secret_access_key: secret_access_key.clone(),
+            session_token: args.session_token.clone(),
+        },
+        (None, None) => AwsCredentials::Default,
+        _ => bail!("--access-key and --secret-key must be provided together"),
+    };
+
+    Ok(AwsConfig {
+        bucket: require_bucket(args)?,
+        region: args.region.clone(),
+        endpoint: args.endpoint.clone(),
+        s3_express: args.s3_express,
+        credentials,
+    })
+}
+
+fn build_gcs_config(args: &UploadArgs) -> Result<GcsConfig> {
+    let credentials = if let Some(key) = &args.gcs_service_account_key {
+        GcsCredentials::ServiceAccountKey(key.clone())
+    } else if let Some(path) = &args.gcs_service_account_path {
+        GcsCredentials::ServiceAccountPath(path.clone())
+    } else {
+        GcsCredentials::Default
+    };
+
+    Ok(GcsConfig {
+        bucket: require_bucket(args)?,
+        credentials,
+    })
+}

--- a/lib/edge/tools/edge_tool/src/upload.rs
+++ b/lib/edge/tools/edge_tool/src/upload.rs
@@ -25,16 +25,10 @@ pub fn run(args: UploadArgs) -> Result<()> {
     }
 
     let files = collect_files(&args.source)?;
-    if files.is_empty() {
+    if files.is_empty() && !args.clean {
         log::warn!("{} has no files to upload", args.source.display());
         return Ok(());
     }
-    log::info!(
-        "uploading {} file(s) from {} to {}",
-        files.len(),
-        args.source.display(),
-        args.destination,
-    );
 
     let runtime = BridgeRuntime::new().context("failed to start the upload runtime")?;
     let concurrency = args.concurrency.max(1);
@@ -43,27 +37,59 @@ pub fn run(args: UploadArgs) -> Result<()> {
         let config = build_gcs_config(&args)?;
         let store =
             GoogleCloudStorage::build_store(&config).context("failed to build the GCS client")?;
-        runtime.block_on(upload_all(
-            &store,
-            &args.source,
-            &args.destination,
-            &files,
-            concurrency,
-        ))?;
+        runtime.block_on(clean_and_upload(&store, &args, &files, concurrency))?;
     } else {
         let config = build_aws_config(&args)?;
         let store = AmazonS3::build_store(&config).context("failed to build the S3 client")?;
-        runtime.block_on(upload_all(
-            &store,
-            &args.source,
-            &args.destination,
-            &files,
-            concurrency,
-        ))?;
+        runtime.block_on(clean_and_upload(&store, &args, &files, concurrency))?;
     }
 
     log::info!("uploaded {} file(s) to {}", files.len(), args.destination);
     Ok(())
+}
+
+async fn clean_and_upload<O: ObjectStore>(
+    store: &O,
+    args: &UploadArgs,
+    files: &[PathBuf],
+    concurrency: usize,
+) -> Result<()> {
+    if args.clean {
+        let removed = clean_destination(store, &destination_prefix(&args.destination)).await?;
+        log::info!(
+            "removed {removed} existing object(s) under {}",
+            args.destination
+        );
+    }
+
+    log::info!(
+        "uploading {} file(s) from {} to {}",
+        files.len(),
+        args.source.display(),
+        args.destination,
+    );
+    upload_all(store, &args.source, &args.destination, files, concurrency).await
+}
+
+/// Delete every object already under `prefix`, so a re-upload doesn't leave
+/// stale files behind from a previous run with a different shape (e.g.
+/// different segment UUIDs).
+async fn clean_destination<O: ObjectStore>(
+    store: &O,
+    prefix: &object_store::path::Path,
+) -> Result<usize> {
+    let locations = store
+        .list(Some(prefix))
+        .map(|meta| meta.map(|meta| meta.location))
+        .boxed();
+
+    let mut removed = 0usize;
+    let mut results = store.delete_stream(locations);
+    while let Some(result) = results.next().await {
+        result.context("failed to delete an existing object under the destination prefix")?;
+        removed += 1;
+    }
+    Ok(removed)
 }
 
 fn collect_files(root: &Path) -> Result<Vec<PathBuf>> {
@@ -135,6 +161,10 @@ async fn upload_file<O: ObjectStore>(
 
     log::debug!("uploaded {} -> {key}", file.display());
     Ok(())
+}
+
+fn destination_prefix(destination: &str) -> object_store::path::Path {
+    object_store::path::Path::from(destination.trim_matches('/'))
 }
 
 fn object_key(destination: &str, relative: &Path) -> Result<object_store::path::Path> {

--- a/lib/edge/tools/edge_tool/src/upsert.rs
+++ b/lib/edge/tools/edge_tool/src/upsert.rs
@@ -1,0 +1,65 @@
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use edge::{EdgeShard, PointId, PointInsertOperations, PointOperations, UpdateOperation};
+use rand::SeedableRng as _;
+use rand::rngs::StdRng;
+
+use crate::args::UpsertArgs;
+use crate::points::{Schema, random_point};
+
+pub fn run(args: UpsertArgs) -> Result<()> {
+    let shard = EdgeShard::load(&args.path, None)
+        .with_context(|| format!("failed to open collection at {}", args.path.display()))?;
+
+    let info = shard.info().context("failed to read collection info")?;
+    let start_id = args.start_id.unwrap_or(info.points_count as u64);
+
+    let config = shard.config();
+    let dense: HashMap<String, usize> = config
+        .vectors
+        .iter()
+        .map(|(name, params)| (name.clone(), params.size))
+        .collect();
+    let sparse = config.sparse_vectors.keys().cloned();
+    let schema = Schema::new(dense, sparse, &info.payload_schema);
+    drop(config);
+
+    if schema.dense.is_empty() && schema.sparse.is_empty() {
+        anyhow::bail!(
+            "collection at {} has no vectors configured",
+            args.path.display()
+        );
+    }
+    log::info!(
+        "upserting {} point(s) (ids {start_id}..{}), {} dense vector(s), {} sparse vector(s), \
+         {} payload field(s)",
+        args.num,
+        start_id + args.num as u64,
+        schema.dense.len(),
+        schema.sparse.len(),
+        schema.payload.len(),
+    );
+
+    let mut rng = StdRng::seed_from_u64(args.seed);
+    let points = (0..args.num as u64)
+        .map(|offset| random_point(PointId::NumId(start_id + offset), &schema, &mut rng))
+        .collect::<Vec<_>>();
+
+    shard
+        .update(UpdateOperation::PointOperation(
+            PointOperations::UpsertPoints(PointInsertOperations::PointsList(points)),
+        ))
+        .context("failed to upsert points")?;
+
+    shard.flush().context("failed to flush the collection")?;
+    log::info!(
+        "upserted {} point(s); collection now has ~{} point(s)",
+        args.num,
+        shard
+            .info()
+            .context("failed to read collection info")?
+            .points_count,
+    );
+    Ok(())
+}


### PR DESCRIPTION
Stacked on top of the UpdateOnly chain (#10146 → #10147 → #10150 → #10151 → #10161 → #10152 → #10154 → this) for review convenience — this PR is otherwise unrelated to that work.

## Summary
- Adds `edge-tool`, a new CLI under `lib/edge/tools/`, mirroring the style of `edge-shard-query`/`edge-shard-update`.
- `create` builds a minimal `EdgeShard` on disk: dense/sparse vectors, quantization presets (scalar, binary, product-x4..x64, turbo1/1.5/2/4), payload indexes (keyword, integer, float, text, geo), target segment count.
- `upsert -n <N>` seeds a collection with random points shaped to its live schema (dense/sparse vectors + indexed payload fields), appending on repeated calls.
- `optimize` runs the shard optimizers (merge/indexing/vacuum) until idle.
- `upload` recursively streams a local collection directory to S3/GCS via multipart upload.

```sh
edge-tool create --dense 1024 --sparse --quantization turbo4 path/to
edge-tool upsert -n 1000 path/to
edge-tool optimize path/to
edge-tool upload --aws --access-key ... path/here path/there
```

See `lib/edge/tools/edge_tool/README.md` for full flag documentation.

## Test plan
- [x] `cargo build -p edge-tool`
- [x] `mold -run cargo clippy -p edge-tool --all-targets` (clean)
- [x] `cargo fmt -p edge-tool -- --check`
- [x] Manual smoke test: `create` (dense+sparse+turbo4 quantization+5 payload index types+segments), `upsert` (twice, verifying sequential/appending ids), `optimize` (idempotent no-op on second run)
- [x] Manual smoke test: `upload` against a local S3-compatible proxy (`lib/edge/tools/s3_proxy`) — all 80 files uploaded and verified present in the bucket, including quantized vector data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
