### PR TITLE
docs(proto): note which fields the server actually requires

### DIFF
--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -1615,6 +1615,7 @@ message PointsIdsList {
 // ---------------------------------------------
 
 message PointStruct {
+  // Must be set: the server rejects a point without an id
   PointId id = 1;
   // deprecated "vector" field
   reserved 2;

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -77,7 +77,7 @@ message Image {
 }
 
 message InferenceObject {
-  // Object to infer
+  // Object to infer. Must be set: the server rejects a request without it
   Value object = 1;
   // Model name
   string model = 2;

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -67,7 +67,8 @@ message Document {
 }
 
 message Image {
-  // Image data, either base64 encoded or URL
+  // Image data, either base64 encoded or URL. Must be set: the server rejects a
+  // request without it
   Value image = 1;
   // Model name
   string model = 2;

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -1620,6 +1620,8 @@ message PointStruct {
   // deprecated "vector" field
   reserved 2;
   map<string, Value> payload = 3;
+  // Optional on the wire, but required in practice: the server rejects a point
+  // without vectors
   optional Vectors vectors = 4;
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -5117,7 +5117,8 @@ pub struct Document {
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Image {
-    /// Image data, either base64 encoded or URL
+    /// Image data, either base64 encoded or URL. Must be set: the server rejects a
+    /// request without it
     #[prost(message, optional, tag = "1")]
     pub image: ::core::option::Option<Value>,
     /// Model name
@@ -5130,7 +5131,7 @@ pub struct Image {
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InferenceObject {
-    /// Object to infer
+    /// Object to infer. Must be set: the server rejects a request without it
     #[prost(message, optional, tag = "1")]
     pub object: ::core::option::Option<Value>,
     /// Model name
@@ -7686,10 +7687,13 @@ pub struct PointsIdsList {
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PointStruct {
+    /// Must be set: the server rejects a point without an id
     #[prost(message, optional, tag = "1")]
     pub id: ::core::option::Option<PointId>,
     #[prost(map = "string, message", tag = "3")]
     pub payload: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
+    /// Optional on the wire, but required in practice: the server rejects a point
+    /// without vectors
     #[prost(message, optional, tag = "4")]
     #[validate(nested)]
     pub vectors: ::core::option::Option<Vectors>,


### PR DESCRIPTION
Four fields in `points.proto` can be left unset by a generated client, and the server rejects the request when they are. The proto does not say so, so someone writing a client from it has no way to know.

| field | what the server does |
|---|---|
| `PointStruct.id` | `Empty ID is not allowed` — `grpc/conversions.rs:1108` |
| `PointStruct.vectors`, declared `optional` | `Expected some vectors` — `grpc/conversions.rs:1102` |
| `Image.image` | `Empty image is not allowed` — `conversions/inference.rs:67` |
| `InferenceObject.object` | `Empty object is not allowed` — `conversions/inference.rs:105` |

Comments only and no behaviour change

So how I found it: a checker I wrote with help from Claude Opus 5, comparing your REST and gRPC descriptions of the same options against each other and against the code. The prompt behind it was

> Compare the REST and gRPC descriptions of the same options against each other and against the code, list every place where the two interfaces promise different things, then verify each one by hand before proposing anything

Then I read every hit by hand, and most of them turned out not to be defects

- four hits about `to_shard_id` are false. The field is in the REST struct with `#[schemars(skip)] // hide for internal use`, so hiding it is deliberate and your comment says as much
- `SliceCondition` already documents `must be >= 1` and the server checks exactly that, nothing to add
- `Document` has no such rejection, left untouched
- six more places live in `points_internal_service.proto`, which is not a public contract

One thing I left alone on purpose its 5 `oneof` variants reject an unset variant the same way: `Vectors`, `OrderValue`, `QuantizationConfig`, `MaxOptimizationThreads`, `BinaryQuantizationQueryEncoding`. "One variant must be set" partly follows from the format itself, so I would rather you decide whether those deserve a line too than add nine comments where 4 were asked for
