### PR TITLE
Add CachedBlobFile: cached reads + write-through appends for object stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3896,6 +3896,7 @@ dependencies = [
  "http 1.5.0",
  "io_bridge",
  "object_store",
+ "tempfile",
  "tokio",
  "url",
 ]

--- a/lib/common/common/src/universal_io/error.rs
+++ b/lib/common/common/src/universal_io/error.rs
@@ -50,6 +50,7 @@ impl IsNotFound for UniversalIoError {
             | Self::UnchangedOpen { .. }
             | Self::QueueIsFull
             | Self::AppendOffsetConflict { .. }
+            | Self::AppendRewriteRequired { .. }
             | Self::S3(_)
             | Self::S3Config { .. }
             | Self::TaskPanicked(_) => false,
@@ -131,6 +132,12 @@ pub enum UniversalIoError {
     #[error("append offset conflict at {path}: expected end-of-file offset {offset}")]
     AppendOffsetConflict { path: PathBuf, offset: u64 },
 
+    /// A native append was rejected because the object reached the store's
+    /// cap on appended blocks; the object can only keep growing through a
+    /// whole-object rewrite.
+    #[error("append to {path} rejected: appended-block limit reached, rewrite required")]
+    AppendRewriteRequired { path: PathBuf },
+
     #[error("S3 object store error: {0}")]
     S3(#[source] Box<dyn std::error::Error + Send + Sync>),
 
@@ -156,6 +163,29 @@ impl UniversalIoError {
             | Self::InvalidFileIndex { .. }
             | Self::Uninitialized { .. }
             | Self::QueueIsFull
+            | Self::AppendRewriteRequired { .. }
+            | Self::S3(_)
+            | Self::S3Config { .. }
+            | Self::UnchangedOpen { .. }
+            | Self::TaskPanicked(_) => false,
+        }
+    }
+
+    pub fn is_append_rewrite_required(&self) -> bool {
+        match self {
+            Self::AppendRewriteRequired { .. } => true,
+            Self::Io(_)
+            | Self::Mmap(_)
+            | Self::Bincode(_)
+            | Self::BytemuckCast(_)
+            | Self::ZerocopySize(_)
+            | Self::IoUringNotSupported(_)
+            | Self::NotFound { .. }
+            | Self::OutOfBounds { .. }
+            | Self::InvalidFileIndex { .. }
+            | Self::Uninitialized { .. }
+            | Self::QueueIsFull
+            | Self::AppendOffsetConflict { .. }
             | Self::S3(_)
             | Self::S3Config { .. }
             | Self::UnchangedOpen { .. }

--- a/lib/common/common/src/universal_io/error.rs
+++ b/lib/common/common/src/universal_io/error.rs
@@ -51,6 +51,7 @@ impl IsNotFound for UniversalIoError {
             | Self::QueueIsFull
             | Self::AppendOffsetConflict { .. }
             | Self::AppendRewriteRequired { .. }
+            | Self::AppendEntityTooSmall { .. }
             | Self::S3(_)
             | Self::S3Config { .. }
             | Self::TaskPanicked(_) => false,
@@ -138,6 +139,12 @@ pub enum UniversalIoError {
     #[error("append to {path} rejected: appended-block limit reached, rewrite required")]
     AppendRewriteRequired { path: PathBuf },
 
+    /// A server-side multipart rewrite was rejected because a copied part
+    /// is below the store's minimum part size; the object can only be
+    /// rebuilt by uploading it whole.
+    #[error("multipart rewrite of {path} rejected: below the store's minimum part size")]
+    AppendEntityTooSmall { path: PathBuf },
+
     #[error("S3 object store error: {0}")]
     S3(#[source] Box<dyn std::error::Error + Send + Sync>),
 
@@ -164,6 +171,7 @@ impl UniversalIoError {
             | Self::Uninitialized { .. }
             | Self::QueueIsFull
             | Self::AppendRewriteRequired { .. }
+            | Self::AppendEntityTooSmall { .. }
             | Self::S3(_)
             | Self::S3Config { .. }
             | Self::UnchangedOpen { .. }
@@ -186,6 +194,30 @@ impl UniversalIoError {
             | Self::Uninitialized { .. }
             | Self::QueueIsFull
             | Self::AppendOffsetConflict { .. }
+            | Self::AppendEntityTooSmall { .. }
+            | Self::S3(_)
+            | Self::S3Config { .. }
+            | Self::UnchangedOpen { .. }
+            | Self::TaskPanicked(_) => false,
+        }
+    }
+
+    pub fn is_append_entity_too_small(&self) -> bool {
+        match self {
+            Self::AppendEntityTooSmall { .. } => true,
+            Self::Io(_)
+            | Self::Mmap(_)
+            | Self::Bincode(_)
+            | Self::BytemuckCast(_)
+            | Self::ZerocopySize(_)
+            | Self::IoUringNotSupported(_)
+            | Self::NotFound { .. }
+            | Self::OutOfBounds { .. }
+            | Self::InvalidFileIndex { .. }
+            | Self::Uninitialized { .. }
+            | Self::QueueIsFull
+            | Self::AppendOffsetConflict { .. }
+            | Self::AppendRewriteRequired { .. }
             | Self::S3(_)
             | Self::S3Config { .. }
             | Self::UnchangedOpen { .. }

--- a/lib/common/common/src/universal_io/error.rs
+++ b/lib/common/common/src/universal_io/error.rs
@@ -52,6 +52,7 @@ impl IsNotFound for UniversalIoError {
             | Self::AppendOffsetConflict { .. }
             | Self::AppendRewriteRequired { .. }
             | Self::AppendEntityTooSmall { .. }
+            | Self::AppendEtagMismatch { .. }
             | Self::S3(_)
             | Self::S3Config { .. }
             | Self::TaskPanicked(_) => false,
@@ -145,6 +146,13 @@ pub enum UniversalIoError {
     #[error("multipart rewrite of {path} rejected: below the store's minimum part size")]
     AppendEntityTooSmall { path: PathBuf },
 
+    /// The append was rejected because the object's entity tag no longer
+    /// matches the one the caller last observed: the object was replaced
+    /// behind the caller's back, which the end-of-file offset check alone
+    /// cannot detect when the lengths happen to coincide.
+    #[error("append to {path} rejected: entity tag mismatch, the object was replaced")]
+    AppendEtagMismatch { path: PathBuf },
+
     #[error("S3 object store error: {0}")]
     S3(#[source] Box<dyn std::error::Error + Send + Sync>),
 
@@ -172,6 +180,7 @@ impl UniversalIoError {
             | Self::QueueIsFull
             | Self::AppendRewriteRequired { .. }
             | Self::AppendEntityTooSmall { .. }
+            | Self::AppendEtagMismatch { .. }
             | Self::S3(_)
             | Self::S3Config { .. }
             | Self::UnchangedOpen { .. }
@@ -195,6 +204,7 @@ impl UniversalIoError {
             | Self::QueueIsFull
             | Self::AppendOffsetConflict { .. }
             | Self::AppendEntityTooSmall { .. }
+            | Self::AppendEtagMismatch { .. }
             | Self::S3(_)
             | Self::S3Config { .. }
             | Self::UnchangedOpen { .. }
@@ -218,6 +228,7 @@ impl UniversalIoError {
             | Self::QueueIsFull
             | Self::AppendOffsetConflict { .. }
             | Self::AppendRewriteRequired { .. }
+            | Self::AppendEtagMismatch { .. }
             | Self::S3(_)
             | Self::S3Config { .. }
             | Self::UnchangedOpen { .. }

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -125,6 +125,10 @@ impl OpenExtra for IoUringOpenExtra {
     fn with_known_len(self, _known_len: u64) -> Self {
         self
     }
+
+    fn with_known_etag(self, _known_etag: Option<String>) -> Self {
+        self
+    }
 }
 
 impl UniversalReadFs for IoUringFs {

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
@@ -54,6 +54,11 @@ where
     pub(super) state: Mutex<State<R>>,
     /// Fast-path gate: `true` when `state` is [`State::Ready`].
     pub(super) is_ready: AtomicBool,
+    /// Entity tag of the remote object, as last known: seeded from the open
+    /// extras, refreshed by [`schedule_reopen`] and [`set_etag`](Self::set_etag).
+    ///
+    /// [`schedule_reopen`]: UniversalRead::schedule_reopen
+    etag: Mutex<Option<String>>,
 }
 
 /// The lifecycle of a [`DiskCache`]'s local mirror, from "not yet materialized"
@@ -165,6 +170,7 @@ where
         local_path: PathBuf,
         options: OpenOptions,
         state: State<R>,
+        etag: Option<String>,
     ) -> Self {
         let is_ready = state.is_ready();
         Self {
@@ -175,7 +181,19 @@ where
             local_path,
             state: Mutex::new(state),
             is_ready: AtomicBool::new(is_ready),
+            etag: Mutex::new(etag),
         }
+    }
+
+    /// Entity tag of the remote object, as last known.
+    pub fn etag(&self) -> Option<String> {
+        self.etag.lock().clone()
+    }
+
+    /// Record a fresh entity tag for the remote object, e.g. after mutating
+    /// it directly on the backing storage.
+    pub fn set_etag(&self, etag: Option<String>) {
+        *self.etag.lock() = etag;
     }
 
     pub(super) fn open_remote(&self) -> UioResult<R> {

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -98,7 +98,9 @@ where
             });
         };
 
-        self.schedule_reopen_with_len(Some(file_info.size))
+        self.schedule_reopen_with_len(Some(file_info.size))?;
+        self.set_etag(file_info.etag);
+        Ok(())
     }
 
     /// Body of [`UniversalRead::schedule_reopen`].

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -101,6 +101,12 @@ where
 }
 
 impl<R: UniversalRead> DiskCacheFs<R> {
+    /// Wrap an already-built remote filesystem handle. The config-driven
+    /// path is [`UniversalReadFileOps::from_context`].
+    pub fn new(config: Arc<DiskCacheConfig>, remote_fs: R::Fs) -> Self {
+        Self { config, remote_fs }
+    }
+
     fn open_remote(
         &self,
         path: impl AsRef<Path>,

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -30,6 +30,8 @@ pub struct DiskCacheFsOpenExtra<RemoteExtra: OpenExtra> {
     remote_extra: RemoteExtra,
     /// The length of the file, if known
     known_len: Option<u64>,
+    /// Entity tag of the remote object, if known
+    known_etag: Option<String>,
 }
 
 impl<RemoteExtra: OpenExtra> OpenExtra for DiskCacheFsOpenExtra<RemoteExtra> {
@@ -41,6 +43,15 @@ impl<RemoteExtra: OpenExtra> OpenExtra for DiskCacheFsOpenExtra<RemoteExtra> {
         Self {
             remote_extra: self.remote_extra,
             known_len: Some(known_len),
+            known_etag: self.known_etag,
+        }
+    }
+
+    fn with_known_etag(self, known_etag: Option<String>) -> Self {
+        Self {
+            remote_extra: self.remote_extra,
+            known_len: self.known_len,
+            known_etag,
         }
     }
 }
@@ -245,6 +256,7 @@ where
             local_path,
             options,
             state,
+            extra.known_etag,
         );
 
         if matches!(populate, Populate::Blocking) {

--- a/lib/common/common/src/universal_io/traits/open_extra.rs
+++ b/lib/common/common/src/universal_io/traits/open_extra.rs
@@ -18,10 +18,18 @@ pub trait OpenExtra: Default + Debug {
 
     /// Hint about the length of the file.
     fn with_known_len(self, known_len: u64) -> Self;
+
+    /// Hint about the entity tag of the remote object, when the backend
+    /// exposes one (object stores). Backends without etags treat this as a
+    /// no-op.
+    #[must_use]
+    fn with_known_etag(self, known_etag: Option<String>) -> Self;
 }
 
 impl OpenExtra for () {
     fn with_prevent_caching(self, _prevent_caching: bool) -> Self {}
 
     fn with_known_len(self, _known_len: u64) -> Self {}
+
+    fn with_known_etag(self, _known_etag: Option<String>) -> Self {}
 }

--- a/lib/common/common/src/universal_io/types.rs
+++ b/lib/common/common/src/universal_io/types.rs
@@ -15,6 +15,11 @@ pub enum UniversalKind {
     IoUring,
     DiskCache,
     SimpleDiskCache,
+    /// Combined remote-blob + local-mirror handle with locally-buffered
+    /// appends (`io_bridge`'s `CachedBlobFile`). Reads are served like
+    /// [`SimpleDiskCache`](Self::SimpleDiskCache); appends become remotely
+    /// durable only when the flusher runs.
+    CachedBlob,
     S3,
     Gcs,
     Azure,
@@ -29,7 +34,9 @@ impl UniversalKind {
     /// or a remote object store.
     pub fn is_in_ram_or_mmap(self) -> bool {
         match self {
-            UniversalKind::Mmap | UniversalKind::SimpleDiskCache => true,
+            UniversalKind::Mmap | UniversalKind::SimpleDiskCache | UniversalKind::CachedBlob => {
+                true
+            }
             UniversalKind::IoUring
             | UniversalKind::DiskCache
             | UniversalKind::S3
@@ -45,6 +52,7 @@ impl UniversalKind {
             UniversalKind::IoUring
             | UniversalKind::DiskCache
             | UniversalKind::SimpleDiskCache
+            | UniversalKind::CachedBlob
             | UniversalKind::S3
             | UniversalKind::Gcs
             | UniversalKind::Azure

--- a/lib/common/io_bridge/src/cached/fs.rs
+++ b/lib/common/io_bridge/src/cached/fs.rs
@@ -8,18 +8,17 @@ use common::universal_io::{
     UniversalReadFileOps, UniversalReadFs, UniversalWriteFileOps,
 };
 
-use super::{AppendMode, CachedBlobFile};
+use super::CachedBlobFile;
 use crate::file::BlobFile;
 use crate::fs::BlobFs;
 use crate::read::AsyncRead;
 use crate::write::AsyncAppend;
 
-/// Construction context for [`CachedBlobFs`]: the local-mirror layout, the
-/// remote backend's own construction config, and the append strategy.
+/// Construction context for [`CachedBlobFs`]: the local-mirror layout and
+/// the remote backend's own construction config.
 pub struct CachedBlobFsContext<C> {
     pub disk_cache: Arc<DiskCacheConfig>,
     pub remote: C,
-    pub append_mode: AppendMode,
 }
 
 /// Filesystem handle for [`CachedBlobFile`]: a [`DiskCacheFs`] for the
@@ -32,20 +31,14 @@ pub struct CachedBlobFsContext<C> {
 pub struct CachedBlobFs<A: AsyncRead + Clone> {
     cache_fs: DiskCacheFs<BlobFile<A>>,
     blob_fs: BlobFs<A>,
-    mode: AppendMode,
 }
 
 impl<A: AsyncRead + Clone> std::fmt::Debug for CachedBlobFs<A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self {
-            cache_fs,
-            blob_fs,
-            mode,
-        } = self;
+        let Self { cache_fs, blob_fs } = self;
         f.debug_struct("CachedBlobFs")
             .field("cache_fs", cache_fs)
             .field("blob_fs", blob_fs)
-            .field("mode", mode)
             .finish()
     }
 }
@@ -57,11 +50,7 @@ where
     type ContextConfig = CachedBlobFsContext<A::Config>;
 
     fn from_context(context: Self::ContextConfig) -> UioResult<Self> {
-        let CachedBlobFsContext {
-            disk_cache,
-            remote,
-            append_mode,
-        } = context;
+        let CachedBlobFsContext { disk_cache, remote } = context;
 
         let blob_fs = BlobFs::<A>::from_context(remote.clone())?;
         let cache_fs = DiskCacheFs::from_context(DiskCacheFsContext {
@@ -69,11 +58,7 @@ where
             remote,
         })?;
 
-        Ok(Self {
-            cache_fs,
-            blob_fs,
-            mode: append_mode,
-        })
+        Ok(Self { cache_fs, blob_fs })
     }
 
     fn list_files(&self, prefix_path: &Path) -> UioResult<Vec<ListedFile>> {
@@ -108,12 +93,7 @@ where
 
         let remote = self.blob_fs.open(path.as_ref(), options, ())?;
 
-        Ok(CachedBlobFile::new(
-            cache,
-            remote,
-            self.mode,
-            options.writeable,
-        ))
+        Ok(CachedBlobFile::new(cache, remote, options.writeable))
     }
 }
 

--- a/lib/common/io_bridge/src/cached/fs.rs
+++ b/lib/common/io_bridge/src/cached/fs.rs
@@ -12,6 +12,7 @@ use super::CachedBlobFile;
 use crate::file::BlobFile;
 use crate::fs::BlobFs;
 use crate::read::AsyncRead;
+use crate::runtime::BridgeRuntime;
 use crate::write::AsyncAppend;
 
 /// Construction context for [`CachedBlobFs`]: the local-mirror layout and
@@ -31,6 +32,18 @@ pub struct CachedBlobFsContext<C> {
 pub struct CachedBlobFs<A: AsyncRead + Clone> {
     cache_fs: DiskCacheFs<BlobFile<A>>,
     blob_fs: BlobFs<A>,
+}
+
+impl<A: AsyncRead + Clone> CachedBlobFs<A> {
+    /// Build both halves around one shared backend handle — unlike
+    /// [`from_context`](UniversalReadFileOps::from_context), which
+    /// constructs each half's backend from the config.
+    pub fn new(remote: A, runtime: BridgeRuntime, disk_cache: Arc<DiskCacheConfig>) -> Self {
+        Self {
+            cache_fs: DiskCacheFs::new(disk_cache, BlobFs::new(remote.clone(), runtime.clone())),
+            blob_fs: BlobFs::new(remote, runtime),
+        }
+    }
 }
 
 impl<A: AsyncRead + Clone> std::fmt::Debug for CachedBlobFs<A> {
@@ -104,23 +117,25 @@ where
     type AppendFile = CachedBlobFile<A>;
 
     // Mutating file ops go straight to the remote.
-    // TODO: delegate to inherent `BlobFs` ops once `BlobFs` loses its
-    // `UniversalWriteFileOps` impl to `CachedBlobFs`.
 
-    fn create(&self, path: &Path, expected_length: usize) -> UioResult<()> {
-        self.blob_fs.create(path, expected_length)
+    fn create(&self, path: &Path, _expected_length: usize) -> UioResult<()> {
+        // Object stores have no fixed-size preallocation; the expected
+        // length is ignored, as the trait allows.
+        self.blob_fs.create(path)
     }
 
-    fn create_dir(&self, path: &Path) -> UioResult<()> {
-        self.blob_fs.create_dir(path)
+    fn create_dir(&self, _path: &Path) -> UioResult<()> {
+        // No materialized directories.
+        Ok(())
     }
 
     fn remove(&self, path: &Path) -> UioResult<()> {
         self.blob_fs.remove(path)
     }
 
-    fn remove_dir(&self, path: &Path) -> UioResult<()> {
-        self.blob_fs.remove_dir(path)
+    fn remove_dir(&self, _path: &Path) -> UioResult<()> {
+        // No materialized directories.
+        Ok(())
     }
 
     fn atomic_save(&self, path: &Path, bytes: &[u8]) -> UioResult<()> {

--- a/lib/common/io_bridge/src/cached/fs.rs
+++ b/lib/common/io_bridge/src/cached/fs.rs
@@ -1,0 +1,157 @@
+//! Filesystem handle producing [`CachedBlobFile`]s.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use common::universal_io::{
+    DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, ListedFile, OpenOptions, UioResult,
+    UniversalReadFileOps, UniversalReadFs, UniversalWriteFileOps,
+};
+
+use super::{AppendMode, CachedBlobFile};
+use crate::file::BlobFile;
+use crate::fs::BlobFs;
+use crate::read::AsyncRead;
+use crate::write::AsyncAppend;
+
+/// Construction context for [`CachedBlobFs`]: the local-mirror layout, the
+/// remote backend's own construction config, and the append strategy.
+pub struct CachedBlobFsContext<C> {
+    pub disk_cache: Arc<DiskCacheConfig>,
+    pub remote: C,
+    pub append_mode: AppendMode,
+}
+
+/// Filesystem handle for [`CachedBlobFile`]: a [`DiskCacheFs`] for the
+/// read-through mirrors plus a [`BlobFs`] for direct remote operations
+/// (metadata, create/remove/atomic_save, and the append handles' remote side).
+///
+/// Unlike [`DiskCacheFs`], `open` accepts `writeable: true`: the mirror itself
+/// stays read-only, and the writeable half lives in the combined handle.
+#[derive(Clone)]
+pub struct CachedBlobFs<A: AsyncRead + Clone> {
+    cache_fs: DiskCacheFs<BlobFile<A>>,
+    blob_fs: BlobFs<A>,
+    mode: AppendMode,
+}
+
+impl<A: AsyncRead + Clone> std::fmt::Debug for CachedBlobFs<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            cache_fs,
+            blob_fs,
+            mode,
+        } = self;
+        f.debug_struct("CachedBlobFs")
+            .field("cache_fs", cache_fs)
+            .field("blob_fs", blob_fs)
+            .field("mode", mode)
+            .finish()
+    }
+}
+
+impl<A: AsyncRead + Clone> UniversalReadFileOps for CachedBlobFs<A>
+where
+    A::Config: Clone,
+{
+    type ContextConfig = CachedBlobFsContext<A::Config>;
+
+    fn from_context(context: Self::ContextConfig) -> UioResult<Self> {
+        let CachedBlobFsContext {
+            disk_cache,
+            remote,
+            append_mode,
+        } = context;
+
+        let blob_fs = BlobFs::<A>::from_context(remote.clone())?;
+        let cache_fs = DiskCacheFs::from_context(DiskCacheFsContext {
+            config: disk_cache,
+            remote,
+        })?;
+
+        Ok(Self {
+            cache_fs,
+            blob_fs,
+            mode: append_mode,
+        })
+    }
+
+    fn list_files(&self, prefix_path: &Path) -> UioResult<Vec<ListedFile>> {
+        // The remote is the source of truth; mirrors are ephemeral.
+        self.blob_fs.list_files(prefix_path)
+    }
+
+    fn exists(&self, path: &Path) -> UioResult<bool> {
+        self.blob_fs.exists(path)
+    }
+}
+
+impl<A: AsyncAppend + Clone> UniversalReadFs for CachedBlobFs<A>
+where
+    A::Config: Clone,
+{
+    type File = CachedBlobFile<A>;
+    type OpenExtra = <DiskCacheFs<BlobFile<A>> as UniversalReadFs>::OpenExtra;
+
+    fn open(
+        &self,
+        path: impl AsRef<Path>,
+        options: OpenOptions,
+        extra: Self::OpenExtra,
+    ) -> UioResult<Self::File> {
+        // The mirror is always opened read-only — appends are buffered in the
+        // combined handle and synced by its flusher — so `writeable` gates
+        // only the remote half.
+        let mut cache_options = options;
+        cache_options.writeable = false;
+        let cache = self.cache_fs.open(path.as_ref(), cache_options, extra)?;
+
+        let remote = self.blob_fs.open(path.as_ref(), options, ())?;
+
+        Ok(CachedBlobFile::new(
+            cache,
+            remote,
+            self.mode,
+            options.writeable,
+        ))
+    }
+}
+
+impl<A: AsyncAppend + Clone> UniversalWriteFileOps for CachedBlobFs<A>
+where
+    A::Config: Clone,
+{
+    type AppendFile = CachedBlobFile<A>;
+
+    // Mutating file ops go straight to the remote.
+    // TODO: delegate to inherent `BlobFs` ops once `BlobFs` loses its
+    // `UniversalWriteFileOps` impl to `CachedBlobFs`.
+
+    fn create(&self, path: &Path, expected_length: usize) -> UioResult<()> {
+        self.blob_fs.create(path, expected_length)
+    }
+
+    fn create_dir(&self, path: &Path) -> UioResult<()> {
+        self.blob_fs.create_dir(path)
+    }
+
+    fn remove(&self, path: &Path) -> UioResult<()> {
+        self.blob_fs.remove(path)
+    }
+
+    fn remove_dir(&self, path: &Path) -> UioResult<()> {
+        self.blob_fs.remove_dir(path)
+    }
+
+    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> UioResult<()> {
+        self.blob_fs.atomic_save(path, bytes)
+    }
+
+    fn open_append(
+        &self,
+        path: impl AsRef<Path>,
+        options: OpenOptions,
+    ) -> UioResult<Self::AppendFile> {
+        self.open(path, options.for_append(), Default::default())
+    }
+}

--- a/lib/common/io_bridge/src/cached/mod.rs
+++ b/lib/common/io_bridge/src/cached/mod.rs
@@ -85,24 +85,22 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
             )));
         }
 
+        let new_len = offset + data.len() as u64;
+
         match self.remote.source().append_support() {
             AppendSupport::Always => {
-                // TODO: switch to the inherent `BlobFile::append_native`
-                // once the specialized remote ops land and `BlobFile`
-                // loses its `UniversalAppend` impl.
-                self.remote.append(offset, data.as_ref())?;
+                self.remote.append_bytes(offset, data, self.cache.etag())?;
             }
             AppendSupport::AboveThreshold { min_offset } => {
                 if offset >= min_offset {
-                    self.remote.append(offset, data.as_ref())?;
+                    self.remote.append_bytes(offset, data, self.cache.etag())?;
                 } else {
-                    self.local_rewrite(offset, data.clone())?;
+                    self.local_rewrite(offset, data)?;
                 }
             }
-            AppendSupport::Never => self.local_rewrite(offset, data.clone())?,
+            AppendSupport::Never => self.local_rewrite(offset, data)?,
         }
 
-        let new_len = offset + data.len() as u64;
         self.cache.schedule_reopen(|_| {
             Some(FileInfo {
                 size: new_len,

--- a/lib/common/io_bridge/src/cached/mod.rs
+++ b/lib/common/io_bridge/src/cached/mod.rs
@@ -6,7 +6,8 @@
 //! pairs the two: reads are served through the lazily-populated local mirror,
 //! while [`UniversalAppend::append`] performs the remote mutation
 //! immediately — a native write-offset append, or a whole-object rewrite for
-//! stores without native append (see [`AppendMode`]).
+//! stores without native append, per the backend's advertised
+//! [`AppendMethod`].
 //!
 //! Appends are durable once the remote acknowledges them, like raw
 //! [`BlobFile`] appends (the flusher is a no-op); callers batch upstream, so
@@ -33,38 +34,19 @@ pub use pipeline::CachedBlobReadPipeline;
 
 use crate::file::BlobFile;
 use crate::read::AsyncRead;
-use crate::write::AsyncAppend;
+use crate::write::{AppendMethod, AppendRequest, AsyncAppend};
 
 /// Minimum remote-prefix size worth a server-side multipart copy; below it a
 /// whole-object PUT re-uploads the prefix instead. Mirrors the S3 5 MiB
 /// minimum for non-last multipart parts.
-// TODO: move to `AsyncRewrite::MIN_COPY_PREFIX` once the backend trait lands.
 const MIN_COPY_PREFIX: u64 = 5 * 1024 * 1024;
-
-/// How an append is performed on the remote.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum AppendMode {
-    /// The store supports native write-offset appends (S3 Express One Zone,
-    /// MinIO AiStor). `soft_limit` rewrites the whole object instead after
-    /// that many native appends, staying clear of the store's cap on appended
-    /// blocks per object; `None` relies on the reactive fallback alone.
-    Native { soft_limit: Option<u32> },
-    /// No native append (plain S3): every append rewrites the object — a
-    /// whole PUT while it is small, a server-side copy of the remote prefix
-    /// once it is large enough.
-    Rewrite,
-}
 
 /// A remote object handle that reads through a local [`DiskCache`] mirror and
 /// appends straight to the remote. See the module docs.
 pub struct CachedBlobFile<A: AsyncRead + Clone> {
     cache: DiskCache<BlobFile<A>>,
     remote: BlobFile<A>,
-    mode: AppendMode,
     writeable: bool,
-    /// Native appends since the last whole-object write, driving
-    /// [`AppendMode::Native`]'s `soft_limit`.
-    native_appends: u32,
 }
 
 impl<A: AsyncRead + Clone> std::fmt::Debug for CachedBlobFile<A> {
@@ -72,33 +54,22 @@ impl<A: AsyncRead + Clone> std::fmt::Debug for CachedBlobFile<A> {
         let Self {
             cache,
             remote,
-            mode,
             writeable,
-            native_appends,
         } = self;
         f.debug_struct("CachedBlobFile")
             .field("cache", cache)
             .field("remote", remote)
-            .field("mode", mode)
             .field("writeable", writeable)
-            .field("native_appends", native_appends)
             .finish()
     }
 }
 
 impl<A: AsyncRead + Clone> CachedBlobFile<A> {
-    pub(crate) fn new(
-        cache: DiskCache<BlobFile<A>>,
-        remote: BlobFile<A>,
-        mode: AppendMode,
-        writeable: bool,
-    ) -> Self {
+    pub(crate) fn new(cache: DiskCache<BlobFile<A>>, remote: BlobFile<A>, writeable: bool) -> Self {
         Self {
             cache,
             remote,
-            mode,
             writeable,
-            native_appends: 0,
         }
     }
 }
@@ -119,22 +90,22 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
             )));
         }
 
-        match self.mode {
-            AppendMode::Native { soft_limit } => {
-                if soft_limit.is_some_and(|limit| self.native_appends >= limit) {
-                    self.rewrite(offset, &data)?;
-                } else {
-                    // TODO: switch to the inherent `BlobFile::append_native`
-                    // once the specialized remote ops land and `BlobFile`
-                    // loses its `UniversalAppend` impl.
-                    match self.remote.append(offset, data.as_ref()) {
-                        Ok(()) => self.native_appends += 1,
-                        Err(err) if err_requires_rewrite(&err) => self.rewrite(offset, &data)?,
-                        Err(err) => return Err(err),
+        match self.remote.source().supported_append() {
+            AppendMethod::Native => {
+                // TODO: switch to the inherent `BlobFile::append_native`
+                // once the specialized remote ops land and `BlobFile`
+                // loses its `UniversalAppend` impl.
+                match self.remote.append(offset, data.as_ref()) {
+                    Ok(()) => {}
+                    // The object hit the store's appended-block cap; the
+                    // rewrite resets it to a single block.
+                    Err(err) if err.is_append_rewrite_required() => {
+                        self.rewrite(offset, data.clone())?;
                     }
+                    Err(err) => return Err(err),
                 }
             }
-            AppendMode::Rewrite => self.rewrite(offset, &data)?,
+            AppendMethod::PartialUpload => self.rewrite(offset, data.clone())?,
         }
 
         let new_len = offset + data.len() as u64;
@@ -153,7 +124,7 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
     /// The remote offers no compare-and-swap here, so `offset` is validated
     /// against the mirror length — this handle's view of the remote EOF,
     /// kept in step after every append (single-writer contract).
-    fn rewrite(&mut self, offset: ByteOffset, data: &[u8]) -> UioResult<()> {
+    fn rewrite(&self, offset: ByteOffset, data: Bytes) -> UioResult<()> {
         let local_len = self.cache.len::<u8>()?;
         if offset != local_len {
             return Err(UniversalIoError::AppendOffsetConflict {
@@ -163,21 +134,23 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
         }
 
         if offset == 0 {
-            self.save_whole(Bytes::copy_from_slice(data))?;
+            self.save_whole(data)?;
         } else if offset >= MIN_COPY_PREFIX {
             // Server-side copy of the remote prefix, `data` as the final part.
-            todo!("multipart rewrite with UploadPartCopy (AsyncRewrite backend capability)")
+            self.remote.runtime().block_on(self.remote.source().append(
+                self.remote.path(),
+                AppendRequest::PartialUpload { offset, data },
+            ))?;
         } else {
             // The prefix is small by construction; read it through the cache
             // (served locally once mirrored).
             let prefix = self.cache.read_bytes(0..offset, Sequential, 1)?;
             let mut whole = Vec::with_capacity(prefix.len() + data.len());
             whole.extend_from_slice(&prefix);
-            whole.extend_from_slice(data);
+            whole.extend_from_slice(&data);
             self.save_whole(Bytes::from(whole))?;
         }
 
-        self.native_appends = 0;
         Ok(())
     }
 
@@ -189,14 +162,6 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
             .runtime()
             .block_on(self.remote.source().save(self.remote.path(), data))
     }
-}
-
-/// Whether a native-append failure means the store demands a full rewrite
-/// (append-block limit exceeded, or write-offset appends unsupported).
-// TODO: classify once `UniversalIoError::AppendRewriteRequired` exists; until
-// then only the proactive `soft_limit` triggers rewrites in `Native` mode.
-fn err_requires_rewrite(_err: &UniversalIoError) -> bool {
-    false
 }
 
 impl<A: AsyncAppend + Clone> UniversalRead for CachedBlobFile<A>

--- a/lib/common/io_bridge/src/cached/mod.rs
+++ b/lib/common/io_bridge/src/cached/mod.rs
@@ -11,10 +11,10 @@
 //!
 //! Appends are durable once the remote acknowledges them, like raw
 //! [`BlobFile`] appends (the flusher is a no-op); callers batch upstream, so
-//! one `append` call is one remote mutation. The mirror's length is advanced
-//! in the same call without extra IO, so this handle's `len`/reads observe
-//! the appended bytes right away; the appended blocks themselves fault in
-//! from the remote on first read.
+//! one `append` call is one remote append operation. The mirror's length is
+//! advanced in the same call without extra IO, so this handle's `len`/reads
+//! observe the appended bytes right away; the appended blocks themselves
+//! fault in from the remote on first read.
 
 mod fs;
 mod pipeline;
@@ -34,7 +34,7 @@ pub use pipeline::CachedBlobReadPipeline;
 
 use crate::file::BlobFile;
 use crate::read::AsyncRead;
-use crate::write::{AppendRequest, AppendSupport, AsyncAppend};
+use crate::write::{AppendSupport, AsyncAppend};
 
 /// A remote object handle that reads through a local [`DiskCache`] mirror and
 /// appends straight to the remote. See the module docs.
@@ -70,9 +70,9 @@ impl<A: AsyncRead + Clone> CachedBlobFile<A> {
 }
 
 impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
-    /// One remote mutation per call: native append or rewrite, then advance
-    /// the mirror to the new length without extra IO (a successful append
-    /// proves `offset` was the remote EOF).
+    /// One remote append operation per call: direct append or whole-object
+    /// rewrite, then advance the mirror to the new length without extra IO
+    /// (a successful append proves `offset` was the remote EOF).
     fn append_bytes(&mut self, offset: ByteOffset, data: Bytes) -> UioResult<()> {
         if data.is_empty() {
             return Ok(());
@@ -90,15 +90,7 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
                 // TODO: switch to the inherent `BlobFile::append_native`
                 // once the specialized remote ops land and `BlobFile`
                 // loses its `UniversalAppend` impl.
-                match self.remote.append(offset, data.as_ref()) {
-                    Ok(()) => {}
-                    // The object hit the store's appended-block cap; the
-                    // rewrite resets it to a single block.
-                    Err(err) if err.is_append_rewrite_required() => {
-                        self.remote_rewrite(offset, data.clone())?;
-                    }
-                    Err(err) => return Err(err),
-                }
+                self.remote.append(offset, data.as_ref())?;
             }
             AppendSupport::AboveThreshold { min_offset } => {
                 if offset >= min_offset {
@@ -119,20 +111,6 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
             })
         })?;
         self.cache.reopen()
-    }
-
-    /// Append `data` while rebuilding the remote object as a single blob —
-    /// the appended-block cap recovery under [`AppendSupport::Always`].
-    fn remote_rewrite(&self, offset: ByteOffset, data: Bytes) -> UioResult<()> {
-        self.check_offset(offset)?;
-        self.remote
-            .runtime()
-            .block_on(
-                self.remote
-                    .source()
-                    .append(self.remote.path(), AppendRequest::Rewrite { offset, data }),
-            )
-            .map(drop)
     }
 
     /// Replace the whole remote object with `[0, offset) + data`, built on

--- a/lib/common/io_bridge/src/cached/mod.rs
+++ b/lib/common/io_bridge/src/cached/mod.rs
@@ -5,9 +5,9 @@
 //! append, and [`DiskCache`] alone is strictly read-only. [`CachedBlobFile`]
 //! pairs the two: reads are served through the lazily-populated local mirror,
 //! while [`UniversalAppend::append`] performs the remote mutation
-//! immediately — a native write-offset append, or a whole-object rewrite for
-//! stores without native append, per the backend's advertised
-//! [`AppendMethod`].
+//! immediately — a direct append, or a whole-object rewrite when the
+//! backend's advertised [`AppendSupport`] leaves the caller to build the
+//! object itself.
 //!
 //! Appends are durable once the remote acknowledges them, like raw
 //! [`BlobFile`] appends (the flusher is a no-op); callers batch upstream, so
@@ -34,12 +34,7 @@ pub use pipeline::CachedBlobReadPipeline;
 
 use crate::file::BlobFile;
 use crate::read::AsyncRead;
-use crate::write::{AppendMethod, AppendRequest, AsyncAppend};
-
-/// Minimum remote-prefix size worth a server-side multipart copy; below it a
-/// whole-object PUT re-uploads the prefix instead. Mirrors the S3 5 MiB
-/// minimum for non-last multipart parts.
-const MIN_COPY_PREFIX: u64 = 5 * 1024 * 1024;
+use crate::write::{AppendRequest, AppendSupport, AsyncAppend};
 
 /// A remote object handle that reads through a local [`DiskCache`] mirror and
 /// appends straight to the remote. See the module docs.
@@ -90,8 +85,8 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
             )));
         }
 
-        match self.remote.source().supported_append() {
-            AppendMethod::Native => {
+        match self.remote.source().append_support() {
+            AppendSupport::Always => {
                 // TODO: switch to the inherent `BlobFile::append_native`
                 // once the specialized remote ops land and `BlobFile`
                 // loses its `UniversalAppend` impl.
@@ -100,12 +95,19 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
                     // The object hit the store's appended-block cap; the
                     // rewrite resets it to a single block.
                     Err(err) if err.is_append_rewrite_required() => {
-                        self.rewrite(offset, data.clone())?;
+                        self.remote_rewrite(offset, data.clone())?;
                     }
                     Err(err) => return Err(err),
                 }
             }
-            AppendMethod::PartialUpload => self.rewrite(offset, data.clone())?,
+            AppendSupport::AboveThreshold { min_offset } => {
+                if offset >= min_offset {
+                    self.remote.append(offset, data.as_ref())?;
+                } else {
+                    self.local_rewrite(offset, data.clone())?;
+                }
+            }
+            AppendSupport::Never => self.local_rewrite(offset, data.clone())?,
         }
 
         let new_len = offset + data.len() as u64;
@@ -119,12 +121,43 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
         self.cache.reopen()
     }
 
-    /// Replace the whole remote object with `[0, offset) + data`.
-    ///
-    /// The remote offers no compare-and-swap here, so `offset` is validated
-    /// against the mirror length — this handle's view of the remote EOF,
-    /// kept in step after every append (single-writer contract).
-    fn rewrite(&self, offset: ByteOffset, data: Bytes) -> UioResult<()> {
+    /// Append `data` while rebuilding the remote object as a single blob —
+    /// the appended-block cap recovery under [`AppendSupport::Always`].
+    fn remote_rewrite(&self, offset: ByteOffset, data: Bytes) -> UioResult<()> {
+        self.check_offset(offset)?;
+        self.remote
+            .runtime()
+            .block_on(
+                self.remote
+                    .source()
+                    .append(self.remote.path(), AppendRequest::Rewrite { offset, data }),
+            )
+            .map(drop)
+    }
+
+    /// Replace the whole remote object with `[0, offset) + data`, built on
+    /// this side — for stores (or object sizes) without direct appends.
+    fn local_rewrite(&self, offset: ByteOffset, data: Bytes) -> UioResult<()> {
+        self.check_offset(offset)?;
+
+        if offset == 0 {
+            self.save_whole(data)
+        } else {
+            // The prefix is small by construction (below the direct-append
+            // threshold); read it through the cache (served locally once
+            // mirrored).
+            let prefix = self.cache.read_bytes(0..offset, Sequential, 1)?;
+            let mut whole = Vec::with_capacity(prefix.len() + data.len());
+            whole.extend_from_slice(&prefix);
+            whole.extend_from_slice(&data);
+            self.save_whole(Bytes::from(whole))
+        }
+    }
+
+    /// The rewrites offer no backend compare-and-swap, so `offset` is
+    /// validated against the mirror length — this handle's view of the
+    /// remote EOF, kept in step after every append (single-writer contract).
+    fn check_offset(&self, offset: ByteOffset) -> UioResult<()> {
         let local_len = self.cache.len::<u8>()?;
         if offset != local_len {
             return Err(UniversalIoError::AppendOffsetConflict {
@@ -132,25 +165,6 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
                 offset,
             });
         }
-
-        if offset == 0 {
-            self.save_whole(data)?;
-        } else if offset >= MIN_COPY_PREFIX {
-            // Server-side copy of the remote prefix, `data` as the final part.
-            self.remote.runtime().block_on(self.remote.source().append(
-                self.remote.path(),
-                AppendRequest::PartialUpload { offset, data },
-            ))?;
-        } else {
-            // The prefix is small by construction; read it through the cache
-            // (served locally once mirrored).
-            let prefix = self.cache.read_bytes(0..offset, Sequential, 1)?;
-            let mut whole = Vec::with_capacity(prefix.len() + data.len());
-            whole.extend_from_slice(&prefix);
-            whole.extend_from_slice(&data);
-            self.save_whole(Bytes::from(whole))?;
-        }
-
         Ok(())
     }
 

--- a/lib/common/io_bridge/src/cached/mod.rs
+++ b/lib/common/io_bridge/src/cached/mod.rs
@@ -1,0 +1,293 @@
+//! Combined remote-blob + local-cache file: the append-capable universal-IO
+//! citizen for object stores.
+//!
+//! [`BlobFile`] alone can only append on backends with a native write-offset
+//! append, and [`DiskCache`] alone is strictly read-only. [`CachedBlobFile`]
+//! pairs the two: reads are served through the lazily-populated local mirror,
+//! while [`UniversalAppend::append`] performs the remote mutation
+//! immediately — a native write-offset append, or a whole-object rewrite for
+//! stores without native append (see [`AppendMode`]).
+//!
+//! Appends are durable once the remote acknowledges them, like raw
+//! [`BlobFile`] appends (the flusher is a no-op); callers batch upstream, so
+//! one `append` call is one remote mutation. The mirror's length is advanced
+//! in the same call without extra IO, so this handle's `len`/reads observe
+//! the appended bytes right away; the appended blocks themselves fault in
+//! from the remote on first read.
+
+mod fs;
+mod pipeline;
+
+use std::ops::Range;
+use std::path::Path;
+
+use bytes::Bytes;
+use common::ext::aligned_vec::ACow;
+use common::generic_consts::{AccessPattern, Sequential};
+use common::universal_io::{
+    ByteOffset, DiskCache, FileInfo, Flusher, UioResult, UniversalAppend, UniversalFlush,
+    UniversalIoError, UniversalKind, UniversalRead, UserData,
+};
+pub use fs::{CachedBlobFs, CachedBlobFsContext};
+pub use pipeline::CachedBlobReadPipeline;
+
+use crate::file::BlobFile;
+use crate::read::AsyncRead;
+use crate::write::AsyncAppend;
+
+/// Minimum remote-prefix size worth a server-side multipart copy; below it a
+/// whole-object PUT re-uploads the prefix instead. Mirrors the S3 5 MiB
+/// minimum for non-last multipart parts.
+// TODO: move to `AsyncRewrite::MIN_COPY_PREFIX` once the backend trait lands.
+const MIN_COPY_PREFIX: u64 = 5 * 1024 * 1024;
+
+/// How an append is performed on the remote.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AppendMode {
+    /// The store supports native write-offset appends (S3 Express One Zone,
+    /// MinIO AiStor). `soft_limit` rewrites the whole object instead after
+    /// that many native appends, staying clear of the store's cap on appended
+    /// blocks per object; `None` relies on the reactive fallback alone.
+    Native { soft_limit: Option<u32> },
+    /// No native append (plain S3): every append rewrites the object — a
+    /// whole PUT while it is small, a server-side copy of the remote prefix
+    /// once it is large enough.
+    Rewrite,
+}
+
+/// A remote object handle that reads through a local [`DiskCache`] mirror and
+/// appends straight to the remote. See the module docs.
+pub struct CachedBlobFile<A: AsyncRead + Clone> {
+    cache: DiskCache<BlobFile<A>>,
+    remote: BlobFile<A>,
+    mode: AppendMode,
+    writeable: bool,
+    /// Native appends since the last whole-object write, driving
+    /// [`AppendMode::Native`]'s `soft_limit`.
+    native_appends: u32,
+}
+
+impl<A: AsyncRead + Clone> std::fmt::Debug for CachedBlobFile<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            cache,
+            remote,
+            mode,
+            writeable,
+            native_appends,
+        } = self;
+        f.debug_struct("CachedBlobFile")
+            .field("cache", cache)
+            .field("remote", remote)
+            .field("mode", mode)
+            .field("writeable", writeable)
+            .field("native_appends", native_appends)
+            .finish()
+    }
+}
+
+impl<A: AsyncRead + Clone> CachedBlobFile<A> {
+    pub(crate) fn new(
+        cache: DiskCache<BlobFile<A>>,
+        remote: BlobFile<A>,
+        mode: AppendMode,
+        writeable: bool,
+    ) -> Self {
+        Self {
+            cache,
+            remote,
+            mode,
+            writeable,
+            native_appends: 0,
+        }
+    }
+}
+
+impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
+    /// One remote mutation per call: native append or rewrite, then advance
+    /// the mirror to the new length without extra IO (a successful append
+    /// proves `offset` was the remote EOF).
+    fn append_bytes(&mut self, offset: ByteOffset, data: Bytes) -> UioResult<()> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        if !self.writeable {
+            return Err(UniversalIoError::Io(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "append requires a handle opened with writeable=true",
+            )));
+        }
+
+        match self.mode {
+            AppendMode::Native { soft_limit } => {
+                if soft_limit.is_some_and(|limit| self.native_appends >= limit) {
+                    self.rewrite(offset, &data)?;
+                } else {
+                    // TODO: switch to the inherent `BlobFile::append_native`
+                    // once the specialized remote ops land and `BlobFile`
+                    // loses its `UniversalAppend` impl.
+                    match self.remote.append(offset, data.as_ref()) {
+                        Ok(()) => self.native_appends += 1,
+                        Err(err) if err_requires_rewrite(&err) => self.rewrite(offset, &data)?,
+                        Err(err) => return Err(err),
+                    }
+                }
+            }
+            AppendMode::Rewrite => self.rewrite(offset, &data)?,
+        }
+
+        let new_len = offset + data.len() as u64;
+        self.cache.schedule_reopen(|_| {
+            Some(FileInfo {
+                size: new_len,
+                last_modified: None,
+                etag: None,
+            })
+        })?;
+        self.cache.reopen()
+    }
+
+    /// Replace the whole remote object with `[0, offset) + data`.
+    ///
+    /// The remote offers no compare-and-swap here, so `offset` is validated
+    /// against the mirror length — this handle's view of the remote EOF,
+    /// kept in step after every append (single-writer contract).
+    fn rewrite(&mut self, offset: ByteOffset, data: &[u8]) -> UioResult<()> {
+        let local_len = self.cache.len::<u8>()?;
+        if offset != local_len {
+            return Err(UniversalIoError::AppendOffsetConflict {
+                path: self.remote.path().to_path_buf(),
+                offset,
+            });
+        }
+
+        if offset == 0 {
+            self.save_whole(Bytes::copy_from_slice(data))?;
+        } else if offset >= MIN_COPY_PREFIX {
+            // Server-side copy of the remote prefix, `data` as the final part.
+            todo!("multipart rewrite with UploadPartCopy (AsyncRewrite backend capability)")
+        } else {
+            // The prefix is small by construction; read it through the cache
+            // (served locally once mirrored).
+            let prefix = self.cache.read_bytes(0..offset, Sequential, 1)?;
+            let mut whole = Vec::with_capacity(prefix.len() + data.len());
+            whole.extend_from_slice(&prefix);
+            whole.extend_from_slice(data);
+            self.save_whole(Bytes::from(whole))?;
+        }
+
+        self.native_appends = 0;
+        Ok(())
+    }
+
+    /// Whole-object atomic PUT.
+    // TODO: move to an inherent `BlobFile::save_whole` alongside the other
+    // specialized remote ops.
+    fn save_whole(&self, data: Bytes) -> UioResult<()> {
+        self.remote
+            .runtime()
+            .block_on(self.remote.source().save(self.remote.path(), data))
+    }
+}
+
+/// Whether a native-append failure means the store demands a full rewrite
+/// (append-block limit exceeded, or write-offset appends unsupported).
+// TODO: classify once `UniversalIoError::AppendRewriteRequired` exists; until
+// then only the proactive `soft_limit` triggers rewrites in `Native` mode.
+fn err_requires_rewrite(_err: &UniversalIoError) -> bool {
+    false
+}
+
+impl<A: AsyncAppend + Clone> UniversalRead for CachedBlobFile<A>
+where
+    A::Config: Clone,
+{
+    type Fs = CachedBlobFs<A>;
+
+    type ReadPipeline<'a, U>
+        = CachedBlobReadPipeline<'a, A, U>
+    where
+        Self: 'a,
+        U: UserData;
+
+    fn reopen(&mut self) -> UioResult<()> {
+        self.cache.reopen()
+    }
+
+    fn schedule_reopen<F: FnOnce(&Path) -> Option<FileInfo>>(
+        &self,
+        get_file_info: F,
+    ) -> UioResult<()> {
+        self.cache.schedule_reopen(get_file_info)
+    }
+
+    fn read_bytes<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        access_pattern: P,
+        align: usize,
+    ) -> UioResult<ACow<'_>> {
+        self.cache.read_bytes(range, access_pattern, align)
+    }
+
+    fn read_whole<T: common::universal_io::Item>(&self) -> UioResult<std::borrow::Cow<'_, [T]>> {
+        self.cache.read_whole()
+    }
+
+    fn len<T>(&self) -> UioResult<u64> {
+        self.cache.len::<T>()
+    }
+
+    fn populate(&self) -> UioResult<()> {
+        self.cache.populate()
+    }
+
+    fn populate_auto() -> bool {
+        false
+    }
+
+    fn clear_ram_cache(&self) -> UioResult<()> {
+        self.cache.clear_ram_cache()
+    }
+
+    fn kind() -> UniversalKind {
+        UniversalKind::CachedBlob
+    }
+}
+
+impl<A: AsyncAppend + Clone> UniversalFlush for CachedBlobFile<A> {
+    fn flusher(&self) -> Flusher {
+        // Appends are durable once the remote acknowledges them.
+        Box::new(|| Ok(()))
+    }
+}
+
+impl<A: AsyncAppend + Clone> UniversalAppend for CachedBlobFile<A>
+where
+    A::Config: Clone,
+{
+    fn append<T: bytemuck::Pod>(&mut self, offset: ByteOffset, data: &[T]) -> UioResult<()> {
+        self.append_bytes(offset, Bytes::copy_from_slice(bytemuck::cast_slice(data)))
+    }
+
+    fn append_batch<'a, T: bytemuck::Pod>(
+        &mut self,
+        offset: ByteOffset,
+        items: impl IntoIterator<Item = &'a [T]>,
+    ) -> UioResult<()> {
+        // Concatenate into a single buffer so the whole batch is one remote
+        // mutation.
+        let slices: Vec<&[u8]> = items
+            .into_iter()
+            .map(|item| bytemuck::cast_slice(item))
+            .collect();
+        let total: usize = slices.iter().map(|slice| slice.len()).sum();
+        let mut buffer = Vec::with_capacity(total);
+        for slice in slices {
+            buffer.extend_from_slice(slice);
+        }
+
+        self.append_bytes(offset, Bytes::from(buffer))
+    }
+}

--- a/lib/common/io_bridge/src/cached/pipeline.rs
+++ b/lib/common/io_bridge/src/cached/pipeline.rs
@@ -1,0 +1,59 @@
+//! Read pipeline for [`CachedBlobFile`]: a thin wrapper delegating to the
+//! disk-cache pipeline, which serves cached blocks locally and fetches
+//! missing ones from the remote concurrently.
+
+use std::ops::Range;
+
+use common::ext::aligned_vec::ACow;
+use common::generic_consts::AccessPattern;
+use common::universal_io::{DiskCache, ReadPipeline, UioResult, UniversalRead, UserData};
+
+use super::CachedBlobFile;
+use crate::file::BlobFile;
+use crate::read::AsyncRead;
+
+type Inner<'file, A, U> = <DiskCache<BlobFile<A>> as UniversalRead>::ReadPipeline<'file, U>;
+
+pub struct CachedBlobReadPipeline<'file, A: AsyncRead + Clone, U: UserData> {
+    inner: Inner<'file, A, U>,
+}
+
+impl<'file, A: AsyncRead + Clone, U: UserData> ReadPipeline<'file, U>
+    for CachedBlobReadPipeline<'file, A, U>
+{
+    type File = CachedBlobFile<A>;
+
+    fn new() -> UioResult<Self> {
+        Ok(Self {
+            inner: <Inner<'file, A, U> as ReadPipeline<'file, U>>::new()?,
+        })
+    }
+
+    fn can_schedule(&mut self) -> bool {
+        self.inner.can_schedule()
+    }
+
+    fn schedule<P: AccessPattern>(
+        &mut self,
+        user_data: U,
+        file: &'file Self::File,
+        range: Range<u64>,
+        align: usize,
+    ) -> UioResult<()> {
+        self.inner
+            .schedule::<P>(user_data, &file.cache, range, align)
+    }
+
+    fn schedule_whole(
+        &mut self,
+        user_data: U,
+        file: &'file Self::File,
+        from: u64,
+    ) -> UioResult<()> {
+        self.inner.schedule_whole(user_data, &file.cache, from)
+    }
+
+    fn wait(&mut self) -> UioResult<Option<(U, ACow<'file>)>> {
+        self.inner.wait()
+    }
+}

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -14,7 +14,7 @@ use crate::fs::BlobFs;
 use crate::pipeline::{BlobReadPipeline, read_into_byte_buffer, read_whole_into_byte_buffer};
 use crate::read::AsyncRead;
 use crate::runtime::BridgeRuntime;
-use crate::write::{AppendRequest, AsyncAppend};
+use crate::write::AsyncAppend;
 
 /// Sync wrapper around a [`AsyncRead`] backend that implements [`UniversalRead`].
 ///
@@ -197,10 +197,7 @@ impl<A: AsyncAppend + Clone> BlobFile<A> {
         }
 
         self.runtime
-            .block_on(
-                self.inner
-                    .append(&self.path, AppendRequest::Append { offset, data }),
-            )
+            .block_on(self.inner.append(&self.path, offset, data))
             .map(drop)
     }
 }
