### PR TITLE
[UIO] `schedule_reopen` takes `&self`

### DIFF
--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -63,7 +63,7 @@ where
     }
 
     fn schedule_reopen<F: FnOnce(&Path) -> Option<FileInfo>>(
-        &mut self,
+        &self,
         get_file_info: F,
     ) -> UioResult<()> {
         self.schedule_reopen_impl(get_file_info)

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -89,7 +89,7 @@ where
     }
 
     pub(super) fn schedule_reopen_impl<F: FnOnce(&Path) -> Option<FileInfo>>(
-        &mut self,
+        &self,
         get_file_info: F,
     ) -> UioResult<()> {
         let Some(file_info) = get_file_info(&self.remote_path) else {
@@ -109,18 +109,19 @@ where
     /// apply.
     ///
     /// [`UniversalRead::schedule_reopen`]: crate::universal_io::UniversalRead::schedule_reopen
-    pub(super) fn schedule_reopen_with_len(&mut self, known_len: Option<u64>) -> UioResult<()> {
+    pub(super) fn schedule_reopen_with_len(&self, known_len: Option<u64>) -> UioResult<()> {
         // Wait for scheduled prefill, if any.
         //
         // warn: this will do a length request if uninit, but when using a
         // cached fs to create the file it should never be uninit.
         self.init_state()?;
 
+        let mut state = self.state.lock();
         let State::Ready {
             remote,
             local,
             scheduled_reopen,
-        } = self.state.get_mut()
+        } = &mut *state
         else {
             unreachable!("init_state drives state to Ready");
         };
@@ -186,15 +187,6 @@ where
             }
         };
 
-        // Re-borrow the state: `open_remote` above needs `&self`.
-        let State::Ready {
-            remote: _,
-            local: _,
-            scheduled_reopen,
-        } = self.state.get_mut()
-        else {
-            unreachable!("state was Ready above");
-        };
         *scheduled_reopen = Some(new_scheduled_reopen);
 
         Ok(())

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -595,7 +595,7 @@ mod tests_mod {
     #[test]
     fn reopen_schedule_missing_from_snapshot_errors() {
         let scn = Scenario::new(BLOCK_SIZE);
-        let mut cache = scn.open::<R>(PREFILL);
+        let cache = scn.open::<R>(PREFILL);
 
         let err = cache.schedule_reopen(|_| None).unwrap_err();
         assert_matches!(err, UniversalIoError::NotFound { .. });

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -78,7 +78,7 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     /// [`CachedReadFs`]: crate::universal_io::CachedReadFs
     /// [`DiskCache`]: crate::universal_io::DiskCache
     fn schedule_reopen<F: FnOnce(&Path) -> Option<FileInfo>>(
-        &mut self,
+        &self,
         get_file_info: F,
     ) -> UioResult<()> {
         let _ = get_file_info;

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -118,7 +118,7 @@ where
 
     #[inline]
     fn schedule_reopen<F: FnOnce(&Path) -> Option<FileInfo>>(
-        &mut self,
+        &self,
         get_file_info: F,
     ) -> UioResult<()> {
         self.0.schedule_reopen(get_file_info)


### PR DESCRIPTION
In #10049, I set up `schedule_reopen` to be a `&mut self` function. However, if we want to make this section non-blocking, we need it to be `&self`. 

Fortunately, it's a pretty simple change.