### PR TITLE
feat: add optional `delete_after_restore` for uploaded snapshot recovery

### DIFF
--- a/openapi/openapi-snapshots.ytt.yaml
+++ b/openapi/openapi-snapshots.ytt.yaml
@@ -27,6 +27,12 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/SnapshotPriority"
+        - name: delete_after_restore
+          in: query
+          description: "If true, delete uploaded snapshot file after successful recovery. On failure the file is kept."
+          required: false
+          schema:
+            type: boolean
         - name: checksum
           in: query
           description: "Optional SHA256 checksum to verify snapshot integrity before recovery."

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -11,6 +11,7 @@ use collection::common::sha_256;
 use collection::common::snapshot_stream::SnapshotStream;
 use collection::operations::snapshot_ops::{
     ShardSnapshotLocation, ShardSnapshotRecover, SnapshotPriority, SnapshotRecover,
+    get_checksum_path,
 };
 use collection::operations::types::CollectionError;
 use collection::operations::verification::new_unchecked_verification_pass;
@@ -54,6 +55,9 @@ use crate::settings::ServiceConfig;
 pub struct SnapshotUploadingParam {
     pub wait: Option<bool>,
     pub priority: Option<SnapshotPriority>,
+    /// If true, delete uploaded snapshot file after successful recovery.
+    #[serde(default)]
+    pub delete_after_restore: Option<bool>,
 
     /// Optional SHA256 checksum to verify snapshot integrity before recovery.
     #[serde(default)]
@@ -204,6 +208,7 @@ async fn upload_snapshot(
 ) -> impl Responder {
     let auth = early_auth.auth;
     let wait = params.wait;
+    let delete_after_restore = params.delete_after_restore.unwrap_or(false);
 
     // Nothing to verify.
     let pass = new_unchecked_verification_pass();
@@ -229,20 +234,40 @@ async fn upload_snapshot(
         let http_client = http_client.client(None)?;
 
         let snapshot_recover = SnapshotRecover {
-            location: snapshot_location,
+            location: snapshot_location.clone(),
             priority: params.priority,
             checksum: None,
             api_key: None,
         };
 
-        do_recover_from_snapshot(
+        let recovered = do_recover_from_snapshot(
             dispatcher.get_ref(),
             &collection.collection_name,
             snapshot_recover,
-            auth,
+            auth.clone(),
             http_client,
         )
-        .await
+        .await?;
+
+        if delete_after_restore {
+            let snapshot_path = snapshot_location.to_file_path().map_err(|_| {
+                StorageError::service_error("Failed to resolve uploaded snapshot local path")
+            })?;
+
+            tokio_fs::remove_file(&snapshot_path)
+                .await
+                .map_err(StorageError::from)?;
+
+            // Uploaded snapshots may have checksum sidecars; cleanup is best-effort.
+            let checksum_path = get_checksum_path(&snapshot_path);
+            if let Err(err) = tokio_fs::remove_file(checksum_path).await {
+                if err.kind() != std::io::ErrorKind::NotFound {
+                    log::warn!("Failed to delete uploaded snapshot checksum sidecar: {err}");
+                }
+            }
+        }
+
+        Ok(recovered)
     };
 
     helpers::time_or_accept(future, wait.unwrap_or(true)).await
@@ -522,6 +547,7 @@ async fn upload_shard_snapshot(
         wait,
         priority,
         checksum,
+        ..
     } = query.into_inner();
 
     // - `recover_shard_snapshot_impl` is *not* cancel safe
@@ -688,6 +714,7 @@ async fn recover_partial_snapshot(
         wait,
         priority,
         checksum,
+        ..
     } = query.into_inner();
 
     // nothing to verify.

--- a/src/actix/api/snapshot_api.rs
+++ b/src/actix/api/snapshot_api.rs
@@ -547,7 +547,7 @@ async fn upload_shard_snapshot(
         wait,
         priority,
         checksum,
-        ..
+        delete_after_restore: _,
     } = query.into_inner();
 
     // - `recover_shard_snapshot_impl` is *not* cancel safe
@@ -714,7 +714,7 @@ async fn recover_partial_snapshot(
         wait,
         priority,
         checksum,
-        ..
+        delete_after_restore: _,
     } = query.into_inner();
 
     // nothing to verify.

--- a/tests/consensus_tests/test_snapshot_upload.py
+++ b/tests/consensus_tests/test_snapshot_upload.py
@@ -12,9 +12,9 @@ N_SHARDS = 3
 COLLECTION_NAME = "test_collection"
 
 
-def create_snapshot(peer_api_uri):
+def create_snapshot(peer_api_uri, collection_name=COLLECTION_NAME):
     r = requests.post(
-        f"{peer_api_uri}/collections/{COLLECTION_NAME}/snapshots")
+        f"{peer_api_uri}/collections/{collection_name}/snapshots")
     assert_http_ok(r)
     return r.json()["result"]["name"]
 
@@ -37,12 +37,16 @@ def get_remote_shards(peer_api_uri):
     return r.json()["result"]["remote_shards"]
 
 
-def upload_snapshot(peer_api_uri, snapshot_path):
+def upload_snapshot(peer_api_uri, snapshot_path, collection_name=COLLECTION_NAME, delete_after_restore=None):
     with open(snapshot_path, "rb") as f:
         print(f"uploading {snapshot_path} to {peer_api_uri}")
         snapshot_file = {"snapshot": f}
+        url = f"{peer_api_uri}/collections/{collection_name}/snapshots/upload"
+        if delete_after_restore is not None:
+            value = str(delete_after_restore).lower()
+            url = f"{url}?delete_after_restore={value}"
         r = requests.post(
-            f"{peer_api_uri}/collections/{COLLECTION_NAME}/snapshots/upload",
+            url,
             files=snapshot_file,
         )
         assert_http_ok(r)
@@ -181,3 +185,46 @@ def recover_from_uploaded_snapshot(tmp_path: pathlib.Path, n_replicas):
     assert replicas_per_shard == {
         shard_id: n_replicas for shard_id in range(N_SHARDS)
     }
+
+
+def test_upload_snapshot_delete_after_restore_failure_keeps_snapshot(tmp_path: pathlib.Path):
+    assert_project_root()
+
+    source_collection = "test_source_cleanup_failure"
+    target_collection = "test_target_cleanup_failure"
+
+    peer_api_uris, peer_dirs, _bootstrap_uri = start_cluster(tmp_path, 1)
+    peer_api_uri = peer_api_uris[0]
+
+    create_collection(peer_api_uri, collection=source_collection, shard_number=1, replication_factor=1)
+    wait_collection_exists_and_active_on_all_peers(source_collection, peer_api_uris)
+    upsert_random_points(peer_api_uri, 5, collection_name=source_collection)
+
+    # Incompatible target (different vector size) to force recovery failure after upload is persisted.
+    # Create incompatible target (different vector size) so recovery fails after upload is saved.
+    requests.put(
+        f"{peer_api_uri}/collections/{target_collection}",
+        json={
+            "vectors": {"size": 8, "distance": "Dot"},
+            "shard_number": 1,
+            "replication_factor": 1,
+            "write_consistency_factor": 1,
+        },
+    ).raise_for_status()
+    wait_collection_exists_and_active_on_all_peers(target_collection, peer_api_uris=[peer_api_uri])
+
+    snapshot_name = create_snapshot(peer_api_uri, source_collection)
+    snapshot_path = Path(peer_dirs[0]) / "snapshots" / source_collection / snapshot_name
+    assert snapshot_path.exists()
+
+    with open(snapshot_path, "rb") as f:
+        r = requests.post(
+            f"{peer_api_uri}/collections/{target_collection}/snapshots/upload",
+            params={"delete_after_restore": "true"},
+            files={"snapshot": f},
+        )
+
+    assert not r.ok
+
+    restored_snapshot_path = Path(peer_dirs[0]) / "snapshots" / target_collection / snapshot_name
+    assert restored_snapshot_path.exists()

--- a/tests/consensus_tests/test_snapshot_upload.py
+++ b/tests/consensus_tests/test_snapshot_upload.py
@@ -200,12 +200,16 @@ def test_upload_snapshot_delete_after_restore_failure_keeps_snapshot(tmp_path: p
     wait_collection_exists_and_active_on_all_peers(source_collection, peer_api_uris)
     upsert_random_points(peer_api_uri, 5, collection_name=source_collection)
 
-    # Incompatible target (different vector size) to force recovery failure after upload is persisted.
+    source_info = requests.get(f"{peer_api_uri}/collections/{source_collection}")
+    assert_http_ok(source_info)
+    source_vector_size = source_info.json()["result"]["config"]["params"]["vectors"]["size"]
+    incompatible_vector_size = source_vector_size + 1
+
     # Create incompatible target (different vector size) so recovery fails after upload is saved.
     requests.put(
         f"{peer_api_uri}/collections/{target_collection}",
         json={
-            "vectors": {"size": 8, "distance": "Dot"},
+            "vectors": {"size": incompatible_vector_size, "distance": "Dot"},
             "shard_number": 1,
             "replication_factor": 1,
             "write_consistency_factor": 1,


### PR DESCRIPTION
Fixes #10207 

### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### What changed and why

This PR adds an optional query parameter to snapshot upload recovery:

- `POST /collections/{collection_name}/snapshots/upload?delete_after_restore=true`

When enabled, Qdrant deletes the uploaded snapshot archive after recovery succeeds.  
If recovery fails, the snapshot file is retained for troubleshooting or retry.

This addresses the request to avoid manual cleanup of uploaded snapshot files while preserving failure diagnostics.

### Implementation details

- Added `delete_after_restore: Option<bool>` to upload query params.
- Updated upload-recover flow in `src/actix/api/snapshot_api.rs`:
  - persist uploaded snapshot as before,
  - run recovery,
  - on success + `delete_after_restore=true`, delete uploaded snapshot file,
  - best-effort cleanup of checksum sidecar if present.
- Added OpenAPI documentation for the new query parameter in `openapi/openapi-snapshots.ytt.yaml`.

### Tests run

- `cargo check -p qdrant`
- `uv --project tests run pytest tests/consensus_tests/test_snapshot_upload.py -k delete_after_restore_failure_keeps_snapshot`

### Notes

- Existing behavior remains unchanged when `delete_after_restore` is not provided (default: retain uploaded snapshot).