### PR TITLE
[UpdateOnly] Writer over object storage

### DIFF
--- a/lib/common/io_bridge/src/cached/mod.rs
+++ b/lib/common/io_bridge/src/cached/mod.rs
@@ -87,18 +87,36 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
 
         let new_len = offset + data.len() as u64;
 
-        match self.remote.source().append_support() {
+        let enabled = log::log_enabled!(target: crate::LATENCY_LOG_TARGET, log::Level::Trace);
+        let start_time = enabled.then(std::time::Instant::now);
+
+        let strategy = match self.remote.source().append_support() {
             AppendSupport::Always => {
                 self.remote.append_bytes(offset, data, self.cache.etag())?;
+                "append"
             }
             AppendSupport::AboveThreshold { min_offset } => {
                 if offset >= min_offset {
                     self.remote.append_bytes(offset, data, self.cache.etag())?;
+                    "append"
                 } else {
                     self.local_rewrite(offset, data)?;
+                    "rewrite"
                 }
             }
-            AppendSupport::Never => self.local_rewrite(offset, data)?,
+            AppendSupport::Never => {
+                self.local_rewrite(offset, data)?;
+                "rewrite"
+            }
+        };
+
+        if let Some(start_time) = start_time {
+            log::trace!(
+                target: crate::LATENCY_LOG_TARGET,
+                "append_bytes({}, {offset}..{new_len}) took {:?} via {strategy}",
+                self.remote.path().display(),
+                start_time.elapsed(),
+            );
         }
 
         self.cache.schedule_reopen(|_| {

--- a/lib/common/io_bridge/src/cached/mod.rs
+++ b/lib/common/io_bridge/src/cached/mod.rs
@@ -18,6 +18,8 @@
 
 mod fs;
 mod pipeline;
+#[cfg(test)]
+mod tests;
 
 use std::ops::Range;
 use std::path::Path;
@@ -26,8 +28,8 @@ use bytes::Bytes;
 use common::ext::aligned_vec::ACow;
 use common::generic_consts::{AccessPattern, Sequential};
 use common::universal_io::{
-    ByteOffset, DiskCache, FileInfo, Flusher, UioResult, UniversalAppend, UniversalFlush,
-    UniversalIoError, UniversalKind, UniversalRead, UserData,
+    ByteOffset, DiskCache, FileInfo, Flusher, OkNotFound as _, UioResult, UniversalAppend,
+    UniversalFlush, UniversalIoError, UniversalKind, UniversalRead, UserData,
 };
 pub use fs::{CachedBlobFs, CachedBlobFsContext};
 pub use pipeline::CachedBlobReadPipeline;
@@ -151,8 +153,13 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
     /// The rewrites offer no backend compare-and-swap, so `offset` is
     /// validated against the mirror length — this handle's view of the
     /// remote EOF, kept in step after every append (single-writer contract).
+    ///
+    /// A remote object that is not there yet reads as length zero: the
+    /// offset-0 rewrite is what creates it, matching the direct-append
+    /// backends (a GCS compose or native append at offset 0 also creates
+    /// the object).
     fn check_offset(&self, offset: ByteOffset) -> UioResult<()> {
-        let local_len = self.cache.len::<u8>()?;
+        let local_len = self.cache.len::<u8>().ok_not_found()?.unwrap_or(0);
         if offset != local_len {
             return Err(UniversalIoError::AppendOffsetConflict {
                 path: self.remote.path().to_path_buf(),

--- a/lib/common/io_bridge/src/cached/tests.rs
+++ b/lib/common/io_bridge/src/cached/tests.rs
@@ -1,0 +1,205 @@
+//! Tests for [`CachedBlobFile`] appends through the caller-side rewrite
+//! path, on a mock backend without native small appends.
+
+use std::assert_matches;
+use std::future::Future;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use common::universal_io::{
+    DiskCacheConfig, ListedFile, OpenOptions, Populate, UniversalWriteFileOps as _,
+};
+use futures::stream::{BoxStream, StreamExt as _};
+
+use super::*;
+use crate::runtime::BridgeRuntime;
+use crate::write::AsyncWrite;
+use crate::{CachedBlobFs, OffsetByteStream};
+
+/// An in-memory single-object backend shaped like an S3 store without
+/// native append (part-copy strategy): direct appends only above the
+/// 5 MiB threshold, so every small append goes through the caller-side
+/// rewrite.
+#[derive(Clone, Default)]
+struct ThresholdMockSource {
+    store: Arc<Mutex<Option<Vec<u8>>>>,
+    direct_appends: Arc<AtomicUsize>,
+}
+
+impl ThresholdMockSource {
+    fn content(&self) -> Option<Vec<u8>> {
+        self.store.lock().unwrap().clone()
+    }
+}
+
+impl AsyncRead for ThresholdMockSource {
+    type Config = ();
+
+    fn open(_config: &()) -> UioResult<Self> {
+        Ok(Self::default())
+    }
+
+    fn list_files(
+        &self,
+        _prefix: &Path,
+    ) -> impl Future<Output = UioResult<Vec<ListedFile>>> + Send + 'static {
+        std::future::ready(Ok(vec![]))
+    }
+
+    fn exists(&self, _path: &Path) -> impl Future<Output = UioResult<bool>> + Send + 'static {
+        std::future::ready(Ok(self.store.lock().unwrap().is_some()))
+    }
+
+    fn read_range(
+        &self,
+        path: &Path,
+        range: Range<u64>,
+    ) -> impl Future<Output = UioResult<BoxStream<'static, UioResult<Bytes>>>> + Send + 'static
+    {
+        let result = match &*self.store.lock().unwrap() {
+            Some(data) => {
+                let end = (range.end as usize).min(data.len());
+                let start = (range.start as usize).min(end);
+                Ok(Bytes::copy_from_slice(&data[start..end]))
+            }
+            None => Err(UniversalIoError::NotFound { path: path.into() }),
+        };
+        async move {
+            let bytes = result?;
+            Ok(futures::stream::once(async move { Ok(bytes) }).boxed())
+        }
+    }
+
+    fn read_from(
+        &self,
+        path: &Path,
+        from: u64,
+    ) -> impl Future<Output = UioResult<(u64, OffsetByteStream)>> + Send + 'static {
+        let result = match &*self.store.lock().unwrap() {
+            Some(data) => Ok((
+                data.len() as u64,
+                Bytes::copy_from_slice(&data[from as usize..]),
+            )),
+            None => Err(UniversalIoError::NotFound { path: path.into() }),
+        };
+        async move {
+            let (size, tail) = result?;
+            Ok((
+                size,
+                futures::stream::once(async move { Ok((0, tail)) }).boxed(),
+            ))
+        }
+    }
+
+    fn len(&self, path: &Path) -> impl Future<Output = UioResult<u64>> + Send + 'static {
+        let result = match &*self.store.lock().unwrap() {
+            Some(data) => Ok(data.len() as u64),
+            None => Err(UniversalIoError::NotFound { path: path.into() }),
+        };
+        std::future::ready(result)
+    }
+
+    fn kind() -> UniversalKind {
+        UniversalKind::S3
+    }
+}
+
+impl AsyncWrite for ThresholdMockSource {
+    fn create(&self, _path: &Path) -> impl Future<Output = UioResult<()>> + Send + 'static {
+        self.store.lock().unwrap().get_or_insert_with(Vec::new);
+        std::future::ready(Ok(()))
+    }
+
+    fn remove(&self, path: &Path) -> impl Future<Output = UioResult<()>> + Send + 'static {
+        let result = match self.store.lock().unwrap().take() {
+            Some(_) => Ok(()),
+            None => Err(UniversalIoError::NotFound { path: path.into() }),
+        };
+        std::future::ready(result)
+    }
+
+    fn save(
+        &self,
+        _path: &Path,
+        bytes: Bytes,
+    ) -> impl Future<Output = UioResult<()>> + Send + 'static {
+        *self.store.lock().unwrap() = Some(bytes.to_vec());
+        std::future::ready(Ok(()))
+    }
+}
+
+impl AsyncAppend for ThresholdMockSource {
+    fn append_support(&self) -> AppendSupport {
+        AppendSupport::AboveThreshold {
+            min_offset: 5 * 1024 * 1024,
+        }
+    }
+
+    fn append(
+        &self,
+        _path: &Path,
+        _offset: u64,
+        _data: Bytes,
+        _expected_etag: Option<String>,
+    ) -> impl Future<Output = UioResult<u64>> + Send + 'static {
+        self.direct_appends.fetch_add(1, Ordering::Relaxed);
+        std::future::ready(Err(UniversalIoError::S3Config {
+            description: "direct append below the advertised threshold".to_string(),
+        }))
+    }
+}
+
+fn cached_fs(source: &ThresholdMockSource, local_dir: &Path) -> CachedBlobFs<ThresholdMockSource> {
+    let config = DiskCacheConfig::new(PathBuf::from("bucket"), local_dir.to_path_buf())
+        .expect("local dir exists");
+    CachedBlobFs::new(source.clone(), BridgeRuntime::global(), Arc::new(config))
+}
+
+fn open_options() -> OpenOptions {
+    OpenOptions {
+        need_sequential: false,
+        populate: Populate::No,
+        ..OpenOptions::new_for_test()
+    }
+}
+
+/// An append at offset 0 to an object that does not exist yet creates
+/// it, like the direct-append backends do — instead of surfacing the
+/// mirror's `NotFound` from the offset check.
+#[test]
+fn rewrite_append_at_offset_zero_creates_the_missing_object() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = ThresholdMockSource::default();
+    let mut file = cached_fs(&source, tmp.path())
+        .open_append("bucket/obj", open_options())
+        .unwrap();
+
+    file.append(0, b"abc".as_slice()).unwrap();
+    assert_eq!(source.content().unwrap(), b"abc");
+
+    file.append(3, b"de".as_slice()).unwrap();
+    assert_eq!(source.content().unwrap(), b"abcde");
+    assert_eq!(file.len::<u8>().unwrap(), 5);
+
+    // Both appends are below the threshold: rewrites only.
+    assert_eq!(source.direct_appends.load(Ordering::Relaxed), 0);
+}
+
+/// A non-zero offset against a missing object is an offset conflict —
+/// the object's length is zero, not unknowable.
+#[test]
+fn rewrite_append_at_nonzero_offset_on_a_missing_object_conflicts() {
+    let tmp = tempfile::tempdir().unwrap();
+    let source = ThresholdMockSource::default();
+    let mut file = cached_fs(&source, tmp.path())
+        .open_append("bucket/obj", open_options())
+        .unwrap();
+
+    let err = file.append(3, b"de".as_slice()).unwrap_err();
+    assert_matches!(
+        err,
+        UniversalIoError::AppendOffsetConflict { offset: 3, .. }
+    );
+    assert!(source.content().is_none());
+}

