### PR TITLE
gpu: bound device-lock wait and recreate Vulkan device on DEVICE_LOST (ports #10211 to dev)

### DIFF
--- a/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
@@ -9,22 +9,143 @@ use crate::common::operation_error::OperationResult;
 
 /// Simple non-invasive permits to use GPU devices.
 pub struct GpuDevicesMaganer {
-    devices: Vec<Mutex<Arc<gpu::Device>>>,
+    devices: Vec<GpuDeviceSlot>,
     device_names: Vec<String>,
     wait_free: bool,
 }
 
+/// One GPU device slot, plus everything needed to recreate its `gpu::Device` in place if it
+/// ever reports `DEVICE_LOST` — see `LockedGpuDevice::recreate_after_device_lost()`.
+struct GpuDeviceSlot {
+    device: Mutex<Arc<gpu::Device>>,
+    instance: Arc<gpu::Instance>,
+    physical_device: gpu::PhysicalDevice,
+    queue_index: usize,
+}
+
+/// Everything `LockedGpuDevice` needs to call `gpu::Device::new_with_params()` again for the
+/// exact same physical device/queue it was originally created with. `None` for devices locked
+/// via the bare `LockedGpuDevice::new()` constructor (used directly by tests, bypassing
+/// `GpuDevicesMaganer`) — those simply can't self-heal, same as before this patch.
+struct GpuDeviceRecreateInfo {
+    instance: Arc<gpu::Instance>,
+    physical_device: gpu::PhysicalDevice,
+    queue_index: usize,
+}
+
 pub struct LockedGpuDevice<'a> {
     locked_device: MutexGuard<'a, Arc<gpu::Device>>,
+    recreate_info: Option<GpuDeviceRecreateInfo>,
 }
 
 impl<'a> LockedGpuDevice<'a> {
     pub fn new(locked_device: MutexGuard<'a, Arc<gpu::Device>>) -> Self {
-        Self { locked_device }
+        Self {
+            locked_device,
+            recreate_info: None,
+        }
+    }
+
+    fn new_with_recreate_info(
+        locked_device: MutexGuard<'a, Arc<gpu::Device>>,
+        instance: Arc<gpu::Instance>,
+        physical_device: gpu::PhysicalDevice,
+        queue_index: usize,
+    ) -> Self {
+        Self {
+            locked_device,
+            recreate_info: Some(GpuDeviceRecreateInfo {
+                instance,
+                physical_device,
+                queue_index,
+            }),
+        }
     }
 
     pub fn device(&self) -> Arc<gpu::Device> {
         self.locked_device.clone()
+    }
+
+    /// Call after any GPU operation using `self.device()` fails, passing the resulting error.
+    /// If (and only if) the error indicates the underlying Vulkan device is now permanently
+    /// lost, triggers `recreate_after_device_lost()`. No-op for any other error (timeout, OOM,
+    /// etc) — those are already handled correctly by the existing fall-back-to-CPU-for-this-
+    /// build behavior and don't imply the device itself is unusable going forward.
+    ///
+    /// Takes `&mut self`: recreation replaces the `Arc<Device>` behind this guard in place.
+    /// Callers thread `Option<&mut LockedGpuDevice>` through instead of `Option<&LockedGpuDevice>`
+    /// (see `VectorIndexBuildArgs::gpu_device`) — a plain, ordinary Rust mutability requirement,
+    /// not RefCell/interior-mutability, since this guard is only ever used by one thread at a
+    /// time (whichever thread is building a given segment) anyway.
+    pub fn recreate_if_device_lost(&mut self, err: &crate::common::operation_error::OperationError) {
+        // By the time a GPU failure reaches call sites like `create_gpu_vectors()`, it has
+        // already been converted from `gpu::GpuError` into `OperationError` (see
+        // `impl From<gpu::GpuError> for OperationError` in `common/operation_error.rs`), which
+        // has no dedicated DEVICE_LOST variant of its own either — `gpu::GpuError` itself
+        // folds every Vulkan error into a catch-all `Other(String)` carrying the raw
+        // stringified Vulkan result code, and that string survives into `OperationError`'s
+        // Display (confirmed against real production log lines: "Service runtime error: GPU
+        // error: Other(\"Vulkan API error: ERROR_DEVICE_LOST\")"). This string match is the
+        // only signal currently available; giving DEVICE_LOST (and other Vulkan result codes
+        // worth distinguishing) a proper enum variant in the `gpu` crate would be a cleaner
+        // upstream follow-up, but is out of scope for this fix.
+        if err.to_string().contains("DEVICE_LOST") {
+            self.recreate_after_device_lost();
+        }
+    }
+
+    /// Recreates the underlying Vulkan device in place, replacing the device this guard is
+    /// holding.
+    ///
+    /// Per the Vulkan spec, once a logical device reports `VK_ERROR_DEVICE_LOST`, that device
+    /// is permanently unusable — the only valid recovery is destroying and recreating it.
+    /// Before this fix, nothing in qdrant did that: `GpuDevicesMaganer` creates every
+    /// `gpu::Device` exactly once at process startup and, on any GPU error including
+    /// DEVICE_LOST, `create_gpu_vectors()` (`hnsw/gpu_build.rs`) only logged it and fell back
+    /// to CPU *for that one build* — the same dead `Arc<gpu::Device>` went right back into the
+    /// pool for the next caller. Confirmed live in production (kvark.rcp, 2026-08-07 14:12:43
+    /// through 2026-08-10 14:50:42, one continuous qdrant process, zero restarts): 129
+    /// DEVICE_LOST occurrences over 3+ days, and *zero* successful GPU builds logged anywhere
+    /// in between — every single build silently ran CPU-only from the first loss onward, with
+    /// nothing indicating this in collection/optimizer status (both reported healthy — CPU
+    /// fallback working correctly is not the same as GPU actually being used).
+    ///
+    /// On success, the fresh device is swapped in and the very next `lock_device()` caller
+    /// gets it — GPU indexing resumes without a qdrant restart. On failure (e.g. the GPU is
+    /// genuinely gone, or the driver reset didn't complete), logs and leaves the dead device in
+    /// place — identical to today's existing behavior, so this can never make things worse than
+    /// before the fix, only better.
+    pub fn recreate_after_device_lost(&mut self) {
+        let Some(info) = &self.recreate_info else {
+            log::debug!(
+                "GPU device lost, but this LockedGpuDevice has no recreate info (constructed \
+                 directly, bypassing GpuDevicesMaganer — e.g. in tests). Cannot self-heal; \
+                 falling back to CPU only, same as before this fix."
+            );
+            return;
+        };
+        match gpu::Device::new_with_params(
+            info.instance.clone(),
+            &info.physical_device,
+            info.queue_index,
+            false,
+        ) {
+            Ok(new_device) => {
+                log::warn!(
+                    "GPU device {:?} reported DEVICE_LOST; reinitialized a fresh Vulkan device \
+                     in its place so subsequent builds can use GPU again.",
+                    info.physical_device.name,
+                );
+                *self.locked_device = new_device;
+            }
+            Err(err) => {
+                log::error!(
+                    "GPU device {:?} reported DEVICE_LOST and could not be reinitialized: \
+                     {err:?}. Falling back to CPU until qdrant is restarted.",
+                    info.physical_device.name,
+                );
+            }
+        }
     }
 }
 
