### PR TITLE
[UpdateOnly] tombstone points in immutable segments via whole-mask rewrite

### DIFF
--- a/lib/common/common/src/stored_bitslice.rs
+++ b/lib/common/common/src/stored_bitslice.rs
@@ -16,7 +16,7 @@ use crate::bitvec::BitVec;
 use crate::generic_consts::Random;
 use crate::universal_io::{
     Flusher, OpenOptions, ReadRange, TypedStorage, UioResult, UniversalIoError, UniversalRead,
-    UniversalReadFs, UniversalWrite,
+    UniversalReadFs, UniversalWrite, UniversalWriteFileOps,
 };
 
 /// `IterOnes` view over a `BitSlice<u64, Lsb0>` — type alias so `self_cell`
@@ -83,6 +83,45 @@ impl<S: UniversalRead> StoredBitSlice<S> {
         self.storage.reopen()?;
         self.element_len = self.storage.len()?;
         Ok(())
+    }
+
+    /// Read the stored bits at `path` — or start from `seed` when the caller
+    /// already holds them, sound only with a single writer — apply `update`
+    /// (which may resize the bits), and replace the file whole via
+    /// [`atomic_save`]: the one mutation that works on backends without
+    /// random-offset writes. When `update` errors, nothing is written.
+    ///
+    /// [`atomic_save`]: UniversalWriteFileOps::atomic_save
+    pub fn atomic_update<Fs, R, E>(
+        fs: &Fs,
+        path: impl AsRef<Path>,
+        options: OpenOptions,
+        extra: Fs::OpenExtra,
+        seed: Option<BitVec>,
+        update: impl FnOnce(&mut BitVec) -> Result<R, E>,
+    ) -> UioResult<Result<R, E>>
+    where
+        Fs: UniversalReadFs<File = S> + UniversalWriteFileOps,
+    {
+        let path = path.as_ref();
+
+        let mut bits = match seed {
+            Some(bits) => bits,
+            None => {
+                // Dropped before the save: Windows cannot replace a mapped file.
+                let stored = Self::open(fs, path, options, extra)?;
+                stored.read_all()?.into_owned()
+            }
+        };
+
+        let result = match update(&mut bits) {
+            Ok(result) => result,
+            Err(err) => return Ok(Err(err)),
+        };
+
+        fs.atomic_save(path, bytemuck::cast_slice(bits.as_raw_slice()))?;
+
+        Ok(Ok(result))
     }
 
     /// Total number of bits available.