--- a/lib/common/io_bridge_object_store/src/lib.rs
+++ b/lib/common/io_bridge_object_store/src/lib.rs
@@ -42,5 +42,6 @@ pub use backend::BlobBackend;
 // stack can be built from this single crate.
 pub use io_bridge::{
     AsyncAppend, AsyncRead, AsyncWrite, BlobFile, BlobFs, BlobReadPipeline, BridgeRuntime,
+    CachedBlobFile, CachedBlobFs, CachedBlobFsContext,
 };
 pub use source::ObjectStoreSource;

--- a/lib/edge/src/lib.rs
+++ b/lib/edge/src/lib.rs
@@ -34,6 +34,7 @@ pub use requests::{
 pub use shard::files::WAL_PATH;
 pub use shard::segment_manifest::{SegmentManifestState, SegmentsManifest};
 pub use update_only::{
-    PointAction, PointCopy, PointPreview, PointUpdates, SegmentConfigInfo, UpdateBatchOutcome,
-    UpdateBatchPlan, UpdateBatchPreview, UpdateOnlyEdgeShard,
+    PointAction, PointApplyKind, PointApplyRecord, PointCopy, PointPreview, PointUpdates,
+    SegmentConfigInfo, UpdateBatchOutcome, UpdateBatchPlan, UpdateBatchPreview,
+    UpdateOnlyEdgeShard,
 };

--- a/lib/edge/src/update_only/apply.rs
+++ b/lib/edge/src/update_only/apply.rs
@@ -5,7 +5,7 @@
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalAppend, UniversalRead, UniversalWrite};
+use common::universal_io::{UniversalAppend, UniversalRead};
 use rayon::ThreadPool;
 use rayon::prelude::*;
 use segment::common::operation_error::{OperationError, OperationResult};
@@ -67,7 +67,7 @@ pub(super) struct PointLocations {
     pub(super) slots: Vec<(Uuid, PointOffsetType)>,
 }
 
-impl<S: UniversalAppend + UniversalWrite + 'static> UpdateOnlyEdgeShard<S> {
+impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S> {
     /// Apply a batch of update operations, each paired with the operation
     /// number to record as its version. Operations are expected in ascending
     /// operation-number order; see [`UpdateBatchPlan::build`] for what is
@@ -192,7 +192,7 @@ impl<S: UniversalAppend + UniversalWrite + 'static> UpdateOnlyEdgeShard<S> {
 /// Open a writer over one segment of the shard, resuming it from the state its
 /// [`LookupSegment`](segment::segment::update_only::LookupSegment) observed —
 /// which also decides whether the segment accepts appends or deletes only.
-fn open_writer<S: UniversalAppend + UniversalWrite + 'static>(
+fn open_writer<S: UniversalAppend + 'static>(
     segments: &LookupSegmentHolder<S>,
     fs: &S::Fs,
     uuid: Uuid,

--- a/lib/edge/src/update_only/apply.rs
+++ b/lib/edge/src/update_only/apply.rs
@@ -36,6 +36,41 @@ pub struct UpdateBatchOutcome {
     /// Points an operation named that no segment holds and the batch did not
     /// create — a payload update to a point that is not there.
     pub missing: usize,
+    /// One record per touched point, in first-touched order: what happened
+    /// to it, and which slots it vacated where.
+    pub points: Vec<PointApplyRecord>,
+}
+
+/// How one point's slots changed under [`apply_batch`]: where its previous
+/// copies were retired, distinguishing an overwrite from a fresh insert.
+///
+/// [`apply_batch`]: UpdateOnlyEdgeShard::apply_batch
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PointApplyRecord {
+    pub id: PointIdType,
+    pub kind: PointApplyKind,
+    /// Slots retired with a tombstone: every segment that held a copy of the
+    /// point, except the write target's own slot when the point is stored.
+    /// Empty for a stored point means a fresh insert, not an overwrite.
+    pub tombstoned: Vec<(Uuid, PointOffsetType)>,
+    /// The write-target slot a stored point left behind without a tombstone:
+    /// appending the point records a mapping that supersedes it.
+    pub superseded: Option<(Uuid, PointOffsetType)>,
+}
+
+/// The per-point action of [`PointApplyRecord`], mirroring the counts on
+/// [`UpdateBatchOutcome`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PointApplyKind {
+    /// Appended to the write target — an overwrite when the record lists
+    /// retired slots, a fresh insert otherwise.
+    Stored,
+    /// Removed from every slot it occupied.
+    Deleted,
+    /// Left untouched: already at or beyond the batch's version.
+    Skipped,
+    /// Named by an operation, held by no segment, not created by the batch.
+    Missing,
 }
 
 /// One copy of a point: where it lives, and at what version.
@@ -116,42 +151,55 @@ impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S> {
                 action,
             } = point;
 
