### PR TITLE
[WIP] Model testing reload postmortem

### DIFF
--- a/.github/workflows/nightly-model-testing.yml
+++ b/.github/workflows/nightly-model-testing.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      disable_snapshots:
+        description: 'Pass --disable-snapshots to both passes (isolates snapshot-dependent bugs)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -79,6 +84,7 @@ jobs:
           INPUT_OP_NUM: ${{ inputs.op_num }}
           INPUT_SEED: ${{ inputs.seed }}
           INPUT_DISABLE_OPTIMIZER: ${{ inputs.disable_optimizer }}
+          INPUT_DISABLE_SNAPSHOTS: ${{ inputs.disable_snapshots }}
         run: |
           # The commit actually under test. `github.sha` is the default branch (master) on a
           # scheduled run, but the checkout above forces `dev`, so reporting `github.sha` points
@@ -98,6 +104,11 @@ jobs:
           else
             echo "OPTIMIZER_FLAG=" >> "$GITHUB_ENV"
           fi
+          if [ "$INPUT_DISABLE_SNAPSHOTS" = "true" ]; then
+            echo "SNAPSHOTS_FLAG=--disable-snapshots" >> "$GITHUB_ENV"
+          else
+            echo "SNAPSHOTS_FLAG=" >> "$GITHUB_ENV"
+          fi
         shell: bash
       # Both runs reuse the single binary built above and share the same seed.
       - name: Run model testing (async scorer)
@@ -111,6 +122,7 @@ jobs:
             --id-pool "$ID_POOL" \
             --on-disk \
             $OPTIMIZER_FLAG \
+            $SNAPSHOTS_FLAG \
             --async-scorer
         shell: bash
         timeout-minutes: 300
@@ -126,7 +138,8 @@ jobs:
             --restart-probability "$RESTART_PROBABILITY" \
             --id-pool "$ID_POOL" \
             --on-disk \
-            $OPTIMIZER_FLAG
+            $OPTIMIZER_FLAG \
+            $SNAPSHOTS_FLAG
         shell: bash
         timeout-minutes: 300
       # Which of the two passes broke is the first thing triage needs: one failing while the

--- a/.github/workflows/nightly-model-testing.yml
+++ b/.github/workflows/nightly-model-testing.yml
@@ -13,6 +13,11 @@ on:
         description: 'RNG seed (leave empty for a random seed)'
         required: false
         default: ''
+      disable_optimizer:
+        description: 'Pass --disable-optimizer to both passes (isolates optimizer-dependent bugs)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -73,6 +78,7 @@ jobs:
         env:
           INPUT_OP_NUM: ${{ inputs.op_num }}
           INPUT_SEED: ${{ inputs.seed }}
+          INPUT_DISABLE_OPTIMIZER: ${{ inputs.disable_optimizer }}
         run: |
           # The commit actually under test. `github.sha` is the default branch (master) on a
           # scheduled run, but the checkout above forces `dev`, so reporting `github.sha` points
@@ -86,6 +92,12 @@ jobs:
           else
             echo "SEED=$(od -An -N8 -tu8 /dev/urandom | tr -d ' ')" >> "$GITHUB_ENV"
           fi
+          # Empty unless requested, so it expands to nothing in the run commands below.
+          if [ "$INPUT_DISABLE_OPTIMIZER" = "true" ]; then
+            echo "OPTIMIZER_FLAG=--disable-optimizer" >> "$GITHUB_ENV"
+          else
+            echo "OPTIMIZER_FLAG=" >> "$GITHUB_ENV"
+          fi
         shell: bash
       # Both runs reuse the single binary built above and share the same seed.
       - name: Run model testing (async scorer)
@@ -98,6 +110,7 @@ jobs:
             --restart-probability "$RESTART_PROBABILITY" \
             --id-pool "$ID_POOL" \
             --on-disk \
+            $OPTIMIZER_FLAG \
             --async-scorer
         shell: bash
         timeout-minutes: 300
@@ -112,7 +125,8 @@ jobs:
             --shard-count "$SHARD_COUNT" \
             --restart-probability "$RESTART_PROBABILITY" \
             --id-pool "$ID_POOL" \