@@ -394,6 +433,82 @@ mod tests {
         f.write_all(&buf).unwrap();
         f.flush().unwrap();
         f
+    }
+
+    // ---- Atomic update tests ----
+
+    fn stored_ones(path: &Path) -> Vec<u64> {
+        let stored: MmapBitSlice =
+            StoredBitSlice::open(&MmapFs, path, OpenOptions::new_for_test(), ()).unwrap();
+        stored.iter_ones().unwrap().collect()
+    }
+
+    #[test]
+    fn atomic_update_reads_applies_and_replaces_the_file() {
+        let f = create_temp_file(&[0b0000_0001]);
+
+        MmapBitSlice::atomic_update(
+            &MmapFs,
+            f.path(),
+            OpenOptions::new_for_test(),
+            (),
+            None,
+            |bits| {
+                bits.set(3, true);
+                Ok::<_, ()>(())
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(stored_ones(f.path()), vec![0, 3]);
+    }
+
+    #[test]
+    fn atomic_update_starts_from_the_seed_without_reading() {
+        let f = create_temp_file(&[0b0000_0001]);
+
+        let mut seed = BitVec::new();
+        seed.resize(64, false);
+        seed.set(5, true);
+
+        MmapBitSlice::atomic_update(
+            &MmapFs,
+            f.path(),
+            OpenOptions::new_for_test(),
+            (),
+            Some(seed),
+            |bits| {
+                bits.set(3, true);
+                Ok::<_, ()>(())
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+        // The seed replaces the stored bits: bit 0 from the file is gone.
+        assert_eq!(stored_ones(f.path()), vec![3, 5]);
+    }
+
+    #[test]
+    fn atomic_update_saves_nothing_when_the_closure_errors() {
+        let f = create_temp_file(&[0b0000_0001]);
+
+        let result = MmapBitSlice::atomic_update(
+            &MmapFs,
+            f.path(),
+            OpenOptions::new_for_test(),
+            (),
+            None,
+            |bits| {
+                bits.set(3, true);
+                Err::<(), _>("rejected")
+            },
+        )
+        .unwrap();
+
+        assert_eq!(result, Err("rejected"));
+        assert_eq!(stored_ones(f.path()), vec![0]);
     }
 
     // ---- Read tests ----

--- a/lib/common/common/src/stored_bitslice.rs
+++ b/lib/common/common/src/stored_bitslice.rs
@@ -445,11 +445,12 @@ mod tests {
 
     #[test]
     fn atomic_update_reads_applies_and_replaces_the_file() {
-        let f = create_temp_file(&[0b0000_0001]);
+        // Handle closed: Windows cannot replace a file that is held open.
+        let path = create_temp_file(&[0b0000_0001]).into_temp_path();
 
         MmapBitSlice::atomic_update(
             &MmapFs,
-            f.path(),
+            &path,
             OpenOptions::new_for_test(),
             (),
             None,
@@ -461,12 +462,13 @@ mod tests {
         .unwrap()
         .unwrap();
 
-        assert_eq!(stored_ones(f.path()), vec![0, 3]);
+        assert_eq!(stored_ones(&path), vec![0, 3]);
     }
 
     #[test]
     fn atomic_update_starts_from_the_seed_without_reading() {
-        let f = create_temp_file(&[0b0000_0001]);
+        // Handle closed: Windows cannot replace a file that is held open.
+        let path = create_temp_file(&[0b0000_0001]).into_temp_path();
 
         let mut seed = BitVec::new();
         seed.resize(64, false);
@@ -474,7 +476,7 @@ mod tests {
 
         MmapBitSlice::atomic_update(
             &MmapFs,
-            f.path(),
+            &path,
             OpenOptions::new_for_test(),
             (),
             Some(seed),
@@ -487,7 +489,7 @@ mod tests {
         .unwrap();
 
         // The seed replaces the stored bits: bit 0 from the file is gone.
-        assert_eq!(stored_ones(f.path()), vec![3, 5]);
+        assert_eq!(stored_ones(&path), vec![3, 5]);
     }
 
     #[test]

--- a/lib/edge/src/read_only/tests.rs
+++ b/lib/edge/src/read_only/tests.rs
@@ -71,7 +71,7 @@ pub(crate) fn upsert(shard: &EdgeShard, ids: impl IntoIterator<Item = u64>) {
         .unwrap();
 }
 
-fn delete(shard: &EdgeShard, ids: impl IntoIterator<Item = u64>) {
+pub(crate) fn delete(shard: &EdgeShard, ids: impl IntoIterator<Item = u64>) {
     let ids = ids.into_iter().map(ExtendedPointId::NumId).collect();
     shard.update(PointOperation(DeletePoints { ids })).unwrap();
 }

--- a/lib/edge/src/update_only/tests.rs
+++ b/lib/edge/src/update_only/tests.rs
@@ -13,9 +13,11 @@ use shard::operations::CollectionUpdateOperations::PointOperation;
 use shard::operations::point_ops::PointOperations::DeletePoints;
 use tempfile::TempDir;
 
-use crate::EdgeShard;
-use crate::read_only::tests::{exact_count, open_follower, scrolled_ids, test_config, upsert};
+use crate::read_only::tests::{
+    delete as leader_delete, exact_count, open_follower, scrolled_ids, test_config, upsert,
+};
 use crate::update_only::UpdateOnlyEdgeShard;
+use crate::{EdgeConfig, EdgeOptimizersConfig, EdgeShard};
 
 /// A flushed shard directory holding points 1 to 10, with the leader that
 /// wrote it closed — a writer opens a directory, not a running shard.
@@ -86,6 +88,74 @@ fn replayed_delete_batch_is_a_no_op() {
 
     let follower = open_follower(dir.path());
     assert_eq!(exact_count(&follower), 9);
+}
+
+/// A flushed shard directory whose points 301 to 1000 live in an immutable
+/// segment: deleting 30% triggers a vacuum, and the lowered indexing
+/// threshold makes the rebuild non-appendable.
+fn vacuumed_leader(prefix: &str) -> TempDir {
+    let dir = tempfile::Builder::new().prefix(prefix).tempdir().unwrap();
+
+    let config = EdgeConfig {
+        optimizers: Some(EdgeOptimizersConfig {
+            deleted_threshold: Some(0.2),
+            vacuum_min_vector_number: Some(1),
+            indexing_threshold: Some(1),
+            ..EdgeOptimizersConfig::default()
+        }),
+        ..test_config()
+    };
+    let leader = EdgeShard::new(dir.path(), config).unwrap();
+    upsert(&leader, 1..=1000);
+    leader_delete(&leader, 1..=300);
+    leader.flush().unwrap();
+    assert!(leader.optimize().unwrap(), "expected a vacuum to run");
+    leader.flush().unwrap();
+
+    dir
+}
+
+/// A delete against an immutable segment rewrites its deleted-points bitmask,
+/// visibly to a fresh writer and to an ordinary follower alike.
+#[cfg_attr(
+    windows,
+    ignore = "the tombstone rewrite replaces id_tracker.deleted while the writer's own \
+              LookupSegment holds it memory-mapped, which Windows refuses"
+)]
+#[test]
+fn delete_batch_tombstones_points_in_immutable_segments() {
+    let dir = vacuumed_leader("edge-update-delete-immutable");
+
+    let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+
+    // The segment holding point 500 must not be the write target, or the
+    // test dodges the delete-only path.
+    let preview = writer.preview_batch(delete_batch([500])).unwrap();
+    let holder = preview.points[0].current.as_ref().unwrap().segment;
+    assert!(
+        !writer
+            .segment_configs()
+            .iter()
+            .any(|info| info.uuid == holder && info.is_write_target),
+        "point 500 should live in a non-appendable segment",
+    );
+
+    let outcome = writer.apply_batch(delete_batch([500])).unwrap();
+    assert_eq!(outcome.deleted, 1);
+
+    // A fresh writer resolves against the rewritten mask.
+    let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+    let replayed = writer.apply_batch(delete_batch([500])).unwrap();
+    assert_eq!(replayed.deleted, 0);
+    assert_eq!(replayed.missing, 1);
+
+    let follower = open_follower(dir.path());
+    assert_eq!(exact_count(&follower), 699);
+    let ids = scrolled_ids(&follower);
+    assert_eq!(ids.len(), 699);
+    assert!(!ids.contains(&ExtendedPointId::NumId(500)));
+    assert!(ids.contains(&ExtendedPointId::NumId(499)));
+    assert!(ids.contains(&ExtendedPointId::NumId(501)));
 }
 
 /// The store tests cannot run on Windows: the leader's writable storage

--- a/lib/segment/src/id_tracker/disk_id_tracker/read_only/mod.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/read_only/mod.rs
@@ -73,10 +73,8 @@ impl<S: UniversalRead> ReadOnlyDiskIdTracker<S> {
         Ok(self.deleted_full.get().expect("just set"))
     }
 
-    /// Whether the full deleted set has been materialized. Test-only: used to
-    /// assert that read-by-id lookups do not trigger a full load.
-    #[cfg(test)]
-    pub(crate) fn deleted_full_materialized(&self) -> bool {
-        self.deleted_full.get().is_some()
+    /// The full deleted set, if already materialized; never triggers the load.
+    pub fn deleted_full_if_materialized(&self) -> Option<&BitVec> {
+        self.deleted_full.get()
     }
 }

--- a/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
@@ -338,13 +338,13 @@ fn read_by_id_does_not_materialize_deleted_set() {
         .unwrap();
 
     assert!(
-        !read_only.deleted_full_materialized(),
+        read_only.deleted_full_if_materialized().is_none(),
         "read-by-id lookups must not materialize the full deleted set",
     );
 
     // A search-style call (whole-slice access) does materialize it.
     let _ = read_only.deleted_point_bitslice();
-    assert!(read_only.deleted_full_materialized());
+    assert!(read_only.deleted_full_if_materialized().is_some());
 }
 
 #[test]

--- a/lib/segment/src/segment/update_only/delete_only/mod.rs
+++ b/lib/segment/src/segment/update_only/delete_only/mod.rs
@@ -3,55 +3,85 @@
 
 use std::path::{Path, PathBuf};
 
+use common::mmap::AdviceSetting;
+use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalWrite;
+use common::universal_io::{OpenOptions, Populate, UniversalRead, UniversalWriteFileOps};
 
-use crate::common::operation_error::OperationResult;
+use super::DeleteOnlyIdTrackerState;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::id_tracker::immutable_id_tracker::deleted_path;
 use crate::types::PointIdType;
 
-/// A segment open for deletes: its mappings, payloads, vectors and indexes
-/// cannot grow, so the only thing a batch can do to it is retire points that
-/// are already there.
+/// A segment open for deletes: nothing in it can grow, so the only thing a
+/// batch can do here is retire points that are already there. Needs only
+/// reads plus [`atomic_save`] from the backend, so object stores qualify.
 ///
-/// This is what every immutable segment of a shard becomes when a batch
-/// touches it — including the segments a point is *moved out of*, whose old
-/// copy has to stop resolving.
-pub struct DeleteOnlySegment<S: UniversalWrite + 'static> {
-    /// Backend the writes go through.
-    // Unread until the deleted-points bitmask can be written, see
-    // `tombstone_points`.
-    #[expect(dead_code)]
+/// [`atomic_save`]: UniversalWriteFileOps::atomic_save
+pub struct DeleteOnlySegment<S: UniversalRead<Fs: UniversalWriteFileOps> + 'static> {
     fs: S::Fs,
-    /// Path to the segment directory.
-    #[expect(dead_code)]
     segment_path: PathBuf,
+    /// Consumed by the first [`tombstone_points`](Self::tombstone_points) in
+    /// place of reading the mask file.
+    id_tracker_state: Option<DeleteOnlyIdTrackerState>,
 }
 
-impl<S: UniversalWrite + 'static> DeleteOnlySegment<S> {
-    /// Open the segment directory at `segment_path` for deletes. Nothing is
-    /// read: an immutable segment's deleted-points bitmask covers slots that
-    /// already exist, so a writer resuming it needs no state from the read
-    /// phase.
-    pub fn open(fs: S::Fs, segment_path: &Path) -> Self {
+impl<S: UniversalRead<Fs: UniversalWriteFileOps> + 'static> DeleteOnlySegment<S> {
+    /// Open the segment directory at `segment_path` for deletes; nothing is
+    /// read.
+    pub fn open(
+        fs: S::Fs,
+        segment_path: &Path,
+        id_tracker_state: Option<DeleteOnlyIdTrackerState>,
+    ) -> Self {
         Self {
             fs,
             segment_path: segment_path.to_path_buf(),
+            id_tracker_state,
         }
     }
 
-    /// Retire the given points, addressed by the slots they occupy — their
-    /// external ids play no part here, an immutable mapping cannot record a
-    /// deletion.
-    ///
-    /// Nothing but the deleted-points bitmask is written: the payload row, the
-    /// vectors and the field indexes at those slots are left untouched.
+    /// Retire the given points by marking the slots they occupy in the
+    /// deleted-points bitmask (`id_tracker.deleted`) — the only thing
+    /// written, the data on those slots stays. The mask is replaced whole,
+    /// see [`StoredBitSlice::atomic_update`].
     pub fn tombstone_points(
         &mut self,
         points: &[(PointIdType, PointOffsetType)],
     ) -> OperationResult<()> {
-        let _ = points;
-        // Today's bitmask is mutated in place at an offset, which an object
-        // store cannot do.
-        todo!("needs an appendable deleted-points bitmask (`DynamicStoredFlags`)")
+        if points.is_empty() {
+            return Ok(());
+        }
+
+        let seed = self.id_tracker_state.take().map(|state| state.deleted);
+
+        StoredBitSlice::<S>::atomic_update(
+            &self.fs,
+            deleted_path(&self.segment_path),
+            OpenOptions {
+                writeable: false,
+                need_sequential: false,
+                populate: Populate::No,
+                advice: AdviceSetting::Global,
+            },
+            Default::default(),
+            seed,
+            |mask| {
+                for &(point_id, internal_id) in points {
+                    let slot = internal_id as usize;
+                    // A slot beyond the mask names a point this segment cannot hold.
+                    if slot >= mask.len() {
+                        return Err(OperationError::service_error(format!(
+                            "cannot tombstone point {point_id} of segment {}: slot {internal_id} \
+                             is beyond its deleted mask ({} slots)",
+                            self.segment_path.display(),
+                            mask.len(),
+                        )));
+                    }
+                    mask.set(slot, true);
+                }
+                Ok(())
+            },
+        )?
     }
 }

--- a/lib/segment/src/segment/update_only/lookup/mod.rs
+++ b/lib/segment/src/segment/update_only/lookup/mod.rs
@@ -11,7 +11,8 @@ use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 use common::universal_io::UniversalRead;
 
-use super::AppendableIdTrackerState;
+use super::{AppendableIdTrackerState, DeleteOnlyIdTrackerState, WriterIdTrackerState};
+use crate::id_tracker::IdTrackerRead as _;
 use crate::id_tracker::read_only_tracker_enum::ReadOnlyIdTrackerEnum;
 use crate::payload_storage::read_only::ReadOnlyPayloadStorage;
 use crate::types::{SegmentConfig, VectorNameBuf};
@@ -37,28 +38,35 @@ pub struct LookupSegment<S: UniversalRead + 'static> {
 }
 
 impl<S: UniversalRead + 'static> LookupSegment<S> {
-    /// The mappings-log state a writer resuming this segment picks up from,
-    /// for [`UpdateOnlySegmentEnum::open`](super::UpdateOnlySegmentEnum::open);
-    /// `None` when the segment has no log to resume, which makes its writer a
-    /// delete-only one.
+    /// The id-tracker state a writer resuming this segment picks up from, for
+    /// [`UpdateOnlySegmentEnum::open`](super::UpdateOnlySegmentEnum::open).
     ///
-    /// The writer kind therefore follows the id-tracker format that was
-    /// actually loaded, which is what decides how a point is retired here — an
-    /// immutable segment marks its deleted-points bitmask, an appendable one
-    /// records a delete in its mappings log.
-    ///
-    /// Taken from this segment's own read of that log rather than left to the
-    /// writer to re-read: a second read costs another round-trip on a remote
-    /// backend, and may land on a different state than the batch resolved
-    /// against.
-    pub fn writer_state(&self) -> Option<AppendableIdTrackerState> {
+    /// Taken from this segment's own reads rather than re-read by the writer:
+    /// a second read costs another round-trip on a remote backend and may
+    /// land on a different state than the batch resolved against. The deleted
+    /// mask is handed over only when already in memory — the disk-resident
+    /// tracker deliberately avoids materializing it.
+    pub fn writer_state(&self) -> WriterIdTrackerState {
         match &*self.id_tracker.borrow() {
-            ReadOnlyIdTrackerEnum::Appendable(id_tracker) => Some(AppendableIdTrackerState {
-                max_claimed_internal_id: id_tracker.max_claimed_internal_id(),
-                pending_inserts: id_tracker.pending_inserts().collect(),
-                mappings_end: id_tracker.mappings_read_to(),
-            }),
-            ReadOnlyIdTrackerEnum::Immutable(_) | ReadOnlyIdTrackerEnum::DiskResident(_) => None,
+            ReadOnlyIdTrackerEnum::Appendable(id_tracker) => {
+                WriterIdTrackerState::Appendable(AppendableIdTrackerState {
+                    max_claimed_internal_id: id_tracker.max_claimed_internal_id(),
+                    pending_inserts: id_tracker.pending_inserts().collect(),
+                    mappings_end: id_tracker.mappings_read_to(),
+                })
+            }
+            ReadOnlyIdTrackerEnum::Immutable(id_tracker) => {
+                WriterIdTrackerState::DeleteOnly(Some(DeleteOnlyIdTrackerState {
+                    deleted: id_tracker.deleted_point_bitslice().to_bitvec(),
+                }))
+            }
+            ReadOnlyIdTrackerEnum::DiskResident(id_tracker) => {
+                WriterIdTrackerState::DeleteOnly(id_tracker.deleted_full_if_materialized().map(
+                    |deleted| DeleteOnlyIdTrackerState {
+                        deleted: deleted.clone(),
+                    },
+                ))
+            }
         }
     }
 }

--- a/lib/segment/src/segment/update_only/mod.rs
+++ b/lib/segment/src/segment/update_only/mod.rs
@@ -17,15 +17,16 @@
 //!   one batch and dropped with it, since the append-only components behind
 //!   them hold nothing across calls.
 //!
-//! The two phases meet at [`AppendableIdTrackerState`]: what a writer must
-//! know about the segment it resumes, taken from the read the lookup phase
-//! already did. See [`LookupSegment::writer_state`].
+//! The two phases meet at [`WriterIdTrackerState`]: what a writer must know
+//! about the segment it resumes, taken from the read the lookup phase already
+//! did. See [`LookupSegment::writer_state`].
 
 mod appendable;
 mod delete_only;
 mod lookup;
 mod segment_enum;
 
+use common::bitvec::BitVec;
 use common::types::PointOffsetType;
 
 pub use self::appendable::AppendableSegment;
@@ -33,6 +34,15 @@ pub use self::delete_only::DeleteOnlySegment;
 pub use self::lookup::LookupSegment;
 pub use self::segment_enum::UpdateOnlySegmentEnum;
 use crate::types::PointIdType;
+
+/// Id-tracker state the read phase hands to a segment's writer; the variant
+/// decides the writer's kind.
+pub enum WriterIdTrackerState {
+    Appendable(AppendableIdTrackerState),
+    /// `None` when the read phase did not hold the deleted mask in memory;
+    /// the writer then reads it itself.
+    DeleteOnly(Option<DeleteOnlyIdTrackerState>),
+}
 
 /// The tail of an appendable segment's mappings log, as the read phase saw it.
 ///
@@ -47,4 +57,10 @@ pub struct AppendableIdTrackerState {
     pub max_claimed_internal_id: Option<PointOffsetType>,
     pub pending_inserts: Vec<PointIdType>,
     pub mappings_end: u64,
+}
+
+/// An immutable segment's deleted-points mask as the read phase held it in
+/// memory, sparing the writer the read of the mask file.
+pub struct DeleteOnlyIdTrackerState {
+    pub deleted: BitVec,
 }

--- a/lib/segment/src/segment/update_only/segment_enum.rs
+++ b/lib/segment/src/segment/update_only/segment_enum.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use common::types::PointOffsetType;
 use common::universal_io::{UniversalAppend, UniversalWrite};
 
-use super::{AppendableIdTrackerState, AppendableSegment, DeleteOnlySegment};
+use super::{AppendableSegment, DeleteOnlySegment, WriterIdTrackerState};
 use crate::common::operation_error::OperationResult;
 use crate::types::{PointIdType, SegmentConfig};
 
@@ -17,23 +17,21 @@ pub enum UpdateOnlySegmentEnum<S: UniversalAppend + UniversalWrite + 'static> {
 }
 
 impl<S: UniversalAppend + UniversalWrite + 'static> UpdateOnlySegmentEnum<S> {
-    /// Open a writer over the segment directory at `segment_path`: appendable
-    /// when the read phase handed over a mappings-log state to resume from,
-    /// delete-only when it had none to give.
+    /// Open a writer over the segment directory at `segment_path`, of the
+    /// kind the read phase's `id_tracker_state` dictates.
     pub fn open(
         fs: &S::Fs,
         segment_path: &Path,
         config: &SegmentConfig,
-        id_tracker_state: Option<AppendableIdTrackerState>,
+        id_tracker_state: WriterIdTrackerState,
     ) -> OperationResult<Self> {
         Ok(match id_tracker_state {
-            Some(state) => Self::Appendable(Box::new(AppendableSegment::open(
-                fs.clone(),
-                segment_path,
-                config,
-                state,
-            )?)),
-            None => Self::DeleteOnly(DeleteOnlySegment::open(fs.clone(), segment_path)),
+            WriterIdTrackerState::Appendable(state) => Self::Appendable(Box::new(
+                AppendableSegment::open(fs.clone(), segment_path, config, state)?,
+            )),
+            WriterIdTrackerState::DeleteOnly(state) => {
+                Self::DeleteOnly(DeleteOnlySegment::open(fs.clone(), segment_path, state))
+            }
         })
     }
 


### PR DESCRIPTION
## What

Implements `DeleteOnlySegment::tombstone_points` — until now a `todo!()`, and the blocker for any update batch that overwrites or deletes a point living in an immutable segment (the common case after optimize).

Retiring marks the slots in the segment's deleted-points bitmask (`id_tracker.deleted`, shared by the immutable and disk-resident tracker formats) and replaces the file whole. Nothing else is written: the data on the slots stays, and the payload row / vectors / field indexes are untouched.

## How

* **`StoredBitSlice::atomic_update`** owns the mutation cycle: read the stored bits — or start from a caller-provided seed — apply the update closure, `atomic_save` the result. A closure error writes nothing. It is the single entry point behind which the stored representation can later change (delta log, roaring). A whole-file replacement is the one mutation that works on backends without random-offset writes, and it is exactly what the read side expects: both read-only trackers `live_reload` this file by opening a fresh handle and diffing, so no read-side changes are needed.
* **`WriterIdTrackerState`** (by analogy to `AppendableIdTrackerState`): `LookupSegment::writer_state` hands the writer what the read phase already observed. The `DeleteOnly` variant carries the deleted mask when the tracker holds it in memory — always for the immutable tracker, only if already materialized for the disk-resident one (which deliberately never loads the full deleted set for read-by-id; forcing the load there would just move the writer's read, not save it). Seeded tombstoning does zero reads: one `atomic_save`, no round-trip.
* **Bound relaxed**: tombstoning needs only reads plus `atomic_save`, so `DeleteOnlySegment` requires `UniversalRead<Fs: UniversalWriteFileOps>` — no `UniversalAppend`, no `UniversalWrite`. This clears the way for dropping `+ UniversalWrite` from `UpdateOnlySegmentEnum`/`apply_batch` (follow-up), after which `BlobFile` qualifies and the writer works over object storage at the type level.

## Divergence from the writable trackers, deliberate

`DiskIdTracker::drop` also zeroes the slot's version (`DELETED_POINT_VERSION`); this path leaves it. The versions file is in-place-mutated, which object stores cannot do, and deletion authority in these formats is the bit — every lookup filters through it before versions are consulted, and the resolve stage reads versions only for located (live) points. A stale version on a tombstoned slot is the same state a crash between drop-bit and drop-version leaves, which `fix_inconsistencies` already absorbs as storage cleanup. Zeroing it remotely would mean rewriting the whole versions file (8 bytes/point vs 1 bit/point) to maintain an invariant nothing on this path reads.

## Tests

* `stored_bitslice`: `atomic_update` read-path, seed-path, and closure-error path (file untouched).
* `edge::update_only`: end-to-end delete against a vacuumed (immutable, indexed) segment through `apply_batch` — asserts the holding segment is not the write target (so the test cannot silently take the appendable path), then verifies the tombstone through a fresh writer (replay → `missing`) and an ordinary follower. Ignored on Windows: the rewrite replaces a file the writer's own `LookupSegment` holds mapped.
* `disk_id_tracker`: materialization probe test adapted to the new `deleted_full_if_materialized` accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)