-            let stored = match action {
+            let kind = match action {
                 PointAction::Skip => {
                     outcome.skipped += 1;
-                    continue;
+                    PointApplyKind::Skipped
                 }
                 PointAction::Missing => {
                     outcome.missing += 1;
-                    continue;
+                    PointApplyKind::Missing
                 }
                 PointAction::Store(point) => {
                     to_store.push(*point);
                     outcome.stored += 1;
-                    true
+                    PointApplyKind::Stored
                 }
                 PointAction::Delete => {
                     outcome.deleted += 1;
-                    false
+                    PointApplyKind::Deleted
                 }
             };
 
-            for (segment, internal_id) in slots {
-                // The copy a stored point leaves behind in the write target
-                // needs no retirement: appending the point records a mapping
-                // that supersedes its old slot, and retiring the id on top of
-                // that would take the new slot with it. Every other segment's
-                // copy does have to stop resolving — an older duplicate left
-                // by an interrupted move included — and a delete retires the
-                // point everywhere it sits.
-                if stored && Some(segment) == write_target_uuid {
-                    continue;
+            let mut record = PointApplyRecord {
+                id,
+                kind,
+                tombstoned: Vec::new(),
+                superseded: None,
+            };
+
+            if matches!(kind, PointApplyKind::Stored | PointApplyKind::Deleted) {
+                for (segment, internal_id) in slots {
+                    // The copy a stored point leaves behind in the write target
+                    // needs no retirement: appending the point records a mapping
+                    // that supersedes its old slot, and retiring the id on top of
+                    // that would take the new slot with it. Every other segment's
+                    // copy does have to stop resolving — an older duplicate left
+                    // by an interrupted move included — and a delete retires the
+                    // point everywhere it sits.
+                    if kind == PointApplyKind::Stored && Some(segment) == write_target_uuid {
+                        record.superseded = Some((segment, internal_id));
+                        continue;
+                    }
+                    to_tombstone
+                        .entry(segment)
+                        .or_default()
+                        .push((id, internal_id));
+                    record.tombstoned.push((segment, internal_id));
                 }
-                to_tombstone
-                    .entry(segment)
-                    .or_default()
-                    .push((id, internal_id));
             }
+
+            outcome.points.push(record);
         }
 
         drop(segments);

--- a/lib/edge/src/update_only/apply.rs
+++ b/lib/edge/src/update_only/apply.rs
@@ -2,6 +2,8 @@
 //! batched pass over the whole point set, so a batch's cost scales with the
 //! points it touches, not the operations in it.
 
+use std::collections::HashMap;
+
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
@@ -77,21 +79,21 @@ impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S> {
     /// error is returned, and re-applying a batch that partially landed skips
     /// the points that already carry its version.
     ///
-    /// Consumes the writer, because it can serve exactly one batch. The
-    /// segments were read when it opened, and that read is both what a batch
-    /// resolves against and what its writers resume from; a second batch would
-    /// resume an appendable segment from a log position its own first batch
-    /// has moved past, and appending there cuts off everything written since.
-    /// Open another writer for the next batch — or, to lift the restriction,
-    /// reload the segments after a batch, which the read-only segment's
-    /// `live_reload` already does for exactly the files a batch appends to.
+    /// Consumes the writer and hands it back on success, ready for the next
+    /// batch: the lookup half of every segment this one wrote to is
+    /// live-reloaded, so the next batch resolves against what this one
+    /// wrote. On error the writer is gone — its lookups may no longer
+    /// describe the durable state, and resolving another batch against them
+    /// can retire the wrong copy of a point. Recover by opening a fresh
+    /// writer over the directory, which also retires whatever the failed
+    /// batch left unpublished.
     pub fn apply_batch(
-        self,
+        mut self,
         operations: impl IntoIterator<Item = (SeqNumberType, CollectionUpdateOperations)>,
-    ) -> OperationResult<UpdateBatchOutcome> {
+    ) -> OperationResult<(Self, UpdateBatchOutcome)> {
         let plan = UpdateBatchPlan::build(operations)?;
         if plan.is_empty() {
-            return Ok(UpdateBatchOutcome::default());
+            return Ok((self, UpdateBatchOutcome::default()));
         }
 
         let hw_counter = HardwareCounterCell::disposable();
@@ -152,15 +154,22 @@ impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S> {
             }
         }
 
+        drop(segments);
+
+        if to_store.is_empty() && to_tombstone.is_empty() {
+            return Ok((self, outcome));
+        }
+
         // 4. Append the resolved points, then retire the slots they replaced.
-        // Writers live for this batch alone, and there is no flush step: the
-        // append-only components behind them buffer nothing across calls, so a
-        // write is durable when it returns.
+        // There is no flush step: the append-only components behind the
+        // writers buffer nothing across calls, so a write is durable when it
+        // returns.
+        let mut written: Vec<Uuid> = Vec::new();
         if !to_store.is_empty() {
             let uuid = write_target_uuid.ok_or_else(|| {
                 OperationError::service_error("No appendable segment exists, expected exactly one")
             })?;
-            let mut writer = open_writer(&segments, &self.fs, uuid)?;
+            let writer = get_writer(&mut self.writers, uuid)?;
 
             writer
                 .as_appendable_mut()
@@ -171,40 +180,54 @@ impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S> {
                 })?
                 .store_points(&to_store, &hw_counter)?;
 
-            // Whatever the write target has to retire goes through the writer
-            // already open: a second one would retire this batch's own
-            // half-written points as it resumed. It happens after the store,
-            // since every write is durable when it returns and the reverse
-            // order can lose a point outright if the process dies in between.
+            // The write target's retirements happen after the store, since
+            // every write is durable when it returns and the reverse order
+            // can lose a point outright if the process dies in between.
             if let Some(points) = to_tombstone.remove(&uuid) {
                 writer.tombstone_points(&points)?;
             }
+            written.push(uuid);
         }
 
         for (uuid, points) in to_tombstone {
-            open_writer(&segments, &self.fs, uuid)?.tombstone_points(&points)?;
+            get_writer(&mut self.writers, uuid)?.tombstone_points(&points)?;
+            written.push(uuid);
         }
 
-        Ok(outcome)
+        self.reload_lookups(&written)?;
+
+        Ok((self, outcome))
+    }
+
+    /// Live-reload the lookup half of every segment in `written`, so the
+    /// next batch resolves against what this one wrote. The writers stay
+    /// open: their in-memory state advanced with each durable write, so a
+    /// reloaded lookup and its held writer describe the same log.
+    fn reload_lookups(&self, written: &[Uuid]) -> OperationResult<()> {
+        let segments = self.segments.read();
+        self.pool.install(|| {
+            written.par_iter().try_for_each(|&uuid| {
+                // Not shared across segments: `HardwareCounterCell` is not
+                // `Sync`, and the writer's accounting is disposable.
+                let hw_counter = HardwareCounterCell::disposable();
+                segments
+                    .get(uuid)?
+                    .write()
+                    .live_reload(&self.fs, &hw_counter)
+            })
+        })
     }
 }
 
-/// Open a writer over one segment of the shard, resuming it from the state its
-/// [`LookupSegment`](segment::segment::update_only::LookupSegment) observed —
-/// which also decides whether the segment accepts appends or deletes only.
-fn open_writer<S: UniversalAppend + 'static>(
-    segments: &LookupSegmentHolder<S>,
-    fs: &S::Fs,
+/// The held writer for segment `uuid`; an error when there is none, which can
+/// only mean the shard's inventory changed under a batch in flight.
+fn get_writer<S: UniversalAppend + 'static>(
+    writers: &mut HashMap<Uuid, UpdateOnlySegmentEnum<S>>,
     uuid: Uuid,
-) -> OperationResult<UpdateOnlySegmentEnum<S>> {
-    let segment = segments.get(uuid)?.read();
-
-    UpdateOnlySegmentEnum::open(
-        fs,
-        &segment.segment_path,
-        &segment.segment_config,
-        segment.writer_state(),
-    )
+) -> OperationResult<&mut UpdateOnlySegmentEnum<S>> {
+    writers
+        .get_mut(&uuid)
+        .ok_or_else(|| OperationError::service_error(format!("No writer open for segment {uuid}")))
 }
 
 /// Locate every point the batch touches: every slot it occupies, with the

--- a/lib/edge/src/update_only/lifecycle.rs
+++ b/lib/edge/src/update_only/lifecycle.rs
@@ -1,10 +1,11 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use common::universal_io::{MmapFile, MmapFs, UniversalRead, UniversalReadFs};
+use common::universal_io::{MmapFile, MmapFs, UniversalAppend, UniversalReadFs};
 use parking_lot::RwLock;
 use rayon::prelude::*;
 use segment::common::operation_error::OperationResult;
-use segment::segment::update_only::LookupSegment;
+use segment::segment::update_only::{LookupSegment, UpdateOnlySegmentEnum};
 use uuid::Uuid;
 
 use crate::read_only::{LocalSegmentEnumerator, SegmentEnumerator};
@@ -21,17 +22,19 @@ impl UpdateOnlyEdgeShard<MmapFile> {
     }
 }
 
-impl<S: UniversalRead + 'static> UpdateOnlyEdgeShard<S> {
+impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S> {
     /// Open a writer over the shard directory at `path`, using `fs` as the
-    /// read backend and `enumerator` to discover the segments.
+    /// backend and `enumerator` to discover the segments.
     ///
     /// Segments are opened in parallel on the shard's thread pool, each over
     /// its own prefetching [`CachedFs`](common::universal_io::CachedFs) (see
     /// [`LookupSegment::open`]) — the same shape as the read-only
     /// follower's load — and entirely cold: no point data is fetched until a
-    /// batch reads a point. A segment that fails to load is an error, not a
-    /// skip — a writer that misses a segment would resolve a point against a
-    /// stale copy of itself, or duplicate it.
+    /// batch reads a point. Each segment's writer is opened here too, resuming
+    /// from the state its lookup half just observed; the store components stay
+    /// unopened until a point is actually stored. A segment that fails to load
+    /// is an error, not a skip — a writer that misses a segment would resolve
+    /// a point against a stale copy of itself, or duplicate it.
     pub fn open(
         fs: S::Fs,
         path: &Path,
@@ -49,22 +52,31 @@ impl<S: UniversalRead + 'static> UpdateOnlyEdgeShard<S> {
         )?;
 
         let segments: Vec<(Uuid, PathBuf)> = enumerator.list_segments()?.into_iter().collect();
-        let opened: Vec<(Uuid, LookupSegment<S>)> = pool.install(|| {
-            segments
-                .into_par_iter()
-                .map(|(uuid, segment_path)| {
-                    // No deferred threshold yet: it belongs to the coordination
-                    // with an external rebuilder, which does not exist in this
-                    // iteration.
-                    let segment = LookupSegment::<S>::open(&fs, &segment_path, None)?;
-                    Ok((uuid, segment))
-                })
-                .collect::<OperationResult<Vec<_>>>()
-        })?;
+        let opened: Vec<(Uuid, LookupSegment<S>, UpdateOnlySegmentEnum<S>)> =
+            pool.install(|| {
+                segments
+                    .into_par_iter()
+                    .map(|(uuid, segment_path)| {
+                        // No deferred threshold yet: it belongs to the coordination
+                        // with an external rebuilder, which does not exist in this
+                        // iteration.
+                        let segment = LookupSegment::<S>::open(&fs, &segment_path, None)?;
+                        let writer = UpdateOnlySegmentEnum::open(
+                            &fs,
+                            &segment_path,
+                            &segment.segment_config,
+                            segment.writer_state(),
+                        )?;
+                        Ok((uuid, segment, writer))
+                    })
+                    .collect::<OperationResult<Vec<_>>>()
+            })?;
 
         let mut holder = LookupSegmentHolder::default();
-        for (uuid, segment) in opened {
+        let mut writers = HashMap::new();
+        for (uuid, segment, writer) in opened {
             holder.insert(uuid, segment);
+            writers.insert(uuid, writer);
         }
 
         if holder.is_empty() {
@@ -78,6 +90,7 @@ impl<S: UniversalRead + 'static> UpdateOnlyEdgeShard<S> {
             path: path.to_path_buf(),
             fs,
             segments: RwLock::new(holder),
+            writers,
             pool,
         })
     }

