### PR TITLE
fix(shard): flush CoW destinations before the payload-index pre-build flush

### DIFF
--- a/lib/common/common/src/toposort.rs
+++ b/lib/common/common/src/toposort.rs
@@ -48,6 +48,11 @@ impl<T: Eq + std::hash::Hash + Copy, V> TopoSort<T, V> {
             .insert(depends_on, value);
     }
 
+    /// Returns the elements `element` depends on, with the value stored per dependency.
+    pub fn dependencies_of(&self, element: &T) -> impl Iterator<Item = (&T, &V)> {
+        self.dependencies.get(element).into_iter().flatten()
+    }
+
     /// Removes dependencies for which the filter function returns false
     pub fn retain(&mut self, filter: impl Fn(&T, &T, &V) -> bool) {
         self.dependencies.retain(|element, deps| {

--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -145,6 +145,46 @@ impl SegmentHolder {
         })
     }
 
+    /// Flushes a single segment outside `flush_all`, honoring its copy-on-write dependencies.
+    ///
+    /// The flush durably advances `segment` PAST the delete halves of any pending copy-on-write
+    /// moves out of it. Those moves are only replayable while a durable pre-image exists, so
+    /// their destinations must be durable at or beyond the move BEFORE the source flushes: they
+    /// are flushed first, mirroring `flush_all`'s dependency ordering. Destinations absent from
+    /// the holder already left through the optimizer's pinned swap path, which caps the WAL
+    /// acknowledge until they are durable. One hop is enough: destinations are appendable
+    /// segments and never copy-on-write sources themselves.
+    ///
+    /// The caller already holds `segment`'s guard (and must keep holding it across whatever
+    /// the flush pins, e.g. the payload-index build), so the guard is passed in rather than
+    /// re-locked. Destination read guards are taken before entering the flush lock to keep the
+    /// [segment locks -> flush lock] ordering documented on `with_flush_serialized`. Lock order
+    /// within segments also matches `apply_points_to_appendable` (copy-on-write source first,
+    /// then the appendable destination).
+    pub fn flush_segment_with_cow_destinations(
+        &self,
+        segment_id: SegmentId,
+        segment: &dyn StorageSegmentEntry,
+    ) -> OperationResult<()> {
+        let cow_destinations: Vec<_> = self
+            .cow_flush_destinations(segment_id)
+            .into_iter()
+            .filter_map(|destination_id| self.get(destination_id))
+            .map(|destination| destination.get())
+            .collect();
+        let destination_guards: Vec<_> = cow_destinations
+            .iter()
+            .map(|destination| destination.read())
+            .collect();
+        self.with_flush_serialized(|| {
+            for destination in &destination_guards {
+                destination.flush(true)?;
+            }
+            segment.flush(true)?;
+            Ok(())
+        })
+    }
+
     fn non_appendable_then_appendable_segments_ids(&self) -> impl Iterator<Item = SegmentId> {
         let non_appendable_segments = self.non_appendable_segments_ids();
         let appendable_segments = self.appendable_segments_ids();
@@ -235,14 +275,9 @@ impl SegmentHolder {
     /// Segment ids holding not-yet-flushed copy-on-write destinations of `segment_id`'s moves.
     ///
     /// Every copy-on-write move out of `segment_id` records an edge here (see
-    /// `apply_points_with_conditional_move`); until the destination is durable at or beyond the
-    /// move, flushing `segment_id` durably bakes in the delete half while the only remaining copy
-    /// is memory-only, and the move's WAL entry stops being replayable (its pre-image is gone).
-    /// Any flush of a single segment outside `flush_all`'s dependency-ordered pass must therefore
-    /// flush these destinations first.
-    ///
-    /// Sorted so callers lock destinations in `flush_all`'s in-group order.
-    pub fn cow_flush_destinations(&self, segment_id: SegmentId) -> Vec<SegmentId> {
+    /// `apply_points_with_conditional_move`). Sorted so callers lock destinations in
+    /// `flush_all`'s in-group order.
+    fn cow_flush_destinations(&self, segment_id: SegmentId) -> Vec<SegmentId> {
         let flush_dependency = self.flush_dependency.lock();
         let mut destinations: Vec<SegmentId> = flush_dependency
             .dependencies_of(&segment_id)

--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -232,6 +232,26 @@ impl SegmentHolder {
         }
     }
 
+    /// Segment ids holding not-yet-flushed copy-on-write destinations of `segment_id`'s moves.
+    ///
+    /// Every copy-on-write move out of `segment_id` records an edge here (see
+    /// `apply_points_with_conditional_move`); until the destination is durable at or beyond the
+    /// move, flushing `segment_id` durably bakes in the delete half while the only remaining copy
+    /// is memory-only, and the move's WAL entry stops being replayable (its pre-image is gone).
+    /// Any flush of a single segment outside `flush_all`'s dependency-ordered pass must therefore
+    /// flush these destinations first.
+    ///
+    /// Sorted so callers lock destinations in `flush_all`'s in-group order.
+    pub fn cow_flush_destinations(&self, segment_id: SegmentId) -> Vec<SegmentId> {
+        let flush_dependency = self.flush_dependency.lock();
+        let mut destinations: Vec<SegmentId> = flush_dependency
+            .dependencies_of(&segment_id)
+            .map(|(destination, _version)| *destination)
+            .collect();
+        destinations.sort_unstable();
+        destinations
+    }
+
     /// Calculates the version of the segments that is safe to acknowledge in WAL
     ///
     /// If there are unsaved changes after flush - detects lowest unsaved change version.

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -793,9 +793,19 @@ impl SegmentHolder {
             &mut RwLockUpgradableReadGuard<dyn SegmentEntry + 'static>,
         ) -> OperationResult<bool>,
     {
+        self.apply_segments_with_id(|_id, segment| f(segment))
+    }
+
+    pub fn apply_segments_with_id<F>(&self, mut f: F) -> OperationResult<usize>
+    where
+        F: FnMut(
+            SegmentId,
+            &mut RwLockUpgradableReadGuard<dyn SegmentEntry + 'static>,
+        ) -> OperationResult<bool>,
+    {
         let mut processed_segments = 0;
-        for (_id, segment) in self.iter() {
-            let is_applied = f(&mut segment.get().upgradable_read())?;
+        for (id, segment) in self.iter() {
+            let is_applied = f(id, &mut segment.get().upgradable_read())?;
             processed_segments += usize::from(is_applied);
         }
         Ok(processed_segments)

--- a/lib/shard/src/update/field_index.rs
+++ b/lib/shard/src/update/field_index.rs
@@ -20,7 +20,7 @@ pub fn create_field_index(
         });
     };
 
-    segments.apply_segments(|write_segment| {
+    segments.apply_segments_with_id(|segment_id, write_segment| {
         write_segment.with_upgraded(|segment| {
             segment.delete_field_index_if_incompatible(op_num, field_name, field_schema)
         })?;
@@ -42,7 +42,33 @@ pub fn create_field_index(
         let already_indexed =
             write_segment.get_indexed_fields().get(field_name) == Some(field_schema);
         if !already_indexed {
-            segments.with_flush_serialized(|| write_segment.flush(true))?;
+            // This flush durably advances the segment PAST the delete halves of any pending
+            // copy-on-write moves out of it. Those moves are only replayable while a durable
+            // pre-image exists, so their destinations must be durable at or beyond the move
+            // BEFORE the source flushes: flush them first, mirroring `flush_all`'s dependency
+            // ordering. Destinations absent from the holder already left through the optimizer's
+            // pinned swap path, which caps the WAL acknowledge until they are durable.
+            //
+            // Destination guards are taken before entering the flush lock to keep the
+            // [segment locks -> flush lock] ordering documented on `with_flush_serialized`.
+            // Lock order within segments also matches `apply_points_to_appendable`
+            // (copy-on-write source first, then the appendable destination).
+            let cow_destinations: Vec<_> = segments
+                .cow_flush_destinations(segment_id)
+                .into_iter()
+                .filter_map(|destination_id| segments.get(destination_id))
+                .map(|destination| destination.get())
+                .collect();
+            let destination_guards: Vec<_> = cow_destinations
+                .iter()
+                .map(|destination| destination.read())
+                .collect();
+            segments.with_flush_serialized(|| {
+                for destination in &destination_guards {
+                    destination.flush(true)?;
+                }
+                write_segment.flush(true)
+            })?;
         }
 
         let (schema, indexes) =

--- a/lib/shard/src/update/field_index.rs
+++ b/lib/shard/src/update/field_index.rs
@@ -42,33 +42,9 @@ pub fn create_field_index(
         let already_indexed =
             write_segment.get_indexed_fields().get(field_name) == Some(field_schema);
         if !already_indexed {
-            // This flush durably advances the segment PAST the delete halves of any pending
-            // copy-on-write moves out of it. Those moves are only replayable while a durable
-            // pre-image exists, so their destinations must be durable at or beyond the move
-            // BEFORE the source flushes: flush them first, mirroring `flush_all`'s dependency
-            // ordering. Destinations absent from the holder already left through the optimizer's
-            // pinned swap path, which caps the WAL acknowledge until they are durable.
-            //
-            // Destination guards are taken before entering the flush lock to keep the
-            // [segment locks -> flush lock] ordering documented on `with_flush_serialized`.
-            // Lock order within segments also matches `apply_points_to_appendable`
-            // (copy-on-write source first, then the appendable destination).
-            let cow_destinations: Vec<_> = segments
-                .cow_flush_destinations(segment_id)
-                .into_iter()
-                .filter_map(|destination_id| segments.get(destination_id))
-                .map(|destination| destination.get())
-                .collect();
-            let destination_guards: Vec<_> = cow_destinations
-                .iter()
-                .map(|destination| destination.read())
-                .collect();
-            segments.with_flush_serialized(|| {
-                for destination in &destination_guards {
-                    destination.flush(true)?;
-                }
-                write_segment.flush(true)
-            })?;
+            // Also flushes the destinations of pending copy-on-write moves out of this
+            // segment first; see `SegmentHolder::flush_segment_with_cow_destinations`.
+            segments.flush_segment_with_cow_destinations(segment_id, &**write_segment)?;
         }
 
         let (schema, indexes) =

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -955,3 +955,76 @@ fn create_field_index_pins_pending_payload_state() {
         "filtered reads must agree with payload storage: the row was cleared",
     );
 }
+
+/// The pre-build flush of `create_field_index` durably advances a segment past the
+/// delete halves of its pending copy-on-write moves. The destinations of those moves
+/// must be durable at or beyond the moves FIRST: otherwise the moves' WAL entries stop
+/// being replayable (the durable pre-image is deleted while the only current copy sits
+/// in the unflushed destination) and a graceful close loses the points. The destination
+/// cannot be relied on to flush itself during the same pass: the `already_indexed`
+/// short-circuit skips its flush, e.g. when it is proxy-wrapped by a running
+/// optimization and the proxy reports the field as present. Root cause of the nightly
+/// model-testing reload divergence (#10095).
+#[test]
+fn create_field_index_flushes_cow_destinations_before_source() {
+    use segment::entry::NonAppendableSegmentEntry as _;
+    use segment::types::{PayloadFieldSchema, PayloadSchemaType};
+
+    use crate::update::set_payload;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let key: PayloadKeyType = "color".parse().unwrap();
+    let schema = PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword);
+
+    let mut source = build_segment_1(dir.path()); // points 1-5, version 6
+    source.appendable_flag = false;
+    let mut destination = empty_segment(dir.path());
+    // The destination already carries the index, so its own pre-build flush below is
+    // skipped by the `already_indexed` short-circuit; only the dependency-aware flush
+    // of the source's visit can cover it.
+    destination
+        .create_field_index(7, &key, Some(&schema), &hw_counter)
+        .unwrap();
+
+    let mut holder = SegmentHolder::default();
+    let source_id = holder.add_new(source);
+    let destination_id = holder.add_new(destination);
+
+    // Durable baseline.
+    holder.flush_all(FlushMode::Sync, true).unwrap();
+
+    // Op 100 modifies point 1, which lives in the non-appendable source: the
+    // copy-on-write arm upserts the updated point into the destination, deletes it from
+    // the source, and records the flush dependency edge.
+    let payload = payload_json! {"other": "value"};
+    let moved = set_payload(&holder, 100, &payload, &[1.into()], &None, &hw_counter).unwrap();
+    assert_eq!(moved, 1);
+
+    create_field_index(&holder, 200, &key, Some(&schema), &hw_counter).unwrap();
+
+    let source_persisted = holder
+        .get(source_id)
+        .unwrap()
+        .get()
+        .read()
+        .persistent_version();
+    let destination_persisted = holder
+        .get(destination_id)
+        .unwrap()
+        .get()
+        .read()
+        .persistent_version();
+
+    assert!(
+        source_persisted >= 100,
+        "the source's pre-build flush must cover the move's delete half to arm the \
+         hazard, got {source_persisted}",
+    );
+    assert!(
+        destination_persisted >= 100,
+        "the move's destination must be durable at or beyond the move once the source \
+         flushed past it; anything lower durably deletes the WAL replay pre-image while \
+         the only remaining copy is memory-only, got {destination_persisted}",
+    );
+}


### PR DESCRIPTION
Fixes #10095: after a restart, points that were successfully written and acknowledged could be missing from the collection.

Animation: [cow-flush-tear-animation.html](https://github.com/user-attachments/files/31022101/cow-flush-tear-animation.html)

## The bug, by example

Point `P` lives in immutable segment `A`. Everything is flushed, and the WAL is truncated accordingly. Correct at that moment: `P` is durable in `A`'s files.

```
WAL:      (empty, truncated after op 99: everything below is durable)
A files:  P (payload {"city": "Berlin"}, vectors)
B files:  (nothing)
```

**Op 100** is a `set_payload` on `P`. The WAL entry stores only the operation, not the point: `op 100: set_payload {"color": "red"} on P`. Since `A` is immutable, applying it is a copy-on-write move: the updated `P` is written into appendable segment `B` (in memory) and `P` is marked deleted in `A` (in memory).

```
WAL:      op 100: set_payload {"color": "red"} on P
A files:  P                     A memory: P deleted
B files:  (nothing)             B memory: P {"city": "Berlin", "color": "red"}
```

A restart here is safe: replay re-applies op 100, finds `P` in `A`'s files, and re-derives the move. The WAL entry alone is not enough (it has no vectors, no other payload keys); replay NEEDS `P`'s old copy somewhere on disk. That old copy is the "pre-image".

**Op 120** is a `create_field_index`. Before building the index on each segment it flushes that segment (the flush-before-build from #9767), one segment at a time. 

Flushing `A` durably persists the deletion of `P` from `A`'s files. `B`'s flush is skipped (see below).

```
WAL:      op 100: set_payload {"color": "red"} on P
          ...
          op 120: create_field_index "color"
A files:  P deleted             A memory: P deleted
B files:  (nothing)             B memory: P {"city": "Berlin", "color": "red"}
```

**Restart.** `B`'s in-memory copy is discarded; segments load from files; the WAL is replayed from op 100:

- `op 100: set_payload on P`: find `P` to move it. `A`'s files: deleted. `B`'s files: nothing. No segment knows `P`. The operation is declined with `No point with id`.
- `op 120: create_field_index`: rebuilds the index. Nothing brings `P` back.

`P` is gone, even though its write was acknowledged long ago. Note that the WAL did nothing wrong: op 100 was correctly kept. It became unreplayable because the flush in step op-120 destroyed the pre-image it depends on without making the new copy durable first.

## Why `B`'s flush is skipped

`create_field_index` iterates appendable segments (destinations) first, which usually flushes `B` before `A`.

But an optimization started on `B` between op 100 and op 120 and proxy-wrapped it, which changes the picture the pass sees:

```
Segment holder when op 120 runs:

  appendable group                      non-appendable group
  (visited & flushed first)             (visited & flushed after)
  ─────────────────────────             ──────────────────────────────────────
  (other appendable segments;           Proxy(B)          <- proxies are never
   B is NOT here anymore)               ├─ wraps B           "appendable"
                                        ├─ memory: P new copy   files: (none)
                                        ├─ reports "color" as already indexed
                                        └─ => pre-build flush of B: SKIPPED

                                        A (immutable)
                                        ├─ memory: P deleted    files: P
                                        ├─ "color" not indexed yet
                                        └─ => force-flushed: deletion of P
                                              becomes DURABLE, pre-image gone

  pending copy-on-write move from op 100:   A ──(P)──► B
  (recorded as a flush_dependency edge: flush B before A)
```

In detail:

- if `B` is proxy-wrapped by a running optimization, it is classified non-appendable (losing its place in the iteration order) and the `already_indexed` check sees the field as present on the proxy, skipping `B`'s flush entirely;
- independently, a move that lands while the pass is already running is ordered behind nothing.

`flush_all` prevents exactly this hazard by locking all segments and flushing destinations before sources. The per-segment flush in `create_field_index` had no such protection; it is the only place that flushes single segments outside `flush_all`.

## The fix

Before flushing a segment, flush the destinations of its pending copy-on-write moves first (they are already tracked in the holder's `flush_dependency` graph). In the example: flushing `A` now flushes `B` first, so the timeline after op 120 becomes:

```
A files:  P deleted             B files:  P {"city": "Berlin", "color": "red"}
```

Replay of op 100 now finds `P` in `B` at version 100, sees the operation is already applied, and skips it. No data depends on memory anymore.

One hop is enough: destinations are appendable segments and never copy-on-write sources themselves. Lock-ordering details are in the code comments.

## Testing

- New regression test reproducing the example (pending CoW move, destination whose flush is skipped, then `create_field_index`): fails without the fix, passes with it.
- 6 of 6 nightly model-testing CI runs green on the fix build (~200k ops and ~400 restart verifications each). Before the fix this workload failed roughly every 1 to 2 runs.
- The failure was traced end-to-end in CI runs 31583878492 and 31583871346; the full investigation lives in #10198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