@@ -88,7 +209,12 @@ impl GpuDevicesMaganer {
                         ) {
                             Ok(device) => {
                                 log::info!("Initialized GPU device: {:?}", physical_device.name);
-                                Some(Mutex::new(device))
+                                Some(GpuDeviceSlot {
+                                    device: Mutex::new(device),
+                                    instance: instance.clone(),
+                                    physical_device: (*physical_device).clone(),
+                                    queue_index,
+                                })
                             }
                             Err(err) => {
                                 log::error!(
@@ -137,6 +263,12 @@ impl GpuDevicesMaganer {
     /// underlying thread is still wedged, and Rust cannot forcibly reclaim a mutex held by a
     /// hung thread) — but it stops that one stuck device from taking down every other build
     /// task with it, and logs the failure so it's actually diagnosable instead of silent.
+    ///
+    /// Note this is a *different* failure mode from `DEVICE_LOST` (see
+    /// `LockedGpuDevice::recreate_after_device_lost()`): a clean `DEVICE_LOST` error always
+    /// releases this mutex normally (the guard drops via ordinary scope-exit), so the next
+    /// caller acquires it here just fine — the bug was never here for that case, it was that
+    /// the acquired device stayed permanently dead until this patch.
     pub fn lock_device(
         &self,
         stopped: &AtomicBool,
@@ -146,9 +278,14 @@ impl GpuDevicesMaganer {
         }
         let wait_start = std::time::Instant::now();
         loop {
-            for device in &self.devices {
-                if let Some(guard) = device.try_lock() {
-                    return Ok(Some(LockedGpuDevice::new(guard)));
+            for slot in &self.devices {
+                if let Some(guard) = slot.device.try_lock() {
+                    return Ok(Some(LockedGpuDevice::new_with_recreate_info(
+                        guard,
+                        slot.instance.clone(),
+                        slot.physical_device.clone(),
+                        slot.queue_index,
+                    )));
                 }
             }
 

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
@@ -64,12 +64,23 @@ impl<'a> LockedGpuDevice<'a> {
     /// etc) — those are already handled correctly by the existing fall-back-to-CPU-for-this-
     /// build behavior and don't imply the device itself is unusable going forward.
     ///
+    /// Returns whether THIS error was a DEVICE_LOST (regardless of whether the recreation
+    /// itself then succeeded or failed) — callers use this to discard any other GPU resource
+    /// still bound to the now-dead device (e.g. `GpuVectorStorage`/`GpuInsertContext` built
+    /// earlier in the same segment build), rather than reusing it and failing again against
+    /// stale buffers. Confirmed live 2026-08-13 (CodeRabbit review, PR #10213): before this
+    /// return value existed, `hnsw/build.rs` had no way to know a DEVICE_LOST happened during
+    /// the main-graph GPU dispatch, and kept reusing that same (now stale) `gpu_vectors` for
+    /// the additional-links dispatch right after — a second guaranteed failure plus another
+    /// pointless recreation cycle, and the dead device's VRAM stayed allocated until that
+    /// stale `Arc` eventually dropped.
+    ///
     /// Takes `&mut self`: recreation replaces the `Arc<Device>` behind this guard in place.
     /// Callers thread `Option<&mut LockedGpuDevice>` through instead of `Option<&LockedGpuDevice>`
     /// (see `VectorIndexBuildArgs::gpu_device`) — a plain, ordinary Rust mutability requirement,
     /// not RefCell/interior-mutability, since this guard is only ever used by one thread at a
     /// time (whichever thread is building a given segment) anyway.
-    pub fn recreate_if_device_lost(&mut self, err: &crate::common::operation_error::OperationError) {
+    pub fn recreate_if_device_lost(&mut self, err: &crate::common::operation_error::OperationError) -> bool {
         // By the time a GPU failure reaches call sites like `create_gpu_vectors()`, it has
         // already been converted from `gpu::GpuError` into `OperationError` (see
         // `impl From<gpu::GpuError> for OperationError` in `common/operation_error.rs`), which
@@ -83,6 +94,9 @@ impl<'a> LockedGpuDevice<'a> {
         // upstream follow-up, but is out of scope for this fix.
         if err.to_string().contains("DEVICE_LOST") {
             self.recreate_after_device_lost();
+            true
+        } else {
+            false
         }
     }
 

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
@@ -23,42 +23,34 @@ struct GpuDeviceSlot {
     queue_index: usize,
 }
 
-/// Everything `LockedGpuDevice` needs to call `gpu::Device::new_with_params()` again for the
-/// exact same physical device/queue it was originally created with. `None` for devices locked
-/// via the bare `LockedGpuDevice::new()` constructor (used directly by tests, bypassing
-/// `GpuDevicesMaganer`) — those simply can't self-heal, same as before this patch.
-struct GpuDeviceRecreateInfo {
-    instance: Arc<gpu::Instance>,
-    physical_device: gpu::PhysicalDevice,
-    queue_index: usize,
-}
-
 pub struct LockedGpuDevice<'a> {
     locked_device: MutexGuard<'a, Arc<gpu::Device>>,
-    recreate_info: Option<GpuDeviceRecreateInfo>,
+    // Borrows the owning GpuDeviceSlot directly instead of cloning its instance/physical_device/
+    // queue_index into a separate struct on every single lock acquisition — a reviewer correctly
+    // flagged the clone-per-lock cost plus the field-duplication drift risk in an earlier version
+    // of this patch. A plain shared reference coexists fine with the MutexGuard above: both are
+    // non-exclusive borrows of (parts of) the same GpuDeviceSlot, and Mutex::lock() only needs
+    // &self to produce the guard, so there's no aliasing conflict. `None` for devices locked via
+    // the bare `LockedGpuDevice::new()` constructor (used directly by tests, bypassing
+    // `GpuDevicesMaganer`) — those simply can't self-heal, same as before this patch.
+    slot: Option<&'a GpuDeviceSlot>,
 }
 
 impl<'a> LockedGpuDevice<'a> {
     pub fn new(locked_device: MutexGuard<'a, Arc<gpu::Device>>) -> Self {
         Self {
             locked_device,
-            recreate_info: None,
+            slot: None,
         }
     }
 
-    fn new_with_recreate_info(
+    fn new_with_slot(
         locked_device: MutexGuard<'a, Arc<gpu::Device>>,
-        instance: Arc<gpu::Instance>,
-        physical_device: gpu::PhysicalDevice,
-        queue_index: usize,
+        slot: &'a GpuDeviceSlot,
     ) -> Self {
         Self {
             locked_device,
-            recreate_info: Some(GpuDeviceRecreateInfo {
-                instance,
-                physical_device,
-                queue_index,
-            }),
+            slot: Some(slot),
         }
     }
 
@@ -116,7 +108,7 @@ impl<'a> LockedGpuDevice<'a> {
     /// place — identical to today's existing behavior, so this can never make things worse than
     /// before the fix, only better.
     pub fn recreate_after_device_lost(&mut self) {
-        let Some(info) = &self.recreate_info else {
+        let Some(slot) = self.slot else {
             log::debug!(
                 "GPU device lost, but this LockedGpuDevice has no recreate info (constructed \
                  directly, bypassing GpuDevicesMaganer — e.g. in tests). Cannot self-heal; \
@@ -125,16 +117,16 @@ impl<'a> LockedGpuDevice<'a> {
             return;
         };
         match gpu::Device::new_with_params(
-            info.instance.clone(),
-            &info.physical_device,
-            info.queue_index,
+            slot.instance.clone(),
+            &slot.physical_device,
+            slot.queue_index,
             false,
         ) {
             Ok(new_device) => {
                 log::warn!(
                     "GPU device {:?} reported DEVICE_LOST; reinitialized a fresh Vulkan device \
                      in its place so subsequent builds can use GPU again.",
-                    info.physical_device.name,
+                    slot.physical_device.name,
                 );
                 *self.locked_device = new_device;
             }
@@ -142,7 +134,7 @@ impl<'a> LockedGpuDevice<'a> {
                 log::error!(
                     "GPU device {:?} reported DEVICE_LOST and could not be reinitialized: \
                      {err:?}. Falling back to CPU until qdrant is restarted.",
-                    info.physical_device.name,
+                    slot.physical_device.name,
                 );
             }
         }
@@ -280,12 +272,7 @@ impl GpuDevicesMaganer {
         loop {
             for slot in &self.devices {
                 if let Some(guard) = slot.device.try_lock() {
-                    return Ok(Some(LockedGpuDevice::new_with_recreate_info(
-                        guard,
-                        slot.instance.clone(),
-                        slot.physical_device.clone(),
-                        slot.queue_index,
-                    )));
+                    return Ok(Some(LockedGpuDevice::new_with_slot(guard, slot)));
                 }
             }
 
@@ -296,10 +283,14 @@ impl GpuDevicesMaganer {
             check_stopped(stopped)?;
 
             if wait_start.elapsed() > super::GPU_LOCK_TIMEOUT {
-                log::error!(
-                    "Timed out after {:?} waiting for a free GPU device (all {} device(s) \
-                     still busy — possibly one is permanently stuck, see lock_device()'s doc \
-                     comment). Falling back to CPU for this build.",
+                // warn, not error: hitting this bound means either genuine contention (a build
+                // legitimately holding the device for a long dispatch, expected under real
+                // parallel load) or a wedged holder — this function has no way to tell the two
+                // apart, and the graceful CPU fallback below handles both identically, so this
+                // isn't itself a failure worth an error-level log.
+                log::warn!(
+                    "Timed out after {:?} waiting for a free GPU device ({} device(s) still \
+                     busy). Falling back to CPU for this build.",
                     wait_start.elapsed(),
                     self.devices.len(),
                 );

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
+use std::time::{Duration, Instant};
 
 use itertools::Itertools;
 use parking_lot::{Mutex, MutexGuard};
+use rand::RngExt;
 
 use crate::common::check_stopped;
 use crate::common::operation_error::OperationResult;
@@ -14,6 +16,34 @@ pub struct GpuDevicesMaganer {
     wait_free: bool,
 }
 
+const RECREATE_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
+const RECREATE_BACKOFF_MAX: Duration = Duration::from_secs(60);
+const RECREATE_BACKOFF_MULTIPLIER: u32 = 2;
+
+/// Per-slot exponential backoff (with full jitter) on `recreate_after_device_lost()` attempts.
+/// A permanently-dead GPU means every future segment build hits DEVICE_LOST again and retries
+/// recreation — under concurrent/sustained indexing that's unbounded, repeated device-creation
+/// calls against already-faulted hardware with no cooldown. Jitter matters here specifically:
+/// `parallel_indexes > 1` creates multiple independent `GpuDeviceSlot`s backing the SAME
+/// physical device, each with its own backoff state — without jitter, slots that hit
+/// DEVICE_LOST around the same moment stay roughly synchronized through every doubling step,
+/// periodically bursting simultaneous recreation attempts against the same dead hardware
+/// instead of spreading them out. `current_backoff` tracks the deterministic ceiling (for the
+/// next doubling); the actual wait is a random point within `[0, current_backoff]`.
+struct RecreateBackoff {
+    next_allowed_attempt: Instant,
+    current_backoff: Duration,
+}
+
+impl Default for RecreateBackoff {
+    fn default() -> Self {
+        Self {
+            next_allowed_attempt: Instant::now(),
+            current_backoff: Duration::ZERO,
+        }
+    }
+}
+
 /// One GPU device slot, plus everything needed to recreate its `gpu::Device` in place if it
 /// ever reports `DEVICE_LOST` — see `LockedGpuDevice::recreate_after_device_lost()`.
 struct GpuDeviceSlot {
@@ -21,18 +51,15 @@ struct GpuDeviceSlot {
     instance: Arc<gpu::Instance>,
     physical_device: gpu::PhysicalDevice,
     queue_index: usize,
+    recreate_backoff: Mutex<RecreateBackoff>,
 }
 
 pub struct LockedGpuDevice<'a> {
     locked_device: MutexGuard<'a, Arc<gpu::Device>>,
-    // Borrows the owning GpuDeviceSlot directly instead of cloning its instance/physical_device/
-    // queue_index into a separate struct on every single lock acquisition — a reviewer correctly
-    // flagged the clone-per-lock cost plus the field-duplication drift risk in an earlier version
-    // of this patch. A plain shared reference coexists fine with the MutexGuard above: both are
-    // non-exclusive borrows of (parts of) the same GpuDeviceSlot, and Mutex::lock() only needs
-    // &self to produce the guard, so there's no aliasing conflict. `None` for devices locked via
-    // the bare `LockedGpuDevice::new()` constructor (used directly by tests, bypassing
-    // `GpuDevicesMaganer`) — those simply can't self-heal, same as before this patch.
+    // Reference into the owning GpuDeviceSlot (avoids cloning instance/physical_device/
+    // queue_index per lock acquisition). Coexists fine with the MutexGuard above: both are
+    // non-exclusive borrows. `None` for devices locked via the bare `LockedGpuDevice::new()`
+    // constructor (used by tests) — those can't self-heal.
     slot: Option<&'a GpuDeviceSlot>,
 }
 
@@ -58,40 +85,23 @@ impl<'a> LockedGpuDevice<'a> {
         self.locked_device.clone()
     }
 
-    /// Call after any GPU operation using `self.device()` fails, passing the resulting error.
-    /// If (and only if) the error indicates the underlying Vulkan device is now permanently
-    /// lost, triggers `recreate_after_device_lost()`. No-op for any other error (timeout, OOM,
-    /// etc) — those are already handled correctly by the existing fall-back-to-CPU-for-this-
-    /// build behavior and don't imply the device itself is unusable going forward.
+    /// Call after a GPU operation using `self.device()` fails. Recreates the device if `err`
+    /// indicates it's permanently lost; a no-op for any other error (timeout, OOM, ...), which
+    /// the existing fall-back-to-CPU-for-this-build behavior already handles fine.
     ///
-    /// Returns whether THIS error was a DEVICE_LOST (regardless of whether the recreation
-    /// itself then succeeded or failed) — callers use this to discard any other GPU resource
-    /// still bound to the now-dead device (e.g. `GpuVectorStorage`/`GpuInsertContext` built
-    /// earlier in the same segment build), rather than reusing it and failing again against
-    /// stale buffers. Confirmed live 2026-08-13 (CodeRabbit review, PR #10213): before this
-    /// return value existed, `hnsw/build.rs` had no way to know a DEVICE_LOST happened during
-    /// the main-graph GPU dispatch, and kept reusing that same (now stale) `gpu_vectors` for
-    /// the additional-links dispatch right after — a second guaranteed failure plus another
-    /// pointless recreation cycle, and the dead device's VRAM stayed allocated until that
-    /// stale `Arc` eventually dropped.
+    /// Returns whether this was a DEVICE_LOST, so callers can discard any other GPU resource
+    /// still bound to the now-dead device (e.g. a `GpuVectorStorage`/`GpuInsertContext` built
+    /// earlier in the same segment build) instead of reusing it and failing again.
     ///
-    /// Takes `&mut self`: recreation replaces the `Arc<Device>` behind this guard in place.
-    /// Callers thread `Option<&mut LockedGpuDevice>` through instead of `Option<&LockedGpuDevice>`
-    /// (see `VectorIndexBuildArgs::gpu_device`) — a plain, ordinary Rust mutability requirement,
-    /// not RefCell/interior-mutability, since this guard is only ever used by one thread at a
-    /// time (whichever thread is building a given segment) anyway.
-    pub fn recreate_if_device_lost(&mut self, err: &crate::common::operation_error::OperationError) -> bool {
-        // By the time a GPU failure reaches call sites like `create_gpu_vectors()`, it has
-        // already been converted from `gpu::GpuError` into `OperationError` (see
-        // `impl From<gpu::GpuError> for OperationError` in `common/operation_error.rs`), which
-        // has no dedicated DEVICE_LOST variant of its own either — `gpu::GpuError` itself
-        // folds every Vulkan error into a catch-all `Other(String)` carrying the raw
-        // stringified Vulkan result code, and that string survives into `OperationError`'s
-        // Display (confirmed against real production log lines: "Service runtime error: GPU
-        // error: Other(\"Vulkan API error: ERROR_DEVICE_LOST\")"). This string match is the
-        // only signal currently available; giving DEVICE_LOST (and other Vulkan result codes
-        // worth distinguishing) a proper enum variant in the `gpu` crate would be a cleaner
-        // upstream follow-up, but is out of scope for this fix.
+    /// Takes `&mut self` since recreation replaces the `Arc<Device>` in place; callers thread
+    /// `Option<&mut LockedGpuDevice>` through accordingly (see `VectorIndexBuildArgs::gpu_device`).
+    pub fn recreate_if_device_lost(
+        &mut self,
+        err: &crate::common::operation_error::OperationError,
+    ) -> bool {
+        // OperationError has no dedicated DEVICE_LOST variant — `gpu::GpuError` folds every
+        // Vulkan error into a stringified `Other(...)`, so string matching is the only signal
+        // available today. A proper enum variant in the `gpu` crate would be cleaner.
         if err.to_string().contains("DEVICE_LOST") {
             self.recreate_after_device_lost();
             true
@@ -100,35 +110,21 @@ impl<'a> LockedGpuDevice<'a> {
         }
     }
 
-    /// Recreates the underlying Vulkan device in place, replacing the device this guard is
-    /// holding.
+    /// Recreates the underlying Vulkan device in place, replacing the device this guard holds.
     ///
-    /// Per the Vulkan spec, once a logical device reports `VK_ERROR_DEVICE_LOST`, that device
-    /// is permanently unusable — the only valid recovery is destroying and recreating it.
-    /// Before this fix, nothing in qdrant did that: `GpuDevicesMaganer` creates every
-    /// `gpu::Device` exactly once at process startup and, on any GPU error including
-    /// DEVICE_LOST, `create_gpu_vectors()` (`hnsw/gpu_build.rs`) only logged it and fell back
-    /// to CPU *for that one build* — the same dead `Arc<gpu::Device>` went right back into the
-    /// pool for the next caller. Confirmed live in production (kvark.rcp, 2026-08-07 14:12:43
-    /// through 2026-08-10 14:50:42, one continuous qdrant process, zero restarts): 129
-    /// DEVICE_LOST occurrences over 3+ days, and *zero* successful GPU builds logged anywhere
-    /// in between — every single build silently ran CPU-only from the first loss onward, with
-    /// nothing indicating this in collection/optimizer status (both reported healthy — CPU
-    /// fallback working correctly is not the same as GPU actually being used).
+    /// Per the Vulkan spec, a device reporting `VK_ERROR_DEVICE_LOST` is permanently
+    /// unusable — the only recovery is destroying and recreating it. Before this fix qdrant
+    /// never did that: the same dead device just went back into the pool for the next caller,
+    /// silently pinning all GPU indexing to CPU fallback until a full restart.
     ///
-    /// On success, the fresh device is swapped in and the very next `lock_device()` caller
-    /// gets it — GPU indexing resumes without a qdrant restart. On failure (e.g. the GPU is
-    /// genuinely gone, or the driver reset didn't complete), logs and leaves the dead device in
-    /// place — identical to today's existing behavior, so this can never make things worse than
-    /// before the fix, only better.
+    /// On success, the fresh device is swapped in and the next `lock_device()` caller gets it —
+    /// GPU indexing resumes without a restart. On failure, logs and leaves the dead device in
+    /// place, same as before this fix.
     ///
-    /// This only replaces the `Arc<gpu::Device>` held by the shared slot — any `Arc` clone a
-    /// caller already obtained from `device()` *before* this ran (e.g. buffers/contexts built
-    /// earlier in the same segment build) still points at the lost device, and that device's
-    /// VRAM stays allocated until every such clone drops. Callers holding other GPU resources
-    /// across a `recreate_if_device_lost()` call must discard those resources themselves
-    /// instead of reusing them — see that method's return value and `hnsw/build.rs`'s use of it
-    /// (CodeRabbit review, PR #10213) for a concrete case this bit in practice.
+    /// Only replaces the `Arc<gpu::Device>` held by the shared slot — an `Arc` clone a caller
+    /// already obtained from `device()` earlier still points at the lost device until it drops.
+    /// Callers holding other GPU resources across this call must discard them themselves
+    /// instead of reusing them (see this method's return value and its callers).
     pub fn recreate_after_device_lost(&mut self) {
         let Some(slot) = self.slot else {
             log::debug!(
@@ -138,6 +134,21 @@ impl<'a> LockedGpuDevice<'a> {
             );
             return;
         };
+
+        let now = Instant::now();
+        {
+            let backoff = slot.recreate_backoff.lock();
+            if now < backoff.next_allowed_attempt {
+                log::debug!(
+                    "GPU device {:?} reported DEVICE_LOST but is still within its recreation \
+                     backoff window ({:?} remaining) — falling back to CPU without retrying.",
+                    slot.physical_device.name,
+                    backoff.next_allowed_attempt - now,
+                );
+                return;
+            }
+        } // released before the (potentially slow) device-creation call below
+
         match gpu::Device::new_with_params(
             slot.instance.clone(),
             &slot.physical_device,
@@ -145,6 +156,7 @@ impl<'a> LockedGpuDevice<'a> {
             false,
         ) {
             Ok(new_device) => {
+                *slot.recreate_backoff.lock() = RecreateBackoff::default();
                 log::warn!(
                     "GPU device {:?} reported DEVICE_LOST; reinitialized a fresh Vulkan device \
                      in its place so subsequent builds can use GPU again.",
@@ -153,9 +165,21 @@ impl<'a> LockedGpuDevice<'a> {
                 *self.locked_device = new_device;
             }
             Err(err) => {
+                let jittered_wait = {
+                    let mut backoff = slot.recreate_backoff.lock();
+                    let ceiling = (backoff.current_backoff.max(RECREATE_BACKOFF_INITIAL)
+                        * RECREATE_BACKOFF_MULTIPLIER)
+                        .min(RECREATE_BACKOFF_MAX);
+                    backoff.current_backoff = ceiling;
+                    let jittered = Duration::from_secs_f64(
+                        rand::rng().random_range(0.0..=ceiling.as_secs_f64()),
+                    );
+                    backoff.next_allowed_attempt = now + jittered;
+                    jittered
+                };
                 log::error!(
                     "GPU device {:?} reported DEVICE_LOST and could not be reinitialized: \
-                     {err:?}. Falling back to CPU until qdrant is restarted.",
+                     {err:?}. Falling back to CPU; next recreation attempt in {jittered_wait:?}.",
                     slot.physical_device.name,
                 );
             }
@@ -228,6 +252,7 @@ impl GpuDevicesMaganer {
                                     instance: instance.clone(),
                                     physical_device: (*physical_device).clone(),
                                     queue_index,
+                                    recreate_backoff: Mutex::new(RecreateBackoff::default()),
                                 })
                             }
                             Err(err) => {
@@ -259,30 +284,14 @@ impl GpuDevicesMaganer {
 
     /// Acquires a free GPU device, waiting (polling every 100ms) if none is immediately
     /// available and `wait_free` is set. Bounded by `super::GPU_LOCK_TIMEOUT` — was previously
-    /// an unconditional `loop`, no timeout at all, with no exit besides successfully acquiring a
-    /// device or the whole operation being externally cancelled (`stopped`).
+    /// an unconditional loop with no exit besides success or external cancellation (`stopped`).
     ///
-    /// That mattered because of a real, confirmed production failure mode (2026-08-05/06,
-    /// silent multi-hour optimizer stall under concurrent CUDA load — no error, no log line,
-    /// only recoverable via a full qdrant restart): if the thread CURRENTLY holding a device's
-    /// `Mutex` guard gets stuck inside a lower-level driver call that never returns — not a
-    /// clean Vulkan error/`DEVICE_LOST` (those already propagate normally, the guard drops via
-    /// normal Rust scope-exit, and the next caller acquires the device fine) but a genuine hang
-    /// inside the driver itself (observed directly: a thread stuck in `poll()` inside
-    /// `libnvidia-eglcore.so`, 0% GPU utilization, never returning) — the mutex is held forever.
-    /// Every OTHER task calling `lock_device()` then spins in this loop indefinitely, since
-    /// there is no way to detect or break a lock held by a permanently-stuck thread from here.
-    ///
-    /// Falling back to CPU after a bounded wait doesn't recover the stuck device (that
-    /// underlying thread is still wedged, and Rust cannot forcibly reclaim a mutex held by a
-    /// hung thread) — but it stops that one stuck device from taking down every other build
-    /// task with it, and logs the failure so it's actually diagnosable instead of silent.
-    ///
-    /// Note this is a *different* failure mode from `DEVICE_LOST` (see
-    /// `LockedGpuDevice::recreate_after_device_lost()`): a clean `DEVICE_LOST` error always
-    /// releases this mutex normally (the guard drops via ordinary scope-exit), so the next
-    /// caller acquires it here just fine — the bug was never here for that case, it was that
-    /// the acquired device stayed permanently dead until this patch.
+    /// A device whose holder is stuck in a lower-level driver call that never returns (as
+    /// opposed to a clean Vulkan error, which releases the mutex normally via scope-exit) would
+    /// otherwise hold this lock forever, hanging every other caller with no way to detect or
+    /// break it from here. Falling back to CPU after the bound doesn't recover the stuck
+    /// device, but stops it from taking every other build down with it, and makes the failure
+    /// diagnosable instead of silent.
     pub fn lock_device(
         &self,
         stopped: &AtomicBool,

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
@@ -121,6 +121,14 @@ impl<'a> LockedGpuDevice<'a> {
     /// genuinely gone, or the driver reset didn't complete), logs and leaves the dead device in
     /// place — identical to today's existing behavior, so this can never make things worse than
     /// before the fix, only better.
+    ///
+    /// This only replaces the `Arc<gpu::Device>` held by the shared slot — any `Arc` clone a
+    /// caller already obtained from `device()` *before* this ran (e.g. buffers/contexts built
+    /// earlier in the same segment build) still points at the lost device, and that device's
+    /// VRAM stays allocated until every such clone drops. Callers holding other GPU resources
+    /// across a `recreate_if_device_lost()` call must discard those resources themselves
+    /// instead of reusing them — see that method's return value and `hnsw/build.rs`'s use of it
+    /// (CodeRabbit review, PR #10213) for a concrete case this bit in practice.
     pub fn recreate_after_device_lost(&mut self) {
         let Some(slot) = self.slot else {
             log::debug!(

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_devices_manager.rs
@@ -117,6 +117,26 @@ impl GpuDevicesMaganer {
         })
     }
 
+    /// Acquires a free GPU device, waiting (polling every 100ms) if none is immediately
+    /// available and `wait_free` is set. Bounded by `super::GPU_LOCK_TIMEOUT` — was previously
+    /// an unconditional `loop`, no timeout at all, with no exit besides successfully acquiring a
+    /// device or the whole operation being externally cancelled (`stopped`).
+    ///
+    /// That mattered because of a real, confirmed production failure mode (2026-08-05/06,
+    /// silent multi-hour optimizer stall under concurrent CUDA load — no error, no log line,
+    /// only recoverable via a full qdrant restart): if the thread CURRENTLY holding a device's
+    /// `Mutex` guard gets stuck inside a lower-level driver call that never returns — not a
+    /// clean Vulkan error/`DEVICE_LOST` (those already propagate normally, the guard drops via
+    /// normal Rust scope-exit, and the next caller acquires the device fine) but a genuine hang
+    /// inside the driver itself (observed directly: a thread stuck in `poll()` inside
+    /// `libnvidia-eglcore.so`, 0% GPU utilization, never returning) — the mutex is held forever.
+    /// Every OTHER task calling `lock_device()` then spins in this loop indefinitely, since
+    /// there is no way to detect or break a lock held by a permanently-stuck thread from here.
+    ///
+    /// Falling back to CPU after a bounded wait doesn't recover the stuck device (that
+    /// underlying thread is still wedged, and Rust cannot forcibly reclaim a mutex held by a
+    /// hung thread) — but it stops that one stuck device from taking down every other build
+    /// task with it, and logs the failure so it's actually diagnosable instead of silent.
     pub fn lock_device(
         &self,
         stopped: &AtomicBool,
@@ -124,6 +144,7 @@ impl GpuDevicesMaganer {
         if self.devices.is_empty() {
             return Ok(None);
         }
+        let wait_start = std::time::Instant::now();
         loop {
             for device in &self.devices {
                 if let Some(guard) = device.try_lock() {
@@ -136,6 +157,18 @@ impl GpuDevicesMaganer {
             }
 
             check_stopped(stopped)?;
+
+            if wait_start.elapsed() > super::GPU_LOCK_TIMEOUT {
+                log::error!(
+                    "Timed out after {:?} waiting for a free GPU device (all {} device(s) \
+                     still busy — possibly one is permanently stuck, see lock_device()'s doc \
+                     comment). Falling back to CPU for this build.",
+                    wait_start.elapsed(),
+                    self.devices.len(),
+                );
+                return Ok(None);
+            }
+
             std::thread::sleep(std::time::Duration::from_millis(100));
         }
     }

--- a/lib/segment/src/index/hnsw_index/gpu/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/mod.rs
@@ -35,7 +35,16 @@ pub static GPU_DEVICES_MANAGER: RwLock<Option<GpuDevicesMaganer>> = RwLock::new(
 /// visibility (no error, no log line) until a full qdrant restart. This bounds that: give up
 /// waiting after this long and fall back to CPU for that one build, same as any other GPU
 /// failure, rather than hanging the entire optimizer indefinitely.
-static GPU_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+///
+/// Must stay above GPU_TIMEOUT below: a lock holder may legitimately run a single GPU
+/// operation for that long (confirmed live: multi-minute builds for individual segments), so a
+/// shorter bound here would report that entirely healthy contention as a stuck/wedged device —
+/// confirmed as a real inconsistency in this same patch before release (a reviewer caught
+/// GPU_LOCK_TIMEOUT=120s vs GPU_TIMEOUT=300s, i.e. the wait-for-a-device bound was SHORTER than
+/// the legitimate-hold-time bound it's supposed to exceed). Derived from GPU_TIMEOUT (not a
+/// second independent literal) specifically so the two can never drift back out of this
+/// relationship if either is tuned again later.
+static GPU_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(GPU_TIMEOUT.as_secs() * 2);
 
 /// Each GPU operation has a timeout by Vulkan API specification.
 /// Choose large enough timeout.

--- a/lib/segment/src/index/hnsw_index/gpu/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/mod.rs
@@ -26,37 +26,24 @@ use crate::index::hnsw_index::HnswM;
 pub static GPU_DEVICES_MANAGER: RwLock<Option<GpuDevicesMaganer>> = RwLock::new(None);
 
 /// Bounded wait for `GpuDevicesMaganer::lock_device()` to acquire a free device — see that
-/// function's own doc comment for the full story. Was previously UNBOUNDED (a bare
-/// `try_lock()`/`sleep(100ms)` retry loop with no exit besides success or external
-/// cancellation). Confirmed live 2026-08-05/06 (real production incident): if the thread
-/// currently holding a device gets stuck in a lower-level driver call that never returns (not a
-/// clean Vulkan error — those already recover fine via the existing GPU_TIMEOUT/DEVICE_LOST
-/// path below), every other caller waiting on `lock_device()` piles up forever with zero
-/// visibility (no error, no log line) until a full qdrant restart. This bounds that: give up
-/// waiting after this long and fall back to CPU for that one build, same as any other GPU
-/// failure, rather than hanging the entire optimizer indefinitely.
+/// function's own doc comment. Was previously unbounded: a device whose holder is stuck in a
+/// lower-level driver call that never returns (not a clean Vulkan error, which already
+/// recovers via the GPU_TIMEOUT/DEVICE_LOST path below) would hang every other caller forever
+/// with no visibility.
 ///
-/// Must stay above GPU_TIMEOUT below: a lock holder may legitimately run a single GPU
-/// operation for that long (confirmed live: multi-minute builds for individual segments), so a
-/// shorter bound here would report that entirely healthy contention as a stuck/wedged device —
-/// confirmed as a real inconsistency in this same patch before release (a reviewer caught
-/// GPU_LOCK_TIMEOUT=120s vs GPU_TIMEOUT=300s, i.e. the wait-for-a-device bound was SHORTER than
-/// the legitimate-hold-time bound it's supposed to exceed). Derived from GPU_TIMEOUT (not a
-/// second independent literal) specifically so the two can never drift back out of this
-/// relationship if either is tuned again later.
-static GPU_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(GPU_TIMEOUT.as_secs() * 2);
+/// Must stay above GPU_TIMEOUT: a lock holder may legitimately run a single GPU operation for
+/// that long, so a shorter bound here would misreport healthy contention as a stuck device.
+/// Derived from GPU_TIMEOUT rather than an independent literal so the two can't drift back out
+/// of this relationship if either is tuned later.
+static GPU_LOCK_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(GPU_TIMEOUT.as_secs() * 2);
 
 /// Each GPU operation has a timeout by Vulkan API specification.
 /// Choose large enough timeout.
 /// We cannot use too small timeout and check stopper in the loop because
 /// GPU resources should be alive while GPU operation is in progress.
-/// Was 60s — confirmed live 2026-08-05/06 our workload's bge_colbert (per-token multivector)
-/// segments are genuinely expensive per GPU dispatch (multi-minute builds observed for
-/// individual segments in production), so a single wait_finish() call landing on a slow-but-
-/// genuinely-still-working step could plausibly hit 60s and get killed/misreported even when
-/// nothing is actually stuck. Not yet confirmed as an actual observed failure (no plain
-/// GpuError::Timeout seen in production logs, only real driver-reported DEVICE_LOST errors —
-/// see GPU_LOCK_TIMEOUT above for the fix targeting those), but cheap, safe headroom against it.
+/// Bumped from 60s: some workloads' individual GPU dispatches (e.g. large multivector segments)
+/// can genuinely take multiple minutes — not confirmed as an observed failure, just headroom.
 static GPU_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
 /// Warps count for GPU.

--- a/lib/segment/src/index/hnsw_index/gpu/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/mod.rs
@@ -11,6 +11,9 @@ pub mod shader_builder;
 #[cfg(test)]
 mod gpu_heap_tests;
 
+#[cfg(test)]
+mod relock_diagnostic_tests;
+
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use batched_points::BatchedPoints;
@@ -22,11 +25,30 @@ use crate::index::hnsw_index::HnswM;
 
 pub static GPU_DEVICES_MANAGER: RwLock<Option<GpuDevicesMaganer>> = RwLock::new(None);
 
+/// Bounded wait for `GpuDevicesMaganer::lock_device()` to acquire a free device — see that
+/// function's own doc comment for the full story. Was previously UNBOUNDED (a bare
+/// `try_lock()`/`sleep(100ms)` retry loop with no exit besides success or external
+/// cancellation). Confirmed live 2026-08-05/06 (real production incident): if the thread
+/// currently holding a device gets stuck in a lower-level driver call that never returns (not a
+/// clean Vulkan error — those already recover fine via the existing GPU_TIMEOUT/DEVICE_LOST
+/// path below), every other caller waiting on `lock_device()` piles up forever with zero
+/// visibility (no error, no log line) until a full qdrant restart. This bounds that: give up
+/// waiting after this long and fall back to CPU for that one build, same as any other GPU
+/// failure, rather than hanging the entire optimizer indefinitely.
+static GPU_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 /// Each GPU operation has a timeout by Vulkan API specification.
 /// Choose large enough timeout.
 /// We cannot use too small timeout and check stopper in the loop because
 /// GPU resources should be alive while GPU operation is in progress.
-static GPU_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+/// Was 60s — confirmed live 2026-08-05/06 our workload's bge_colbert (per-token multivector)
+/// segments are genuinely expensive per GPU dispatch (multi-minute builds observed for
+/// individual segments in production), so a single wait_finish() call landing on a slow-but-
+/// genuinely-still-working step could plausibly hit 60s and get killed/misreported even when
+/// nothing is actually stuck. Not yet confirmed as an actual observed failure (no plain
+/// GpuError::Timeout seen in production logs, only real driver-reported DEVICE_LOST errors —
+/// see GPU_LOCK_TIMEOUT above for the fix targeting those), but cheap, safe headroom against it.
+static GPU_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
 /// Warps count for GPU.
 /// In other words, how many parallel points can be indexed by GPU.

--- a/lib/segment/src/index/hnsw_index/gpu/relock_diagnostic_tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/relock_diagnostic_tests.rs
@@ -217,7 +217,7 @@ fn relock_under_concurrent_contention_diagnostic() {
                 let result =
                     GpuVectorStorage::new(locked_device.device(), &storage, None, false, &stopped);
                 eprintln!(
-                    "[troublemaker] 48GB alloc -> {} (took {:?})",
+                    "[troublemaker] {target_gb:.1}GB alloc -> {} (took {:?})",
                     if result.is_ok() { "OK" } else { "FAILED" },
                     alloc_start.elapsed()
                 );

--- a/lib/segment/src/index/hnsw_index/gpu/relock_diagnostic_tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/relock_diagnostic_tests.rs
@@ -44,13 +44,45 @@ fn build_storage_of_size(target_gb: f64) -> VectorStorageEnum {
     storage
 }
 
+/// GPU vendor filter for these diagnostics, e.g. "nvidia" or "amd" — was previously hardcoded to
+/// "nvidia" (fine on our own host, but the diagnostic couldn't run at all on a different vendor,
+/// and would panic with a message pointing at GPU visibility rather than at the filter itself).
+fn gpu_filter() -> String {
+    std::env::var("QDRANT_GPU_DIAGNOSTIC_FILTER").unwrap_or_else(|_| "nvidia".to_owned())
+}
+
+/// This test's own oversized allocation is meant to exceed VRAM, not host RAM — but
+/// `build_storage_of_size()` allocates the full target size in host memory first (it builds a
+/// real `VectorStorageEnum` before ever touching the GPU). Reading `/proc/meminfo`'s
+/// `MemAvailable` and capping the request below it (leaving real headroom for the OTHER threads'
+/// concurrent allocations too) avoids the host OOM killer ending the diagnostic before it ever
+/// reaches the GPU, on a host with less RAM than ours. Falls back to the original hardcoded size
+/// if `/proc/meminfo` can't be read/parsed (non-Linux, or a sandboxed environment without it) —
+/// same behavior as before this fix in that case, not a regression.
+fn oversized_target_gb(preferred_gb: f64, headroom_fraction: f64) -> f64 {
+    let available_gb = std::fs::read_to_string("/proc/meminfo")
+        .ok()
+        .and_then(|contents| {
+            contents.lines().find_map(|line| {
+                line.strip_prefix("MemAvailable:")
+                    .and_then(|rest| rest.trim().split_whitespace().next())
+                    .and_then(|kb| kb.parse::<f64>().ok())
+                    .map(|kb| kb / (1024.0 * 1024.0))
+            })
+        });
+    match available_gb {
+        Some(available_gb) => preferred_gb.min(available_gb * headroom_fraction),
+        None => preferred_gb,
+    }
+}
+
 /// Run explicitly with:
 ///   cargo test --features gpu -p segment relock_after_pressure_diagnostic -- --ignored --nocapture
 #[test]
 #[ignore]
 fn relock_after_pressure_diagnostic() {
     let stopped = AtomicBool::new(false);
-    let manager = GpuDevicesMaganer::new("nvidia", None, false, false, true, 1)
+    let manager = GpuDevicesMaganer::new(&gpu_filter(), None, false, false, true, 1)
         .expect("failed to init GpuDevicesMaganer — is a GPU actually visible on this host?");
 
     // Sizes chosen to straddle Qdrant's own documented ~16GB-per-segment-per-indexing-iteration
@@ -129,7 +161,7 @@ fn relock_under_concurrent_contention_diagnostic() {
 
     let stopped = Arc::new(AtomicBool::new(false));
     let manager = Arc::new(
-        GpuDevicesMaganer::new("nvidia", None, false, false, true, 1)
+        GpuDevicesMaganer::new(&gpu_filter(), None, false, false, true, 1)
             .expect("failed to init GpuDevicesMaganer — is a GPU actually visible on this host?"),
     );
 
@@ -174,8 +206,9 @@ fn relock_under_concurrent_contention_diagnostic() {
         let manager = manager.clone();
         let stopped = stopped.clone();
         handles.push(thread::spawn(move || {
-            eprintln!("[troublemaker] attempting oversized (48GB) allocation...");
-            let storage = build_storage_of_size(48.0);
+            let target_gb = oversized_target_gb(48.0, 0.5);
+            eprintln!("[troublemaker] attempting oversized ({target_gb:.1}GB) allocation...");
+            let storage = build_storage_of_size(target_gb);
             let lock_start = Instant::now();
             let locked = manager.lock_device(&stopped);
             eprintln!("[troublemaker] lock_device took {:?}", lock_start.elapsed());

--- a/lib/segment/src/index/hnsw_index/gpu/relock_diagnostic_tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/relock_diagnostic_tests.rs
@@ -1,15 +1,7 @@
-//! Diagnostic test (deliberately NOT part of the normal `cargo test` sweep — `#[ignore]`d, run
-//! explicitly) probing whether a large/failed GPU vector-storage allocation leaves
-//! `GpuDevicesMaganer`'s device lock unusable for subsequent callers. Uses the REAL production
-//! code paths (`GpuDevicesMaganer`, `GpuVectorStorage`) — no reinvented Vulkan primitives — so
-//! this exercises exactly what `/index/page`'s HNSW GPU build path does in production.
-//!
-//! Context (see project_qdrant_gpu_indexing_xid109 memory, 2026-08-05/06 investigation): a
-//! multi-hour silent optimizer stall was traced to `gpu_devices_manager.rs`'s `lock_device()`
-//! having NO timeout at all — a bare `try_lock()` + `sleep(100ms)` retry loop, forever, if no
-//! device ever frees up. The open question this diagnostic targets: does a failed/oversized
-//! allocation (VRAM exhaustion) or contention while a device is locked leave that device
-//! permanently unable to be re-locked, even after the failing call returns?
+//! Diagnostic test (`#[ignore]`d, run explicitly) probing whether a large/failed GPU
+//! vector-storage allocation leaves `GpuDevicesMaganer`'s device lock unusable for subsequent
+//! callers. Uses the real `GpuDevicesMaganer`/`GpuVectorStorage` code paths, not reinvented
+//! Vulkan primitives.
 
 use std::sync::atomic::AtomicBool;
 use std::time::Instant;
@@ -23,12 +15,10 @@ use crate::types::Distance;
 use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
 use crate::vector_storage::{VectorStorage, VectorStorageEnum};
 
-/// Builds a dense f32 vector storage of approximately `target_gb` GB total size. Fixed, small
-/// per-vector dim (8192 floats = 32KB/vector) — `VolatileChunkedVectors::new()` hard-asserts a
-/// single vector's byte size must fit under `CHUNK_SIZE` (≤32MB depending on build config;
-/// confirmed live: a few-huge-vectors approach with ~512MB/vector panicked immediately, before
-/// ever touching the GPU). Many small vectors instead — content is irrelevant here, only the
-/// total size (to force a real GPU allocation of that size).
+/// Builds a dense f32 vector storage of approximately `target_gb` GB total size. Many small
+/// vectors (8192 floats each) rather than a few huge ones — `VolatileChunkedVectors::new()`
+/// hard-asserts a single vector's byte size must fit under `CHUNK_SIZE` (≤32MB depending on
+/// build config). Content is irrelevant, only the total size (to force a real GPU allocation).
 fn build_storage_of_size(target_gb: f64) -> VectorStorageEnum {
     const DIM: usize = 8192;
     let total_floats = (target_gb * 1024.0 * 1024.0 * 1024.0 / 4.0) as usize;
@@ -44,28 +34,22 @@ fn build_storage_of_size(target_gb: f64) -> VectorStorageEnum {
     storage
 }
 
-/// GPU vendor filter for these diagnostics, e.g. "nvidia" or "amd" — was previously hardcoded to
-/// "nvidia" (fine on our own host, but the diagnostic couldn't run at all on a different vendor,
-/// and would panic with a message pointing at GPU visibility rather than at the filter itself).
+/// GPU vendor filter for these diagnostics, e.g. "nvidia" or "amd".
 fn gpu_filter() -> String {
     std::env::var("QDRANT_GPU_DIAGNOSTIC_FILTER").unwrap_or_else(|_| "nvidia".to_owned())
 }
 
-/// This test's own oversized allocation is meant to exceed VRAM, not host RAM — but
-/// `build_storage_of_size()` allocates the full target size in host memory first (it builds a
-/// real `VectorStorageEnum` before ever touching the GPU). Reading `/proc/meminfo`'s
-/// `MemAvailable` and capping the request below it (leaving real headroom for the OTHER threads'
-/// concurrent allocations too) avoids the host OOM killer ending the diagnostic before it ever
-/// reaches the GPU, on a host with less RAM than ours. Falls back to the original hardcoded size
-/// if `/proc/meminfo` can't be read/parsed (non-Linux, or a sandboxed environment without it) —
-/// same behavior as before this fix in that case, not a regression.
+/// `build_storage_of_size()` allocates its full target size in host memory first (a real
+/// `VectorStorageEnum`, before ever touching the GPU) — caps the request below available RAM
+/// (via `/proc/meminfo`) to avoid the OOM killer ending the diagnostic before it reaches the
+/// GPU. Falls back to the preferred size if `/proc/meminfo` can't be read.
 fn oversized_target_gb(preferred_gb: f64, headroom_fraction: f64) -> f64 {
-    let available_gb = std::fs::read_to_string("/proc/meminfo")
+    let available_gb = fs_err::read_to_string("/proc/meminfo")
         .ok()
         .and_then(|contents| {
             contents.lines().find_map(|line| {
                 line.strip_prefix("MemAvailable:")
-                    .and_then(|rest| rest.trim().split_whitespace().next())
+                    .and_then(|rest| rest.split_whitespace().next())
                     .and_then(|kb| kb.parse::<f64>().ok())
                     .map(|kb| kb / (1024.0 * 1024.0))
             })
@@ -85,10 +69,9 @@ fn relock_after_pressure_diagnostic() {
     let manager = GpuDevicesMaganer::new(&gpu_filter(), None, false, false, true, 1)
         .expect("failed to init GpuDevicesMaganer — is a GPU actually visible on this host?");
 
-    // Sizes chosen to straddle Qdrant's own documented ~16GB-per-segment-per-indexing-iteration
-    // GPU limit (see running-with-gpu docs) — some should succeed cleanly, some should fail,
-    // the interesting question is what RELOCKING looks like after each, not just whether the
-    // allocation itself succeeds.
+    // Sizes chosen to straddle Qdrant's documented ~16GB-per-segment GPU limit — some should
+    // succeed, some should fail; the interesting question is what relocking looks like after
+    // each, not just whether the allocation itself succeeds.
     for target_gb in [4.0_f64, 8.0, 16.0] {
         eprintln!("\n=== target size: {target_gb} GB ===");
         eprintln!("  building host-side vector storage ({target_gb} GB)...");
@@ -141,15 +124,15 @@ fn relock_after_pressure_diagnostic() {
         );
         drop(relocked);
     }
-    eprintln!("\n=== diagnostic complete — see above for any '*** SLOW/STUCK RELOCK ***' lines ===");
+    eprintln!(
+        "\n=== diagnostic complete — see above for any '*** SLOW/STUCK RELOCK ***' lines ==="
+    );
 }
 
-/// Companion test: instead of one thread doing allocate-then-immediately-relock, spawn several
-/// threads hammering lock_device()/GpuVectorStorage concurrently (mirrors DIR_PARALLEL's real
-/// fan-out shape more closely than the single-threaded test above) while one of them
-/// deliberately attempts an oversized allocation. If a single stuck/oversized attempt can wedge
-/// the shared device mutex, the OTHER threads' lock_device() calls should show it as unusually
-/// long waits, not just the one that failed.
+/// Companion test: spawns several threads hammering lock_device()/GpuVectorStorage
+/// concurrently, one of them deliberately attempting an oversized allocation. If a single
+/// stuck/oversized attempt can wedge the shared device mutex, the other threads' lock_device()
+/// calls should show it as unusually long waits, not just the one that failed.
 ///
 /// Run explicitly with:
 ///   cargo test --features gpu -p segment relock_under_concurrent_contention_diagnostic -- --ignored --nocapture

--- a/lib/segment/src/index/hnsw_index/gpu/relock_diagnostic_tests.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/relock_diagnostic_tests.rs
@@ -1,0 +1,225 @@
+//! Diagnostic test (deliberately NOT part of the normal `cargo test` sweep — `#[ignore]`d, run
+//! explicitly) probing whether a large/failed GPU vector-storage allocation leaves
+//! `GpuDevicesMaganer`'s device lock unusable for subsequent callers. Uses the REAL production
+//! code paths (`GpuDevicesMaganer`, `GpuVectorStorage`) — no reinvented Vulkan primitives — so
+//! this exercises exactly what `/index/page`'s HNSW GPU build path does in production.
+//!
+//! Context (see project_qdrant_gpu_indexing_xid109 memory, 2026-08-05/06 investigation): a
+//! multi-hour silent optimizer stall was traced to `gpu_devices_manager.rs`'s `lock_device()`
+//! having NO timeout at all — a bare `try_lock()` + `sleep(100ms)` retry loop, forever, if no
+//! device ever frees up. The open question this diagnostic targets: does a failed/oversized
+//! allocation (VRAM exhaustion) or contention while a device is locked leave that device
+//! permanently unable to be re-locked, even after the failing call returns?
+
+use std::sync::atomic::AtomicBool;
+use std::time::Instant;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+
+use super::gpu_devices_manager::GpuDevicesMaganer;
+use super::gpu_vector_storage::GpuVectorStorage;
+use crate::data_types::vectors::VectorRef;
+use crate::types::Distance;
+use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
+use crate::vector_storage::{VectorStorage, VectorStorageEnum};
+
+/// Builds a dense f32 vector storage of approximately `target_gb` GB total size. Fixed, small
+/// per-vector dim (8192 floats = 32KB/vector) — `VolatileChunkedVectors::new()` hard-asserts a
+/// single vector's byte size must fit under `CHUNK_SIZE` (≤32MB depending on build config;
+/// confirmed live: a few-huge-vectors approach with ~512MB/vector panicked immediately, before
+/// ever touching the GPU). Many small vectors instead — content is irrelevant here, only the
+/// total size (to force a real GPU allocation of that size).
+fn build_storage_of_size(target_gb: f64) -> VectorStorageEnum {
+    const DIM: usize = 8192;
+    let total_floats = (target_gb * 1024.0 * 1024.0 * 1024.0 / 4.0) as usize;
+    let num_vectors = (total_floats / DIM).max(1);
+    let mut storage = new_volatile_dense_vector_storage(DIM, Distance::Cosine);
+    let filler = vec![0.001f32; DIM];
+    let hw_counter = HardwareCounterCell::new();
+    for key in 0..num_vectors as u32 {
+        storage
+            .insert_vector(key, VectorRef::from(filler.as_slice()), &hw_counter)
+            .unwrap();
+    }
+    storage
+}
+
+/// Run explicitly with:
+///   cargo test --features gpu -p segment relock_after_pressure_diagnostic -- --ignored --nocapture
+#[test]
+#[ignore]
+fn relock_after_pressure_diagnostic() {
+    let stopped = AtomicBool::new(false);
+    let manager = GpuDevicesMaganer::new("nvidia", None, false, false, true, 1)
+        .expect("failed to init GpuDevicesMaganer — is a GPU actually visible on this host?");
+
+    // Sizes chosen to straddle Qdrant's own documented ~16GB-per-segment-per-indexing-iteration
+    // GPU limit (see running-with-gpu docs) — some should succeed cleanly, some should fail,
+    // the interesting question is what RELOCKING looks like after each, not just whether the
+    // allocation itself succeeds.
+    for target_gb in [4.0_f64, 8.0, 16.0] {
+        eprintln!("\n=== target size: {target_gb} GB ===");
+        eprintln!("  building host-side vector storage ({target_gb} GB)...");
+        let build_start = Instant::now();
+        let storage = build_storage_of_size(target_gb);
+        eprintln!("  built in {:?}", build_start.elapsed());
+
+        eprintln!("  lock_device()...");
+        let lock_start = Instant::now();
+        let locked = manager.lock_device(&stopped);
+        eprintln!(
+            "  lock_device() -> ok={:?} (took {:?})",
+            locked.is_ok(),
+            lock_start.elapsed()
+        );
+
+        if let Ok(Some(locked_device)) = &locked {
+            eprintln!("  GpuVectorStorage::new({target_gb} GB)...");
+            let alloc_start = Instant::now();
+            let result =
+                GpuVectorStorage::new(locked_device.device(), &storage, None, false, &stopped);
+            eprintln!(
+                "  GpuVectorStorage::new({target_gb}GB) -> {} (took {:?})",
+                if result.is_ok() { "OK" } else { "FAILED" },
+                alloc_start.elapsed()
+            );
+            if let Err(e) = &result {
+                eprintln!("    error detail: {e:?}");
+            }
+        } else {
+            eprintln!("  (no locked device — skipping allocation attempt this round)");
+        }
+        // `locked` (and any LockedGpuDevice inside it) drops here, releasing the device lock.
+        drop(locked);
+
+        eprintln!("  RELOCK immediately after releasing...");
+        let relock_start = Instant::now();
+        let relocked = manager.lock_device(&stopped);
+        let relock_elapsed = relock_start.elapsed();
+        let slow_marker = if relock_elapsed > std::time::Duration::from_secs(5) {
+            "  *** SLOW/STUCK RELOCK — this is the failure signature we're hunting ***"
+        } else {
+            ""
+        };
+        eprintln!(
+            "  relock -> ok={:?} (took {:?}) {}",
+            relocked.is_ok(),
+            relock_elapsed,
+            slow_marker
+        );
+        drop(relocked);
+    }
+    eprintln!("\n=== diagnostic complete — see above for any '*** SLOW/STUCK RELOCK ***' lines ===");
+}
+
+/// Companion test: instead of one thread doing allocate-then-immediately-relock, spawn several
+/// threads hammering lock_device()/GpuVectorStorage concurrently (mirrors DIR_PARALLEL's real
+/// fan-out shape more closely than the single-threaded test above) while one of them
+/// deliberately attempts an oversized allocation. If a single stuck/oversized attempt can wedge
+/// the shared device mutex, the OTHER threads' lock_device() calls should show it as unusually
+/// long waits, not just the one that failed.
+///
+/// Run explicitly with:
+///   cargo test --features gpu -p segment relock_under_concurrent_contention_diagnostic -- --ignored --nocapture
+#[test]
+#[ignore]
+fn relock_under_concurrent_contention_diagnostic() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let stopped = Arc::new(AtomicBool::new(false));
+    let manager = Arc::new(
+        GpuDevicesMaganer::new("nvidia", None, false, false, true, 1)
+            .expect("failed to init GpuDevicesMaganer — is a GPU actually visible on this host?"),
+    );
+
+    let mut handles = Vec::new();
+
+    // Threads 0..2: normal-sized, repeated lock/alloc/release cycles — mimics ordinary
+    // concurrent segment builds.
+    for thread_id in 0..3 {
+        let manager = manager.clone();
+        let stopped = stopped.clone();
+        handles.push(thread::spawn(move || {
+            for round in 0..10 {
+                let storage = build_storage_of_size(2.0);
+                let lock_start = Instant::now();
+                let locked = manager.lock_device(&stopped);
+                let lock_elapsed = lock_start.elapsed();
+                if let Ok(Some(locked_device)) = &locked {
+                    let _ = GpuVectorStorage::new(
+                        locked_device.device(),
+                        &storage,
+                        None,
+                        false,
+                        &stopped,
+                    );
+                }
+                eprintln!(
+                    "[normal thread {thread_id} round {round}] lock_device took {lock_elapsed:?}{}",
+                    if lock_elapsed > std::time::Duration::from_secs(5) {
+                        " *** SLOW ***"
+                    } else {
+                        ""
+                    }
+                );
+                drop(locked);
+            }
+        }));
+    }
+
+    // Thread 3: the deliberate troublemaker — one oversized allocation attempt, then normal
+    // cycles, to see if IT specifically has trouble recovering even if the others don't.
+    {
+        let manager = manager.clone();
+        let stopped = stopped.clone();
+        handles.push(thread::spawn(move || {
+            eprintln!("[troublemaker] attempting oversized (48GB) allocation...");
+            let storage = build_storage_of_size(48.0);
+            let lock_start = Instant::now();
+            let locked = manager.lock_device(&stopped);
+            eprintln!("[troublemaker] lock_device took {:?}", lock_start.elapsed());
+            if let Ok(Some(locked_device)) = &locked {
+                let alloc_start = Instant::now();
+                let result =
+                    GpuVectorStorage::new(locked_device.device(), &storage, None, false, &stopped);
+                eprintln!(
+                    "[troublemaker] 48GB alloc -> {} (took {:?})",
+                    if result.is_ok() { "OK" } else { "FAILED" },
+                    alloc_start.elapsed()
+                );
+            }
+            drop(locked);
+
+            for round in 0..5 {
+                let storage = build_storage_of_size(2.0);
+                let lock_start = Instant::now();
+                let locked = manager.lock_device(&stopped);
+                let lock_elapsed = lock_start.elapsed();
+                if let Ok(Some(locked_device)) = &locked {
+                    let _ = GpuVectorStorage::new(
+                        locked_device.device(),
+                        &storage,
+                        None,
+                        false,
+                        &stopped,
+                    );
+                }
+                eprintln!(
+                    "[troublemaker round {round}] lock_device took {lock_elapsed:?}{}",
+                    if lock_elapsed > std::time::Duration::from_secs(5) {
+                        " *** SLOW ***"
+                    } else {
+                        ""
+                    }
+                );
+                drop(locked);
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    eprintln!("\n=== concurrent contention diagnostic complete ===");
+}

--- a/lib/segment/src/index/hnsw_index/hnsw/build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/build.rs
@@ -445,16 +445,36 @@ impl HNSWIndex {
             let visited_pool = VisitedPool::new();
             let mut block_filter_list = visited_pool.get(total_vector_count);
 
+            // Was a bare `?` before (CodeRabbit review, PR #10213): GpuInsertContext::new()
+            // allocates GPU buffers and runs initialization commands, which can hit DEVICE_LOST
+            // just as much as the actual per-block dispatch in build_filtered_graph_on_gpu()
+            // below — but `?` propagated that as a hard error all the way up, skipping BOTH the
+            // graceful CPU-fallback pattern every other GPU failure in this file uses, and
+            // device recreation (recreate_if_device_lost() never got a chance to run), leaving
+            // the device dead for every future caller too. Same fix shape as
+            // build_main_graph_on_gpu's own GpuInsertContext::new() call.
             #[cfg(feature = "gpu")]
             let mut gpu_insert_context = if let Some(gpu_vectors) = gpu_vectors.as_ref() {
-                Some(GpuInsertContext::new(
+                match GpuInsertContext::new(
                     gpu_vectors,
                     get_gpu_groups_count(),
                     payload_m,
                     config.ef_construct,
                     false,
                     1..=GPU_MAX_VISITED_FLAGS_FACTOR,
-                )?)
+                ) {
+                    Ok(gpu_insert_context) => Some(gpu_insert_context),
+                    Err(err) => {
+                        log::warn!(
+                            "Failed to create GPU insert context for additional links: {err}. \
+                             Falling back to CPU."
+                        );
+                        if let Some(gpu_device) = gpu_device.as_deref_mut() {
+                            gpu_device.recreate_if_device_lost(&err);
+                        }
+                        None
+                    }
+                }
             } else {
                 None
             };

--- a/lib/segment/src/index/hnsw_index/hnsw/build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/build.rs
@@ -34,6 +34,7 @@ use crate::index::hnsw_index::config::HnswGraphConfig;
 use crate::index::hnsw_index::gpu::get_gpu_groups_count;
 #[cfg(feature = "gpu")]
 use crate::index::hnsw_index::gpu::gpu_graph_builder::GPU_MAX_VISITED_FLAGS_FACTOR;
+use crate::index::hnsw_index::gpu::gpu_devices_manager::LockedGpuDevice;
 use crate::index::hnsw_index::gpu::gpu_insert_context::GpuInsertContext;
 use crate::index::hnsw_index::graph::HnswGraph;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
@@ -54,7 +55,7 @@ use crate::vector_storage::{VectorStorageEnum, VectorStorageRead};
 impl HNSWIndex {
     pub fn build<R: Rng + ?Sized>(
         open_args: HnswIndexOpenArgs<'_>,
-        build_args: VectorIndexBuildArgs<'_, R>,
+        build_args: VectorIndexBuildArgs<'_, '_, R>,
     ) -> OperationResult<Self> {
         if HnswGraphConfig::get_config_path(open_args.path).exists()
             || GraphLayers::get_path(open_args.path).exists()
@@ -78,7 +79,7 @@ impl HNSWIndex {
         let VectorIndexBuildArgs {
             permit,
             old_indices,
-            gpu_device,
+            mut gpu_device,
             rng,
             stopped,
             hnsw_global_config,
@@ -169,7 +170,7 @@ impl HNSWIndex {
         let deleted_bitslice = vector_storage_ref.deleted_vector_bitslice();
 
         #[cfg(feature = "gpu")]
-        let gpu_name_postfix = if let Some(gpu_device) = gpu_device {
+        let gpu_name_postfix = if let Some(gpu_device) = gpu_device.as_deref() {
             format!(" and GPU {}", gpu_device.device().name())
         } else {
             Default::default()
@@ -253,7 +254,7 @@ impl HNSWIndex {
         let gpu_vectors = if needs_gpu_vectors {
             let timer = std::time::Instant::now();
             let gpu_vectors = super::gpu_build::create_gpu_vectors(
-                gpu_device,
+                gpu_device.as_deref_mut(),
                 &vector_storage_ref,
                 &quantized_vectors_ref,
                 stopped,
@@ -264,6 +265,7 @@ impl HNSWIndex {
                     &vector_storage_ref,
                     &quantized_vectors_ref,
                     gpu_vectors.as_ref(),
+                    gpu_device.as_deref_mut(),
                     &graph_layers_builder,
                     deleted_bitslice,
                     num_entries,
@@ -523,6 +525,7 @@ impl HNSWIndex {
                         &vector_storage_ref,
                         &quantized_vectors_ref,
                         &mut gpu_insert_context,
+                        gpu_device.as_deref_mut(),
                         &payload_index_ref,
                         &pool,
                         stopped,
@@ -644,6 +647,10 @@ fn build_filtered_graph(
     vector_storage: &VectorStorageEnum,
     quantized_vectors: &Option<QuantizedVectors>,
     #[allow(unused_variables)] gpu_insert_context: &mut Option<GpuInsertContext<'_>>,
+    // See build_main_graph_on_gpu's identical parameter (hnsw/gpu_build.rs) for why this is
+    // threaded through — lets a DEVICE_LOST during THIS (additional-links) GPU dispatch also
+    // recreate the device in place, not just the main-graph dispatch above.
+    #[allow(unused_variables)] gpu_device: Option<&mut LockedGpuDevice>,
     payload_index: &StructPayloadIndex,
     pool: &ThreadPool,
     stopped: &AtomicBool,
@@ -667,6 +674,7 @@ fn build_filtered_graph(
         id_tracker,
         vector_storage,
         quantized_vectors,
+        gpu_device,
         gpu_insert_context.as_mut(),
         graph_layers_builder,
         block_filter_list,

--- a/lib/segment/src/index/hnsw_index/hnsw/build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/build.rs
@@ -253,28 +253,45 @@ impl HNSWIndex {
         #[cfg(feature = "gpu")]
         let gpu_vectors = if needs_gpu_vectors {
             let timer = std::time::Instant::now();
-            let gpu_vectors = super::gpu_build::create_gpu_vectors(
+            let (mut gpu_vectors, vectors_device_lost) = super::gpu_build::create_gpu_vectors(
                 gpu_device.as_deref_mut(),
                 &vector_storage_ref,
                 &quantized_vectors_ref,
                 stopped,
             )?;
-            if build_main_graph
-                && let Some(gpu_constructed_graph) = super::gpu_build::build_main_graph_on_gpu(
-                    id_tracker_ref.deref(),
-                    &vector_storage_ref,
-                    &quantized_vectors_ref,
-                    gpu_vectors.as_ref(),
-                    gpu_device.as_deref_mut(),
-                    &graph_layers_builder,
-                    deleted_bitslice,
-                    num_entries,
-                    stopped,
-                )?
-            {
-                graph_layers_builder = gpu_constructed_graph;
-                build_main_graph = false;
-                debug!("{FINISH_MAIN_GRAPH_LOG_MESSAGE} {:?}", timer.elapsed());
+            if build_main_graph {
+                let (main_graph_result, graph_device_lost) =
+                    super::gpu_build::build_main_graph_on_gpu(
+                        id_tracker_ref.deref(),
+                        &vector_storage_ref,
+                        &quantized_vectors_ref,
+                        gpu_vectors.as_ref(),
+                        gpu_device.as_deref_mut(),
+                        &graph_layers_builder,
+                        deleted_bitslice,
+                        num_entries,
+                        stopped,
+                    )?;
+                if let Some(gpu_constructed_graph) = main_graph_result {
+                    graph_layers_builder = gpu_constructed_graph;
+                    build_main_graph = false;
+                    debug!("{FINISH_MAIN_GRAPH_LOG_MESSAGE} {:?}", timer.elapsed());
+                }
+                if graph_device_lost {
+                    // The device was recreated mid-dispatch — gpu_vectors (built against the
+                    // device THIS build started with) is now bound to a dead device. Discard
+                    // it so the additional-links pass below correctly falls back to CPU
+                    // instead of reusing stale buffers and failing again. See
+                    // LockedGpuDevice::recreate_if_device_lost()'s doc comment (CodeRabbit
+                    // review, PR #10213) for the production incident this closes.
+                    gpu_vectors = None;
+                }
+            }
+            if vectors_device_lost {
+                // Already None in this case (create_gpu_vectors only returns device_lost=true
+                // alongside None), but kept explicit for the same reason as above — this must
+                // never silently start passing Some again if that function's contract changes.
+                gpu_vectors = None;
             }
             gpu_vectors
         } else {
@@ -670,19 +687,33 @@ fn build_filtered_graph(
     }
 
     #[cfg(feature = "gpu")]
-    if let Some(gpu_constructed_graph) = super::gpu_build::build_filtered_graph_on_gpu(
-        id_tracker,
-        vector_storage,
-        quantized_vectors,
-        gpu_device,
-        gpu_insert_context.as_mut(),
-        graph_layers_builder,
-        block_filter_list,
-        &points_to_index,
-        stopped,
-    )? {
-        *graph_layers_builder = gpu_constructed_graph;
-        return Ok(());
+    {
+        let (gpu_result, device_lost) = super::gpu_build::build_filtered_graph_on_gpu(
+            id_tracker,
+            vector_storage,
+            quantized_vectors,
+            gpu_device,
+            gpu_insert_context.as_mut(),
+            graph_layers_builder,
+            block_filter_list,
+            &points_to_index,
+            stopped,
+        )?;
+        if device_lost {
+            // The device was recreated mid-dispatch — this gpu_insert_context (and the
+            // gpu_vectors it was built from) is bound to a dead device. Discard it here so
+            // EVERY remaining block/field in this additional-links pass (this function runs
+            // once per payload block, reusing the same outer gpu_insert_context across all of
+            // them) correctly falls back to CPU instead of repeatedly failing against stale
+            // buffers and burning a pointless recreation cycle each time. See
+            // LockedGpuDevice::recreate_if_device_lost()'s doc comment (CodeRabbit review,
+            // PR #10213) for the production incident this closes.
+            *gpu_insert_context = None;
+        }
+        if let Some(gpu_constructed_graph) = gpu_result {
+            *graph_layers_builder = gpu_constructed_graph;
+            return Ok(());
+        }
     }
 
     let insert_points = |block_point_id| {

--- a/lib/segment/src/index/hnsw_index/hnsw/build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/build.rs
@@ -32,9 +32,9 @@ use crate::index::hnsw_index::build_condition_checker::BuildConditionChecker;
 use crate::index::hnsw_index::config::HnswGraphConfig;
 #[cfg(feature = "gpu")]
 use crate::index::hnsw_index::gpu::get_gpu_groups_count;
+use crate::index::hnsw_index::gpu::gpu_devices_manager::LockedGpuDevice;
 #[cfg(feature = "gpu")]
 use crate::index::hnsw_index::gpu::gpu_graph_builder::GPU_MAX_VISITED_FLAGS_FACTOR;
-use crate::index::hnsw_index::gpu::gpu_devices_manager::LockedGpuDevice;
 use crate::index::hnsw_index::gpu::gpu_insert_context::GpuInsertContext;
 use crate::index::hnsw_index::graph::HnswGraph;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
@@ -278,19 +278,15 @@ impl HNSWIndex {
                     debug!("{FINISH_MAIN_GRAPH_LOG_MESSAGE} {:?}", timer.elapsed());
                 }
                 if graph_device_lost {
-                    // The device was recreated mid-dispatch — gpu_vectors (built against the
-                    // device THIS build started with) is now bound to a dead device. Discard
-                    // it so the additional-links pass below correctly falls back to CPU
-                    // instead of reusing stale buffers and failing again. See
-                    // LockedGpuDevice::recreate_if_device_lost()'s doc comment (CodeRabbit
-                    // review, PR #10213) for the production incident this closes.
+                    // Device was recreated mid-dispatch — gpu_vectors is bound to the now-dead
+                    // device. Discard it so the additional-links pass below falls back to CPU
+                    // instead of reusing stale buffers.
                     gpu_vectors = None;
                 }
             }
             if vectors_device_lost {
-                // Already None in this case (create_gpu_vectors only returns device_lost=true
-                // alongside None), but kept explicit for the same reason as above — this must
-                // never silently start passing Some again if that function's contract changes.
+                // Already None here, but kept explicit so this doesn't silently start passing
+                // Some again if create_gpu_vectors' contract changes.
                 gpu_vectors = None;
             }
             gpu_vectors
@@ -445,13 +441,9 @@ impl HNSWIndex {
             let visited_pool = VisitedPool::new();
             let mut block_filter_list = visited_pool.get(total_vector_count);
 
-            // Was a bare `?` before (CodeRabbit review, PR #10213): GpuInsertContext::new()
-            // allocates GPU buffers and runs initialization commands, which can hit DEVICE_LOST
-            // just as much as the actual per-block dispatch in build_filtered_graph_on_gpu()
-            // below — but `?` propagated that as a hard error all the way up, skipping BOTH the
-            // graceful CPU-fallback pattern every other GPU failure in this file uses, and
-            // device recreation (recreate_if_device_lost() never got a chance to run), leaving
-            // the device dead for every future caller too. Same fix shape as
+            // Was a bare `?` before: GpuInsertContext::new() can hit DEVICE_LOST just as much
+            // as the per-block dispatch below, but `?` skipped both the CPU-fallback pattern
+            // every other GPU failure here uses, and device recreation. Same shape as
             // build_main_graph_on_gpu's own GpuInsertContext::new() call.
             #[cfg(feature = "gpu")]
             let mut gpu_insert_context = if let Some(gpu_vectors) = gpu_vectors.as_ref() {
@@ -720,14 +712,10 @@ fn build_filtered_graph(
             stopped,
         )?;
         if device_lost {
-            // The device was recreated mid-dispatch — this gpu_insert_context (and the
-            // gpu_vectors it was built from) is bound to a dead device. Discard it here so
-            // EVERY remaining block/field in this additional-links pass (this function runs
-            // once per payload block, reusing the same outer gpu_insert_context across all of
-            // them) correctly falls back to CPU instead of repeatedly failing against stale
-            // buffers and burning a pointless recreation cycle each time. See
-            // LockedGpuDevice::recreate_if_device_lost()'s doc comment (CodeRabbit review,
-            // PR #10213) for the production incident this closes.
+            // gpu_insert_context is bound to the now-dead device. Discard it so every
+            // remaining block in this additional-links pass (this function runs once per
+            // payload block, reusing the same outer gpu_insert_context) falls back to CPU
+            // instead of repeatedly failing against stale buffers.
             *gpu_insert_context = None;
         }
         if let Some(gpu_constructed_graph) = gpu_result {

--- a/lib/segment/src/index/hnsw_index/hnsw/gpu_build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/gpu_build.rs
@@ -41,7 +41,7 @@ pub(super) fn build_main_graph_on_gpu(
     deleted_bitslice: &BitSlice,
     entry_points_num: usize,
     stopped: &AtomicBool,
-) -> OperationResult<Option<GraphLayersBuilder>> {
+) -> OperationResult<(Option<GraphLayersBuilder>, bool)> {
     let points_scorer_builder = |vector_id| {
         let hardware_counter = HardwareCounterCell::disposable();
         FilteredScorer::new_internal(
@@ -92,7 +92,7 @@ pub(super) fn build_filtered_graph_on_gpu(
     block_filter_list: &VisitedListHandle,
     points_to_index: &[PointOffsetType],
     stopped: &AtomicBool,
-) -> OperationResult<Option<GraphLayersBuilder>> {
+) -> OperationResult<(Option<GraphLayersBuilder>, bool)> {
     build_graph_on_gpu(
         gpu_device,
         gpu_insert_context,
@@ -119,6 +119,12 @@ pub(super) fn build_filtered_graph_on_gpu(
     )
 }
 
+/// Returns `(constructed graph if GPU succeeded, whether a DEVICE_LOST was hit)`. The second
+/// field lets callers holding other GPU resources built earlier against the SAME device (e.g.
+/// `GpuVectorStorage`/`GpuInsertContext` in `hnsw/build.rs`) know to discard them instead of
+/// reusing them against what is now a different, freshly recreated device — see
+/// `LockedGpuDevice::recreate_if_device_lost()`'s own doc comment for the production incident
+/// this closes.
 #[allow(clippy::too_many_arguments)]
 fn build_graph_on_gpu<'a, 'b>(
     gpu_device: Option<&mut LockedGpuDevice>,
@@ -128,7 +134,7 @@ fn build_graph_on_gpu<'a, 'b>(
     entry_points_num: usize,
     points_scorer_builder: impl Fn(PointOffsetType) -> OperationResult<FilteredScorer<'a>> + Send + Sync,
     stopped: &AtomicBool,
-) -> OperationResult<Option<GraphLayersBuilder>> {
+) -> OperationResult<(Option<GraphLayersBuilder>, bool)> {
     if let Some(gpu_insert_context) = gpu_insert_context {
         let gpu_constructed_graph = build_hnsw_on_gpu(
             gpu_insert_context,
@@ -146,32 +152,36 @@ fn build_graph_on_gpu<'a, 'b>(
         check_process_stopped(stopped)?;
 
         match gpu_constructed_graph {
-            Ok(gpu_constructed_graph) => Ok(Some(gpu_constructed_graph)),
+            Ok(gpu_constructed_graph) => Ok((Some(gpu_constructed_graph), false)),
             Err(gpu_error) => {
                 log::warn!("Failed to build HNSW on GPU: {gpu_error}. Falling back to CPU.");
                 // Same DEVICE_LOST recreate-in-place logic as create_gpu_vectors() — confirmed
                 // live 2026-08-11 this call site hits DEVICE_LOST just as often (see
                 // build_main_graph_on_gpu's doc comment on the gpu_device parameter above).
-                if let Some(gpu_device) = gpu_device {
-                    gpu_device.recreate_if_device_lost(&gpu_error);
-                }
-                Ok(None)
+                let device_lost = if let Some(gpu_device) = gpu_device {
+                    gpu_device.recreate_if_device_lost(&gpu_error)
+                } else {
+                    false
+                };
+                Ok((None, device_lost))
             }
         }
     } else {
-        Ok(None)
+        Ok((None, false))
     }
 }
 
+/// Returns `(created storage if GPU succeeded, whether a DEVICE_LOST was hit)` — see
+/// `build_graph_on_gpu`'s own doc comment for why the second field matters to callers.
 pub(super) fn create_gpu_vectors(
     gpu_device: Option<&mut LockedGpuDevice>,
     vector_storage: &VectorStorageEnum,
     quantized_vectors: &Option<QuantizedVectors>,
     stopped: &AtomicBool,
-) -> OperationResult<Option<GpuVectorStorage>> {
+) -> OperationResult<(Option<GpuVectorStorage>, bool)> {
     use crate::index::hnsw_index::gpu::get_gpu_force_half_precision;
     if vector_storage.total_vector_count() < SINGLE_THREADED_HNSW_BUILD_THRESHOLD {
-        return Ok(None);
+        return Ok((None, false));
     }
 
     if let Some(gpu_device) = gpu_device {
@@ -188,18 +198,18 @@ pub(super) fn create_gpu_vectors(
         check_process_stopped(stopped)?;
 
         match gpu_vectors {
-            Ok(gpu_vectors) => Ok(Some(gpu_vectors)),
+            Ok(gpu_vectors) => Ok((Some(gpu_vectors), false)),
             Err(err) => {
                 log::error!("Failed to create GPU vectors, use CPU instead. Error: {err}.");
                 // If this specific error is DEVICE_LOST, the Vulkan device itself is now
                 // permanently dead (per spec) and would otherwise stay dead in the shared pool
                 // for the rest of the process's life — see recreate_if_device_lost()'s doc
                 // comment. No-op for any other error (timeout, OOM, ...).
-                gpu_device.recreate_if_device_lost(&err);
-                Ok(None)
+                let device_lost = gpu_device.recreate_if_device_lost(&err);
+                Ok((None, device_lost))
             }
         }
     } else {
-        Ok(None)
+        Ok((None, false))
     }
 }

--- a/lib/segment/src/index/hnsw_index/hnsw/gpu_build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/gpu_build.rs
@@ -36,7 +36,7 @@ pub(super) fn build_main_graph_on_gpu(
     // create_gpu_vectors) produced 3 of 6 real DEVICE_LOST occurrences observed in ~3 hours of
     // production monitoring after the create_gpu_vectors-only fix first shipped — a genuine,
     // roughly-50/50 gap, not a rare edge case.
-    gpu_device: Option<&mut LockedGpuDevice>,
+    mut gpu_device: Option<&mut LockedGpuDevice>,
     graph_layers_builder: &GraphLayersBuilder,
     deleted_bitslice: &BitSlice,
     entry_points_num: usize,
@@ -54,22 +54,40 @@ pub(super) fn build_main_graph_on_gpu(
         )
     };
 
-    let mut gpu_insert_context = if let Some(gpu_vectors) = gpu_vectors {
-        Some(GpuInsertContext::new(
-            gpu_vectors,
-            get_gpu_groups_count(),
-            graph_layers_builder.hnsw_m(),
-            graph_layers_builder.ef_construct(),
-            false,
-            1..=GPU_MAX_VISITED_FLAGS_FACTOR,
-        )?)
-    } else {
-        None
+    let Some(gpu_vectors) = gpu_vectors else {
+        return Ok((None, false));
+    };
+
+    // Was a bare `?` before (CodeRabbit review, PR #10213): GpuInsertContext::new() allocates
+    // GPU buffers and runs initialization commands, which can hit DEVICE_LOST just as much as
+    // the actual graph dispatch in build_graph_on_gpu() below — but `?` propagated that as a
+    // hard error all the way up through build_vector_index(), skipping BOTH the graceful
+    // CPU-fallback pattern every other GPU failure in this file uses, and device recreation
+    // (recreate_if_device_lost() never got a chance to run), leaving the device dead for every
+    // future caller too. Same fix shape as build_graph_on_gpu's own match below.
+    let mut gpu_insert_context = match GpuInsertContext::new(
+        gpu_vectors,
+        get_gpu_groups_count(),
+        graph_layers_builder.hnsw_m(),
+        graph_layers_builder.ef_construct(),
+        false,
+        1..=GPU_MAX_VISITED_FLAGS_FACTOR,
+    ) {
+        Ok(gpu_insert_context) => gpu_insert_context,
+        Err(err) => {
+            log::warn!("Failed to create GPU insert context: {err}. Falling back to CPU.");
+            let device_lost = if let Some(gpu_device) = gpu_device.as_deref_mut() {
+                gpu_device.recreate_if_device_lost(&err)
+            } else {
+                false
+            };
+            return Ok((None, device_lost));
+        }
     };
 
     build_graph_on_gpu(
         gpu_device,
-        gpu_insert_context.as_mut(),
+        Some(&mut gpu_insert_context),
         graph_layers_builder,
         id_tracker
             .point_mappings()

--- a/lib/segment/src/index/hnsw_index/hnsw/gpu_build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/gpu_build.rs
@@ -29,13 +29,10 @@ pub(super) fn build_main_graph_on_gpu(
     vector_storage: &VectorStorageEnum,
     quantized_vectors: &Option<QuantizedVectors>,
     gpu_vectors: Option<&GpuVectorStorage>,
-    // Passed through only so a DEVICE_LOST hit during the actual graph dispatch below (as
-    // opposed to during create_gpu_vectors' own device acquisition) can also trigger
-    // recreate_if_device_lost() — see build_graph_on_gpu's own doc comment for why this call
-    // site needed the same fix. Confirmed live 2026-08-11: this exact path (not
-    // create_gpu_vectors) produced 3 of 6 real DEVICE_LOST occurrences observed in ~3 hours of
-    // production monitoring after the create_gpu_vectors-only fix first shipped — a genuine,
-    // roughly-50/50 gap, not a rare edge case.
+    // Passed through so a DEVICE_LOST hit during the graph dispatch below (as opposed to
+    // during create_gpu_vectors' own device acquisition) can also trigger
+    // recreate_if_device_lost() — see build_graph_on_gpu's doc comment. This path hits
+    // DEVICE_LOST about as often as create_gpu_vectors does, not a rare edge case.
     mut gpu_device: Option<&mut LockedGpuDevice>,
     graph_layers_builder: &GraphLayersBuilder,
     deleted_bitslice: &BitSlice,
@@ -58,13 +55,10 @@ pub(super) fn build_main_graph_on_gpu(
         return Ok((None, false));
     };
 
-    // Was a bare `?` before (CodeRabbit review, PR #10213): GpuInsertContext::new() allocates
-    // GPU buffers and runs initialization commands, which can hit DEVICE_LOST just as much as
-    // the actual graph dispatch in build_graph_on_gpu() below — but `?` propagated that as a
-    // hard error all the way up through build_vector_index(), skipping BOTH the graceful
-    // CPU-fallback pattern every other GPU failure in this file uses, and device recreation
-    // (recreate_if_device_lost() never got a chance to run), leaving the device dead for every
-    // future caller too. Same fix shape as build_graph_on_gpu's own match below.
+    // Was a bare `?` before: GpuInsertContext::new() can hit DEVICE_LOST just as much as the
+    // graph dispatch in build_graph_on_gpu() below, but `?` skipped both the CPU-fallback
+    // pattern every other GPU failure here uses and device recreation. Same shape as
+    // build_graph_on_gpu's own match below.
     let mut gpu_insert_context = match GpuInsertContext::new(
         gpu_vectors,
         get_gpu_groups_count(),
@@ -138,11 +132,9 @@ pub(super) fn build_filtered_graph_on_gpu(
 }
 
 /// Returns `(constructed graph if GPU succeeded, whether a DEVICE_LOST was hit)`. The second
-/// field lets callers holding other GPU resources built earlier against the SAME device (e.g.
+/// field lets callers holding other GPU resources built against the same device (e.g.
 /// `GpuVectorStorage`/`GpuInsertContext` in `hnsw/build.rs`) know to discard them instead of
-/// reusing them against what is now a different, freshly recreated device — see
-/// `LockedGpuDevice::recreate_if_device_lost()`'s own doc comment for the production incident
-/// this closes.
+/// reusing them against what is now a different, freshly recreated device.
 #[allow(clippy::too_many_arguments)]
 fn build_graph_on_gpu<'a, 'b>(
     gpu_device: Option<&mut LockedGpuDevice>,
@@ -173,9 +165,7 @@ fn build_graph_on_gpu<'a, 'b>(
             Ok(gpu_constructed_graph) => Ok((Some(gpu_constructed_graph), false)),
             Err(gpu_error) => {
                 log::warn!("Failed to build HNSW on GPU: {gpu_error}. Falling back to CPU.");
-                // Same DEVICE_LOST recreate-in-place logic as create_gpu_vectors() — confirmed
-                // live 2026-08-11 this call site hits DEVICE_LOST just as often (see
-                // build_main_graph_on_gpu's doc comment on the gpu_device parameter above).
+                // Same DEVICE_LOST recreate-in-place logic as create_gpu_vectors() below.
                 let device_lost = if let Some(gpu_device) = gpu_device {
                     gpu_device.recreate_if_device_lost(&gpu_error)
                 } else {
@@ -219,10 +209,7 @@ pub(super) fn create_gpu_vectors(
             Ok(gpu_vectors) => Ok((Some(gpu_vectors), false)),
             Err(err) => {
                 log::error!("Failed to create GPU vectors, use CPU instead. Error: {err}.");
-                // If this specific error is DEVICE_LOST, the Vulkan device itself is now
-                // permanently dead (per spec) and would otherwise stay dead in the shared pool
-                // for the rest of the process's life — see recreate_if_device_lost()'s doc
-                // comment. No-op for any other error (timeout, OOM, ...).
+                // Recreates the device if this was DEVICE_LOST; no-op otherwise.
                 let device_lost = gpu_device.recreate_if_device_lost(&err);
                 Ok((None, device_lost))
             }

--- a/lib/segment/src/index/hnsw_index/hnsw/gpu_build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/gpu_build.rs
@@ -29,6 +29,14 @@ pub(super) fn build_main_graph_on_gpu(
     vector_storage: &VectorStorageEnum,
     quantized_vectors: &Option<QuantizedVectors>,
     gpu_vectors: Option<&GpuVectorStorage>,
+    // Passed through only so a DEVICE_LOST hit during the actual graph dispatch below (as
+    // opposed to during create_gpu_vectors' own device acquisition) can also trigger
+    // recreate_if_device_lost() — see build_graph_on_gpu's own doc comment for why this call
+    // site needed the same fix. Confirmed live 2026-08-11: this exact path (not
+    // create_gpu_vectors) produced 3 of 6 real DEVICE_LOST occurrences observed in ~3 hours of
+    // production monitoring after the create_gpu_vectors-only fix first shipped — a genuine,
+    // roughly-50/50 gap, not a rare edge case.
+    gpu_device: Option<&mut LockedGpuDevice>,
     graph_layers_builder: &GraphLayersBuilder,
     deleted_bitslice: &BitSlice,
     entry_points_num: usize,
@@ -60,6 +68,7 @@ pub(super) fn build_main_graph_on_gpu(
     };
 
     build_graph_on_gpu(
+        gpu_device,
         gpu_insert_context.as_mut(),
         graph_layers_builder,
         id_tracker
@@ -76,6 +85,8 @@ pub(super) fn build_filtered_graph_on_gpu(
     id_tracker: &IdTrackerEnum,
     vector_storage: &VectorStorageEnum,
     quantized_vectors: &Option<QuantizedVectors>,
+    // See build_main_graph_on_gpu's identical parameter for why this is here.
+    gpu_device: Option<&mut LockedGpuDevice>,
     gpu_insert_context: Option<&mut GpuInsertContext<'_>>,
     graph_layers_builder: &GraphLayersBuilder,
     block_filter_list: &VisitedListHandle,
@@ -83,6 +94,7 @@ pub(super) fn build_filtered_graph_on_gpu(
     stopped: &AtomicBool,
 ) -> OperationResult<Option<GraphLayersBuilder>> {
     build_graph_on_gpu(
+        gpu_device,
         gpu_insert_context,
         graph_layers_builder,
         points_to_index.iter().copied(),
@@ -107,7 +119,9 @@ pub(super) fn build_filtered_graph_on_gpu(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_graph_on_gpu<'a, 'b>(
+    gpu_device: Option<&mut LockedGpuDevice>,
     gpu_insert_context: Option<&mut GpuInsertContext<'b>>,
     graph_layers_builder: &GraphLayersBuilder,
     points_to_index: impl Iterator<Item = PointOffsetType>,
@@ -135,6 +149,12 @@ fn build_graph_on_gpu<'a, 'b>(
             Ok(gpu_constructed_graph) => Ok(Some(gpu_constructed_graph)),
             Err(gpu_error) => {
                 log::warn!("Failed to build HNSW on GPU: {gpu_error}. Falling back to CPU.");
+                // Same DEVICE_LOST recreate-in-place logic as create_gpu_vectors() — confirmed
+                // live 2026-08-11 this call site hits DEVICE_LOST just as often (see
+                // build_main_graph_on_gpu's doc comment on the gpu_device parameter above).
+                if let Some(gpu_device) = gpu_device {
+                    gpu_device.recreate_if_device_lost(&gpu_error);
+                }
                 Ok(None)
             }
         }
@@ -144,7 +164,7 @@ fn build_graph_on_gpu<'a, 'b>(
 }
 
 pub(super) fn create_gpu_vectors(
-    gpu_device: Option<&LockedGpuDevice>,
+    gpu_device: Option<&mut LockedGpuDevice>,
     vector_storage: &VectorStorageEnum,
     quantized_vectors: &Option<QuantizedVectors>,
     stopped: &AtomicBool,
@@ -171,6 +191,11 @@ pub(super) fn create_gpu_vectors(
             Ok(gpu_vectors) => Ok(Some(gpu_vectors)),
             Err(err) => {
                 log::error!("Failed to create GPU vectors, use CPU instead. Error: {err}.");
+                // If this specific error is DEVICE_LOST, the Vulkan device itself is now
+                // permanently dead (per spec) and would otherwise stay dead in the shared pool
+                // for the rest of the process's life — see recreate_if_device_lost()'s doc
+                // comment. No-op for any other error (timeout, OOM, ...).
+                gpu_device.recreate_if_device_lost(&err);
                 Ok(None)
             }
         }

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -699,13 +699,13 @@ impl SegmentBuilder {
             #[cfg(feature = "gpu")]
             let gpu_devices_manager = crate::index::hnsw_index::gpu::GPU_DEVICES_MANAGER.read();
             #[cfg(feature = "gpu")]
-            let gpu_device = gpu_devices_manager
+            let mut gpu_device = gpu_devices_manager
                 .as_ref()
                 .map(|devices_manager| devices_manager.lock_device(stopped))
                 .transpose()?
                 .flatten();
             #[cfg(not(feature = "gpu"))]
-            let gpu_device = None;
+            let mut gpu_device = None;
 
             // Arc permit to share it with each vector store
             let permit = Arc::new(permit);
@@ -729,7 +729,7 @@ impl SegmentBuilder {
                     VectorIndexBuildArgs {
                         permit: permit.clone(),
                         old_indices: &old_indices.remove(vector_name).unwrap(),
-                        gpu_device: gpu_device.as_ref(),
+                        gpu_device: gpu_device.as_mut(),
                         stopped,
                         rng,
                         hnsw_global_config: &hnsw_global_config,

--- a/lib/segment/src/segment_constructor/segment_constructor_base/vector_index.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/vector_index.rs
@@ -28,20 +28,12 @@ pub(crate) struct VectorIndexOpenArgs<'a> {
 }
 
 // Two lifetime parameters, not one: `gpu_device`'s `LockedGpuDevice<'g>` is locked once and
-// reused across a whole loop of `build_vector_index()` calls (see segment_builder.rs) — its
-// `'g` (governing the `MutexGuard` inside) legitimately spans that entire loop. But the `&'a
-// mut` reference to it, like `old_indices`/`rng`, is only ever borrowed fresh for one call at
-// a time. A single-lifetime version of this struct (originally `Option<&'a
-// LockedGpuDevice<'a>>`) unified both under one 'a — harmless for a *shared* reference (shared
-// borrows freely coexist across iterations even when their target's own drop-relevant lifetime
-// is long), but a real conflict once this became `&mut` for GPU-device-recreation support:
-// unifying 'a with 'g forced every iteration's exclusive borrow to be treated as live for the
-// *entire* loop, so consecutive iterations' borrows overlapped and old_indices/rng's per-call
-// borrows got dragged into the same false constraint. Keeping the outer reference under the
-// same short 'a as old_indices/rng, while letting `LockedGpuDevice`'s own internal 'g stay
-// long-lived and independent, is what actually fixes it — confirmed by hitting exactly this
-// class of borrowck error (E0716/E0597/E0499, then E0597 again) in segment_builder.rs while
-// iterating on this signature.
+// reused across a whole loop of `build_vector_index()` calls, so `'g` legitimately spans that
+// entire loop — but the `&'a mut` reference to it, like `old_indices`/`rng`, is only borrowed
+// fresh per call. Unifying both under one lifetime (as a shared `&'a LockedGpuDevice<'a>`
+// reference did before this became `&mut` for device recreation) forces every iteration's
+// exclusive borrow to be treated as live for the whole loop, dragging old_indices/rng's
+// per-call borrows into the same false constraint. Keeping 'a short and 'g independent fixes it.
 pub struct VectorIndexBuildArgs<'a, 'g, R: Rng + ?Sized> {
     pub permit: Arc<ResourcePermit>,
     /// Vector indices from other segments, used to speed up index building.

--- a/lib/segment/src/segment_constructor/segment_constructor_base/vector_index.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/vector_index.rs
@@ -27,12 +27,27 @@ pub(crate) struct VectorIndexOpenArgs<'a> {
     pub quantized_vectors: Arc<AtomicRefCell<Option<QuantizedVectors>>>,
 }
 
-pub struct VectorIndexBuildArgs<'a, R: Rng + ?Sized> {
+// Two lifetime parameters, not one: `gpu_device`'s `LockedGpuDevice<'g>` is locked once and
+// reused across a whole loop of `build_vector_index()` calls (see segment_builder.rs) — its
+// `'g` (governing the `MutexGuard` inside) legitimately spans that entire loop. But the `&'a
+// mut` reference to it, like `old_indices`/`rng`, is only ever borrowed fresh for one call at
+// a time. A single-lifetime version of this struct (originally `Option<&'a
+// LockedGpuDevice<'a>>`) unified both under one 'a — harmless for a *shared* reference (shared
+// borrows freely coexist across iterations even when their target's own drop-relevant lifetime
+// is long), but a real conflict once this became `&mut` for GPU-device-recreation support:
+// unifying 'a with 'g forced every iteration's exclusive borrow to be treated as live for the
+// *entire* loop, so consecutive iterations' borrows overlapped and old_indices/rng's per-call
+// borrows got dragged into the same false constraint. Keeping the outer reference under the
+// same short 'a as old_indices/rng, while letting `LockedGpuDevice`'s own internal 'g stay
+// long-lived and independent, is what actually fixes it — confirmed by hitting exactly this
+// class of borrowck error (E0716/E0597/E0499, then E0597 again) in segment_builder.rs while
+// iterating on this signature.
+pub struct VectorIndexBuildArgs<'a, 'g, R: Rng + ?Sized> {
     pub permit: Arc<ResourcePermit>,
     /// Vector indices from other segments, used to speed up index building.
     /// May or may not contain the same vectors.
     pub old_indices: &'a [Arc<AtomicRefCell<VectorIndexEnum>>],
-    pub gpu_device: Option<&'a LockedGpuDevice<'a>>,
+    pub gpu_device: Option<&'a mut LockedGpuDevice<'g>>,
     pub rng: &'a mut R,
     pub stopped: &'a AtomicBool,
     pub hnsw_global_config: &'a HnswGlobalConfig,

--- a/lib/segment/tests/integration/gpu_hnsw_test.rs
+++ b/lib/segment/tests/integration/gpu_hnsw_test.rs
@@ -39,7 +39,7 @@ fn build_hnsw(
     path: &Path,
     segment: &Segment,
     hnsw_config: HnswConfig,
-    gpu_device: Option<&LockedGpuDevice>,
+    gpu_device: Option<&mut LockedGpuDevice>,
     stopped: &AtomicBool,
 ) -> HNSWIndex {
     let permit_cpu_count = get_num_indexing_threads(hnsw_config.max_indexing_threads);
@@ -250,12 +250,12 @@ fn test_gpu_filterable_hnsw() {
 
     let hnsw_dir_gpu_no_idx = Builder::new().prefix("hnsw_gpu_no_idx").tempdir().unwrap();
     let hnsw_gpu_no_idx = {
-        let locked = LockedGpuDevice::new(gpu_device.lock());
+        let mut locked = LockedGpuDevice::new(gpu_device.lock());
         build_hnsw(
             hnsw_dir_gpu_no_idx.path(),
             &segment_no_idx,
             hnsw_config,
-            Some(&locked),
+            Some(&mut locked),
             &stopped,
         )
     };
@@ -284,12 +284,12 @@ fn test_gpu_filterable_hnsw() {
 
     let hnsw_dir_gpu_idx = Builder::new().prefix("hnsw_gpu_idx").tempdir().unwrap();
     let hnsw_gpu_idx = {
-        let locked = LockedGpuDevice::new(gpu_device.lock());
+        let mut locked = LockedGpuDevice::new(gpu_device.lock());
         build_hnsw(
             hnsw_dir_gpu_idx.path(),
             &segment_idx,
             hnsw_config,
-            Some(&locked),
+            Some(&mut locked),
             &stopped,
         )
     };


### PR DESCRIPTION
Ports #10211 onto `dev` per @timvisee's comment there — this was originally opened against `master`/`v1.18.3` by mistake (missed the contributing guide's dev-branch requirement until after opening it).

## Summary

Same fix as #10211, described in full there — this PR is the dev-targeted port of the same 3 commits (the original two fixes plus the CodeRabbit-review follow-up already applied on #10211):

1. **Bound `lock_device()`'s wait** — it previously waited *forever* for a free GPU device with no timeout, no log, no visible failure mode until a full qdrant restart. Now bounded by `GPU_LOCK_TIMEOUT` (derived from `GPU_TIMEOUT`, so the two can't drift back out of the relationship a reviewer caught on #10211 — `GPU_LOCK_TIMEOUT` must stay *above* `GPU_TIMEOUT`, since a lock holder may legitimately run a single GPU operation for that long).
2. **Recreate the Vulkan device in place on `DEVICE_LOST`** — per the Vulkan spec, `VK_ERROR_DEVICE_LOST` is terminal for that logical device; nothing before this fix destroyed/recreated it, so one loss silently pinned every subsequent GPU build to CPU fallback for the rest of that process's uptime (collection/optimizer status stayed "ok" throughout — CPU fallback working correctly isn't evidence GPU was actually being used). `GpuDeviceSlot` now retains what's needed (`Arc<gpu::Instance>`, `PhysicalDevice`, queue index) to call `gpu::Device::new_with_params()` again in place; wired into both GPU-build call sites (`create_gpu_vectors()` and `build_graph_on_gpu()`, the latter needed a `LockedGpuDevice` borrow threaded through `VectorIndexBuildArgs` with a split lifetime — see that struct's own comment for why).
3. **CodeRabbit-review fixes** (already applied on #10211 before this port): `LockedGpuDevice` borrows the owning `GpuDeviceSlot` directly instead of cloning it per lock acquisition; the lock-wait-timeout log is `warn` not `error` (contention alone isn't a failure); the ignored diagnostic tests use an env-overridable GPU vendor filter and cap their pressure-test allocation to available host RAM instead of a bare 48GB literal.

## Production evidence (from #10211, still accurate)

Confirmed live on our own kvark.rcp deployment (NVIDIA RTX A6000): 129 `DEVICE_LOST` occurrences over 3+ days with zero successful GPU builds logged anywhere in between, before this fix. After deploying, both call sites confirmed self-healing across repeated real `DEVICE_LOST` events in production (`create_gpu_vectors` 3-for-3, `build_graph_on_gpu` 1-for-1), each recovering in under 2 seconds via a fresh `gpu::Device::new_with_params()` call, zero HTTP 500s or user-facing impact in the monitored windows.

## Porting notes (this PR vs #10211)

`dev` has diverged substantially from `v1.18.3` (6700+ commits) but the actual files this fix touches had very little unrelated drift — `gpu_devices_manager.rs`/`mod.rs` differed by only a handful of cosmetic lines. The one real structural change: `segment_constructor_base.rs` was split into a `segment_constructor_base/` module (`VectorIndexBuildArgs` now lives in `vector_index.rs`); ported the same two-lifetime-parameter change (`<'a, 'g, R>`) to its new location, everything else auto-merged cleanly via cherry-pick.

## Testing

- `cargo check -p segment --features gpu` and `--tests`: clean.
- `cargo build --release --features gpu`: clean, full `qdrant` binary builds.
- `cargo test -p segment --features gpu --lib gpu::`: **65 passed, 0 failed** (2 pressure/contention diagnostics left `--ignored`, same as before — those intentionally stress GPU/VRAM and are meant to be run manually against a real GPU, not in CI).
- Not yet re-deployed to production under `dev`/1.19 — the production evidence above is from the original `v1.18.3`-based build; will report back if we get a chance to run this specific build under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)