--- a/lib/edge/src/update_only/mod.rs
+++ b/lib/edge/src/update_only/mod.rs
@@ -38,7 +38,7 @@ use segment::segment::update_only::UpdateOnlySegmentEnum;
 use segment::types::SegmentConfig;
 use uuid::Uuid;
 
-pub use self::apply::UpdateBatchOutcome;
+pub use self::apply::{PointApplyKind, PointApplyRecord, UpdateBatchOutcome};
 pub use self::batch::{PointUpdates, UpdateBatchPlan};
 use self::holder::LookupSegmentHolder;
 pub use self::preview::{PointAction, PointCopy, PointPreview, UpdateBatchPreview};

--- a/lib/edge/src/update_only/mod.rs
+++ b/lib/edge/src/update_only/mod.rs
@@ -7,8 +7,9 @@
 //!
 //! * a batch is folded before it is applied: a point is read at most once and
 //!   written at most once, however many operations named it;
-//! * only the components a write needs are opened, and every lookup is one
-//!   batched pass per component over the whole point set;
+//! * writers are opened once, at shard open, next to the segments they resume
+//!   from; the store components only on the first point actually stored. Every
+//!   lookup is one batched pass per component over the whole point set;
 //! * there is no WAL: a batch is durable when the storages are flushed.
 //!
 //! Storage is append-only throughout. Updating a point appends it in full and
@@ -26,12 +27,14 @@ mod preview;
 #[cfg(test)]
 mod tests;
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use common::universal_io::UniversalRead;
+use common::universal_io::UniversalAppend;
 use parking_lot::RwLock;
 use rayon::ThreadPool;
+use segment::segment::update_only::UpdateOnlySegmentEnum;
 use segment::types::SegmentConfig;
 use uuid::Uuid;
 
