### PR TITLE
fix(api): reject empty gRPC dense vectors

### DIFF
--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -364,7 +364,14 @@ impl Validate for grpc::Vector {
 impl Validate for grpc::vector::Vector {
     fn validate(&self) -> Result<(), ValidationErrors> {
         match self {
-            grpc::vector::Vector::Dense(_dense) => Ok(()),
+            grpc::vector::Vector::Dense(dense) => {
+                if dense.data.is_empty() {
+                    let mut errors = ValidationErrors::new();
+                    errors.add("data", ValidationError::new("empty_vector"));
+                    return Err(errors);
+                }
+                Ok(())
+            }
             grpc::vector::Vector::Sparse(sparse) => sparse.validate(),
             grpc::vector::Vector::MultiDense(multi) => multi.validate(),
             grpc::vector::Vector::Document(_document) => Ok(()),
@@ -601,7 +608,7 @@ mod tests {
     use validator::Validate;
 
     use crate::grpc::qdrant::{
-        CreateCollection, CreateFieldIndexCollection, CreateVectorNameRequest,
+        CreateCollection, CreateFieldIndexCollection, CreateVectorNameRequest, DenseVector,
         DenseVectorCreationConfig, FieldCondition, GeoBoundingBox, GeoLineString, GeoPoint,
         GeoPolygon, GeoRadius, SearchPoints, UpdateCollection, create_vector_name_request,
     };
@@ -957,5 +964,22 @@ mod tests {
             ..Default::default()
         };
         assert!(good_request.validate().is_ok());
+    }
+
+    #[test]
+    fn test_dense_vector_validation() {
+        let empty = crate::grpc::qdrant::vector::Vector::Dense(DenseVector { data: vec![] });
+        assert!(
+            empty.validate().is_err(),
+            "empty dense vector should error on validation"
+        );
+
+        let populated = crate::grpc::qdrant::vector::Vector::Dense(DenseVector {
+            data: vec![1.0, 2.0],
+        });
+        assert!(
+            populated.validate().is_ok(),
+            "populated dense vector should pass validation"
+        );
     }
 }


### PR DESCRIPTION
## The problem

The modern gRPC `grpc::vector::Vector::Dense` validation path accepted an empty `data` array.

This was inconsistent with the existing behavior for sparse vectors, multi-dense vectors, and REST dense-vector inputs. Those paths already reject empty vectors. Because the dense gRPC variant returned `Ok(())` without checking its contents, a zero-length embedding could pass API validation and continue into the conversion and storage path.

Fixes #10106.

## Changes

- Validate `grpc::vector::Vector::Dense` before conversion.
- Return an `empty_vector` validation error on the `data` field when the dense vector is empty.
- Preserve the existing behavior for populated dense vectors.
- Add a focused regression test covering both empty and populated dense vectors.

## Validation

Focused test:

```text
cargo +nightly test -p api test_dense_vector_validation --lib
```

Result:

```text
1 passed; 0 failed
```

Formatting:

```text
cargo +nightly fmt --all -- --check
```

Clippy was run against the affected API library:

```text
cargo +nightly clippy -p api --lib -- \
  -A clippy::chunks-exact-to-as-chunks \
  -A clippy::double-must-use \
  -D warnings
```

The two allowed lints are unrelated existing warnings from the `segment` crate and generated gRPC code. No warnings from this change remained.

A final search found no open pull request implementing #10106.

## AI disclosure

The implementation and tests were produced with OpenAI Codex under human direction and review. Codex inspected the issue and repository, implemented the validation and regression test, and ran the formatter, focused test, redundancy check, and targeted Clippy validation.

I reviewed the proposed change and  am responsible for the submission and subsequent maintainer communication.