### PR TITLE
Integrate batched HNSW

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11839,6 +11839,11 @@
             "default": true,
             "type": "boolean"
           },
+          "async_hnsw_graph": {
+            "description": "Allow the batched io_uring-based HNSW graph search. When disabled, the HNSW graph is *never* opened on io_uring. When enabled, the graph backend is decided based on `storage.performance.io_uring` option and links placement.",
+            "default": false,
+            "type": "boolean"
+          },
           "write_segment_manifest": {
             "description": "Write a segment manifest (`segments_manifest.json`, next to the `segments/` directory) listing the shard's segments and their state, so out-of-process readers can discover segments without scanning the filesystem.",
             "default": false,

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -34,6 +34,11 @@ pub struct FeatureFlags {
     /// When enabled, payload storage backend is decided based on `storage.performance.io_uring` option and payload storage type.
     pub async_payload_storage: bool,
 
+    /// Allow the batched io_uring-based HNSW graph search.
+    /// When disabled, the HNSW graph is *never* opened on io_uring.
+    /// When enabled, the graph backend is decided based on `storage.performance.io_uring` option and links placement.
+    pub async_hnsw_graph: bool,
+
     /// Write a segment manifest (`segments_manifest.json`, next to the `segments/` directory)
     /// listing the shard's segments and their
     /// state, so out-of-process readers can discover segments without scanning the filesystem.
@@ -70,6 +75,7 @@ impl Default for FeatureFlags {
             appendable_quantization: true,
             single_file_mmap_vector_storage: true,
             async_payload_storage: true,
+            async_hnsw_graph: false,
             write_segment_manifest: false,
             append_only_mutations: false,
             compact_bitmask: false,
@@ -98,6 +104,7 @@ impl FeatureFlags {
             appendable_quantization: true,
             single_file_mmap_vector_storage: true,
             async_payload_storage: true,
+            async_hnsw_graph: true,
             write_segment_manifest: true,
             // Deliberately not enabled by `all`: these change mutation semantics and the
             // persisted storage format, and `all` is enabled in dev and e2e configs.

--- a/lib/segment/src/index/hnsw_index/graph.rs
+++ b/lib/segment/src/index/hnsw_index/graph.rs
@@ -9,14 +9,13 @@ use super::GraphWithVectorsScorers;
 use super::entry_points::{EntryPoint, EntryPoints};
 use super::graph_layers::{GraphLayers, SearchAlgorithm};
 use super::graph_layers_batched::GraphLayersBatched;
-use super::graph_links::{GraphLinks, GraphLinksResidency};
+use super::graph_links::{GraphLinks, GraphLinksFile, GraphLinksFormat, GraphLinksResidency};
 use super::point_scorer::{FilteredScorer, ScorerFilters};
 use crate::common::operation_error::OperationResult;
 
 #[derive(Debug)]
 pub enum HnswGraph<S: UniversalRead> {
     Direct(GraphLayers),
-    #[expect(dead_code)]
     Batched(Box<GraphLayersBatched<S>>),
 }
 
@@ -45,6 +44,28 @@ pub enum SearchScorers<'a> {
 }
 
 impl<S: UniversalRead> HnswGraph<S> {
+    /// Whether [`Self::open_universal`] will open a batched-IO graph.
+    pub(super) fn is_batched(
+        fs: &impl UniversalReadFs<File = S>,
+        dir: &Path,
+        residency: GraphLinksResidency,
+    ) -> OperationResult<bool> {
+        let format = GraphLayers::probe_links_format(fs, dir)?;
+        Ok(format.is_some_and(|format| Self::format_is_batched(format, residency)))
+    }
+
+    fn format_is_batched(format: GraphLinksFormat, residency: GraphLinksResidency) -> bool {
+        if residency == GraphLinksResidency::Pinned {
+            return false;
+        }
+        match format {
+            GraphLinksFormat::CompressedWithVectors | GraphLinksFormat::Compressed => {
+                S::kind().can_be_async()
+            }
+            GraphLinksFormat::Plain => false,
+        }
+    }
+
     pub fn open_universal(
         fs: &impl UniversalReadFs<File = S>,
         dir: &Path,
@@ -53,11 +74,15 @@ impl<S: UniversalRead> HnswGraph<S> {
     where
         S: 'static,
     {
-        // Note that on non-borrowable backends this materializes the links
-        // into heap RAM whatever the residency.
-        Ok(HnswGraph::Direct(GraphLayers::load_universal(
-            fs, dir, residency,
-        )?))
+        Ok(if Self::is_batched(fs, dir, residency)? {
+            HnswGraph::Batched(Box::new(GraphLayersBatched::open(fs, dir, residency)?))
+        } else {
+            // Note that on non-borrowable backends this materializes the
+            // links into heap RAM whatever the residency: `Plain` is not
+            // supported by the batched view, and `Pinned` asks for
+            // materialization explicitly.
+            HnswGraph::Direct(GraphLayers::load_universal(fs, dir, residency)?)
+        })
     }
 
     /// Schedule background prefetch of the files [`Self::open_universal`]
@@ -72,9 +97,14 @@ impl<S: UniversalRead> HnswGraph<S> {
         let Some(format) = GraphLayers::probe_links_format(fs, dir)? else {
             return Ok(());
         };
+        let options = if Self::format_is_batched(format, residency) {
+            GraphLinksFile::<S>::preopen_options(format, residency)
+        } else {
+            GraphLinks::preopen_options(residency)
+        };
         fs.schedule_prefetch(
             &GraphLayers::get_links_path(dir, format),
-            Some(GraphLinks::preopen_options(residency)),
+            Some(options),
             None,
         )?;
         Ok(())

--- a/lib/segment/src/index/hnsw_index/graph.rs
+++ b/lib/segment/src/index/hnsw_index/graph.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::AtomicBool;
 use common::types::{PointOffsetType, ScoredPointOffset};
 #[cfg(not(target_os = "linux"))]
 use common::universal_io::MmapFile;
-use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalKind, UniversalRead, UniversalReadFs};
 #[cfg(target_os = "linux")]
 use common::universal_io::{IoUringFile, IoUringFs};
 use itertools::Itertools as _;
@@ -31,9 +31,6 @@ pub type HnswLinksStorage = cfg_select! {
     _ => MmapFile,
 };
 
-/// Default for [`GraphSearchArgs::batch_size`].
-pub const DEFAULT_LINKS_BATCH_SIZE: usize = 512;
-
 /// Args for [`HnswGraph::search`].
 pub struct GraphSearchArgs<'a> {
     pub top: usize,
@@ -41,7 +38,6 @@ pub struct GraphSearchArgs<'a> {
     pub algorithm: SearchAlgorithm,
     pub scorers: SearchScorers<'a>,
     pub custom_entry_points: Option<&'a [PointOffsetType]>,
-    pub batch_size: usize,
     pub is_stopped: &'a AtomicBool,
 }
 
@@ -144,7 +140,6 @@ impl<S: UniversalRead> HnswGraph<S> {
             algorithm,
             mut scorers,
             custom_entry_points,
-            batch_size,
             is_stopped,
         } = args;
 
@@ -154,6 +149,19 @@ impl<S: UniversalRead> HnswGraph<S> {
         };
         let Some(entry) = self.get_entry_point(filters, custom_entry_points)? else {
             return Ok(Vec::new());
+        };
+
+        let batch_size = match S::kind() {
+            UniversalKind::IoUring => 4,
+            // Not tested, but let's assume it's same as for IoUring
+            UniversalKind::Mmap => 4,
+            // Network-based backends.
+            UniversalKind::DiskCache
+            | UniversalKind::SimpleDiskCache
+            | UniversalKind::S3
+            | UniversalKind::Gcs
+            | UniversalKind::Azure
+            | UniversalKind::UioGrpc => 16,
         };
 
         match (self, &mut scorers) {

--- a/lib/segment/src/index/hnsw_index/graph.rs
+++ b/lib/segment/src/index/hnsw_index/graph.rs
@@ -2,7 +2,11 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
 use common::types::{PointOffsetType, ScoredPointOffset};
-use common::universal_io::{CachedReadFs, MmapFile, UniversalRead, UniversalReadFs};
+#[cfg(not(target_os = "linux"))]
+use common::universal_io::MmapFile;
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+#[cfg(target_os = "linux")]
+use common::universal_io::{IoUringFile, IoUringFs};
 use itertools::Itertools as _;
 
 use super::GraphWithVectorsScorers;
@@ -22,7 +26,10 @@ pub enum HnswGraph<S: UniversalRead> {
 /// Backend the writable [`HNSWIndex`][1] reads its graph links through.
 ///
 /// [1]: super::hnsw::HNSWIndex
-pub type HnswLinksStorage = MmapFile;
+pub type HnswLinksStorage = cfg_select! {
+    target_os = "linux" => IoUringFile,
+    _ => MmapFile,
+};
 
 /// Default for [`GraphSearchArgs::batch_size`].
 pub const DEFAULT_LINKS_BATCH_SIZE: usize = 512;
@@ -41,6 +48,26 @@ pub struct GraphSearchArgs<'a> {
 pub enum SearchScorers<'a> {
     Regular(FilteredScorer<'a>),
     WithVectors(GraphWithVectorsScorers<'a>),
+}
+
+impl HnswGraph<HnswLinksStorage> {
+    pub fn open(
+        dir: &Path,
+        residency: GraphLinksResidency,
+        do_convert: bool,
+        with_uring: bool,
+    ) -> OperationResult<Self> {
+        if with_uring {
+            #[cfg(target_os = "linux")]
+            if Self::is_batched(&IoUringFs, dir, residency)? {
+                let graph = GraphLayersBatched::open(&IoUringFs, dir, residency)?;
+                return Ok(HnswGraph::Batched(Box::new(graph)));
+            }
+        }
+
+        let graph = GraphLayers::load(dir, residency, do_convert)?;
+        Ok(HnswGraph::Direct(graph))
+    }
 }
 
 impl<S: UniversalRead> HnswGraph<S> {

--- a/lib/segment/src/index/hnsw_index/graph.rs
+++ b/lib/segment/src/index/hnsw_index/graph.rs
@@ -1,0 +1,203 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+
+use common::types::{PointOffsetType, ScoredPointOffset};
+use common::universal_io::{CachedReadFs, MmapFile, UniversalRead, UniversalReadFs};
+use itertools::Itertools as _;
+
+use super::GraphWithVectorsScorers;
+use super::entry_points::{EntryPoint, EntryPoints};
+use super::graph_layers::{GraphLayers, SearchAlgorithm};
+use super::graph_layers_batched::GraphLayersBatched;
+use super::graph_links::{GraphLinks, GraphLinksResidency};
+use super::point_scorer::{FilteredScorer, ScorerFilters};
+use crate::common::operation_error::OperationResult;
+
+#[derive(Debug)]
+pub enum HnswGraph<S: UniversalRead> {
+    Direct(GraphLayers),
+    #[expect(dead_code)]
+    Batched(Box<GraphLayersBatched<S>>),
+}
+
+/// Backend the writable [`HNSWIndex`][1] reads its graph links through.
+///
+/// [1]: super::hnsw::HNSWIndex
+pub type HnswLinksStorage = MmapFile;
+
+/// Default for [`GraphSearchArgs::batch_size`].
+pub const DEFAULT_LINKS_BATCH_SIZE: usize = 512;
+
+/// Args for [`HnswGraph::search`].
+pub struct GraphSearchArgs<'a> {
+    pub top: usize,
+    pub ef: usize,
+    pub algorithm: SearchAlgorithm,
+    pub scorers: SearchScorers<'a>,
+    pub custom_entry_points: Option<&'a [PointOffsetType]>,
+    pub batch_size: usize,
+    pub is_stopped: &'a AtomicBool,
+}
+
+pub enum SearchScorers<'a> {
+    Regular(FilteredScorer<'a>),
+    WithVectors(GraphWithVectorsScorers<'a>),
+}
+
+impl<S: UniversalRead> HnswGraph<S> {
+    pub fn open_universal(
+        fs: &impl UniversalReadFs<File = S>,
+        dir: &Path,
+        residency: GraphLinksResidency,
+    ) -> OperationResult<Self>
+    where
+        S: 'static,
+    {
+        // Note that on non-borrowable backends this materializes the links
+        // into heap RAM whatever the residency.
+        Ok(HnswGraph::Direct(GraphLayers::load_universal(
+            fs, dir, residency,
+        )?))
+    }
+
+    /// Schedule background prefetch of the files [`Self::open_universal`]
+    /// will read: the graph data plus whichever links format is present,
+    /// probed in the same order as the open.
+    pub fn preopen_universal(
+        fs: &impl CachedReadFs<File = S>,
+        dir: &Path,
+        residency: GraphLinksResidency,
+    ) -> OperationResult<()> {
+        fs.schedule_prefetch(&GraphLayers::get_path(dir), None, None)?;
+        let Some(format) = GraphLayers::probe_links_format(fs, dir)? else {
+            return Ok(());
+        };
+        fs.schedule_prefetch(
+            &GraphLayers::get_links_path(dir, format),
+            Some(GraphLinks::preopen_options(residency)),
+            None,
+        )?;
+        Ok(())
+    }
+
+    pub fn search(&self, args: GraphSearchArgs<'_>) -> OperationResult<Vec<ScoredPointOffset>> {
+        let GraphSearchArgs {
+            top,
+            ef,
+            algorithm,
+            mut scorers,
+            custom_entry_points,
+            batch_size,
+            is_stopped,
+        } = args;
+
+        let filters = match &scorers {
+            SearchScorers::Regular(scorer) => scorer.filters(),
+            SearchScorers::WithVectors(scorers) => scorers.links.filters(),
+        };
+        let Some(entry) = self.get_entry_point(filters, custom_entry_points)? else {
+            return Ok(Vec::new());
+        };
+
+        match (self, &mut scorers) {
+            (HnswGraph::Direct(graph), SearchScorers::Regular(scorer)) => {
+                Ok(graph.search(top, ef, algorithm, scorer, entry, is_stopped)?)
+            }
+            (HnswGraph::Direct(graph), SearchScorers::WithVectors(scorers)) => {
+                Ok(graph.search_with_vectors(top, ef, *scorers, entry, is_stopped)?)
+            }
+            (HnswGraph::Batched(graph), SearchScorers::Regular(scorer)) => {
+                graph.search(top, ef, algorithm, scorer, entry, batch_size, is_stopped)
+            }
+            (HnswGraph::Batched(graph), SearchScorers::WithVectors(scorers)) => {
+                graph.search_with_vectors(top, ef, *scorers, entry, batch_size, is_stopped)
+            }
+        }
+    }
+
+    fn get_entry_point(
+        &self,
+        filters: &ScorerFilters<'_>,
+        custom_entry_points: Option<&[PointOffsetType]>,
+    ) -> OperationResult<Option<EntryPoint>> {
+        let custom_best = custom_entry_points
+            .unwrap_or_default()
+            .iter()
+            .filter(|&&point_id| filters.check_vector(point_id))
+            .map(|&point_id| {
+                let level = self.point_level(point_id)?;
+                OperationResult::Ok(EntryPoint { point_id, level })
+            })
+            .process_results(|it| it.max_by_key(|ep| ep.level))?;
+        Ok(custom_best.or_else(|| {
+            self.entry_points()
+                .get_entry_point(|point_id| filters.check_vector(point_id))
+        }))
+    }
+
+    fn point_level(&self, point_id: PointOffsetType) -> OperationResult<usize> {
+        match self {
+            HnswGraph::Direct(graph) => Ok(graph.point_level(point_id)),
+            HnswGraph::Batched(graph) => graph.links.point_level(point_id),
+        }
+    }
+
+    fn entry_points(&self) -> &EntryPoints {
+        match self {
+            HnswGraph::Direct(graph) => &graph.entry_points,
+            HnswGraph::Batched(graph) => &graph.entry_points,
+        }
+    }
+
+    pub fn has_inline_vectors(&self) -> bool {
+        match self {
+            HnswGraph::Direct(graph) => graph.links.format().is_with_vectors(),
+            HnswGraph::Batched(graph) => graph.links.is_with_vectors(),
+        }
+    }
+
+    pub(super) fn as_direct(&self) -> Option<&GraphLayers> {
+        match self {
+            HnswGraph::Direct(graph) => Some(graph),
+            HnswGraph::Batched(_) => None,
+        }
+    }
+
+    pub fn num_points(&self) -> usize {
+        match self {
+            HnswGraph::Direct(graph) => graph.links.num_points(),
+            HnswGraph::Batched(graph) => graph.num_points(),
+        }
+    }
+
+    pub fn files(&self, path: &Path) -> Vec<PathBuf> {
+        match self {
+            HnswGraph::Direct(graph) => graph.files(path),
+            HnswGraph::Batched(graph) => vec![
+                GraphLayers::get_path(path),
+                GraphLayers::get_links_path(path, graph.links.format()),
+            ],
+        }
+    }
+
+    pub fn links_heap_size_bytes(&self) -> usize {
+        match self {
+            HnswGraph::Direct(graph) => graph.links_heap_size_bytes(),
+            HnswGraph::Batched(_) => 0,
+        }
+    }
+
+    pub fn populate(&self) -> OperationResult<()> {
+        match self {
+            HnswGraph::Direct(graph) => graph.links.populate(),
+            HnswGraph::Batched(graph) => graph.links.populate(),
+        }
+    }
+
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        match self {
+            HnswGraph::Direct(graph) => graph.links.clear_cache(),
+            HnswGraph::Batched(graph) => graph.links.clear_cache(),
+        }
+    }
+}

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -33,9 +33,7 @@ use std::sync::atomic::AtomicBool;
 use common::fixed_length_priority_queue::FixedLengthPriorityQueue;
 use common::fs::atomic_save;
 use common::types::{PointOffsetType, ScoredPointOffset};
-use common::universal_io::{
-    CachedReadFs, MmapFs, OpenOptions, Populate, UniversalReadFs, read_bin_via,
-};
+use common::universal_io::{MmapFs, UniversalReadFs, read_bin_via};
 use fs_err as fs;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -48,7 +46,7 @@ use crate::common::operation_error::{
 };
 use crate::common::utils::rev_range;
 use crate::index::hnsw_index::graph_links::{GraphLinksFormatParam, serialize_graph_links};
-use crate::index::hnsw_index::point_scorer::{FilteredBytesScorer, FilteredScorer, ScorerFilters};
+use crate::index::hnsw_index::point_scorer::{FilteredBytesScorer, FilteredScorer};
 use crate::index::hnsw_index::search_context::SearchContext;
 use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
 use crate::vector_storage::RawScorer;
@@ -503,30 +501,6 @@ impl GraphLayers {
         self.links.point_level(point_id)
     }
 
-    pub fn get_entry_point(
-        &self,
-        filters: &ScorerFilters,
-        custom_entry_points: Option<&[PointOffsetType]>,
-    ) -> Option<EntryPoint> {
-        // Try to get it from custom entry points
-        custom_entry_points
-            .and_then(|custom_entry_points| {
-                custom_entry_points
-                    .iter()
-                    .filter(|&&point_id| filters.check_vector(point_id))
-                    .map(|&point_id| {
-                        let level = self.point_level(point_id);
-                        EntryPoint { point_id, level }
-                    })
-                    .max_by_key(|ep| ep.level)
-            })
-            .or_else(|| {
-                // Otherwise use normal entry points
-                self.entry_points
-                    .get_entry_point(|point_id| filters.check_vector(point_id))
-            })
-    }
-
     #[cfg(any(test, feature = "testing"))]
     pub fn unfiltered_entry_point(&self) -> EntryPoint {
         self.entry_points.get_entry_point(|_| true).unwrap()
@@ -608,10 +582,6 @@ impl GraphLayers {
         ]
     }
 
-    pub fn num_points(&self) -> usize {
-        self.links.num_points()
-    }
-
     /// Heap RAM held by the graph links, in bytes.
     /// Zero when the links are backed by a live (mmap-backed) file handle;
     /// see [`GraphLinks::heap_size_bytes`].
@@ -658,37 +628,6 @@ impl GraphLayers {
             }
         }
         Ok(None)
-    }
-
-    /// Schedule background prefetch of the files [`Self::load_universal`] will
-    /// read: the graph data plus whichever links format is present, probed in
-    /// the same order as the load.
-    pub fn preopen_universal(
-        fs: &impl CachedReadFs,
-        dir: &Path,
-        residency: GraphLinksResidency,
-    ) -> OperationResult<()> {
-        // Graph data
-        fs.schedule_prefetch(&Self::get_path(dir), None, None)?;
-
-        // The load reads `Cached` links with a *blocking* populate and
-        // materializes `Pinned` links into heap; at prefetch time both become
-        // a background populate so the fetch overlaps the rest of the open.
-        // `Cold` links stay unpopulated, matching the load.
-        let populate = match residency {
-            GraphLinksResidency::Cold => Populate::No,
-            GraphLinksResidency::Cached | GraphLinksResidency::Pinned => Populate::PreferBackground,
-        };
-        let options = OpenOptions {
-            populate,
-            ..GraphLinks::open_options(residency)
-        };
-
-        // Links
-        if let Some(format) = Self::probe_links_format(fs, dir)? {
-            fs.schedule_prefetch(&Self::get_links_path(dir, format), Some(options), None)?;
-        }
-        Ok(())
     }
 
     /// Load purely through universal IO, without the format conversion path of
@@ -787,26 +726,11 @@ impl GraphLayers {
         )
         .unwrap();
     }
-
-    pub fn populate(&self) -> OperationResult<()> {
-        self.links.populate()?;
-        Ok(())
-    }
-
-    pub fn clear_cache(&self) -> OperationResult<()> {
-        let Self {
-            hnsw_m: _,
-            links,
-            entry_points: _,
-            visited_pool: _,
-        } = self;
-        links.clear_cache()?;
-        Ok(())
-    }
 }
 
 #[cfg(test)]
 mod tests {
+    use common::universal_io::MmapFile;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
     use rstest::rstest;
@@ -815,6 +739,7 @@ mod tests {
     use super::*;
     use crate::data_types::vectors::VectorElementType;
     use crate::fixtures::index_fixtures::{TestRawScorerProducer, random_vector};
+    use crate::index::hnsw_index::graph::HnswGraph;
     use crate::index::hnsw_index::tests::{
         create_graph_layer_builder_fixture, create_graph_layer_fixture,
     };
@@ -874,7 +799,7 @@ mod tests {
         // Same order as the segment open path: snapshot, then preopen, then load.
         let mut cached_fs = CachedFs::new(MmapFs, dir.path()).unwrap();
         cached_fs.cache_file_info().unwrap();
-        GraphLayers::preopen_universal(&cached_fs, dir.path(), residency).unwrap();
+        HnswGraph::<MmapFile>::preopen_universal(&cached_fs, dir.path(), residency).unwrap();
 
         // Everything `load_universal` reads must now come from the prefetch pool.
         for entry in fs_err::read_dir(dir.path()).unwrap() {

--- a/lib/segment/src/index/hnsw_index/graph_layers_batched.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_batched.rs
@@ -22,7 +22,6 @@ use crate::index::visited_pool::{VisitedListHandle, VisitedPool};
 use crate::vector_storage::RawScorer;
 use crate::vector_storage::query_scorer::QueryScorerBytes;
 
-#[cfg_attr(not(test), expect(dead_code))]
 pub struct GraphLayersBatched<S: UniversalRead> {
     hnsw_m: HnswM,
     pub(super) links: GraphLinksFile<S>,
@@ -36,8 +35,8 @@ impl<S: UniversalRead> std::fmt::Debug for GraphLayersBatched<S> {
     }
 }
 
-#[cfg_attr(not(test), expect(dead_code))]
 impl<S: UniversalRead> GraphLayersBatched<S> {
+    #[cfg_attr(not(test), expect(dead_code))]
     pub fn open(
         fs: &impl UniversalReadFs<File = S>,
         dir: &Path,

--- a/lib/segment/src/index/hnsw_index/graph_layers_batched.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_batched.rs
@@ -36,7 +36,6 @@ impl<S: UniversalRead> std::fmt::Debug for GraphLayersBatched<S> {
 }
 
 impl<S: UniversalRead> GraphLayersBatched<S> {
-    #[cfg_attr(not(test), expect(dead_code))]
     pub fn open(
         fs: &impl UniversalReadFs<File = S>,
         dir: &Path,

--- a/lib/segment/src/index/hnsw_index/graph_links/links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/links.rs
@@ -63,6 +63,23 @@ impl GraphLinks {
         }
     }
 
+    /// Open options for scheduling a prefetch of the links file ahead of a
+    /// load with the same `residency`.
+    pub(in crate::index::hnsw_index) fn preopen_options(
+        residency: GraphLinksResidency,
+    ) -> OpenOptions {
+        let populate = match residency {
+            GraphLinksResidency::Cold => Populate::No,
+            GraphLinksResidency::Cached | GraphLinksResidency::Pinned => Populate::PreferBackground,
+        };
+        OpenOptions {
+            writeable: false,
+            need_sequential: false,
+            populate,
+            advice: AdviceSetting::Advice(Advice::Random),
+        }
+    }
+
     pub fn load_universal<Fs>(
         fs: &Fs,
         path: &Path,

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -9,6 +9,7 @@ use crate::common::BYTES_IN_KB;
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerEnum;
 use crate::index::hnsw_index::config::HnswGraphConfig;
+use crate::index::hnsw_index::graph::{HnswGraph, HnswLinksStorage};
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::hnsw_index::graph_links::GraphLinksResidency;
 use crate::index::struct_payload_index::StructPayloadIndex;
@@ -47,7 +48,7 @@ pub struct HNSWIndex {
     payload_index: Arc<AtomicRefCell<StructPayloadIndex>>,
     config: HnswGraphConfig,
     path: PathBuf,
-    graph: GraphLayers,
+    graph: HnswGraph<HnswLinksStorage>,
     searches_telemetry: HNSWSearchesTelemetry,
     is_on_disk: bool,
 }
@@ -79,7 +80,7 @@ impl HNSWIndex {
         let (memory, residency) = graph_residency(&hnsw_config, None);
         let is_on_disk = memory.is_on_disk();
 
-        let graph = GraphLayers::load(path, residency, do_convert)?;
+        let graph = HnswGraph::Direct(GraphLayers::load(path, residency, do_convert)?);
 
         Ok(HNSWIndex {
             id_tracker,
@@ -109,7 +110,7 @@ impl HNSWIndex {
 
     #[cfg(test)]
     pub(super) fn graph(&self) -> &GraphLayers {
-        &self.graph
+        self.graph.as_direct().unwrap()
     }
 
     pub fn get_quantized_vectors(&self) -> Arc<AtomicRefCell<Option<QuantizedVectors>>> {

--- a/lib/segment/src/index/hnsw_index/hnsw.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw.rs
@@ -2,14 +2,17 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
+use common::flags::feature_flags;
 use common::universal_io::{MmapFs, Populate, UniversalReadFs};
 
 use self::telemetry::HNSWSearchesTelemetry;
 use crate::common::BYTES_IN_KB;
+use crate::common::io_uring::{IoUringFallback, use_io_uring};
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::IdTrackerEnum;
 use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph::{HnswGraph, HnswLinksStorage};
+#[cfg(test)]
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::hnsw_index::graph_links::GraphLinksResidency;
 use crate::index::struct_payload_index::StructPayloadIndex;
@@ -80,7 +83,12 @@ impl HNSWIndex {
         let (memory, residency) = graph_residency(&hnsw_config, None);
         let is_on_disk = memory.is_on_disk();
 
-        let graph = HnswGraph::Direct(GraphLayers::load(path, residency, do_convert)?);
+        let with_uring = use_io_uring(
+            IoUringFallback::Mmap,
+            memory,
+            feature_flags().async_hnsw_graph,
+        );
+        let graph = HnswGraph::open(path, residency, do_convert, with_uring)?;
 
         Ok(HNSWIndex {
             id_tracker,

--- a/lib/segment/src/index/hnsw_index/hnsw/build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/build.rs
@@ -34,6 +34,7 @@ use crate::index::hnsw_index::gpu::get_gpu_groups_count;
 #[cfg(feature = "gpu")]
 use crate::index::hnsw_index::gpu::gpu_graph_builder::GPU_MAX_VISITED_FLAGS_FACTOR;
 use crate::index::hnsw_index::gpu::gpu_insert_context::GpuInsertContext;
+use crate::index::hnsw_index::graph::HnswGraph;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::hnsw_index::graph_layers_builder::GraphLayersBuilder;
 use crate::index::hnsw_index::graph_layers_healer::GraphLayersHealer;
@@ -591,7 +592,7 @@ impl HNSWIndex {
             payload_index,
             config,
             path: path.to_owned(),
-            graph,
+            graph: HnswGraph::Direct(graph),
             searches_telemetry: HNSWSearchesTelemetry::new(),
             is_on_disk,
         })

--- a/lib/segment/src/index/hnsw_index/hnsw/old_index.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/old_index.rs
@@ -12,6 +12,7 @@ use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
 use crate::index::VectorIndexEnum;
 use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
+use crate::index::hnsw_index::graph_links::GraphLinksResidency;
 use crate::types::HnswGlobalConfig;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
@@ -20,6 +21,9 @@ use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 /// Once decided, it is converted to [`OldIndex`].
 pub(super) struct OldIndexCandidate<'a> {
     index: AtomicRef<'a, HNSWIndex>,
+    /// The same graph as `index.graph`, but opened as direct/mmap.
+    /// None if `index.graph` is already direct.
+    reopened_graph: Option<GraphLayers>,
     /// Mapping from old index to new index.
     /// `old_to_new[old_idx] == Some(new_idx)`.
     old_to_new: Vec<Option<PointOffsetType>>,
@@ -31,6 +35,9 @@ pub(super) struct OldIndexCandidate<'a> {
 
 pub(in crate::index::hnsw_index) struct OldIndex<'a> {
     pub(super) index: AtomicRef<'a, HNSWIndex>,
+    /// The same graph as `index.graph`, but opened as direct/mmap.
+    /// None if `index.graph` is already direct.
+    reopened_graph: Option<GraphLayers>,
     /// Mapping from old index to new index.
     /// `old_to_new[old_idx] == Some(new_idx)`.
     pub old_to_new: Vec<Option<PointOffsetType>>,
@@ -77,7 +84,16 @@ impl<'a> OldIndexCandidate<'a> {
         }
         drop(old_quantized_vectors_ref);
 
-        let old_graph = old_index.graph.as_direct().expect(GRAPH_IS_DIRECT);
+        // Reopen the graph as direct if needed.
+        let mut reopened_graph = None;
+        let old_graph = match old_index.graph.as_direct() {
+            Some(graph) => graph,
+            None => reopened_graph.insert(
+                GraphLayers::load(&old_index.path, GraphLinksResidency::Cold, false)
+                    .inspect_err(|err| log::warn!("Failed to reopen the old HNSW graph: {err}"))
+                    .ok()?,
+            ),
+        };
 
         let new_deleted = vector_storage.deleted_vector_bitslice();
         let old_id_tracker = old_index.id_tracker.borrow();
@@ -182,6 +198,7 @@ impl<'a> OldIndexCandidate<'a> {
 
         Some(OldIndexCandidate {
             index: old_index,
+            reopened_graph,
             old_to_new,
             valid_points,
             missing_points,
@@ -189,6 +206,12 @@ impl<'a> OldIndexCandidate<'a> {
     }
 
     pub(super) fn reuse(self, total_vector_count: usize) -> OldIndex<'a> {
+        if let Some(graph) = &self.reopened_graph
+            && let Err(err) = graph.links.populate()
+        {
+            log::debug!("Failed to populate the old HNSW graph links: {err}");
+        }
+
         let mut new_to_old = vec![None; total_vector_count];
         for (old_offset, new_offset) in self.old_to_new.iter().copied().enumerate() {
             if let Some(new_offset) = new_offset {
@@ -204,6 +227,7 @@ impl<'a> OldIndexCandidate<'a> {
 
         OldIndex {
             index: self.index,
+            reopened_graph: self.reopened_graph,
             old_to_new: self.old_to_new,
             new_to_old,
         }
@@ -217,8 +241,9 @@ impl OldIndex<'_> {
     }
 
     pub(in crate::index::hnsw_index) fn graph(&self) -> &GraphLayers {
-        self.index.graph.as_direct().expect(GRAPH_IS_DIRECT)
+        match &self.reopened_graph {
+            Some(reopened_graph) => reopened_graph,
+            None => self.index.graph.as_direct().expect("opened in `evaluate`"),
+        }
     }
 }
-
-const GRAPH_IS_DIRECT: &str = "the writable HNSW index graph is mmap-backed";

--- a/lib/segment/src/index/hnsw_index/hnsw/old_index.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/old_index.rs
@@ -11,7 +11,7 @@ use super::HNSWIndex;
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
 use crate::index::VectorIndexEnum;
 use crate::index::hnsw_index::config::HnswGraphConfig;
-use crate::index::hnsw_index::graph_layers::{GraphLayers, GraphLayersWithVectors};
+use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::types::HnswGlobalConfig;
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectors;
 use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
@@ -77,6 +77,8 @@ impl<'a> OldIndexCandidate<'a> {
         }
         drop(old_quantized_vectors_ref);
 
+        let old_graph = old_index.graph.as_direct().expect(GRAPH_IS_DIRECT);
+
         let new_deleted = vector_storage.deleted_vector_bitslice();
         let old_id_tracker = old_index.id_tracker.borrow();
 
@@ -91,7 +93,7 @@ impl<'a> OldIndexCandidate<'a> {
 
         // Rough check whether the point is included in the old graph.
         // If it's included, it almost certainly has at least one outgoing link at level 0.
-        let old_graph_has_point = |id: PointOffsetType| !old_index.graph.links.links_empty(id, 0);
+        let old_graph_has_point = |id: PointOffsetType| !old_graph.links.links_empty(id, 0);
 
         // Build old_to_new mapping.
         let mut valid_points = 0;
@@ -211,10 +213,12 @@ impl<'a> OldIndexCandidate<'a> {
 impl OldIndex<'_> {
     pub(super) fn point_level(&self, new_id: PointOffsetType) -> Option<usize> {
         let old_id = self.new_to_old[new_id as usize]?;
-        Some(self.index.graph.links.point_level(old_id))
+        Some(self.graph().links.point_level(old_id))
     }
 
     pub(in crate::index::hnsw_index) fn graph(&self) -> &GraphLayers {
-        &self.index.graph
+        self.index.graph.as_direct().expect(GRAPH_IS_DIRECT)
     }
 }
+
+const GRAPH_IS_DIRECT: &str = "the writable HNSW index graph is mmap-backed";

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
@@ -19,7 +19,7 @@ use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
 use crate::index::UniversalReadExt;
 use crate::index::field_index::ReadOnlyFieldIndex;
 use crate::index::hnsw_index::config::HnswGraphConfig;
-use crate::index::hnsw_index::graph_layers::GraphLayers;
+use crate::index::hnsw_index::graph::HnswGraph;
 use crate::index::hnsw_index::graph_links::GraphLinksResidency;
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
 use crate::index::struct_payload_index::read_only::ReadOnlyStructPayloadIndex;
@@ -28,14 +28,7 @@ use crate::types::HnswConfig;
 use crate::vector_storage::quantized::quantized_vectors::ReadOnlyQuantizedVectors;
 use crate::vector_storage::read_only::VectorStorageReadEnum;
 
-/// Read-only, generic-over-storage counterpart of [`HNSWIndex`].
-///
-/// The graph itself stays a plain [`GraphLayers`] (it materializes into RAM on
-/// load via [`GraphLayers::load_universal`] over a [`UniversalRead`](common::universal_io::UniversalRead) filesystem),
-/// so only the id tracker, vector storage and quantized vectors are
-/// parameterized by the backing storage `S`.
-///
-/// [`HNSWIndex`]: super::super::HNSWIndex
+/// Read-only, generic-over-storage counterpart of [`super::HNSWIndex`].
 pub struct ReadOnlyHNSWIndex<S: UniversalReadExt> {
     id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
     vector_storage: Arc<AtomicRefCell<VectorStorageReadEnum<S>>>,
@@ -53,7 +46,7 @@ pub struct ReadOnlyHNSWIndex<S: UniversalReadExt> {
     /// the next caller retries.
     ///
     /// [`LoadProfile`]: crate::data_types::load_profile::LoadProfile
-    graph: OnceCell<GraphLayers>,
+    graph: OnceCell<HnswGraph<S>>,
     /// The segment's raw backend, retained for the deferred graph load: the
     /// caching `fs` the eager open reads through only lives for that open.
     fs: S::Fs,
@@ -80,16 +73,17 @@ type ReadView<'a, S> = HNSWIndexReadView<
         VectorStorageReadEnum<S>,
         ReadOnlyFieldIndex<S>,
     >,
+    S,
 >;
 
 /// Whether a `populate_override` defers the graph load to first use.
 ///
 /// A cold override parks the graph *unloaded*, not merely cold: unlike the
-/// other components, a cold graph load still reads the whole links file on a
-/// remote backend (see [`ReadOnlyHNSWIndex::graph`]), so the demotion the
-/// override asks for is only achievable by not loading. A config-derived cold
-/// placement (no override) keeps the eager load. Mirrors the cold-override
-/// match of `VectorIndexReadEnum::open_sparse`.
+/// other components, a cold in-RAM [`HnswGraph`] load still reads the
+/// whole links file on a remote backend (see [`ReadOnlyHNSWIndex::graph`]),
+/// so the demotion the override asks for is only achievable by not loading.
+/// A config-derived cold placement (no override) keeps the eager load.
+/// Mirrors the cold-override match of `VectorIndexReadEnum::open_sparse`.
 fn graph_deferred(populate_override: Option<Populate>) -> bool {
     match populate_override {
         Some(Populate::No | Populate::Auto | Populate::Partial(_)) => true,
@@ -115,7 +109,7 @@ impl<S: UniversalReadExt> ReadOnlyHNSWIndex<S> {
         // Graph data and links
         if !graph_deferred(populate_override) {
             let (_memory, residency) = graph_residency(hnsw_config, populate_override);
-            GraphLayers::preopen_universal(fs, path, residency)?;
+            HnswGraph::preopen_universal(fs, path, residency)?;
         }
 
         Ok(())
@@ -151,14 +145,12 @@ impl<S: UniversalReadExt> ReadOnlyHNSWIndex<S> {
     {
         let config = load_or_derive_config(fs, path, &hnsw_config, &vector_storage)?;
 
-        // Note that non-borrowable backends materialize the links into heap
-        // RAM whatever the residency.
         let (memory, residency) = graph_residency(&hnsw_config, populate_override);
         let is_on_disk = memory.is_on_disk();
         let graph = if graph_deferred(populate_override) {
             OnceCell::new()
         } else {
-            OnceCell::with_value(GraphLayers::load_universal(fs, path, residency)?)
+            OnceCell::with_value(HnswGraph::open_universal(fs, path, residency)?)
         };
 
         Ok(Self {
@@ -178,23 +170,24 @@ impl<S: UniversalReadExt> ReadOnlyHNSWIndex<S> {
 
     /// The graph, loading it on the first call when the open deferred it.
     ///
-    /// The deferral exists because a cold placement is not enough on a remote
-    /// backend: even a cold graph load must mirror the whole links file
-    /// (`GraphLinksView` requires one contiguous slice), so the only way not
-    /// to fetch it is not to load it. The profile predicted this vector would
-    /// never be scored; when a request scores it anyway, it pays the load
-    /// here — through the raw backend, without the open's prefetch pool.
+    /// The deferral exists because a cold placement is not enough for an
+    /// in-RAM [`HnswGraph`] on a remote backend: its load must
+    /// mirror the whole links file (`GraphLinksView` requires one contiguous
+    /// slice), so the only way not to fetch it is not to load it. The profile
+    /// predicted this vector would never be scored; when a request scores it
+    /// anyway, it pays the load here — through the raw backend, without the
+    /// open's prefetch pool.
     ///
     /// The load runs inside the cell's lock: a search burst on a deferred
     /// vector performs one load while the other callers block on it, rather
     /// than each fetching the whole graph. A failed load is not cached —
     /// the next caller retries.
-    fn graph(&self) -> OperationResult<&GraphLayers>
+    fn graph(&self) -> OperationResult<&HnswGraph<S>>
     where
         S: 'static,
     {
         self.graph
-            .get_or_try_init(|| GraphLayers::load_universal(&self.fs, &self.path, self.residency))
+            .get_or_try_init(|| HnswGraph::open_universal(&self.fs, &self.path, self.residency))
     }
 
     pub fn is_on_disk(&self) -> bool {

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::universal_io::{CachedReadFs, OkNotFound, Populate, UniversalReadFs};
+use common::universal_io::{CachedReadFs, OkNotFound, Populate, UniversalRead, UniversalReadFs};
 use once_cell::sync::OnceCell;
 
 use super::read_view::HNSWIndexReadView;
@@ -76,19 +76,18 @@ type ReadView<'a, S> = HNSWIndexReadView<
     S,
 >;
 
-/// Whether a `populate_override` defers the graph load to first use.
-///
-/// A cold override parks the graph *unloaded*, not merely cold: unlike the
-/// other components, a cold in-RAM [`HnswGraph`] load still reads the
-/// whole links file on a remote backend (see [`ReadOnlyHNSWIndex::graph`]),
-/// so the demotion the override asks for is only achievable by not loading.
-/// A config-derived cold placement (no override) keeps the eager load.
-/// Mirrors the cold-override match of `VectorIndexReadEnum::open_sparse`.
-fn graph_deferred(populate_override: Option<Populate>) -> bool {
-    match populate_override {
+/// Whether the graph load is deferred to first use.
+fn graph_deferred<S: UniversalRead>(
+    fs: &impl UniversalReadFs<File = S>,
+    path: &Path,
+    populate_override: Option<Populate>,
+    residency: GraphLinksResidency,
+) -> OperationResult<bool> {
+    let cold_override = match populate_override {
         Some(Populate::No | Populate::Auto | Populate::Partial(_)) => true,
         Some(Populate::Blocking | Populate::PreferBackground) | None => false,
-    }
+    };
+    Ok(cold_override && !HnswGraph::<S>::is_batched(fs, path, residency)?)
 }
 
 impl<S: UniversalReadExt> ReadOnlyHNSWIndex<S> {
@@ -107,8 +106,8 @@ impl<S: UniversalReadExt> ReadOnlyHNSWIndex<S> {
             .ok_not_found()?;
 
         // Graph data and links
-        if !graph_deferred(populate_override) {
-            let (_memory, residency) = graph_residency(hnsw_config, populate_override);
+        let (_memory, residency) = graph_residency(hnsw_config, populate_override);
+        if !graph_deferred(fs, path, populate_override, residency)? {
             HnswGraph::preopen_universal(fs, path, residency)?;
         }
 
@@ -147,7 +146,7 @@ impl<S: UniversalReadExt> ReadOnlyHNSWIndex<S> {
 
         let (memory, residency) = graph_residency(&hnsw_config, populate_override);
         let is_on_disk = memory.is_on_disk();
-        let graph = if graph_deferred(populate_override) {
+        let graph = if graph_deferred(fs, path, populate_override, residency)? {
             OnceCell::new()
         } else {
             OnceCell::with_value(HnswGraph::open_universal(fs, path, residency)?)
@@ -238,5 +237,91 @@ impl<S: UniversalReadExt> ReadOnlyHNSWIndex<S> {
             };
             f(read_view)
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::universal_io::MmapFs;
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::index::hnsw_index::graph_links::GraphLinksFormat;
+    use crate::index::hnsw_index::tests::create_graph_layer_builder_fixture;
+    use crate::types::Distance;
+
+    /// Pins which graph representation each (backend, format, residency) cell
+    /// loads — and its links residency. The decision lives in
+    /// [`HnswGraph::open_universal`], with the materialization fallback still
+    /// in `GraphLinksEnum::from_storage`. Search through the loaded graphs is
+    /// covered by the `graph_layers_batched` parity tests.
+    #[test]
+    fn test_open_matrix() {
+        let mut rng = StdRng::seed_from_u64(42);
+
+        for format in [
+            GraphLinksFormat::Plain,
+            GraphLinksFormat::Compressed,
+            GraphLinksFormat::CompressedWithVectors,
+        ] {
+            let dir = Builder::new().prefix("graph_dir").tempdir().unwrap();
+            let (vector_holder, graph_layers_builder) = create_graph_layer_builder_fixture(
+                100,
+                8,
+                8,
+                false,
+                format.is_with_vectors(),
+                Distance::Cosine,
+                &mut rng,
+            );
+            let graph_links_vectors = vector_holder.graph_links_vectors();
+            graph_layers_builder
+                .into_graph_layers(
+                    dir.path(),
+                    format.with_param_for_tests(graph_links_vectors.as_ref()),
+                    true,
+                )
+                .unwrap();
+
+            check_backend(&MmapFs, dir.path(), format);
+            #[cfg(target_os = "linux")]
+            check_backend(&common::universal_io::IoUringFs, dir.path(), format);
+        }
+    }
+
+    fn check_backend<Fs>(fs: &Fs, dir: &Path, format: GraphLinksFormat)
+    where
+        Fs: UniversalReadFs,
+        Fs::File: 'static,
+    {
+        for residency in [
+            GraphLinksResidency::Cold,
+            GraphLinksResidency::Cached,
+            GraphLinksResidency::Pinned,
+        ] {
+            let context = format!("{:?}, {format:?}, {residency:?}", Fs::File::kind());
+
+            let graph = HnswGraph::open_universal(fs, dir, residency).unwrap();
+            let expect_batched = residency != GraphLinksResidency::Pinned
+                && match format {
+                    GraphLinksFormat::CompressedWithVectors | GraphLinksFormat::Compressed => {
+                        Fs::File::kind().can_be_async()
+                    }
+                    GraphLinksFormat::Plain => false,
+                };
+            match &graph {
+                HnswGraph::Direct(direct) => {
+                    assert!(!expect_batched, "{context}");
+                    // Links are materialized into heap when pinned explicitly,
+                    // or as the fallback for non-borrowable backends.
+                    let expect_heap = !Fs::File::kind().is_in_ram_or_mmap()
+                        || residency == GraphLinksResidency::Pinned;
+                    assert_eq!(direct.links_heap_size_bytes() > 0, expect_heap, "{context}");
+                }
+                HnswGraph::Batched(_) => assert!(expect_batched, "{context}"),
+            }
+        }
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_only/mod.rs
@@ -242,7 +242,9 @@ impl<S: UniversalReadExt> ReadOnlyHNSWIndex<S> {
 
 #[cfg(test)]
 mod tests {
-    use common::universal_io::MmapFs;
+    use GraphLinksFormat::{Compressed, CompressedWithVectors, Plain};
+    use GraphLinksResidency::{Cached, Cold, Pinned};
+    use common::universal_io::{MmapFs, UniversalKind as Kind};
     use rand::SeedableRng;
     use rand::rngs::StdRng;
     use tempfile::Builder;
@@ -252,11 +254,6 @@ mod tests {
     use crate::index::hnsw_index::tests::create_graph_layer_builder_fixture;
     use crate::types::Distance;
 
-    /// Pins which graph representation each (backend, format, residency) cell
-    /// loads — and its links residency. The decision lives in
-    /// [`HnswGraph::open_universal`], with the materialization fallback still
-    /// in `GraphLinksEnum::from_storage`. Search through the loaded graphs is
-    /// covered by the `graph_layers_batched` parity tests.
     #[test]
     fn test_open_matrix() {
         let mut rng = StdRng::seed_from_u64(42);
@@ -285,43 +282,47 @@ mod tests {
                 )
                 .unwrap();
 
-            check_backend(&MmapFs, dir.path(), format);
+            test_open_matrix_impl(&MmapFs, dir.path(), format);
             #[cfg(target_os = "linux")]
-            check_backend(&common::universal_io::IoUringFs, dir.path(), format);
+            test_open_matrix_impl(&common::universal_io::IoUringFs, dir.path(), format);
         }
     }
 
-    fn check_backend<Fs>(fs: &Fs, dir: &Path, format: GraphLinksFormat)
+    fn test_open_matrix_impl<Fs>(fs: &Fs, dir: &Path, format: GraphLinksFormat)
     where
         Fs: UniversalReadFs,
         Fs::File: 'static,
     {
-        for residency in [
-            GraphLinksResidency::Cold,
-            GraphLinksResidency::Cached,
-            GraphLinksResidency::Pinned,
-        ] {
-            let context = format!("{:?}, {format:?}, {residency:?}", Fs::File::kind());
+        #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+        enum ExpectedResult {
+            Batched,
+            Mmap,
+            Vec,
+        }
+        use ExpectedResult::{Batched, Mmap, Vec};
 
+        #[rustfmt::skip]
+        let row = match (Fs::File::kind(), format) {
+            //                                         Cold     Cached   Pinned
+            (Kind::Mmap,    Plain)                 => [Mmap,    Mmap,    Vec],
+            (Kind::Mmap,    Compressed)            => [Mmap,    Mmap,    Vec],
+            (Kind::Mmap,    CompressedWithVectors) => [Mmap,    Mmap,    Vec],
+
+            (Kind::IoUring, Plain)                 => [Vec,     Vec,     Vec],
+            (Kind::IoUring, Compressed)            => [Batched, Batched, Vec],
+            (Kind::IoUring, CompressedWithVectors) => [Batched, Batched, Vec],
+
+            _ => unreachable!(),
+        };
+
+        for (residency, expected) in [Cold, Cached, Pinned].into_iter().zip(row) {
             let graph = HnswGraph::open_universal(fs, dir, residency).unwrap();
-            let expect_batched = residency != GraphLinksResidency::Pinned
-                && match format {
-                    GraphLinksFormat::CompressedWithVectors | GraphLinksFormat::Compressed => {
-                        Fs::File::kind().can_be_async()
-                    }
-                    GraphLinksFormat::Plain => false,
-                };
-            match &graph {
-                HnswGraph::Direct(direct) => {
-                    assert!(!expect_batched, "{context}");
-                    // Links are materialized into heap when pinned explicitly,
-                    // or as the fallback for non-borrowable backends.
-                    let expect_heap = !Fs::File::kind().is_in_ram_or_mmap()
-                        || residency == GraphLinksResidency::Pinned;
-                    assert_eq!(direct.links_heap_size_bytes() > 0, expect_heap, "{context}");
-                }
-                HnswGraph::Batched(_) => assert!(expect_batched, "{context}"),
-            }
+            let actual = match &graph {
+                HnswGraph::Direct(direct) if direct.links_heap_size_bytes() > 0 => Vec,
+                HnswGraph::Direct(_) => Mmap,
+                HnswGraph::Batched(_) => Batched,
+            };
+            assert_eq!(actual, expected, "{format:?} {residency:?}");
         }
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/dispatch.rs
@@ -1,5 +1,6 @@
 use common::condition_checker::ConditionChecker;
 use common::types::ScoredPointOffset;
+use common::universal_io::UniversalRead;
 
 use super::HNSWIndexReadView;
 use crate::common::operation_error::OperationResult;
@@ -14,12 +15,13 @@ use crate::types::{Filter, QuantizationSearchParams, SearchParams};
 use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
 use crate::vector_storage::{RawScorerBuilder, VectorStorageRead};
 
-impl<'a, I, V, Q, P> HNSWIndexReadView<'a, I, V, Q, P>
+impl<'a, I, V, Q, P, S> HNSWIndexReadView<'a, I, V, Q, P, S>
 where
     I: IdTrackerRead,
     V: VectorStorageRead + RawScorerBuilder,
     Q: QuantizedVectorsRead,
     P: PayloadIndexRead,
+    S: UniversalRead,
 {
     pub(crate) fn search(
         &self,

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/mod.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/mod.rs
@@ -1,12 +1,14 @@
 mod dispatch;
 mod search;
 
+use common::universal_io::UniversalRead;
+
 use super::telemetry::HNSWSearchesTelemetry;
 use crate::id_tracker::{IdTrackerEnum, IdTrackerRead};
 use crate::index::PayloadIndexRead;
 use crate::index::field_index::FieldIndex;
 use crate::index::hnsw_index::config::HnswGraphConfig;
-use crate::index::hnsw_index::graph_layers::GraphLayers;
+use crate::index::hnsw_index::graph::{HnswGraph, HnswLinksStorage};
 use crate::index::struct_payload_index::StructPayloadIndexReadView;
 use crate::payload_storage::payload_storage_enum::PayloadStorageEnum;
 use crate::vector_storage::quantized::quantized_vectors::{QuantizedVectors, QuantizedVectorsRead};
@@ -23,13 +25,14 @@ pub struct HNSWIndexReadView<
     V: VectorStorageRead,
     Q: QuantizedVectorsRead,
     P: PayloadIndexRead,
+    S: UniversalRead,
 > {
     pub(crate) id_tracker: &'a I,
     pub(crate) vector_storage: &'a V,
     pub(crate) quantized_vectors: Option<&'a Q>,
     pub(crate) payload_index: P,
     pub(crate) config: &'a HnswGraphConfig,
-    pub(crate) graph: &'a GraphLayers,
+    pub(crate) graph: &'a HnswGraph<S>,
     pub(crate) searches_telemetry: &'a HNSWSearchesTelemetry,
 }
 
@@ -49,4 +52,5 @@ pub(crate) type HNSWIndexReadViewEnum<'a> = HNSWIndexReadView<
         VectorStorageEnum,
         FieldIndex,
     >,
+    HnswLinksStorage,
 >;

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
@@ -10,7 +10,7 @@ use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::id_tracker::IdTrackerRead;
 use crate::index::PayloadIndexRead;
 use crate::index::hnsw_index::GraphWithVectorsScorers;
-use crate::index::hnsw_index::graph::{DEFAULT_LINKS_BATCH_SIZE, GraphSearchArgs, SearchScorers};
+use crate::index::hnsw_index::graph::{GraphSearchArgs, SearchScorers};
 use crate::index::hnsw_index::graph_layers::SearchAlgorithm;
 use crate::index::hnsw_index::point_scorer::{BatchFilteredSearcher, FilteredScorer};
 use crate::index::query_estimator::adjust_to_available_vectors;
@@ -137,7 +137,6 @@ where
                     base: base_scorer_bytes,
                 }),
                 custom_entry_points,
-                batch_size: DEFAULT_LINKS_BATCH_SIZE,
                 is_stopped: &is_stopped,
             })?))
         };
@@ -162,7 +161,6 @@ where
                 algorithm,
                 scorers: SearchScorers::Regular(points_scorer),
                 custom_entry_points,
-                batch_size: DEFAULT_LINKS_BATCH_SIZE,
                 is_stopped: &is_stopped,
             })?;
 

--- a/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/read_view/search.rs
@@ -1,6 +1,7 @@
 use common::bitvec::BitSlice;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::{DeferredBehavior, PointOffsetType, ScoredPointOffset};
+use common::universal_io::UniversalRead;
 
 use super::HNSWIndexReadView;
 use crate::common::operation_error::OperationResult;
@@ -9,7 +10,8 @@ use crate::data_types::vectors::{QueryVector, VectorInternal};
 use crate::id_tracker::IdTrackerRead;
 use crate::index::PayloadIndexRead;
 use crate::index::hnsw_index::GraphWithVectorsScorers;
-use crate::index::hnsw_index::graph_layers::{GraphLayersWithVectors, SearchAlgorithm};
+use crate::index::hnsw_index::graph::{DEFAULT_LINKS_BATCH_SIZE, GraphSearchArgs, SearchScorers};
+use crate::index::hnsw_index::graph_layers::SearchAlgorithm;
 use crate::index::hnsw_index::point_scorer::{BatchFilteredSearcher, FilteredScorer};
 use crate::index::query_estimator::adjust_to_available_vectors;
 use crate::index::query_optimization::optimized_filter::OptimizedFilter;
@@ -21,12 +23,13 @@ use crate::vector_storage::quantized::quantized_vectors::QuantizedVectorsRead;
 use crate::vector_storage::query::DiscoverQuery;
 use crate::vector_storage::{RawScorerBuilder, VectorStorageRead};
 
-impl<'a, I, V, Q, P> HNSWIndexReadView<'a, I, V, Q, P>
+impl<'a, I, V, Q, P, S> HNSWIndexReadView<'a, I, V, Q, P, S>
 where
     I: IdTrackerRead,
     V: VectorStorageRead + RawScorerBuilder,
     Q: QuantizedVectorsRead,
     P: PayloadIndexRead,
+    S: UniversalRead,
 {
     pub(super) fn search_with_graph(
         &self,
@@ -124,30 +127,26 @@ where
                 return Ok(None);
             };
 
-            let Some(entry_point) = self
-                .graph
-                .get_entry_point(link_scorer_filtered.filters(), custom_entry_points)
-            else {
-                return Ok(Some(Vec::new()));
-            };
-            Ok(Some(self.graph.search_with_vectors(
+            Ok(Some(self.graph.search(GraphSearchArgs {
                 top,
-                std::cmp::max(ef, oversampled_top),
-                GraphWithVectorsScorers {
+                ef: std::cmp::max(ef, oversampled_top),
+                algorithm: SearchAlgorithm::Hnsw,
+                scorers: SearchScorers::WithVectors(GraphWithVectorsScorers {
                     links: &link_scorer_filtered,
                     links_bytes: &link_scorer_filtered_bytes,
                     base: base_scorer_bytes,
-                },
-                entry_point,
-                &vector_query_context.is_stopped(),
-            )?))
+                }),
+                custom_entry_points,
+                batch_size: DEFAULT_LINKS_BATCH_SIZE,
+                is_stopped: &is_stopped,
+            })?))
         };
 
         let regular_search = || -> OperationResult<Vec<ScoredPointOffset>> {
             let filter_context = filter
                 .map(|f| self.payload_index.filter_context(f, &hw_counter))
                 .transpose()?;
-            let mut points_scorer = construct_search_scorer(
+            let points_scorer = construct_search_scorer(
                 vector,
                 self.vector_storage,
                 self.quantized_vectors,
@@ -157,20 +156,15 @@ where
                 filter_context,
             )?;
 
-            let entry_point = self
-                .graph
-                .get_entry_point(points_scorer.filters(), custom_entry_points);
-            let search_result = match entry_point {
-                Some(entry_point) => self.graph.search(
-                    oversampled_top,
-                    ef,
-                    algorithm,
-                    &mut points_scorer,
-                    entry_point,
-                    &is_stopped,
-                )?,
-                None => Vec::new(),
-            };
+            let search_result = self.graph.search(GraphSearchArgs {
+                top: oversampled_top,
+                ef,
+                algorithm,
+                scorers: SearchScorers::Regular(points_scorer),
+                custom_entry_points,
+                batch_size: DEFAULT_LINKS_BATCH_SIZE,
+                is_stopped: &is_stopped,
+            })?;
 
             postprocess_search_result(
                 search_result,

--- a/lib/segment/src/index/hnsw_index/mod.rs
+++ b/lib/segment/src/index/hnsw_index/mod.rs
@@ -6,6 +6,7 @@ use crate::vector_storage::query_scorer::QueryScorerBytes;
 pub mod build_condition_checker;
 mod config;
 mod entry_points;
+mod graph;
 pub mod graph_layers;
 mod graph_layers_batched;
 pub mod graph_layers_builder;


### PR DESCRIPTION
This PR integrates batched HNSW.

For edge/serverless: enabled for async backends (io_uring/s3/etc).
For Qdrant server: enabled when `async_hnsw_graph` is set.