### PR TITLE
[LiveReload] Preload all vector storages

### DIFF
--- a/lib/segment/src/vector_storage/dense/read_only/immutable/live_reload.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyImmutableDenseVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -12,6 +12,11 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> LiveReload
     for ReadOnlyImmutableDenseVectorStorage<T, S>
 {
     type File = S;
+
+    fn live_preload<Fs: CachedReadFs<File = S>>(&self, _fs: &Fs) -> OperationResult<()> {
+        // Reload only applies deletes directly from arguments. No file to check.
+        Ok(())
+    }
 
     /// Vector data is immutable, so only the in-memory deletion flags are patched
     /// from the authoritative `deleted_points`; `fs` and `new_points` are unused.

--- a/lib/segment/src/vector_storage/dense/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyChunkedDenseVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -12,6 +12,13 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> LiveReload
     for ReadOnlyChunkedDenseVectorStorage<T, S>
 {
     type File = S;
+
+    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+        self.vectors.live_preload(fs)?;
+        // TODO(uio): use upcoming bitmap structure
+        self.deleted.live_preload(fs)?;
+        Ok(())
+    }
 
     /// Reload the chunked vectors, apply `deleted_points`, and fold in the
     /// persisted deletion of each appended offset — a live point may have a

--- a/lib/segment/src/vector_storage/dense/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/mod.rs
@@ -110,6 +110,20 @@ mod tests {
     /// After `live_reload`, the read-only view reflects appends and deletions.
     #[test]
     fn live_reload_picks_up_appends_and_deletions() {
+        reload_picks_up_appends_and_deletions(false);
+    }
+
+    /// Preload must stage every file the reload opens: after the preload the
+    /// backing files are deleted, so the reload can only succeed from the
+    /// prefetch pool (parked mmap handles keep reading deleted files on unix).
+    #[test]
+    fn live_preload_then_reload_picks_up_appends_and_deletions() {
+        reload_picks_up_appends_and_deletions(true);
+    }
+
+    fn reload_picks_up_appends_and_deletions(preload: bool) {
+        use common::universal_io::{CachedFs, CachedReadFs};
+
         const DIM: usize = 64;
         let dir = Builder::new().prefix("ro_dense_reload").tempdir().unwrap();
         let mut rng = StdRng::seed_from_u64(7);
@@ -164,18 +178,24 @@ mod tests {
             writer.delete_vector(id).unwrap();
         }
         writer.flusher()().unwrap();
+        drop(writer);
 
         let new_ids: Vec<PointOffsetType> = (first.len()..first.len() + second.len())
             .map(|offset| offset as PointOffsetType)
             .collect();
-        reader
-            .live_reload(
-                &MmapFs,
-                &SortedSlice::new(&deleted_ids).unwrap(),
-                &SortedSlice::new(&new_ids).unwrap(),
-                &hw,
-            )
-            .unwrap();
+        let deleted = SortedSlice::new(&deleted_ids).unwrap();
+        let new = SortedSlice::new(&new_ids).unwrap();
+        if preload {
+            let mut cached_fs = CachedFs::new(MmapFs, dir.path()).unwrap();
+            cached_fs.cache_file_info().unwrap();
+            reader.live_preload(&cached_fs).unwrap();
+
+            fs_err::remove_dir_all(dir.path()).unwrap();
+
+            reader.live_reload(&cached_fs, &deleted, &new, &hw).unwrap();
+        } else {
+            reader.live_reload(&MmapFs, &deleted, &new, &hw).unwrap();
+        }
 
         assert_eq!(reader.total_vector_count(), first.len() + second.len());
         assert_eq!(reader.deleted_vector_count(), deleted_ids.len());

--- a/lib/segment/src/vector_storage/multi_dense/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -12,6 +12,14 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> LiveReload
     for ReadOnlyChunkedMultiDenseVectorStorage<T, S>
 {
     type File = S;
+
+    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+        self.vectors.live_preload(fs)?;
+        self.offsets.live_preload(fs)?;
+        // TODO(uio): use upcoming bitmap structure
+        self.deleted.live_preload(fs)?;
+        Ok(())
+    }
 
     /// Reload the vectors and offsets, apply `deleted_points`, and fold in the
     /// persisted deletion of each appended offset — a live point may have a

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/live_reload.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
 
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
@@ -9,6 +9,10 @@ use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedC
 
 impl<S: UniversalRead> LiveReload for QuantizedChunkedStorageRead<S> {
     type File = S;
+
+    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+        self.data.live_preload(fs)
+    }
 
     /// Pick up quantized vectors a writer appended to the chunked backing.
     fn live_reload<Fs: UniversalReadFs<File = S>>(

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/live_reload.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
 
 use super::MultivectorOffsetsStorageChunkedRead;
 use crate::common::operation_error::OperationResult;
@@ -9,6 +9,10 @@ use crate::index::field_index::LiveReload;
 
 impl<S: UniversalRead> LiveReload for MultivectorOffsetsStorageChunkedRead<S> {
     type File = S;
+
+    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+        self.data.live_preload(fs)
+    }
 
     /// Pick up offsets a writer appended to the chunked backing.
     fn live_reload<Fs: UniversalReadFs<File = S>>(

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
 
 use super::{ReadOnlyQuantizedVectorStorage, ReadOnlyQuantizedVectors};
 use crate::common::live_reload::LiveReload;
@@ -9,6 +9,10 @@ use crate::common::operation_error::OperationResult;
 
 impl<S: UniversalRead> LiveReload for ReadOnlyQuantizedVectors<S> {
     type File = S;
+
+    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+        self.storage_impl.live_preload(fs)
+    }
 
     /// Reload appended quantized vectors from disk (chunked layouts only).
     fn live_reload<Fs: UniversalReadFs<File = S>>(
@@ -25,6 +29,39 @@ impl<S: UniversalRead> LiveReload for ReadOnlyQuantizedVectors<S> {
 
 impl<S: UniversalRead> LiveReload for ReadOnlyQuantizedVectorStorage<S> {
     type File = S;
+
+    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+        match self {
+            // Ram/Mmap layouts are immutable: nothing to stage.
+            ReadOnlyQuantizedVectorStorage::ScalarRam(_)
+            | ReadOnlyQuantizedVectorStorage::ScalarMmap(_)
+            | ReadOnlyQuantizedVectorStorage::PQRam(_)
+            | ReadOnlyQuantizedVectorStorage::PQMmap(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryRam(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryMmap(_)
+            | ReadOnlyQuantizedVectorStorage::TQRam(_)
+            | ReadOnlyQuantizedVectorStorage::TQMmap(_)
+            | ReadOnlyQuantizedVectorStorage::ScalarRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::ScalarMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::PQRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::PQMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(_)
+            | ReadOnlyQuantizedVectorStorage::TQRamMulti(_)
+            | ReadOnlyQuantizedVectorStorage::TQMmapMulti(_) => {}
+            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => q.storage().live_preload(fs)?,
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => q.storage().live_preload(fs)?,
+            ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(q) => {
+                q.storage().storage().live_preload(fs)?;
+                q.offsets_storage().live_preload(fs)?;
+            }
+            ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => {
+                q.storage().storage().live_preload(fs)?;
+                q.offsets_storage().live_preload(fs)?;
+            }
+        }
+        Ok(())
+    }
 
     /// Pick up quantized vectors a writer appended. Only the chunked (appendable)
     /// layouts grow; Ram/Mmap are immutable, so they no-op. Deletions aren't

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
@@ -542,6 +542,20 @@ fn assert_internal_scorer_eq(
 /// `ReadOnlyChunkedVectors`'s own tests.
 #[test]
 fn live_reload_chunked_preserves_scores() {
+    reload_chunked_preserves_scores(false);
+}
+
+/// Preload must stage every file the reload opens: after the preload the
+/// quantized storage's files are deleted, so the reload can only succeed from
+/// the prefetch pool (parked mmap handles keep reading deleted files on unix).
+#[test]
+fn live_preload_then_reload_chunked_preserves_scores() {
+    reload_chunked_preserves_scores(true);
+}
+
+fn reload_chunked_preserves_scores(preload: bool) {
+    use common::universal_io::{CachedFs, CachedReadFs};
+
     let dir = tempfile::Builder::new().prefix("src").tempdir().unwrap();
     let quant_dir = tempfile::Builder::new().prefix("quant").tempdir().unwrap();
     let mut rng = StdRng::seed_from_u64(SEED);
@@ -584,8 +598,24 @@ fn live_reload_chunked_preserves_scores() {
     };
 
     let empty = SortedSlice::new(&[]).unwrap();
-    ro.live_reload(&MmapFs, &empty, &empty, &HardwareCounterCell::disposable())
+    if preload {
+        let mut cached_fs = CachedFs::new(MmapFs, quant_dir.path()).unwrap();
+        cached_fs.cache_file_info().unwrap();
+        ro.live_preload(&cached_fs).unwrap();
+
+        fs_err::remove_dir_all(quant_dir.path()).unwrap();
+
+        ro.live_reload(
+            &cached_fs,
+            &empty,
+            &empty,
+            &HardwareCounterCell::disposable(),
+        )
         .unwrap();
+    } else {
+        ro.live_reload(&MmapFs, &empty, &empty, &HardwareCounterCell::disposable())
+            .unwrap();
+    }
 
     let after: Vec<_> = {
         let scorer = ro

--- a/lib/segment/src/vector_storage/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/read_only/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
 
 use super::VectorStorageReadEnum;
 use crate::common::live_reload::LiveReload;
@@ -9,6 +9,24 @@ use crate::common::operation_error::OperationResult;
 
 impl<S: UniversalRead> LiveReload for VectorStorageReadEnum<S> {
     type File = S;
+
+    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+        match self {
+            VectorStorageReadEnum::Dense(s) => s.live_preload(fs),
+            VectorStorageReadEnum::DenseByte(s) => s.live_preload(fs),
+            VectorStorageReadEnum::DenseHalf(s) => s.live_preload(fs),
+            VectorStorageReadEnum::DenseChunked(s) => s.live_preload(fs),
+            VectorStorageReadEnum::DenseChunkedByte(s) => s.live_preload(fs),
+            VectorStorageReadEnum::DenseChunkedHalf(s) => s.live_preload(fs),
+            VectorStorageReadEnum::MultiDenseChunked(s) => s.live_preload(fs),
+            VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.live_preload(fs),
+            VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.live_preload(fs),
+            VectorStorageReadEnum::DenseTurbo(s) => s.live_preload(fs),
+            VectorStorageReadEnum::DenseTurboChunked(s) => s.live_preload(fs),
+            VectorStorageReadEnum::MultiDenseTurbo(s) => s.live_preload(fs),
+            VectorStorageReadEnum::Sparse(s) => s.live_preload(fs),
+        }
+    }
 
     fn live_reload<Fs: UniversalReadFs<File = S>>(
         &mut self,

--- a/lib/segment/src/vector_storage/sparse/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlySparseVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -9,6 +9,13 @@ use crate::common::operation_error::OperationResult;
 
 impl<S: UniversalRead> LiveReload for ReadOnlySparseVectorStorage<S> {
     type File = S;
+
+    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+        self.storage.live_preload(fs)?;
+        // TODO(uio): use upcoming bitmap structure
+        self.deleted.live_preload(fs)?;
+        Ok(())
+    }
 
     /// Reload the Blobstore, apply `deleted_points`, fold in the persisted
     /// deletion of each appended offset, and recompute `next_point_offset`.

--- a/lib/segment/src/vector_storage/sparse/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/mod.rs
@@ -11,7 +11,7 @@ mod read_ops;
 #[derive(Debug)]
 pub struct ReadOnlySparseVectorStorage<S: UniversalRead> {
     storage: BlobstoreReader<StoredSparseVector, S>,
-    /// Flags marking deleted vectors.
+    /// Flags marking deleted vectors, since storage is append-only.
     deleted: InMemoryBitvecFlags,
     next_point_offset: usize,
 }
@@ -170,6 +170,20 @@ mod tests {
     /// After `live_reload`, the read-only view reflects appends and deletions.
     #[test]
     fn live_reload_picks_up_appends_and_deletions() {
+        reload_picks_up_appends_and_deletions(false);
+    }
+
+    /// Preload must stage every file the reload opens: after the preload the
+    /// backing files are deleted, so the reload can only succeed from the
+    /// prefetch pool (parked mmap handles keep reading deleted files on unix).
+    #[test]
+    fn live_preload_then_reload_picks_up_appends_and_deletions() {
+        reload_picks_up_appends_and_deletions(true);
+    }
+
+    fn reload_picks_up_appends_and_deletions(preload: bool) {
+        use common::universal_io::{CachedFs, CachedReadFs};
+
         let dir = Builder::new().prefix("ro_sparse_reload").tempdir().unwrap();
         let hw = HardwareCounterCell::disposable();
 
@@ -209,18 +223,24 @@ mod tests {
             writer.delete_vector(id).unwrap();
         }
         writer.flusher()().unwrap();
+        drop(writer);
 
         let new_ids: Vec<PointOffsetType> = (first.len()..first.len() + second.len())
             .map(|offset| offset as PointOffsetType)
             .collect();
-        reader
-            .live_reload(
-                &MmapFs,
-                &SortedSlice::new(&deleted_ids).unwrap(),
-                &SortedSlice::new(&new_ids).unwrap(),
-                &hw,
-            )
-            .unwrap();
+        let deleted = SortedSlice::new(&deleted_ids).unwrap();
+        let new = SortedSlice::new(&new_ids).unwrap();
+        if preload {
+            let mut cached_fs = CachedFs::new(MmapFs, dir.path()).unwrap();
+            cached_fs.cache_file_info().unwrap();
+            reader.live_preload(&cached_fs).unwrap();
+
+            fs_err::remove_dir_all(dir.path()).unwrap();
+
+            reader.live_reload(&cached_fs, &deleted, &new, &hw).unwrap();
+        } else {
+            reader.live_reload(&MmapFs, &deleted, &new, &hw).unwrap();
+        }
 
         assert_eq!(reader.total_vector_count(), first.len() + second.len());
         assert_eq!(reader.deleted_vector_count(), deleted_ids.len());

--- a/lib/segment/src/vector_storage/turbo/multi_turbo/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/turbo/multi_turbo/read_only/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyChunkedMultiTurboVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -9,6 +9,14 @@ use crate::common::operation_error::OperationResult;
 
 impl<S: UniversalRead> LiveReload for ReadOnlyChunkedMultiTurboVectorStorage<S> {
     type File = S;
+
+    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+        self.storage.live_preload(fs)?;
+        self.offsets.live_preload(fs)?;
+        // TODO(uio): use upcoming bitmap structure
+        self.deleted.live_preload(fs)?;
+        Ok(())
+    }
 
     /// Reload the vectors and offsets, apply `deleted_points`, and fold in the
     /// persisted deletion of each appended offset — a live point may have a

--- a/lib/segment/src/vector_storage/turbo/read_only/immutable/live_reload.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/immutable/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyImmutableTurboVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -9,6 +9,11 @@ use crate::common::operation_error::OperationResult;
 
 impl<S: UniversalRead> LiveReload for ReadOnlyImmutableTurboVectorStorage<S> {
     type File = S;
+
+    fn live_preload<Fs: CachedReadFs<File = S>>(&self, _fs: &Fs) -> OperationResult<()> {
+        // No new data to fetch, deletions are applied directly from arguments
+        Ok(())
+    }
 
     /// Vector data is immutable, so only the in-memory deletion flags are patched
     /// from the authoritative `deleted_points`; `fs` and `new_points` are unused.

--- a/lib/segment/src/vector_storage/turbo/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/live_reload.rs
@@ -1,7 +1,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
 
 use super::ReadOnlyChunkedTurboVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -9,6 +9,13 @@ use crate::common::operation_error::OperationResult;
 
 impl<S: UniversalRead> LiveReload for ReadOnlyChunkedTurboVectorStorage<S> {
     type File = S;
+
+    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+        self.storage.live_preload(fs)?;
+        // TODO(uio): use upcoming bitmap structure
+        self.deleted.live_preload(fs)?;
+        Ok(())
+    }
 
     /// Reload the chunked vectors, apply `deleted_points`, and fold in the
     /// persisted deletion of each appended offset — a live point may have a


### PR DESCRIPTION
This PR implements `live_preload` for normal and quantized vector storages. Nothing very interesting here since all appendable ones depend on chunked storage, which has already been taken care of in #10225. 

However, many of these will have to be adapted once the new roaring-first deleted structure gets merged. I put `TODO(uio)` comments where applicable.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>