### PR TITLE
fix(common): use checked u32 conversion for simple_disk_cache block range

### DIFF
--- a/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/mod.rs
@@ -51,12 +51,14 @@ const REMOTE_OPEN_OPTIONS: OpenOptions = OpenOptions {
 };
 
 fn to_block_range(byte_range: Range<u64>) -> Range<u32> {
-    let start = (byte_range.start / BLOCK_SIZE as u64) as u32;
+    let start = u32::try_from(byte_range.start / BLOCK_SIZE as u64)
+        .expect("file too large for block cache (>70 TiB)");
     if byte_range.start >= byte_range.end {
         // empty byte range returns empty block range
         return start..start;
     }
-    let end = byte_range.end.div_ceil(BLOCK_SIZE as u64) as u32;
+    let end = u32::try_from(byte_range.end.div_ceil(BLOCK_SIZE as u64))
+        .expect("file too large for block cache (>70 TiB)");
     start..end
 }
 


### PR DESCRIPTION
Closes #10183

`to_block_range` cast block indices with a raw `as u32`, which silently truncates instead of erroring. Once a single file passes 64 TiB the start/end wrap to small numbers and the caller multiplies them back into a wrong byte offset, reading the wrong region rather than failing.

This mirrors the guard the sibling `disk_cache/cached_slice.rs` already uses: `u32::try_from(...).expect("file too large for block cache (>70 TiB)")`, so an out-of-range file fails loudly and consistently instead of silently misreading.

Low severity in practice (needs a single `>= 64 TiB` file), so this is a consistency/hardening cleanup with no behavioral test.

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### AI disclosure (per CONTRIBUTING.md)

- [AI] fix(common): use checked u32 conversion for simple_disk_cache block range - AI-assisted, reviewed by me.
- Initial prompt: "In lib/common/common/src/universal_io/simple_disk_cache/mod.rs, to_block_range casts block indices with `as u32` which silently truncates past 64 TiB. Replace both casts with u32::try_from(...).expect(...) mirroring disk_cache/cached_slice.rs."

Draft: I could not build the crate locally (a pre-existing toolchain issue with the `common` crate here), so I'm relying on CI.
