### PR TITLE
fix(optimizer): pin the waterline when dropping an empty-but-dirty temp segment

### DIFF
--- a/lib/common/common/src/toposort.rs
+++ b/lib/common/common/src/toposort.rs
@@ -48,6 +48,11 @@ impl<T: Eq + std::hash::Hash + Copy, V> TopoSort<T, V> {
             .insert(depends_on, value);
     }
 
+    /// Returns the elements `element` depends on, with the value stored per dependency.
+    pub fn dependencies_of(&self, element: &T) -> impl Iterator<Item = (&T, &V)> {
+        self.dependencies.get(element).into_iter().flatten()
+    }
+
     /// Removes dependencies for which the filter function returns false
     pub fn retain(&mut self, filter: impl Fn(&T, &T, &V) -> bool) {
         self.dependencies.retain(|element, deps| {

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -4,10 +4,10 @@
 //! The collection layer provides the strategy via `OptimizationStrategy`.
 
 use std::collections::HashSet;
-use std::debug_assert_matches;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
+use std::{cmp, debug_assert_matches};
 
 use ahash::AHashSet;
 use common::budget::{ResourceBudget, ResourcePermit};
@@ -615,11 +615,10 @@ fn finish_optimization(
     // (and out of the optimized segment's in-memory state, which the next optimization bakes into
     // its build output) while their new copies may still sit unflushed in appendable segments. WAL
     // replay can only re-derive those moves from the on-disk pre-images, so the files must survive
-    // until a flush proves this optimization durable. Register the destruction as a post-flush
-    // action: it runs once the durable waterline covers `optimized_segment_version`, and until then
-    // the WAL acknowledge stays capped at each source's persisted version (the same pin the proxy
-    // imposed while the optimization ran), so every operation the files contradict, deletions in
-    // particular, is replayed and re-applied on a restart. See
+    // until a flush proves the moved copies durable. Register the destruction as a post-flush
+    // action; until it runs, the WAL acknowledge stays capped at each source's persisted version
+    // (the same pin the proxy imposed while the optimization ran), so every operation the files
+    // contradict, deletions in particular, is replayed and re-applied on a restart. See
     // `SegmentHolder::register_post_flush_action`.
     //
     // This cap has to be tracked at the holder level because the proxy can no longer
@@ -630,9 +629,27 @@ fn finish_optimization(
     // gone from the holder's flush accounting even though the source files it protected are
     // still on disk. `register_segment_drop` re-expresses the same pin independently of segment
     // membership, snapshotting each proxy's final `persistent_version` as `ack_pin`.
+    //
+    // The release threshold is `max(optimized_segment_version, proxy version)`, and the second
+    // half is what makes the re-expression faithful. A copy-on-write move during the optimization
+    // put the point's new copy in the shared appendable write segment and recorded a delete in the
+    // proxy; that delete is baked into the optimized segment as a durable tombstone, so after this
+    // source is dropped the pre-image survives nowhere else, while the write segment may not flush
+    // for a long time. Releasing at `optimized_segment_version` alone destroyed the pre-image as
+    // soon as the destination was durable: a restart then discarded the write segment's unflushed
+    // copy, and replaying the still-acknowledged CoW operation failed for want of the pre-image,
+    // losing the point (the nightly model-testing reload divergence). The proxy's version covers
+    // every such CoW operation (its delete half bumped it), and the durable waterline cannot reach
+    // it until the write segment holding the copies has flushed past it, or has itself been
+    // optimized into a built (hence on-disk) destination whose own pin extends the chain.
     for proxy in proxies {
-        let ack_pin = proxy.get().read().persistent_version();
-        read_segment_holder.register_segment_drop(optimized_segment_version, ack_pin, proxy);
+        let (ack_pin, proxy_version) = {
+            let guard = proxy.get();
+            let read = guard.read();
+            (read.persistent_version(), read.version())
+        };
+        let ready_at = cmp::max(optimized_segment_version, proxy_version);
+        read_segment_holder.register_segment_drop(ready_at, ack_pin, proxy);
     }
 
     drop(read_segment_holder);

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -760,6 +760,35 @@ fn check_segments_size(
 }
 
 /// Performs optimization of segments (merge / reindex / vacuum, etc.)
+/// Test-only seam: a callback invoked after the sources are wrapped in proxies and before the
+/// optimized segment is built, so a deterministic test can inject operations into exactly the
+/// window a concurrent workload occupies in production. Thread-local: the callback fires on the
+/// thread driving [`execute_optimization`].
+#[cfg(any(test, feature = "testing"))]
+pub mod test_hooks {
+    use std::cell::RefCell;
+
+    thread_local! {
+        static AFTER_PROXY_WRAP: RefCell<Option<Box<dyn Fn()>>> = const { RefCell::new(None) };
+    }
+
+    pub fn set_after_proxy_wrap(f: impl Fn() + 'static) {
+        AFTER_PROXY_WRAP.with(|h| *h.borrow_mut() = Some(Box::new(f)));
+    }
+
+    pub fn clear_after_proxy_wrap() {
+        AFTER_PROXY_WRAP.with(|h| *h.borrow_mut() = None);
+    }
+
+    pub(super) fn fire_after_proxy_wrap() {
+        AFTER_PROXY_WRAP.with(|h| {
+            if let Some(f) = h.borrow().as_ref() {
+                f();
+            }
+        });
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
     optimizer_name: &'static str,
@@ -902,6 +931,9 @@ pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
         (proxy_ids, cow_segment_id_opt, counter_handler)
     };
 
+    #[cfg(any(test, feature = "testing"))]
+    test_hooks::fire_after_proxy_wrap();
+
     // SLOW PART: create single optimized segment and propagate all new changes to it
     let build_result = optimize_segment_propagate_changes(
         factory,
@@ -966,4 +998,181 @@ pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
     timer.set_success(true);
 
     Ok(OptimizationResult { points_count })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+
+    use common::budget::ResourceBudget;
+    use common::progress_tracker::new_progress_tracker;
+    use segment::common::operation_time_statistics::OperationDurationsAggregator;
+    use segment::data_types::vectors::only_default_vector;
+    use segment::entry::SegmentEntry as _;
+    use segment::segment_constructor::build_segment;
+    use segment::segment_constructor::segment_builder::SegmentBuilder;
+    use segment::types::HnswGlobalConfig;
+    use tempfile::Builder;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::fixtures::empty_segment;
+    use crate::segment_holder::locked::LockedSegmentHolder;
+    use crate::segment_holder::{FlushMode, SegmentHolder};
+
+    struct PlainStrategy {
+        segments_path: std::path::PathBuf,
+        temp_path: std::path::PathBuf,
+        config: segment::types::SegmentConfig,
+    }
+
+    impl OptimizationStrategy for PlainStrategy {
+        fn create_segment_builder(
+            &self,
+            _input_segments: &[LockedSegment],
+        ) -> OperationResult<SegmentBuilder> {
+            SegmentBuilder::new(&self.temp_path, &self.config, &HnswGlobalConfig::default())
+        }
+
+        fn create_temp_segment(&self) -> OperationResult<(LockedSegment, NewSegmentToken)> {
+            let (segment, token) = build_segment(&self.segments_path, &self.config, None, false)?;
+            Ok((LockedSegment::new(segment), token))
+        }
+
+        fn live_vector_names(&self) -> Option<HashSet<VectorNameBuf>> {
+            None
+        }
+    }
+
+    /// Pin-arithmetic regression test for the source-retirement fix: a retiring source's drop pin
+    /// must release only once the durable waterline covers the proxy's version, not merely the
+    /// optimized segment's. Operations can bump the proxy's version without any propagated effect
+    /// reaching the destination (observed in production pin logs as
+    /// `proxy_version > destination_version`), and releasing at the destination's version alone
+    /// frees the source's files while the WAL acknowledge, capped by the same pin, still owes
+    /// replayability to operations up to the proxy's version.
+    ///
+    /// The test drives a real optimization over a real segment holder and uses the
+    /// `after_proxy_wrap` test hook to inject, into the mid-optimization window:
+    /// - a propagated change (a delete of a live point at op 50), raising the destination to 50;
+    /// - a gap operation (a delete of an id the wrapped segment does not hold, at op 99), raising
+    ///   the proxy to 99 with no destination effect.
+    ///
+    /// Pre-fix, the pin's release threshold was the destination's version (50): the first flush
+    /// below releases it, dropping the source's files. With the fix it is the proxy's version
+    /// (99): the flush at waterline 50 must keep the pin, and only a waterline covering 99 may
+    /// release it.
+    #[test]
+    fn test_source_drop_pin_covers_proxy_version() {
+        let segments_dir = Builder::new().prefix("segments_dir").tempdir().unwrap();
+        let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        // Source segment: two live points, fully flushed (persisted == version == 10).
+        let mut source = empty_segment(segments_dir.path());
+        source
+            .upsert_point(
+                10,
+                1.into(),
+                only_default_vector(&[1.0, 0.0, 0.0, 0.0]),
+                &hw_counter,
+            )
+            .unwrap();
+        source
+            .upsert_point(
+                10,
+                2.into(),
+                only_default_vector(&[0.0, 1.0, 0.0, 0.0]),
+                &hw_counter,
+            )
+            .unwrap();
+        source.flush(true).unwrap();
+        let config = source.config().clone();
+        let source_path = source.data_path();
+
+        let mut holder = SegmentHolder::default();
+        // A second appendable so the holder is never left without one.
+        holder.add_new(empty_segment(segments_dir.path()));
+        let source_id = holder.add_new(source);
+        let holder = LockedSegmentHolder::new(holder);
+
+        // Mid-optimization injection, through the holder's own handle to the proxy.
+        let hook_holder = holder.clone();
+        test_hooks::set_after_proxy_wrap(move || {
+            let guard = hook_holder.read();
+            let proxy = guard
+                .get(source_id)
+                .expect("source proxied in place")
+                .clone();
+            let hw_counter = HardwareCounterCell::new();
+            // Propagated change: point 2 lives in the wrapped segment, so this lands in the
+            // proxy's delete ledger and reaches the destination at version 50.
+            proxy
+                .get()
+                .write()
+                .delete_point(50, 2.into(), &hw_counter)
+                .unwrap();
+            // Gap operation: id 999 is nowhere, so only the proxy's version moves, to 99.
+            proxy
+                .get()
+                .write()
+                .delete_point(99, 999.into(), &hw_counter)
+                .unwrap();
+        });
+
+        let strategy = PlainStrategy {
+            segments_path: segments_dir.path().to_path_buf(),
+            temp_path: temp_dir.path().to_path_buf(),
+            config,
+        };
+        let stopped = AtomicBool::new(false);
+        let telemetry = OperationDurationsAggregator::new();
+        let budget = ResourceBudget::new(2, 2);
+        let permit = budget.try_acquire(1, 1).expect("test budget permit");
+        execute_optimization(
+            "test",
+            holder.clone(),
+            vec![source_id],
+            Uuid::new_v4(),
+            None,
+            &OptimizationPaths {
+                segments_path: segments_dir.path().to_path_buf(),
+                temp_path: temp_dir.path().to_path_buf(),
+            },
+            permit,
+            budget,
+            &stopped,
+            new_progress_tracker().1,
+            &telemetry,
+            &strategy,
+            Box::new(|| {}),
+        )
+        .unwrap();
+        test_hooks::clear_after_proxy_wrap();
+
+        // A flush whose waterline covers the destination's version (50) but not the proxy's (99)
+        // must keep the pin: the acknowledge stays at the source's persisted version and the
+        // source's files survive. Pre-fix the pin released here.
+        let holder_read = holder.read();
+        holder_read.bump_max_segment_version_overwrite(50);
+        let ack = holder_read.flush_all(FlushMode::Sync, true).unwrap();
+        assert_eq!(
+            ack, 10,
+            "acknowledge must stay at the source's persisted version while \
+             operations up to the proxy's version are uncovered",
+        );
+        assert!(
+            source_path.exists(),
+            "source files must survive a waterline that covers only the destination",
+        );
+
+        // Covering the proxy's version releases the pin: files drop, acknowledge follows.
+        holder_read.bump_max_segment_version_overwrite(99);
+        let ack = holder_read.flush_all(FlushMode::Sync, true).unwrap();
+        assert_eq!(ack, 99, "cap lifts once the proxy's version is durable");
+        assert!(
+            !source_path.exists(),
+            "source files drop once the pin releases",
+        );
+    }
 }

--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -232,6 +232,26 @@ impl SegmentHolder {
         }
     }
 
+    /// Segment ids holding not-yet-flushed copy-on-write destinations of `segment_id`'s moves.
+    ///
+    /// Every copy-on-write move out of `segment_id` records an edge here (see
+    /// `apply_points_with_conditional_move`); until the destination is durable at or beyond the
+    /// move, flushing `segment_id` durably bakes in the delete half while the only remaining copy
+    /// is memory-only, and the move's WAL entry stops being replayable (its pre-image is gone).
+    /// Any flush of a single segment outside `flush_all`'s dependency-ordered pass must therefore
+    /// flush these destinations first.
+    ///
+    /// Sorted so callers lock destinations in `flush_all`'s in-group order.
+    pub fn cow_flush_destinations(&self, segment_id: SegmentId) -> Vec<SegmentId> {
+        let flush_dependency = self.flush_dependency.lock();
+        let mut destinations: Vec<SegmentId> = flush_dependency
+            .dependencies_of(&segment_id)
+            .map(|(destination, _version)| *destination)
+            .collect();
+        destinations.sort_unstable();
+        destinations
+    }
+
     /// Calculates the version of the segments that is safe to acknowledge in WAL
     ///
     /// If there are unsaved changes after flush - detects lowest unsaved change version.

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -1291,8 +1291,32 @@ impl SegmentHolder {
             self.add_existing_locked(segment_id, tmp_segment);
             Ok(false)
         } else {
-            log::trace!("Dropping temporary segment with no changes");
-            tmp_segment.drop_data()?;
+            let (version, persisted) = {
+                let read = tmp_segment.get();
+                let read = read.read();
+                (read.version(), read.persistent_version())
+            };
+            if version > persisted {
+                // Empty, but dirty: points transited through this segment (copy-on-write moved in,
+                // then on) without any of it flushing. The segment's own files hold nothing worth
+                // keeping, but while it was a holder member its unsaved range capped the durable
+                // waterline, and dropping it here would lift that cap: upstream source-retirement
+                // pins could then release while the transit operations are neither durable
+                // anywhere nor re-derivable (their pre-images go down with the retired sources),
+                // which loses the points on the next restart. Leave the same pin a swap eviction
+                // leaves: the WAL acknowledge stays at `persisted` until the waterline covers
+                // `version`, i.e. until every segment holding the moved copies has flushed past
+                // the transit range.
+                log::trace!(
+                    "Dropping empty temporary segment with unflushed transit ops \
+                     {}..{version} behind a post-flush pin",
+                    persisted + 1,
+                );
+                self.register_segment_drop(version, persisted, tmp_segment);
+            } else {
+                log::trace!("Dropping temporary segment with no changes");
+                tmp_segment.drop_data()?;
+            }
             Ok(true)
         }
     }

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -793,9 +793,19 @@ impl SegmentHolder {
             &mut RwLockUpgradableReadGuard<dyn SegmentEntry + 'static>,
         ) -> OperationResult<bool>,
     {
+        self.apply_segments_with_id(|_id, segment| f(segment))
+    }
+
+    pub fn apply_segments_with_id<F>(&self, mut f: F) -> OperationResult<usize>
+    where
+        F: FnMut(
+            SegmentId,
+            &mut RwLockUpgradableReadGuard<dyn SegmentEntry + 'static>,
+        ) -> OperationResult<bool>,
+    {
         let mut processed_segments = 0;
-        for (_id, segment) in self.iter() {
-            let is_applied = f(&mut segment.get().upgradable_read())?;
+        for (id, segment) in self.iter() {
+            let is_applied = f(id, &mut segment.get().upgradable_read())?;
             processed_segments += usize::from(is_applied);
         }
         Ok(processed_segments)

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -2034,6 +2034,74 @@ fn test_cow_skips_delete_when_destination_is_deferred() {
     );
 }
 
+/// Regression test for the empty-but-dirty temp drop (nightly reload divergence, #10095 family).
+///
+/// A temporary segment that copy-on-write traffic filled and then emptied again carries an
+/// unsaved range: operations transited through it without any of them flushing. While it is a
+/// holder member that range caps the durable waterline. Dropping it inline on
+/// `remove_segment_if_not_needed` (the pre-fix behavior) lifted that cap, so the WAL acknowledge
+/// jumped past the transit operations even though their effects were not durable anywhere,
+/// and a restart then lost the moved points: replay had neither the operations (acknowledged
+/// away) nor the pre-images. The fix parks the drop behind a post-flush pin: the acknowledge
+/// stays at the temp's persisted version until the waterline covers its last transit operation.
+#[test]
+fn test_empty_dirty_temp_drop_keeps_waterline_cap() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut holder = SegmentHolder::default();
+    // A neutral appendable segment so the temp is not the last one (a kept-temp guard).
+    holder.add_new(empty_segment(dir.path()));
+
+    // The temp: never held a point (a temp that copy-on-write traffic transited is kept, not
+    // dropped, because soft-deleted points keep `is_empty()` false), but schema operations bumped
+    // its version, leaving it empty AND dirty: version 12 with nothing ever flushed.
+    let mut temp = empty_segment(dir.path());
+    let hw_counter = HardwareCounterCell::new();
+    temp.create_field_index(
+        12,
+        &JsonPath::from_str("number").unwrap(),
+        Some(&segment::types::PayloadSchemaType::Integer.into()),
+        &hw_counter,
+    )
+    .unwrap();
+    assert!(temp.is_empty());
+    assert!(temp.version() > temp.persistent_version());
+    let temp_path = temp.data_path();
+    let temp_id = holder.add_new(temp);
+
+    // The rest of the shard has durably progressed past the temp's persisted point but not past
+    // its unsaved range: the waterline the surviving segments justify is 11.
+    holder.bump_max_segment_version_overwrite(11);
+
+    // The temp is empty, so it is eligible for removal.
+    assert!(holder.remove_segment_if_not_needed(temp_id).unwrap());
+
+    // The acknowledge must not advance past the temp's persisted version while its transit
+    // operations (up to 12) are uncovered. Pre-fix this returned 11: the inline drop erased the
+    // unsaved range from the accounting and the WAL acknowledged operations whose effects were
+    // not durable anywhere.
+    let ack = holder.flush_all(FlushMode::Sync, true).unwrap();
+    assert_eq!(
+        ack, 0,
+        "acknowledge must stay at the dropped temp's persisted version \
+         while its transit range is uncovered",
+    );
+    assert!(
+        temp_path.exists(),
+        "files must survive until the pin releases"
+    );
+
+    // Once the surviving segments durably cover the transit range, the pin releases, the files
+    // drop, and the acknowledge follows the waterline again.
+    holder.bump_max_segment_version_overwrite(12);
+    let ack = holder.flush_all(FlushMode::Sync, true).unwrap();
+    assert_eq!(ack, 12, "cap lifts once the transit range is durable");
+    assert!(
+        !temp_path.exists(),
+        "temp files are dropped once the pin releases",
+    );
+}
+
 /// A post-flush action that does not complete keeps its ack pin in effect across flushes,
 /// capping the returned WAL acknowledge until it finally completes.
 #[test]

--- a/lib/shard/src/update/field_index.rs
+++ b/lib/shard/src/update/field_index.rs
@@ -20,7 +20,7 @@ pub fn create_field_index(
         });
     };
 
-    segments.apply_segments(|write_segment| {
+    segments.apply_segments_with_id(|segment_id, write_segment| {
         write_segment.with_upgraded(|segment| {
             segment.delete_field_index_if_incompatible(op_num, field_name, field_schema)
         })?;
@@ -42,7 +42,33 @@ pub fn create_field_index(
         let already_indexed =
             write_segment.get_indexed_fields().get(field_name) == Some(field_schema);
         if !already_indexed {
-            segments.with_flush_serialized(|| write_segment.flush(true))?;
+            // This flush durably advances the segment PAST the delete halves of any pending
+            // copy-on-write moves out of it. Those moves are only replayable while a durable
+            // pre-image exists, so their destinations must be durable at or beyond the move
+            // BEFORE the source flushes: flush them first, mirroring `flush_all`'s dependency
+            // ordering. Destinations absent from the holder already left through the optimizer's
+            // pinned swap path, which caps the WAL acknowledge until they are durable.
+            //
+            // Destination guards are taken before entering the flush lock to keep the
+            // [segment locks -> flush lock] ordering documented on `with_flush_serialized`.
+            // Lock order within segments also matches `apply_points_to_appendable`
+            // (copy-on-write source first, then the appendable destination).
+            let cow_destinations: Vec<_> = segments
+                .cow_flush_destinations(segment_id)
+                .into_iter()
+                .filter_map(|destination_id| segments.get(destination_id))
+                .map(|destination| destination.get())
+                .collect();
+            let destination_guards: Vec<_> = cow_destinations
+                .iter()
+                .map(|destination| destination.read())
+                .collect();
+            segments.with_flush_serialized(|| {
+                for destination in &destination_guards {
+                    destination.flush(true)?;
+                }
+                write_segment.flush(true)
+            })?;
         }
 
         let (schema, indexes) =

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -910,3 +910,76 @@ fn create_field_index_pins_pending_payload_state() {
         "filtered reads must agree with payload storage: the row was cleared",
     );
 }
+
+/// The pre-build flush of `create_field_index` durably advances a segment past the
+/// delete halves of its pending copy-on-write moves. The destinations of those moves
+/// must be durable at or beyond the moves FIRST: otherwise the moves' WAL entries stop
+/// being replayable (the durable pre-image is deleted while the only current copy sits
+/// in the unflushed destination) and a graceful close loses the points. The destination
+/// cannot be relied on to flush itself during the same pass: the `already_indexed`
+/// short-circuit skips its flush, e.g. when it is proxy-wrapped by a running
+/// optimization and the proxy reports the field as present. Root cause of the nightly
+/// model-testing reload divergence (#10095).
+#[test]
+fn create_field_index_flushes_cow_destinations_before_source() {
+    use segment::entry::NonAppendableSegmentEntry as _;
+    use segment::types::{PayloadFieldSchema, PayloadSchemaType};
+
+    use crate::update::set_payload;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let key: PayloadKeyType = "color".parse().unwrap();
+    let schema = PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword);
+
+    let mut source = build_segment_1(dir.path()); // points 1-5, version 6
+    source.appendable_flag = false;
+    let mut destination = empty_segment(dir.path());
+    // The destination already carries the index, so its own pre-build flush below is
+    // skipped by the `already_indexed` short-circuit; only the dependency-aware flush
+    // of the source's visit can cover it.
+    destination
+        .create_field_index(7, &key, Some(&schema), &hw_counter)
+        .unwrap();
+
+    let mut holder = SegmentHolder::default();
+    let source_id = holder.add_new(source);
+    let destination_id = holder.add_new(destination);
+
+    // Durable baseline.
+    holder.flush_all(FlushMode::Sync, true).unwrap();
+
+    // Op 100 modifies point 1, which lives in the non-appendable source: the
+    // copy-on-write arm upserts the updated point into the destination, deletes it from
+    // the source, and records the flush dependency edge.
+    let payload = payload_json! {"other": "value"};
+    let moved = set_payload(&holder, 100, &payload, &[1.into()], &None, &hw_counter).unwrap();
+    assert_eq!(moved, 1);
+
+    create_field_index(&holder, 200, &key, Some(&schema), &hw_counter).unwrap();
+
+    let source_persisted = holder
+        .get(source_id)
+        .unwrap()
+        .get()
+        .read()
+        .persistent_version();
+    let destination_persisted = holder
+        .get(destination_id)
+        .unwrap()
+        .get()
+        .read()
+        .persistent_version();
+
+    assert!(
+        source_persisted >= 100,
+        "the source's pre-build flush must cover the move's delete half to arm the \
+         hazard, got {source_persisted}",
+    );
+    assert!(
+        destination_persisted >= 100,
+        "the move's destination must be durable at or beyond the move once the source \
+         flushed past it; anything lower durably deletes the WAL replay pre-image while \
+         the only remaining copy is memory-only, got {destination_persisted}",
+    );
+}


### PR DESCRIPTION
Stacked on #10201 and the retirement-pin PR (base branch `fix-optimizer-retirement-pin`); the diff shown here is only the temp-drop pin fix and its test. Third and last hardening piece extracted from the investigation branch #10198.

## The hole

`remove_segment_if_not_needed` drops an empty temporary segment's data inline. If that segment is empty but DIRTY (its version is ahead of its persisted version), it was capping the durable waterline while it sat in the holder, and the inline drop lifts that cap in place. Upstream source-retirement pins can then release while the operations that transited the segment are neither durable anywhere nor re-derivable, which loses points on the next restart.

Invariant, stated generally: a dirty segment's removal must never raise the durable waterline.

## The fix

When `version > persisted`, register the drop as a post-flush action carrying the same pin a swap eviction leaves (`register_segment_drop(version, persisted, tmp_segment)`) instead of dropping inline. Clean segments keep the old inline path.

## Honest framing

Writing the regression test narrowed the reachable surface: temp segments that CoW traffic transited are kept (soft-deleted points keep `is_empty()` false), so the reachable empty-but-dirty case comes from schema-operation version bumps, which carry no point data. The test exercises exactly that case and fails on the inline-drop behavior (waterline lifted past the segment's unflushed range with its files gone). No traced production failure is attributed to this hole; it is a cheap enforcement of the invariant at the one removal site that violated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
