### PR TITLE
Fix append-only shards unopenable after delete/update — alternative to #10188

### DIFF
--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -600,7 +600,6 @@ impl NonAppendableSegmentEntry for Segment {
             .id_tracker
             .borrow()
             .internal_id_with_behavior(point_id, DeferredBehavior::WithDeferred);
-        let append_only = self.is_append_only_delete();
         match internal_id {
             // Point does already not exist anymore
             None => Ok(false),
@@ -609,17 +608,7 @@ impl NonAppendableSegmentEntry for Segment {
                 point_id,
                 Some(internal_id),
                 |segment| {
-                    if append_only {
-                        // Tombstone-only: leave payload row and field
-                        // indexes at `internal_id` untouched so the on-disk
-                        // structures stay append-only. Readers filter via
-                        // the id tracker's deleted bitslice.
-                        segment.delete_point_tombstone_only(internal_id)?;
-                    } else {
-                        segment.delete_point_internal(internal_id, hw_counter)?;
-                        segment.version_tracker.set_payload(Some(op_num));
-                    }
-
+                    segment.delete_point_internal(internal_id, Some(op_num), hw_counter)?;
                     Ok((true, Some(internal_id)))
                 },
             ),

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -655,11 +655,25 @@ impl Segment {
         Ok(applied)
     }
 
+    /// `op_num` is only used to bump the payload-storage entry in
+    /// `Segment::version_tracker`, so pass `None` when there is no
+    /// associated operation (e.g. repair on load).
     pub fn delete_point_internal(
         &mut self,
         internal_id: PointOffsetType,
+        op_num: Option<SeqNumberType>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
+        if self.is_append_only_delete() {
+            // Tombstone-only: leave the payload row and field-index postings
+            // at `internal_id` in place so the on-disk structures stay
+            // append-only. Readers filter the tombstone via the id tracker's
+            // deleted bitslice (see
+            // `PointMappingsRefEnum::filter_deferred_and_deleted`). Payload
+            // storage is untouched, so the version tracker is not bumped.
+            return self.id_tracker.borrow_mut().drop_internal(internal_id);
+        }
+
         // Mark point as deleted, drop mapping
         self.payload_index
             .borrow_mut()
@@ -671,6 +685,9 @@ impl Segment {
         // the point sits at or above the deferred threshold, with double-delete
         // protection inside `PointMappings::drop`.
         id_tracker.drop_internal(internal_id)?;
+        drop(id_tracker);
+
+        self.version_tracker.set_payload(op_num);
 
         // Before, we propagated point deletions to also delete its vectors. This turns
         // out to be problematic because this sometimes makes us lose vector data
@@ -685,18 +702,6 @@ impl Segment {
         // }
 
         Ok(())
-    }
-
-    /// Append-only counterpart to [`Segment::delete_point_internal`]: only
-    /// touches the id tracker, leaving the payload row and field-index
-    /// postings at `internal_id` in place. Readers filter the tombstone
-    /// via the id tracker's deleted bitslice (see
-    /// `PointMappingsRefEnum::filter_deferred_and_deleted`).
-    pub fn delete_point_tombstone_only(
-        &mut self,
-        internal_id: PointOffsetType,
-    ) -> OperationResult<()> {
-        self.id_tracker.borrow_mut().drop_internal(internal_id)
     }
 
     fn bump_segment_version(&mut self, op_num: SeqNumberType) {
@@ -779,7 +784,7 @@ impl Segment {
             );
 
             for internal_id in ids_to_clean {
-                self.delete_point_internal(internal_id, &disposable_hw_counter)?;
+                self.delete_point_internal(internal_id, None, &disposable_hw_counter)?;
             }
 
             self.flush(true)?;

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -2709,7 +2709,7 @@ fn test_deleted_deferred_point_count() {
         for d in 0..n_deferred {
             let delete_id = segment.id_tracker.borrow().deferred_internal_id().unwrap() + d as u32;
             segment
-                .delete_point_internal(delete_id, &hw_counter)
+                .delete_point_internal(delete_id, None, &hw_counter)
                 .unwrap();
 
             let deleted_count = d + 1; // The first index is 0 but this point is deleted, so count must be 1.
@@ -2724,7 +2724,7 @@ fn test_deleted_deferred_point_count() {
 
             // Do the operation twice to test that we don't double count the same point.
             segment
-                .delete_point_internal(delete_id, &hw_counter)
+                .delete_point_internal(delete_id, None, &hw_counter)
                 .unwrap();
 
             assert_eq!(

--- a/lib/segment/tests/append_only_storages.rs
+++ b/lib/segment/tests/append_only_storages.rs
@@ -134,8 +134,15 @@ fn append_only_storages_serve_the_ordinary_write_paths() {
     drop(segment);
 
     // Everything survives a reload through the ordinary loader.
-    let segment = load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
+    let mut segment =
+        load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
     assert!(segment.append_only_mutations);
+
+    // The repair every shard loader runs; deleting the leftovers it finds would
+    // fail here, leaving the segment permanently unopenable.
+    segment
+        .check_consistency_and_repair()
+        .expect("append-only leftovers must not be reported as inconsistencies");
 
     assert_eq!(segment.available_point_count(), 5);
     let payload = segment.payload(3.into(), &hw_counter).unwrap();

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -665,7 +665,7 @@ fn test_proxy_deferred() {
     let initial_deferred_point_count = wrapped_segment.size_info().num_deferred_points.unwrap();
 
     wrapped_segment
-        .delete_point_internal(3, &hw_counter)
+        .delete_point_internal(3, None, &hw_counter)
         .unwrap();
 
     assert_eq!(


### PR DESCRIPTION
## Alternative to #10188

Same underlying bug as #10188: under `serverless_compatible` (`append_only_storages`), `check_consistency_and_repair` — which every shard loader runs on open — calls `delete_point_internal` on dangling-version internal ids found by `fix_id_tracker_inconsistencies`. `delete_point_internal` unconditionally clears the payload row and field-index postings via the Blobstore-backed payload index, which append-only storage refuses (`Logstore::delete_value` strict since #10154). Result: any shard that had an ordinary delete or update of an existing point becomes permanently unopenable.

#10188 fixes this by adding an `is_append_only_delete()` early-return inside `check_consistency_and_repair` itself, and keeps a separate `delete_point_tombstone_only` helper that the *other* delete path (`Segment::delete_point`) already branches to externally.

This PR takes a different angle: fold the append-only decision into `delete_point_internal` itself, instead of asking every caller to remember it.

### Why

The bug exists because the append-only check lived at call sites rather than in the primitive itself — `delete_point` had it, `check_consistency_and_repair` didn't. Putting the branch inside `delete_point_internal` removes the whole class of bug (a caller forgetting to check `is_append_only_delete()`) rather than patching this one instance of it.

### Changes

- `delete_point_internal` now branches on `self.is_append_only_delete()` internally: tombstone-only (id tracker drop only, matching the design's tombstone-only intent) when true, full payload/field-index clear + id-tracker drop otherwise.
- `delete_point_tombstone_only` is removed — both call sites (`Segment::delete_point`, and `check_consistency_and_repair`'s cleanup loop) now just call `delete_point_internal` unconditionally and get the correct behavior for free.
- `version_tracker.set_payload` (tracks the payload-storage version for partial snapshots) moves inside `delete_point_internal` too, under the same branch — it's only bumped when payload storage is actually touched, which the append-only branch never does. This required threading through an explicit `op_num: Option<SeqNumberType>` parameter, since `check_consistency_and_repair`'s repair pass has no real operation number to associate the change with (passes `None`, matching its current behavior of never bumping that tracker during repair).

### Test plan

- [x] Added the same regression assertion #10188 added to `lib/segment/tests/append_only_storages.rs` (calling `check_consistency_and_repair` on the reloaded segment) — fails without the fix, passes with it.
- [x] `cargo test -p segment --lib` 1046 passed, `cargo test -p segment --test append_only_storages` 2 passed
- [x] `cargo test -p shard --lib` 125 passed
- [x] `cargo clippy -p segment -p shard --all-targets` clean

Happy to close this in favor of #10188 if the flag-based approach is preferred — mainly wanted to put the alternative up for comparison given the design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)