@@ -506,14 +503,9 @@ mod tests {
         fn append(
             &self,
             path: &Path,
-            request: AppendRequest,
+            offset: u64,
+            data: Bytes,
         ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
-            let AppendRequest::Append { offset, data } = request else {
-                return std::future::ready(Err(UniversalIoError::Io(std::io::Error::new(
-                    std::io::ErrorKind::Unsupported,
-                    "MutableMockSource only supports native appends",
-                ))));
-            };
             self.append_calls
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let mut guard = self.store.lock().unwrap();
@@ -545,13 +537,7 @@ mod tests {
 
         // A rejected stale append must not materialize the object.
         let err = BridgeRuntime::global()
-            .block_on(source.append(
-                Path::new("obj"),
-                AppendRequest::Append {
-                    offset: 5,
-                    data: Bytes::from_static(b"x"),
-                },
-            ))
+            .block_on(source.append(Path::new("obj"), 5, Bytes::from_static(b"x")))
             .unwrap_err();
         assert!(matches!(err, UniversalIoError::AppendOffsetConflict { .. }));
         assert!(source.content().is_none());

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -199,7 +199,7 @@ impl<A: AsyncAppend + Clone> BlobFile<A> {
         self.runtime
             .block_on(
                 self.inner
-                    .append(&self.path, AppendRequest::Native { offset, data }),
+                    .append(&self.path, AppendRequest::Append { offset, data }),
             )
             .map(drop)
     }
@@ -499,8 +499,8 @@ mod tests {
     }
 
     impl AsyncAppend for MutableMockSource {
-        fn supported_append(&self) -> crate::AppendMethod {
-            crate::AppendMethod::Native
+        fn append_support(&self) -> crate::AppendSupport {
+            crate::AppendSupport::Always
         }
 
         fn append(
@@ -508,7 +508,7 @@ mod tests {
             path: &Path,
             request: AppendRequest,
         ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
-            let AppendRequest::Native { offset, data } = request else {
+            let AppendRequest::Append { offset, data } = request else {
                 return std::future::ready(Err(UniversalIoError::Io(std::io::Error::new(
                     std::io::ErrorKind::Unsupported,
                     "MutableMockSource only supports native appends",
@@ -547,7 +547,7 @@ mod tests {
         let err = BridgeRuntime::global()
             .block_on(source.append(
                 Path::new("obj"),
-                AppendRequest::Native {
+                AppendRequest::Append {
                     offset: 5,
                     data: Bytes::from_static(b"x"),
                 },

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -6,8 +6,8 @@ use bytes::Bytes;
 use common::ext::aligned_vec::ACow;
 use common::generic_consts::AccessPattern;
 use common::universal_io::{
-    ByteOffset, Flusher, Item, UioResult, UniversalAppend, UniversalFlush, UniversalIoError,
-    UniversalKind, UniversalRead, UserData,
+    ByteOffset, Flusher, Item, UioResult, UniversalFlush, UniversalIoError, UniversalKind,
+    UniversalRead, UserData,
 };
 
 use crate::fs::BlobFs;
@@ -184,7 +184,17 @@ impl<A: AsyncAppend + Clone> BlobFile<A> {
     /// One append RPC at exactly `offset`; the backend itself validates the
     /// offset against the current object size (the compare-and-swap), so no
     /// local length tracking is needed.
-    fn append_bytes(&self, offset: ByteOffset, data: Bytes) -> UioResult<()> {
+    ///
+    /// `expected_etag`, when provided, is the entity tag the caller last
+    /// observed for the object (from a listing, or tracked across its own
+    /// appends); it travels to the backend as a server-side precondition —
+    /// see [`AsyncAppend::append`] for which operations can honor it.
+    pub fn append_bytes(
+        &self,
+        offset: ByteOffset,
+        data: Bytes,
+        expected_etag: Option<String>,
+    ) -> UioResult<()> {
         if data.is_empty() {
             return Ok(());
         }
@@ -197,36 +207,15 @@ impl<A: AsyncAppend + Clone> BlobFile<A> {
         }
 
         self.runtime
-            .block_on(self.inner.append(&self.path, offset, data))
+            .block_on(self.inner.append(&self.path, offset, data, expected_etag))
             .map(drop)
     }
 }
 
-impl<A: AsyncAppend + Clone> UniversalAppend for BlobFile<A> {
-    fn append<T: bytemuck::Pod>(&mut self, offset: ByteOffset, data: &[T]) -> UioResult<()> {
-        self.append_bytes(offset, Bytes::copy_from_slice(bytemuck::cast_slice(data)))
-    }
-
-    fn append_batch<'a, T: bytemuck::Pod>(
-        &mut self,
-        offset: ByteOffset,
-        items: impl IntoIterator<Item = &'a [T]>,
-    ) -> UioResult<()> {
-        // Concatenate into a single buffer so the whole batch lands in one
-        // request.
-        let slices: Vec<&[u8]> = items
-            .into_iter()
-            .map(|item| bytemuck::cast_slice(item))
-            .collect();
-        let total: usize = slices.iter().map(|slice| slice.len()).sum();
-        let mut buffer = Vec::with_capacity(total);
-        for slice in slices {
-            buffer.extend_from_slice(slice);
-        }
-
-        self.append_bytes(offset, Bytes::from(buffer))
-    }
-}
+// Deliberately no `UniversalAppend` impl: the append-capable universal-IO
+// citizen for object stores is `CachedBlobFile`, which drives this handle
+// through `append_bytes` and supplies its tracked etag. A raw `BlobFile`
+// append through the trait would bypass that guard.
 
 #[cfg(test)]
 mod tests {
@@ -505,14 +494,22 @@ mod tests {
             path: &Path,
             offset: u64,
             data: Bytes,
+            expected_etag: Option<String>,
         ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
             self.append_calls
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let mut guard = self.store.lock().unwrap();
-            // Validate the offset before materializing anything: a rejected
-            // append must not leave an empty object behind.
+            // A content-derived etag, honored like a real store's
+            // precondition.
+            let current_etag = guard
+                .as_ref()
+                .map(|object| format!("etag-{}", object.len()));
+            // Validate the preconditions before materializing anything: a
+            // rejected append must not leave an empty object behind.
             let current_len = guard.as_ref().map_or(0, |object| object.len() as u64);
-            let result = if current_len == offset {
+            let result = if expected_etag.is_some() && expected_etag != current_etag {
+                Err(UniversalIoError::AppendEtagMismatch { path: path.into() })
+            } else if current_len == offset {
                 let object = guard.get_or_insert_with(Vec::new);
                 object.extend_from_slice(&data);
                 Ok(object.len() as u64)
@@ -533,45 +530,31 @@ mod tests {
     #[test]
     fn append_creates_missing_object() {
         let source = MutableMockSource::default();
-        let mut file = mutable_file(&source);
+        let file = mutable_file(&source);
 
         // A rejected stale append must not materialize the object.
         let err = BridgeRuntime::global()
-            .block_on(source.append(Path::new("obj"), 5, Bytes::from_static(b"x")))
+            .block_on(source.append(Path::new("obj"), 5, Bytes::from_static(b"x"), None))
             .unwrap_err();
         assert!(matches!(err, UniversalIoError::AppendOffsetConflict { .. }));
         assert!(source.content().is_none());
 
-        file.append(0, b"abc".as_slice()).unwrap();
-        file.append(3, b"de".as_slice()).unwrap();
+        file.append_bytes(0, Bytes::from_static(b"abc"), None)
+            .unwrap();
+        file.append_bytes(3, Bytes::from_static(b"de"), None)
+            .unwrap();
         assert_eq!(source.content().unwrap(), b"abcde");
         assert_eq!(<BlobFile<_> as UniversalRead>::len::<u8>(&file).unwrap(), 5);
     }
 
     #[test]
-    fn append_batch_is_a_single_request() {
-        let source = MutableMockSource::default();
-        let mut file = mutable_file(&source);
-
-        file.append(0, b"start".as_slice()).unwrap();
-        let batch: [&[u8]; 3] = [b"ab", b"cd", b"ef"];
-        file.append_batch(5, batch).unwrap();
-
-        let append_calls = source
-            .append_calls
-            .load(std::sync::atomic::Ordering::Relaxed);
-        assert_eq!(append_calls, 2);
-        assert_eq!(source.content().unwrap(), b"startabcdef");
-    }
-
-    #[test]
     fn empty_append_succeeds_without_request() {
         let source = MutableMockSource::default();
-        let mut file = mutable_file(&source);
+        let file = mutable_file(&source);
 
-        file.append(0, b"abc".as_slice()).unwrap();
-        file.append::<u8>(3, &[]).unwrap();
-        file.append_batch::<u8>(3, std::iter::empty()).unwrap();
+        file.append_bytes(0, Bytes::from_static(b"abc"), None)
+            .unwrap();
+        file.append_bytes(3, Bytes::new(), None).unwrap();
 
         let append_calls = source
             .append_calls
@@ -585,27 +568,65 @@ mod tests {
     #[test]
     fn append_conflict_recovery() {
         let source = MutableMockSource::default();
-        let mut first = mutable_file(&source);
-        let mut second = mutable_file(&source);
+        let first = mutable_file(&source);
+        let second = mutable_file(&source);
 
-        first.append(0, b"aaa".as_slice()).unwrap();
-        second.append(3, b"bbb".as_slice()).unwrap();
+        first
+            .append_bytes(0, Bytes::from_static(b"aaa"), None)
+            .unwrap();
+        second
+            .append_bytes(3, Bytes::from_static(b"bbb"), None)
+            .unwrap();
 
-        let err = first.append(3, b"ccc".as_slice()).unwrap_err();
+        let err = first
+            .append_bytes(3, Bytes::from_static(b"ccc"), None)
+            .unwrap_err();
         assert!(matches!(
             err,
             UniversalIoError::AppendOffsetConflict { offset: 3, .. }
         ));
 
         let eof = <BlobFile<_> as UniversalRead>::len::<u8>(&first).unwrap();
-        first.append(eof, b"ccc".as_slice()).unwrap();
+        first
+            .append_bytes(eof, Bytes::from_static(b"ccc"), None)
+            .unwrap();
         assert_eq!(source.content().unwrap(), b"aaabbbccc");
+    }
+
+    /// The expected etag travels to the backend as a precondition: a
+    /// matching etag lets the append through, a stale one (or a missing
+    /// object) rejects it without mutating anything.
+    #[test]
+    fn append_bytes_passes_the_expected_etag_precondition() {
+        let source = MutableMockSource::default();
+        let file = mutable_file(&source);
+
+        // No object yet: an expected etag cannot match anything.
+        let err = file
+            .append_bytes(0, Bytes::from_static(b"abc"), Some("etag-0".to_string()))
+            .unwrap_err();
+        assert!(matches!(err, UniversalIoError::AppendEtagMismatch { .. }));
+        assert!(source.content().is_none());
+
+        file.append_bytes(0, Bytes::from_static(b"abc"), None)
+            .unwrap();
+
+        // The current etag: the append proceeds.
+        file.append_bytes(3, Bytes::from_static(b"de"), Some("etag-3".to_string()))
+            .unwrap();
+
+        // The previous etag is stale now: rejected, nothing lands.
+        let err = file
+            .append_bytes(5, Bytes::from_static(b"f"), Some("etag-3".to_string()))
+            .unwrap_err();
+        assert!(matches!(err, UniversalIoError::AppendEtagMismatch { .. }));
+        assert_eq!(source.content().unwrap(), b"abcde");
     }
 
     #[test]
     fn append_requires_writeable_open() {
         let fs = BlobFs::new(MutableMockSource::default(), BridgeRuntime::global());
-        let mut file = fs
+        let file = fs
             .open(
                 "obj",
                 OpenOptions {
@@ -616,36 +637,36 @@ mod tests {
             )
             .unwrap();
 
-        assert!(file.append(0, b"x".as_slice()).is_err());
+        assert!(
+            file.append_bytes(0, Bytes::from_static(b"x"), None)
+                .is_err()
+        );
     }
 
     #[test]
     fn append_flusher_is_a_no_op() {
         let source = MutableMockSource::default();
-        let mut file = mutable_file(&source);
+        let file = mutable_file(&source);
 
-        file.append(0, b"abc".as_slice()).unwrap();
+        file.append_bytes(0, Bytes::from_static(b"abc"), None)
+            .unwrap();
         (file.flusher())().unwrap();
     }
 
     #[test]
-    fn blob_fs_write_file_ops_round_trip() {
-        use common::universal_io::{UniversalReadFileOps as _, UniversalWriteFileOps as _};
+    fn blob_fs_write_ops_round_trip() {
+        use common::universal_io::UniversalReadFileOps as _;
 
         let source = MutableMockSource::default();
         let fs = BlobFs::new(source.clone(), BridgeRuntime::global());
         let path = Path::new("obj");
 
         assert!(!fs.exists(path).unwrap());
-        fs.create(path, 0).unwrap();
+        fs.create(path).unwrap();
         assert!(fs.exists(path).unwrap());
 
         fs.atomic_save(path, b"xyz").unwrap();
         assert_eq!(source.content().unwrap(), b"xyz");
-
-        // Directory ops are no-ops for object stores.
-        fs.create_dir(Path::new("dir")).unwrap();
-        fs.remove_dir(Path::new("dir")).unwrap();
 
         fs.remove(path).unwrap();
         assert!(!fs.exists(path).unwrap());

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -14,7 +14,7 @@ use crate::fs::BlobFs;
 use crate::pipeline::{BlobReadPipeline, read_into_byte_buffer, read_whole_into_byte_buffer};
 use crate::read::AsyncRead;
 use crate::runtime::BridgeRuntime;
-use crate::write::AsyncAppend;
+use crate::write::{AppendRequest, AsyncAppend};
 
 /// Sync wrapper around a [`AsyncRead`] backend that implements [`UniversalRead`].
 ///
@@ -197,7 +197,10 @@ impl<A: AsyncAppend + Clone> BlobFile<A> {
         }
 
         self.runtime
-            .block_on(self.inner.append(&self.path, offset, data))
+            .block_on(
+                self.inner
+                    .append(&self.path, AppendRequest::Native { offset, data }),
+            )
             .map(drop)
     }
 }
@@ -496,12 +499,21 @@ mod tests {
     }
 
     impl AsyncAppend for MutableMockSource {
+        fn supported_append(&self) -> crate::AppendMethod {
+            crate::AppendMethod::Native
+        }
+
         fn append(
             &self,
             path: &Path,
-            offset: u64,
-            data: Bytes,
+            request: AppendRequest,
         ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
+            let AppendRequest::Native { offset, data } = request else {
+                return std::future::ready(Err(UniversalIoError::Io(std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    "MutableMockSource only supports native appends",
+                ))));
+            };
             self.append_calls
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let mut guard = self.store.lock().unwrap();
@@ -533,7 +545,13 @@ mod tests {
 
         // A rejected stale append must not materialize the object.
         let err = BridgeRuntime::global()
-            .block_on(source.append(Path::new("obj"), 5, Bytes::from_static(b"x")))
+            .block_on(source.append(
+                Path::new("obj"),
+                AppendRequest::Native {
+                    offset: 5,
+                    data: Bytes::from_static(b"x"),
+                },
+            ))
             .unwrap_err();
         assert!(matches!(err, UniversalIoError::AppendOffsetConflict { .. }));
         assert!(source.content().is_none());

--- a/lib/common/io_bridge/src/fs.rs
+++ b/lib/common/io_bridge/src/fs.rs
@@ -3,10 +3,9 @@ use std::path::Path;
 use bytes::Bytes;
 use common::universal_io::{
     ListedFile, OpenOptions, UioResult, UniversalReadFileOps, UniversalReadFs,
-    UniversalWriteFileOps,
 };
 
-use crate::{AsyncAppend, AsyncRead, BlobFile, BridgeRuntime};
+use crate::{AsyncRead, AsyncWrite, BlobFile, BridgeRuntime};
 
 /// Filesystem handle for an object-store backend: an [`AsyncRead`] handle plus
 /// the [`BridgeRuntime`] used to drive its async operations. Opens per-object
@@ -74,48 +73,26 @@ impl<A: AsyncRead + Clone> UniversalReadFileOps for BlobFs<A> {
     }
 }
 
-/// Requires [`AsyncAppend`], not just [`AsyncWrite`](crate::AsyncWrite): a write-capable
-/// filesystem must hand out append handles, and only backends with a native
-/// single-request append can produce one (`BlobFile` appends through
-/// [`AsyncAppend::append`]). Backends that can only put whole objects stay
-/// read-only through universal I/O.
-impl<A: AsyncAppend + Clone> UniversalWriteFileOps for BlobFs<A> {
-    type AppendFile = BlobFile<A>;
-
-    fn create(&self, path: &Path, _expected_length: usize) -> UioResult<()> {
-        // Object stores have no fixed-size preallocation; the expected
-        // length is ignored, as the trait allows.
+/// Deliberately no [`UniversalWriteFileOps`] impl: the write-capable
+/// universal-IO filesystem for object stores is
+/// [`CachedBlobFs`](crate::CachedBlobFs), which delegates its mutating file
+/// ops to these inherent methods and hands out
+/// [`CachedBlobFile`](crate::CachedBlobFile) append handles.
+///
+/// [`UniversalWriteFileOps`]: common::universal_io::UniversalWriteFileOps
+impl<A: AsyncWrite + Clone> BlobFs<A> {
+    pub fn create(&self, path: &Path) -> UioResult<()> {
         self.runtime.block_on(self.inner.create(path))
     }
 
-    fn create_dir(&self, _path: &Path) -> UioResult<()> {
-        // No materialized directories.
-        Ok(())
-    }
-
-    fn remove(&self, path: &Path) -> UioResult<()> {
+    pub fn remove(&self, path: &Path) -> UioResult<()> {
         self.runtime.block_on(self.inner.remove(path))
     }
 
-    fn remove_dir(&self, _path: &Path) -> UioResult<()> {
-        // No materialized directories.
-        Ok(())
-    }
-
-    fn atomic_save(&self, path: &Path, bytes: &[u8]) -> UioResult<()> {
-        // A whole-object put is atomic on object stores.
+    /// A whole-object put, atomic on object stores.
+    pub fn atomic_save(&self, path: &Path, bytes: &[u8]) -> UioResult<()> {
         self.runtime
             .block_on(self.inner.save(path, Bytes::copy_from_slice(bytes)))
-    }
-
-    /// The very handle [`UniversalReadFs::open`] hands out, always writeable.
-    /// Performs no IO — the object is not touched until the first append or
-    /// read. Blob handles have no open-time knobs, so `options` is unused.
-    fn open_append(&self, path: impl AsRef<Path>, _options: OpenOptions) -> UioResult<BlobFile<A>> {
-        Ok(
-            BlobFile::new(self.inner.clone(), self.runtime.clone(), path.as_ref())
-                .with_writeable(true),
-        )
     }
 }
 

--- a/lib/common/io_bridge/src/lib.rs
+++ b/lib/common/io_bridge/src/lib.rs
@@ -123,4 +123,4 @@ pub use fs::BlobFs;
 pub use pipeline::BlobReadPipeline;
 pub use read::{AsyncRead, OffsetByteStream, with_running_offsets};
 pub use runtime::BridgeRuntime;
-pub use write::{AppendRequest, AppendSupport, AsyncAppend, AsyncWrite};
+pub use write::{AppendSupport, AsyncAppend, AsyncWrite};

--- a/lib/common/io_bridge/src/lib.rs
+++ b/lib/common/io_bridge/src/lib.rs
@@ -117,12 +117,10 @@ pub(crate) const LATENCY_LOG_TARGET: &str = "io_bridge::latency";
 #[cfg(test)]
 mod tests;
 
-pub use cached::{
-    AppendMode, CachedBlobFile, CachedBlobFs, CachedBlobFsContext, CachedBlobReadPipeline,
-};
+pub use cached::{CachedBlobFile, CachedBlobFs, CachedBlobFsContext, CachedBlobReadPipeline};
 pub use file::BlobFile;
 pub use fs::BlobFs;
 pub use pipeline::BlobReadPipeline;
 pub use read::{AsyncRead, OffsetByteStream, with_running_offsets};
 pub use runtime::BridgeRuntime;
-pub use write::{AsyncAppend, AsyncWrite};
+pub use write::{AppendMethod, AppendRequest, AsyncAppend, AsyncWrite};

--- a/lib/common/io_bridge/src/lib.rs
+++ b/lib/common/io_bridge/src/lib.rs
@@ -123,4 +123,4 @@ pub use fs::BlobFs;
 pub use pipeline::BlobReadPipeline;
 pub use read::{AsyncRead, OffsetByteStream, with_running_offsets};
 pub use runtime::BridgeRuntime;
-pub use write::{AppendMethod, AppendRequest, AsyncAppend, AsyncWrite};
+pub use write::{AppendRequest, AppendSupport, AsyncAppend, AsyncWrite};

--- a/lib/common/io_bridge/src/lib.rs
+++ b/lib/common/io_bridge/src/lib.rs
@@ -99,6 +99,7 @@
 //!   the buffer back as a plain `AVec<u8>`. This removes the two redundant
 //!   copies that an "aggregate to `Bytes`, then copy out" path would do.
 
+mod cached;
 mod file;
 mod fs;
 mod pipeline;
@@ -116,6 +117,9 @@ pub(crate) const LATENCY_LOG_TARGET: &str = "io_bridge::latency";
 #[cfg(test)]
 mod tests;
 
+pub use cached::{
+    AppendMode, CachedBlobFile, CachedBlobFs, CachedBlobFsContext, CachedBlobReadPipeline,
+};
 pub use file::BlobFile;
 pub use fs::BlobFs;
 pub use pipeline::BlobReadPipeline;

--- a/lib/common/io_bridge/src/write.rs
+++ b/lib/common/io_bridge/src/write.rs
@@ -30,24 +30,31 @@ pub trait AsyncWrite: AsyncRead {
     ) -> impl Future<Output = UioResult<()>> + Send + 'static;
 }
 
-/// How a backend grows objects, advertised by
-/// [`AsyncAppend::supported_append`].
+/// When the backend accepts a direct append ([`AppendRequest::Append`]),
+/// advertised by [`AsyncAppend::append_support`]. Deliberately silent on
+/// *how* the backend performs the operation — that is the backend's
+/// business; this only tells the caller when it must fall back to building
+/// the whole object itself.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum AppendMethod {
-    /// Native single-request write-offset appends (S3 Express One Zone,
-    /// MinIO AiStor). Stores cap appended blocks per object; hitting the cap
-    /// surfaces as [`UniversalIoError::AppendRewriteRequired`] and callers
-    /// recover with a whole-object rewrite.
+pub enum AppendSupport {
+    /// Direct appends at any offset: a write-offset append (S3 Express,
+    /// MinIO AiStor) or a `compose` concatenation (GCS). Stores that cap
+    /// appended blocks per object surface the cap as
+    /// [`UniversalIoError::AppendRewriteRequired`], and callers recover
+    /// with one [`AppendRequest::Rewrite`].
     ///
     /// [`UniversalIoError::AppendRewriteRequired`]: common::universal_io::UniversalIoError::AppendRewriteRequired
-    Native,
-    /// No native append (plain S3): the object only grows by a rewrite —
-    /// a server-side copy of the existing prefix with the new data uploaded
-    /// as the final multipart part.
-    PartialUpload,
+    Always,
+    /// Direct appends only once the existing object is at least
+    /// `min_offset` bytes (plain S3: appends land as multipart prefix
+    /// copies, whose non-last parts must be ≥ 5 MiB). Below the threshold
+    /// the caller must write the whole object itself.
+    AboveThreshold { min_offset: u64 },
+    /// No direct appends: the caller always writes the whole object itself.
+    Never,
 }
 
-/// One append operation; each variant matches an [`AppendMethod`].
+/// One append operation.
 ///
 /// In both variants `offset` MUST equal the current object size and acts as
 /// a compare-and-swap token: the backend rejects a mismatching request with
@@ -57,15 +64,14 @@ pub enum AppendMethod {
 /// [`UniversalIoError::AppendOffsetConflict`]: common::universal_io::UniversalIoError::AppendOffsetConflict
 #[derive(Clone, Debug)]
 pub enum AppendRequest {
-    /// Append `data` at `offset` in a single native write-offset request,
-    /// growing the object in place. `offset == 0` creates the object if it
-    /// is missing.
-    Native { offset: u64, data: Bytes },
-    /// Rewrite the object as its existing `[0, offset)` prefix (server-side
-    /// copy, never downloaded) followed by `data`. Also the appended-block
-    /// cap recovery path for [`AppendMethod::Native`] backends, which all
-    /// sit on multipart-capable stores.
-    PartialUpload { offset: u64, data: Bytes },
+    /// Append `data` at `offset`, growing the object in place — by whatever
+    /// mechanism the backend has. `offset == 0` creates the object if it is
+    /// missing. Valid within the backend's advertised [`AppendSupport`].
+    Append { offset: u64, data: Bytes },
+    /// Append `data` at `offset` AND rebuild the object as a single blob:
+    /// the appended-block cap recovery for [`AppendSupport::Always`]
+    /// stores whose direct appends accumulate per-object blocks.
+    Rewrite { offset: u64, data: Bytes },
 }
 
 /// Blob backends supporting appends.
@@ -74,10 +80,9 @@ pub enum AppendRequest {
 ///
 /// [`UniversalAppend`]: common::universal_io::UniversalAppend
 pub trait AsyncAppend: AsyncWrite {
-    /// The append method this backend advertises; callers pick the matching
-    /// [`AppendRequest`] variant. Implementations reject request variants
-    /// they do not support.
-    fn supported_append(&self) -> AppendMethod;
+    /// When this backend accepts direct appends; below/without that, the
+    /// caller writes the whole object itself through [`AsyncWrite::save`].
+    fn append_support(&self) -> AppendSupport;
 
     /// Perform `request` on the object at `path`. Returns the new total
     /// object size in bytes. See [`AppendRequest`] for the offset

--- a/lib/common/io_bridge/src/write.rs
+++ b/lib/common/io_bridge/src/write.rs
@@ -71,11 +71,23 @@ pub trait AsyncAppend: AsyncWrite {
     /// with [`UniversalIoError::AppendOffsetConflict`], so concurrent
     /// appenders cannot silently interleave.
     ///
+    /// `expected_etag`, when provided, is the entity tag the caller last
+    /// observed for the object. Backends attach it as a server-side
+    /// precondition where the store offers one (S3 rewrites:
+    /// `x-amz-copy-source-if-match`), rejecting with
+    /// [`UniversalIoError::AppendEtagMismatch`] if the object was replaced
+    /// behind the caller's back — which the offset compare-and-swap alone
+    /// cannot detect when the lengths coincide. Operations without a
+    /// matching precondition (native write-offset appends, GCS compose)
+    /// ignore it.
+    ///
     /// [`UniversalIoError::AppendOffsetConflict`]: common::universal_io::UniversalIoError::AppendOffsetConflict
+    /// [`UniversalIoError::AppendEtagMismatch`]: common::universal_io::UniversalIoError::AppendEtagMismatch
     fn append(
         &self,
         path: &Path,
         offset: u64,
         data: Bytes,
+        expected_etag: Option<String>,
     ) -> impl Future<Output = UioResult<u64>> + Send + 'static;
 }

--- a/lib/common/io_bridge/src/write.rs
+++ b/lib/common/io_bridge/src/write.rs
@@ -30,7 +30,7 @@ pub trait AsyncWrite: AsyncRead {
     ) -> impl Future<Output = UioResult<()>> + Send + 'static;
 }
 
-/// When the backend accepts a direct append ([`AppendRequest::Append`]),
+/// When the backend accepts a direct append ([`AsyncAppend::append`]),
 /// advertised by [`AsyncAppend::append_support`]. Deliberately silent on
 /// *how* the backend performs the operation — that is the backend's
 /// business; this only tells the caller when it must fall back to building
@@ -39,11 +39,8 @@ pub trait AsyncWrite: AsyncRead {
 pub enum AppendSupport {
     /// Direct appends at any offset: a write-offset append (S3 Express,
     /// MinIO AiStor) or a `compose` concatenation (GCS). Stores that cap
-    /// appended blocks per object surface the cap as
-    /// [`UniversalIoError::AppendRewriteRequired`], and callers recover
-    /// with one [`AppendRequest::Rewrite`].
-    ///
-    /// [`UniversalIoError::AppendRewriteRequired`]: common::universal_io::UniversalIoError::AppendRewriteRequired
+    /// appended blocks per object recover internally with a whole-object
+    /// rewrite when an append hits the cap.
     Always,
     /// Direct appends only once the existing object is at least
     /// `min_offset` bytes (plain S3: appends land as multipart prefix
@@ -52,26 +49,6 @@ pub enum AppendSupport {
     AboveThreshold { min_offset: u64 },
     /// No direct appends: the caller always writes the whole object itself.
     Never,
-}
-
-/// One append operation.
-///
-/// In both variants `offset` MUST equal the current object size and acts as
-/// a compare-and-swap token: the backend rejects a mismatching request with
-/// [`UniversalIoError::AppendOffsetConflict`], so concurrent appenders
-/// cannot silently interleave.
-///
-/// [`UniversalIoError::AppendOffsetConflict`]: common::universal_io::UniversalIoError::AppendOffsetConflict
-#[derive(Clone, Debug)]
-pub enum AppendRequest {
-    /// Append `data` at `offset`, growing the object in place — by whatever
-    /// mechanism the backend has. `offset == 0` creates the object if it is
-    /// missing. Valid within the backend's advertised [`AppendSupport`].
-    Append { offset: u64, data: Bytes },
-    /// Append `data` at `offset` AND rebuild the object as a single blob:
-    /// the appended-block cap recovery for [`AppendSupport::Always`]
-    /// stores whose direct appends accumulate per-object blocks.
-    Rewrite { offset: u64, data: Bytes },
 }
 
 /// Blob backends supporting appends.
@@ -84,12 +61,21 @@ pub trait AsyncAppend: AsyncWrite {
     /// caller writes the whole object itself through [`AsyncWrite::save`].
     fn append_support(&self) -> AppendSupport;
 
-    /// Perform `request` on the object at `path`. Returns the new total
-    /// object size in bytes. See [`AppendRequest`] for the offset
-    /// compare-and-swap contract.
+    /// Append `data` to the object at `path`, growing it in place — by
+    /// whatever mechanism the backend has. `offset == 0` creates the object
+    /// if it is missing. Valid within the backend's advertised
+    /// [`AppendSupport`]. Returns the new total object size in bytes.
+    ///
+    /// `offset` MUST equal the current object size and acts as a
+    /// compare-and-swap token: the backend rejects a mismatching request
+    /// with [`UniversalIoError::AppendOffsetConflict`], so concurrent
+    /// appenders cannot silently interleave.
+    ///
+    /// [`UniversalIoError::AppendOffsetConflict`]: common::universal_io::UniversalIoError::AppendOffsetConflict
     fn append(
         &self,
         path: &Path,
-        request: AppendRequest,
+        offset: u64,
+        data: Bytes,
     ) -> impl Future<Output = UioResult<u64>> + Send + 'static;
 }

--- a/lib/common/io_bridge/src/write.rs
+++ b/lib/common/io_bridge/src/write.rs
@@ -30,26 +30,61 @@ pub trait AsyncWrite: AsyncRead {
     ) -> impl Future<Output = UioResult<()>> + Send + 'static;
 }
 
-/// Blob backends supporting native single-request appends.
+/// How a backend grows objects, advertised by
+/// [`AsyncAppend::supported_append`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AppendMethod {
+    /// Native single-request write-offset appends (S3 Express One Zone,
+    /// MinIO AiStor). Stores cap appended blocks per object; hitting the cap
+    /// surfaces as [`UniversalIoError::AppendRewriteRequired`] and callers
+    /// recover with a whole-object rewrite.
+    ///
+    /// [`UniversalIoError::AppendRewriteRequired`]: common::universal_io::UniversalIoError::AppendRewriteRequired
+    Native,
+    /// No native append (plain S3): the object only grows by a rewrite —
+    /// a server-side copy of the existing prefix with the new data uploaded
+    /// as the final multipart part.
+    PartialUpload,
+}
+
+/// One append operation; each variant matches an [`AppendMethod`].
+///
+/// In both variants `offset` MUST equal the current object size and acts as
+/// a compare-and-swap token: the backend rejects a mismatching request with
+/// [`UniversalIoError::AppendOffsetConflict`], so concurrent appenders
+/// cannot silently interleave.
+///
+/// [`UniversalIoError::AppendOffsetConflict`]: common::universal_io::UniversalIoError::AppendOffsetConflict
+#[derive(Clone, Debug)]
+pub enum AppendRequest {
+    /// Append `data` at `offset` in a single native write-offset request,
+    /// growing the object in place. `offset == 0` creates the object if it
+    /// is missing.
+    Native { offset: u64, data: Bytes },
+    /// Rewrite the object as its existing `[0, offset)` prefix (server-side
+    /// copy, never downloaded) followed by `data`. Also the appended-block
+    /// cap recovery path for [`AppendMethod::Native`] backends, which all
+    /// sit on multipart-capable stores.
+    PartialUpload { offset: u64, data: Bytes },
+}
+
+/// Blob backends supporting appends.
 ///
 /// Powers the [`UniversalAppend`] impl on [`BlobFile`](crate::BlobFile).
 ///
 /// [`UniversalAppend`]: common::universal_io::UniversalAppend
 pub trait AsyncAppend: AsyncWrite {
-    /// Append `data` to the object at `path` in a single request, growing it
-    /// in place. Returns the new total object size in bytes.
-    ///
-    /// `offset` MUST equal the current object size (`0` creates the object
-    /// if it is missing) and acts as a compare-and-swap token: the backend
-    /// rejects a mismatching append with
-    /// [`UniversalIoError::AppendOffsetConflict`], so concurrent appenders
-    /// cannot silently interleave.
-    ///
-    /// [`UniversalIoError::AppendOffsetConflict`]: common::universal_io::UniversalIoError::AppendOffsetConflict
+    /// The append method this backend advertises; callers pick the matching
+    /// [`AppendRequest`] variant. Implementations reject request variants
+    /// they do not support.
+    fn supported_append(&self) -> AppendMethod;
+
+    /// Perform `request` on the object at `path`. Returns the new total
+    /// object size in bytes. See [`AppendRequest`] for the offset
+    /// compare-and-swap contract.
     fn append(
         &self,
         path: &Path,
-        offset: u64,
-        data: Bytes,
+        request: AppendRequest,
     ) -> impl Future<Output = UioResult<u64>> + Send + 'static;
 }

--- a/lib/common/io_bridge_object_store/Cargo.toml
+++ b/lib/common/io_bridge_object_store/Cargo.toml
@@ -19,3 +19,4 @@ url = { workspace = true }
 
 [dev-dependencies]
 common = { path = "../common", features = ["testing"] }
+tempfile = { workspace = true }

--- a/lib/common/io_bridge_object_store/src/append.rs
+++ b/lib/common/io_bridge_object_store/src/append.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use common::universal_io::{UioResult, UniversalIoError};
-use io_bridge::AsyncAppend;
+use io_bridge::{AppendMethod, AppendRequest, AsyncAppend};
 use object_store::aws::{AmazonS3, AwsAuthorizer};
 use object_store::client::{HttpClient, HttpConnector as _, HttpRequestBody, ReqwestConnector};
 use object_store::{ClientOptions, ObjectStoreExt as _};
@@ -36,6 +36,11 @@ const WRITE_OFFSET_HEADER: &str = "x-amz-write-offset-bytes";
 /// S3 error code returned when the write offset does not match the current
 /// object size.
 const INVALID_WRITE_OFFSET_CODE: &str = "InvalidWriteOffset";
+
+/// S3 error code returned when the object reached the store's cap on
+/// appended blocks (10,000 parts); the object can only keep growing through
+/// a whole-object rewrite.
+const TOO_MANY_PARTS_CODE: &str = "TooManyParts";
 
 /// State for issuing native append requests: a lazily-built shared HTTP
 /// client plus the resolved object-URL base and signing region.
@@ -92,25 +97,43 @@ impl AppendContext {
 }
 
 impl AsyncAppend for ObjectStoreSource<AmazonS3> {
+    fn supported_append(&self) -> AppendMethod {
+        // The append context exists exactly when the backend/config supports
+        // write-offset appends; plain S3 falls back to multipart rewrites.
+        if self.append_context().is_some() {
+            AppendMethod::Native
+        } else {
+            AppendMethod::PartialUpload
+        }
+    }
+
     fn append(
         &self,
         path: &std::path::Path,
-        offset: u64,
-        data: Bytes,
+        request: AppendRequest,
     ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
         let store = self.store().clone();
         let context = self.append_context().cloned();
         let key = crate::source::build_key(path);
 
         async move {
-            let Some(context) = context else {
-                return Err(UniversalIoError::S3Config {
-                    description: "append is not supported for this S3 backend/config (append context missing)"
-                        .to_string(),
-                });
-            };
+            match request {
+                AppendRequest::Native { offset, data } => {
+                    let Some(context) = context else {
+                        return Err(UniversalIoError::S3Config {
+                            description: "append is not supported for this S3 backend/config (append context missing)"
+                                .to_string(),
+                        });
+                    };
 
-            append_request(&store, &context, &key, offset, data).await
+                    append_request(&store, &context, &key, offset, data).await
+                }
+                AppendRequest::PartialUpload { offset: _, data: _ } => {
+                    // CreateMultipartUpload + UploadPartCopy of `[0, offset)`
+                    // + UploadPart(data) + CompleteMultipartUpload.
+                    todo!("multipart rewrite with UploadPartCopy")
+                }
+            }
         }
     }
 }
@@ -241,6 +264,16 @@ async fn append_request(
         // Read the body for the S3 error code (best-effort).
         let body = response.into_body().bytes().await.unwrap_or_default();
         let body_text = String::from_utf8_lossy(&body);
+
+        // The appended-block cap is a permanent property of the object —
+        // report it as rewrite-required so the caller can recover, instead
+        // of an opaque failure. Anything unrecognized stays a hard error
+        // rather than silently triggering a full-object rewrite.
+        if status == http::StatusCode::BAD_REQUEST && body_text.contains(TOO_MANY_PARTS_CODE) {
+            return Err(UniversalIoError::AppendRewriteRequired {
+                path: PathBuf::from(key.to_string()),
+            });
+        }
 
         // AWS reports a write-offset mismatch as 400 InvalidWriteOffset;
         // some S3-compatibles use 412 instead.
@@ -596,6 +629,18 @@ mod tests {
             err,
             UniversalIoError::AppendOffsetConflict { offset: 5, .. }
         );
+    }
+
+    /// The appended-block cap surfaces as `AppendRewriteRequired`, so the
+    /// caller recovers with a whole-object rewrite.
+    #[test]
+    fn too_many_parts_is_rewrite_required() {
+        let (endpoint, _seen) = stub_server(vec![
+            StubResponse::new(400).body("<Error><Code>TooManyParts</Code></Error>"),
+        ]);
+
+        let err = append_data_at(&endpoint, 5).unwrap_err();
+        assert_matches!(err, UniversalIoError::AppendRewriteRequired { .. });
     }
 
     /// Only the `InvalidWriteOffset` error code makes a 400 a conflict;

--- a/lib/common/io_bridge_object_store/src/append/context/compose.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/compose.rs
@@ -1,0 +1,287 @@
+//! The GCS `compose` append strategy: the appended data is uploaded as a
+//! temporary object, then the destination is atomically rewritten as the
+//! server-side concatenation `compose([existing, temporary])` — nothing is
+//! downloaded. Like the S3 strategies, the compose call itself is
+//! hand-issued: `object_store` does not expose `compose`.
+
+use std::sync::{Arc, OnceLock};
+
+use bytes::Bytes;
+use common::universal_io::{UioResult, UniversalIoError};
+use object_store::client::{HttpClient, HttpRequestBody};
+use object_store::gcp::GoogleCloudStorage;
+use object_store::{ObjectStoreExt as _, PutPayload};
+use url::Url;
+
+use super::signed::build_http_client;
+
+/// JSON API base in production.
+const DEFAULT_API_BASE: &str = "https://storage.googleapis.com";
+
+/// The GCS `compose` append strategy.
+///
+/// Unlike the S3 rewrites, the compose is a real compare-and-swap: it is
+/// conditional (`ifGenerationMatch`) on the destination generation observed
+/// before the upload, so a concurrent rewrite surfaces as an offset
+/// conflict instead of silently losing data.
+///
+/// Each append grows the destination's component count by one; GCS does not
+/// cap the count, but readers of heavily-composed objects may benefit from
+/// an occasional flattening rewrite.
+#[derive(Debug, Clone)]
+pub struct ComposeAppend {
+    /// Reqwest-backed HTTP client for the compose request, built on first
+    /// use and shared across clones.
+    client: Arc<OnceLock<HttpClient>>,
+    /// Whether to allow a plain-http API base (test endpoints).
+    allow_http: bool,
+    /// GCS bucket name.
+    bucket: String,
+    /// JSON API base; [`DEFAULT_API_BASE`] in production.
+    api_base: Url,
+}
+
+impl ComposeAppend {
+    pub fn new(bucket: String) -> Self {
+        let api_base = Url::parse(DEFAULT_API_BASE).expect("default API base is a valid URL");
+        Self::with_api_base(bucket, api_base, false)
+    }
+
+    /// Point the JSON API at a custom (possibly plain-http) endpoint.
+    pub fn with_api_base(bucket: String, api_base: Url, allow_http: bool) -> Self {
+        Self {
+            client: Arc::new(OnceLock::new()),
+            allow_http,
+            bucket,
+            api_base,
+        }
+    }
+
+    /// Append `data` at `offset` (== the current object size) by composing
+    /// the existing object with the uploaded data. Returns the new total
+    /// object size.
+    pub(in crate::append) async fn append(
+        &self,
+        store: &Arc<GoogleCloudStorage>,
+        key: &object_store::path::Path,
+        offset: u64,
+        data: Bytes,
+    ) -> UioResult<u64> {
+        let final_size = offset + data.len() as u64;
+        let conflict = || UniversalIoError::AppendOffsetConflict {
+            path: std::path::PathBuf::from(key.to_string()),
+            offset,
+        };
+
+        // An empty prefix means a plain put produces the right object.
+        if offset == 0 {
+            store
+                .put(key, PutPayload::from(data))
+                .await
+                .map_err(UniversalIoError::s3)?;
+            return Ok(final_size);
+        }
+
+        // Observe the destination: its size must match the caller's view of
+        // the object, and its generation anchors the compose CAS below.
+        let meta = match store.head(key).await {
+            Ok(meta) => meta,
+            Err(object_store::Error::NotFound { .. }) => return Err(conflict()),
+            Err(other) => return Err(UniversalIoError::s3(other)),
+        };
+        if meta.size != offset {
+            return Err(conflict());
+        }
+
+        // The appended bytes as a temporary neighbor object. The name is
+        // deterministic: under the single-writer contract a collision is a
+        // leftover of our own failed attempt, and overwriting it is exactly
+        // right.
+        let temp_key = object_store::path::Path::from(format!("{key}.compose-append"));
+        store
+            .put(&temp_key, PutPayload::from(data))
+            .await
+            .map_err(UniversalIoError::s3)?;
+
+        let bearer = store
+            .credentials()
+            .get_credential()
+            .await
+            .map_err(UniversalIoError::s3)?
+            .bearer
+            .clone();
+        let result = self
+            .compose_request(&bearer, key, &temp_key, meta.version.as_deref(), offset)
+            .await;
+
+        // Best effort: an orphaned temporary object only wastes its own
+        // bytes and is overwritten by the next append anyway.
+        let _ = store.delete(&temp_key).await;
+
+        result?;
+        Ok(final_size)
+    }
+
+    /// `POST /storage/v1/b/{bucket}/o/{dest}/compose` — atomically replace
+    /// `dest` with the concatenation of `dest` and `temp`, conditional on
+    /// `dest` still being at `generation`.
+    async fn compose_request(
+        &self,
+        bearer: &str,
+        dest: &object_store::path::Path,
+        temp: &object_store::path::Path,
+        generation: Option<&str>,
+        offset: u64,
+    ) -> UioResult<()> {
+        let client = self.client()?;
+
+        let mut url = self.api_base.clone();
+        url.path_segments_mut()
+            .map_err(|()| UniversalIoError::S3Config {
+                description: "compose API base cannot be a base URL".to_string(),
+            })?
+            .pop_if_empty()
+            .extend(["storage", "v1", "b", self.bucket.as_str(), "o"])
+            // One segment: the `/`s of the object name are percent-encoded.
+            .push(dest.as_ref())
+            .push("compose");
+        if let Some(generation) = generation {
+            url.query_pairs_mut()
+                .append_pair("ifGenerationMatch", generation);
+        }
+
+        // Hand-built JSON: object names in our storage layouts are plain
+        // path characters, never JSON metacharacters.
+        let body = format!(
+            r#"{{"sourceObjects":[{{"name":"{dest}"}},{{"name":"{temp}"}}],"destination":{{}}}}"#,
+        );
+
+        let request = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(url.as_str())
+            .header(http::header::AUTHORIZATION, format!("Bearer {bearer}"))
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .body(HttpRequestBody::from(Bytes::from(body)))
+            .map_err(|err| UniversalIoError::S3Config {
+                description: format!("compose request for {dest}: {err}"),
+            })?;
+
+        let response = client
+            .execute(request)
+            .await
+            .map_err(UniversalIoError::s3)?;
+        let status = response.status();
+
+        // The generation moved: the object was rewritten since we observed
+        // it — the compose CAS caught a lost race.
+        if status == http::StatusCode::PRECONDITION_FAILED {
+            return Err(UniversalIoError::AppendOffsetConflict {
+                path: std::path::PathBuf::from(dest.to_string()),
+                offset,
+            });
+        }
+
+        if !status.is_success() {
+            let body = response.into_body().bytes().await.unwrap_or_default();
+            let excerpt: String = String::from_utf8_lossy(&body).chars().take(512).collect();
+            return Err(UniversalIoError::s3(std::io::Error::other(format!(
+                "compose for {dest} failed with status {status}: {excerpt}",
+            ))));
+        }
+        Ok(())
+    }
+
+    /// The shared HTTP client, built on first call. Concurrent first calls
+    /// may build a transient extra client; exactly one is kept.
+    fn client(&self) -> UioResult<HttpClient> {
+        if let Some(client) = self.client.get() {
+            return Ok(client.clone());
+        }
+        let client = build_http_client(self.allow_http)?;
+        Ok(self.client.get_or_init(|| client).clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::assert_matches;
+
+    use super::super::stub::{StubResponse, stub_server};
+    use super::*;
+
+    fn compose_at(endpoint: &str, generation: Option<&str>) -> UioResult<()> {
+        let compose =
+            ComposeAppend::with_api_base("bucket".to_string(), Url::parse(endpoint).unwrap(), true);
+        let dest = object_store::path::Path::from("dir/append.dat");
+        let temp = object_store::path::Path::from("dir/append.dat.compose-append");
+
+        io_bridge::BridgeRuntime::global().block_on(compose.compose_request(
+            "stub-token",
+            &dest,
+            &temp,
+            generation,
+            5,
+        ))
+    }
+
+    #[test]
+    fn compose_posts_the_conditional_source_list() {
+        let (endpoint, seen) = stub_server(vec![StubResponse::new(200).body("{}")]);
+
+        compose_at(&endpoint, Some("42")).unwrap();
+
+        let seen = seen.lock().unwrap();
+        let [request] = &seen[..] else {
+            panic!("expected exactly one request");
+        };
+        assert_eq!(request.method, "POST");
+        assert_eq!(
+            request.path,
+            "/storage/v1/b/bucket/o/dir%2Fappend.dat/compose?ifGenerationMatch=42"
+        );
+        assert!(request.signed);
+        assert_eq!(
+            String::from_utf8_lossy(&request.body),
+            r#"{"sourceObjects":[{"name":"dir/append.dat"},{"name":"dir/append.dat.compose-append"}],"destination":{}}"#,
+        );
+    }
+
+    /// Without an observed generation there is no precondition to send.
+    #[test]
+    fn compose_without_a_generation_sends_no_precondition() {
+        let (endpoint, seen) = stub_server(vec![StubResponse::new(200).body("{}")]);
+
+        compose_at(&endpoint, None).unwrap();
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(
+            seen[0].path,
+            "/storage/v1/b/bucket/o/dir%2Fappend.dat/compose"
+        );
+    }
+
+    /// A failed generation precondition means the object was rewritten
+    /// behind our back — an offset conflict, not an opaque error.
+    #[test]
+    fn compose_precondition_failure_is_an_offset_conflict() {
+        let (endpoint, _seen) = stub_server(vec![StubResponse::new(412)]);
+
+        let err = compose_at(&endpoint, Some("42")).unwrap_err();
+        assert_matches!(
+            err,
+            UniversalIoError::AppendOffsetConflict { offset: 5, .. }
+        );
+    }
+
+    #[test]
+    fn compose_failure_surfaces_the_body_excerpt() {
+        let (endpoint, _seen) =
+            stub_server(vec![StubResponse::new(403).body("compose denied by stub")]);
+
+        let err = compose_at(&endpoint, Some("42")).unwrap_err();
+        assert_matches!(err, UniversalIoError::S3(_));
+        let message = err.to_string();
+        assert!(message.contains("403"), "{message}");
+        assert!(message.contains("compose denied by stub"), "{message}");
+    }
+}

--- a/lib/common/io_bridge_object_store/src/append/context/mod.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/mod.rs
@@ -1,0 +1,33 @@
+//! The append strategies: one object per strategy, each implementing its
+//! own append logic, combined by [`AppendContext`].
+
+mod compose;
+mod native;
+pub(super) mod part_copy;
+mod signed;
+#[cfg(test)]
+mod stub;
+
+pub use compose::ComposeAppend;
+pub use native::NativeAppend;
+pub use part_copy::PartCopyAppend;
+pub use signed::SignedRequestContext;
+
+/// The append strategy of the configured store: one object per strategy,
+/// each implementing its own append logic. The backend picks the variant
+/// from its config (see [`BlobBackend::append_context`]).
+///
+/// [`BlobBackend::append_context`]: crate::BlobBackend::append_context
+#[derive(Debug, Clone)]
+pub enum AppendContext {
+    /// The store honors native single-request write-offset appends
+    /// (`PutObject` + `x-amz-write-offset-bytes`): S3 Express One Zone,
+    /// MinIO AiStor.
+    Native(NativeAppend),
+    /// Plain S3: appends land as whole-object multipart rewrites whose
+    /// prefix parts are server-side `UploadPartCopy` requests.
+    PartCopy(PartCopyAppend),
+    /// GCS: appends land as server-side `compose` requests — the new data
+    /// uploaded as a temporary object, then composed onto the existing one.
+    Compose(ComposeAppend),
+}

--- a/lib/common/io_bridge_object_store/src/append/context/mod.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/mod.rs
@@ -13,6 +13,65 @@ pub use native::NativeAppend;
 pub use part_copy::PartCopyAppend;
 pub use signed::SignedRequestContext;
 
+/// Text of the first `<tag>…</tag>` element in an S3 XML response, with
+/// surrounding whitespace trimmed. Tolerates attributes on the opening tag
+/// (`<Error xmlns="…">`) and pretty-printed bodies. Deliberately not a
+/// general XML parser — S3 error/result elements are flat text.
+fn extract_xml_tag<'a>(body: &'a str, tag: &str) -> Option<&'a str> {
+    let open_prefix = format!("<{tag}");
+    let close = format!("</{tag}>");
+
+    let mut rest = body;
+    let content = loop {
+        let after_name = &rest[rest.find(&open_prefix)? + open_prefix.len()..];
+        // The tag name must end right here — with the closing `>` or with
+        // whitespace-separated attributes — otherwise this occurrence is a
+        // longer tag name (e.g. `<CodeDetail>` when looking for `<Code>`).
+        if let Some(content) = after_name.strip_prefix('>') {
+            break content;
+        }
+        if after_name.starts_with(char::is_whitespace) {
+            break &after_name[after_name.find('>')? + 1..];
+        }
+        rest = after_name;
+    };
+
+    Some(content[..content.find(&close)?].trim())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_xml_tag;
+
+    #[test]
+    fn extract_xml_tag_tolerates_formatting_variations() {
+        // The plain shape AWS produces.
+        assert_eq!(
+            extract_xml_tag("<Error><Code>NoSuchKey</Code></Error>", "Code"),
+            Some("NoSuchKey"),
+        );
+        // Attributes on the opening tag.
+        assert_eq!(
+            extract_xml_tag(r#"<Code xmlns="http://ns">NoSuchKey</Code>"#, "Code"),
+            Some("NoSuchKey"),
+        );
+        // Pretty-printed body: surrounding whitespace is trimmed.
+        assert_eq!(
+            extract_xml_tag("<Code>\n    NoSuchKey\n</Code>", "Code"),
+            Some("NoSuchKey"),
+        );
+        // A longer tag name sharing the prefix must not match.
+        assert_eq!(
+            extract_xml_tag("<CodeDetail>X</CodeDetail><Code>Y</Code>", "Code"),
+            Some("Y"),
+        );
+        assert_eq!(extract_xml_tag("<CodeDetail>X</CodeDetail>", "Code"), None);
+        // Unclosed or absent elements.
+        assert_eq!(extract_xml_tag("<Code>NoSuchKey", "Code"), None);
+        assert_eq!(extract_xml_tag("no xml at all", "Code"), None);
+    }
+}
+
 /// The append strategy of the configured store: one object per strategy,
 /// each implementing its own append logic. The backend picks the variant
 /// from its config (see [`BlobBackend::append_context`]).

--- a/lib/common/io_bridge_object_store/src/append/context/mod.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/mod.rs
@@ -6,7 +6,7 @@ mod native;
 pub(super) mod part_copy;
 mod signed;
 #[cfg(test)]
-mod stub;
+pub(super) mod stub;
 
 pub use compose::ComposeAppend;
 pub use native::NativeAppend;

--- a/lib/common/io_bridge_object_store/src/append/context/native.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/native.rs
@@ -14,24 +14,23 @@
 //! against this implementation yet.
 
 use std::path::PathBuf;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
 use common::universal_io::{UioResult, UniversalIoError};
-use io_bridge::{AppendMethod, AppendRequest, AsyncAppend};
+use object_store::ObjectStoreExt as _;
 use object_store::aws::{AmazonS3, AwsAuthorizer};
-use object_store::client::{HttpClient, HttpConnector as _, HttpRequestBody, ReqwestConnector};
-use object_store::{ClientOptions, ObjectStoreExt as _};
-use url::Url;
+use object_store::client::HttpRequestBody;
 
-use crate::source::ObjectStoreSource;
+use super::part_copy::PartCopyAppend;
+use super::signed::SignedRequestContext;
 
 /// Response header carrying the object size after an append.
 const OBJECT_SIZE_HEADER: &str = "x-amz-object-size";
 
 /// Request header selecting the write-offset append behavior of `PutObject`.
-const WRITE_OFFSET_HEADER: &str = "x-amz-write-offset-bytes";
+pub(super) const WRITE_OFFSET_HEADER: &str = "x-amz-write-offset-bytes";
 
 /// S3 error code returned when the write offset does not match the current
 /// object size.
@@ -41,102 +40,6 @@ const INVALID_WRITE_OFFSET_CODE: &str = "InvalidWriteOffset";
 /// appended blocks (10,000 parts); the object can only keep growing through
 /// a whole-object rewrite.
 const TOO_MANY_PARTS_CODE: &str = "TooManyParts";
-
-/// State for issuing native append requests: a lazily-built shared HTTP
-/// client plus the resolved object-URL base and signing region.
-///
-/// Built once per source by [`BlobBackend::append_context`]; construction is
-/// cheap — the HTTP client (TLS setup, connection pool) is only built on the
-/// first append, so sources that never append pay nothing.
-///
-/// [`BlobBackend::append_context`]: crate::BlobBackend::append_context
-#[derive(Debug, Clone)]
-pub struct AppendContext {
-    /// Reqwest-backed HTTP client, built on first use and shared across
-    /// clones of the source (and thus across file handles opened from it).
-    client: Arc<OnceLock<HttpClient>>,
-    /// Whether to allow plain-http endpoints; mirrors `build_store`.
-    allow_http: bool,
-    /// Base URL under which object keys live: path-style
-    /// `{endpoint}/{bucket}` for custom endpoints, or the virtual-hosted
-    /// `https://{bucket}.s3.{region}.amazonaws.com` for real AWS.
-    object_url_base: Url,
-    /// SigV4 signing region.
-    region: String,
-}
-
-impl AppendContext {
-    pub fn new(allow_http: bool, object_url_base: Url, region: String) -> Self {
-        Self {
-            client: Arc::new(OnceLock::new()),
-            allow_http,
-            object_url_base,
-            region,
-        }
-    }
-
-    /// The shared HTTP client, built on first call. Concurrent first calls
-    /// may build a transient extra client; exactly one is kept.
-    fn client(&self) -> UioResult<HttpClient> {
-        if let Some(client) = self.client.get() {
-            return Ok(client.clone());
-        }
-
-        let mut options = ClientOptions::new();
-        if self.allow_http {
-            options = options.with_allow_http(true);
-        }
-        let client = ReqwestConnector::default()
-            .connect(&options)
-            .map_err(|err| UniversalIoError::S3Config {
-                description: format!("append http client: {err}"),
-            })?;
-
-        Ok(self.client.get_or_init(|| client).clone())
-    }
-}
-
-impl AsyncAppend for ObjectStoreSource<AmazonS3> {
-    fn supported_append(&self) -> AppendMethod {
-        // The append context exists exactly when the backend/config supports
-        // write-offset appends; plain S3 falls back to multipart rewrites.
-        if self.append_context().is_some() {
-            AppendMethod::Native
-        } else {
-            AppendMethod::PartialUpload
-        }
-    }
-
-    fn append(
-        &self,
-        path: &std::path::Path,
-        request: AppendRequest,
-    ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
-        let store = self.store().clone();
-        let context = self.append_context().cloned();
-        let key = crate::source::build_key(path);
-
-        async move {
-            match request {
-                AppendRequest::Native { offset, data } => {
-                    let Some(context) = context else {
-                        return Err(UniversalIoError::S3Config {
-                            description: "append is not supported for this S3 backend/config (append context missing)"
-                                .to_string(),
-                        });
-                    };
-
-                    append_request(&store, &context, &key, offset, data).await
-                }
-                AppendRequest::PartialUpload { offset: _, data: _ } => {
-                    // CreateMultipartUpload + UploadPartCopy of `[0, offset)`
-                    // + UploadPart(data) + CompleteMultipartUpload.
-                    todo!("multipart rewrite with UploadPartCopy")
-                }
-            }
-        }
-    }
-}
 
 /// Total attempts for one append: transient failures (connection errors,
 /// 5xx, 429) are retried with a short linear backoff, like `object_store`
@@ -148,12 +51,44 @@ const MAX_ATTEMPTS: u32 = 3;
 /// Backoff before retry attempt `n` is `n * RETRY_BACKOFF`.
 const RETRY_BACKOFF: Duration = Duration::from_millis(100);
 
+/// The native append strategy: a signed single-request `PutObject` with
+/// `x-amz-write-offset-bytes`, atomically growing the object in place.
+#[derive(Debug, Clone)]
+pub struct NativeAppend {
+    signed: SignedRequestContext,
+}
+
+impl NativeAppend {
+    pub fn new(signed: SignedRequestContext) -> Self {
+        Self { signed }
+    }
+
+    /// Append `data` at `offset` (== the current object size). Returns the
+    /// new total object size.
+    pub(in crate::append) async fn append(
+        &self,
+        store: &Arc<AmazonS3>,
+        key: &object_store::path::Path,
+        offset: u64,
+        data: Bytes,
+    ) -> UioResult<u64> {
+        append_request(store, &self.signed, key, offset, data).await
+    }
+
+    /// The part-copy strategy over the same store, used to compact an
+    /// object that reached the appended-block cap — every native-append
+    /// store is multipart-capable.
+    pub(in crate::append) fn part_copy(&self) -> PartCopyAppend {
+        PartCopyAppend::new(self.signed.clone())
+    }
+}
+
 /// Issue a signed `PutObject` request with `x-amz-write-offset-bytes`,
 /// atomically growing the object at `key` by `data`. Returns the new total
 /// object size.
 async fn append_request(
     store: &Arc<AmazonS3>,
-    context: &AppendContext,
+    context: &SignedRequestContext,
     key: &object_store::path::Path,
     offset: u64,
     data: Bytes,
@@ -164,14 +99,7 @@ async fn append_request(
         .await
         .map_err(UniversalIoError::s3)?;
     let client = context.client()?;
-
-    let mut url = context.object_url_base.clone();
-    url.path_segments_mut()
-        .map_err(|()| UniversalIoError::S3Config {
-            description: "append object url cannot be a base".to_string(),
-        })?
-        .pop_if_empty()
-        .extend(key.parts().map(|part| part.as_ref().to_string()));
+    let url = context.object_url(key)?;
 
     let data_len = data.len() as u64;
 
@@ -323,12 +251,11 @@ async fn append_request(
 #[cfg(test)]
 mod tests {
     use std::assert_matches;
-    use std::io::{BufRead as _, BufReader, Read as _, Write as _};
-    use std::net::{TcpListener, TcpStream};
-    use std::sync::Mutex;
 
     use object_store::aws::AmazonS3Builder;
+    use url::Url;
 
+    use super::super::stub::{StubResponse, stub_server, stub_store_and_context};
     use super::*;
 
     /// Request building failures (URIs the `http` crate rejects) surface as
@@ -344,185 +271,29 @@ mod tests {
                 .build()
                 .unwrap(),
         );
-        let context = AppendContext::new(
+        let context = SignedRequestContext::new(
             true,
+            "bucket".to_string(),
             Url::parse("http://localhost:9000/bucket").unwrap(),
             "us-east-1".to_string(),
         );
         // `url` accepts this; `http` caps URIs at u16::MAX bytes.
         let key = object_store::path::Path::from("k".repeat(70_000));
 
-        let result = io_bridge::BridgeRuntime::global().block_on(append_request(
-            &store,
-            &context,
-            &key,
-            0,
-            Bytes::from_static(b"data"),
-        ));
-        assert!(matches!(result, Err(UniversalIoError::S3Config { .. })));
-    }
-
-    /// The HTTP client is built on first use and then reused; building it
-    /// performs no IO.
-    #[test]
-    fn client_is_built_lazily_and_cached() {
-        let context = AppendContext::new(
-            true,
-            Url::parse("http://localhost:9000/bucket").unwrap(),
-            "us-east-1".to_string(),
+        let result = io_bridge::BridgeRuntime::global().block_on(
+            NativeAppend::new(context).append(&store, &key, 0, Bytes::from_static(b"data")),
         );
-        assert!(context.client.get().is_none());
-
-        context.client().unwrap();
-        assert!(context.client.get().is_some());
-        context.client().unwrap();
-    }
-
-    /// Canned response served by [`stub_server`].
-    struct StubResponse {
-        status: u16,
-        headers: Vec<(&'static str, String)>,
-        body: &'static str,
-    }
-
-    impl StubResponse {
-        fn new(status: u16) -> Self {
-            Self {
-                status,
-                headers: Vec::new(),
-                body: "",
-            }
-        }
-
-        fn header(mut self, name: &'static str, value: impl ToString) -> Self {
-            self.headers.push((name, value.to_string()));
-            self
-        }
-
-        fn body(mut self, body: &'static str) -> Self {
-            self.body = body;
-            self
-        }
-    }
-
-    /// One request as observed by [`stub_server`].
-    struct SeenRequest {
-        method: String,
-        path: String,
-        write_offset: Option<String>,
-        signed: bool,
-        body: Vec<u8>,
-    }
-
-    /// Minimal local HTTP/1.1 server: serves the canned responses in order,
-    /// one connection per response (every response carries
-    /// `connection: close`, so retries and the `head()` reconciliation
-    /// arrive as fresh connections), recording each request. The listener
-    /// stops after the last response, so an unexpected extra request fails
-    /// to connect instead of hanging the test.
-    fn stub_server(responses: Vec<StubResponse>) -> (String, Arc<Mutex<Vec<SeenRequest>>>) {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let endpoint = format!("http://{}", listener.local_addr().unwrap());
-        let seen = Arc::new(Mutex::new(Vec::new()));
-
-        let seen_in_server = Arc::clone(&seen);
-        std::thread::spawn(move || {
-            for response in responses {
-                let Ok((mut stream, _)) = listener.accept() else {
-                    return;
-                };
-                let Some(request) = read_request(&mut stream) else {
-                    return;
-                };
-                seen_in_server.lock().unwrap().push(request);
-
-                let mut payload = format!("HTTP/1.1 {} Stub\r\n", response.status);
-                for (name, value) in &response.headers {
-                    payload += &format!("{name}: {value}\r\n");
-                }
-                // A HEAD response declares a length without carrying a body.
-                let has_length = response
-                    .headers
-                    .iter()
-                    .any(|(name, _)| name.eq_ignore_ascii_case("content-length"));
-                if !has_length {
-                    payload += &format!("content-length: {}\r\n", response.body.len());
-                }
-                payload += "connection: close\r\n\r\n";
-                payload += response.body;
-                let _ = stream.write_all(payload.as_bytes());
-            }
-        });
-
-        (endpoint, seen)
-    }
-
-    fn read_request(stream: &mut TcpStream) -> Option<SeenRequest> {
-        let mut reader = BufReader::new(stream);
-
-        let mut request_line = String::new();
-        reader.read_line(&mut request_line).ok()?;
-        let mut parts = request_line.split_whitespace();
-        let method = parts.next()?.to_string();
-        let path = parts.next()?.to_string();
-
-        let mut content_length = 0;
-        let mut write_offset = None;
-        let mut signed = false;
-        loop {
-            let mut line = String::new();
-            reader.read_line(&mut line).ok()?;
-            let line = line.trim_end();
-            if line.is_empty() {
-                break;
-            }
-            let (name, value) = line.split_once(':')?;
-            let value = value.trim().to_string();
-            if name.eq_ignore_ascii_case("content-length") {
-                content_length = value.parse().ok()?;
-            } else if name.eq_ignore_ascii_case(WRITE_OFFSET_HEADER) {
-                write_offset = Some(value);
-            } else if name.eq_ignore_ascii_case("authorization") {
-                signed = true;
-            }
-        }
-
-        let mut body = vec![0; content_length];
-        reader.read_exact(&mut body).ok()?;
-
-        Some(SeenRequest {
-            method,
-            path,
-            write_offset,
-            signed,
-            body,
-        })
+        assert!(matches!(result, Err(UniversalIoError::S3Config { .. })));
     }
 
     /// Append `b"data"` at `offset` to `dir/append.dat` via the stub, so a
     /// consistent store would report a new object size of `offset + 4`.
     fn append_data_at(endpoint: &str, offset: u64) -> UioResult<u64> {
-        let store = Arc::new(
-            AmazonS3Builder::new()
-                .with_bucket_name("bucket")
-                .with_region("us-east-1")
-                .with_access_key_id("id")
-                .with_secret_access_key("secret")
-                .with_endpoint(endpoint)
-                .with_allow_http(true)
-                .build()
-                .unwrap(),
-        );
-        let context = AppendContext::new(
-            true,
-            Url::parse(&format!("{endpoint}/bucket")).unwrap(),
-            "us-east-1".to_string(),
-        );
+        let (store, context) = stub_store_and_context(endpoint);
         let key = object_store::path::Path::from("dir/append.dat");
 
-        io_bridge::BridgeRuntime::global().block_on(append_request(
+        io_bridge::BridgeRuntime::global().block_on(NativeAppend::new(context).append(
             &store,
-            &context,
             &key,
             offset,
             Bytes::from_static(b"data"),

--- a/lib/common/io_bridge_object_store/src/append/context/native.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/native.rs
@@ -36,6 +36,10 @@ pub(super) const WRITE_OFFSET_HEADER: &str = "x-amz-write-offset-bytes";
 /// object size.
 const INVALID_WRITE_OFFSET_CODE: &str = "InvalidWriteOffset";
 
+/// S3 error code distinguishing a missing *object* (recoverable stale view)
+/// from a missing *bucket* (a config/endpoint problem) on a 404.
+const NO_SUCH_KEY_CODE: &str = "NoSuchKey";
+
 /// S3 error code returned when the object reached the store's cap on
 /// appended blocks (10,000 parts); the object can only keep growing through
 /// a whole-object rewrite.
@@ -123,7 +127,7 @@ async fn append_request(
         // Signs all headers present on the request (including the
         // write-offset header) plus the payload SHA-256, and adds
         // host/date/token headers.
-        AwsAuthorizer::new(&credential, "s3", &context.region)
+        AwsAuthorizer::new(&credential, context.service, &context.region)
             .try_authorize(&mut request, None)
             .map_err(UniversalIoError::s3)?;
 
@@ -208,12 +212,19 @@ async fn append_request(
         let write_offset_conflict = match status {
             http::StatusCode::BAD_REQUEST => body_text.contains(INVALID_WRITE_OFFSET_CODE),
             http::StatusCode::PRECONDITION_FAILED => true,
-            // A missing object while a nonzero offset was expected is a
+            // A missing *object* while a nonzero offset was expected is a
             // stale view of the object (deleted behind our back) — the same
             // reopen-and-retry recovery as an offset mismatch, matching the
-            // in-memory emulation. At offset 0 a 404 is a genuine
-            // missing-target error (e.g. missing bucket).
-            http::StatusCode::NOT_FOUND => offset > 0,
+            // in-memory emulation; stores that return bodiless 404s keep
+            // that recovery. A missing *bucket* is a config/endpoint
+            // problem and must stay a hard error — it is also the runtime
+            // guard against drift in the zonal-endpoint derivation. At
+            // offset 0 a 404 is a genuine missing-target error.
+            http::StatusCode::NOT_FOUND => {
+                offset > 0
+                    && super::extract_xml_tag(&body_text, "Code")
+                        .is_none_or(|code| code == NO_SUCH_KEY_CODE)
+            }
             _ => false,
         };
 
@@ -235,9 +246,16 @@ async fn append_request(
         }
 
         return match status {
-            http::StatusCode::NOT_FOUND => Err(UniversalIoError::NotFound {
-                path: PathBuf::from(key.to_string()),
-            }),
+            // Only a missing object is a plain not-found; a NoSuchBucket
+            // body falls through to the loud error carrying the excerpt.
+            http::StatusCode::NOT_FOUND
+                if super::extract_xml_tag(&body_text, "Code")
+                    .is_none_or(|code| code == NO_SUCH_KEY_CODE) =>
+            {
+                Err(UniversalIoError::NotFound {
+                    path: PathBuf::from(key.to_string()),
+                })
+            }
             _ => {
                 let excerpt: String = body_text.chars().take(512).collect();
                 Err(UniversalIoError::s3(std::io::Error::other(format!(
@@ -276,6 +294,7 @@ mod tests {
             "bucket".to_string(),
             Url::parse("http://localhost:9000/bucket").unwrap(),
             "us-east-1".to_string(),
+            "s3",
         );
         // `url` accepts this; `http` caps URIs at u16::MAX bytes.
         let key = object_store::path::Path::from("k".repeat(70_000));
@@ -428,7 +447,7 @@ mod tests {
 
     /// A missing object under a nonzero offset is a stale view of the
     /// object (deleted behind our back): the same recovery as an offset
-    /// mismatch.
+    /// mismatch. Bodiless 404s (and explicit NoSuchKey) both qualify.
     #[test]
     fn not_found_at_a_nonzero_offset_is_a_conflict() {
         let (endpoint, _seen) = stub_server(vec![StubResponse::new(404)]);
@@ -438,6 +457,31 @@ mod tests {
             err,
             UniversalIoError::AppendOffsetConflict { offset: 5, .. }
         );
+
+        let (endpoint, _seen) = stub_server(vec![
+            StubResponse::new(404).body("<Error><Code>NoSuchKey</Code></Error>"),
+        ]);
+
+        let err = append_data_at(&endpoint, 5).unwrap_err();
+        assert_matches!(
+            err,
+            UniversalIoError::AppendOffsetConflict { offset: 5, .. }
+        );
+    }
+
+    /// A 404 whose body names a missing *bucket* is a config/endpoint
+    /// problem (e.g. a directory bucket addressed through the standard
+    /// endpoint): it must surface loudly instead of masquerading as a
+    /// recoverable offset conflict or a missing file.
+    #[test]
+    fn not_found_for_a_missing_bucket_is_a_hard_error() {
+        let (endpoint, _seen) = stub_server(vec![
+            StubResponse::new(404).body("<Error><Code>NoSuchBucket</Code></Error>"),
+        ]);
+
+        let err = append_data_at(&endpoint, 5).unwrap_err();
+        assert_matches!(err, UniversalIoError::S3(_));
+        assert!(err.to_string().contains("NoSuchBucket"), "{err}");
     }
 
     /// At offset 0 a 404 is a genuine missing target (e.g. missing bucket).

--- a/lib/common/io_bridge_object_store/src/append/context/part_copy.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/part_copy.rs
@@ -1,0 +1,430 @@
+//! Whole-object rewrite for stores without native append: a multipart
+//! upload whose prefix parts are server-side `UploadPartCopy` requests —
+//! nothing but the appended data crosses the network — completed as a
+//! single atomic replace.
+//!
+//! Like the native append, this issues the requests itself: the
+//! `object_store` crate keeps provider-specific operations such as
+//! `UploadPartCopy` out of its portable surface (its internal part-copy is
+//! crate-private and range-less).
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use common::universal_io::{UioResult, UniversalIoError};
+use object_store::aws::{AmazonS3, AwsAuthorizer, AwsCredential};
+use object_store::client::{HttpClient, HttpRequestBody};
+use url::Url;
+
+use super::signed::SignedRequestContext;
+
+/// Max bytes per `UploadPartCopy` part: the S3 5 GiB part-size ceiling.
+const MAX_COPY_PART_SIZE: u64 = 5 * 1024 * 1024 * 1024;
+
+/// Minimum existing-object size this strategy can append to: the copied
+/// prefix lands as non-last multipart parts, which S3 requires to be at
+/// least 5 MiB. Below this, callers must write the whole object themselves.
+pub(crate) const MIN_DIRECT_OFFSET: u64 = 5 * 1024 * 1024;
+
+/// One signed S3 request against a fixed object URL. Returns the response
+/// headers and body text; non-2xx statuses become errors carrying `step`
+/// and a body excerpt.
+struct SignedObjectClient<'a> {
+    client: HttpClient,
+    credential: Arc<AwsCredential>,
+    region: &'a str,
+    url: Url,
+}
+
+impl SignedObjectClient<'_> {
+    async fn request(
+        &self,
+        method: http::Method,
+        query: &str,
+        headers: &[(&str, &str)],
+        body: HttpRequestBody,
+        step: &str,
+    ) -> UioResult<(http::HeaderMap, String)> {
+        let mut url = self.url.clone();
+        url.set_query(Some(query));
+
+        let mut builder = http::Request::builder().method(method).uri(url.as_str());
+        for (name, value) in headers {
+            builder = builder.header(*name, *value);
+        }
+        let mut request = builder
+            .body(body)
+            .map_err(|err| UniversalIoError::S3Config {
+                description: format!("{step} request: {err}"),
+            })?;
+
+        AwsAuthorizer::new(&self.credential, "s3", self.region)
+            .try_authorize(&mut request, None)
+            .map_err(UniversalIoError::s3)?;
+
+        let response = self
+            .client
+            .execute(request)
+            .await
+            .map_err(UniversalIoError::s3)?;
+        let status = response.status();
+        let response_headers = response.headers().clone();
+        let body = response.into_body().bytes().await.unwrap_or_default();
+        let body_text = String::from_utf8_lossy(&body).into_owned();
+
+        if !status.is_success() {
+            let excerpt: String = body_text.chars().take(512).collect();
+            return Err(UniversalIoError::s3(std::io::Error::other(format!(
+                "{step} failed with status {status}: {excerpt}",
+            ))));
+        }
+        Ok((response_headers, body_text))
+    }
+}
+
+/// The part-copy append strategy for stores without native append: the
+/// object is rewritten as its existing prefix (server-side `UploadPartCopy`)
+/// plus the appended data, in one atomic multipart replace.
+#[derive(Debug, Clone)]
+pub struct PartCopyAppend {
+    signed: SignedRequestContext,
+}
+
+impl PartCopyAppend {
+    pub fn new(signed: SignedRequestContext) -> Self {
+        Self { signed }
+    }
+
+    /// Append `data` at `offset` (== the current object size) by rewriting
+    /// the whole object. Returns the new total object size.
+    pub(in crate::append) async fn append(
+        &self,
+        store: &Arc<AmazonS3>,
+        key: &object_store::path::Path,
+        offset: u64,
+        data: Bytes,
+    ) -> UioResult<u64> {
+        multipart_rewrite(store, &self.signed, key, offset, data).await
+    }
+}
+
+/// Rewrite the object at `key` as its existing `[0, offset)` prefix plus
+/// `data`: `CreateMultipartUpload`, server-side `UploadPartCopy` of the
+/// prefix, `data` as the final part, `CompleteMultipartUpload` (an atomic
+/// replace). Returns the new total object size.
+///
+/// There is no compare-and-swap here — S3 evaluates the copy source when
+/// the part copy runs — so the caller must hold the single-writer contract
+/// (`CachedBlobFile` validates `offset` against its mirror length first).
+async fn multipart_rewrite(
+    store: &Arc<AmazonS3>,
+    context: &SignedRequestContext,
+    key: &object_store::path::Path,
+    offset: u64,
+    data: Bytes,
+) -> UioResult<u64> {
+    let credential = store
+        .credentials()
+        .get_credential()
+        .await
+        .map_err(UniversalIoError::s3)?;
+    let client = SignedObjectClient {
+        client: context.client()?,
+        credential,
+        region: &context.region,
+        url: context.object_url(key)?,
+    };
+
+    let (_, body) = client
+        .request(
+            http::Method::POST,
+            "uploads",
+            &[],
+            HttpRequestBody::from(Bytes::new()),
+            "initiate multipart rewrite",
+        )
+        .await?;
+    let upload_id = extract_xml_tag(&body, "UploadId")
+        .ok_or_else(|| {
+            UniversalIoError::s3(std::io::Error::other(format!(
+                "initiate multipart rewrite for {key}: no UploadId in response",
+            )))
+        })?
+        .to_string();
+
+    let result = rewrite_parts(&client, context, key, offset, data, &upload_id).await;
+    if result.is_err() {
+        // Best effort: an orphaned multipart upload holds storage until it
+        // is aborted (or reaped by a bucket lifecycle rule).
+        let _ = client
+            .request(
+                http::Method::DELETE,
+                &format!("uploadId={upload_id}"),
+                &[],
+                HttpRequestBody::from(Bytes::new()),
+                "abort multipart rewrite",
+            )
+            .await;
+    }
+    result
+}
+
+/// The part copies and completion of [`multipart_rewrite`], separated so a
+/// failure of any step aborts the multipart upload.
+async fn rewrite_parts(
+    client: &SignedObjectClient<'_>,
+    context: &SignedRequestContext,
+    key: &object_store::path::Path,
+    offset: u64,
+    data: Bytes,
+    upload_id: &str,
+) -> UioResult<u64> {
+    let mut etags = Vec::new();
+
+    // Server-side copy of `[0, offset)`, split evenly so every part fits
+    // the 5 GiB part ceiling while — at more than one part — staying at
+    // least half of it, far above the S3 5 MiB non-last-part minimum. A
+    // single part is >= 5 MiB by the caller's `MIN_COPY_PREFIX` bound.
+    let copy_source = format!("/{}/{}", context.bucket, key);
+    let part_len = offset.div_ceil(offset.div_ceil(MAX_COPY_PART_SIZE).max(1));
+    let mut start = 0;
+    while start < offset {
+        let end = (start + part_len).min(offset);
+        let part_number = etags.len() + 1;
+        let (_, body) = client
+            .request(
+                http::Method::PUT,
+                &format!("partNumber={part_number}&uploadId={upload_id}"),
+                &[
+                    ("x-amz-copy-source", copy_source.as_str()),
+                    (
+                        "x-amz-copy-source-range",
+                        &format!("bytes={start}-{}", end - 1),
+                    ),
+                ],
+                HttpRequestBody::from(Bytes::new()),
+                "multipart rewrite part copy",
+            )
+            .await?;
+        // `UploadPartCopy` reports failures after 200 OK inside the body,
+        // so a successful copy is recognized by its ETag.
+        let etag = extract_xml_tag(&body, "ETag").ok_or_else(|| {
+            let excerpt: String = body.chars().take(512).collect();
+            UniversalIoError::s3(std::io::Error::other(format!(
+                "multipart rewrite part copy for {key}: no ETag in response: {excerpt}",
+            )))
+        })?;
+        etags.push(etag.to_string());
+        start = end;
+    }
+
+    // The new data as the final part (no minimum size for the last part).
+    let final_size = offset + data.len() as u64;
+    let part_number = etags.len() + 1;
+    let (headers, _) = client
+        .request(
+            http::Method::PUT,
+            &format!("partNumber={part_number}&uploadId={upload_id}"),
+            &[],
+            HttpRequestBody::from(data),
+            "multipart rewrite data part",
+        )
+        .await?;
+    let etag = headers
+        .get(http::header::ETAG)
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| {
+            UniversalIoError::s3(std::io::Error::other(format!(
+                "multipart rewrite data part for {key}: no ETag response header",
+            )))
+        })?;
+    etags.push(etag.to_string());
+
+    let mut complete = String::from("<CompleteMultipartUpload>");
+    for (index, etag) in etags.iter().enumerate() {
+        complete += &format!(
+            "<Part><PartNumber>{}</PartNumber><ETag>{etag}</ETag></Part>",
+            index + 1,
+        );
+    }
+    complete += "</CompleteMultipartUpload>";
+
+    let (_, body) = client
+        .request(
+            http::Method::POST,
+            &format!("uploadId={upload_id}"),
+            &[],
+            HttpRequestBody::from(Bytes::from(complete)),
+            "complete multipart rewrite",
+        )
+        .await?;
+    // `CompleteMultipartUpload` also reports failures after 200 OK inside
+    // the body.
+    if body.contains("<Error") {
+        let excerpt: String = body.chars().take(512).collect();
+        return Err(UniversalIoError::s3(std::io::Error::other(format!(
+            "complete multipart rewrite for {key} failed: {excerpt}",
+        ))));
+    }
+
+    Ok(final_size)
+}
+
+/// Text of the first `<tag>…</tag>` element in an S3 XML response.
+fn extract_xml_tag<'a>(body: &'a str, tag: &str) -> Option<&'a str> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = body.find(&open)? + open.len();
+    let end = body[start..].find(&close)? + start;
+    Some(&body[start..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use std::assert_matches;
+
+    use super::super::stub::{StubResponse, stub_server, stub_store_and_context};
+    use super::*;
+
+    /// Multipart-rewrite `dir/append.dat` as its `[0, offset)` prefix plus
+    /// `b"data"` via the stub.
+    fn rewrite_data_at(endpoint: &str, offset: u64) -> UioResult<u64> {
+        let (store, context) = stub_store_and_context(endpoint);
+        let key = object_store::path::Path::from("dir/append.dat");
+
+        io_bridge::BridgeRuntime::global().block_on(PartCopyAppend::new(context).append(
+            &store,
+            &key,
+            offset,
+            Bytes::from_static(b"data"),
+        ))
+    }
+
+    fn initiate_ok() -> StubResponse {
+        StubResponse::new(200).body(
+            "<InitiateMultipartUploadResult><UploadId>upload-1</UploadId>\
+             </InitiateMultipartUploadResult>",
+        )
+    }
+
+    fn copy_part_ok() -> StubResponse {
+        StubResponse::new(200).body("<CopyPartResult><ETag>\"etag-copy\"</ETag></CopyPartResult>")
+    }
+
+    fn data_part_ok() -> StubResponse {
+        StubResponse::new(200).header("etag", "\"etag-data\"")
+    }
+
+    fn complete_ok() -> StubResponse {
+        StubResponse::new(200).body("<CompleteMultipartUploadResult/>")
+    }
+
+    #[test]
+    fn multipart_rewrite_copies_the_prefix_and_completes() {
+        let (endpoint, seen) = stub_server(vec![
+            initiate_ok(),
+            copy_part_ok(),
+            data_part_ok(),
+            complete_ok(),
+        ]);
+
+        let offset = 10 * 1024 * 1024;
+        assert_eq!(rewrite_data_at(&endpoint, offset).unwrap(), offset + 4);
+
+        let seen = seen.lock().unwrap();
+        let [initiate, copy, upload, complete] = &seen[..] else {
+            panic!("expected exactly four requests");
+        };
+
+        assert_eq!(initiate.method, "POST");
+        assert_eq!(initiate.path, "/bucket/dir/append.dat?uploads");
+        assert!(initiate.signed);
+
+        assert_eq!(copy.method, "PUT");
+        assert_eq!(
+            copy.path,
+            "/bucket/dir/append.dat?partNumber=1&uploadId=upload-1"
+        );
+        assert_eq!(copy.copy_source.as_deref(), Some("/bucket/dir/append.dat"));
+        assert_eq!(copy.copy_range.as_deref(), Some("bytes=0-10485759"));
+
+        assert_eq!(upload.method, "PUT");
+        assert_eq!(
+            upload.path,
+            "/bucket/dir/append.dat?partNumber=2&uploadId=upload-1"
+        );
+        assert_eq!(upload.body, b"data");
+
+        assert_eq!(complete.method, "POST");
+        assert_eq!(complete.path, "/bucket/dir/append.dat?uploadId=upload-1");
+        assert_eq!(
+            String::from_utf8_lossy(&complete.body),
+            "<CompleteMultipartUpload>\
+             <Part><PartNumber>1</PartNumber><ETag>\"etag-copy\"</ETag></Part>\
+             <Part><PartNumber>2</PartNumber><ETag>\"etag-data\"</ETag></Part>\
+             </CompleteMultipartUpload>"
+        );
+    }
+
+    /// A prefix over the 5 GiB part ceiling is copied in evenly-split
+    /// parts, all within the ceiling.
+    #[test]
+    fn multipart_rewrite_splits_the_prefix_at_the_part_ceiling() {
+        let (endpoint, seen) = stub_server(vec![
+            initiate_ok(),
+            copy_part_ok(),
+            copy_part_ok(),
+            data_part_ok(),
+            complete_ok(),
+        ]);
+
+        let offset = MAX_COPY_PART_SIZE + 1;
+        assert_eq!(rewrite_data_at(&endpoint, offset).unwrap(), offset + 4);
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 5);
+        assert_eq!(seen[1].copy_range.as_deref(), Some("bytes=0-2684354560"));
+        assert_eq!(
+            seen[2].copy_range.as_deref(),
+            Some("bytes=2684354561-5368709120")
+        );
+        assert!(seen[3].path.contains("partNumber=3"), "{}", seen[3].path);
+    }
+
+    /// A failing step aborts the multipart upload, so it does not linger
+    /// holding storage for its uploaded parts.
+    #[test]
+    fn multipart_rewrite_aborts_on_failure() {
+        let (endpoint, seen) = stub_server(vec![
+            initiate_ok(),
+            StubResponse::new(500),
+            StubResponse::new(204),
+        ]);
+
+        let err = rewrite_data_at(&endpoint, 10 * 1024 * 1024).unwrap_err();
+        assert_matches!(err, UniversalIoError::S3(_));
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 3);
+        assert_eq!(seen[2].method, "DELETE");
+        assert_eq!(seen[2].path, "/bucket/dir/append.dat?uploadId=upload-1");
+    }
+
+    /// `CompleteMultipartUpload` can fail after 200 OK, reporting the error
+    /// in the body; the upload is aborted like any other failure.
+    #[test]
+    fn multipart_rewrite_complete_error_in_a_200_body_is_an_error() {
+        let (endpoint, seen) = stub_server(vec![
+            initiate_ok(),
+            copy_part_ok(),
+            data_part_ok(),
+            StubResponse::new(200).body("<Error><Code>InternalError</Code></Error>"),
+            StubResponse::new(204),
+        ]);
+
+        let err = rewrite_data_at(&endpoint, 10 * 1024 * 1024).unwrap_err();
+        assert_matches!(err, UniversalIoError::S3(_));
+        assert!(err.to_string().contains("InternalError"), "{err}");
+        assert_eq!(seen.lock().unwrap().last().unwrap().method, "DELETE");
+    }
+}

--- a/lib/common/io_bridge_object_store/src/append/context/part_copy.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/part_copy.rs
@@ -218,7 +218,6 @@ async fn multipart_rewrite(
 
 /// The part copies and completion of [`multipart_rewrite`], separated so a
 /// failure of any step aborts the multipart upload.
-#[expect(clippy::too_many_arguments, reason = "internal helper")]
 async fn rewrite_parts(
     client: &SignedObjectClient<'_>,
     context: &SignedRequestContext,

--- a/lib/common/io_bridge_object_store/src/append/context/part_copy.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/part_copy.rs
@@ -8,6 +8,7 @@
 //! `UploadPartCopy` out of its portable surface (its internal part-copy is
 //! crate-private and range-less).
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -21,6 +22,11 @@ use super::signed::SignedRequestContext;
 /// Max bytes per `UploadPartCopy` part: the S3 5 GiB part-size ceiling.
 const MAX_COPY_PART_SIZE: u64 = 5 * 1024 * 1024 * 1024;
 
+/// S3 error code returned when a non-last multipart part is below the
+/// store's minimum part size (5 MiB on AWS): the rewrite is impossible
+/// server-side, the caller must rebuild the object by uploading it whole.
+const ENTITY_TOO_SMALL_CODE: &str = "EntityTooSmall";
+
 /// Minimum existing-object size this strategy can append to: the copied
 /// prefix lands as non-last multipart parts, which S3 requires to be at
 /// least 5 MiB. Below this, callers must write the whole object themselves.
@@ -28,12 +34,15 @@ pub(crate) const MIN_DIRECT_OFFSET: u64 = 5 * 1024 * 1024;
 
 /// One signed S3 request against a fixed object URL. Returns the response
 /// headers and body text; non-2xx statuses become errors carrying `step`
-/// and a body excerpt.
+/// and a body excerpt, with [`ENTITY_TOO_SMALL_CODE`] mapped to the typed
+/// [`UniversalIoError::AppendEntityTooSmall`].
 struct SignedObjectClient<'a> {
     client: HttpClient,
     credential: Arc<AwsCredential>,
     region: &'a str,
     url: Url,
+    /// The object's path, for error reporting.
+    path: PathBuf,
 }
 
 impl SignedObjectClient<'_> {
@@ -73,6 +82,11 @@ impl SignedObjectClient<'_> {
         let body_text = String::from_utf8_lossy(&body).into_owned();
 
         if !status.is_success() {
+            if extract_xml_tag(&body_text, "Code") == Some(ENTITY_TOO_SMALL_CODE) {
+                return Err(UniversalIoError::AppendEntityTooSmall {
+                    path: self.path.clone(),
+                });
+            }
             let excerpt: String = body_text.chars().take(512).collect();
             return Err(UniversalIoError::s3(std::io::Error::other(format!(
                 "{step} failed with status {status}: {excerpt}",
@@ -133,6 +147,7 @@ async fn multipart_rewrite(
         credential,
         region: &context.region,
         url: context.object_url(key)?,
+        path: PathBuf::from(key.to_string()),
     };
 
     let (_, body) = client
@@ -261,6 +276,11 @@ async fn rewrite_parts(
     // `CompleteMultipartUpload` also reports failures after 200 OK inside
     // the body.
     if body.contains("<Error") {
+        if extract_xml_tag(&body, "Code") == Some(ENTITY_TOO_SMALL_CODE) {
+            return Err(UniversalIoError::AppendEntityTooSmall {
+                path: PathBuf::from(key.to_string()),
+            });
+        }
         let excerpt: String = body.chars().take(512).collect();
         return Err(UniversalIoError::s3(std::io::Error::other(format!(
             "complete multipart rewrite for {key} failed: {excerpt}",

--- a/lib/common/io_bridge_object_store/src/append/context/part_copy.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/part_copy.rs
@@ -28,6 +28,10 @@ const MAX_COPY_PART_SIZE: u64 = 5 * 1024 * 1024 * 1024;
 /// server-side, the caller must rebuild the object by uploading it whole.
 const ENTITY_TOO_SMALL_CODE: &str = "EntityTooSmall";
 
+/// Request header making an `UploadPartCopy` conditional on the source
+/// object's entity tag; a mismatch fails the copy with 412.
+const COPY_SOURCE_IF_MATCH: &str = "x-amz-copy-source-if-match";
+
 /// Minimum existing-object size this strategy can append to: the copied
 /// prefix lands as non-last multipart parts, which S3 requires to be at
 /// least 5 MiB. Below this, callers must write the whole object themselves.
@@ -90,6 +94,13 @@ impl SignedObjectClient<'_> {
                     path: self.path.clone(),
                 });
             }
+            // The only precondition these requests carry is
+            // [`COPY_SOURCE_IF_MATCH`], so a 412 is an etag mismatch.
+            if status == http::StatusCode::PRECONDITION_FAILED {
+                return Err(UniversalIoError::AppendEtagMismatch {
+                    path: self.path.clone(),
+                });
+            }
             let excerpt: String = body_text.chars().take(512).collect();
             return Err(UniversalIoError::s3(std::io::Error::other(format!(
                 "{step} failed with status {status}: {excerpt}",
@@ -114,14 +125,20 @@ impl PartCopyAppend {
 
     /// Append `data` at `offset` (== the current object size) by rewriting
     /// the whole object. Returns the new total object size.
+    ///
+    /// `expected_etag` is attached to the prefix copies as
+    /// `x-amz-copy-source-if-match`, so the store itself rejects the
+    /// rewrite (as [`UniversalIoError::AppendEtagMismatch`]) if the object
+    /// no longer carries the entity tag the caller last observed.
     pub(in crate::append) async fn append(
         &self,
         store: &Arc<AmazonS3>,
         key: &object_store::path::Path,
         offset: u64,
         data: Bytes,
+        expected_etag: Option<&str>,
     ) -> UioResult<u64> {
-        multipart_rewrite(store, &self.signed, key, offset, data).await
+        multipart_rewrite(store, &self.signed, key, offset, data, expected_etag).await
     }
 }
 
@@ -130,15 +147,17 @@ impl PartCopyAppend {
 /// prefix, `data` as the final part, `CompleteMultipartUpload` (an atomic
 /// replace). Returns the new total object size.
 ///
-/// There is no compare-and-swap here — S3 evaluates the copy source when
-/// the part copy runs — so the caller must hold the single-writer contract
-/// (`CachedBlobFile` validates `offset` against its mirror length first).
+/// Without `expected_etag` there is no compare-and-swap here — S3 evaluates
+/// the copy source when the part copy runs — so the caller must hold the
+/// single-writer contract (`CachedBlobFile` validates `offset` against its
+/// mirror length first).
 async fn multipart_rewrite(
     store: &Arc<AmazonS3>,
     context: &SignedRequestContext,
     key: &object_store::path::Path,
     offset: u64,
     data: Bytes,
+    expected_etag: Option<&str>,
 ) -> UioResult<u64> {
     let credential = store
         .credentials()
@@ -171,7 +190,16 @@ async fn multipart_rewrite(
         })?
         .to_string();
 
-    let result = rewrite_parts(&client, context, key, offset, data, &upload_id).await;
+    let result = rewrite_parts(
+        &client,
+        context,
+        key,
+        offset,
+        data,
+        expected_etag,
+        &upload_id,
+    )
+    .await;
     if result.is_err() {
         // Best effort: an orphaned multipart upload holds storage until it
         // is aborted (or reaped by a bucket lifecycle rule).
@@ -190,37 +218,39 @@ async fn multipart_rewrite(
 
 /// The part copies and completion of [`multipart_rewrite`], separated so a
 /// failure of any step aborts the multipart upload.
+#[expect(clippy::too_many_arguments, reason = "internal helper")]
 async fn rewrite_parts(
     client: &SignedObjectClient<'_>,
     context: &SignedRequestContext,
     key: &object_store::path::Path,
     offset: u64,
     data: Bytes,
+    expected_etag: Option<&str>,
     upload_id: &str,
 ) -> UioResult<u64> {
     let mut etags = Vec::new();
-
-    // Server-side copy of `[0, offset)`, split evenly so every part fits
-    // the 5 GiB part ceiling while — at more than one part — staying at
-    // least half of it, far above the S3 5 MiB non-last-part minimum. A
-    // single part is >= 5 MiB by the caller's `MIN_COPY_PREFIX` bound.
     let copy_source = format!("/{}/{}", context.bucket, key);
     let part_len = offset.div_ceil(offset.div_ceil(MAX_COPY_PART_SIZE).max(1));
     let mut start = 0;
     while start < offset {
         let end = (start + part_len).min(offset);
         let part_number = etags.len() + 1;
+        let range = format!("bytes={start}-{}", end - 1);
+        let mut headers = vec![
+            ("x-amz-copy-source", copy_source.as_str()),
+            ("x-amz-copy-source-range", range.as_str()),
+        ];
+        // The store itself verifies the copied prefix still carries the
+        // caller's entity tag: a genuine compare-and-swap, unlike the
+        // unconditional rewrite. Rejected as 412 by `request`.
+        if let Some(expected_etag) = expected_etag {
+            headers.push((COPY_SOURCE_IF_MATCH, expected_etag));
+        }
         let (_, body) = client
             .request(
                 http::Method::PUT,
                 &format!("partNumber={part_number}&uploadId={upload_id}"),
-                &[
-                    ("x-amz-copy-source", copy_source.as_str()),
-                    (
-                        "x-amz-copy-source-range",
-                        &format!("bytes={start}-{}", end - 1),
-                    ),
-                ],
+                &headers,
                 HttpRequestBody::from(Bytes::new()),
                 "multipart rewrite part copy",
             )
@@ -304,6 +334,14 @@ mod tests {
     /// Multipart-rewrite `dir/append.dat` as its `[0, offset)` prefix plus
     /// `b"data"` via the stub.
     fn rewrite_data_at(endpoint: &str, offset: u64) -> UioResult<u64> {
+        rewrite_data_at_if_match(endpoint, offset, None)
+    }
+
+    fn rewrite_data_at_if_match(
+        endpoint: &str,
+        offset: u64,
+        expected_etag: Option<&str>,
+    ) -> UioResult<u64> {
         let (store, context) = stub_store_and_context(endpoint);
         let key = object_store::path::Path::from("dir/append.dat");
 
@@ -312,6 +350,7 @@ mod tests {
             &key,
             offset,
             Bytes::from_static(b"data"),
+            expected_etag,
         ))
     }
 
@@ -404,6 +443,44 @@ mod tests {
             Some("bytes=2684354561-5368709120")
         );
         assert!(seen[3].path.contains("partNumber=3"), "{}", seen[3].path);
+    }
+
+    /// The expected etag rides the part copies as
+    /// `x-amz-copy-source-if-match`; unconditional rewrites send no such
+    /// header.
+    #[test]
+    fn expected_etag_is_sent_as_copy_source_if_match() {
+        let (endpoint, seen) = stub_server(vec![
+            initiate_ok(),
+            copy_part_ok(),
+            data_part_ok(),
+            complete_ok(),
+        ]);
+
+        let offset = 10 * 1024 * 1024;
+        rewrite_data_at_if_match(&endpoint, offset, Some("\"expected\"")).unwrap();
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen[1].copy_if_match.as_deref(), Some("\"expected\""));
+        // The data part carries no copy source, hence no precondition.
+        assert_eq!(seen[2].copy_if_match, None);
+    }
+
+    /// A 412 on the conditional part copy is the store rejecting the etag
+    /// precondition: the object changed behind the caller's back. The
+    /// multipart upload is aborted like any other failure.
+    #[test]
+    fn copy_source_if_match_rejection_is_an_etag_mismatch() {
+        let (endpoint, seen) = stub_server(vec![
+            initiate_ok(),
+            StubResponse::new(412),
+            StubResponse::new(204),
+        ]);
+
+        let err =
+            rewrite_data_at_if_match(&endpoint, 10 * 1024 * 1024, Some("\"stale\"")).unwrap_err();
+        assert_matches!(err, UniversalIoError::AppendEtagMismatch { .. });
+        assert_eq!(seen.lock().unwrap().last().unwrap().method, "DELETE");
     }
 
     /// A failing step aborts the multipart upload, so it does not linger

--- a/lib/common/io_bridge_object_store/src/append/context/part_copy.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/part_copy.rs
@@ -17,6 +17,7 @@ use object_store::aws::{AmazonS3, AwsAuthorizer, AwsCredential};
 use object_store::client::{HttpClient, HttpRequestBody};
 use url::Url;
 
+use super::extract_xml_tag;
 use super::signed::SignedRequestContext;
 
 /// Max bytes per `UploadPartCopy` part: the S3 5 GiB part-size ceiling.
@@ -40,6 +41,8 @@ struct SignedObjectClient<'a> {
     client: HttpClient,
     credential: Arc<AwsCredential>,
     region: &'a str,
+    /// SigV4 service name, from [`SignedRequestContext::service`].
+    service: &'static str,
     url: Url,
     /// The object's path, for error reporting.
     path: PathBuf,
@@ -67,7 +70,7 @@ impl SignedObjectClient<'_> {
                 description: format!("{step} request: {err}"),
             })?;
 
-        AwsAuthorizer::new(&self.credential, "s3", self.region)
+        AwsAuthorizer::new(&self.credential, self.service, self.region)
             .try_authorize(&mut request, None)
             .map_err(UniversalIoError::s3)?;
 
@@ -146,6 +149,7 @@ async fn multipart_rewrite(
         client: context.client()?,
         credential,
         region: &context.region,
+        service: context.service,
         url: context.object_url(key)?,
         path: PathBuf::from(key.to_string()),
     };
@@ -288,15 +292,6 @@ async fn rewrite_parts(
     }
 
     Ok(final_size)
-}
-
-/// Text of the first `<tag>…</tag>` element in an S3 XML response.
-fn extract_xml_tag<'a>(body: &'a str, tag: &str) -> Option<&'a str> {
-    let open = format!("<{tag}>");
-    let close = format!("</{tag}>");
-    let start = body.find(&open)? + open.len();
-    let end = body[start..].find(&close)? + start;
-    Some(&body[start..end])
 }
 
 #[cfg(test)]

--- a/lib/common/io_bridge_object_store/src/append/context/signed.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/signed.rs
@@ -1,0 +1,105 @@
+//! Shared transport state for the hand-signed S3 requests both S3 append
+//! strategies are built on.
+
+use std::sync::{Arc, OnceLock};
+
+use common::universal_io::{UioResult, UniversalIoError};
+use object_store::ClientOptions;
+use object_store::client::{HttpClient, HttpConnector as _, ReqwestConnector};
+use url::Url;
+
+/// State for issuing hand-signed S3 requests — the operations the
+/// `object_store` crate does not expose (write-offset appends,
+/// `UploadPartCopy`): a lazily-built shared HTTP client plus the resolved
+/// object-URL base, bucket, and signing region.
+///
+/// Built once per source; construction is cheap — the HTTP client (TLS
+/// setup, connection pool) is only built on the first append, so sources
+/// that never append pay nothing.
+#[derive(Debug, Clone)]
+pub struct SignedRequestContext {
+    /// Reqwest-backed HTTP client, built on first use and shared across
+    /// clones of the source (and thus across file handles opened from it).
+    client: Arc<OnceLock<HttpClient>>,
+    /// Whether to allow plain-http endpoints; mirrors `build_store`.
+    allow_http: bool,
+    /// Bucket name, as needed by the `x-amz-copy-source` header of the
+    /// part-copy rewrites.
+    pub(super) bucket: String,
+    /// Base URL under which object keys live: path-style
+    /// `{endpoint}/{bucket}` for custom endpoints, or the virtual-hosted
+    /// `https://{bucket}.s3.{region}.amazonaws.com` for real AWS.
+    object_url_base: Url,
+    /// SigV4 signing region.
+    pub(super) region: String,
+}
+
+impl SignedRequestContext {
+    pub fn new(allow_http: bool, bucket: String, object_url_base: Url, region: String) -> Self {
+        Self {
+            client: Arc::new(OnceLock::new()),
+            allow_http,
+            bucket,
+            object_url_base,
+            region,
+        }
+    }
+
+    /// The shared HTTP client, built on first call. Concurrent first calls
+    /// may build a transient extra client; exactly one is kept.
+    pub(super) fn client(&self) -> UioResult<HttpClient> {
+        if let Some(client) = self.client.get() {
+            return Ok(client.clone());
+        }
+        let client = build_http_client(self.allow_http)?;
+        Ok(self.client.get_or_init(|| client).clone())
+    }
+
+    /// Absolute URL of the object at `key` under the context's base.
+    pub(super) fn object_url(&self, key: &object_store::path::Path) -> UioResult<Url> {
+        let mut url = self.object_url_base.clone();
+        url.path_segments_mut()
+            .map_err(|()| UniversalIoError::S3Config {
+                description: "append object url cannot be a base".to_string(),
+            })?
+            .pop_if_empty()
+            .extend(key.parts().map(|part| part.as_ref().to_string()));
+        Ok(url)
+    }
+}
+
+/// Build the reqwest-backed HTTP client the hand-issued append requests
+/// run on.
+pub(super) fn build_http_client(allow_http: bool) -> UioResult<HttpClient> {
+    let mut options = ClientOptions::new();
+    if allow_http {
+        options = options.with_allow_http(true);
+    }
+    ReqwestConnector::default()
+        .connect(&options)
+        .map_err(|err| UniversalIoError::S3Config {
+            description: format!("append http client: {err}"),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The HTTP client is built on first use and then reused; building it
+    /// performs no IO.
+    #[test]
+    fn client_is_built_lazily_and_cached() {
+        let context = SignedRequestContext::new(
+            true,
+            "bucket".to_string(),
+            Url::parse("http://localhost:9000/bucket").unwrap(),
+            "us-east-1".to_string(),
+        );
+        assert!(context.client.get().is_none());
+
+        context.client().unwrap();
+        assert!(context.client.get().is_some());
+        context.client().unwrap();
+    }
+}

--- a/lib/common/io_bridge_object_store/src/append/context/signed.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/signed.rs
@@ -27,21 +27,33 @@ pub struct SignedRequestContext {
     /// part-copy rewrites.
     pub(super) bucket: String,
     /// Base URL under which object keys live: path-style
-    /// `{endpoint}/{bucket}` for custom endpoints, or the virtual-hosted
-    /// `https://{bucket}.s3.{region}.amazonaws.com` for real AWS.
+    /// `{endpoint}/{bucket}` for custom endpoints, the virtual-hosted
+    /// `https://{bucket}.s3.{region}.amazonaws.com` for real AWS, or the
+    /// zonal `https://{bucket}.s3express-{az}.{region}.amazonaws.com` for
+    /// S3 Express directory buckets.
     object_url_base: Url,
     /// SigV4 signing region.
     pub(super) region: String,
+    /// SigV4 service name: `"s3"`, or `"s3express"` for S3 Express One
+    /// Zone directory buckets, which reject signatures scoped to `"s3"`.
+    pub(super) service: &'static str,
 }
 
 impl SignedRequestContext {
-    pub fn new(allow_http: bool, bucket: String, object_url_base: Url, region: String) -> Self {
+    pub fn new(
+        allow_http: bool,
+        bucket: String,
+        object_url_base: Url,
+        region: String,
+        service: &'static str,
+    ) -> Self {
         Self {
             client: Arc::new(OnceLock::new()),
             allow_http,
             bucket,
             object_url_base,
             region,
+            service,
         }
     }
 
@@ -95,6 +107,7 @@ mod tests {
             "bucket".to_string(),
             Url::parse("http://localhost:9000/bucket").unwrap(),
             "us-east-1".to_string(),
+            "s3",
         );
         assert!(context.client.get().is_none());
 

--- a/lib/common/io_bridge_object_store/src/append/context/stub.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/stub.rs
@@ -1,0 +1,165 @@
+//! Test-only local HTTP stub for exercising the hand-signed S3 requests of
+//! [`native`](super::native) and [`rewrite`](super::rewrite) hermetically.
+
+use std::io::{BufRead as _, BufReader, Read as _, Write as _};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+
+use object_store::aws::{AmazonS3, AmazonS3Builder};
+use url::Url;
+
+use super::signed::SignedRequestContext;
+
+/// Canned response served by [`stub_server`].
+pub(super) struct StubResponse {
+    status: u16,
+    headers: Vec<(&'static str, String)>,
+    body: &'static str,
+}
+
+impl StubResponse {
+    pub(super) fn new(status: u16) -> Self {
+        Self {
+            status,
+            headers: Vec::new(),
+            body: "",
+        }
+    }
+
+    pub(super) fn header(mut self, name: &'static str, value: impl ToString) -> Self {
+        self.headers.push((name, value.to_string()));
+        self
+    }
+
+    pub(super) fn body(mut self, body: &'static str) -> Self {
+        self.body = body;
+        self
+    }
+}
+
+/// One request as observed by [`stub_server`].
+pub(super) struct SeenRequest {
+    pub(super) method: String,
+    pub(super) path: String,
+    pub(super) write_offset: Option<String>,
+    pub(super) copy_source: Option<String>,
+    pub(super) copy_range: Option<String>,
+    pub(super) signed: bool,
+    pub(super) body: Vec<u8>,
+}
+
+/// Minimal local HTTP/1.1 server: serves the canned responses in order,
+/// one connection per response (every response carries
+/// `connection: close`, so retries and the `head()` reconciliation
+/// arrive as fresh connections), recording each request. The listener
+/// stops after the last response, so an unexpected extra request fails
+/// to connect instead of hanging the test.
+pub(super) fn stub_server(responses: Vec<StubResponse>) -> (String, Arc<Mutex<Vec<SeenRequest>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let endpoint = format!("http://{}", listener.local_addr().unwrap());
+    let seen = Arc::new(Mutex::new(Vec::new()));
+
+    let seen_in_server = Arc::clone(&seen);
+    std::thread::spawn(move || {
+        for response in responses {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            let Some(request) = read_request(&mut stream) else {
+                return;
+            };
+            seen_in_server.lock().unwrap().push(request);
+
+            let mut payload = format!("HTTP/1.1 {} Stub\r\n", response.status);
+            for (name, value) in &response.headers {
+                payload += &format!("{name}: {value}\r\n");
+            }
+            // A HEAD response declares a length without carrying a body.
+            let has_length = response
+                .headers
+                .iter()
+                .any(|(name, _)| name.eq_ignore_ascii_case("content-length"));
+            if !has_length {
+                payload += &format!("content-length: {}\r\n", response.body.len());
+            }
+            payload += "connection: close\r\n\r\n";
+            payload += response.body;
+            let _ = stream.write_all(payload.as_bytes());
+        }
+    });
+
+    (endpoint, seen)
+}
+
+fn read_request(stream: &mut TcpStream) -> Option<SeenRequest> {
+    let mut reader = BufReader::new(stream);
+
+    let mut request_line = String::new();
+    reader.read_line(&mut request_line).ok()?;
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next()?.to_string();
+    let path = parts.next()?.to_string();
+
+    let mut content_length = 0;
+    let mut write_offset = None;
+    let mut copy_source = None;
+    let mut copy_range = None;
+    let mut signed = false;
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line).ok()?;
+        let line = line.trim_end();
+        if line.is_empty() {
+            break;
+        }
+        let (name, value) = line.split_once(':')?;
+        let value = value.trim().to_string();
+        if name.eq_ignore_ascii_case("content-length") {
+            content_length = value.parse().ok()?;
+        } else if name.eq_ignore_ascii_case(super::native::WRITE_OFFSET_HEADER) {
+            write_offset = Some(value);
+        } else if name.eq_ignore_ascii_case("x-amz-copy-source") {
+            copy_source = Some(value);
+        } else if name.eq_ignore_ascii_case("x-amz-copy-source-range") {
+            copy_range = Some(value);
+        } else if name.eq_ignore_ascii_case("authorization") {
+            signed = true;
+        }
+    }
+
+    let mut body = vec![0; content_length];
+    reader.read_exact(&mut body).ok()?;
+
+    Some(SeenRequest {
+        method,
+        path,
+        write_offset,
+        copy_source,
+        copy_range,
+        signed,
+        body,
+    })
+}
+
+/// A store + signed-request context wired to the stub `endpoint`, for the
+/// bucket `bucket`.
+pub(super) fn stub_store_and_context(endpoint: &str) -> (Arc<AmazonS3>, SignedRequestContext) {
+    let store = Arc::new(
+        AmazonS3Builder::new()
+            .with_bucket_name("bucket")
+            .with_region("us-east-1")
+            .with_access_key_id("id")
+            .with_secret_access_key("secret")
+            .with_endpoint(endpoint)
+            .with_allow_http(true)
+            .build()
+            .unwrap(),
+    );
+    let context = SignedRequestContext::new(
+        true,
+        "bucket".to_string(),
+        Url::parse(&format!("{endpoint}/bucket")).unwrap(),
+        "us-east-1".to_string(),
+    );
+    (store, context)
+}

--- a/lib/common/io_bridge_object_store/src/append/context/stub.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/stub.rs
@@ -164,6 +164,7 @@ pub(in crate::append) fn stub_store_and_context(
         "bucket".to_string(),
         Url::parse(&format!("{endpoint}/bucket")).unwrap(),
         "us-east-1".to_string(),
+        "s3",
     );
     (store, context)
 }

--- a/lib/common/io_bridge_object_store/src/append/context/stub.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/stub.rs
@@ -44,6 +44,7 @@ pub(in crate::append) struct SeenRequest {
     pub(in crate::append) write_offset: Option<String>,
     pub(in crate::append) copy_source: Option<String>,
     pub(in crate::append) copy_range: Option<String>,
+    pub(in crate::append) copy_if_match: Option<String>,
     pub(in crate::append) signed: bool,
     pub(in crate::append) body: Vec<u8>,
 }
@@ -106,6 +107,7 @@ fn read_request(stream: &mut TcpStream) -> Option<SeenRequest> {
     let mut write_offset = None;
     let mut copy_source = None;
     let mut copy_range = None;
+    let mut copy_if_match = None;
     let mut signed = false;
     loop {
         let mut line = String::new();
@@ -124,6 +126,8 @@ fn read_request(stream: &mut TcpStream) -> Option<SeenRequest> {
             copy_source = Some(value);
         } else if name.eq_ignore_ascii_case("x-amz-copy-source-range") {
             copy_range = Some(value);
+        } else if name.eq_ignore_ascii_case("x-amz-copy-source-if-match") {
+            copy_if_match = Some(value);
         } else if name.eq_ignore_ascii_case("authorization") {
             signed = true;
         }
@@ -138,6 +142,7 @@ fn read_request(stream: &mut TcpStream) -> Option<SeenRequest> {
         write_offset,
         copy_source,
         copy_range,
+        copy_if_match,
         signed,
         body,
     })

--- a/lib/common/io_bridge_object_store/src/append/context/stub.rs
+++ b/lib/common/io_bridge_object_store/src/append/context/stub.rs
@@ -11,14 +11,14 @@ use url::Url;
 use super::signed::SignedRequestContext;
 
 /// Canned response served by [`stub_server`].
-pub(super) struct StubResponse {
+pub(in crate::append) struct StubResponse {
     status: u16,
     headers: Vec<(&'static str, String)>,
     body: &'static str,
 }
 
 impl StubResponse {
-    pub(super) fn new(status: u16) -> Self {
+    pub(in crate::append) fn new(status: u16) -> Self {
         Self {
             status,
             headers: Vec::new(),
@@ -26,26 +26,26 @@ impl StubResponse {
         }
     }
 
-    pub(super) fn header(mut self, name: &'static str, value: impl ToString) -> Self {
+    pub(in crate::append) fn header(mut self, name: &'static str, value: impl ToString) -> Self {
         self.headers.push((name, value.to_string()));
         self
     }
 
-    pub(super) fn body(mut self, body: &'static str) -> Self {
+    pub(in crate::append) fn body(mut self, body: &'static str) -> Self {
         self.body = body;
         self
     }
 }
 
 /// One request as observed by [`stub_server`].
-pub(super) struct SeenRequest {
-    pub(super) method: String,
-    pub(super) path: String,
-    pub(super) write_offset: Option<String>,
-    pub(super) copy_source: Option<String>,
-    pub(super) copy_range: Option<String>,
-    pub(super) signed: bool,
-    pub(super) body: Vec<u8>,
+pub(in crate::append) struct SeenRequest {
+    pub(in crate::append) method: String,
+    pub(in crate::append) path: String,
+    pub(in crate::append) write_offset: Option<String>,
+    pub(in crate::append) copy_source: Option<String>,
+    pub(in crate::append) copy_range: Option<String>,
+    pub(in crate::append) signed: bool,
+    pub(in crate::append) body: Vec<u8>,
 }
 
 /// Minimal local HTTP/1.1 server: serves the canned responses in order,
@@ -54,7 +54,9 @@ pub(super) struct SeenRequest {
 /// arrive as fresh connections), recording each request. The listener
 /// stops after the last response, so an unexpected extra request fails
 /// to connect instead of hanging the test.
-pub(super) fn stub_server(responses: Vec<StubResponse>) -> (String, Arc<Mutex<Vec<SeenRequest>>>) {
+pub(in crate::append) fn stub_server(
+    responses: Vec<StubResponse>,
+) -> (String, Arc<Mutex<Vec<SeenRequest>>>) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let endpoint = format!("http://{}", listener.local_addr().unwrap());
     let seen = Arc::new(Mutex::new(Vec::new()));
@@ -143,7 +145,9 @@ fn read_request(stream: &mut TcpStream) -> Option<SeenRequest> {
 
 /// A store + signed-request context wired to the stub `endpoint`, for the
 /// bucket `bucket`.
-pub(super) fn stub_store_and_context(endpoint: &str) -> (Arc<AmazonS3>, SignedRequestContext) {
+pub(in crate::append) fn stub_store_and_context(
+    endpoint: &str,
+) -> (Arc<AmazonS3>, SignedRequestContext) {
     let store = Arc::new(
         AmazonS3Builder::new()
             .with_bucket_name("bucket")

--- a/lib/common/io_bridge_object_store/src/append/mod.rs
+++ b/lib/common/io_bridge_object_store/src/append/mod.rs
@@ -7,6 +7,8 @@
 
 mod context;
 
+use std::path::PathBuf;
+
 use bytes::Bytes;
 use common::universal_io::{UioResult, UniversalIoError};
 pub use context::{
@@ -15,6 +17,7 @@ pub use context::{
 use io_bridge::{AppendSupport, AsyncAppend};
 use object_store::aws::AmazonS3;
 use object_store::gcp::GoogleCloudStorage;
+use object_store::{ObjectStoreExt as _, PutPayload};
 
 use crate::source::ObjectStoreSource;
 
@@ -56,10 +59,22 @@ impl AsyncAppend for ObjectStoreSource<AmazonS3> {
                 AppendContext::Native(native) => {
                     match native.append(&store, &key, offset, data.clone()).await {
                         // The object hit the store's appended-block cap;
-                        // rebuilding it as a single blob via the part-copy
-                        // strategy resets the cap.
+                        // rebuilding it as a single blob resets the cap.
                         Err(err) if err.is_append_rewrite_required() => {
-                            native.part_copy().append(&store, &key, offset, data).await
+                            let rewrite = native
+                                .part_copy()
+                                .append(&store, &key, offset, data.clone())
+                                .await;
+                            match rewrite {
+                                // The store also rejected the server-side
+                                // rebuild: the prefix is below its minimum
+                                // multipart part size. Download it and
+                                // rewrite the whole object.
+                                Err(err) if err.is_append_entity_too_small() => {
+                                    download_rewrite(&store, &key, offset, data).await
+                                }
+                                result => result,
+                            }
                         }
                         result => result,
                     }
@@ -77,6 +92,47 @@ impl AsyncAppend for ObjectStoreSource<AmazonS3> {
             }
         }
     }
+}
+
+/// Last-resort appended-block cap recovery, for when the store rejects even
+/// the server-side rebuild because the object is below its minimum multipart
+/// part size: download the existing prefix and atomically PUT the whole
+/// object back as `[0, offset) + data`. That same rejection bounds the
+/// download — the object is smaller than one minimum part (5 MiB on AWS).
+async fn download_rewrite(
+    store: &AmazonS3,
+    key: &object_store::path::Path,
+    offset: u64,
+    data: Bytes,
+) -> UioResult<u64> {
+    let existing = store
+        .get(key)
+        .await
+        .map_err(UniversalIoError::s3)?
+        .bytes()
+        .await
+        .map_err(UniversalIoError::s3)?;
+
+    // The same compare-and-swap token as a direct append: a prefix of a
+    // different length means `offset` is not the current object size.
+    if existing.len() as u64 != offset {
+        return Err(UniversalIoError::AppendOffsetConflict {
+            path: PathBuf::from(key.to_string()),
+            offset,
+        });
+    }
+
+    let mut whole = Vec::with_capacity(existing.len() + data.len());
+    whole.extend_from_slice(&existing);
+    whole.extend_from_slice(&data);
+    let new_len = whole.len() as u64;
+
+    store
+        .put(key, PutPayload::from(whole))
+        .await
+        .map_err(UniversalIoError::s3)?;
+
+    Ok(new_len)
 }
 
 impl AsyncAppend for ObjectStoreSource<GoogleCloudStorage> {
@@ -165,5 +221,89 @@ mod tests {
             seen[2].copy_source.as_deref(),
             Some("/bucket/dir/append.dat")
         );
+    }
+
+    /// The responses of a part-copy rewrite attempt that the store rejects
+    /// at the complete step because the object is below its minimum part
+    /// size — followed by the abort of the orphaned multipart upload.
+    fn rejected_part_copy_attempt() -> Vec<StubResponse> {
+        vec![
+            // Native write-offset PUT: rejected with the appended-block cap.
+            StubResponse::new(400).body("<Error><Code>TooManyParts</Code></Error>"),
+            // The part-copy rewrite attempt: initiate, prefix copy, data
+            // part — then the complete is rejected and the upload aborted.
+            StubResponse::new(200).body(
+                "<InitiateMultipartUploadResult><UploadId>upload-1</UploadId>\
+                 </InitiateMultipartUploadResult>",
+            ),
+            StubResponse::new(200)
+                .body("<CopyPartResult><ETag>\"etag-copy\"</ETag></CopyPartResult>"),
+            StubResponse::new(200).header("etag", "\"etag-data\""),
+            StubResponse::new(400).body("<Error><Code>EntityTooSmall</Code></Error>"),
+            StubResponse::new(204),
+        ]
+    }
+
+    /// A capped object the store also refuses to rewrite server-side
+    /// (`EntityTooSmall`) is recovered by downloading the prefix and
+    /// PUTting the whole object back.
+    #[test]
+    fn entity_too_small_rewrite_downloads_and_puts_the_whole_object() {
+        let mut responses = rejected_part_copy_attempt();
+        responses.extend([
+            // Download of the existing 5-byte prefix.
+            StubResponse::new(200)
+                .header("last-modified", "Tue, 14 Jul 2026 12:00:00 GMT")
+                .header("etag", "\"stub\"")
+                .body("abcde"),
+            // Whole-object PUT of prefix + appended data.
+            StubResponse::new(200).header("etag", "\"stub-2\""),
+        ]);
+        let (endpoint, seen) = stub_server(responses);
+        let (store, context) = stub_store_and_context(&endpoint);
+        let source = ObjectStoreSource::new(store)
+            .with_append_context(AppendContext::Native(NativeAppend::new(context)));
+
+        let new_len = io_bridge::BridgeRuntime::global()
+            .block_on(source.append(Path::new("dir/append.dat"), 5, Bytes::from_static(b"data")))
+            .unwrap();
+        assert_eq!(new_len, 9);
+
+        let seen = seen.lock().unwrap();
+        let methods: Vec<&str> = seen.iter().map(|request| request.method.as_str()).collect();
+        assert_eq!(
+            methods,
+            ["PUT", "POST", "PUT", "PUT", "POST", "DELETE", "GET", "PUT"]
+        );
+        assert_eq!(seen[7].body, b"abcdedata");
+        assert!(seen[7].write_offset.is_none());
+    }
+
+    /// The download-rewrite must not rebuild the object from a stale view:
+    /// a downloaded prefix whose length disagrees with `offset` is an
+    /// offset conflict, and no PUT is issued.
+    #[test]
+    fn download_rewrite_with_a_stale_offset_is_a_conflict() {
+        let mut responses = rejected_part_copy_attempt();
+        responses.extend([
+            // The object is 6 bytes, not the expected 5.
+            StubResponse::new(200)
+                .header("last-modified", "Tue, 14 Jul 2026 12:00:00 GMT")
+                .header("etag", "\"stub\"")
+                .body("abcdef"),
+        ]);
+        let (endpoint, seen) = stub_server(responses);
+        let (store, context) = stub_store_and_context(&endpoint);
+        let source = ObjectStoreSource::new(store)
+            .with_append_context(AppendContext::Native(NativeAppend::new(context)));
+
+        let err = io_bridge::BridgeRuntime::global()
+            .block_on(source.append(Path::new("dir/append.dat"), 5, Bytes::from_static(b"data")))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            UniversalIoError::AppendOffsetConflict { offset: 5, .. }
+        ));
+        assert_eq!(seen.lock().unwrap().len(), 7);
     }
 }

--- a/lib/common/io_bridge_object_store/src/append/mod.rs
+++ b/lib/common/io_bridge_object_store/src/append/mod.rs
@@ -1,0 +1,130 @@
+//! Appends for object stores, powering the `AsyncAppend` impls on
+//! [`ObjectStoreSource`]. The configured store's [`AppendContext`] selects
+//! the strategy object: a native single-request write-offset append
+//! ([`NativeAppend`]), a whole-object multipart rewrite with server-side
+//! prefix copies ([`PartCopyAppend`]) for S3 stores without native append,
+//! or a server-side `compose` concatenation ([`ComposeAppend`]) on GCS.
+
+mod context;
+
+use common::universal_io::{UioResult, UniversalIoError};
+pub use context::{
+    AppendContext, ComposeAppend, NativeAppend, PartCopyAppend, SignedRequestContext,
+};
+use io_bridge::{AppendRequest, AppendSupport, AsyncAppend};
+use object_store::aws::AmazonS3;
+use object_store::gcp::GoogleCloudStorage;
+
+use crate::source::ObjectStoreSource;
+
+impl AsyncAppend for ObjectStoreSource<AmazonS3> {
+    fn append_support(&self) -> AppendSupport {
+        match self.append_context() {
+            Some(AppendContext::Native(_)) => AppendSupport::Always,
+            // Part-copy appends carry the copied prefix as non-last
+            // multipart parts, which S3 caps from below.
+            Some(AppendContext::PartCopy(_)) => AppendSupport::AboveThreshold {
+                min_offset: context::part_copy::MIN_DIRECT_OFFSET,
+            },
+            // A compose context on an S3 store is a config error; `Never`
+            // keeps the caller from ever exercising it.
+            Some(AppendContext::Compose(_)) | None => AppendSupport::Never,
+        }
+    }
+
+    fn append(
+        &self,
+        path: &std::path::Path,
+        request: AppendRequest,
+    ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
+        let store = self.store().clone();
+        let context = self.append_context().cloned();
+        let key = crate::source::build_key(path);
+
+        async move {
+            let Some(context) = context else {
+                return Err(UniversalIoError::S3Config {
+                    description: "append is not supported for this S3 backend/config \
+                                  (append context missing)"
+                        .to_string(),
+                });
+            };
+
+            match request {
+                AppendRequest::Append { offset, data } => match context {
+                    AppendContext::Native(native) => {
+                        native.append(&store, &key, offset, data).await
+                    }
+                    // A direct append on a part-copy store IS the rewrite;
+                    // the caller respects the advertised threshold.
+                    AppendContext::PartCopy(part_copy) => {
+                        part_copy.append(&store, &key, offset, data).await
+                    }
+                    AppendContext::Compose(_) => Err(UniversalIoError::S3Config {
+                        description: "compose append context belongs to a GCS store, \
+                                      not an S3 one"
+                            .to_string(),
+                    }),
+                },
+                AppendRequest::Rewrite { offset, data } => match context {
+                    AppendContext::PartCopy(part_copy) => {
+                        part_copy.append(&store, &key, offset, data).await
+                    }
+                    // Native stores rewrite too — compacting an object that
+                    // reached the appended-block cap — via the part-copy
+                    // strategy over the same store.
+                    AppendContext::Native(native) => {
+                        native.part_copy().append(&store, &key, offset, data).await
+                    }
+                    AppendContext::Compose(_) => Err(UniversalIoError::S3Config {
+                        description: "compose append context belongs to a GCS store, \
+                                      not an S3 one"
+                            .to_string(),
+                    }),
+                },
+            }
+        }
+    }
+}
+
+impl AsyncAppend for ObjectStoreSource<GoogleCloudStorage> {
+    fn append_support(&self) -> AppendSupport {
+        // Compose appends at any size: no part-size minimums, no
+        // appended-block cap — callers never need a fallback.
+        AppendSupport::Always
+    }
+
+    fn append(
+        &self,
+        path: &std::path::Path,
+        request: AppendRequest,
+    ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
+        let store = self.store().clone();
+        let context = self.append_context().cloned();
+        let key = crate::source::build_key(path);
+
+        async move {
+            let Some(context) = context else {
+                return Err(UniversalIoError::S3Config {
+                    description: "append is not supported for this GCS backend/config \
+                                  (append context missing)"
+                        .to_string(),
+                });
+            };
+
+            // Both request shapes are the same operation under compose:
+            // `[0, offset)` is the existing object either way.
+            let (AppendRequest::Append { offset, data } | AppendRequest::Rewrite { offset, data }) =
+                request;
+
+            match context {
+                AppendContext::Compose(compose) => compose.append(&store, &key, offset, data).await,
+                AppendContext::Native(_) | AppendContext::PartCopy(_) => {
+                    Err(UniversalIoError::S3Config {
+                        description: "S3 append context on a GCS store".to_string(),
+                    })
+                }
+            }
+        }
+    }
+}

--- a/lib/common/io_bridge_object_store/src/append/mod.rs
+++ b/lib/common/io_bridge_object_store/src/append/mod.rs
@@ -7,11 +7,12 @@
 
 mod context;
 
+use bytes::Bytes;
 use common::universal_io::{UioResult, UniversalIoError};
 pub use context::{
     AppendContext, ComposeAppend, NativeAppend, PartCopyAppend, SignedRequestContext,
 };
-use io_bridge::{AppendRequest, AppendSupport, AsyncAppend};
+use io_bridge::{AppendSupport, AsyncAppend};
 use object_store::aws::AmazonS3;
 use object_store::gcp::GoogleCloudStorage;
 
@@ -35,7 +36,8 @@ impl AsyncAppend for ObjectStoreSource<AmazonS3> {
     fn append(
         &self,
         path: &std::path::Path,
-        request: AppendRequest,
+        offset: u64,
+        data: Bytes,
     ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
         let store = self.store().clone();
         let context = self.append_context().cloned();
@@ -50,38 +52,28 @@ impl AsyncAppend for ObjectStoreSource<AmazonS3> {
                 });
             };
 
-            match request {
-                AppendRequest::Append { offset, data } => match context {
-                    AppendContext::Native(native) => {
-                        native.append(&store, &key, offset, data).await
+            match context {
+                AppendContext::Native(native) => {
+                    match native.append(&store, &key, offset, data.clone()).await {
+                        // The object hit the store's appended-block cap;
+                        // rebuilding it as a single blob via the part-copy
+                        // strategy resets the cap.
+                        Err(err) if err.is_append_rewrite_required() => {
+                            native.part_copy().append(&store, &key, offset, data).await
+                        }
+                        result => result,
                     }
-                    // A direct append on a part-copy store IS the rewrite;
-                    // the caller respects the advertised threshold.
-                    AppendContext::PartCopy(part_copy) => {
-                        part_copy.append(&store, &key, offset, data).await
-                    }
-                    AppendContext::Compose(_) => Err(UniversalIoError::S3Config {
-                        description: "compose append context belongs to a GCS store, \
-                                      not an S3 one"
-                            .to_string(),
-                    }),
-                },
-                AppendRequest::Rewrite { offset, data } => match context {
-                    AppendContext::PartCopy(part_copy) => {
-                        part_copy.append(&store, &key, offset, data).await
-                    }
-                    // Native stores rewrite too — compacting an object that
-                    // reached the appended-block cap — via the part-copy
-                    // strategy over the same store.
-                    AppendContext::Native(native) => {
-                        native.part_copy().append(&store, &key, offset, data).await
-                    }
-                    AppendContext::Compose(_) => Err(UniversalIoError::S3Config {
-                        description: "compose append context belongs to a GCS store, \
-                                      not an S3 one"
-                            .to_string(),
-                    }),
-                },
+                }
+                // A direct append on a part-copy store IS the rewrite;
+                // the caller respects the advertised threshold.
+                AppendContext::PartCopy(part_copy) => {
+                    part_copy.append(&store, &key, offset, data).await
+                }
+                AppendContext::Compose(_) => Err(UniversalIoError::S3Config {
+                    description: "compose append context belongs to a GCS store, \
+                                  not an S3 one"
+                        .to_string(),
+                }),
             }
         }
     }
@@ -97,7 +89,8 @@ impl AsyncAppend for ObjectStoreSource<GoogleCloudStorage> {
     fn append(
         &self,
         path: &std::path::Path,
-        request: AppendRequest,
+        offset: u64,
+        data: Bytes,
     ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
         let store = self.store().clone();
         let context = self.append_context().cloned();
@@ -112,11 +105,6 @@ impl AsyncAppend for ObjectStoreSource<GoogleCloudStorage> {
                 });
             };
 
-            // Both request shapes are the same operation under compose:
-            // `[0, offset)` is the existing object either way.
-            let (AppendRequest::Append { offset, data } | AppendRequest::Rewrite { offset, data }) =
-                request;
-
             match context {
                 AppendContext::Compose(compose) => compose.append(&store, &key, offset, data).await,
                 AppendContext::Native(_) | AppendContext::PartCopy(_) => {
@@ -126,5 +114,56 @@ impl AsyncAppend for ObjectStoreSource<GoogleCloudStorage> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use context::stub::{StubResponse, stub_server, stub_store_and_context};
+
+    use super::*;
+    use crate::source::ObjectStoreSource;
+
+    /// An append on a native store that hits the appended-block cap falls
+    /// back to the part-copy rewrite within the same `append` call.
+    #[test]
+    fn native_cap_hit_falls_back_to_part_copy_rewrite() {
+        let (endpoint, seen) = stub_server(vec![
+            // Native write-offset PUT: rejected with the appended-block cap.
+            StubResponse::new(400).body("<Error><Code>TooManyParts</Code></Error>"),
+            // The part-copy rewrite: initiate, prefix copy, data part, complete.
+            StubResponse::new(200).body(
+                "<InitiateMultipartUploadResult><UploadId>upload-1</UploadId>\
+                 </InitiateMultipartUploadResult>",
+            ),
+            StubResponse::new(200)
+                .body("<CopyPartResult><ETag>\"etag-copy\"</ETag></CopyPartResult>"),
+            StubResponse::new(200).header("etag", "\"etag-data\""),
+            StubResponse::new(200).body("<CompleteMultipartUploadResult/>"),
+        ]);
+        let (store, context) = stub_store_and_context(&endpoint);
+        let source = ObjectStoreSource::new(store)
+            .with_append_context(AppendContext::Native(NativeAppend::new(context)));
+
+        let offset: u64 = 10 * 1024 * 1024;
+        let new_len = io_bridge::BridgeRuntime::global()
+            .block_on(source.append(
+                Path::new("dir/append.dat"),
+                offset,
+                Bytes::from_static(b"data"),
+            ))
+            .unwrap();
+        assert_eq!(new_len, offset + 4);
+
+        let seen = seen.lock().unwrap();
+        let methods: Vec<&str> = seen.iter().map(|request| request.method.as_str()).collect();
+        assert_eq!(methods, ["PUT", "POST", "PUT", "PUT", "POST"]);
+        assert_eq!(seen[0].write_offset.as_deref(), Some(&*offset.to_string()));
+        assert_eq!(
+            seen[2].copy_source.as_deref(),
+            Some("/bucket/dir/append.dat")
+        );
     }
 }

--- a/lib/common/io_bridge_object_store/src/append/mod.rs
+++ b/lib/common/io_bridge_object_store/src/append/mod.rs
@@ -41,6 +41,7 @@ impl AsyncAppend for ObjectStoreSource<AmazonS3> {
         path: &std::path::Path,
         offset: u64,
         data: Bytes,
+        expected_etag: Option<String>,
     ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
         let store = self.store().clone();
         let context = self.append_context().cloned();
@@ -57,13 +58,21 @@ impl AsyncAppend for ObjectStoreSource<AmazonS3> {
 
             match context {
                 AppendContext::Native(native) => {
+                    // The write-offset PUT has no etag precondition;
+                    // `expected_etag` applies from the rewrite fallbacks on.
                     match native.append(&store, &key, offset, data.clone()).await {
                         // The object hit the store's appended-block cap;
                         // rebuilding it as a single blob resets the cap.
                         Err(err) if err.is_append_rewrite_required() => {
                             let rewrite = native
                                 .part_copy()
-                                .append(&store, &key, offset, data.clone())
+                                .append(
+                                    &store,
+                                    &key,
+                                    offset,
+                                    data.clone(),
+                                    expected_etag.as_deref(),
+                                )
                                 .await;
                             match rewrite {
                                 // The store also rejected the server-side
@@ -71,7 +80,14 @@ impl AsyncAppend for ObjectStoreSource<AmazonS3> {
                                 // multipart part size. Download it and
                                 // rewrite the whole object.
                                 Err(err) if err.is_append_entity_too_small() => {
-                                    download_rewrite(&store, &key, offset, data).await
+                                    download_rewrite(
+                                        &store,
+                                        &key,
+                                        offset,
+                                        data,
+                                        expected_etag.as_deref(),
+                                    )
+                                    .await
                                 }
                                 result => result,
                             }
@@ -82,7 +98,9 @@ impl AsyncAppend for ObjectStoreSource<AmazonS3> {
                 // A direct append on a part-copy store IS the rewrite;
                 // the caller respects the advertised threshold.
                 AppendContext::PartCopy(part_copy) => {
-                    part_copy.append(&store, &key, offset, data).await
+                    part_copy
+                        .append(&store, &key, offset, data, expected_etag.as_deref())
+                        .await
                 }
                 AppendContext::Compose(_) => Err(UniversalIoError::S3Config {
                     description: "compose append context belongs to a GCS store, \
@@ -99,19 +117,27 @@ impl AsyncAppend for ObjectStoreSource<AmazonS3> {
 /// part size: download the existing prefix and atomically PUT the whole
 /// object back as `[0, offset) + data`. That same rejection bounds the
 /// download — the object is smaller than one minimum part (5 MiB on AWS).
+///
+/// `expected_etag` is checked against the downloaded prefix's own etag —
+/// the GET carries it, so the guard costs no extra request here.
 async fn download_rewrite(
     store: &AmazonS3,
     key: &object_store::path::Path,
     offset: u64,
     data: Bytes,
+    expected_etag: Option<&str>,
 ) -> UioResult<u64> {
-    let existing = store
-        .get(key)
-        .await
-        .map_err(UniversalIoError::s3)?
-        .bytes()
-        .await
-        .map_err(UniversalIoError::s3)?;
+    let result = store.get(key).await.map_err(UniversalIoError::s3)?;
+
+    if let Some(expected) = expected_etag
+        && result.meta.e_tag.as_deref() != Some(expected)
+    {
+        return Err(UniversalIoError::AppendEtagMismatch {
+            path: PathBuf::from(key.to_string()),
+        });
+    }
+
+    let existing = result.bytes().await.map_err(UniversalIoError::s3)?;
 
     // The same compare-and-swap token as a direct append: a prefix of a
     // different length means `offset` is not the current object size.
@@ -147,6 +173,9 @@ impl AsyncAppend for ObjectStoreSource<GoogleCloudStorage> {
         path: &std::path::Path,
         offset: u64,
         data: Bytes,
+        // GCS compose preconditions are generation-based, not etag-based,
+        // so the expected etag cannot be honored here.
+        _expected_etag: Option<String>,
     ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
         let store = self.store().clone();
         let context = self.append_context().cloned();
@@ -209,6 +238,7 @@ mod tests {
                 Path::new("dir/append.dat"),
                 offset,
                 Bytes::from_static(b"data"),
+                None,
             ))
             .unwrap();
         assert_eq!(new_len, offset + 4);
@@ -265,7 +295,12 @@ mod tests {
             .with_append_context(AppendContext::Native(NativeAppend::new(context)));
 
         let new_len = io_bridge::BridgeRuntime::global()
-            .block_on(source.append(Path::new("dir/append.dat"), 5, Bytes::from_static(b"data")))
+            .block_on(source.append(
+                Path::new("dir/append.dat"),
+                5,
+                Bytes::from_static(b"data"),
+                None,
+            ))
             .unwrap();
         assert_eq!(new_len, 9);
 
@@ -298,7 +333,12 @@ mod tests {
             .with_append_context(AppendContext::Native(NativeAppend::new(context)));
 
         let err = io_bridge::BridgeRuntime::global()
-            .block_on(source.append(Path::new("dir/append.dat"), 5, Bytes::from_static(b"data")))
+            .block_on(source.append(
+                Path::new("dir/append.dat"),
+                5,
+                Bytes::from_static(b"data"),
+                None,
+            ))
             .unwrap_err();
         assert!(matches!(
             err,

--- a/lib/common/io_bridge_object_store/src/backends/aws.rs
+++ b/lib/common/io_bridge_object_store/src/backends/aws.rs
@@ -92,9 +92,11 @@ impl BlobBackend for AmazonS3 {
         let (endpoint, region) =
             resolve_endpoint_and_region(config, |name| std::env::var(name).ok());
 
-        let object_url_base = match &endpoint {
+        let (object_url_base, service) = match &endpoint {
             // Path-style addressing, as object_store uses for custom
-            // endpoints.
+            // endpoints. An explicit endpoint stays the operator override
+            // (VPC endpoints, FIPS, MinIO & co) and keeps plain "s3"
+            // signing.
             Some(endpoint) => {
                 let mut url = Url::parse(endpoint)
                     .map_err(|err| s3_config_error(format!("append endpoint url: {err}")))?;
@@ -102,14 +104,33 @@ impl BlobBackend for AmazonS3 {
                     .map_err(|()| s3_config_error("append endpoint url cannot be a base".into()))?
                     .pop_if_empty()
                     .push(&config.bucket);
-                url
+                (url, "s3")
+            }
+            // S3 Express directory buckets only exist on their zonal
+            // endpoint and reject signatures scoped to "s3".
+            None if config.s3_express => {
+                let az = directory_bucket_az(&config.bucket).ok_or_else(|| {
+                    s3_config_error(format!(
+                        "s3_express appends need a directory bucket named \
+                         `<name>--<az>--x-s3`, got `{}`",
+                        config.bucket,
+                    ))
+                })?;
+                let url = format!(
+                    "https://{}.s3express-{az}.{region}.amazonaws.com",
+                    config.bucket,
+                );
+                let url = Url::parse(&url)
+                    .map_err(|err| s3_config_error(format!("append object url: {err}")))?;
+                (url, "s3express")
             }
             // Virtual-hosted-style addressing, as object_store uses for real
             // AWS.
             None => {
                 let url = format!("https://{}.s3.{region}.amazonaws.com", config.bucket);
-                Url::parse(&url)
-                    .map_err(|err| s3_config_error(format!("append object url: {err}")))?
+                let url = Url::parse(&url)
+                    .map_err(|err| s3_config_error(format!("append object url: {err}")))?;
+                (url, "s3")
             }
         };
 
@@ -118,8 +139,13 @@ impl BlobBackend for AmazonS3 {
         // built lazily on first append.
         let allow_http = endpoint.is_some();
 
-        let context =
-            SignedRequestContext::new(allow_http, config.bucket.clone(), object_url_base, region);
+        let context = SignedRequestContext::new(
+            allow_http,
+            config.bucket.clone(),
+            object_url_base,
+            region,
+            service,
+        );
 
         Ok(Some(if config.s3_express || config.native_append {
             AppendContext::Native(NativeAppend::new(context))
@@ -127,6 +153,16 @@ impl BlobBackend for AmazonS3 {
             AppendContext::PartCopy(PartCopyAppend::new(context))
         }))
     }
+}
+
+/// The availability-zone segment of a directory-bucket name
+/// (`<name>--<az>--x-s3`), from which the zonal S3 Express endpoint is
+/// derived. `object_store`'s builder performs the same derivation
+/// internally (object_store 0.14.1 `aws/builder.rs`) but does not expose
+/// it, hence the duplication.
+fn directory_bucket_az(bucket: &str) -> Option<&str> {
+    let (_, az) = bucket.strip_suffix("--x-s3")?.rsplit_once("--")?;
+    (!az.is_empty()).then_some(az)
 }
 
 /// Resolve the endpoint and signing region for appends the same way
@@ -215,5 +251,42 @@ mod tests {
         };
         let (endpoint, _) = resolve_endpoint_and_region(&config(AwsCredentials::Default), env_s3);
         assert_eq!(endpoint.as_deref(), Some("http://s3:9000"));
+    }
+
+    #[test]
+    fn directory_bucket_az_parses_the_mandatory_suffix() {
+        assert_eq!(
+            directory_bucket_az("my-bucket--use1-az4--x-s3"),
+            Some("use1-az4")
+        );
+        // Extra `--` in the name: the az is the last segment before the
+        // suffix.
+        assert_eq!(
+            directory_bucket_az("a--b--use1-az4--x-s3"),
+            Some("use1-az4")
+        );
+        assert_eq!(directory_bucket_az("plain-bucket"), None);
+        assert_eq!(directory_bucket_az("no-az--x-s3"), None);
+        assert_eq!(directory_bucket_az("empty-az----x-s3"), None);
+    }
+
+    /// `s3_express` without a parseable directory-bucket suffix cannot
+    /// derive the zonal endpoint and must fail loudly at construction.
+    #[test]
+    fn s3_express_append_context_requires_a_directory_bucket_name() {
+        let mut express = config(AwsCredentials::Static {
+            access_key_id: "id".to_string(),
+            secret_access_key: "secret".to_string(),
+            session_token: None,
+        });
+        express.s3_express = true;
+        express.region = Some("us-east-1".to_string());
+
+        let err = <AmazonS3 as BlobBackend>::append_context(&express).unwrap_err();
+        assert!(matches!(err, UniversalIoError::S3Config { .. }), "{err}");
+
+        express.bucket = "bucket--use1-az4--x-s3".to_string();
+        let context = <AmazonS3 as BlobBackend>::append_context(&express).unwrap();
+        assert!(matches!(context, Some(AppendContext::Native(_))));
     }
 }

--- a/lib/common/io_bridge_object_store/src/backends/aws.rs
+++ b/lib/common/io_bridge_object_store/src/backends/aws.rs
@@ -4,7 +4,7 @@ use common::universal_io::{UioResult, UniversalIoError, UniversalKind};
 use object_store::aws::{AmazonS3, AmazonS3Builder};
 use url::Url;
 
-use crate::append::AppendContext;
+use crate::append::{AppendContext, NativeAppend, PartCopyAppend, SignedRequestContext};
 use crate::backend::BlobBackend;
 
 /// SigV4 signing needs a region even for endpoints that ignore it.
@@ -24,6 +24,12 @@ pub struct AwsConfig {
     pub endpoint: Option<String>,
     /// Enable S3 Express One Zone (`*--x-s3` directory buckets).
     pub s3_express: bool,
+    /// The store honors native write-offset appends (`PutObject` +
+    /// `x-amz-write-offset-bytes`). Not detectable from the endpoint — the
+    /// operator declares it for stores like MinIO AiStor or RustFS;
+    /// `s3_express` implies it. Left off (plain S3 Standard), appends go
+    /// through multipart rewrites with server-side prefix copies.
+    pub native_append: bool,
     /// How to authenticate to S3.
     pub credentials: AwsCredentials,
 }
@@ -112,11 +118,14 @@ impl BlobBackend for AmazonS3 {
         // built lazily on first append.
         let allow_http = endpoint.is_some();
 
-        Ok(Some(AppendContext::new(
-            allow_http,
-            object_url_base,
-            region,
-        )))
+        let context =
+            SignedRequestContext::new(allow_http, config.bucket.clone(), object_url_base, region);
+
+        Ok(Some(if config.s3_express || config.native_append {
+            AppendContext::Native(NativeAppend::new(context))
+        } else {
+            AppendContext::PartCopy(PartCopyAppend::new(context))
+        }))
     }
 }
 
@@ -161,6 +170,7 @@ mod tests {
             region: None,
             endpoint: None,
             s3_express: false,
+            native_append: false,
             credentials,
         }
     }

--- a/lib/common/io_bridge_object_store/src/backends/gcp.rs
+++ b/lib/common/io_bridge_object_store/src/backends/gcp.rs
@@ -3,6 +3,7 @@
 use common::universal_io::{UioResult, UniversalIoError, UniversalKind};
 use object_store::gcp::{GoogleCloudStorage, GoogleCloudStorageBuilder};
 
+use crate::append::{AppendContext, ComposeAppend};
 use crate::backend::BlobBackend;
 
 /// Connection parameters for [`GoogleCloudStorage`]. Fed into
@@ -52,5 +53,11 @@ impl BlobBackend for GoogleCloudStorage {
 
     fn kind() -> UniversalKind {
         UniversalKind::Gcs
+    }
+
+    fn append_context(config: &Self::Config) -> UioResult<Option<AppendContext>> {
+        Ok(Some(AppendContext::Compose(ComposeAppend::new(
+            config.bucket.clone(),
+        ))))
     }
 }

--- a/lib/common/io_bridge_object_store/src/lib.rs
+++ b/lib/common/io_bridge_object_store/src/lib.rs
@@ -34,7 +34,9 @@ mod source;
 #[cfg(test)]
 mod tests;
 
-pub use append::AppendContext;
+pub use append::{
+    AppendContext, ComposeAppend, NativeAppend, PartCopyAppend, SignedRequestContext,
+};
 pub use backend::BlobBackend;
 // Re-export the bridge core so a complete object-store-backed `UniversalRead`
 // stack can be built from this single crate.

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -404,16 +404,26 @@ mod tests {
     /// single-request (see [`crate::append`]); this exists so the `BlobFile`
     /// append stack can be exercised hermetically.
     impl io_bridge::AsyncAppend for ObjectStoreSource<InMemory> {
+        fn supported_append(&self) -> io_bridge::AppendMethod {
+            io_bridge::AppendMethod::Native
+        }
+
         fn append(
             &self,
             path: &Path,
-            offset: u64,
-            data: Bytes,
+            request: io_bridge::AppendRequest,
         ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
             let store = self.store().clone();
             let key = build_key(path);
 
             async move {
+                let io_bridge::AppendRequest::Native { offset, data } = request else {
+                    return Err(UniversalIoError::Io(std::io::Error::new(
+                        std::io::ErrorKind::Unsupported,
+                        "InMemory emulation only supports native appends",
+                    )));
+                };
+
                 let conflict = || UniversalIoError::AppendOffsetConflict {
                     path: PathBuf::from(key.to_string()),
                     offset,

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -374,7 +374,7 @@ fn build_dir_prefix(path: &Path) -> object_store::path::Path {
 mod tests {
     use bytes::Bytes;
     use common::generic_consts::{Random, Sequential};
-    use common::universal_io::{ListedFile, ReadRange, UioResult, UniversalAppend, UniversalRead};
+    use common::universal_io::{DiskCacheConfig, ListedFile, ReadRange, UioResult, UniversalRead};
     use io_bridge::{BlobFile, BridgeRuntime};
     use object_store::memory::InMemory;
     use object_store::{PutMode, UpdateVersion};
@@ -413,6 +413,7 @@ mod tests {
             path: &Path,
             offset: u64,
             data: Bytes,
+            expected_etag: Option<String>,
         ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
             let store = self.store().clone();
             let key = build_key(path);
@@ -422,10 +423,18 @@ mod tests {
                     path: PathBuf::from(key.to_string()),
                     offset,
                 };
+                let etag_mismatch = || UniversalIoError::AppendEtagMismatch {
+                    path: PathBuf::from(key.to_string()),
+                };
 
                 loop {
                     match store.head(&key).await {
                         Ok(meta) => {
+                            if let Some(expected) = &expected_etag
+                                && meta.e_tag.as_deref() != Some(expected.as_str())
+                            {
+                                return Err(etag_mismatch());
+                            }
                             if meta.size != offset {
                                 return Err(conflict());
                             }
@@ -453,6 +462,9 @@ mod tests {
                             }
                         }
                         Err(object_store::Error::NotFound { .. }) => {
+                            if expected_etag.is_some() {
+                                return Err(etag_mismatch());
+                            }
                             if offset != 0 {
                                 return Err(conflict());
                             }
@@ -747,14 +759,19 @@ mod tests {
     }
 
     /// The backend-generic append battery from `common`, run over the S3
-    /// stack (`BlobFs`/`BlobFile` over an object store) via the in-memory
-    /// append emulation. The real write-offset RPC is covered by the gated
-    /// `test_native_append_flow` integration test.
+    /// stack (`CachedBlobFs`/`CachedBlobFile` over an object store) via the
+    /// in-memory append emulation. The real write-offset RPC is covered by
+    /// the gated `test_native_append_flow` integration test.
     #[test]
     fn append_conformance_over_object_store() {
-        let fs = io_bridge::BlobFs::new(
+        let local_dir = tempfile::tempdir().unwrap();
+        let config =
+            DiskCacheConfig::new(PathBuf::from("conformance"), local_dir.path().to_path_buf())
+                .unwrap();
+        let fs = io_bridge::CachedBlobFs::new(
             ObjectStoreSource::new(Arc::new(InMemory::new())),
             BridgeRuntime::global(),
+            Arc::new(config),
         );
         common::universal_io::conformance::run_append_conformance(&fs, Path::new("conformance"));
     }
@@ -763,13 +780,15 @@ mod tests {
     fn append_through_blob_file() {
         let runtime = BridgeRuntime::global();
         let store = Arc::new(InMemory::new());
-        let mut file = make_file(runtime, store, "log");
+        let file = make_file(runtime, store, "log");
 
-        // Create-on-first-append at offset 0, then single-request batches.
-        file.append(0, b"hello ".as_slice()).unwrap();
-        file.append(6, b"world".as_slice()).unwrap();
-        let batch: [&[u8]; 2] = [b"!", b"?"];
-        file.append_batch(11, batch).unwrap();
+        // Create-on-first-append at offset 0, then sequential appends.
+        file.append_bytes(0, Bytes::from_static(b"hello "), None)
+            .unwrap();
+        file.append_bytes(6, Bytes::from_static(b"world"), None)
+            .unwrap();
+        file.append_bytes(11, Bytes::from_static(b"!?"), None)
+            .unwrap();
 
         let bytes = file.read_whole::<u8>().unwrap();
         assert_eq!(&bytes[..], b"hello world!?");

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -411,19 +411,13 @@ mod tests {
         fn append(
             &self,
             path: &Path,
-            request: io_bridge::AppendRequest,
+            offset: u64,
+            data: Bytes,
         ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
             let store = self.store().clone();
             let key = build_key(path);
 
             async move {
-                let io_bridge::AppendRequest::Append { offset, data } = request else {
-                    return Err(UniversalIoError::Io(std::io::Error::new(
-                        std::io::ErrorKind::Unsupported,
-                        "InMemory emulation only supports native appends",
-                    )));
-                };
-
                 let conflict = || UniversalIoError::AppendOffsetConflict {
                     path: PathBuf::from(key.to_string()),
                     offset,

--- a/lib/common/io_bridge_object_store/src/source.rs
+++ b/lib/common/io_bridge_object_store/src/source.rs
@@ -404,8 +404,8 @@ mod tests {
     /// single-request (see [`crate::append`]); this exists so the `BlobFile`
     /// append stack can be exercised hermetically.
     impl io_bridge::AsyncAppend for ObjectStoreSource<InMemory> {
-        fn supported_append(&self) -> io_bridge::AppendMethod {
-            io_bridge::AppendMethod::Native
+        fn append_support(&self) -> io_bridge::AppendSupport {
+            io_bridge::AppendSupport::Always
         }
 
         fn append(
@@ -417,7 +417,7 @@ mod tests {
             let key = build_key(path);
 
             async move {
-                let io_bridge::AppendRequest::Native { offset, data } = request else {
+                let io_bridge::AppendRequest::Append { offset, data } = request else {
                     return Err(UniversalIoError::Io(std::io::Error::new(
                         std::io::ErrorKind::Unsupported,
                         "InMemory emulation only supports native appends",

--- a/lib/common/io_bridge_object_store/src/tests/integration.rs
+++ b/lib/common/io_bridge_object_store/src/tests/integration.rs
@@ -3,10 +3,9 @@
 use std::assert_matches;
 use std::path::Path;
 
+use bytes::Bytes;
 use common::generic_consts::Random;
-use common::universal_io::{
-    ListedFile, ReadRange, UioResult, UniversalAppend, UniversalIoError, UniversalRead,
-};
+use common::universal_io::{ListedFile, ReadRange, UioResult, UniversalIoError, UniversalRead};
 use io_bridge::{AsyncRead, BridgeRuntime};
 use object_store::aws::AmazonS3;
 
@@ -141,32 +140,38 @@ fn test_native_append_flow() {
     // Fresh key per run so reruns do not collide with leftover objects.
     let key = format!("append-{}.log", std::process::id());
 
-    let mut file = BlobFile::<ObjectStoreSource<AmazonS3>>::open(
+    let file = BlobFile::<ObjectStoreSource<AmazonS3>>::open(
         &rustfs_aws_config(),
         runtime.clone(),
         key.as_str(),
     )
     .expect("open");
-    file.append(0, b"hello ".as_slice())
+    file.append_bytes(0, Bytes::from_static(b"hello "), None)
         .expect("first append creates the object");
-    file.append(6, b"world".as_slice()).expect("append");
+    file.append_bytes(6, Bytes::from_static(b"world"), None)
+        .expect("append");
 
     let bytes = file.read_whole::<u8>().expect("read_whole");
     assert_eq!(&bytes[..], b"hello world");
 
     // A second handle appends behind this handle's back...
-    let mut interloper =
+    let interloper =
         BlobFile::<ObjectStoreSource<AmazonS3>>::open(&rustfs_aws_config(), runtime, key.as_str())
             .expect("open");
-    interloper.append(11, b"A".as_slice()).expect("append");
+    interloper
+        .append_bytes(11, Bytes::from_static(b"A"), None)
+        .expect("append");
 
     // ...so an append at the stale offset conflicts without writing, and
     // re-deriving the offset from the actual length recovers.
-    let err = file.append(11, b"B".as_slice()).unwrap_err();
+    let err = file
+        .append_bytes(11, Bytes::from_static(b"B"), None)
+        .unwrap_err();
     assert_matches!(err, UniversalIoError::AppendOffsetConflict { .. });
     let eof = file.len::<u8>().expect("len");
     assert_eq!(eof, 12);
-    file.append(eof, b"B".as_slice()).expect("append");
+    file.append_bytes(eof, Bytes::from_static(b"B"), None)
+        .expect("append");
 
     let bytes = file.read_whole::<u8>().expect("read_whole");
     assert_eq!(&bytes[..], b"hello worldAB");

--- a/lib/common/io_bridge_object_store/src/tests/rustfs.rs
+++ b/lib/common/io_bridge_object_store/src/tests/rustfs.rs
@@ -27,6 +27,7 @@ pub fn rustfs_aws_config() -> AwsConfig {
         region: Some("us-east-1".into()),
         endpoint: Some(rustfs_endpoint()),
         s3_express: false,
+        native_append: true,
         credentials: AwsCredentials::Static {
             access_key_id: env::var("RUSTFS_ACCESS_KEY").unwrap_or_else(|_| "rustfsadmin".into()),
             secret_access_key: env::var("RUSTFS_SECRET_KEY")

--- a/lib/edge/tools/edge_tool/src/upload.rs
+++ b/lib/edge/tools/edge_tool/src/upload.rs
@@ -234,6 +234,7 @@ fn build_aws_config(args: &UploadArgs) -> Result<AwsConfig> {
         region: args.region.clone(),
         endpoint: args.endpoint.clone(),
         s3_express: args.s3_express,
+        native_append: false,
         credentials,
     })
 }

--- a/lib/edge/tools/shard_query/src/main.rs
+++ b/lib/edge/tools/shard_query/src/main.rs
@@ -561,6 +561,7 @@ fn build_aws_config(conn: &ConnectionArgs) -> Result<AwsConfig> {
         region: conn.region.clone(),
         endpoint: conn.endpoint.clone(),
         s3_express: conn.s3_express,
+        native_append: false,
         credentials,
     })
 }

--- a/lib/edge/tools/shard_update/src/main.rs
+++ b/lib/edge/tools/shard_update/src/main.rs
@@ -548,6 +548,7 @@ fn build_aws_config(conn: &ConnectionArgs) -> Result<AwsConfig> {
         region: conn.region.clone(),
         endpoint: conn.endpoint.clone(),
         s3_express: conn.s3_express,
+        native_append: false,
         credentials,
     })
 }

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -242,6 +242,7 @@ impl From<UniversalIoError> for OperationError {
             | UniversalIoError::Uninitialized { .. }
             | UniversalIoError::QueueIsFull
             | UniversalIoError::AppendOffsetConflict { .. }
+            | UniversalIoError::AppendRewriteRequired { .. }
             | UniversalIoError::S3(_)
             | UniversalIoError::S3Config { .. }
             | UniversalIoError::TaskPanicked(_) => Self::service_error(err.to_string()),
@@ -367,6 +368,7 @@ impl From<BlobstoreError> for OperationError {
                 | UniversalIoError::UnchangedOpen { .. }
                 | UniversalIoError::QueueIsFull
                 | UniversalIoError::AppendOffsetConflict { .. }
+                | UniversalIoError::AppendRewriteRequired { .. }
                 | UniversalIoError::S3(_)
                 | UniversalIoError::S3Config { .. }
                 | UniversalIoError::TaskPanicked(_)) => {

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -243,6 +243,7 @@ impl From<UniversalIoError> for OperationError {
             | UniversalIoError::QueueIsFull
             | UniversalIoError::AppendOffsetConflict { .. }
             | UniversalIoError::AppendRewriteRequired { .. }
+            | UniversalIoError::AppendEntityTooSmall { .. }
             | UniversalIoError::S3(_)
             | UniversalIoError::S3Config { .. }
             | UniversalIoError::TaskPanicked(_) => Self::service_error(err.to_string()),
@@ -369,6 +370,7 @@ impl From<BlobstoreError> for OperationError {
                 | UniversalIoError::QueueIsFull
                 | UniversalIoError::AppendOffsetConflict { .. }
                 | UniversalIoError::AppendRewriteRequired { .. }
+                | UniversalIoError::AppendEntityTooSmall { .. }
                 | UniversalIoError::S3(_)
                 | UniversalIoError::S3Config { .. }
                 | UniversalIoError::TaskPanicked(_)) => {

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -244,6 +244,7 @@ impl From<UniversalIoError> for OperationError {
             | UniversalIoError::AppendOffsetConflict { .. }
             | UniversalIoError::AppendRewriteRequired { .. }
             | UniversalIoError::AppendEntityTooSmall { .. }
+            | UniversalIoError::AppendEtagMismatch { .. }
             | UniversalIoError::S3(_)
             | UniversalIoError::S3Config { .. }
             | UniversalIoError::TaskPanicked(_) => Self::service_error(err.to_string()),
@@ -371,6 +372,7 @@ impl From<BlobstoreError> for OperationError {
                 | UniversalIoError::AppendOffsetConflict { .. }
                 | UniversalIoError::AppendRewriteRequired { .. }
                 | UniversalIoError::AppendEntityTooSmall { .. }
+                | UniversalIoError::AppendEtagMismatch { .. }
                 | UniversalIoError::S3(_)
                 | UniversalIoError::S3Config { .. }
                 | UniversalIoError::TaskPanicked(_)) => {

--- a/lib/segment/src/segment/read_only/tests.rs
+++ b/lib/segment/src/segment/read_only/tests.rs
@@ -294,6 +294,7 @@ fn read_only_segment_over_s3() {
             std::env::var("RUSTFS_ENDPOINT").unwrap_or_else(|_| "http://localhost:9000".into()),
         ),
         s3_express: false,
+        native_append: false,
         credentials: AwsCredentials::Static {
             access_key_id: std::env::var("RUSTFS_ACCESS_KEY")
                 .unwrap_or_else(|_| "rustfsadmin".into()),

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -503,6 +503,7 @@ impl IoBackend {
             common::universal_io::UniversalKind::IoUring => Some(Self::IoUring),
             common::universal_io::UniversalKind::DiskCache
             | common::universal_io::UniversalKind::SimpleDiskCache
+            | common::universal_io::UniversalKind::CachedBlob
             | common::universal_io::UniversalKind::S3
             | common::universal_io::UniversalKind::Gcs
             | common::universal_io::UniversalKind::Azure

--- a/src/tonic/api/storage_read_api/helpers.rs
+++ b/src/tonic/api/storage_read_api/helpers.rs
@@ -269,6 +269,7 @@ pub fn io_error_to_status(e: UniversalIoError) -> Status {
         UniversalIoError::QueueIsFull => Status::internal(e.to_string()),
         UniversalIoError::AppendOffsetConflict { .. } => Status::aborted(e.to_string()),
         UniversalIoError::AppendRewriteRequired { .. } => Status::aborted(e.to_string()),
+        UniversalIoError::AppendEntityTooSmall { .. } => Status::aborted(e.to_string()),
         UniversalIoError::S3(_)
         | UniversalIoError::S3Config { .. }
         | UniversalIoError::TaskPanicked(_) => Status::internal(e.to_string()),

--- a/src/tonic/api/storage_read_api/helpers.rs
+++ b/src/tonic/api/storage_read_api/helpers.rs
@@ -268,6 +268,7 @@ pub fn io_error_to_status(e: UniversalIoError) -> Status {
         UniversalIoError::ZerocopySize(e) => Status::internal(e),
         UniversalIoError::QueueIsFull => Status::internal(e.to_string()),
         UniversalIoError::AppendOffsetConflict { .. } => Status::aborted(e.to_string()),
+        UniversalIoError::AppendRewriteRequired { .. } => Status::aborted(e.to_string()),
         UniversalIoError::S3(_)
         | UniversalIoError::S3Config { .. }
         | UniversalIoError::TaskPanicked(_) => Status::internal(e.to_string()),

--- a/src/tonic/api/storage_read_api/helpers.rs
+++ b/src/tonic/api/storage_read_api/helpers.rs
@@ -270,6 +270,7 @@ pub fn io_error_to_status(e: UniversalIoError) -> Status {
         UniversalIoError::AppendOffsetConflict { .. } => Status::aborted(e.to_string()),
         UniversalIoError::AppendRewriteRequired { .. } => Status::aborted(e.to_string()),
         UniversalIoError::AppendEntityTooSmall { .. } => Status::aborted(e.to_string()),
+        UniversalIoError::AppendEtagMismatch { .. } => Status::aborted(e.to_string()),
         UniversalIoError::S3(_)
         | UniversalIoError::S3Config { .. }
         | UniversalIoError::TaskPanicked(_) => Status::internal(e.to_string()),


### PR DESCRIPTION
## Motivation

Appending to object-store objects was only possible on stores with a native write-offset append (S3 Express One Zone / MinIO AiStor), through `BlobFile`'s `UniversalAppend` impl. Everything else — plain S3, GCS — had no append story, and even native stores cap the number of appended blocks per object, so an occasional rewrite is unavoidable.

## What this adds

### `CachedBlobFile` / `CachedBlobFs` (`lib/common/io_bridge/src/cached/`)

A combined handle pairing a `DiskCache<BlobFile<A>>` mirror (reads) with a writeable `BlobFile<A>` (appends), implementing `UniversalRead` + `UniversalAppend` + `UniversalFlush` so it plugs into blobstore `Logstore` and the update-only segment components.

- **Write-through appends, durable at `Ok`**: one `append`/`append_batch` call is one remote mutation (batches are concatenated); the flusher is a no-op.
- **Zero-IO length sync**: a successful append proves `offset` was the remote EOF, so the mirror length advances via `schedule_reopen` with the known new length — no HEAD round-trip. Appended blocks fault in from the remote on first read.
- **`CachedBlobFs::open` accepts `writeable: true`** (unlike `DiskCacheFs`): the mirror stays read-only, the flag gates the remote half.

### Per-store append strategies (`io_bridge_object_store/src/append/`)

`AppendContext` is an enum of strategy objects, one per store capability, each owning its append logic in its own file:

| Strategy | Store | Mechanism |
|---|---|---|
| `NativeAppend` | S3 Express, MinIO AiStor | signed `PutObject` + `x-amz-write-offset-bytes`; retry + lost-ack reconciliation |
| `PartCopyAppend` | plain S3 | one atomic multipart rewrite; prefix as server-side `UploadPartCopy` parts (evenly split under the 5 GiB ceiling) |
| `ComposeAppend` | GCS | appended bytes as a temp neighbor object, then server-side `compose`, conditional on the observed generation — a real compare-and-swap |

Nothing but the appended data ever crosses the network. `object_store` keeps all three operations out of its portable surface (its part-copy is crate-private and range-less), so the requests are hand-issued through the public escape hatches (`AmazonS3::credentials` + `AwsAuthorizer`, `GoogleCloudStorage::credentials` bearer), sharing a lazily-built `SignedRequestContext` transport.

The store's capability is config-declared: `s3_express` implies native append; `AwsConfig::native_append` declares it for AiStor-like endpoints (not detectable from the endpoint); everything else on S3 gets `PartCopy`, GCS gets `Compose`.

### `AppendSupport`: the caller learns only the fallback threshold

`AsyncAppend::append_support()` tells `CachedBlobFile` the one thing it needs — when a direct append is possible — and stays silent on mechanism:

- `Always` — direct appends at any offset (native; compose — no part minimums, no cap).
- `AboveThreshold { min_offset }` — part-copy: the copied prefix lands as non-last multipart parts, ≥ 5 MiB each. Below the threshold `CachedBlobFile` rebuilds the object itself (prefix from the local mirror + whole-object PUT).
- `Never` — the caller always rebuilds.

Hitting a native store's appended-block cap surfaces as `UniversalIoError::AppendRewriteRequired` (S3 `TooManyParts`), and the caller recovers with one `AppendRequest::Rewrite` — "append and rebuild as a single blob" — served by the part-copy strategy. No client-side append counters: they reset on restart and can never be authoritative; the store is.

## Abstraction relations

```text
CachedBlobFile<A>                                                (io_bridge)
 │  append_support() -> Always | AboveThreshold{min_offset} | Never
 │  append(AppendRequest::Append | AppendRequest::Rewrite)
 ▼
trait AsyncAppend
 │  impl for ObjectStoreSource<AmazonS3> / <GoogleCloudStorage>  (io_bridge_object_store)
 ▼
enum AppendContext                        (selected from AwsConfig / GcsConfig)
 ├─ Native(NativeAppend)      write-offset PutObject ──────┐ block-cap
 ├─ PartCopy(PartCopyAppend)  multipart UploadPartCopy  ◀──┘ compaction
 └─ Compose(ComposeAppend)    temp object + compose (generation CAS)

NativeAppend, PartCopyAppend ──▶ SignedRequestContext
                                 (lazy HTTP client · SigV4 · object URL base)
```

## Not in this PR

- Moving the specialized remote ops onto inherent `BlobFile`/`BlobFs` methods and dropping the trait impls (TODOs in `cached/`).
- Upstream `object_store` exposure of `UploadPartCopy` (would replace the hand-signed part copies).
- GCS full-flow hermetic test (only the compose request itself is stub-tested; the regular-client put/head/delete legs can't target the stub) and compose component-count flattening.
- Conformance/integration test coverage for the combined `CachedBlobFile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
