### PR TITLE
fix(optimizer): retire sources only after their CoW moves are durable

### DIFF
--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -4,10 +4,10 @@
 //! The collection layer provides the strategy via `OptimizationStrategy`.
 
 use std::collections::HashSet;
-use std::debug_assert_matches;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
+use std::{cmp, debug_assert_matches};
 
 use ahash::AHashSet;
 use common::budget::{ResourceBudget, ResourcePermit};
@@ -615,11 +615,10 @@ fn finish_optimization(
     // (and out of the optimized segment's in-memory state, which the next optimization bakes into
     // its build output) while their new copies may still sit unflushed in appendable segments. WAL
     // replay can only re-derive those moves from the on-disk pre-images, so the files must survive
-    // until a flush proves this optimization durable. Register the destruction as a post-flush
-    // action: it runs once the durable waterline covers `optimized_segment_version`, and until then
-    // the WAL acknowledge stays capped at each source's persisted version (the same pin the proxy
-    // imposed while the optimization ran), so every operation the files contradict, deletions in
-    // particular, is replayed and re-applied on a restart. See
+    // until a flush proves the moved copies durable. Register the destruction as a post-flush
+    // action; until it runs, the WAL acknowledge stays capped at each source's persisted version
+    // (the same pin the proxy imposed while the optimization ran), so every operation the files
+    // contradict, deletions in particular, is replayed and re-applied on a restart. See
     // `SegmentHolder::register_post_flush_action`.
     //
     // This cap has to be tracked at the holder level because the proxy can no longer
@@ -630,9 +629,27 @@ fn finish_optimization(
     // gone from the holder's flush accounting even though the source files it protected are
     // still on disk. `register_segment_drop` re-expresses the same pin independently of segment
     // membership, snapshotting each proxy's final `persistent_version` as `ack_pin`.
+    //
+    // The release threshold is `max(optimized_segment_version, proxy version)`, and the second
+    // half is what makes the re-expression faithful. A copy-on-write move during the optimization
+    // put the point's new copy in the shared appendable write segment and recorded a delete in the
+    // proxy; that delete is baked into the optimized segment as a durable tombstone, so after this
+    // source is dropped the pre-image survives nowhere else, while the write segment may not flush
+    // for a long time. Releasing at `optimized_segment_version` alone destroyed the pre-image as
+    // soon as the destination was durable: a restart then discarded the write segment's unflushed
+    // copy, and replaying the still-acknowledged CoW operation failed for want of the pre-image,
+    // losing the point (the nightly model-testing reload divergence). The proxy's version covers
+    // every such CoW operation (its delete half bumped it), and the durable waterline cannot reach
+    // it until the write segment holding the copies has flushed past it, or has itself been
+    // optimized into a built (hence on-disk) destination whose own pin extends the chain.
     for proxy in proxies {
-        let ack_pin = proxy.get().read().persistent_version();
-        read_segment_holder.register_segment_drop(optimized_segment_version, ack_pin, proxy);
+        let (ack_pin, proxy_version) = {
+            let guard = proxy.get();
+            let read = guard.read();
+            (read.persistent_version(), read.version())
+        };
+        let ready_at = cmp::max(optimized_segment_version, proxy_version);
+        read_segment_holder.register_segment_drop(ready_at, ack_pin, proxy);
     }
 
     drop(read_segment_holder);

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -760,6 +760,35 @@ fn check_segments_size(
 }
 
 /// Performs optimization of segments (merge / reindex / vacuum, etc.)
+/// Test-only seam: a callback invoked after the sources are wrapped in proxies and before the
+/// optimized segment is built, so a deterministic test can inject operations into exactly the
+/// window a concurrent workload occupies in production. Thread-local: the callback fires on the
+/// thread driving [`execute_optimization`].
+#[cfg(any(test, feature = "testing"))]
+pub mod test_hooks {
+    use std::cell::RefCell;
+
+    thread_local! {
+        static AFTER_PROXY_WRAP: RefCell<Option<Box<dyn Fn()>>> = const { RefCell::new(None) };
+    }
+
+    pub fn set_after_proxy_wrap(f: impl Fn() + 'static) {
+        AFTER_PROXY_WRAP.with(|h| *h.borrow_mut() = Some(Box::new(f)));
+    }
+
+    pub fn clear_after_proxy_wrap() {
+        AFTER_PROXY_WRAP.with(|h| *h.borrow_mut() = None);
+    }
+
+    pub(super) fn fire_after_proxy_wrap() {
+        AFTER_PROXY_WRAP.with(|h| {
+            if let Some(f) = h.borrow().as_ref() {
+                f();
+            }
+        });
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
     optimizer_name: &'static str,
@@ -902,6 +931,9 @@ pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
         (proxy_ids, cow_segment_id_opt, counter_handler)
     };
 
+    #[cfg(any(test, feature = "testing"))]
+    test_hooks::fire_after_proxy_wrap();
+
     // SLOW PART: create single optimized segment and propagate all new changes to it
     let build_result = optimize_segment_propagate_changes(
         factory,
@@ -966,4 +998,181 @@ pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
     timer.set_success(true);
 
     Ok(OptimizationResult { points_count })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+
+    use common::budget::ResourceBudget;
+    use common::progress_tracker::new_progress_tracker;
+    use segment::common::operation_time_statistics::OperationDurationsAggregator;
+    use segment::data_types::vectors::only_default_vector;
+    use segment::entry::SegmentEntry as _;
+    use segment::segment_constructor::build_segment;
+    use segment::segment_constructor::segment_builder::SegmentBuilder;
+    use segment::types::HnswGlobalConfig;
+    use tempfile::Builder;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::fixtures::empty_segment;
+    use crate::segment_holder::locked::LockedSegmentHolder;
+    use crate::segment_holder::{FlushMode, SegmentHolder};
+
+    struct PlainStrategy {
+        segments_path: std::path::PathBuf,
+        temp_path: std::path::PathBuf,
+        config: segment::types::SegmentConfig,
+    }
+
+    impl OptimizationStrategy for PlainStrategy {
+        fn create_segment_builder(
+            &self,
+            _input_segments: &[LockedSegment],
+        ) -> OperationResult<SegmentBuilder> {
+            SegmentBuilder::new(&self.temp_path, &self.config, &HnswGlobalConfig::default())
+        }
+
+        fn create_temp_segment(&self) -> OperationResult<(LockedSegment, NewSegmentToken)> {
+            let (segment, token) = build_segment(&self.segments_path, &self.config, None, false)?;
+            Ok((LockedSegment::new(segment), token))
+        }
+
+        fn live_vector_names(&self) -> Option<HashSet<VectorNameBuf>> {
+            None
+        }
+    }
+
+    /// Pin-arithmetic regression test for the source-retirement fix: a retiring source's drop pin
+    /// must release only once the durable waterline covers the proxy's version, not merely the
+    /// optimized segment's. Operations can bump the proxy's version without any propagated effect
+    /// reaching the destination (observed in production pin logs as
+    /// `proxy_version > destination_version`), and releasing at the destination's version alone
+    /// frees the source's files while the WAL acknowledge, capped by the same pin, still owes
+    /// replayability to operations up to the proxy's version.
+    ///
+    /// The test drives a real optimization over a real segment holder and uses the
+    /// `after_proxy_wrap` test hook to inject, into the mid-optimization window:
+    /// - a propagated change (a delete of a live point at op 50), raising the destination to 50;
+    /// - a gap operation (a delete of an id the wrapped segment does not hold, at op 99), raising
+    ///   the proxy to 99 with no destination effect.
+    ///
+    /// Pre-fix, the pin's release threshold was the destination's version (50): the first flush
+    /// below releases it, dropping the source's files. With the fix it is the proxy's version
+    /// (99): the flush at waterline 50 must keep the pin, and only a waterline covering 99 may
+    /// release it.
+    #[test]
+    fn test_source_drop_pin_covers_proxy_version() {
+        let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
+        let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        // Source segment: two live points, fully flushed (persisted == version == 10).
+        let mut source = empty_segment(segments_dir.path());
+        source
+            .upsert_point(
+                10,
+                1.into(),
+                only_default_vector(&[1.0, 0.0, 0.0, 0.0]),
+                &hw_counter,
+            )
+            .unwrap();
+        source
+            .upsert_point(
+                10,
+                2.into(),
+                only_default_vector(&[0.0, 1.0, 0.0, 0.0]),
+                &hw_counter,
+            )
+            .unwrap();
+        source.flush(true).unwrap();
+        let config = source.config().clone();
+        let source_path = source.data_path();
+
+        let mut holder = SegmentHolder::default();
+        // A second appendable so the holder is never left without one.
+        holder.add_new(empty_segment(segments_dir.path()));
+        let source_id = holder.add_new(source);
+        let holder = LockedSegmentHolder::new(holder);
+
+        // Mid-optimization injection, through the holder's own handle to the proxy.
+        let hook_holder = holder.clone();
+        test_hooks::set_after_proxy_wrap(move || {
+            let guard = hook_holder.read();
+            let proxy = guard
+                .get(source_id)
+                .expect("source proxied in place")
+                .clone();
+            let hw_counter = HardwareCounterCell::new();
+            // Propagated change: point 2 lives in the wrapped segment, so this lands in the
+            // proxy's delete ledger and reaches the destination at version 50.
+            proxy
+                .get()
+                .write()
+                .delete_point(50, 2.into(), &hw_counter)
+                .unwrap();
+            // Gap operation: id 999 is nowhere, so only the proxy's version moves, to 99.
+            proxy
+                .get()
+                .write()
+                .delete_point(99, 999.into(), &hw_counter)
+                .unwrap();
+        });
+
+        let strategy = PlainStrategy {
+            segments_path: segments_dir.path().to_path_buf(),
+            temp_path: temp_dir.path().to_path_buf(),
+            config,
+        };
+        let stopped = AtomicBool::new(false);
+        let telemetry = OperationDurationsAggregator::new();
+        let budget = ResourceBudget::new(2, 2);
+        let permit = budget.try_acquire(1, 1).expect("test budget permit");
+        execute_optimization(
+            "test",
+            holder.clone(),
+            vec![source_id],
+            Uuid::new_v4(),
+            None,
+            &OptimizationPaths {
+                segments_path: segments_dir.path().to_path_buf(),
+                temp_path: temp_dir.path().to_path_buf(),
+            },
+            permit,
+            budget,
+            &stopped,
+            new_progress_tracker().1,
+            &telemetry,
+            &strategy,
+            Box::new(|| {}),
+        )
+        .unwrap();
+        test_hooks::clear_after_proxy_wrap();
+
+        // A flush whose waterline covers the destination's version (50) but not the proxy's (99)
+        // must keep the pin: the acknowledge stays at the source's persisted version and the
+        // source's files survive. Pre-fix the pin released here.
+        let holder_read = holder.read();
+        holder_read.bump_max_segment_version_overwrite(50);
+        let ack = holder_read.flush_all(FlushMode::Sync, true).unwrap();
+        assert_eq!(
+            ack, 10,
+            "acknowledge must stay at the source's persisted version while \
+             operations up to the proxy's version are uncovered",
+        );
+        assert!(
+            source_path.exists(),
+            "source files must survive a waterline that covers only the destination",
+        );
+
+        // Covering the proxy's version releases the pin: files drop, acknowledge follows.
+        holder_read.bump_max_segment_version_overwrite(99);
+        let ack = holder_read.flush_all(FlushMode::Sync, true).unwrap();
+        assert_eq!(ack, 99, "cap lifts once the proxy's version is durable");
+        assert!(
+            !source_path.exists(),
+            "source files drop once the pin releases",
+        );
+    }
 }


### PR DESCRIPTION
Follow-up hardening to #10201 (merged), second of three fixes extracted from the #10095 investigation branch #10198. Independent of #10201: this hole needs no index operation, only ordinary traffic during an optimization.

## The hole

While an optimization runs, the source segment is wrapped in a proxy. A copy-on-write update of a point in the source puts the new copy in the shared appendable write segment and records a delete in the proxy. That delete gets baked into the optimized segment as a durable tombstone the moment the build lands on disk; the write segment holding the new copy may stay unflushed for a long time.

`finish_optimization` scheduled the retired source's file destruction to run once the durable waterline covered `optimized_segment_version` (the build cut). Operations that arrived through the proxy after the cut sit above that version, so the source files could be destroyed while the moved point's only current copy was memory-only. On a graceful restart that copy is discarded, and WAL replay of the CoW operation cannot re-derive it because its pre-image (the source files) is gone: the point is silently lost.

## Example

Source segment fully flushed at version 10, holding points 1 and 2. Optimization starts, source is proxied.

| op | what | destination version | proxy version |
|---|---|---|---|
| 50 | delete point 2 (in the source: recorded in the proxy, propagated to the destination; the delete half of a CoW move looks the same) | 50 | 50 |
| 99 | delete point 999 (not in the source: gap op, proxy only) | 50 | 99 |

Old pin: source files destroyed once the waterline reaches 50, while the WAL acknowledge, capped by the same pin, still owes replayability up to 99.
New pin: released at `max(50, 99) = 99`; a flush at waterline 50 keeps the files and the acknowledge stays at 10, a flush covering 99 drops the files and lifts the acknowledge to 99.

## The fix

Release the drop pin at `max(optimized_segment_version, proxy_version)`. The proxy's version covers every CoW operation sourced from it (each delete half bumped it), and the waterline cannot reach it until the write segment holding the copies has flushed past it, or has itself been optimized into an on-disk destination whose own pin extends the chain. This is the same cap the proxy imposed on the WAL acknowledge while it was a holder member, now carried through to file destruction. Three lines of arithmetic; source files are held a little longer.

## Evidence

The regression test (`test_source_drop_pin_covers_proxy_version`) drives the real `execute_optimization` and injects the two operations above through a new testing-only `after_proxy_wrap` hook. It fails on the old arithmetic (files gone at waterline 50) and passes with the fix.

In CI, the instrumented investigation traced two failures whose lost points had consolidated into a never-flushed write segment exactly this way; with this fix on the investigation branch, failure onset moved from 15-81 restart verifications to 236+ before the remaining path was root-caused separately (#10201). No specific production loss is attributed to this hole alone, but the gap is real and cheap to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
