### PR TITLE
Replace permutation_iterator with rand's index sampler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,15 +536,6 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
-
-[[package]]
-name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
@@ -978,16 +969,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "blake2-rfc"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
-dependencies = [
- "arrayvec 0.4.12",
- "constant_time_eq 0.1.5",
 ]
 
 [[package]]
@@ -1655,12 +1636,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -2780,7 +2755,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f54fe4785e899d4d6f43793b151c63c5647240fc630b005509d2614a939f693"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
  "cfg-if",
  "fallible-iterator",
  "gimli 0.33.0",
@@ -3044,17 +3019,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -3062,7 +3026,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -4498,7 +4462,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -4627,12 +4591,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4747,7 +4705,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
  "itoa",
 ]
 
@@ -5062,7 +5020,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97f6fccfd2d9d2df765ca23ff85fe5cc437fb0e6d3e164e4d3cbe09d14780c93"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
  "bitflags 2.11.0",
  "thiserror 2.0.19",
  "zerocopy",
@@ -5093,16 +5051,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "permutation_iterator"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55405179fe06e4e3820ddaf9f9b51cdff9e7496af9554acdb2b1921a86ca9cb"
-dependencies = [
- "blake2-rfc",
- "rand 0.7.3",
-]
 
 [[package]]
 name = "pest"
