### PR TITLE
fix(quantization): skip cc compile when no SIMD sources were added

### DIFF
--- a/lib/quantization/build.rs
+++ b/lib/quantization/build.rs
@@ -36,6 +36,9 @@ fn main() {
     } else if target_arch == "aarch64" && target_feature.split(',').any(|feat| feat == "neon") {
         builder.file("cpp/neon.c");
         builder.flag("-O3");
+    } else {
+        // No SIMD sources for this target; nothing to compile.
+        return;
     }
 
     builder.compile("simd_utils");


### PR DESCRIPTION
### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [[Contributing document](https://claude.ai/chat/docs/CONTRIBUTING.md)](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [[Pull Requests](https://claude.ai/pulls)](../../../pulls) for the same update/change?

---

`lib/quantization/build.rs` adds C sources only for `x86_64` and `aarch64`+NEON, but calls `builder.compile("simd_utils")` outside that branching. On any other architecture, no sources are added and the build fails before any Rust gets compiled.

```
cargo:warning=ar: '.../out/libsimd_utils.a': No such file
error occurred in cc-rs: command did not execute successfully (status code exit status: 1): ZERO_AR_DATE="1" "ar" "s" ".../out/libsimd_utils.a"
```

`ar` is present and working here. `ar s` updates the index of an archive that was never created, so a cross-compilation toolchain doesn't help.

The fix returns early when no sources were added. `lib/segment/build.rs` already handles this by constructing its `cc::Build` inside the guard.

This is safe on the affected targets because nothing references the archive. The `extern "C"` blocks declaring those symbols are gated to the same architectures, in `encoded_vectors_binary.rs:1070,1115` and `encoded_vectors_u8.rs:833,842`.

Reproduced on `riscv64gc-unknown-linux-gnu` with `cargo check -p quantization --target riscv64gc-unknown-linux-gnu`, which fails on `dev` and passes with this change. `x86_64` is unaffected. Also expected to affect `s390x`, `powerpc64le`, 32-bit `arm` without NEON, and `wasm32`.

The same fix appears in the portability work in #9981, which is now closed. Extracting it here since it stands on its own.

Formatted with `cargo +nightly fmt --all`. Checked with `cargo clippy -p quantization`; the full workspace run needs a newer `protoc` than I have on Ubuntu 22.04.