### PR TITLE
Fix getting stuck on reshard down abort

### DIFF
--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -1008,6 +1008,7 @@ impl ShardReplicaSet {
         hw_measurement_acc: HwMeasurementAcc,
         force: bool,
         deferred_behavior: DeferredBehavior,
+        wait: WaitUntil,
     ) -> CollectionResult<UpdateResult> {
         let local_shard_guard = self.local.read().await;
 
@@ -1065,13 +1066,7 @@ impl ShardReplicaSet {
 
         // TODO(resharding): Assign clock tag to the operation!? 🤔
         let result = self
-            .update_local(
-                op.into(),
-                WaitUntil::Visible,
-                None,
-                hw_measurement_acc,
-                force,
-            )
+            .update_local(op.into(), wait, None, hw_measurement_acc, force)
             .await?
             .ok_or_else(|| {
                 CollectionError::bad_request(format!(

--- a/lib/collection/src/shards/shard_holder/resharding.rs
+++ b/lib/collection/src/shards/shard_holder/resharding.rs
@@ -18,6 +18,7 @@ use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::replica_set::ShardReplicaSet;
 use crate::shards::resharding::{ReshardKey, ReshardState, ReshardingStage};
 use crate::shards::shard::{PeerId, ShardId};
+use crate::shards::shard_trait::WaitUntil;
 
 /// Outcome of a resharding pre-check: whether caller should run the operation,
 /// or treat it as already-applied no-op.
@@ -453,6 +454,7 @@ impl ShardHolder {
                     HwMeasurementAcc::disposable(),
                     true,
                     DeferredBehavior::WithDeferred,
+                    WaitUntil::Wal,
                 )
                 .await?;
         }

--- a/lib/collection/tests/integration/common/mod.rs
+++ b/lib/collection/tests/integration/common/mod.rs
@@ -2,6 +2,7 @@ use std::num::NonZeroU32;
 use std::path::Path;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use collection::collection::{Collection, RequestShardTransfer};
 use collection::config::{CollectionConfigInternal, CollectionParams, WalConfig};
 use collection::operations::types::CollectionResult;
@@ -12,6 +13,11 @@ use collection::shards::channel_service::ChannelService;
 use collection::shards::collection_shard_distribution::CollectionShardDistribution;
 use collection::shards::replica_set::replica_set_state::ReplicaState;
 use collection::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
+use collection::shards::resharding::ReshardKey;
+use collection::shards::shard::{PeerId, ShardId};
+use collection::shards::transfer::{
+    ShardTransfer, ShardTransferConsensus, ShardTransferKey, ShardTransferMethod,
+};
 use common::budget::ResourceBudget;
 use segment::types::Distance;
 
@@ -37,6 +43,21 @@ pub const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {
 
 #[cfg(test)]
 pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32) -> Collection {
+    collection_fixture(
+        collection_path,
+        shard_number,
+        TEST_OPTIMIZERS_CONFIG.clone(),
+    )
+    .await
+}
+
+/// Like [`simple_collection_fixture`], but with a custom optimizers config.
+#[cfg(test)]
+pub async fn collection_fixture(
+    collection_path: &Path,
+    shard_number: u32,
+    optimizer_config: OptimizersConfig,
+) -> Collection {
     let wal_config = WalConfig {
         wal_capacity_mb: 1,
         wal_segments_ahead: 0,
@@ -51,7 +72,7 @@ pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32
 
     let collection_config = CollectionConfigInternal {
         params: collection_params,
-        optimizer_config: TEST_OPTIMIZERS_CONFIG.clone(),
+        optimizer_config,
         wal_config,
         hnsw_config: Default::default(),
         quantization_config: Default::default(),
@@ -71,6 +92,86 @@ pub async fn simple_collection_fixture(collection_path: &Path, shard_number: u32
     )
     .await
     .unwrap()
+}
+
+/// `Collection::start_resharding` never touches its `ShardTransferConsensus`
+/// argument (the resharding driver is disabled), so every method can be a stub.
+pub struct NoopReshardingConsensus;
+
+#[async_trait]
+impl ShardTransferConsensus for NoopReshardingConsensus {
+    fn this_peer_id(&self) -> PeerId {
+        0
+    }
+
+    fn peers(&self) -> Vec<PeerId> {
+        vec![0]
+    }
+
+    fn consensus_commit_term(&self) -> (u64, u64) {
+        (0, 0)
+    }
+
+    fn recovered_switch_to_partial(
+        &self,
+        _transfer_config: &ShardTransfer,
+        _collection_id: CollectionId,
+    ) -> CollectionResult<()> {
+        unimplemented!("not exercised by start_resharding")
+    }
+
+    async fn start_shard_transfer(
+        &self,
+        _transfer_config: ShardTransfer,
+        _collection_id: CollectionId,
+    ) -> CollectionResult<()> {
+        unimplemented!("not exercised by start_resharding")
+    }
+
+    async fn restart_shard_transfer(
+        &self,
+        _transfer_config: ShardTransfer,
+        _collection_id: CollectionId,
+        _default_method: ShardTransferMethod,
+    ) -> CollectionResult<()> {
+        unimplemented!("not exercised by start_resharding")
+    }
+
+    async fn abort_shard_transfer(
+        &self,
+        _transfer: ShardTransferKey,
+        _collection_id: CollectionId,
+        _reason: &str,
+    ) -> CollectionResult<()> {
+        unimplemented!("not exercised by start_resharding")
+    }
+
+    async fn set_shard_replica_set_state(
+        &self,
+        _peer_id: Option<PeerId>,
+        _collection_id: CollectionId,
+        _shard_id: ShardId,
+        _state: ReplicaState,
+        _from_state: Option<ReplicaState>,
+    ) -> CollectionResult<()> {
+        unimplemented!("not exercised by start_resharding")
+    }
+
+    async fn commit_read_hashring(
+        &self,
+        _collection_id: CollectionId,
+        _reshard_key: ReshardKey,
+    ) -> CollectionResult<()> {
+        unimplemented!("not exercised by start_resharding")
+    }
+
+    async fn commit_write_hashring(
+        &self,
+        _collection_id: CollectionId,
+        _reshard_key: ReshardKey,
+    ) -> CollectionResult<()> {
+        unimplemented!("not exercised by start_resharding")
+    }
 }
 
 pub fn dummy_on_replica_failure() -> ChangePeerFromState {

--- a/lib/collection/tests/integration/consensus_idempotency_test.rs
+++ b/lib/collection/tests/integration/consensus_idempotency_test.rs
@@ -9,100 +9,14 @@
 //! `test_resharding_replay.py`); here we cover what a single process can drive
 //! deterministically.
 
-use async_trait::async_trait;
 use collection::operations::cluster_ops::ReshardingDirection;
-use collection::operations::types::{CollectionError, CollectionResult};
-use collection::shards::CollectionId;
+use collection::operations::types::CollectionError;
 use collection::shards::replica_set::replica_set_state::ReplicaState;
 use collection::shards::resharding::ReshardKey;
-use collection::shards::shard::{PeerId, ShardId};
-use collection::shards::transfer::{
-    ShardTransfer, ShardTransferConsensus, ShardTransferKey, ShardTransferMethod,
-};
 use tempfile::Builder;
 use uuid::Uuid;
 
-use crate::common::simple_collection_fixture;
-
-/// `Collection::start_resharding` never touches its `ShardTransferConsensus`
-/// argument (the resharding driver is disabled), so every method can be a stub.
-struct NoopReshardingConsensus;
-
-#[async_trait]
-impl ShardTransferConsensus for NoopReshardingConsensus {
-    fn this_peer_id(&self) -> PeerId {
-        0
-    }
-
-    fn peers(&self) -> Vec<PeerId> {
-        vec![0]
-    }
-
-    fn consensus_commit_term(&self) -> (u64, u64) {
-        (0, 0)
-    }
-
-    fn recovered_switch_to_partial(
-        &self,
-        _transfer_config: &ShardTransfer,
-        _collection_id: CollectionId,
-    ) -> CollectionResult<()> {
-        unimplemented!("not exercised by start_resharding")
-    }
-
-    async fn start_shard_transfer(
-        &self,
-        _transfer_config: ShardTransfer,
-        _collection_id: CollectionId,
-    ) -> CollectionResult<()> {
-        unimplemented!("not exercised by start_resharding")
-    }
-
-    async fn restart_shard_transfer(
-        &self,
-        _transfer_config: ShardTransfer,
-        _collection_id: CollectionId,
-        _default_method: ShardTransferMethod,
-    ) -> CollectionResult<()> {
-        unimplemented!("not exercised by start_resharding")
-    }
-
-    async fn abort_shard_transfer(
-        &self,
-        _transfer: ShardTransferKey,
-        _collection_id: CollectionId,
-        _reason: &str,
-    ) -> CollectionResult<()> {
-        unimplemented!("not exercised by start_resharding")
-    }
-
-    async fn set_shard_replica_set_state(
-        &self,
-        _peer_id: Option<PeerId>,
-        _collection_id: CollectionId,
-        _shard_id: ShardId,
-        _state: ReplicaState,
-        _from_state: Option<ReplicaState>,
-    ) -> CollectionResult<()> {
-        unimplemented!("not exercised by start_resharding")
-    }
-
-    async fn commit_read_hashring(
-        &self,
-        _collection_id: CollectionId,
-        _reshard_key: ReshardKey,
-    ) -> CollectionResult<()> {
-        unimplemented!("not exercised by start_resharding")
-    }
-
-    async fn commit_write_hashring(
-        &self,
-        _collection_id: CollectionId,
-        _reshard_key: ReshardKey,
-    ) -> CollectionResult<()> {
-        unimplemented!("not exercised by start_resharding")
-    }
-}
+use crate::common::{NoopReshardingConsensus, simple_collection_fixture};
 
 /// [audit-B] Setting a resharding-*up* replica `Dead` aborts the resharding
 /// first (dropping the shard) and then converges: the shard is gone, the

--- a/lib/collection/tests/integration/main.rs
+++ b/lib/collection/tests/integration/main.rs
@@ -9,6 +9,7 @@ mod grouping_test;
 mod lookup_test;
 mod multi_vec_test;
 mod pagination_test;
+mod resharding_abort_deferred_points_test;
 mod snapshot_recovery_test;
 mod sparse_idf_test;
 mod wal_less_snapshot_clocks_test;

--- a/lib/collection/tests/integration/resharding_abort_deferred_points_test.rs
+++ b/lib/collection/tests/integration/resharding_abort_deferred_points_test.rs
@@ -1,0 +1,122 @@
+//! Regression test: aborting a scale-down resharding must not wait for
+//! deferred points to become visible.
+//!
+//! `abort_resharding` holds the shard-holder write lock while
+//! `scale_down_cleanup_points` deletes the points that were migrated into the
+//! remaining shards. If that delete waits for *visibility*
+//! (`WaitUntil::Visible`, no timeout) and `prevent_unoptimized` is enabled,
+//! it only resolves once an optimization has cleared every deferred point of
+//! the shard. When the optimizer cannot make progress, the write lock is held
+//! indefinitely: every shard-holder reader (REST/gRPC handlers, searches,
+//! telemetry) hangs behind it, and in a cluster the consensus apply thread —
+//! which drives this abort on `SetShardReplicaState(Dead)` for a
+//! `ReshardingScaleDown` replica, e.g. after killing that peer — wedges the
+//! whole node.
+
+use std::time::Duration;
+
+use collection::operations::CollectionUpdateOperations;
+use collection::operations::cluster_ops::ReshardingDirection;
+use collection::operations::point_ops::{
+    BatchPersisted, BatchVectorStructPersisted, PointInsertOperationsInternal, PointOperations,
+    WriteOrdering,
+};
+use collection::optimizers_builder::OptimizersConfig;
+use collection::shards::replica_set::replica_set_state::ReplicaState;
+use collection::shards::resharding::ReshardKey;
+use collection::shards::shard_trait::WaitUntil;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use itertools::Itertools;
+use tempfile::Builder;
+use uuid::Uuid;
+
+use crate::common::{NoopReshardingConsensus, TEST_OPTIMIZERS_CONFIG, collection_fixture};
+
+/// Abort of a scale-down resharding must complete even if deferred points can
+/// never become visible. The optimizer is disabled here
+/// (`max_optimization_threads: 0`), so once a point is deferred it stays
+/// deferred: an abort whose cleanup waits for visibility hangs forever and
+/// trips the timeout below.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_abort_resharding_down_does_not_wait_for_deferred_points() {
+    let dir = Builder::new().prefix("collection").tempdir().unwrap();
+
+    let optimizer_config = OptimizersConfig {
+        // 1 KB indexing threshold: with 4-dim f32 vectors points become
+        // deferred from segment offset 64 on, so a moderate insert is
+        // guaranteed to leave deferred points behind.
+        indexing_threshold: Some(1),
+        max_optimization_threads: Some(0),
+        prevent_unoptimized: Some(true),
+        ..TEST_OPTIMIZERS_CONFIG
+    };
+    let collection = collection_fixture(dir.path(), 2, optimizer_config).await;
+
+    // Scale-down resharding: drain shard 1 into shard 0.
+    let key = ReshardKey {
+        uuid: Uuid::new_v4(),
+        direction: ReshardingDirection::Down,
+        peer_id: 0,
+        shard_id: 1,
+        shard_key: None,
+    };
+    collection
+        .start_resharding(
+            key.clone(),
+            Box::new(NoopReshardingConsensus),
+            std::future::ready(()),
+            std::future::ready(()),
+        )
+        .await
+        .expect("start_resharding down must succeed");
+    collection
+        .set_shard_replica_state(
+            1,
+            0,
+            ReplicaState::ReshardingScaleDown,
+            Some(ReplicaState::Active),
+        )
+        .await
+        .expect("marking the target replica ReshardingScaleDown must succeed");
+
+    // Upsert while the resharding hash ring is active: points whose home is
+    // shard 1 are dual-written into shard 0 (their post-resharding home), so
+    // shard 0 now holds points outside its own hash ring — exactly what the
+    // abort's cleanup deletes. `WaitUntil::Segment` (not `Visible`): the
+    // setup itself must not wait on the disabled optimizer.
+    let batch = BatchPersisted {
+        ids: (0..1000_u64).map(u64::into).collect_vec(),
+        vectors: BatchVectorStructPersisted::Single(
+            (0..1000).map(|i| vec![i as f32, 0.0, 1.0, 1.0]).collect(),
+        ),
+        payloads: None,
+    };
+    let insert = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::from(batch),
+    ));
+    collection
+        .update_from_client(
+            insert,
+            WaitUntil::Segment,
+            None,
+            WriteOrdering::default(),
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("insert must succeed");
+
+    // The abort itself: scroll plus one delete operation on ~500 points. Its
+    // correctness must not depend on optimizer progress, so it has to finish
+    // promptly; the generous timeout only guards against the hang.
+    let abort = collection.abort_resharding(key, false, Default::default());
+    tokio::time::timeout(Duration::from_secs(30), abort)
+        .await
+        .expect("abort_resharding must not hang waiting for deferred points to become visible")
+        .expect("abort_resharding must succeed");
+
+    assert!(
+        collection.resharding_state().await.is_none(),
+        "resharding state must be cleared after abort",
+    );
+}


### PR DESCRIPTION
When resharding down is aborted, it needs to clean up now foreign points that are already copied to other shards.

This step of finding and deleting points is blocking. It results in a few properties:

- the consensus operation (abort resharding) is blocking
- it uses `WaitUntil::Visible` when processing those deletes
- it blocks on any deferred points

Having deferred points amplifies this effect a lot. To work through them it may need multiple optimizer cycles. Because this blocks the abort operation, it can result in a peer becoming completely unresponsive for tens of minutes.

This PR changes the behavior to use `WaitUntil::Wal`. It causes all foreign points to be cleaned up eventually. It means we don't wait on deferred points. It changes the blocking behavior from tens of minutes to milliseconds, fixing the problem.

Caveat: during this period such foreign points may leak into other places. A stream records transfer would also transfer these foreign points to new replicas. It can break data consistency. It would only happen in an unhappy path though, with a specific sequence of events. It needs monitoring on how it behaves on a real cluster.

A follow up PR is needed to get rid of this caveat.

A test is added to prove this changes behavior.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