@@ -5942,7 +5890,7 @@ dependencies = [
  "common",
  "config",
  "console-subscriber",
- "constant_time_eq 0.5.0",
+ "constant_time_eq",
  "ctrlc",
  "env_logger",
  "fs-err",
@@ -6064,7 +6012,7 @@ dependencies = [
 name = "quantization"
 version = "0.1.0"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec",
  "bytemuck",
  "cc",
  "common",
@@ -6074,7 +6022,6 @@ dependencies = [
  "num_threads",
  "ordered-float 5.3.0",
  "parking_lot",
- "permutation_iterator",
  "quantization",
  "rand 0.10.2",
  "rand_distr",
@@ -6243,19 +6190,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -6289,16 +6223,6 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
@@ -6315,15 +6239,6 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -6359,15 +6274,6 @@ checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
  "rand 0.10.2",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -9082,12 +8988,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/lib/quantization/Cargo.toml
+++ b/lib/quantization/Cargo.toml
@@ -20,7 +20,6 @@ cc = { workspace = true }
 [dependencies]
 fs-err = { workspace = true }
 serde = { workspace = true }
-permutation_iterator = "0.1.2"
 rand = { workspace = true }
 rayon = { workspace = true }
 num-traits = { workspace = true }

--- a/lib/quantization/benches/binary.rs
+++ b/lib/quantization/benches/binary.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use criterion::{Criterion, criterion_group, criterion_main};
-use permutation_iterator::Permutor;
 use quantization::encoded_storage::TestEncodedStorageBuilder;
 use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
 use quantization::encoded_vectors_binary::{
@@ -70,8 +69,11 @@ fn binary_bench(c: &mut Criterion) {
         });
     });
 
-    let permutor = Permutor::new(vectors_count as u64);
-    let permutation: Vec<u32> = permutor.map(|i| i as u32).collect();
+    let permutation: Vec<u32> =
+        rand::seq::index::sample(&mut rand::rng(), vectors_count, vectors_count)
+            .into_iter()
+            .map(|i| i as u32)
+            .collect();
 
     group.bench_function("score binary random access u128", |b| {
         b.iter(|| {
@@ -114,8 +116,11 @@ fn binary_bench(c: &mut Criterion) {
         });
     });
 
-    let permutor = Permutor::new(vectors_count as u64);
-    let permutation: Vec<u32> = permutor.map(|i| i as u32).collect();
+    let permutation: Vec<u32> =
+        rand::seq::index::sample(&mut rand::rng(), vectors_count, vectors_count)
+            .into_iter()
+            .map(|i| i as u32)
+            .collect();
 
     group.bench_function("score binary random access u8", |b| {
         b.iter(|| {
@@ -165,8 +170,11 @@ fn binary_scalar_query_bench_impl(c: &mut Criterion) {
     let encoded_query = encoded_u128.encode_query(&query);
 
     let hardware_counter = HardwareCounterCell::new();
-    let permutor = Permutor::new(vectors_count as u64);
-    let permutation: Vec<u32> = permutor.map(|i| i as u32).collect();
+    let permutation: Vec<u32> =
+        rand::seq::index::sample(&mut rand::rng(), vectors_count, vectors_count)
+            .into_iter()
+            .map(|i| i as u32)
+            .collect();
 
     group.bench_function("binary u128 scalar query", |b| {
         b.iter(|| {

--- a/lib/quantization/benches/encode.rs
+++ b/lib/quantization/benches/encode.rs
@@ -1,7 +1,6 @@
 use std::sync::atomic::AtomicBool;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use permutation_iterator::Permutor;
 use quantization::encoded_storage::TestEncodedStorageBuilder;
 use quantization::encoded_vectors::{DistanceType, EncodedVectors, VectorParameters};
 use quantization::encoded_vectors_u8::{self, EncodedVectorsU8, ScalarQuantizationMethod};
@@ -75,8 +74,11 @@ fn encode_dot_bench(c: &mut Criterion) {
         });
     });
 
-    let permutor = Permutor::new(vectors_count as u64);
-    let permutation: Vec<u32> = permutor.map(|i| i as u32).collect();
+    let permutation: Vec<u32> =
+        rand::seq::index::sample(&mut rand::rng(), vectors_count, vectors_count)
+            .into_iter()
+            .map(|i| i as u32)
+            .collect();
 
     #[cfg(target_arch = "x86_64")]
     group.bench_function("score random access u8 avx", |b| {
@@ -179,8 +181,11 @@ fn encode_l1_bench(c: &mut Criterion) {
         });
     });
 
-    let permutor = Permutor::new(vectors_count as u64);
-    let permutation: Vec<u32> = permutor.map(|i| i as u32).collect();
+    let permutation: Vec<u32> =
+        rand::seq::index::sample(&mut rand::rng(), vectors_count, vectors_count)
+            .into_iter()
+            .map(|i| i as u32)
+            .collect();
 
     #[cfg(target_arch = "x86_64")]
     group.bench_function("score random access u8 avx", |b| {

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -362,9 +362,8 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
         }
 
         // find random subset of data as random non-intersected indexes
-        let permutor = permutation_iterator::Permutor::new(count as u64);
         let mut selected_vectors: Vec<usize> =
-            permutor.map(|i| i as usize).take(sample_size).collect();
+            rand::seq::index::sample(&mut rand::rng(), count, sample_size).into_vec();
         if stopped.load(Ordering::Relaxed) {
             return Err(EncodingError::Stopped);
         }

--- a/lib/quantization/src/quantile.rs
+++ b/lib/quantization/src/quantile.rs
@@ -1,6 +1,5 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use permutation_iterator::Permutor;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 
 use crate::EncodingError;
@@ -157,14 +156,11 @@ where
 
     // Random sample of `R` indices in `[0, count)`, sorted ascending so
     // the iterator can step through them with monotonic `nth(skip)`
-    // calls. `Permutor` produces a deterministic permutation per
-    // `count` — same input collection produces the same sample, which
-    // is what we want for reproducible recall across runs.
+    // calls. Seeded from the thread RNG, so the sample differs between
+    // runs.
     let actual_sample = sample_size.min(count);
-    let mut indices: Vec<usize> = Permutor::new(count as u64)
-        .map(|i| i as usize)
-        .take(actual_sample)
-        .collect();
+    let mut indices: Vec<usize> =
+        rand::seq::index::sample(&mut rand::rng(), count, actual_sample).into_vec();
     indices.sort_unstable();
 
     // One pair of P-square estimators per coord. The interleaved
@@ -282,7 +278,7 @@ where
     Ok(intervals)
 }
 
-// Take random vectors from the input iterator using `Permutor`.
+// Take a random subset of vectors from the input iterator.
 fn take_random_vectors<'a>(
     vector_data: impl Iterator<Item = impl AsRef<[f32]> + 'a>,
     count: usize,
@@ -290,8 +286,8 @@ fn take_random_vectors<'a>(
     stopped: &AtomicBool,
 ) -> Result<Vec<impl AsRef<[f32]> + 'a>, EncodingError> {
     let slice_size = std::cmp::min(count, sample_size);
-    let permutor = Permutor::new(count as u64);
-    let mut selected_vectors: Vec<usize> = permutor.map(|i| i as usize).take(slice_size).collect();
+    let mut selected_vectors: Vec<usize> =
+        rand::seq::index::sample(&mut rand::rng(), count, slice_size).into_vec();
     selected_vectors.sort_unstable();
 
     let mut data_slice = Vec::with_capacity(slice_size);


### PR DESCRIPTION
## Motivation

`cargo audit` flags `rand 0.7.3` as unsound (RUSTSEC-2026-0097), and a reverse-dependency trace shows `permutation_iterator 0.1.2` is its **sole importer**.

It pins the entire legacy rand 0.7 stack into the build for no other reason. The advisory's suggested remedy is upgrading rand, but that upgrade would have to happen inside `permutation_iterator`, and the crate is unmaintained (0.1.2, never ported off rand 0.7), so the audit finding is permanent for as long as we depend on it.

Everything we actually used it for is one operation: pick `k` distinct random indices out of `n`, to select training samples for PQ / scalar / quantile quantization, plus random-access orders in two benches. That is exactly `rand::seq::index::sample`, which is already in the tree via the workspace rand.

## What this PR does

* Switches the three src call sites (`quantile.rs` x2, `encoded_vectors_pq.rs`) and the two benches (`encode.rs`, `binary.rs`) to `rand::seq::index::sample`, and drops the `permutation_iterator` dependency. No new module, no in-tree sampling code to maintain or review.
* Fixes a comment in `quantile.rs` that claimed the permutation was "deterministic per `count`", giving "reproducible recall across runs". That was never true: the old crate keyed itself from `thread_rng` on every call. The comment now matches reality.

## What we gain

11 crates leave `Cargo.lock`:

| crate | version |
|---|---|
| `permutation_iterator` | 0.1.2 |
| `rand` | 0.7.3 |
| `rand_core` | 0.5.1 |
| `rand_chacha` | 0.2.2 |
| `rand_hc` | 0.2.0 |
| `getrandom` | 0.1.16 |
| `wasi` | 0.9.0+wasi-snapshot-preview1 |
| `blake2-rfc` | 0.2.18 |
| `constant_time_eq` | 0.1.5 |
| `arrayvec` | 0.4.12 |
| `nodrop` | 0.1.14 |

`cargo audit` no longer reports RUSTSEC-2026-0097 against rand 0.7.3. The 0.8.5 / 0.9.2 flags remain (via jsonwebtoken / raft and the workspace) and are out of scope here.

## Behavior

Behavior-neutral by design: `rand::rng()` keeps the per-call random keying the old crate had, and the permutation only selects quantization training samples, so nothing persisted depends on the ordering. Which sample a given run draws changes, as it already did between any two runs.

`sample` panics if `amount > length`. Every call site already clamps the sample to the population (`sample_size.min(count)`, `min(count, sample_size)`, `KMEANS_SAMPLE_SIZE.min(count)`), so that path is unreachable.

## Allocation

The old iterator was O(1) state, so this is the one real tradeoff. `rand::seq::index::sample` picks its algorithm from the shape of the request:

* `count >= 500_000`: rejection sampling, O(sample_size). About 120 KB at the largest call site (PQ, 10k samples) against the 80 KB `Vec` that site already built.
* `count < 500_000`: partial Fisher-Yates over a transient `Vec<u32>` of `count`, so at most 2 MB, since that branch cannot be taken above 500k.

Sample sizes are fixed and small: 2048 / 4096 / 8192 for TQ (per `TQBits::sample_size`), 5000 for SQ, 10000 for PQ k-means. For context, `find_quantile_interval_per_coordinate` already holds ~200 KB of P-square estimators alongside this.

## Verification

`cargo test -p quantization` green (118 unit + 91 integration), `cargo clippy -p quantization --all-targets` clean, both benches compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
