### PR TITLE
fix(segment): propagate mmap read errors from numeric index check_values_any

### DIFF
--- a/lib/segment/benches/numeric_index_check_values.rs
+++ b/lib/segment/benches/numeric_index_check_values.rs
@@ -70,7 +70,10 @@ pub fn struct_numeric_check_values(c: &mut Criterion) {
         b.iter(|| {
             let random_index = rng.random_range(0..NUM_POINTS) as PointOffsetType;
 
-            if mmap_index.check_values_any(random_index, |value| *value > 0.5, &hw_counter) {
+            if mmap_index
+                .check_values_any(random_index, |value| *value > 0.5, &hw_counter)
+                .unwrap()
+            {
                 count += 1;
             }
         })

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/read_ops.rs
@@ -45,8 +45,8 @@ where
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         _hw_counter: &HardwareCounterCell,
-    ) -> bool {
-        self.point_to_values.check_values_any(idx, |v| check_fn(v))
+    ) -> OperationResult<bool> {
+        Ok(self.point_to_values.check_values_any(idx, |v| check_fn(v)))
     }
 
     fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {

--- a/lib/segment/src/index/field_index/numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/lifecycle.rs
@@ -100,7 +100,7 @@ where
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
-    ) -> bool {
+    ) -> OperationResult<bool> {
         self.inner.check_values_any(idx, check_fn, hw_counter)
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/read_ops.rs
@@ -24,8 +24,8 @@ where
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         _hw_counter: &HardwareCounterCell,
-    ) -> bool {
-        self.in_memory_index.check_values_any(idx, check_fn)
+    ) -> OperationResult<bool> {
+        Ok(self.in_memory_index.check_values_any(idx, check_fn))
     }
 
     fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_ops.rs
@@ -104,8 +104,8 @@ where
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         _hw_counter: &HardwareCounterCell,
-    ) -> bool {
-        self.in_memory_index.check_values_any(idx, check_fn)
+    ) -> OperationResult<bool> {
+        Ok(self.in_memory_index.check_values_any(idx, check_fn))
     }
 
     fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {

--- a/lib/segment/src/index/field_index/numeric_index/numeric_index_read.rs
+++ b/lib/segment/src/index/field_index/numeric_index/numeric_index_read.rs
@@ -25,15 +25,15 @@ use crate::telemetry::PayloadIndexTelemetry;
 /// [`NumericIndexInner`]: super::NumericIndexInner
 pub trait NumericIndexRead<T: Encodable + Numericable + Default + StoredValue> {
     /// Hardware counter is used only by the mmap-backed variant; in-memory
-    /// variants ignore it. Returns `false` if the mmap read fails (matches
-    /// the legacy enum dispatcher behavior — see the FIXME on
-    /// [`super::NumericIndexInner::check_values_any`]).
+    /// variants ignore it. Returns an error if the underlying mmap read
+    /// fails, so a transient IO failure surfaces to the caller instead of
+    /// being silently reported as "no match".
     fn check_values_any(
         &self,
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
-    ) -> bool;
+    ) -> OperationResult<bool>;
 
     /// Batched counterpart of [`Self::check_values_any`].
     fn for_each_matching_value<I, F, M, U>(
@@ -50,7 +50,7 @@ pub trait NumericIndexRead<T: Encodable + Numericable + Default + StoredValue> {
         M: FnMut(U, bool),
     {
         for (tag, idx) in items {
-            on_match(tag, self.check_values_any(idx, &check_fn, hw_counter));
+            on_match(tag, self.check_values_any(idx, &check_fn, hw_counter)?);
         }
         Ok(())
     }

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/read_ops.rs
@@ -26,18 +26,15 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
-    ) -> bool {
-        // FIXME: don't silently ignore error — propagate it once
-        // [`NumericIndexRead::check_values_any`] returns `OperationResult`.
+    ) -> OperationResult<bool> {
         let hw_counter = ConditionedCounter::always(hw_counter);
 
         if self.storage.deleted.is_active(idx) {
             self.storage
                 .point_to_values
                 .check_values_any(idx, |v| check_fn(v), &hw_counter)
-                .unwrap_or(false)
         } else {
-            false
+            Ok(false)
         }
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/query.rs
+++ b/lib/segment/src/index/field_index/numeric_index/query.rs
@@ -362,11 +362,11 @@ where
     type Error = OperationError;
 
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
-        Ok(self.index.check_values_any(
+        self.index.check_values_any(
             point_id,
             |value| self.typed_range.check_range(*value),
             &self.hw_counter,
-        ))
+        )
     }
 
     fn check_batched<K: CheckItem>(

--- a/lib/segment/src/index/field_index/numeric_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_only/read_ops.rs
@@ -34,7 +34,7 @@ where
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
-    ) -> bool {
+    ) -> OperationResult<bool> {
         self.inner.check_values_any(idx, check_fn, hw_counter)
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/read_ops.rs
@@ -32,7 +32,7 @@ where
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
-    ) -> bool {
+    ) -> OperationResult<bool> {
         match self {
             ReadOnlyNumericIndexInner::Appendable(index) => {
                 index.check_values_any(idx, check_fn, hw_counter)

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_ops.rs
@@ -30,9 +30,7 @@ where
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
-    ) -> bool {
-        // FIXME: don't silently ignore mmap-read errors; promote the trait
-        // method's return type to `OperationResult<bool>` and propagate.
+    ) -> OperationResult<bool> {
         match self {
             NumericIndexInner::Mutable(index) => index.check_values_any(idx, check_fn, hw_counter),
             NumericIndexInner::Immutable(index) => {


### PR DESCRIPTION
Closes #10180

On-disk numeric range checks silently swallowed mmap read errors: `NumericIndexRead::check_values_any` returned a bare `bool` and the on-disk impl ended with `.unwrap_or(false)`, so a failed mmap read was downgraded to "point does not match". A filtered search or scroll could then return a silently incomplete result set that looks successful, with no error for the client to see or retry.

This promotes `check_values_any` to `OperationResult<bool>` and propagates the error:

- on-disk impl drops `.unwrap_or(false)` and returns the read `Result` directly;
- the in-memory (mutable/immutable) impls wrap their infallible result in `Ok(...)`;
- the enum dispatchers and the `NumericIndex` wrapper thread the `Result` through;
- `RangeConditionChecker::check`, which already returns `OperationResult<bool>`, now returns the propagated error instead of `Ok(...)`.

This is exactly the change the two in-tree FIXMEs asked for (`numeric_index_read.rs` trait doc and `storage/read_ops.rs`); both are removed. No behavior change on the success path - only that a real read error now surfaces instead of being reported as "no match".

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### New feature submissions

- [x] Not a new feature (bugfix).

### AI disclosure (per CONTRIBUTING.md)

- [AI] fix(segment): propagate mmap read errors from numeric index check_values_any - AI-assisted, reviewed by me.
- Initial prompt: "In lib/segment/src/index/field_index/numeric_index, NumericIndexRead::check_values_any returns bool and the on-disk impl uses .unwrap_or(false), swallowing mmap read errors (see the two FIXMEs). Promote the trait method to OperationResult<bool>, propagate the error through all impls, the dispatcher, the NumericIndex wrapper, and the RangeConditionChecker caller."
