### PR TITLE
Include `ETag` in `FileInfo`

### DIFF
--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -18,6 +18,8 @@ pub struct FileInfo {
     pub size: u64,
     /// Last modification time, when the listing backend exposes one
     pub last_modified: Option<std::time::SystemTime>,
+    /// Entity tag, when the listing backend exposes one (object stores)
+    pub etag: Option<String>,
 }
 
 impl FileInfo {
@@ -25,13 +27,23 @@ impl FileInfo {
     pub fn full_eq(&self, other: &FileInfo) -> bool {
         let Self {
             size,
-            last_modified,
-        } = self;
+            last_modified: Some(last_modified),
+            etag: Some(etag),
+        } = self
+        else {
+            return false;
+        };
 
-        size == &other.size
-            && last_modified
-                .zip(other.last_modified)
-                .is_some_and(|(this, other)| this == other)
+        let Self {
+            size: other_size,
+            last_modified: Some(other_last_modified),
+            etag: Some(other_etag),
+        } = other
+        else {
+            return false;
+        };
+
+        size == other_size && last_modified == other_last_modified && etag == other_etag
     }
 }
 
@@ -156,6 +168,7 @@ impl<Fs: UniversalReadFs> CachedFs<Fs> {
                 path: path.clone(),
                 size: info.size,
                 last_modified: info.last_modified,
+                etag: info.etag.clone(),
             })
             .collect()
     }
@@ -174,10 +187,12 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
                      path,
                      size,
                      last_modified,
+                     etag,
                  }| {
                     let info = FileInfo {
                         size,
                         last_modified,
+                        etag,
                     };
                     (path, info)
                 },

--- a/lib/common/common/src/universal_io/local_file_ops.rs
+++ b/lib/common/common/src/universal_io/local_file_ops.rs
@@ -123,6 +123,7 @@ pub fn local_list_files(prefix_path: &Path) -> UioResult<Vec<ListedFile>> {
                 path: entry.path(),
                 size: metadata.len(),
                 last_modified: metadata.modified().ok(),
+                etag: None,
             });
         }
     }
@@ -141,6 +142,7 @@ pub fn local_list_files(prefix_path: &Path) -> UioResult<Vec<ListedFile>> {
                     path: entry.path(),
                     size: metadata.len(),
                     last_modified: metadata.modified().ok(),
+                    etag: None,
                 });
             }
         }

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -239,6 +239,9 @@ pub struct ListedFile {
     /// Last modification time, when the backend exposes one (local
     /// filesystems, object stores); `None` otherwise.
     pub last_modified: Option<std::time::SystemTime>,
+    /// Entity tag, when the backend exposes one (object stores); `None`
+    /// otherwise.
+    pub etag: Option<String>,
 }
 
 pub type ByteOffset = u64;

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -148,6 +148,7 @@ impl<S: BlobBackend> AsyncRead for ObjectStoreSource<S> {
                             path: PathBuf::from(location),
                             size: e.size,
                             last_modified: Some(SystemTime::from(e.last_modified)),
+                            etag: e.e_tag,
                         })
                     })
                     .collect()),
@@ -699,7 +700,11 @@ mod tests {
                      path,
                      size,
                      last_modified: _,
-                 }| (path.to_string_lossy().into_owned(), size),
+                     etag,
+                 }| {
+                    assert!(etag.is_some(), "object store listings must carry etags");
+                    (path.to_string_lossy().into_owned(), size)
+                },
             )
             .collect();
         files.sort();

--- a/lib/common/io_bridge_object_store/src/tests/integration.rs
+++ b/lib/common/io_bridge_object_store/src/tests/integration.rs
@@ -199,6 +199,7 @@ fn test_list_files() {
         path,
         size,
         last_modified: _,
+        etag: _,
     } in &files
     {
         assert!(path.to_string_lossy().starts_with("listed/"));

--- a/lib/uio-grpc-client/src/read.rs
+++ b/lib/uio-grpc-client/src/read.rs
@@ -150,6 +150,8 @@ impl Client {
                 last_modified: entry
                     .last_modified
                     .and_then(|ts| std::time::SystemTime::try_from(ts).ok()),
+                // The ListFiles proto doesn't carry etags
+                etag: None,
             })
             .collect())
     }

--- a/lib/uio-grpc-client/src/tests.rs
+++ b/lib/uio-grpc-client/src/tests.rs
@@ -216,11 +216,13 @@ async fn list_files() {
                 path: PathBuf::from("data/a.bin"),
                 size: 10,
                 last_modified: Some(mock_modified_time()),
+                etag: None,
             },
             ListedFile {
                 path: PathBuf::from("data/b.bin"),
                 size: 10,
                 last_modified: Some(mock_modified_time()),
+                etag: None,
             },
         ]
     );

--- a/src/tonic/api/storage_read_api/mod.rs
+++ b/src/tonic/api/storage_read_api/mod.rs
@@ -101,6 +101,7 @@ where
                      path,
                      size,
                      last_modified,
+                     etag: _,
                  }| {
                     path.strip_prefix(&base).ok().map(|rel| {
                         // Always use forward slashes in gRPC responses regardless of OS.


### PR DESCRIPTION
In relation with #10050, to be able to accurately compare if a file has changed or not, we need a stricter signal than the 1 second resolution `last_modified` time.

This PR adds `e_tag` optional field to be able to use it as a change signal, if provided. 