### PR TITLE
Replace sys-info dependency with already-present sysinfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5983,7 +5983,7 @@ dependencies = [
  "slog",
  "slog-stdlog",
  "storage",
- "sys-info",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.19",
  "tikv-jemalloc-ctl",
@@ -7972,16 +7972,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "sys-info"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ ctrlc = "3.5.2"
 env_logger = { workspace = true }
 serde_cbor = { workspace = true }
 uuid = { workspace = true }
-sys-info = "0.9.1"
+sysinfo = { workspace = true }
 ordered-float = { workspace = true }
 ahash = { workspace = true }
 urlencoding = { workspace = true }
@@ -292,6 +292,7 @@ serde_json = { version = "~1.0", features = ["preserve_order"] }
 slab = "0.4.12"
 strum = { version = "0.28.0", features = ["derive"] }
 stumpalo = "0.5.1"
+sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 tap = "1.0.1"
 tar = "0.4.46"
 tempfile = "3.27.0"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -98,7 +98,7 @@ vaporetto = { version = "0.6.5" }
 rust-stemmers = { package = "qdrant-rust-stemmers", version = "1.2.2" }
 # Memory only; disable `user` so macOS does not pull objc2 via open-directory
 # (objc2::Retained's IntoIterator blanket impl overflows trait resolution).
-sysinfo = { version = "0.39", default-features = false, features = ["system"] }
+sysinfo = { workspace = true }
 charabia = { version = "0.9.9", default-features = false, features = [
     "greek",
     "hebrew",

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -162,16 +162,10 @@ fn collect_audit_telemetry(
 }
 
 fn get_system_data(storage_path: &Path) -> RunningEnvironmentTelemetry {
-    let distribution = if let Ok(release) = sys_info::linux_os_release() {
-        release.id
-    } else {
-        sys_info::os_type().ok()
-    };
-    let distribution_version = if let Ok(release) = sys_info::linux_os_release() {
-        release.version_id
-    } else {
-        sys_info::os_release().ok()
-    };
+    // `ID` from `/etc/os-release` on Linux (e.g. "ubuntu"); the OS name on
+    // other platforms.
+    let distribution = Some(sysinfo::System::distribution_id());
+    let distribution_version = sysinfo::System::os_version();
     let mut cpu_flags = vec![];
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
@@ -240,8 +234,8 @@ fn get_system_data(storage_path: &Path) -> RunningEnvironmentTelemetry {
         // `statvfs` to every telemetry request.
         disk_size: shard::quota::global()
             .disk_capacity_bytes(storage_path)
-            .map(|total| (total / 1024) as usize)
-            .or_else(|| sys_info::disk_info().ok().map(|x| x.total as usize)),
+            .or_else(|| common::disk_usage::disk_usage(storage_path).map(|usage| usage.total))
+            .map(|total| (total / 1024) as usize),
         cpu_flags: cpu_flags.join(","),
         cpu_endian: Some(CpuEndian::current()),
         gpu_devices,


### PR DESCRIPTION
## What

Removes the `sys-info` crate. Its only consumer was the app telemetry (`get_system_data`), which now reads the same values through `sysinfo` (already in the tree) and `common::disk_usage`:

* `distribution` / `distribution_version`: `sysinfo::System::distribution_id()` and `os_version()` statics (no refresh cycle needed).
* `disk_size` fallback: `common::disk_usage::disk_usage(storage_path)` instead of `sys_info::disk_info()`.
* `sysinfo` is hoisted to `[workspace.dependencies]` and shared by the root crate and `segment` (identical spec: `default-features = false`, `features = ["system"]`).

## What we gain

* **One system-info crate instead of two overlapping ones.** `segment` needs `sysinfo` for cgroup-aware memory accounting (`sys-info` only reads `/proc/meminfo`, so consolidation had to go this direction). `sys-info` was the redundant one.
* **A dormant C-binding crate leaves the build.** `sys-info` 0.9.1 is years old and bundles C sources compiled via a `cc` build script; dropping it removes that build step and FFI surface. `sysinfo` is pure Rust and actively maintained, and with `default-features = false` we compile only the small "system" slice.
* **A more meaningful disk-size fallback** (see below): it now measures the filesystem hosting the storage path, in the same units as the primary quota-manager path, instead of a decimal-KB sum over all local mounts.

## Telemetry output equivalence

Verified against both crates' source and a side-by-side run (Ubuntu, both stacks byte-identical: `Some("ubuntu")` / `Some("26.04")`). Both read `/etc/os-release` `ID` / `VERSION_ID` with the same quote handling, so mainline Linux (including the Debian-based Docker images) reports identical values.

Corner cases that do change:

* No `/etc/os-release` (scratch/distroless): `distribution` becomes `"linux"` instead of `"Linux"`, and `distribution_version` comes from `/etc/lsb-release` (or is absent) instead of the kernel release.
* macOS / Windows: `"Darwin"`/`"Windows"` become `"macos"`/`"windows"`; macOS version becomes the product version instead of the Darwin kernel release.
* `disk_size` fallback (only fires when the quota manager has no reading): `sys_info::disk_info()` summed capacity across all local rw `/dev/*` mounts and divided by 1000, disagreeing with the primary path in both scope and units. The fallback now reports the storage filesystem in KiB, exactly matching what the primary path reports for the same node. On a multi-mount host this is a distribution shift in the reported values (storage filesystem capacity, not the sum of all disks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)