-            --on-disk
+            --on-disk \
+            $OPTIMIZER_FLAG
         shell: bash
         timeout-minutes: 300
       # Which of the two passes broke is the first thing triage needs: one failing while the

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -734,6 +734,11 @@ pub async fn run(
             // [`verify::assert_clocks_match`] for why both mismatch directions are bugs.
             log::info!("op:{i} restart: collect_clock_ticks");
             let pre_clocks = verify::collect_clock_ticks(&collection).await;
+            // Pre-close placement of every live point (segment, dir, versions), printed for any
+            // id the reload loses. Together with the reload postmortem this makes both sides of
+            // the custody question observable: which directory's memory held the point at close,
+            // and which reloaded directory lacks it. See `verify::capture_placement`.
+            let pre_close_placement = verify::capture_placement(&collection).await;
             log::info!("op:{i} restart: stop_gracefully");
             collection.stop_gracefully().await;
             // `into_inner` makes the invariant checked, not assumed: if any background task still
@@ -764,6 +769,16 @@ pub async fn run(
                     missing.len(),
                     verify::describe_missing_points(&collection, &missing).await,
                 );
+                for id in &missing {
+                    match pre_close_placement.get(id) {
+                        Some(sightings) => {
+                            log::error!("pre-close placement of {id:?}: {}", sightings.join("; "),)
+                        }
+                        None => log::error!(
+                            "pre-close placement of {id:?}: not visible in any segment before close",
+                        ),
+                    }
+                }
             }
             verify::assert_matches_model(&live, &model, &format!("restart at op:{i}"));
             // Clock check AFTER the model check: a lost WAL tail trips both, and the model diff

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -754,6 +754,17 @@ pub async fn run(
             verify::wait_for_pending_updates(&collection).await;
             log::info!("op:{i} restart: scroll + verify");
             let live = verify::collect_model_from_collection(&collection).await;
+            // Probe the engine for every id the reload lost, while the reopened collection is
+            // still around: the panic message alone cannot say whether the point never reached
+            // disk or reached it and was removed again. See `describe_missing_points`.
+            if live.len() != model.len() {
+                let (_, missing) = verify::id_diff(&live, &model);
+                log::error!(
+                    "op:{i} reload lost {} point(s):{}",
+                    missing.len(),
+                    verify::describe_missing_points(&collection, &missing).await,
+                );
+            }
             verify::assert_matches_model(&live, &model, &format!("restart at op:{i}"));
             // Clock check AFTER the model check: a lost WAL tail trips both, and the model diff
             // (extra/missing ids) is the established postmortem signature for that class, so it

--- a/lib/collection/src/model_testing/verify.rs
+++ b/lib/collection/src/model_testing/verify.rs
@@ -76,6 +76,60 @@ pub(super) fn id_diff(actual: &Model, expected: &Model) -> (Vec<PointIdType>, Ve
     (extra, missing)
 }
 
+/// Engine-side postmortem for points a reload lost, logged before the panic that reports them.
+///
+/// Says, per point, whether any segment still knows the id and in what state. The two answers
+/// separate the candidate mechanisms:
+///
+/// - **unknown to every segment**: nothing on disk ever recorded the point, so the WAL was
+///   acknowledged past a write that only ever existed in an in-memory pending buffer.
+/// - **known but soft-deleted, or known at an older version**: the point did reach disk and a
+///   later durable write (a copy-on-write move's source-side delete, typically) removed or
+///   reverted it without its counterpart surviving.
+///
+/// The distinction matters because the restart is an in-process close+reopen, not a crash: the page
+/// cache keeps every byte ever written whether or not it was fsynced, so anything genuinely absent
+/// was never written at all.
+pub(super) async fn describe_missing_points(
+    collection: &Collection,
+    missing: &[PointIdType],
+) -> String {
+    use common::types::DeferredBehavior;
+
+    let holder = collection.shards_holder.read().await;
+    let mut out = String::new();
+    for (shard_id, replica_set) in holder.get_shards() {
+        let Some(segments) = replica_set.segments_for_testing().await else {
+            continue;
+        };
+        let segments = segments.read();
+        for id in missing {
+            let mut sightings = Vec::new();
+            for (segment_id, locked) in segments.iter() {
+                let segment = locked.get();
+                let segment = segment.read();
+                let visible = segment.has_point(*id, DeferredBehavior::WithDeferred);
+                let version = segment.point_version(*id);
+                if visible || version.is_some() {
+                    sightings.push(format!(
+                        "segment {segment_id}: visible={visible} version={version:?} \
+                         (segment version={}, persisted={})",
+                        segment.version(),
+                        segment.persistent_version(),
+                    ));
+                }
+            }
+            let verdict = if sightings.is_empty() {
+                "unknown to every segment (never written to disk)".to_string()
+            } else {
+                sightings.join("; ")
+            };
+            out.push_str(&format!("\n  shard {shard_id} id {id:?}: {verdict}"));
+        }
+    }
+    out
+}
+
 pub(super) fn assert_matches_model(actual: &Model, expected: &Model, ctx: &str) {
     if actual.len() != expected.len() {
         let (extra, missing) = id_diff(actual, expected);

--- a/lib/collection/src/model_testing/verify.rs
+++ b/lib/collection/src/model_testing/verify.rs
@@ -141,8 +141,6 @@ pub(super) async fn describe_missing_points(
 pub(super) async fn capture_placement(
     collection: &Collection,
 ) -> HashMap<PointIdType, Vec<String>> {
-    use common::types::DeferredBehavior;
-
     let holder = collection.shards_holder.read().await;
     let mut out: HashMap<PointIdType, Vec<String>> = HashMap::new();
     for (shard_id, replica_set) in holder.get_shards() {

--- a/lib/collection/src/model_testing/verify.rs
+++ b/lib/collection/src/model_testing/verify.rs
@@ -130,6 +130,48 @@ pub(super) async fn describe_missing_points(
     out
 }
 
+/// Where every point lives, captured from the live engine: id -> per-segment sightings with the
+/// segment's directory, the point's version there, and the segment's version/persisted pair.
+///
+/// Captured immediately before a restart's `stop_gracefully` and printed for any id the reload
+/// loses, this pins the pre-close side of the custody question: the reload postmortem says which
+/// reloaded directories lack the point, and this says which directory's in-memory state held it,
+/// at what claimed durability. A segment that appears here as clean (version == persisted) but
+/// whose reloaded directory lacks the point is a flush whose content does not match its claim.
+pub(super) async fn capture_placement(
+    collection: &Collection,
+) -> HashMap<PointIdType, Vec<String>> {
+    use common::types::DeferredBehavior;
+
+    let holder = collection.shards_holder.read().await;
+    let mut out: HashMap<PointIdType, Vec<String>> = HashMap::new();
+    for (shard_id, replica_set) in holder.get_shards() {
+        let Some(segments) = replica_set.segments_for_testing().await else {
+            continue;
+        };
+        let segments = segments.read();
+        for (segment_id, locked) in segments.iter() {
+            let guard = locked.get();
+            let read = guard.read();
+            let dir = read
+                .data_path()
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            let (seg_version, seg_persisted) = (read.version(), read.persistent_version());
+            for point_id in read.read_range(None, None) {
+                let version = read.point_version(point_id);
+                let deferred = read.point_is_deferred(point_id);
+                out.entry(point_id).or_default().push(format!(
+                    "shard {shard_id} segment {segment_id} dir {dir} point_version={version:?} \
+                     deferred={deferred} segment={seg_version}/{seg_persisted}",
+                ));
+            }
+        }
+    }
+    out
+}
+
 pub(super) fn assert_matches_model(actual: &Model, expected: &Model, ctx: &str) {
     if actual.len() != expected.len() {
         let (extra, missing) = id_diff(actual, expected);

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -802,7 +802,10 @@ impl LocalShard {
             .expect("Failed to create progress style");
         bar.set_style(progress_style);
 
-        log::debug!(
+        // Info, not debug: the replay window is the first thing a reload-divergence postmortem
+        // needs (a point missing after restart whose write index falls below `from` was
+        // acknowledged as durable without ever reaching disk), and it is one line per shard load.
+        log::info!(
             "Recovering shard {} starting reading WAL from {} up to {} (last_applied_seq:{:?})",
             self.path.display(),
             from,

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -491,6 +491,32 @@ impl LocalShard {
             log::debug!("Deduplicated {res} points for {collection_id}/{shard_id}");
         }
 
+        // One line per reload naming every segment that made it back: directory, version,
+        // persisted version, live point count. The custody-chain analysis of a lost point ends at
+        // a fork this inventory resolves: a pre-image holder that was durable when its hop ran can
+        // fail replay either because its directory was never loaded here, or because its loaded
+        // content lacks the point. Without the inventory those two read identically.
+        {
+            let inventory = segment_holder
+                .iter()
+                .map(|(segment_id, locked)| {
+                    let guard = locked.get();
+                    let read = guard.read();
+                    format!(
+                        "{segment_id}:{}:{}/{}:{}pts",
+                        read.data_path()
+                            .file_name()
+                            .map(|n| n.to_string_lossy().into_owned())
+                            .unwrap_or_default(),
+                        read.version(),
+                        read.persistent_version(),
+                        read.available_point_count(),
+                    )
+                })
+                .join(", ");
+            log::info!("reloaded segment inventory {shard_id}: [{inventory}]");
+        }
+
         clear_temp_segments(shard_path);
         let optimizers = build_optimizers(
             shard_path,

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -902,6 +902,35 @@ impl LocalShard {
                     return Err(err.clone());
                 }
                 Err(err @ CollectionError::NotFound { .. }) => log::warn!("{err}"),
+                Err(err @ CollectionError::PointNotFound { missed_point_id }) => {
+                    log::error!("{err}");
+                    // Replay just declined an operation because its point has no pre-image: the
+                    // reload-divergence signature. Say what each loaded segment knows about the id
+                    // at this exact moment, so the postmortem does not have to reconstruct it from
+                    // acknowledge arithmetic. `WithDeferred` so a deferred-only copy still counts.
+                    let segments = self.segments.read();
+                    let mut sightings = Vec::new();
+                    for (segment_id, locked) in segments.iter() {
+                        let guard = locked.get();
+                        let read = guard.read();
+                        let version = read.point_version(*missed_point_id);
+                        let visible =
+                            read.has_point(*missed_point_id, DeferredBehavior::WithDeferred);
+                        if version.is_some() || visible {
+                            sightings.push(format!(
+                                "segment {segment_id}: visible={visible} version={version:?}"
+                            ));
+                        }
+                    }
+                    log::error!(
+                        "replay decline postmortem: op_num={op_num} id={missed_point_id:?}: {}",
+                        if sightings.is_empty() {
+                            "no loaded segment knows the id".to_string()
+                        } else {
+                            sightings.join("; ")
+                        },
+                    );
+                }
                 Err(err) => log::error!("{err}"),
                 Ok(_) => (),
             }

--- a/lib/collection/src/shards/local_shard/testing.rs
+++ b/lib/collection/src/shards/local_shard/testing.rs
@@ -1,9 +1,16 @@
 use segment::id_tracker::IdTracker;
 use shard::segment_holder::FlushMode;
+use shard::segment_holder::locked::LockedSegmentHolder;
 
 use crate::shards::local_shard::LocalShard;
 
 impl LocalShard {
+    /// Testing helper: segment holder, for the model testing reload postmortem (see
+    /// `model_testing::verify::describe_missing_points`).
+    pub(crate) fn segments_for_testing(&self) -> LockedSegmentHolder {
+        self.segments.clone()
+    }
+
     // Testing helper: performs partial flush of the segments
     pub fn partial_flush(&self) {
         let segments = self.segments.read();

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -407,6 +407,18 @@ impl ShardReplicaSet {
         self.local.read().await.is_some()
     }
 
+    /// Segment holder of the plain local shard, for the model testing postmortem only (see
+    /// `model_testing::verify::describe_missing_points`). `None` for proxies and remotes.
+    #[cfg(feature = "testing")]
+    pub(crate) async fn segments_for_testing(
+        &self,
+    ) -> Option<shard::segment_holder::locked::LockedSegmentHolder> {
+        match &*self.local.read().await {
+            Some(Shard::Local(local)) => Some(local.segments_for_testing()),
+            _ => None,
+        }
+    }
+
     /// Checks if the shard exists locally and not a proxy.
     pub async fn is_local(&self) -> bool {
         let local_read = self.local.read().await;

--- a/lib/collection/src/update_workers/flush_workers.rs
+++ b/lib/collection/src/update_workers/flush_workers.rs
@@ -23,14 +23,7 @@ impl UpdateWorkers {
     /// Returns an error on flush failure
     fn flush_segments(segments: LockedSegmentHolder) -> OperationResult<SeqNumberType> {
         let read_segments = segments.read();
-        // DIAGNOSTIC EXPERIMENT, not the intended fix: the reload divergence is now pinned to a
-        // flush pass that durably persisted a CoW source's deletes while leaving the destination
-        // of the same moves unflushed (segment 11 at 36930/36930 vs segment 7 at 36808/36808 in
-        // run 31570040346), the exact hazard flush_all's locking exists to prevent. A synchronous
-        // flush holds every segment lock through execution, so capture and execution cannot be
-        // interleaved by copy-on-write moves. If this zeroes the failures, the background flush's
-        // capture/execute split is confirmed as the final layer.
-        let flushed_version = read_segments.flush_all(FlushMode::Sync, false)?;
+        let flushed_version = read_segments.flush_all(FlushMode::Background, false)?;
         Ok(match read_segments.failed_operation.iter().cloned().min() {
             None => flushed_version,
             Some(failed_operation) => min(failed_operation, flushed_version),

--- a/lib/collection/src/update_workers/flush_workers.rs
+++ b/lib/collection/src/update_workers/flush_workers.rs
@@ -23,7 +23,14 @@ impl UpdateWorkers {
     /// Returns an error on flush failure
     fn flush_segments(segments: LockedSegmentHolder) -> OperationResult<SeqNumberType> {
         let read_segments = segments.read();
-        let flushed_version = read_segments.flush_all(FlushMode::Background, false)?;
+        // DIAGNOSTIC EXPERIMENT, not the intended fix: the reload divergence is now pinned to a
+        // flush pass that durably persisted a CoW source's deletes while leaving the destination
+        // of the same moves unflushed (segment 11 at 36930/36930 vs segment 7 at 36808/36808 in
+        // run 31570040346), the exact hazard flush_all's locking exists to prevent. A synchronous
+        // flush holds every segment lock through execution, so capture and execution cannot be
+        // interleaved by copy-on-write moves. If this zeroes the failures, the background flush's
+        // capture/execute split is confirmed as the final layer.
+        let flushed_version = read_segments.flush_all(FlushMode::Sync, false)?;
         Ok(match read_segments.failed_operation.iter().cloned().min() {
             None => flushed_version,
             Some(failed_operation) => min(failed_operation, flushed_version),

--- a/lib/collection/src/update_workers/flush_workers.rs
+++ b/lib/collection/src/update_workers/flush_workers.rs
@@ -93,6 +93,14 @@ impl UpdateWorkers {
             segments.write().report_optimizer_error(err);
         }
 
+        // Pairs with the "flush ack decision" line in `get_max_persisted_version`: that one says
+        // what the segments justified, this one says what the WAL was actually told, after the
+        // `keep_from` cap. Everything below `ack` stops being replayable.
+        log::info!(
+            "WAL ack: shard={} ack={ack} (confirmed={confirmed_version}, keep_from={keep_from})",
+            shard_path.display(),
+        );
+
         if let Err(err) = wal.blocking_lock().ack(ack) {
             log::warn!("Failed to acknowledge WAL version: {err}");
             segments.write().report_optimizer_error(err);

--- a/lib/common/common/src/toposort.rs
+++ b/lib/common/common/src/toposort.rs
@@ -48,6 +48,11 @@ impl<T: Eq + std::hash::Hash + Copy, V> TopoSort<T, V> {
             .insert(depends_on, value);
     }
 
+    /// Returns the elements `element` depends on, with the value stored per dependency.
+    pub fn dependencies_of(&self, element: &T) -> impl Iterator<Item = (&T, &V)> {
+        self.dependencies.get(element).into_iter().flatten()
+    }
+
     /// Removes dependencies for which the filter function returns false
     pub fn retain(&mut self, filter: impl Fn(&T, &T, &V) -> bool) {
         self.dependencies.retain(|element, deps| {

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -489,6 +489,19 @@ impl StorageSegmentEntry for Segment {
                 return Ok(());
             };
 
+            // Every durable-state write for a segment funnels through this closure, whichever
+            // caller captured it (flush worker, snapshot force-flush, testing helpers). A source
+            // segment's on-disk version has been observed advancing past a CoW operation with no
+            // flush-pass decision logged in the window, so flush executions must be individually
+            // attributable, not only pass-level decisions.
+            log::info!(
+                "segment flush exec: dir {:?} captured_version={:?}",
+                segment_path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned()),
+                state.version,
+            );
+
             let flush_components = || {
                 // Flush mapping first to prevent having orphan internal ids.
 

--- a/lib/shard/src/locked_segment.rs
+++ b/lib/shard/src/locked_segment.rs
@@ -113,6 +113,20 @@ impl LockedSegment {
     }
 
     fn drop_data_with_timeout(self, timeout: Duration) -> Result<(), DropDataOutcome> {
+        // Every path that destroys segment files funnels through here. A lost point's last
+        // durable directory has now been observed missing at reload with no pin release and no
+        // load-time reclaim logged, so the deleting path is one this line will finally name.
+        log::info!(
+            "drop_data: dir {:?} version={} persisted={}",
+            self.get()
+                .read()
+                .data_path()
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default(),
+            self.get().read().version(),
+            self.get().read().persistent_version(),
+        );
         match self {
             LockedSegment::Original(segment) => {
                 match try_unwrap_with_timeout(segment, DROP_SPIN_TIMEOUT, timeout) {

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -812,8 +812,6 @@ fn check_segments_size(
 }
 
 /// Performs optimization of segments (merge / reindex / vacuum, etc.)
-#[allow(clippy::too_many_arguments)]
-
 /// Test-only seam: a callback invoked after the sources are wrapped in proxies and before the
 /// optimized segment is built, so a deterministic test can inject operations into exactly the
 /// window a concurrent workload occupies in production. Thread-local: the callback fires on the
@@ -843,6 +841,7 @@ pub mod test_hooks {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
     optimizer_name: &'static str,
     segment_holder: LockedSegmentHolder,

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -4,10 +4,10 @@
 //! The collection layer provides the strategy via `OptimizationStrategy`.
 
 use std::collections::HashSet;
-use std::debug_assert_matches;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
+use std::{cmp, debug_assert_matches};
 
 use ahash::AHashSet;
 use common::budget::{ResourceBudget, ResourcePermit};
@@ -615,11 +615,10 @@ fn finish_optimization(
     // (and out of the optimized segment's in-memory state, which the next optimization bakes into
     // its build output) while their new copies may still sit unflushed in appendable segments. WAL
     // replay can only re-derive those moves from the on-disk pre-images, so the files must survive
-    // until a flush proves this optimization durable. Register the destruction as a post-flush
-    // action: it runs once the durable waterline covers `optimized_segment_version`, and until then
-    // the WAL acknowledge stays capped at each source's persisted version (the same pin the proxy
-    // imposed while the optimization ran), so every operation the files contradict, deletions in
-    // particular, is replayed and re-applied on a restart. See
+    // until a flush proves the moved copies durable. Register the destruction as a post-flush
+    // action; until it runs, the WAL acknowledge stays capped at each source's persisted version
+    // (the same pin the proxy imposed while the optimization ran), so every operation the files
+    // contradict, deletions in particular, is replayed and re-applied on a restart. See
     // `SegmentHolder::register_post_flush_action`.
     //
     // This cap has to be tracked at the holder level because the proxy can no longer
@@ -630,28 +629,31 @@ fn finish_optimization(
     // gone from the holder's flush accounting even though the source files it protected are
     // still on disk. `register_segment_drop` re-expresses the same pin independently of segment
     // membership, snapshotting each proxy's final `persistent_version` as `ack_pin`.
+    //
+    // The release threshold is `max(optimized_segment_version, proxy version)`, and the second
+    // half is what makes the re-expression faithful. A copy-on-write move during the optimization
+    // put the point's new copy in the shared appendable write segment and recorded a delete in the
+    // proxy; that delete is baked into the optimized segment as a durable tombstone, so after this
+    // source is dropped the pre-image survives nowhere else, while the write segment may not flush
+    // for a long time. Releasing at `optimized_segment_version` alone destroyed the pre-image as
+    // soon as the destination was durable: a restart then discarded the write segment's unflushed
+    // copy, and replaying the still-acknowledged CoW operation failed for want of the pre-image,
+    // losing the point (the nightly model-testing reload divergence). The proxy's version covers
+    // every such CoW operation (its delete half bumped it), and the durable waterline cannot reach
+    // it until the write segment holding the copies has flushed past it, or has itself been
+    // optimized into a built (hence on-disk) destination whose own pin extends the chain.
     for proxy in proxies {
-        let ack_pin = proxy.get().read().persistent_version();
-        // The pin is released once the waterline covers `optimized_segment_version`, so a proxy
-        // whose version sits above that is the case to watch: whatever those operations touched is
-        // not represented by the destination, and after the release nothing pins them either.
-        // Splitting the proxy's version into its wrapped and propagated halves says which side
-        // carries them, which decides whether that gap is benign bookkeeping or lost data.
-        let proxy_version = proxy.get().read().version();
-        let wrapped_version = match &proxy {
-            LockedSegment::Proxy(p) => p.read().wrapped_segment.get().read().version(),
-            LockedSegment::Original(_) => proxy_version,
+        let (ack_pin, proxy_version) = {
+            let guard = proxy.get();
+            let read = guard.read();
+            (read.persistent_version(), read.version())
         };
+        let ready_at = cmp::max(optimized_segment_version, proxy_version);
         log::info!(
-            "segment drop pin: ack_pin={ack_pin} ready_at={optimized_segment_version} \
-             proxy_version={proxy_version} wrapped_version={wrapped_version}{}",
-            if proxy_version > optimized_segment_version {
-                " ABOVE_DESTINATION"
-            } else {
-                ""
-            },
+            "segment drop pin: ack_pin={ack_pin} ready_at={ready_at} \
+             proxy_version={proxy_version} destination_version={optimized_segment_version}",
         );
-        read_segment_holder.register_segment_drop(optimized_segment_version, ack_pin, proxy);
+        read_segment_holder.register_segment_drop(ready_at, ack_pin, proxy);
     }
 
     drop(read_segment_holder);

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -813,6 +813,36 @@ fn check_segments_size(
 
 /// Performs optimization of segments (merge / reindex / vacuum, etc.)
 #[allow(clippy::too_many_arguments)]
+
+/// Test-only seam: a callback invoked after the sources are wrapped in proxies and before the
+/// optimized segment is built, so a deterministic test can inject operations into exactly the
+/// window a concurrent workload occupies in production. Thread-local: the callback fires on the
+/// thread driving [`execute_optimization`].
+#[cfg(any(test, feature = "testing"))]
+pub mod test_hooks {
+    use std::cell::RefCell;
+
+    thread_local! {
+        static AFTER_PROXY_WRAP: RefCell<Option<Box<dyn Fn()>>> = const { RefCell::new(None) };
+    }
+
+    pub fn set_after_proxy_wrap(f: impl Fn() + 'static) {
+        AFTER_PROXY_WRAP.with(|h| *h.borrow_mut() = Some(Box::new(f)));
+    }
+
+    pub fn clear_after_proxy_wrap() {
+        AFTER_PROXY_WRAP.with(|h| *h.borrow_mut() = None);
+    }
+
+    pub(super) fn fire_after_proxy_wrap() {
+        AFTER_PROXY_WRAP.with(|h| {
+            if let Some(f) = h.borrow().as_ref() {
+                f();
+            }
+        });
+    }
+}
+
 pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
     optimizer_name: &'static str,
     segment_holder: LockedSegmentHolder,
@@ -954,6 +984,9 @@ pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
         (proxy_ids, cow_segment_id_opt, counter_handler)
     };
 
+    #[cfg(any(test, feature = "testing"))]
+    test_hooks::fire_after_proxy_wrap();
+
     // SLOW PART: create single optimized segment and propagate all new changes to it
     let build_result = optimize_segment_propagate_changes(
         factory,
@@ -1018,4 +1051,181 @@ pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
     timer.set_success(true);
 
     Ok(OptimizationResult { points_count })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+
+    use common::budget::ResourceBudget;
+    use common::progress_tracker::new_progress_tracker;
+    use segment::common::operation_time_statistics::OperationDurationsAggregator;
+    use segment::data_types::vectors::only_default_vector;
+    use segment::entry::SegmentEntry as _;
+    use segment::segment_constructor::build_segment;
+    use segment::segment_constructor::segment_builder::SegmentBuilder;
+    use segment::types::HnswGlobalConfig;
+    use tempfile::Builder;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::fixtures::empty_segment;
+    use crate::segment_holder::locked::LockedSegmentHolder;
+    use crate::segment_holder::{FlushMode, SegmentHolder};
+
+    struct PlainStrategy {
+        segments_path: std::path::PathBuf,
+        temp_path: std::path::PathBuf,
+        config: segment::types::SegmentConfig,
+    }
+
+    impl OptimizationStrategy for PlainStrategy {
+        fn create_segment_builder(
+            &self,
+            _input_segments: &[LockedSegment],
+        ) -> OperationResult<SegmentBuilder> {
+            SegmentBuilder::new(&self.temp_path, &self.config, &HnswGlobalConfig::default())
+        }
+
+        fn create_temp_segment(&self) -> OperationResult<(LockedSegment, NewSegmentToken)> {
+            let (segment, token) = build_segment(&self.segments_path, &self.config, None, false)?;
+            Ok((LockedSegment::new(segment), token))
+        }
+
+        fn live_vector_names(&self) -> Option<HashSet<VectorNameBuf>> {
+            None
+        }
+    }
+
+    /// Pin-arithmetic regression test for the source-retirement fix: a retiring source's drop pin
+    /// must release only once the durable waterline covers the proxy's version, not merely the
+    /// optimized segment's. Operations can bump the proxy's version without any propagated effect
+    /// reaching the destination (observed in production pin logs as
+    /// `proxy_version > destination_version`), and releasing at the destination's version alone
+    /// frees the source's files while the WAL acknowledge, capped by the same pin, still owes
+    /// replayability to operations up to the proxy's version.
+    ///
+    /// The test drives a real optimization over a real segment holder and uses the
+    /// `after_proxy_wrap` test hook to inject, into the mid-optimization window:
+    /// - a propagated change (a delete of a live point at op 50), raising the destination to 50;
+    /// - a gap operation (a delete of an id the wrapped segment does not hold, at op 99), raising
+    ///   the proxy to 99 with no destination effect.
+    ///
+    /// Pre-fix, the pin's release threshold was the destination's version (50): the first flush
+    /// below releases it, dropping the source's files. With the fix it is the proxy's version
+    /// (99): the flush at waterline 50 must keep the pin, and only a waterline covering 99 may
+    /// release it.
+    #[test]
+    fn test_source_drop_pin_covers_proxy_version() {
+        let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
+        let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        // Source segment: two live points, fully flushed (persisted == version == 10).
+        let mut source = empty_segment(segments_dir.path());
+        source
+            .upsert_point(
+                10,
+                1.into(),
+                only_default_vector(&[1.0, 0.0, 0.0, 0.0]),
+                &hw_counter,
+            )
+            .unwrap();
+        source
+            .upsert_point(
+                10,
+                2.into(),
+                only_default_vector(&[0.0, 1.0, 0.0, 0.0]),
+                &hw_counter,
+            )
+            .unwrap();
+        source.flush(true).unwrap();
+        let config = source.config().clone();
+        let source_path = source.data_path();
+
+        let mut holder = SegmentHolder::default();
+        // A second appendable so the holder is never left without one.
+        holder.add_new(empty_segment(segments_dir.path()));
+        let source_id = holder.add_new(source);
+        let holder = LockedSegmentHolder::new(holder);
+
+        // Mid-optimization injection, through the holder's own handle to the proxy.
+        let hook_holder = holder.clone();
+        test_hooks::set_after_proxy_wrap(move || {
+            let guard = hook_holder.read();
+            let proxy = guard
+                .get(source_id)
+                .expect("source proxied in place")
+                .clone();
+            let hw_counter = HardwareCounterCell::new();
+            // Propagated change: point 2 lives in the wrapped segment, so this lands in the
+            // proxy's delete ledger and reaches the destination at version 50.
+            proxy
+                .get()
+                .write()
+                .delete_point(50, 2.into(), &hw_counter)
+                .unwrap();
+            // Gap operation: id 999 is nowhere, so only the proxy's version moves, to 99.
+            proxy
+                .get()
+                .write()
+                .delete_point(99, 999.into(), &hw_counter)
+                .unwrap();
+        });
+
+        let strategy = PlainStrategy {
+            segments_path: segments_dir.path().to_path_buf(),
+            temp_path: temp_dir.path().to_path_buf(),
+            config,
+        };
+        let stopped = AtomicBool::new(false);
+        let telemetry = OperationDurationsAggregator::new();
+        let budget = ResourceBudget::new(2, 2);
+        let permit = budget.try_acquire(1, 1).expect("test budget permit");
+        execute_optimization(
+            "test",
+            holder.clone(),
+            vec![source_id],
+            Uuid::new_v4(),
+            None,
+            &OptimizationPaths {
+                segments_path: segments_dir.path().to_path_buf(),
+                temp_path: temp_dir.path().to_path_buf(),
+            },
+            permit,
+            budget,
+            &stopped,
+            new_progress_tracker().1,
+            &telemetry,
+            &strategy,
+            Box::new(|| {}),
+        )
+        .unwrap();
+        test_hooks::clear_after_proxy_wrap();
+
+        // A flush whose waterline covers the destination's version (50) but not the proxy's (99)
+        // must keep the pin: the acknowledge stays at the source's persisted version and the
+        // source's files survive. Pre-fix the pin released here.
+        let holder_read = holder.read();
+        holder_read.bump_max_segment_version_overwrite(50);
+        let ack = holder_read.flush_all(FlushMode::Sync, true).unwrap();
+        assert_eq!(
+            ack, 10,
+            "acknowledge must stay at the source's persisted version while \
+             operations up to the proxy's version are uncovered",
+        );
+        assert!(
+            source_path.exists(),
+            "source files must survive a waterline that covers only the destination",
+        );
+
+        // Covering the proxy's version releases the pin: files drop, acknowledge follows.
+        holder_read.bump_max_segment_version_overwrite(99);
+        let ack = holder_read.flush_all(FlushMode::Sync, true).unwrap();
+        assert_eq!(ack, 99, "cap lifts once the proxy's version is durable");
+        assert!(
+            !source_path.exists(),
+            "source files drop once the pin releases",
+        );
+    }
 }

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -565,6 +565,28 @@ fn finish_optimization(
             .unwrap();
     }
 
+    // Completeness audit, still under the update lock so the state is frozen: every point still
+    // visible through a proxy (wrapped minus proxied deletes) was untouched during this
+    // optimization, so the build must have carried it into the optimized segment. One that the
+    // destination has no version for is about to leave the holder with the source and, once the
+    // source's ack pin releases, be acknowledged out of the WAL: the exact reload-divergence loss.
+    // The version arithmetic the flush relies on cannot see this (a segment's version is "highest
+    // op seen", not "contains everything below it"), so containment is checked directly here.
+    for (proxy, proxy_id) in locked_proxies.iter().zip(proxy_ids) {
+        let proxy_guard = proxy.get();
+        let proxy_read = proxy_guard.read();
+        for point_id in proxy_read.read_range(None, None) {
+            if optimized_segment.point_version(point_id).is_none() {
+                log::error!(
+                    "optimizer build dropped point {point_id:?}: visible in source proxy \
+                     {proxy_id} at version {:?}, absent from optimized segment (version {})",
+                    proxy_read.point_version(point_id),
+                    optimized_segment.version(),
+                );
+            }
+        }
+    }
+
     // Replace proxy segments with new optimized segment
     let point_count = optimized_segment.available_point_count();
     let optimized_segment_version = optimized_segment.version();

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -31,7 +31,7 @@ use segment::entry::{
 };
 use segment::segment::{Segment, SegmentVersion};
 use segment::segment_constructor::segment_builder::SegmentBuilder;
-use segment::types::{PointIdType, VectorNameBuf};
+use segment::types::{PointIdType, SeqNumberType, VectorNameBuf};
 use uuid::Uuid;
 
 use crate::locked_segment::LockedSegment;
@@ -565,34 +565,39 @@ fn finish_optimization(
             .unwrap();
     }
 
-    // Completeness audit, still under the update lock so the state is frozen: every point still
-    // visible through a proxy (wrapped minus proxied deletes) was untouched during this
-    // optimization, so the build must have carried it into the optimized segment. One that the
-    // destination has no version for is about to leave the holder with the source and, once the
-    // source's ack pin releases, be acknowledged out of the WAL: the exact reload-divergence loss.
-    // The version arithmetic the flush relies on cannot see this (a segment's version is "highest
-    // op seen", not "contains everything below it"), so containment is checked directly here.
-    for (proxy, proxy_id) in locked_proxies.iter().zip(proxy_ids) {
-        let proxy_guard = proxy.get();
-        let proxy_read = proxy_guard.read();
-        for point_id in proxy_read.read_range(None, None) {
-            if optimized_segment.point_version(point_id).is_none() {
-                log::error!(
-                    "optimizer build dropped point {point_id:?}: visible in source proxy \
-                     {proxy_id} at version {:?}, absent from optimized segment (version {})",
-                    proxy_read.point_version(point_id),
-                    optimized_segment.version(),
-                );
-            }
-        }
-    }
+    // Containment audit, phase 1 of 2: snapshot each source's visible ids while the update lock
+    // freezes the state, but defer the (comparatively slow) destination probing to after the swap,
+    // outside the critical section. Nine instrumented CI passes with the probing inside the lock
+    // produced zero reproductions against a historical one-in-three run failure rate, consistent
+    // with the added lock time suppressing the race under investigation; keeping only the cheap id
+    // snapshot here minimizes that distortion. The proxies stay alive (moved into the post-flush
+    // drop actions below) and the destination is immutable after the swap, so probing later loses
+    // nothing: every point still visible through a proxy was untouched during the optimization and
+    // the build must have carried it into the optimized segment. The flush's version arithmetic
+    // cannot see a violation (a segment's version is "highest op seen", not "contains everything
+    // below it"), which is why containment is checked directly.
+    type AuditSnapshot = Vec<(SegmentId, Vec<(PointIdType, Option<SeqNumberType>)>)>;
+    let audit_visible: AuditSnapshot = locked_proxies
+        .iter()
+        .zip(proxy_ids)
+        .map(|(proxy, proxy_id)| {
+            let guard = proxy.get();
+            let read = guard.read();
+            let ids = read
+                .read_range(None, None)
+                .into_iter()
+                .map(|id| (id, read.point_version(id)))
+                .collect();
+            (*proxy_id, ids)
+        })
+        .collect();
 
     // Replace proxy segments with new optimized segment
     let point_count = optimized_segment.available_point_count();
     let optimized_segment_version = optimized_segment.version();
     let mut writable_segment_holder = RwLockUpgradableReadGuard::upgrade(upgradable_segment_holder);
 
-    let (_, proxies) = writable_segment_holder.swap_new(optimized_segment, proxy_ids);
+    let (destination_id, proxies) = writable_segment_holder.swap_new(optimized_segment, proxy_ids);
     debug_assert_eq!(
         proxies.len(),
         proxy_ids.len(),
@@ -679,6 +684,44 @@ fn finish_optimization(
     drop(read_segment_holder);
     // Allow updates again
     drop(update_guard);
+
+    // Containment audit, phase 2: probe the destination for every id snapshotted under the update
+    // lock, now outside the critical section. The destination only grows after the swap (it is in
+    // the holder as an ordinary segment), so an id it has no version for now was already absent at
+    // swap time: the build dropped it, and once its source's ack pin releases nothing represents
+    // it anywhere durable.
+    {
+        let holder_read = segment_holder.read();
+        if let Some(destination) = holder_read.get(destination_id) {
+            let destination = destination.get();
+            let destination_read = destination.read();
+            for (source_id, ids) in &audit_visible {
+                for (point_id, source_version) in ids {
+                    if destination_read.point_version(*point_id).is_some() {
+                        continue;
+                    }
+                    // Absent from the destination. A CoW move between the swap and this probe
+                    // legitimately deletes the point here while a newer copy lives in an
+                    // appendable segment, so only a point that no holder segment knows at the
+                    // snapshot version or above is a genuine drop.
+                    let survives_elsewhere = holder_read.iter().any(|(_, locked)| {
+                        let guard = locked.get();
+                        let read = guard.read();
+                        read.point_version(*point_id) >= *source_version
+                            && read.point_version(*point_id).is_some()
+                    });
+                    if !survives_elsewhere {
+                        log::error!(
+                            "optimizer build dropped point {point_id:?}: visible in source proxy \
+                             {source_id} at swap time (version {source_version:?}), absent from \
+                             optimized segment {destination_id} (version \
+                             {optimized_segment_version}) and from every other holder segment",
+                        );
+                    }
+                }
+            }
+        }
+    }
 
     // Drop all pointers to proxies, so we can de-arc them
     drop(locked_proxies);

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -31,7 +31,7 @@ use segment::entry::{
 };
 use segment::segment::{Segment, SegmentVersion};
 use segment::segment_constructor::segment_builder::SegmentBuilder;
-use segment::types::{PointIdType, SeqNumberType, VectorNameBuf};
+use segment::types::{PointIdType, VectorNameBuf};
 use uuid::Uuid;
 
 use crate::locked_segment::LockedSegment;
@@ -565,33 +565,6 @@ fn finish_optimization(
             .unwrap();
     }
 
-    // Containment audit, phase 1 of 2: snapshot each source's visible ids while the update lock
-    // freezes the state, but defer the (comparatively slow) destination probing to after the swap,
-    // outside the critical section. Nine instrumented CI passes with the probing inside the lock
-    // produced zero reproductions against a historical one-in-three run failure rate, consistent
-    // with the added lock time suppressing the race under investigation; keeping only the cheap id
-    // snapshot here minimizes that distortion. The proxies stay alive (moved into the post-flush
-    // drop actions below) and the destination is immutable after the swap, so probing later loses
-    // nothing: every point still visible through a proxy was untouched during the optimization and
-    // the build must have carried it into the optimized segment. The flush's version arithmetic
-    // cannot see a violation (a segment's version is "highest op seen", not "contains everything
-    // below it"), which is why containment is checked directly.
-    type AuditSnapshot = Vec<(SegmentId, Vec<(PointIdType, Option<SeqNumberType>)>)>;
-    let audit_visible: AuditSnapshot = locked_proxies
-        .iter()
-        .zip(proxy_ids)
-        .map(|(proxy, proxy_id)| {
-            let guard = proxy.get();
-            let read = guard.read();
-            let ids = read
-                .read_range(None, None)
-                .into_iter()
-                .map(|id| (id, read.point_version(id)))
-                .collect();
-            (*proxy_id, ids)
-        })
-        .collect();
-
     // Replace proxy segments with new optimized segment
     let point_count = optimized_segment.available_point_count();
     let optimized_segment_version = optimized_segment.version();
@@ -685,37 +658,42 @@ fn finish_optimization(
     // Allow updates again
     drop(update_guard);
 
-    // Containment audit, phase 2: probe the destination for every id snapshotted under the update
-    // lock, now outside the critical section. The destination only grows after the swap (it is in
-    // the holder as an ordinary segment), so an id it has no version for now was already absent at
-    // swap time: the build dropped it, and once its source's ack pin releases nothing represents
-    // it anywhere durable.
+    // Containment audit, fully outside the swap's critical section: an evicted proxy is frozen
+    // (no writes reach a segment outside the holder, and its wrapped files survive until the ack
+    // pin releases), so its visible set still equals the swap-time set. Every point visible
+    // through a proxy was untouched during the optimization and the build must have carried it
+    // into the optimized segment; the flush's version arithmetic cannot see a violation (a
+    // segment's version is "highest op seen", not "contains everything below it"). A point absent
+    // from the destination is excused only if some holder segment knows it at the proxy's version
+    // or above, which covers CoW moves that legitimately deleted it from the destination after
+    // the swap. Zero work is added under the update lock: fourteen instrumented CI passes with
+    // in-lock probing produced zero reproductions against a historical one-in-three run failure
+    // rate, so the audit itself was suppressing the race it was built to catch.
     {
         let holder_read = segment_holder.read();
         if let Some(destination) = holder_read.get(destination_id) {
             let destination = destination.get();
             let destination_read = destination.read();
-            for (source_id, ids) in &audit_visible {
-                for (point_id, source_version) in ids {
-                    if destination_read.point_version(*point_id).is_some() {
+            for proxy in &locked_proxies {
+                let proxy_guard = proxy.get();
+                let proxy_read = proxy_guard.read();
+                for point_id in proxy_read.read_range(None, None) {
+                    if destination_read.point_version(point_id).is_some() {
                         continue;
                     }
-                    // Absent from the destination. A CoW move between the swap and this probe
-                    // legitimately deletes the point here while a newer copy lives in an
-                    // appendable segment, so only a point that no holder segment knows at the
-                    // snapshot version or above is a genuine drop.
+                    let source_version = proxy_read.point_version(point_id);
                     let survives_elsewhere = holder_read.iter().any(|(_, locked)| {
                         let guard = locked.get();
                         let read = guard.read();
-                        read.point_version(*point_id) >= *source_version
-                            && read.point_version(*point_id).is_some()
+                        let v = read.point_version(point_id);
+                        v.is_some() && v >= source_version
                     });
                     if !survives_elsewhere {
                         log::error!(
-                            "optimizer build dropped point {point_id:?}: visible in source proxy \
-                             {source_id} at swap time (version {source_version:?}), absent from \
-                             optimized segment {destination_id} (version \
-                             {optimized_segment_version}) and from every other holder segment",
+                            "optimizer build dropped point {point_id:?}: visible in an evicted \
+                             source proxy (version {source_version:?}), absent from optimized \
+                             segment {destination_id} (version {optimized_segment_version}) and \
+                             from every other holder segment",
                         );
                     }
                 }

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -134,6 +134,11 @@ fn cleanup_cancelled_optimized_segment(segments_path: &Path, output_segment_uuid
     if !orphan_path.exists() {
         return;
     }
+    // Deliberately loud: this deletes a segment directory outside the drop_data funnel, on the
+    // assumption that a cancellation can never arrive after the swap published the segment. A
+    // live segment's directory has been observed missing at reload with every other deletion
+    // path exonerated, so every deletion here must be attributable.
+    log::warn!("removing cancelled optimized segment dir {output_segment_uuid}");
     if let Err(err) = safe_delete_with_suffix(&orphan_path) {
         log::warn!(
             "Failed to remove cancelled optimized segment at {}: {err}",

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -632,6 +632,25 @@ fn finish_optimization(
     // membership, snapshotting each proxy's final `persistent_version` as `ack_pin`.
     for proxy in proxies {
         let ack_pin = proxy.get().read().persistent_version();
+        // The pin is released once the waterline covers `optimized_segment_version`, so a proxy
+        // whose version sits above that is the case to watch: whatever those operations touched is
+        // not represented by the destination, and after the release nothing pins them either.
+        // Splitting the proxy's version into its wrapped and propagated halves says which side
+        // carries them, which decides whether that gap is benign bookkeeping or lost data.
+        let proxy_version = proxy.get().read().version();
+        let wrapped_version = match &proxy {
+            LockedSegment::Proxy(p) => p.read().wrapped_segment.get().read().version(),
+            LockedSegment::Original(_) => proxy_version,
+        };
+        log::info!(
+            "segment drop pin: ack_pin={ack_pin} ready_at={optimized_segment_version} \
+             proxy_version={proxy_version} wrapped_version={wrapped_version}{}",
+            if proxy_version > optimized_segment_version {
+                " ABOVE_DESTINATION"
+            } else {
+                ""
+            },
+        );
         read_segment_holder.register_segment_drop(optimized_segment_version, ack_pin, proxy);
     }
 

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -955,6 +955,9 @@ impl NonAppendableSegmentEntry for ProxySegment {
                         },
                     );
                     was_deleted = prev.is_none();
+                    // Ledger for lost-point postmortems, see the "cow move" line in
+                    // `apply_points_with_conditional_move`.
+                    log::info!("proxy delete: point {point_id:?} op {op_num} (wrapped original)");
                     if let Some(prev) = prev {
                         debug_assert!(
                             prev.operation_version < op_num,
@@ -983,6 +986,7 @@ impl NonAppendableSegmentEntry for ProxySegment {
                         },
                     );
                     was_deleted = prev.is_none();
+                    log::info!("proxy delete: point {point_id:?} op {op_num} (wrapped proxy)");
                     if let Some(prev) = prev {
                         debug_assert!(
                             prev.operation_version < op_num,

--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -34,6 +34,11 @@ impl SegmentHolder {
             FlushMode::Sync => true,
             FlushMode::Background => false,
         };
+        // Pass boundary marker: flusher executions have been observed from passes that neither
+        // reach their decision line nor log an error, advancing CoW sources past operations whose
+        // destinations never flushed. Pairing every pass start with the decision at its end makes
+        // a mid-list death visible and, together with the callers' own logs, attributable.
+        log::info!("flush_all start: mode={mode:?} force={force}");
         let lock_order: Vec<_> = self.non_appendable_then_appendable_segments_ids().collect();
 
         // Grab and keep to segment RwLock's until the end of this function

--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -237,6 +237,26 @@ impl SegmentHolder {
         }
     }
 
+    /// Segment ids holding not-yet-flushed copy-on-write destinations of `segment_id`'s moves.
+    ///
+    /// Every copy-on-write move out of `segment_id` records an edge here (see
+    /// `apply_points_with_conditional_move`); until the destination is durable at or beyond the
+    /// move, flushing `segment_id` durably bakes in the delete half while the only remaining copy
+    /// is memory-only, and the move's WAL entry stops being replayable (its pre-image is gone).
+    /// Any flush of a single segment outside `flush_all`'s dependency-ordered pass must therefore
+    /// flush these destinations first.
+    ///
+    /// Sorted so callers lock destinations in `flush_all`'s in-group order.
+    pub fn cow_flush_destinations(&self, segment_id: SegmentId) -> Vec<SegmentId> {
+        let flush_dependency = self.flush_dependency.lock();
+        let mut destinations: Vec<SegmentId> = flush_dependency
+            .dependencies_of(&segment_id)
+            .map(|(destination, _version)| *destination)
+            .collect();
+        destinations.sort_unstable();
+        destinations
+    }
+
     /// Calculates the version of the segments that is safe to acknowledge in WAL
     ///
     /// If there are unsaved changes after flush - detects lowest unsaved change version.

--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -250,8 +250,11 @@ impl SegmentHolder {
             .max_persisted_segment_version_overwrite
             .load(Ordering::Relaxed);
 
+        let overwrite_floor = max_persisted_version;
         let mut min_unsaved_version: SeqNumberType = SeqNumberType::MAX;
         let mut has_unsaved = false;
+        // Per-segment state behind the decision, for the diagnostic below.
+        let mut segment_states = Vec::with_capacity(lock_order.len());
 
         for (read_segment, segment_id) in segment_reads.into_iter().zip(lock_order) {
             let segment_version = read_segment.version();
@@ -261,6 +264,10 @@ impl SegmentHolder {
                 "Flushed segment {segment_id}:{:?} version: {segment_version} to persisted: {segment_persisted_version}",
                 read_segment.data_path(),
             );
+
+            segment_states.push(format!(
+                "{segment_id}:{segment_version}/{segment_persisted_version}"
+            ));
 
             if segment_version > segment_persisted_version {
                 has_unsaved = true;
@@ -272,17 +279,33 @@ impl SegmentHolder {
             drop(read_segment);
         }
 
-        if has_unsaved {
-            log::trace!(
-                "Some segments have unsaved changes, lowest unsaved version: {min_unsaved_version}"
-            );
-            min_unsaved_version
+        let (result, source) = if has_unsaved {
+            (min_unsaved_version, "min_unsaved")
+        } else if max_persisted_version == overwrite_floor && overwrite_floor > 0 {
+            // Everything looks saved and the no-op overwrite floor is what carries the result:
+            // the acknowledge point then rests on operations that hit no segment at all.
+            (max_persisted_version, "overwrite_floor")
         } else {
-            log::trace!(
-                "All segments flushed successfully, max persisted version: {max_persisted_version}"
-            );
-            max_persisted_version
-        }
+            (max_persisted_version, "max_segment_persisted")
+        };
+
+        // The whole reload-divergence class is "the WAL was acknowledged past a write that never
+        // reached disk", and this is the function that picks that acknowledge point. One line per
+        // flush pass (5s interval by default) records what it decided and from which input, so a
+        // later postmortem can walk back to the pass that acked past a lost point's write.
+        log::info!(
+            "flush ack decision: version={result} from={source} \
+             (overwrite_floor={overwrite_floor}, max_segment_persisted={max_persisted_version}, \
+             min_unsaved={}, segments=[{}])",
+            if has_unsaved {
+                min_unsaved_version.to_string()
+            } else {
+                "none".to_string()
+            },
+            segment_states.join(", "),
+        );
+
+        result
     }
 
     /// Grab the RwLock's for all the given segment IDs.

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -1165,6 +1165,14 @@ impl SegmentHolder {
                             hw_counter,
                         )?;
 
+                        // A lost point's last engine event is either a CoW move or a proxied
+                        // delete (a plain delete the model also applies cannot lose a point the
+                        // model keeps), so ledger both: together with the proxy's delete line this
+                        // makes the full life of any lost id greppable in a failing run.
+                        log::info!(
+                            "cow move: point {point_id:?} op {op_num} segment {idx} -> {appendable_idx}"
+                        );
+
                         // Keep the source of the CoW operation as the deferred point is invisible until indexing.
                         if !appendable_write_segment.point_is_deferred(point_id) {
                             write_segment.delete_point(op_num, point_id, hw_counter)?;

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -1169,8 +1169,16 @@ impl SegmentHolder {
                         // delete (a plain delete the model also applies cannot lose a point the
                         // model keeps), so ledger both: together with the proxy's delete line this
                         // makes the full life of any lost id greppable in a failing run.
+                        // The source's persisted version against the point's version says whether
+                        // the pre-image this move consumes was durable at this moment: replay can
+                        // only re-derive the move if it still is at reopen. Recording it per hop
+                        // turns a lost id's ledger into a custody chain with numbers.
                         log::info!(
-                            "cow move: point {point_id:?} op {op_num} segment {idx} -> {appendable_idx}"
+                            "cow move: point {point_id:?} op {op_num} segment {idx} -> {appendable_idx} \
+                             (source version={}/persisted={}, point pre-version={:?})",
+                            write_segment.version(),
+                            write_segment.persistent_version(),
+                            write_segment.point_version(point_id),
                         );
 
                         // Keep the source of the CoW operation as the deferred point is invisible until indexing.

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -851,9 +851,19 @@ impl SegmentHolder {
             &mut RwLockUpgradableReadGuard<dyn SegmentEntry + 'static>,
         ) -> OperationResult<bool>,
     {
+        self.apply_segments_with_id(|_id, segment| f(segment))
+    }
+
+    pub fn apply_segments_with_id<F>(&self, mut f: F) -> OperationResult<usize>
+    where
+        F: FnMut(
+            SegmentId,
+            &mut RwLockUpgradableReadGuard<dyn SegmentEntry + 'static>,
+        ) -> OperationResult<bool>,
+    {
         let mut processed_segments = 0;
-        for (_id, segment) in self.iter() {
-            let is_applied = f(&mut segment.get().upgradable_read())?;
+        for (id, segment) in self.iter() {
+            let is_applied = f(id, &mut segment.get().upgradable_read())?;
             processed_segments += usize::from(is_applied);
         }
         Ok(processed_segments)

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -605,6 +605,17 @@ impl SegmentHolder {
         // until they complete on a later flush, so a transient failure never advances the WAL
         // acknowledge past data that is still on disk.
         ready.sort_by_key(|action| action.ready_at);
+        // Releasing a pin is the moment the WAL acknowledge is allowed past `ack_pin`, so it is the
+        // other half of the reload-divergence question: the pin is released once the waterline
+        // covers the optimized segment's version, which does not by itself prove that operations
+        // above that version, still held by the dropped source, live anywhere durable.
+        for action in &ready {
+            log::info!(
+                "post-flush pin released: ready_at={} ack_pin={} at waterline={waterline}",
+                action.ready_at,
+                action.ack_pin,
+            );
+        }
         let mut first_error = None;
         let mut blocked = false;
         ready.retain_mut(|action| {

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -352,13 +352,18 @@ impl SegmentHolder {
                 let guard = segment.get();
                 let guard = guard.read();
                 let (version, persisted) = (guard.version(), guard.persistent_version());
+                let dir = guard
+                    .data_path()
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_default();
                 departing.push(if version > persisted {
                     format!(
-                        "{remove_id}:{version}/{persisted} DIRTY(ops {}..{version})",
+                        "{remove_id}@{dir}:{version}/{persisted} DIRTY(ops {}..{version})",
                         persisted + 1
                     )
                 } else {
-                    format!("{remove_id}:{version}/{persisted}")
+                    format!("{remove_id}@{dir}:{version}/{persisted}")
                 });
             }
         }
@@ -396,7 +401,12 @@ impl SegmentHolder {
             let guard = new_segment.get();
             let guard = guard.read();
             log::info!(
-                "segment swap: destination {new_id}:{}/{} replaces {remove_ids:?}",
+                "segment swap: destination {new_id}@{}:{}/{} replaces {remove_ids:?}",
+                guard
+                    .data_path()
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_default(),
                 guard.version(),
                 guard.persistent_version(),
             );

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -1337,8 +1337,32 @@ impl SegmentHolder {
             self.add_existing_locked(segment_id, tmp_segment);
             Ok(false)
         } else {
-            log::trace!("Dropping temporary segment with no changes");
-            tmp_segment.drop_data()?;
+            let (version, persisted) = {
+                let read = tmp_segment.get();
+                let read = read.read();
+                (read.version(), read.persistent_version())
+            };
+            if version > persisted {
+                // Empty, but dirty: points transited through this segment (copy-on-write moved in,
+                // then on) without any of it flushing. The segment's own files hold nothing worth
+                // keeping, but while it was a holder member its unsaved range capped the durable
+                // waterline, and dropping it here would lift that cap: upstream source-retirement
+                // pins could then release while the transit operations are neither durable
+                // anywhere nor re-derivable (their pre-images go down with the retired sources),
+                // which loses the points on the next restart. Leave the same pin a swap eviction
+                // leaves: the WAL acknowledge stays at `persisted` until the waterline covers
+                // `version`, i.e. until every segment holding the moved copies has flushed past
+                // the transit range.
+                log::trace!(
+                    "Dropping empty temporary segment with unflushed transit ops \
+                     {}..{version} behind a post-flush pin",
+                    persisted + 1,
+                );
+                self.register_segment_drop(version, persisted, tmp_segment);
+            } else {
+                log::trace!("Dropping temporary segment with no changes");
+                tmp_segment.drop_data()?;
+            }
             Ok(true)
         }
     }

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -330,6 +330,15 @@ impl SegmentHolder {
 
     pub fn remove(&mut self, remove_ids: &[SegmentId]) -> Vec<LockedSegment> {
         let mut removed_segments = vec![];
+        // State of every departing segment, captured while it is still reachable.
+        //
+        // A segment that leaves the holder while its version is ahead of its persisted version
+        // takes those operations with it, and `get_max_persisted_version` cannot see them: it maxes
+        // over the segments that remain. If the replacement does not carry those points, the WAL is
+        // acknowledged past writes that exist nowhere, which is the reload-divergence signature.
+        // This line is the un-stale version of that observation, taken at the removal itself rather
+        // than inferred from the previous flush pass.
+        let mut departing = Vec::with_capacity(remove_ids.len());
         for remove_id in remove_ids {
             let removed_segment = self.appendable_segments.remove(remove_id);
             if let Some(segment) = removed_segment {
@@ -339,6 +348,22 @@ impl SegmentHolder {
             if let Some(segment) = removed_segment {
                 removed_segments.push(segment);
             }
+            if let Some(segment) = removed_segments.last() {
+                let guard = segment.get();
+                let guard = guard.read();
+                let (version, persisted) = (guard.version(), guard.persistent_version());
+                departing.push(if version > persisted {
+                    format!(
+                        "{remove_id}:{version}/{persisted} DIRTY(ops {}..{version})",
+                        persisted + 1
+                    )
+                } else {
+                    format!("{remove_id}:{version}/{persisted}")
+                });
+            }
+        }
+        if !departing.is_empty() {
+            log::info!("segments leaving holder: [{}]", departing.join(", "));
         }
         removed_segments
     }
@@ -364,6 +389,18 @@ impl SegmentHolder {
         T: Into<LockedSegment>,
     {
         let new_id = self.add_new(segment);
+        // Pairs with the "segments leaving holder" line logged by `remove` just below: this says
+        // what the replacement carries, so a source departing with operations the destination's
+        // version does not cover is visible as such, with no inference across flush passes.
+        if let Some(new_segment) = self.get(new_id) {
+            let guard = new_segment.get();
+            let guard = guard.read();
+            log::info!(
+                "segment swap: destination {new_id}:{}/{} replaces {remove_ids:?}",
+                guard.version(),
+                guard.persistent_version(),
+            );
+        }
         (new_id, self.remove(remove_ids))
     }
 

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use rand::RngExt;
-use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, VectorInternal, only_default_vector};
+use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, VectorInternal};
 use segment::json_path::JsonPath;
 use segment::payload_json;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use rand::RngExt;
-use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, VectorInternal};
+use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, VectorInternal, only_default_vector};
 use segment::json_path::JsonPath;
 use segment::payload_json;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment;
@@ -2031,6 +2031,74 @@ fn test_cow_skips_delete_when_destination_is_deferred() {
     assert!(
         non_app.point_version(100.into()).is_some(),
         "Point 100 should still exist in the source (delete skipped for deferred destination)"
+    );
+}
+
+/// Regression test for the empty-but-dirty temp drop (nightly reload divergence, #10095 family).
+///
+/// A temporary segment that copy-on-write traffic filled and then emptied again carries an
+/// unsaved range: operations transited through it without any of them flushing. While it is a
+/// holder member that range caps the durable waterline. Dropping it inline on
+/// `remove_segment_if_not_needed` (the pre-fix behavior) lifted that cap, so the WAL acknowledge
+/// jumped past the transit operations even though their effects were not durable anywhere,
+/// and a restart then lost the moved points: replay had neither the operations (acknowledged
+/// away) nor the pre-images. The fix parks the drop behind a post-flush pin: the acknowledge
+/// stays at the temp's persisted version until the waterline covers its last transit operation.
+#[test]
+fn test_empty_dirty_temp_drop_keeps_waterline_cap() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut holder = SegmentHolder::default();
+    // A neutral appendable segment so the temp is not the last one (a kept-temp guard).
+    holder.add_new(empty_segment(dir.path()));
+
+    // The temp: never held a point (a temp that copy-on-write traffic transited is kept, not
+    // dropped, because soft-deleted points keep `is_empty()` false), but schema operations bumped
+    // its version, leaving it empty AND dirty: version 12 with nothing ever flushed.
+    let mut temp = empty_segment(dir.path());
+    let hw_counter = HardwareCounterCell::new();
+    temp.create_field_index(
+        12,
+        &JsonPath::from_str("number").unwrap(),
+        Some(&segment::types::PayloadSchemaType::Integer.into()),
+        &hw_counter,
+    )
+    .unwrap();
+    assert!(temp.is_empty());
+    assert!(temp.version() > temp.persistent_version());
+    let temp_path = temp.data_path();
+    let temp_id = holder.add_new(temp);
+
+    // The rest of the shard has durably progressed past the temp's persisted point but not past
+    // its unsaved range: the waterline the surviving segments justify is 11.
+    holder.bump_max_segment_version_overwrite(11);
+
+    // The temp is empty, so it is eligible for removal.
+    assert!(holder.remove_segment_if_not_needed(temp_id).unwrap());
+
+    // The acknowledge must not advance past the temp's persisted version while its transit
+    // operations (up to 12) are uncovered. Pre-fix this returned 11: the inline drop erased the
+    // unsaved range from the accounting and the WAL acknowledged operations whose effects were
+    // not durable anywhere.
+    let ack = holder.flush_all(FlushMode::Sync, true).unwrap();
+    assert_eq!(
+        ack, 0,
+        "acknowledge must stay at the dropped temp's persisted version \
+         while its transit range is uncovered",
+    );
+    assert!(
+        temp_path.exists(),
+        "files must survive until the pin releases"
+    );
+
+    // Once the surviving segments durably cover the transit range, the pin releases, the files
+    // drop, and the acknowledge follows the waterline again.
+    holder.bump_max_segment_version_overwrite(12);
+    let ack = holder.flush_all(FlushMode::Sync, true).unwrap();
+    assert_eq!(ack, 12, "cap lifts once the transit range is durable");
+    assert!(
+        !temp_path.exists(),
+        "temp files are dropped once the pin releases",
     );
 }
 

--- a/lib/shard/src/update/field_index.rs
+++ b/lib/shard/src/update/field_index.rs
@@ -20,7 +20,7 @@ pub fn create_field_index(
         });
     };
 
-    segments.apply_segments(|write_segment| {
+    segments.apply_segments_with_id(|segment_id, write_segment| {
         write_segment.with_upgraded(|segment| {
             segment.delete_field_index_if_incompatible(op_num, field_name, field_schema)
         })?;
@@ -42,7 +42,33 @@ pub fn create_field_index(
         let already_indexed =
             write_segment.get_indexed_fields().get(field_name) == Some(field_schema);
         if !already_indexed {
-            segments.with_flush_serialized(|| write_segment.flush(true))?;
+            // This flush durably advances the segment PAST the delete halves of any pending
+            // copy-on-write moves out of it. Those moves are only replayable while a durable
+            // pre-image exists, so their destinations must be durable at or beyond the move
+            // BEFORE the source flushes: flush them first, mirroring `flush_all`'s dependency
+            // ordering. Destinations absent from the holder already left through the optimizer's
+            // pinned swap path, which caps the WAL acknowledge until they are durable.
+            //
+            // Destination guards are taken before entering the flush lock to keep the
+            // [segment locks -> flush lock] ordering documented on `with_flush_serialized`.
+            // Lock order within segments also matches `apply_points_to_appendable`
+            // (copy-on-write source first, then the appendable destination).
+            let cow_destinations: Vec<_> = segments
+                .cow_flush_destinations(segment_id)
+                .into_iter()
+                .filter_map(|destination_id| segments.get(destination_id))
+                .map(|destination| destination.get())
+                .collect();
+            let destination_guards: Vec<_> = cow_destinations
+                .iter()
+                .map(|destination| destination.read())
+                .collect();
+            segments.with_flush_serialized(|| {
+                for destination in &destination_guards {
+                    destination.flush(true)?;
+                }
+                write_segment.flush(true)
+            })?;
         }
 
         let (schema, indexes) =

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -910,3 +910,76 @@ fn create_field_index_pins_pending_payload_state() {
         "filtered reads must agree with payload storage: the row was cleared",
     );
 }
+
+/// The pre-build flush of `create_field_index` durably advances a segment past the
+/// delete halves of its pending copy-on-write moves. The destinations of those moves
+/// must be durable at or beyond the moves FIRST: otherwise the moves' WAL entries stop
+/// being replayable (the durable pre-image is deleted while the only current copy sits
+/// in the unflushed destination) and a graceful close loses the points. The destination
+/// cannot be relied on to flush itself during the same pass: the `already_indexed`
+/// short-circuit skips its flush, e.g. when it is proxy-wrapped by a running
+/// optimization and the proxy reports the field as present. Root cause of the nightly
+/// model-testing reload divergence (#10095).
+#[test]
+fn create_field_index_flushes_cow_destinations_before_source() {
+    use segment::entry::NonAppendableSegmentEntry as _;
+    use segment::types::{PayloadFieldSchema, PayloadSchemaType};
+
+    use crate::update::set_payload;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let key: PayloadKeyType = "color".parse().unwrap();
+    let schema = PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword);
+
+    let mut source = build_segment_1(dir.path()); // points 1-5, version 6
+    source.appendable_flag = false;
+    let mut destination = empty_segment(dir.path());
+    // The destination already carries the index, so its own pre-build flush below is
+    // skipped by the `already_indexed` short-circuit; only the dependency-aware flush
+    // of the source's visit can cover it.
+    destination
+        .create_field_index(7, &key, Some(&schema), &hw_counter)
+        .unwrap();
+
+    let mut holder = SegmentHolder::default();
+    let source_id = holder.add_new(source);
+    let destination_id = holder.add_new(destination);
+
+    // Durable baseline.
+    holder.flush_all(FlushMode::Sync, true).unwrap();
+
+    // Op 100 modifies point 1, which lives in the non-appendable source: the
+    // copy-on-write arm upserts the updated point into the destination, deletes it from
+    // the source, and records the flush dependency edge.
+    let payload = payload_json! {"other": "value"};
+    let moved = set_payload(&holder, 100, &payload, &[1.into()], &None, &hw_counter).unwrap();
+    assert_eq!(moved, 1);
+
+    create_field_index(&holder, 200, &key, Some(&schema), &hw_counter).unwrap();
+
+    let source_persisted = holder
+        .get(source_id)
+        .unwrap()
+        .get()
+        .read()
+        .persistent_version();
+    let destination_persisted = holder
+        .get(destination_id)
+        .unwrap()
+        .get()
+        .read()
+        .persistent_version();
+
+    assert!(
+        source_persisted >= 100,
+        "the source's pre-build flush must cover the move's delete half to arm the \
+         hazard, got {source_persisted}",
+    );
+    assert!(
+        destination_persisted >= 100,
+        "the move's destination must be durable at or beyond the move once the source \
+         flushed past it; anything lower durably deletes the WAL replay pre-image while \
+         the only remaining copy is memory-only, got {destination_persisted}",
+    );
+}


### PR DESCRIPTION
Investigation branch for the nightly model-testing reload divergence (#10095): points present in the model go missing from the collection after a close+reopen, always missing and never extra, only with the optimizer enabled. This branch carries two shipped hardening fixes, two regression tests, and the diagnostic instrumentation that root-caused the bug; it is not intended to merge as-is. **Root cause found 2026-08-12: see below.**

## Symptom and blast radius

After an in-process close+reopen (the tester's mid-run restart or final reload), points whose writes the WAL already acknowledged are gone: `unknown to every segment`, and replaying their operations is declined with `No point with id`. Live reads before the close are always correct; only the durable trail breaks. The tester's reopen is the gentlest possible restart (same process, page cache intact, no fsync dependence), so any real graceful restart or redeploy would lose at least as much. This is a durability contract violation on acknowledged writes.

## Root cause: `create_field_index`'s per-segment force-flush tears CoW durability

**Found 2026-08-12 (runs 31583878492 and 31583871346, pass-boundary-marker build).** The "flush passes dying mid-list" reading of the earlier attribution is retracted: the flusher executions that advance CoW sources past unflushed destinations do not belong to any `flush_all` pass at all. They are `create_field_index` (lib/shard/src/update/field_index.rs), the pre-build whole-segment flush introduced by #9767, which force-flushes segments **one at a time** (`with_flush_serialized(|| write_segment.flush(true))`) inside `apply_segments` — outside `flush_all`'s all-segment lock and CoW dependency ordering. The new pass markers made these waves identifiable: broad flusher executions with no `flush_all start` and no end-of-pass decision.

The complete evidenced chain from run 31583878492 (1 point lost, shard 1):

1. The point's last full write (op 3611) lives in non-appendable source segment 11. The WAL is legally truncated to 5015 — correct at the time, since the pre-image was durable in the source. The acknowledge machinery is not at fault.
2. `cow move: op 5197, segment 11 -> 18`: an update moves the point into appendable destination 18 (dir `4fb13960`, persisted 5181). The WAL entry for op 5197 is only replayable while the source's durable files still hold the pre-image.
3. Destination 18 is proxy-wrapped by a starting optimization moments later.
4. A `CreateFieldIndex` operation (~op 5252) walks all segments, force-flushing each before building: source 11 flushes at captured version 5252, **durably baking in the op-5197 delete-half**. The proxied destination is skipped entirely — `ProxySegment::get_indexed_fields` (wrapped + changed indexes) reports the field as present, so the `already_indexed` "cheap idempotent ensure-call" gate skips its flush.
5. The tester closes; destination 18 leaves dirty (ops 5182..5401, persisted 5181). At reopen the replay window 5015..5402 contains op 5197, but no durable copy of the pre-image exists anywhere: `No point with id` decline, point lost.

Run 31583871346 is identical at scale: 7 points CoW-moved into destination 36 (`eafcbfa8`) at ops 18917-18949 exactly as it was proxy-wrapped; the index-op wave flushed every source at 19106 and skipped the proxy; the destination reloaded at 18915. The decisive control: after reopen, WAL replay re-runs the same index operation against the reloaded (unproxied) segments and happily flushes the same directory — the skip is proxy-specific.

Why the appendable-first argument (which cleared #9767 in review) does not hold: `apply_segments` does iterate appendable destinations before non-appendable sources, but (a) a proxy-wrapped destination is classified non-appendable and ordered among the sources, (b) the `already_indexed` gate can skip the destination's flush outright, and (c) a CoW move landing mid-pass is ordered behind nothing at all. Any one of these durably advances a source past an operation whose destination copy is memory-only.

The invariant, stated generally: **never durably advance a CoW source past an operation whose destination is not durable at or beyond it.** `flush_all` enforces this with all-segment lock capture plus dependency-ordered flushing; the hand-rolled per-segment flush does not.

Fix implemented as 6bdfca854: before flushing segment S, `create_field_index` now flushes S's pending `flush_dependency` destinations first (one hop suffices since destinations are appendable and never CoW sources). Lock order source-then-destination matches `apply_points_to_appendable`, destination guards are taken before the flush lock to keep the documented `[segment locks -> flush lock]` ordering, and the upgradable read already held on S blocks new CoW moves out of S during the visit. Regression test c85eed477 reproduces the loss shape deterministically (pending move + `already_indexed` destination + holder-wide index create) and was verified failing with the dependency flush neutralized. Validation wave of 6 CI runs in flight; pre-fix failure rate was roughly one per 1-2 runs.

This also explains every stubborn observation: optimizer-off runs never fail (no non-appendable segments, no CoW moves), the `FlushMode::Sync` experiment changed nothing (the tear is outside `flush_all`), losses are missing-never-extra (delete-half durable, insert-half lost), and failures cluster within minutes of a pass starting (the tester creates indexes early and often).

## Fixes shipped on this branch (extractable)

- 6bdfca854 `fix(shard): flush CoW destinations before the payload-index pre-build flush` — **the root-cause fix** (see above), with regression test c85eed477 proven failing pre-fix.

- 69734091d `fix(optimizer): retire sources only after their CoW moves are durable` — retirement pins released once the waterline covered the destination's version, ignoring CoW transit out of the retiring source. Release now waits for `max(destination version, proxy version)`. Pre-fix, traced pin releases dropped pre-image files; post-fix, every traced failure shows pins holding and files surviving.
- b87304b36 `fix(optimizer): pin the waterline when dropping an empty-but-dirty temp segment` — an unpinned dirty removal lifted the waterline cap. Now it leaves the same drop pin as swap evictions.
- 874d6f3ed `test_source_drop_pin_covers_proxy_version` — deterministic regression test for the retirement-pin fix, driving a real `execute_optimization` with a mid-optimization CoW + gap op injected through a test hook; verified failing on pre-fix pin arithmetic and passing with the fix.
- 1bddc7e7a regression test for the temp-drop fix, verified failing on pre-fix behavior and passing with it. Writing it surfaced a scope correction, recorded in the commit: temps that CoW traffic transited are kept (soft-deleted points keep `is_empty()` false), so the reachable empty-but-dirty case comes from schema-operation version bumps, and this fix's causal share in the nightly failures is accordingly small.

Validation: pre-fix builds failed at >=1 in 2 runs with first divergence at 15-81 restart verifications; post-fix waves moved onset to 230-460 with failures continuing at a reduced rate through the residual path above. The fixes guard real invariants independently of the remaining bug.

## Hypotheses tested and refuted (instrument in parentheses)

- Optimizer build drops live points (swap-time containment audit: 0 hits across ~3000 swaps, including failing runs).
- Premature release of wrapped-source data (pin logging: wrapped version above the release point in 0 of 1557 registrations).
- No-op acknowledge floor overshoot (flush-decision logging: 0 of 72 decisions, 0 of 34 acks).
- WAL-replay non-idempotency as a separate layer (replay-decline dumps disproved both supporting observations).
- Background flush capture/execute interleave (FlushMode::Sync experiment: failures unchanged; the toggle is still on the branch head and will be reverted).
- Load-time directory reclaim (no reclaim warnings in any failing log).
- Unattributed file deletion (drop_data funnel + cancelled-cleanup logging: in the attributed failures, no directory was deleted at all).
- Concurrent snapshots as the vehicle (--disable-snapshots A/B: a snapshots-off run failed both passes identically; 7 of 10 fatal windows had no snapshot activity). The snapshot path's force-flush is real but not necessary for the loss.

## Branch anatomy

- 3 fix commits + 3 regression tests (above), extractable to a clean PR (the root-cause fix + 2 hardening fixes).
- The FlushMode::Sync experiment toggle is reverted (081c0a725); the flush worker is back on Background mode for the validation wave.
- 2 CI conveniences: dispatch inputs for --disable-optimizer (control arm: 0 failures in 3 runs) and --disable-snapshots.
- ~17 diagnostic commits (reload postmortem, pre-close placement capture, per-reload segment inventory, replay-decline dumps, CoW/proxy-delete ledger with per-hop source durability, WAL acknowledge decision + pin registration/release logs, dir-tagged departures and swap destinations, drop_data and cancelled-cleanup logging, per-segment flush-execution logging, flush pass boundary markers). Several are worth keeping for future soak triage; to be discussed separately.

Reproduction notes: CI reproduces at roughly one failure per 1-2 runs within minutes of a pass starting (`gh workflow run nightly-model-testing.yml --ref <branch> -f op_num=200000`); local reproduction failed across ~900 restart verifications on a 24-core box including CI-shaped runs, and seed replay does not reproduce (the workload is deterministic, the schedule is not).

