### PR TITLE
Fix append-only shards becoming permanently unopenable after a delete or update

### DIFF
--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -765,6 +765,16 @@ impl Segment {
         // Get rid of mappingless points.
         let ids_to_clean = self.fix_id_tracker_inconsistencies()?;
 
+        // A mappingless slot is the normal resting state here, not a leftover to
+        // clean: an append-only delete tombstones in the id tracker and leaves
+        // the payload row and field indexes in place, and every mutation clones
+        // the point to a fresh slot. Deleting them is what those storages
+        // refuse, and it would fail every load of the segment from here on.
+        // They stay unreachable until the next optimization reclaims them.
+        if self.is_append_only_delete() {
+            return Ok(());
+        }
+
         // There are some leftovers to clean from segment.
         // After that we need to set internal version to 0, so that
         // we won't need to clean them again.

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -765,12 +765,9 @@ impl Segment {
         // Get rid of mappingless points.
         let ids_to_clean = self.fix_id_tracker_inconsistencies()?;
 
-        // A mappingless slot is the normal resting state here, not a leftover to
-        // clean: an append-only delete tombstones in the id tracker and leaves
-        // the payload row and field indexes in place, and every mutation clones
-        // the point to a fresh slot. Deleting them is what those storages
-        // refuse, and it would fail every load of the segment from here on.
-        // They stay unreachable until the next optimization reclaims them.
+        // Append-only leaves mappingless slots by design (tombstone-only delete,
+        // clone-on-mutate). They are unreachable, the next optimization reclaims
+        // them, and deleting them is precisely what these storages refuse.
         if self.is_append_only_delete() {
             return Ok(());
         }

--- a/lib/segment/tests/append_only_storages.rs
+++ b/lib/segment/tests/append_only_storages.rs
@@ -138,10 +138,8 @@ fn append_only_storages_serve_the_ordinary_write_paths() {
         load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
     assert!(segment.append_only_mutations);
 
-    // The mappingless slots the tombstone-only delete and the mutation clones
-    // leave behind must not read as corruption: the repair every shard loader
-    // runs would try to delete them, which these storages refuse, leaving the
-    // segment permanently unopenable.
+    // The repair every shard loader runs; deleting the leftovers it finds would
+    // fail here, leaving the segment permanently unopenable.
     segment
         .check_consistency_and_repair()
         .expect("append-only leftovers must not be reported as inconsistencies");

--- a/lib/segment/tests/append_only_storages.rs
+++ b/lib/segment/tests/append_only_storages.rs
@@ -134,8 +134,17 @@ fn append_only_storages_serve_the_ordinary_write_paths() {
     drop(segment);
 
     // Everything survives a reload through the ordinary loader.
-    let segment = load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
+    let mut segment =
+        load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
     assert!(segment.append_only_mutations);
+
+    // The mappingless slots the tombstone-only delete and the mutation clones
+    // leave behind must not read as corruption: the repair every shard loader
+    // runs would try to delete them, which these storages refuse, leaving the
+    // segment permanently unopenable.
+    segment
+        .check_consistency_and_repair()
+        .expect("append-only leftovers must not be reported as inconsistencies");
 
     assert_eq!(segment.available_point_count(), 5);
     let payload = segment.payload(3.into(), &hw_counter).unwrap();

--- a/lib/shard/src/update/points/upsert.rs
+++ b/lib/shard/src/update/points/upsert.rs
@@ -2,7 +2,6 @@
 
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::flags::feature_flags;
 use parking_lot::RwLockWriteGuard;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::data_types::named_vectors::NamedVectors;
@@ -213,13 +212,7 @@ where
         let updated_points = segments.apply_points_with_conditional_move(
             op_num,
             ids_chunk,
-            |id, write_segment| {
-                debug_assert!(
-                    !feature_flags().append_only_storages,
-                    "This should never be called in append-only mode"
-                );
-                points_map[&id].upsert_into(write_segment, op_num, hw_counter)
-            },
+            |id, write_segment| points_map[&id].upsert_into(write_segment, op_num, hw_counter),
             |id, raw_vectors, updated_vectors, old_payload| {
                 points_map[&id].write_moved(raw_vectors, updated_vectors, old_payload)
             },


### PR DESCRIPTION
Under `serverless_compatible` (which forces `append_only_storages`), a shard becomes permanently unopenable after an ordinary delete or an update of an existing point.

```sh
edge-tool create --dense 4 --payload-index age:integer ./v1
edge-tool upsert -n 5 --start-id 0 ./v1
edge-tool upsert -n 5 --start-id 0 ./v1     # same ids
edge-tool optimize ./v1                      # any reopen
→ failed to repair segment …: Operation not supported in append-only mode: deleting values
```

Every subsequent open fails the same way.

## Cause

Append-only mode deliberately leaves mappingless slots behind:

- `delete_point` is tombstone-only — it drops the point from the id tracker and leaves the payload row and field indexes at `internal_id` in place, on purpose, so committed on-disk structures stay append-only.
- every mutation of an existing point clones it to a fresh internal id and repoints the id tracker.

Either way the old internal id keeps a non-deleted *version* and loses its external mapping. `IdTracker::fix_inconsistencies` classifies exactly that as corruption ("point was deleted, but version and likely the storage wasn't cleaned up") and hands the ids to `check_consistency_and_repair`, which calls `delete_point_internal` on each. That deletes payload rows and field-index values — which is what an append-only Blobstore refuses, unconditionally, since #10154 kept `Logstore::delete_value` strict.

So the repair every shard loader runs (`EdgeShard::load`, and `LocalShard` at `local_shard/mod.rs:455`) tries to perform the one operation these storages cannot, on state the design intends to exist.

## Fix

`check_consistency_and_repair` skips the storage cleanup on an append-only segment. The slots are unreachable — no mapping, so no read finds them, which is what tombstone-only deletes already rely on — and the next optimization reclaims them.

`fix_id_tracker_inconsistencies` still runs: a mapping without a version is a genuine incomplete insert, and repairing it only touches the id tracker.

Also drops the `debug_assert` in `upsert_points_impl` claiming the in-place upsert path is never reached in append-only mode. It is, for every existing point that lives in a non-proxy appendable segment — `apply_points_with_conditional_move` routes to the move path only for immutable segments — so re-upserting a point panicked every debug build. In release the assert compiled out and the load failure above is what you got instead.

## Test plan

- [x] `lib/segment/tests/append_only_storages.rs` now runs `check_consistency_and_repair` on the reloaded segment, which is what the gap was: the test already exercised deletes, clones and a reload, but never the repair, so CI stayed green. It fails without this change.
- [x] `cargo test -p segment --lib` 1001 passed, `--test append_only_storages` 2 passed
- [x] `cargo test -p shard --lib` 125 passed, `cargo test -p edge --lib` 59 passed
- [x] clippy + fmt clean on `segment`, `shard`
- [x] The repro above reopens and keeps serving after the fix (5 points, then 10 after appending 5 more)
