### PR TITLE
perf(segment): more performant AVX-512 dot product kernel

### DIFF
--- a/lib/segment/src/spaces/mod.rs
+++ b/lib/segment/src/spaces/mod.rs
@@ -8,6 +8,9 @@ pub mod simple_sse;
 #[cfg(target_arch = "x86_64")]
 pub mod simple_avx;
 
+#[cfg(target_arch = "x86_64")]
+pub mod simple_avx512;
+
 pub mod metric_f16;
 pub mod metric_uint;
 

--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -3,6 +3,8 @@ use common::types::ScoreType;
 use super::metric::{Metric, MetricPostProcessing};
 #[cfg(target_arch = "x86_64")]
 use super::simple_avx::*;
+#[cfg(target_arch = "x86_64")]
+use super::simple_avx512::*;
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use super::simple_neon::*;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -13,6 +15,9 @@ use crate::types::Distance;
 
 #[cfg(target_arch = "x86_64")]
 pub(crate) const MIN_DIM_SIZE_AVX: usize = 32;
+
+#[cfg(target_arch = "x86_64")]
+pub(crate) const MIN_DIM_SIZE_AVX512: usize = 64;
 
 #[cfg(any(
     target_arch = "x86",
@@ -129,6 +134,10 @@ impl Metric<VectorElementType> for DotProductMetric {
     fn similarity(v1: &[VectorElementType], v2: &[VectorElementType]) -> ScoreType {
         #[cfg(target_arch = "x86_64")]
         {
+            if is_x86_feature_detected!("avx512f") && v1.len() >= MIN_DIM_SIZE_AVX512 {
+                return unsafe { dot_similarity_avx512(v1, v2) };
+            }
+
             if is_x86_feature_detected!("avx")
                 && is_x86_feature_detected!("fma")
                 && v1.len() >= MIN_DIM_SIZE_AVX

--- a/lib/segment/src/spaces/simple_avx512.rs
+++ b/lib/segment/src/spaces/simple_avx512.rs
@@ -1,0 +1,79 @@
+use std::arch::x86_64::*;
+
+use common::types::ScoreType;
+
+use crate::data_types::vectors::VectorElementType;
+
+#[target_feature(enable = "avx512f")]
+pub(crate) unsafe fn dot_similarity_avx512(
+    v1: &[VectorElementType],
+    v2: &[VectorElementType],
+) -> ScoreType {
+    unsafe {
+        let n = v1.len();
+        let m = n - (n % 64);
+        let mut ptr1: *const f32 = v1.as_ptr();
+        let mut ptr2: *const f32 = v2.as_ptr();
+        let mut sum512_1: __m512 = _mm512_setzero_ps();
+        let mut sum512_2: __m512 = _mm512_setzero_ps();
+        let mut sum512_3: __m512 = _mm512_setzero_ps();
+        let mut sum512_4: __m512 = _mm512_setzero_ps();
+        let mut i: usize = 0;
+        while i < m {
+            sum512_1 = _mm512_fmadd_ps(_mm512_loadu_ps(ptr1), _mm512_loadu_ps(ptr2), sum512_1);
+            sum512_2 = _mm512_fmadd_ps(
+                _mm512_loadu_ps(ptr1.add(16)),
+                _mm512_loadu_ps(ptr2.add(16)),
+                sum512_2,
+            );
+            sum512_3 = _mm512_fmadd_ps(
+                _mm512_loadu_ps(ptr1.add(32)),
+                _mm512_loadu_ps(ptr2.add(32)),
+                sum512_3,
+            );
+            sum512_4 = _mm512_fmadd_ps(
+                _mm512_loadu_ps(ptr1.add(48)),
+                _mm512_loadu_ps(ptr2.add(48)),
+                sum512_4,
+            );
+
+            ptr1 = ptr1.add(64);
+            ptr2 = ptr2.add(64);
+            i += 64;
+        }
+
+        let mut result = _mm512_reduce_add_ps(_mm512_add_ps(
+            _mm512_add_ps(sum512_1, sum512_2),
+            _mm512_add_ps(sum512_3, sum512_4),
+        ));
+
+        for j in 0..n - m {
+            result += (*ptr1.add(j)) * (*ptr2.add(j));
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_dot_avx512() {
+        use crate::spaces::simple::dot_similarity;
+
+        if !is_x86_feature_detected!("avx512f") {
+            println!("avx512 test skipped");
+            return;
+        }
+        // Sizes around the 64-element unroll boundary, including remainders.
+        for n in [64, 65, 127, 128, 512, 517] {
+            let v1: Vec<f32> = (0..n).map(|i| (i as f32).sin()).collect();
+            let v2: Vec<f32> = (0..n).map(|i| (i as f32 * 0.7).cos()).collect();
+            let simd = unsafe { super::dot_similarity_avx512(&v1, &v2) };
+            let scalar = dot_similarity(&v1, &v2);
+            assert!(
+                (simd - scalar).abs() <= scalar.abs().max(1.0) * 1e-5,
+                "n={n}: {simd} vs {scalar}",
+            );
+        }
+    }
+}

--- a/lib/segment/src/spaces/simple_avx512.rs
+++ b/lib/segment/src/spaces/simple_avx512.rs
@@ -9,48 +9,40 @@ pub(crate) unsafe fn dot_similarity_avx512(
     v1: &[VectorElementType],
     v2: &[VectorElementType],
 ) -> ScoreType {
+    const STEP: usize = 16;
     unsafe {
-        let n = v1.len();
-        let m = n - (n % 64);
+        let mut n = v1.len();
         let mut ptr1: *const f32 = v1.as_ptr();
         let mut ptr2: *const f32 = v2.as_ptr();
-        let mut sum512_1: __m512 = _mm512_setzero_ps();
-        let mut sum512_2: __m512 = _mm512_setzero_ps();
-        let mut sum512_3: __m512 = _mm512_setzero_ps();
-        let mut sum512_4: __m512 = _mm512_setzero_ps();
-        let mut i: usize = 0;
-        while i < m {
-            sum512_1 = _mm512_fmadd_ps(_mm512_loadu_ps(ptr1), _mm512_loadu_ps(ptr2), sum512_1);
-            sum512_2 = _mm512_fmadd_ps(
-                _mm512_loadu_ps(ptr1.add(16)),
-                _mm512_loadu_ps(ptr2.add(16)),
-                sum512_2,
-            );
-            sum512_3 = _mm512_fmadd_ps(
-                _mm512_loadu_ps(ptr1.add(32)),
-                _mm512_loadu_ps(ptr2.add(32)),
-                sum512_3,
-            );
-            sum512_4 = _mm512_fmadd_ps(
-                _mm512_loadu_ps(ptr1.add(48)),
-                _mm512_loadu_ps(ptr2.add(48)),
-                sum512_4,
-            );
+        let mut sum: __m512 = _mm512_setzero_ps();
+        while n >= STEP {
+            let a1 = _mm512_loadu_ps(ptr1);
+            let a2 = _mm512_loadu_ps(ptr2);
+            ptr1 = ptr1.add(STEP);
+            ptr2 = ptr2.add(STEP);
+            n -= STEP;
 
-            ptr1 = ptr1.add(64);
-            ptr2 = ptr2.add(64);
-            i += 64;
+            sum = _mm512_fmadd_ps(a1, a2, sum);
         }
+        let sum = _mm512_reduce_add_ps(sum);
+        dot_similarity_tail(sum, ptr1, ptr2, n)
+    }
+}
 
-        let mut result = _mm512_reduce_add_ps(_mm512_add_ps(
-            _mm512_add_ps(sum512_1, sum512_2),
-            _mm512_add_ps(sum512_3, sum512_4),
-        ));
-
-        for j in 0..n - m {
-            result += (*ptr1.add(j)) * (*ptr2.add(j));
+// Handle the tail of the dot product.  This is a separate function, because otherwise the compiler
+// generates general-case code with AVX512 and AVX, ignoring the fact that the length is below 16
+// (even explicit `assert!(len < 16)` doesn't change it).
+//
+// Actually, inline(never) is only marginally faster than no attribute macro, but also makes it more
+// future-proof.
+#[inline(never)]
+unsafe fn dot_similarity_tail(acc: f32, ptr1: *const f32, ptr2: *const f32, len: usize) -> f32 {
+    unsafe {
+        let mut sum = acc;
+        for i in 0..len {
+            sum += ptr1.add(i).read() * ptr2.add(i).read()
         }
-        result
+        sum
     }
 }
 


### PR DESCRIPTION
Performance-tuned AVX512 dot product kernel.

Comparing with the recent dev and the implementation at #9447, it gives the following results on 1024-element vectors on AWS's c6i instance (Intel Ice Lake) with 8 (less memory pressure) and 16 (more memory pressure) threads.

Average QPS on 200k vectors (the more, the better):

| Threads | Dim  | dev       | #9447     | this PR   |
|---------|------|-----------|-----------|-----------|
| 8       | 1024 | *774*     | 793       | **813**   |
| 8       | 1023 | 633       | *599*     | **708**   |
| 16      | 1024 | *1144*    | 1170      | **1185**  |
| 16      | 1023 | 1008      | *993*     | **1112**  |


### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
