### PR TITLE
fix: do not panic when the global quota manager is installed twice

### DIFF
--- a/lib/shard/src/quota/mod.rs
+++ b/lib/shard/src/quota/mod.rs
@@ -36,15 +36,16 @@ static GLOBAL: OnceLock<Arc<QuotaManager>> = OnceLock::new();
 /// Install the node's quota manager, once at startup before anything measures a
 /// resource. `storage` does it while building the table of contents.
 ///
-/// A second call is a startup-order bug — the quota it configures would silently
-/// not be the one enforced — so it is loud rather than ignored.
+/// In a node, a second call is a startup-order bug: the quota it configures
+/// would silently not be the one enforced, so it is logged loudly. It is not
+/// fatal, because test harnesses legitimately build several tables of contents
+/// in one process, and the first one installed is as good as any there.
 pub fn set_global(manager: Arc<QuotaManager>) {
     if GLOBAL.set(manager).is_err() {
         log::error!(
             "Global quota manager was already initialized; \
              the quota configured for this node is not the one being enforced",
         );
-        debug_assert!(false, "global quota manager initialized twice");
     }
 }
 


### PR DESCRIPTION
## Problem

`TableOfContent::new` installs the process-global quota manager (`lib/storage/src/content_manager/toc/mod.rs:170`), and `quota::set_global` treated a second install as a startup-order bug with a `debug_assert!`.

`GLOBAL` is a `OnceLock`, so it is per-process state, and a test binary runs all of its tests as threads in a single process. Every test that builds its own `TableOfContent` installs the manager again, so all but the first one panic:

```
thread 'tokio-rt-worker' panicked at lib/shard/src/quota/mod.rs:47:9:
global quota manager initialized twice
```

On the `qdrant` binary that is 23 of 160 tests: `common::auth::tests`, `consensus::tests::collection_creation_passes_consensus`, and all of `tonic::api::storage_read_api::tests`. `lib/storage/tests/integration/alias_tests.rs` builds a table of contents per test too, so it has the same exposure. CI stays green because `cargo nextest run` forks a separate process per test, which leaves the `OnceLock` empty every time.

## Fix

Drop the `debug_assert!` and keep the `log::error!`. Building several tables of contents in one process is legitimate for test harnesses and for the multi-peer consensus test, and the first manager installed is as good as any there. A node that installs twice still reports it loudly in its logs, which is where that bug would be found.

## Testing

| command | before | after |
| --- | --- | --- |
| `cargo test --bin qdrant` | 137 passed, 23 failed | 160 passed, 0 failed |
| `cargo nextest run --bin qdrant` | 160 passed | 160 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)