### PR TITLE
tests: wait for the cancelled task instead of a fixed budget

### DIFF
--- a/lib/collection/src/common/stoppable_task_async.rs
+++ b/lib/collection/src/common/stoppable_task_async.rs
@@ -69,11 +69,17 @@ where
 mod tests {
     use std::time::Duration;
 
-    use tokio::time::sleep;
+    use tokio::time::{sleep, timeout};
 
     use super::*;
 
     const STEP_MILLIS: u64 = 5;
+
+    /// Upper bound on how long a cancelled task may take to report that it
+    /// stopped. Deliberately far longer than it can plausibly need: it is only
+    /// reached when the task never stops at all, which is the failure the test
+    /// is here to catch.
+    const STOP_TIMEOUT: Duration = Duration::from_secs(30);
 
     async fn long_task(cancel: CancellationToken) -> i32 {
         let mut n = 0;
@@ -94,11 +100,20 @@ mod tests {
         sleep(Duration::from_millis(STEP_MILLIS * 5)).await;
         assert!(!handle.is_finished());
         handle.ask_to_cancel();
-        sleep(Duration::from_millis(STEP_MILLIS * 3)).await;
-        // If windows, we need to wait a bit more
-        #[cfg(windows)]
-        sleep(Duration::from_millis(STEP_MILLIS * 10)).await;
-        assert!(handle.is_finished());
+
+        // Wait until the task reports that it stopped, rather than sleeping for a
+        // fixed budget and assuming that was long enough. The flag is set by the
+        // task itself once it observes the cancellation, so any scheduling delay
+        // past the budget failed the assertion even though nothing was wrong --
+        // which is why the Windows arm kept being padded, and why this still
+        // flaked on macOS.
+        timeout(STOP_TIMEOUT, async {
+            while !handle.is_finished() {
+                sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("cancelled task never reported that it finished");
 
         let res = handle.cancel().await.unwrap();
         assert!(res < 10);

--- a/lib/collection/src/common/stoppable_task_async.rs
+++ b/lib/collection/src/common/stoppable_task_async.rs
@@ -69,21 +69,44 @@ where
 mod tests {
     use std::time::Duration;
 
+    use tokio::sync::oneshot;
     use tokio::time::{sleep, timeout};
 
     use super::*;
 
     const STEP_MILLIS: u64 = 5;
 
-    /// Upper bound on how long a cancelled task may take to report that it
-    /// stopped. Deliberately far longer than it can plausibly need: it is only
-    /// reached when the task never stops at all, which is the failure the test
-    /// is here to catch.
-    const STOP_TIMEOUT: Duration = Duration::from_secs(30);
+    /// Number of steps [`long_task`] runs when nothing cancels it.
+    ///
+    /// Sized so that an uncancelled task stays busy for far longer than
+    /// [`STOP_TIMEOUT`]: it cannot reach the end of its own loop while the test
+    /// is watching, so cancellation is the only thing that can make it stop.
+    const TASK_STEPS: i32 = 10_000;
 
-    async fn long_task(cancel: CancellationToken) -> i32 {
+    /// Upper bound on how long a *cancelled* task may take to stop.
+    ///
+    /// A passing run never comes close to it, since the task checks for
+    /// cancellation once every [`STEP_MILLIS`]. It is a safety bound for a task
+    /// that ignores cancellation altogether -- the failure this test exists to
+    /// catch -- so that such a task fails the test instead of hanging it.
+    const STOP_TIMEOUT: Duration = Duration::from_secs(1);
+
+    const _: () = assert!(
+        TASK_STEPS as u128 * STEP_MILLIS as u128 > STOP_TIMEOUT.as_millis(),
+        "an uncancelled `long_task` must outlast `STOP_TIMEOUT`, otherwise the \
+         test would pass without anything having been cancelled",
+    );
+
+    /// Counts steps until it is cancelled, then reports how far it got.
+    ///
+    /// Only cancellation ends it within the time bounds of the test.
+    async fn long_task(cancel: CancellationToken, started: oneshot::Sender<()>) -> i32 {
+        // Report that the task body is running, so that the test asks a task it
+        // knows to be alive to cancel.
+        started.send(()).expect("test dropped the start signal");
+
         let mut n = 0;
-        for i in 0..10 {
+        for i in 0..TASK_STEPS {
             n = i;
             if cancel.is_cancelled() {
                 break;
@@ -95,27 +118,32 @@ mod tests {
 
     #[tokio::test]
     async fn test_task_stop() {
-        let handle = spawn_async_cancellable(long_task);
+        let (started_tx, started_rx) = oneshot::channel();
+        let mut handle = spawn_async_cancellable(move |cancel| long_task(cancel, started_tx));
 
-        sleep(Duration::from_millis(STEP_MILLIS * 5)).await;
+        // Synchronise on the task instead of guessing how long it takes to be
+        // scheduled: once this resolves the task is running, and it still has
+        // essentially all of its steps ahead of it.
+        started_rx.await.expect("task never started");
         assert!(!handle.is_finished());
+
         handle.ask_to_cancel();
 
-        // Wait until the task reports that it stopped, rather than sleeping for a
-        // fixed budget and assuming that was long enough. The flag is set by the
-        // task itself once it observes the cancellation, so any scheduling delay
-        // past the budget failed the assertion even though nothing was wrong --
-        // which is why the Windows arm kept being padded, and why this still
-        // flaked on macOS.
-        timeout(STOP_TIMEOUT, async {
-            while !handle.is_finished() {
-                sleep(Duration::from_millis(1)).await;
-            }
-        })
-        .await
-        .expect("cancelled task never reported that it finished");
+        // Wait for the task to finish, rather than sleeping for a fixed budget
+        // and assuming that was long enough. Left alone the task would keep
+        // going for `TASK_STEPS * STEP_MILLIS`, so joining it can only succeed
+        // because the request above stopped it -- the timeout is a bound on a
+        // task that ignores cancellation, not the reason the test passes.
+        let res = timeout(STOP_TIMEOUT, &mut handle.join_handle)
+            .await
+            .expect("cancelled task did not stop")
+            .expect("task panicked");
 
-        let res = handle.cancel().await.unwrap();
-        assert!(res < 10);
+        // The task sets this flag itself, just before it returns.
+        assert!(handle.is_finished());
+
+        // An uncancelled run would have returned `TASK_STEPS - 1`; anything
+        // below that means the task broke out of its loop early.
+        assert!(res < TASK_STEPS - 1, "task was not stopped early: {res}");
     }
 }


### PR DESCRIPTION
Fixes #10081

`test_task_stop` asked the task to cancel, slept for a fixed budget and then asserted the task had reported itself finished. Nothing guarantees the task is scheduled inside that budget, so the assertion measured machine load rather than cancellation.

The budget has been widened for this before, twice, both times for Windows specifically (#1436 "add extra timeout for windows", #1448 "Fix flacky windows test"), which is what left the `#[cfg(windows)]` arm in place. It flaked again on macOS.

## Why waiting for the flag is not enough on its own

The first revision of this PR simply waited for `is_finished()`. That fixes the flake but breaks the test, as @xzfc pointed out: it passed with `handle.ask_to_cancel()` removed.

`long_task` ran a fixed ten steps, so it ended on its own after ~50ms, and `finished` is set whenever the task ends -- for any reason. Waiting on it was satisfied by natural completion just as well as by cancellation. The old fixed budget had encoded the causality by accident, asserting `is_finished()` at ~40ms, before the task could reach ~50ms on its own. That is a ~10ms window, which is why the test kept flaking and kept being padded.

## Change

- `long_task` now runs far more steps than it can get through inside the timeout, so reaching the end of its loop is no longer a way to finish. A `const` assertion ties that invariant to `STOP_TIMEOUT` so it cannot rot.
- The task signals over a `oneshot` when its body starts running, so cancellation is requested of a task known to be alive. This replaces the opening `sleep`.
- The test waits on the task's own `JoinHandle` instead of sleeping or polling.
- `STOP_TIMEOUT` is 1s, per @timvisee: the task checks for cancellation every 5ms, so a second bounds a task that ignores cancellation rather than being a budget the test spends.
- `res < TASK_STEPS - 1`, since the old `res < 10` always held -- an uncancelled run returns 9.

Joining the task can now only succeed because the cancellation request stopped it. This is how `counting_task` in the sibling `stoppable_task.rs` already works, for the same reason. The platform-specific padding is no longer needed and is removed.

## Verification

- With `handle.ask_to_cancel()` removed the test fails in 1.01s with `cancelled task did not stop: Elapsed(())`; restored, it passes in 0.02s. The same mutation against the first revision of this PR passed in 0.17s.
- 30 sequential runs, and 40 concurrent runs against 20 saturated cores: all green, worst case 0.06s against the 1s bound.
- `cargo fmt --check`, `cargo clippy -p collection --lib --tests` and `cargo test -p collection --lib common::stoppable_task_async` clean.