@@ -46,12 +49,17 @@ pub use self::preview::{PointAction, PointCopy, PointPreview, UpdateBatchPreview
 /// Compared to [`EdgeShard`](crate::EdgeShard), there is no WAL, no
 /// optimizers, and no `EdgeConfig` — the write target's own segment config is
 /// the only configuration a write needs.
-pub struct UpdateOnlyEdgeShard<S: UniversalRead + 'static> {
+pub struct UpdateOnlyEdgeShard<S: UniversalAppend + 'static> {
     path: PathBuf,
-    /// Backend the segments were opened on, and the one a batch's writers go
-    /// through.
+    /// Backend the segments were opened on; live-reloads their lookup
+    /// halves after a batch writes to them.
     fs: S::Fs,
     segments: RwLock<LookupSegmentHolder<S>>,
+    /// One writer per segment, opened at shard open from the state its
+    /// [`LookupSegment`](segment::segment::update_only::LookupSegment)
+    /// observed — which also decided whether the segment accepts appends or
+    /// deletes only.
+    writers: HashMap<Uuid, UpdateOnlySegmentEnum<S>>,
     /// Thread pool the per-segment work of a batch runs on: on a remote
     /// backend each segment's reads block on the network, so segments are
     /// visited in parallel.
@@ -68,7 +76,7 @@ pub struct SegmentConfigInfo {
     pub config: SegmentConfig,
 }
 
-impl<S: UniversalRead + 'static> UpdateOnlyEdgeShard<S> {
+impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S> {
     pub fn path(&self) -> &Path {
         &self.path
     }

--- a/lib/edge/src/update_only/preview.rs
+++ b/lib/edge/src/update_only/preview.rs
@@ -8,7 +8,7 @@
 //! [`apply_batch`]: UpdateOnlyEdgeShard::apply_batch
 
 use common::types::PointOffsetType;
-use common::universal_io::UniversalRead;
+use common::universal_io::{UniversalAppend, UniversalRead};
 use rayon::ThreadPool;
 use segment::common::operation_error::OperationResult;
 use segment::data_types::fully_qualified_point::FullyQualifiedPoint;
@@ -113,7 +113,7 @@ pub(super) fn resolve_batch<S: UniversalRead + 'static>(
     Ok(points)
 }
 
-impl<S: UniversalRead + 'static> UpdateOnlyEdgeShard<S> {
+impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S> {
     /// Resolve a batch without writing anything: what
     /// [`apply_batch`](Self::apply_batch) would do, reported per point.
     ///

--- a/lib/edge/src/update_only/tests.rs
+++ b/lib/edge/src/update_only/tests.rs
@@ -48,7 +48,7 @@ fn delete_batch_retires_points_and_leaves_the_rest() {
     let dir = leader_with_ten_points("edge-update-delete");
 
     let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
-    let outcome = writer.apply_batch(delete_batch([3, 7])).unwrap();
+    let (_writer, outcome) = writer.apply_batch(delete_batch([3, 7])).unwrap();
 
     assert_eq!(outcome.deleted, 2);
     assert_eq!(outcome.stored, 0);
@@ -67,22 +67,24 @@ fn delete_batch_retires_points_and_leaves_the_rest() {
     );
 }
 
-/// A retried invocation — a fresh writer over the same directory — replays the
-/// batch harmlessly: the points it deletes are already gone, so they resolve
+/// A retried batch replays harmlessly, through the same writer (whose lookups
+/// were reloaded after the first batch) and through a fresh one over the same
+/// directory alike: the points it deletes are already gone, so they resolve
 /// to nothing.
-///
-/// Replaying through the *same* writer needs no test:
-/// [`apply_batch`](UpdateOnlyEdgeShard::apply_batch) consumes it, so a second
-/// batch does not compile.
 #[test]
 fn replayed_delete_batch_is_a_no_op() {
     let dir = leader_with_ten_points("edge-update-delete-replay");
 
     let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
-    assert_eq!(writer.apply_batch(delete_batch([3])).unwrap().deleted, 1);
+    let (writer, outcome) = writer.apply_batch(delete_batch([3])).unwrap();
+    assert_eq!(outcome.deleted, 1);
+
+    let (_writer, replayed) = writer.apply_batch(delete_batch([3])).unwrap();
+    assert_eq!(replayed.deleted, 0);
+    assert_eq!(replayed.missing, 1);
 
     let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
-    let replayed = writer.apply_batch(delete_batch([3])).unwrap();
+    let (_writer, replayed) = writer.apply_batch(delete_batch([3])).unwrap();
     assert_eq!(replayed.deleted, 0);
     assert_eq!(replayed.missing, 1);
 
@@ -140,12 +142,17 @@ fn delete_batch_tombstones_points_in_immutable_segments() {
         "point 500 should live in a non-appendable segment",
     );
 
-    let outcome = writer.apply_batch(delete_batch([500])).unwrap();
+    let (writer, outcome) = writer.apply_batch(delete_batch([500])).unwrap();
     assert_eq!(outcome.deleted, 1);
 
-    // A fresh writer resolves against the rewritten mask.
+    // The same writer resolves against the rewritten mask through its
+    // reloaded lookup, and a fresh writer through its own open.
+    let (_writer, replayed) = writer.apply_batch(delete_batch([500])).unwrap();
+    assert_eq!(replayed.deleted, 0);
+    assert_eq!(replayed.missing, 1);
+
     let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
-    let replayed = writer.apply_batch(delete_batch([500])).unwrap();
+    let (_writer, replayed) = writer.apply_batch(delete_batch([500])).unwrap();
     assert_eq!(replayed.deleted, 0);
     assert_eq!(replayed.missing, 1);
 
@@ -226,7 +233,7 @@ mod store {
         };
 
         let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
-        let outcome = writer
+        let (_writer, outcome) = writer
             .apply_batch(store_batch(100, vec![new_point, rewritten]))
             .unwrap();
 
@@ -266,9 +273,12 @@ mod store {
         assert_eq!(results[1].payload, Some(payload_json! { "kind": "fresh" }),);
     }
 
-    /// A retried store batch — a fresh writer over the same directory — is a
-    /// no-op: every point already carries the batch's version, which only a
-    /// published versions array can tell it.
+    /// A retried store batch is a no-op — through the same writer and through
+    /// a fresh one over the same directory alike: every point already carries
+    /// the batch's version, which only a published versions array can tell
+    /// it. The same-writer replay is what the post-batch lookup reload buys:
+    /// without it, the resolve would not see the version the first batch
+    /// published and would store the point again.
     #[test]
     fn replayed_store_batch_is_a_no_op() {
         let dir = leader_with_ten_points("edge-update-store-replay");
@@ -276,10 +286,15 @@ mod store {
 
         let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
         let batch = || store_batch(100, vec![point(11)]);
-        assert_eq!(writer.apply_batch(batch()).unwrap().stored, 1);
+        let (writer, outcome) = writer.apply_batch(batch()).unwrap();
+        assert_eq!(outcome.stored, 1);
+
+        let (_writer, replayed) = writer.apply_batch(batch()).unwrap();
+        assert_eq!(replayed.stored, 0);
+        assert_eq!(replayed.skipped, 1);
 
         let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
-        let replayed = writer.apply_batch(batch()).unwrap();
+        let (_writer, replayed) = writer.apply_batch(batch()).unwrap();
         assert_eq!(replayed.stored, 0);
         assert_eq!(replayed.skipped, 1);
 
@@ -297,16 +312,55 @@ mod store {
         recreate_payload_storages_append_only(dir.path());
 
         let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
-        assert_eq!(
-            writer
-                .apply_batch(store_batch(100, vec![point(11)]))
-                .unwrap()
-                .stored,
-            1,
-        );
+        let (_writer, outcome) = writer
+            .apply_batch(store_batch(100, vec![point(11)]))
+            .unwrap();
+        assert_eq!(outcome.stored, 1);
 
         let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
-        let second = writer
+        let (_writer, second) = writer
+            .apply_batch([
+                (
+                    101,
+                    PointOperation(UpsertPoints(PointsList(vec![point(12)]))),
+                ),
+                (
+                    102,
+                    PointOperation(DeletePoints {
+                        ids: vec![ExtendedPointId::NumId(2)],
+                    }),
+                ),
+            ])
+            .unwrap();
+        assert_eq!(second.stored, 1);
+        assert_eq!(second.deleted, 1);
+
+        let follower = open_follower(dir.path());
+        assert_eq!(exact_count(&follower), 11);
+        assert_eq!(
+            scrolled_ids(&follower),
+            [1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+                .map(ExtendedPointId::NumId)
+                .to_vec(),
+        );
+        assert_follower_vectors(&follower, &[11, 12]);
+    }
+
+    /// Sequential batches through one writer: the second batch stores and
+    /// deletes through the same held writers the first one used, resolving
+    /// against the lookups reloaded after it — no re-open in between.
+    #[test]
+    fn sequential_batches_through_one_writer() {
+        let dir = leader_with_ten_points("edge-update-store-sequential");
+        recreate_payload_storages_append_only(dir.path());
+
+        let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+        let (writer, outcome) = writer
+            .apply_batch(store_batch(100, vec![point(11)]))
+            .unwrap();
+        assert_eq!(outcome.stored, 1);
+
+        let (_writer, second) = writer
             .apply_batch([
                 (
                     101,

--- a/lib/edge/src/update_only/tests.rs
+++ b/lib/edge/src/update_only/tests.rs
@@ -16,7 +16,7 @@ use tempfile::TempDir;
 use crate::read_only::tests::{
     delete as leader_delete, exact_count, open_follower, scrolled_ids, test_config, upsert,
 };
-use crate::update_only::UpdateOnlyEdgeShard;
+use crate::update_only::{PointApplyKind, UpdateOnlyEdgeShard};
 use crate::{EdgeConfig, EdgeOptimizersConfig, EdgeShard};
 
 /// A flushed shard directory holding points 1 to 10, with the leader that
@@ -54,6 +54,21 @@ fn delete_batch_retires_points_and_leaves_the_rest() {
     assert_eq!(outcome.stored, 0);
     assert_eq!(outcome.skipped, 0);
     assert_eq!(outcome.missing, 0);
+
+    // Each record names the one slot its point vacated.
+    assert_eq!(
+        outcome
+            .points
+            .iter()
+            .map(|record| record.id)
+            .collect::<Vec<_>>(),
+        [3, 7].map(ExtendedPointId::NumId).to_vec(),
+    );
+    for record in &outcome.points {
+        assert_eq!(record.kind, PointApplyKind::Deleted);
+        assert_eq!(record.tombstoned.len(), 1);
+        assert_eq!(record.superseded, None);
+    }
 
     // A reader opened afterwards must see the deletes, and nothing else: a
     // writer retiring the wrong slots would take neighbouring points with it.
@@ -144,6 +159,10 @@ fn delete_batch_tombstones_points_in_immutable_segments() {
 
     let (writer, outcome) = writer.apply_batch(delete_batch([500])).unwrap();
     assert_eq!(outcome.deleted, 1);
+    // The record names the immutable segment the point was deleted from.
+    assert_eq!(outcome.points[0].kind, PointApplyKind::Deleted);
+    assert_eq!(outcome.points[0].tombstoned.len(), 1);
+    assert_eq!(outcome.points[0].tombstoned[0].0, holder);
 
     // The same writer resolves against the rewritten mask through its
     // reloaded lookup, and a fresh writer through its own open.
@@ -241,6 +260,21 @@ mod store {
         assert_eq!(outcome.deleted, 0);
         assert_eq!(outcome.skipped, 0);
         assert_eq!(outcome.missing, 0);
+
+        // The records tell a fresh insert from an overwrite: the new point
+        // vacated nothing, the rewritten one superseded its old write-target
+        // slot in place (no tombstone needed there).
+        let [fresh, overwrite] = &outcome.points[..] else {
+            panic!("expected one record per touched point");
+        };
+        assert_eq!(fresh.id, ExtendedPointId::NumId(11));
+        assert_eq!(fresh.kind, PointApplyKind::Stored);
+        assert!(fresh.tombstoned.is_empty());
+        assert_eq!(fresh.superseded, None);
+        assert_eq!(overwrite.id, ExtendedPointId::NumId(5));
+        assert_eq!(overwrite.kind, PointApplyKind::Stored);
+        assert!(overwrite.tombstoned.is_empty());
+        assert!(overwrite.superseded.is_some());
 
         let follower = open_follower(dir.path());
         assert_eq!(exact_count(&follower), 11);

--- a/lib/edge/tools/shard_update/src/main.rs
+++ b/lib/edge/tools/shard_update/src/main.rs
@@ -1,7 +1,6 @@
 //! Experimental binary that opens an [`UpdateOnlyEdgeShard`] over a local
 //! shard directory — or directly over object storage (AWS S3 / S3-compatible,
-//! or Google Cloud Storage) — and dry-runs a batch of random upserts against
-//! it.
+//! or Google Cloud Storage) — and runs a batch of random upserts against it.
 //!
 //! The counterpart of `edge-shard-query` for the write path. Point ids to
 //! overwrite are taken from the command line; the *shape* of each generated
@@ -10,13 +9,19 @@
 //! in its payload-index schema — so the batch is exactly what a real client
 //! could have written.
 //!
-//! Since the writer's write half is not implemented yet
-//! (`store_points`/`tombstone_points` are `todo!()`), the tool stops at the
-//! resolution stage: it runs [`preview_batch`], which shares the decision
-//! pipeline with the real `apply_batch`, and logs what *would* happen — which
-//! segments hold each point today, in which slots and at what versions, which
-//! points would be stored/skipped, and which slots would be tombstoned.
-//! Nothing is written, on any backend.
+//! By default the tool dry-runs: it runs [`preview_batch`], which shares the
+//! decision pipeline with the real apply, and logs what *would* happen —
+//! which segments hold each point today, in which slots and at what versions,
+//! which points would be stored/skipped, and which slots would be tombstoned.
+//! Nothing is written.
+//!
+//! With `--apply` it calls [`apply_batch`] instead and writes for real:
+//! appends to the write target and tombstones in every segment holding an
+//! older copy — over object storage through the appendable
+//! [`CachedBlobFile`], so the mutations are direct appends or server-side
+//! rewrites per the store's capability, durable once the run reports `Ok`.
+//!
+//! [`apply_batch`]: UpdateOnlyEdgeShard::apply_batch
 //!
 //! Example — local shard directory:
 //!
@@ -54,8 +59,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result, anyhow};
 use clap::{Args as ClapArgs, Parser, ValueEnum};
 use common::universal_io::{
-    DiskCache, DiskCacheConfig, DiskCacheFs, DiskCacheFsContext, MmapFile, OkNotFound as _,
-    UniversalRead, UniversalReadFileOps, UniversalReadFs, read_json_via,
+    DiskCacheConfig, MmapFile, OkNotFound as _, UniversalAppend, UniversalRead,
+    UniversalReadFileOps, UniversalReadFs, read_json_via,
 };
 use edge::external::uuid::Uuid;
 use edge::{
@@ -67,7 +72,9 @@ use edge::{
 };
 use io_bridge_object_store::backends::aws::{AwsConfig, AwsCredentials};
 use io_bridge_object_store::backends::gcp::{GcsConfig, GcsCredentials};
-use io_bridge_object_store::{AsyncRead, BlobFile, ObjectStoreSource};
+use io_bridge_object_store::{
+    AsyncAppend, CachedBlobFile, CachedBlobFs, CachedBlobFsContext, ObjectStoreSource,
+};
 use object_store::aws::AmazonS3;
 use object_store::gcp::GoogleCloudStorage;
 use rand::rngs::StdRng;
@@ -88,12 +95,18 @@ enum Backend {
 #[derive(Parser, Debug)]
 #[command(
     about = "Open an UpdateOnlyEdgeShard over a local directory or S3/GCS object storage and \
-             dry-run a batch of random upserts (nothing is written: the write half is not \
-             implemented yet)"
+             run a batch of random upserts against it — a dry run by default, written for real \
+             with --apply"
 )]
 struct Cli {
     #[command(flatten)]
     connection: ConnectionArgs,
+
+    /// Apply the batch for real: append to the write target and tombstone
+    /// older copies, durable on the backend once the run reports Ok. Without
+    /// this flag the batch is only resolved and logged; nothing is written.
+    #[arg(long)]
+    apply: bool,
 
     /// Point ids to overwrite with random points: comma-separated integers or
     /// UUIDs. Ids no segment holds are created rather than overwritten.
@@ -151,6 +164,12 @@ struct ConnectionArgs {
     /// [AWS] Use S3 Express One Zone (directory buckets, named `*--x-s3`).
     #[arg(long, env = "S3_EXPRESS")]
     s3_express: bool,
+
+    /// [AWS] The store honors native write-offset appends without being S3
+    /// Express — MinIO AiStor, RustFS. Implied by --s3-express; leave off
+    /// for plain S3, where appends go through server-side rewrites.
+    #[arg(long, env = "S3_NATIVE_APPEND")]
+    native_append: bool,
 
     /// [GCS] Path to a service-account JSON key file. Takes precedence over
     /// `--gcs-service-account-key`; if neither is set, application default
@@ -439,16 +458,9 @@ fn log_preview_point(point: &edge::PointPreview) {
     }
 }
 
-/// Generate the random batch, resolve it against the open shard, and log what
-/// it would do. The backend is behind `S`, so this is the whole dry run for
-/// local and object-storage shards alike.
-fn dry_run<S: UniversalRead + 'static>(
-    shard: &UpdateOnlyEdgeShard<S>,
-    schema: &ShardSchema,
-    ids: &[PointId],
-    op_num: u64,
-    seed: u64,
-) -> Result<()> {
+/// Generate the random upsert batch off the shard's schema, logging each
+/// point's shape.
+fn generate_batch(schema: &ShardSchema, ids: &[PointId], seed: u64) -> UpdateOperation {
     let mut rng = StdRng::seed_from_u64(seed);
     let points: Vec<PointStructPersisted> = ids
         .iter()
@@ -482,7 +494,20 @@ fn dry_run<S: UniversalRead + 'static>(
         })
         .collect();
 
-    let operation = UpdateOperation::PointOperation(PointOperations::UpsertPoints(points.into()));
+    UpdateOperation::PointOperation(PointOperations::UpsertPoints(points.into()))
+}
+
+/// Generate the random batch, resolve it against the open shard, and log what
+/// it would do. The backend is behind `S`, so this is the whole dry run for
+/// local and object-storage shards alike.
+fn dry_run<S: UniversalRead + 'static>(
+    shard: &UpdateOnlyEdgeShard<S>,
+    schema: &ShardSchema,
+    ids: &[PointId],
+    op_num: u64,
+    seed: u64,
+) -> Result<()> {
+    let operation = generate_batch(schema, ids, seed);
 
     let preview = shard
         .preview_batch([(op_num, operation)])
@@ -516,7 +541,34 @@ fn dry_run<S: UniversalRead + 'static>(
     for (segment, count) in &tombstones {
         log::info!("summary: segment {segment} would receive {count} tombstone(s)");
     }
-    log::info!("dry run only: store_points/tombstone_points are not implemented — nothing written");
+    log::info!("dry run: nothing written — pass --apply to write");
+
+    Ok(())
+}
+
+/// Generate the random batch and apply it for real: appends to the write
+/// target, tombstones in every segment holding an older copy — durable on
+/// the backend once this returns `Ok`.
+fn apply_run<S: UniversalAppend + 'static>(
+    shard: UpdateOnlyEdgeShard<S>,
+    schema: &ShardSchema,
+    ids: &[PointId],
+    op_num: u64,
+    seed: u64,
+) -> Result<()> {
+    let operation = generate_batch(schema, ids, seed);
+
+    let outcome = shard
+        .apply_batch([(op_num, operation)])
+        .context("failed to apply the batch")?;
+
+    log::info!(
+        "applied: {} stored, {} deleted, {} skipped, {} missing",
+        outcome.stored,
+        outcome.deleted,
+        outcome.skipped,
+        outcome.missing,
+    );
 
     Ok(())
 }
@@ -548,7 +600,7 @@ fn build_aws_config(conn: &ConnectionArgs) -> Result<AwsConfig> {
         region: conn.region.clone(),
         endpoint: conn.endpoint.clone(),
         s3_express: conn.s3_express,
-        native_append: false,
+        native_append: conn.native_append,
         credentials,
     })
 }
@@ -568,16 +620,17 @@ fn build_gcs_config(conn: &ConnectionArgs) -> Result<GcsConfig> {
     })
 }
 
-/// Build the disk-cache-backed filesystem used to read segment data: each
-/// remote block is fetched from object storage once and served from the local
-/// mirror afterwards.
+/// Build the combined cached-blob filesystem: reads are served through a
+/// local disk-cache mirror (each remote block fetched once), appends go
+/// straight to the remote.
 fn build_cached_fs<A>(
     remote_config: A::Config,
     remote_prefix: &Path,
     cache_dir: &Path,
-) -> Result<DiskCacheFs<BlobFile<A>>>
+) -> Result<CachedBlobFs<A>>
 where
-    A: AsyncRead + Clone,
+    A: AsyncAppend + Clone,
+    A::Config: Clone,
 {
     fs_err::create_dir_all(cache_dir)
         .with_context(|| format!("failed to create cache dir {}", cache_dir.display()))?;
@@ -585,11 +638,11 @@ where
     let config = DiskCacheConfig::new(remote_prefix.to_path_buf(), cache_dir.to_path_buf())
         .context("failed to build disk cache config")?;
 
-    DiskCacheFs::<BlobFile<A>>::from_context(DiskCacheFsContext {
-        config: Arc::new(config),
+    CachedBlobFs::<A>::from_context(CachedBlobFsContext {
+        disk_cache: Arc::new(config),
         remote: remote_config,
     })
-    .context("failed to build disk-cache filesystem")
+    .context("failed to build cached-blob filesystem")
 }
 
 /// Dry-run against a local shard directory: segments discovered by scanning
@@ -609,14 +662,20 @@ fn run_local(cli: &Cli, ids: &[PointId]) -> Result<()> {
     );
 
     let schema = read_schema(&shard, &common::universal_io::MmapFs, &path)?;
-    dry_run(&shard, &schema, ids, cli.op_num, cli.seed)
+    if cli.apply {
+        apply_run(shard, &schema, ids, cli.op_num, cli.seed)
+    } else {
+        dry_run(&shard, &schema, ids, cli.op_num, cli.seed)
+    }
 }
 
-/// Dry-run against object storage: segments discovered from the leader's
-/// segment manifest, read through the local disk cache.
+/// Run against object storage: segments discovered from the leader's
+/// segment manifest, reads through the local disk cache, appends (with
+/// `--apply`) straight to the remote.
 fn run_remote<A>(cli: &Cli, ids: &[PointId], remote_config: A::Config) -> Result<()>
 where
-    A: AsyncRead + Clone,
+    A: AsyncAppend + Clone,
+    A::Config: Clone,
 {
     let prefix = PathBuf::from(&cli.connection.prefix);
     let cache_dir = cli
@@ -630,7 +689,7 @@ where
 
     let enumerator = ManifestSegmentEnumerator::new(cached_fs.clone(), &prefix);
     let shard =
-        UpdateOnlyEdgeShard::<DiskCache<BlobFile<A>>>::open(cached_fs.clone(), &prefix, enumerator)
+        UpdateOnlyEdgeShard::<CachedBlobFile<A>>::open(cached_fs.clone(), &prefix, enumerator)
             .context("failed to open update-only edge shard over object storage")?;
     log::info!(
         "opened update-only shard with {} segment(s)",
@@ -638,7 +697,11 @@ where
     );
 
     let schema = read_schema(&shard, &cached_fs, &prefix)?;
-    dry_run(&shard, &schema, ids, cli.op_num, cli.seed)
+    if cli.apply {
+        apply_run(shard, &schema, ids, cli.op_num, cli.seed)
+    } else {
+        dry_run(&shard, &schema, ids, cli.op_num, cli.seed)
+    }
 }
 
 fn main() -> Result<()> {

--- a/lib/edge/tools/shard_update/src/main.rs
+++ b/lib/edge/tools/shard_update/src/main.rs
@@ -70,9 +70,9 @@ use edge::external::uuid::Uuid;
 use edge::{
     FullyQualifiedPoint, ManifestSegmentEnumerator, PAYLOAD_INDEX_CONFIG_FILE, Payload,
     PayloadConfig, PayloadFieldSchema, PayloadSchemaParams, PayloadSchemaType, PointAction,
-    PointId, PointOperations, PointStructPersisted, SegmentConfig, SegmentConfigInfo, SparseVector,
-    UpdateOnlyEdgeShard, UpdateOperation, VectorPersisted, VectorStructPersisted,
-    get_payload_index_path,
+    PointApplyKind, PointApplyRecord, PointId, PointOperations, PointStructPersisted,
+    SegmentConfig, SegmentConfigInfo, SparseVector, UpdateOnlyEdgeShard, UpdateOperation,
+    VectorPersisted, VectorStructPersisted, get_payload_index_path,
 };
 use io_bridge_object_store::backends::aws::{AwsConfig, AwsCredentials};
 use io_bridge_object_store::backends::gcp::{GcsConfig, GcsCredentials};
@@ -586,6 +586,9 @@ fn apply_run<S: UniversalAppend + 'static>(
             outcome.skipped,
             outcome.missing,
         );
+        for record in &outcome.points {
+            log_apply_record(record);
+        }
 
         if !interactive {
             return Ok(());
@@ -596,6 +599,47 @@ fn apply_run<S: UniversalAppend + 'static>(
         }
         op_num += 1;
         seed = seed.wrapping_add(1);
+    }
+}
+
+/// One line per applied point: whether it was created fresh or overwrote
+/// existing copies, and from which segments (and slots) the old copies were
+/// removed.
+fn log_apply_record(record: &PointApplyRecord) {
+    let PointApplyRecord {
+        id,
+        kind,
+        tombstoned,
+        superseded,
+    } = record;
+
+    let slot = |(segment, internal_id): &(Uuid, _)| format!("segment {segment} slot {internal_id}");
+    let tombstoned_list = tombstoned.iter().map(slot).collect::<Vec<_>>();
+
+    match kind {
+        PointApplyKind::Stored => {
+            let mut retired = tombstoned_list;
+            if let Some(superseded) = superseded {
+                retired.push(format!("{} (superseded in place)", slot(superseded)));
+            }
+            if retired.is_empty() {
+                log::info!("point {id}: created — no previous copy in any segment");
+            } else {
+                log::info!(
+                    "point {id}: overwritten — old copies deleted from {}",
+                    retired.join(", "),
+                );
+            }
+        }
+        PointApplyKind::Deleted => {
+            log::info!("point {id}: deleted from {}", tombstoned_list.join(", "));
+        }
+        PointApplyKind::Skipped => {
+            log::info!("point {id}: skipped — already at or beyond this op-num");
+        }
+        PointApplyKind::Missing => {
+            log::info!("point {id}: no segment holds it — nothing to do");
+        }
     }
 }
 

--- a/lib/edge/tools/shard_update/src/main.rs
+++ b/lib/edge/tools/shard_update/src/main.rs
@@ -20,6 +20,10 @@
 //! older copy — over object storage through the appendable
 //! [`CachedBlobFile`], so the mutations are direct appends or server-side
 //! rewrites per the store's capability, durable once the run reports `Ok`.
+//! Adding `--interactive` keeps the session open: after each batch the tool
+//! prompts on stdin for the next round's ids and applies them through the
+//! writer `apply_batch` handed back — no shard re-open — with the op-num
+//! incremented per round.
 //!
 //! [`apply_batch`]: UpdateOnlyEdgeShard::apply_batch
 //!
@@ -107,6 +111,13 @@ struct Cli {
     /// this flag the batch is only resolved and logged; nothing is written.
     #[arg(long)]
     apply: bool,
+
+    /// After a batch is applied, prompt on stdin for the next round's ids
+    /// (comma-separated; an empty line or EOF quits) and apply them through
+    /// the same writer — no shard re-open — with --op-num incremented by one
+    /// per round.
+    #[arg(long, requires = "apply")]
+    interactive: bool,
 
     /// Point ids to overwrite with random points: comma-separated integers or
     /// UUIDs. Ids no segment holds are created rather than overwritten.
@@ -548,29 +559,73 @@ fn dry_run<S: UniversalAppend + 'static>(
 
 /// Generate the random batch and apply it for real: appends to the write
 /// target, tombstones in every segment holding an older copy — durable on
-/// the backend once this returns `Ok`.
+/// the backend once this returns `Ok`. With `interactive`, keeps prompting
+/// for the next round's ids and applies them through the writer the previous
+/// `apply_batch` handed back, one op-num (and seed) higher per round.
 fn apply_run<S: UniversalAppend + 'static>(
-    shard: UpdateOnlyEdgeShard<S>,
+    mut shard: UpdateOnlyEdgeShard<S>,
     schema: &ShardSchema,
     ids: &[PointId],
-    op_num: u64,
-    seed: u64,
+    mut op_num: u64,
+    mut seed: u64,
+    interactive: bool,
 ) -> Result<()> {
-    let operation = generate_batch(schema, ids, seed);
+    let mut ids = ids.to_vec();
+    loop {
+        let operation = generate_batch(schema, &ids, seed);
 
-    let (_shard, outcome) = shard
-        .apply_batch([(op_num, operation)])
-        .context("failed to apply the batch")?;
+        let (returned, outcome) = shard
+            .apply_batch([(op_num, operation)])
+            .context("failed to apply the batch")?;
+        shard = returned;
 
-    log::info!(
-        "applied: {} stored, {} deleted, {} skipped, {} missing",
-        outcome.stored,
-        outcome.deleted,
-        outcome.skipped,
-        outcome.missing,
-    );
+        log::info!(
+            "applied at op-num {op_num}: {} stored, {} deleted, {} skipped, {} missing",
+            outcome.stored,
+            outcome.deleted,
+            outcome.skipped,
+            outcome.missing,
+        );
 
-    Ok(())
+        if !interactive {
+            return Ok(());
+        }
+        match prompt_next_ids()? {
+            Some(next_ids) => ids = next_ids,
+            None => return Ok(()),
+        }
+        op_num += 1;
+        seed = seed.wrapping_add(1);
+    }
+}
+
+/// Read the next round's ids from stdin: comma-separated on one line, with
+/// unparsable input re-prompted; an empty line or EOF ends the session.
+fn prompt_next_ids() -> Result<Option<Vec<PointId>>> {
+    loop {
+        eprint!("next ids (comma-separated, empty to quit): ");
+        let mut line = String::new();
+        if std::io::stdin()
+            .read_line(&mut line)
+            .context("failed to read ids from stdin")?
+            == 0
+        {
+            return Ok(None);
+        }
+        let line = line.trim();
+        if line.is_empty() {
+            return Ok(None);
+        }
+
+        match line
+            .split(',')
+            .map(|raw| parse_point_id(raw.trim()))
+            .collect::<Result<Vec<_>>>()
+        {
+            Ok(ids) => return Ok(Some(ids)),
+            Err(err) => log::warn!("{err:#}"),
+        }
+    }
 }
 
 /// The bucket name, required by the object-storage backends.
@@ -663,7 +718,7 @@ fn run_local(cli: &Cli, ids: &[PointId]) -> Result<()> {
 
     let schema = read_schema(&shard, &common::universal_io::MmapFs, &path)?;
     if cli.apply {
-        apply_run(shard, &schema, ids, cli.op_num, cli.seed)
+        apply_run(shard, &schema, ids, cli.op_num, cli.seed, cli.interactive)
     } else {
         dry_run(&shard, &schema, ids, cli.op_num, cli.seed)
     }
@@ -698,7 +753,7 @@ where
 
     let schema = read_schema(&shard, &cached_fs, &prefix)?;
     if cli.apply {
-        apply_run(shard, &schema, ids, cli.op_num, cli.seed)
+        apply_run(shard, &schema, ids, cli.op_num, cli.seed, cli.interactive)
     } else {
         dry_run(&shard, &schema, ids, cli.op_num, cli.seed)
     }

--- a/lib/edge/tools/shard_update/src/main.rs
+++ b/lib/edge/tools/shard_update/src/main.rs
@@ -59,8 +59,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result, anyhow};
 use clap::{Args as ClapArgs, Parser, ValueEnum};
 use common::universal_io::{
-    DiskCacheConfig, MmapFile, OkNotFound as _, UniversalAppend, UniversalRead,
-    UniversalReadFileOps, UniversalReadFs, read_json_via,
+    DiskCacheConfig, MmapFile, OkNotFound as _, UniversalAppend, UniversalReadFileOps,
+    UniversalReadFs, read_json_via,
 };
 use edge::external::uuid::Uuid;
 use edge::{
@@ -206,7 +206,7 @@ struct ShardSchema {
 /// parsed during the open — no extra reads) plus the payload-index schema,
 /// which is the one file the writer deliberately never opens, so the tool
 /// reads it through `fs` itself.
-fn read_schema<S: UniversalRead + 'static, F: UniversalReadFs>(
+fn read_schema<S: UniversalAppend + 'static, F: UniversalReadFs>(
     shard: &UpdateOnlyEdgeShard<S>,
     fs: &F,
     shard_path: &Path,
@@ -500,7 +500,7 @@ fn generate_batch(schema: &ShardSchema, ids: &[PointId], seed: u64) -> UpdateOpe
 /// Generate the random batch, resolve it against the open shard, and log what
 /// it would do. The backend is behind `S`, so this is the whole dry run for
 /// local and object-storage shards alike.
-fn dry_run<S: UniversalRead + 'static>(
+fn dry_run<S: UniversalAppend + 'static>(
     shard: &UpdateOnlyEdgeShard<S>,
     schema: &ShardSchema,
     ids: &[PointId],
@@ -558,7 +558,7 @@ fn apply_run<S: UniversalAppend + 'static>(
 ) -> Result<()> {
     let operation = generate_batch(schema, ids, seed);
 
-    let outcome = shard
+    let (_shard, outcome) = shard
         .apply_batch([(op_num, operation)])
         .context("failed to apply the batch")?;
 

--- a/lib/segment/src/segment/update_only/lookup/live_reload.rs
+++ b/lib/segment/src/segment/update_only/lookup/live_reload.rs
@@ -1,0 +1,52 @@
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::sorted_slice::SortedSlice;
+use common::universal_io::UniversalRead;
+
+use super::LookupSegment;
+use crate::common::live_reload::LiveReload as _;
+use crate::common::operation_error::OperationResult;
+
+impl<S: UniversalRead + 'static> LookupSegment<S> {
+    /// Refresh every component to the current on-disk state (id-tracker
+    /// delta → payload storage and vector storages) without re-opening the
+    /// segment — the mirror of [`ReadOnlySegment::live_reload`], over the
+    /// components a lookup holds.
+    ///
+    /// Unlike the read-only segment there is no retained delta: an error
+    /// leaves the components out of step with the changes already drained
+    /// from the id tracker, and the segment must be discarded rather than
+    /// reloaded again.
+    ///
+    /// [`ReadOnlySegment::live_reload`]: crate::segment::read_only::ReadOnlySegment::live_reload
+    pub fn live_reload(
+        &mut self,
+        fs: &S::Fs,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let Self {
+            segment_path: _,
+            id_tracker,
+            payload_storage,
+            vector_data,
+            segment_config: _,
+            appendable: _,
+        } = self;
+
+        let delta = id_tracker.borrow_mut().live_reload(fs)?;
+
+        // SAFETY: `LiveReloadResult` keeps both lists sorted ascending.
+        let deleted = unsafe { SortedSlice::new_unchecked(&delta.deleted) };
+        let inserted = unsafe { SortedSlice::new_unchecked(&delta.inserted) };
+
+        payload_storage
+            .borrow_mut()
+            .live_reload(fs, &deleted, &inserted, hw_counter)?;
+        for vector_storage in vector_data.values() {
+            vector_storage
+                .borrow_mut()
+                .live_reload(fs, &deleted, &inserted, hw_counter)?;
+        }
+
+        Ok(())
+    }
+}

--- a/lib/segment/src/segment/update_only/lookup/mod.rs
+++ b/lib/segment/src/segment/update_only/lookup/mod.rs
@@ -2,6 +2,7 @@
 //! against, and nothing that writes.
 
 mod lifecycle;
+mod live_reload;
 mod resolve;
 
 use std::collections::HashMap;

--- a/lib/segment/src/segment/update_only/segment_enum.rs
+++ b/lib/segment/src/segment/update_only/segment_enum.rs
@@ -4,19 +4,19 @@
 use std::path::Path;
 
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalAppend, UniversalWrite};
+use common::universal_io::UniversalAppend;
 
 use super::{AppendableSegment, DeleteOnlySegment, WriterIdTrackerState};
 use crate::common::operation_error::OperationResult;
 use crate::types::{PointIdType, SegmentConfig};
 
 /// A segment opened for writing: appendable, or accepting deletes only.
-pub enum UpdateOnlySegmentEnum<S: UniversalAppend + UniversalWrite + 'static> {
+pub enum UpdateOnlySegmentEnum<S: UniversalAppend + 'static> {
     DeleteOnly(DeleteOnlySegment<S>),
     Appendable(Box<AppendableSegment<S>>),
 }
 
-impl<S: UniversalAppend + UniversalWrite + 'static> UpdateOnlySegmentEnum<S> {
+impl<S: UniversalAppend + 'static> UpdateOnlySegmentEnum<S> {
     /// Open a writer over the segment directory at `segment_path`, of the
     /// kind the read phase's `id_tracker_state` dictates.
     pub fn open(


### PR DESCRIPTION
Stacked on #10206 (`cached-blob-file-append`).

Toward running the update-only writer (`UpdateOnlyEdgeShard::apply_batch`) directly against S3/GCS through the appendable `CachedBlobFile` that #10206 introduces — including sequential batches on one held writer.

## Commits

1. **Drop the vestigial `S: UniversalWrite` bound** from `UpdateOnlySegmentEnum` and `apply_batch`/`open_writer`. Neither writer kind performs in-place writes anymore — `AppendableSegment` is built on `UniversalAppend`, and `DeleteOnlySegment` tombstones via whole-mask `atomic_save` — so the bound only survived from the earlier `DiskIdTracker`-based iterations that mutated the deleted mask in place. Removing it is what makes `apply_batch` instantiable with `CachedBlobFile` (object stores cannot serve in-place `UniversalWrite`, by design).

2. **`edge-shard-update` gains `--apply`.** The object-storage backends open through `CachedBlobFs`/`CachedBlobFile` instead of the read-only `DiskCacheFs` handle, so the shard is appendable in both modes; `--apply` runs `apply_batch` with the same schema-derived batch the dry run resolves (generation is shared, so the preview cannot drift from the apply). Dry run stays the default. `--native-append` exposes `AwsConfig::native_append` for AiStor/RustFS-style endpoints.

3. **`CachedBlobFile`: latency tracing for `append_bytes`.** Trace-level timing (append vs rewrite strategy) under the existing io_bridge latency log target.

4. **`UpdateOnlyEdgeShard`: sequential batches through one writer.** Writers open once at shard open, next to the lookup segments they resume from. `apply_batch` hands the writer back on success, live-reloading the lookup half of every segment the batch wrote to (new `LookupSegment::live_reload`, mirroring the read-only segment's). On error the writer is consumed — its lookups may no longer describe the durable state; recover by opening a fresh writer.

5. **`edge-shard-update`: `--interactive` mode.** After each applied batch, prompt on stdin for the next round's ids and apply them through the writer `apply_batch` handed back — no shard re-open — with op-num (and seed) incremented per round.

## Verified

- `cargo test -p edge update_only` — passes with the relaxed bound and sequential-writer path, including `store_batch_appends_points_end_to_end`.
- Tool dry run against a real leader-produced shard: unchanged behavior.
- Tool `--apply` against a copy of that shard: the writer opens and refuses cleanly — its appendable segment's payload storage was created in mutable mode, which the append-only writer rejects. That is the known segment-bootstrap gap (`lifecycle.rs` `todo!()`; the edge tests work around it by recreating payload storages append-only), not a wiring failure.

## Remaining scope (this PR or follow-ups)

- Bootstrap: creating the appendable segment with append-only components, so a leader-produced shard gains a usable write target.