### PR TITLE
Add `acosh` expression to formula query

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -15266,6 +15266,9 @@
             "$ref": "#/components/schemas/LnExpression"
           },
           {
+            "$ref": "#/components/schemas/AcoshExpression"
+          },
+          {
             "$ref": "#/components/schemas/LinDecayExpression"
           },
           {
@@ -15472,6 +15475,17 @@
         ],
         "properties": {
           "ln": {
+            "$ref": "#/components/schemas/Expression"
+          }
+        }
+      },
+      "AcoshExpression": {
+        "type": "object",
+        "required": [
+          "acosh"
+        ],
+        "properties": {
+          "acosh": {
             "$ref": "#/components/schemas/Expression"
           }
         }

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -3658,6 +3658,9 @@ fn unparse_expression(
             Variant::Log10(Box::new(unparse_expression(*expr, conditions)))
         }
         ParsedExpression::Ln(expr) => Variant::Ln(Box::new(unparse_expression(*expr, conditions))),
+        ParsedExpression::Acosh(expr) => {
+            Variant::Acosh(Box::new(unparse_expression(*expr, conditions)))
+        }
         ParsedExpression::Abs(expr) => {
             Variant::Abs(Box::new(unparse_expression(*expr, conditions)))
         }

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -976,6 +976,8 @@ message Expression {
     DecayParamsExpression gauss_decay = 18;
     // Linear decay
     DecayParamsExpression lin_decay = 19;
+    // Inverse hyperbolic cosine
+    Expression acosh = 20;
   }
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -6572,7 +6572,7 @@ pub struct Formula {
 pub struct Expression {
     #[prost(
         oneof = "expression::Variant",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20"
     )]
     #[validate(nested)]
     pub variant: ::core::option::Option<expression::Variant>,
@@ -6638,6 +6638,9 @@ pub mod expression {
         /// Linear decay
         #[prost(message, tag = "19")]
         LinDecay(::prost::alloc::boxed::Box<super::DecayParamsExpression>),
+        /// Inverse hyperbolic cosine
+        #[prost(message, tag = "20")]
+        Acosh(::prost::alloc::boxed::Box<super::Expression>),
     }
 }
 #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -464,6 +464,7 @@ impl Validate for super::qdrant::expression::Variant {
             grpc::expression::Variant::Exp(expression) => expression.validate(),
             grpc::expression::Variant::Log10(expression) => expression.validate(),
             grpc::expression::Variant::Ln(expression) => expression.validate(),
+            grpc::expression::Variant::Acosh(expression) => expression.validate(),
             grpc::expression::Variant::ExpDecay(decay_params_expression) => {
                 decay_params_expression.validate()
             }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -945,6 +945,7 @@ pub enum Expression {
     Exp(ExpExpression),
     Log10(Log10Expression),
     Ln(LnExpression),
+    Acosh(AcoshExpression),
     LinDecay(LinDecayExpression),
     ExpDecay(ExpDecayExpression),
     GaussDecay(GaussDecayExpression),
@@ -1047,6 +1048,12 @@ pub struct Log10Expression {
 pub struct LnExpression {
     #[validate(nested)]
     pub ln: Box<Expression>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]
+pub struct AcoshExpression {
+    #[validate(nested)]
+    pub acosh: Box<Expression>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -278,6 +278,7 @@ impl Validate for Expression {
             Expression::Exp(exp_expression) => exp_expression.validate(),
             Expression::Log10(log10_expression) => log10_expression.validate(),
             Expression::Ln(ln_expression) => ln_expression.validate(),
+            Expression::Acosh(acosh_expression) => acosh_expression.validate(),
             Expression::LinDecay(lin_decay_expression) => lin_decay_expression.validate(),
             Expression::ExpDecay(exp_decay_expression) => exp_decay_expression.validate(),
             Expression::GaussDecay(gauss_decay_expression) => gauss_decay_expression.validate(),

--- a/lib/collection/src/problems/unindexed_field.rs
+++ b/lib/collection/src/problems/unindexed_field.rs
@@ -508,6 +508,10 @@ impl<'a> Extractor<'a> {
                 self.update_from_expression(expression_internal);
                 return;
             }
+            ExpressionInternal::Acosh(expression_internal) => {
+                self.update_from_expression(expression_internal);
+                return;
+            }
             ExpressionInternal::Abs(expression_internal) => {
                 self.update_from_expression(expression_internal);
                 return;

--- a/lib/edge/ffi/src/ops/formula.rs
+++ b/lib/edge/ffi/src/ops/formula.rs
@@ -282,6 +282,14 @@ impl Expression {
         })
     }
 
+    /// Inverse hyperbolic cosine.
+    #[uniffi::constructor]
+    pub fn acosh(expression: Arc<Expression>) -> Result<Arc<Self>> {
+        Self::node(&[&expression], || {
+            ExpressionInternal::Acosh(Box::new(expression.inner.clone()))
+        })
+    }
+
     /// Absolute value.
     #[uniffi::constructor]
     pub fn abs(expression: Arc<Expression>) -> Result<Arc<Self>> {
@@ -377,6 +385,8 @@ fn assert_every_expression_is_mapped(e: ExpressionInternal) {
         ExpressionInternal::Log10(_) => {}
         // [`Expression::ln`]
         ExpressionInternal::Ln(_) => {}
+        // [`Expression::acosh`]
+        ExpressionInternal::Acosh(_) => {}
         // [`Expression::abs`]
         ExpressionInternal::Abs(_) => {}
         // [`Expression::decay`], with every [`DecayKind`]

--- a/lib/edge/python/qdrant_edge.pyi
+++ b/lib/edge/python/qdrant_edge.pyi
@@ -2518,6 +2518,11 @@ class Expression(Enum):
         ...
 
     @staticmethod
+    def Acosh(expr: "Expression") -> "Expression":
+        """Create an inverse hyperbolic cosine expression."""
+        ...
+
+    @staticmethod
     def Abs(expr: "Expression") -> "Expression":
         """Create an absolute value expression."""
         ...

--- a/lib/edge/python/src/types/formula/expression.rs
+++ b/lib/edge/python/src/types/formula/expression.rs
@@ -67,6 +67,7 @@ impl FromPyObject<'_, '_> for PyExpression {
             PyExpressionInterface::Exp { expr } => ExpressionInternal::Exp(expr.into_box()),
             PyExpressionInterface::Log10 { expr } => ExpressionInternal::Log10(expr.into_box()),
             PyExpressionInterface::Ln { expr } => ExpressionInternal::Ln(expr.into_box()),
+            PyExpressionInterface::Acosh { expr } => ExpressionInternal::Acosh(expr.into_box()),
             PyExpressionInterface::Abs { expr } => ExpressionInternal::Abs(expr.into_box()),
 
             PyExpressionInterface::Decay {
@@ -158,6 +159,10 @@ impl<'py> IntoPyObject<'py> for PyExpression {
                 expr: Boxed::from_box(expr),
             },
 
+            ExpressionInternal::Acosh(expr) => PyExpressionInterface::Acosh {
+                expr: Boxed::from_box(expr),
+            },
+
             ExpressionInternal::Abs(expr) => PyExpressionInterface::Abs {
                 expr: Boxed::from_box(expr),
             },
@@ -241,6 +246,7 @@ impl Repr for PyExpression {
             ExpressionInternal::Exp(expr) => ("Exp", &[("expr", PyExpression::wrap_ref(expr))]),
             ExpressionInternal::Log10(expr) => ("Log10", &[("expr", PyExpression::wrap_ref(expr))]),
             ExpressionInternal::Ln(expr) => ("Ln", &[("expr", PyExpression::wrap_ref(expr))]),
+            ExpressionInternal::Acosh(expr) => ("Acosh", &[("expr", PyExpression::wrap_ref(expr))]),
             ExpressionInternal::Abs(expr) => ("Abs", &[("expr", PyExpression::wrap_ref(expr))]),
 
             ExpressionInternal::Decay {

--- a/lib/edge/python/src/types/formula/expression_interface.rs
+++ b/lib/edge/python/src/types/formula/expression_interface.rs
@@ -73,6 +73,10 @@ pub enum PyExpressionInterface {
         expr: Boxed<PyExpression>,
     },
 
+    Acosh {
+        expr: Boxed<PyExpression>,
+    },
+
     Abs {
         expr: Boxed<PyExpression>,
     },
@@ -128,6 +132,7 @@ impl Repr for PyExpressionInterface {
             PyExpressionInterface::Exp { expr } => ("Exp", &[("expr", expr)]),
             PyExpressionInterface::Log10 { expr } => ("Log10", &[("expr", expr)]),
             PyExpressionInterface::Ln { expr } => ("Ln", &[("expr", expr)]),
+            PyExpressionInterface::Acosh { expr } => ("Acosh", &[("expr", expr)]),
             PyExpressionInterface::Abs { expr } => ("Abs", &[("expr", expr)]),
 
             PyExpressionInterface::Decay {

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -250,6 +250,16 @@ impl FormulaScorer<'_> {
                     expression: format!("ln({value}) = {ln_value}"),
                 })
             }
+            ParsedExpression::Acosh(expr) => {
+                let value = self.eval_expression(expr, point_id)?;
+                let acosh_value = value.acosh();
+                if acosh_value.is_finite() {
+                    return Ok(acosh_value);
+                }
+                Err(OperationError::NonFiniteNumber {
+                    expression: format!("acosh({value}) = {acosh_value}"),
+                })
+            }
             ParsedExpression::Abs(expr) => {
                 let value = self.eval_expression(expr, point_id)?;
                 Ok(value.abs())
@@ -440,6 +450,17 @@ mod tests {
         ParsedExpression::Constant(PreciseScoreOrdered::from(10.0)), ParsedExpression::new_score_id(0), None
     ), 10.0 / 1.0)]
     #[case(ParsedExpression::new_neg(ParsedExpression::Constant(PreciseScoreOrdered::from(10.0))), -10.0)]
+    #[case(
+        ParsedExpression::new_acosh(ParsedExpression::Constant(PreciseScoreOrdered::from(1.0))),
+        0.0
+    )]
+    // acosh(cosh(2)) == 2
+    #[case(
+        ParsedExpression::new_acosh(ParsedExpression::Constant(PreciseScoreOrdered::from(
+            3.7621956910836314
+        ))),
+        2.0
+    )]
     // Error cases
     #[case(ParsedExpression::new_geo_distance(
         GeoPoint::new_unchecked(-100.43383200156751, 25.717877679163667), JsonPath::new(GEO_FIELD_NAME)
@@ -469,6 +490,11 @@ mod tests {
     #[should_panic(expected = r#"NonFiniteNumber { expression: "ln(0) = -inf" }"#)]
     #[case(
         ParsedExpression::new_ln(ParsedExpression::Constant(PreciseScoreOrdered::from(0.0))),
+        0.0
+    )]
+    #[should_panic(expected = r#"NonFiniteNumber { expression: "acosh(0.5) = NaN" }"#)]
+    #[case(
+        ParsedExpression::new_acosh(ParsedExpression::Constant(PreciseScoreOrdered::from(0.5))),
         0.0
     )]
     #[test]

--- a/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
@@ -79,6 +79,7 @@ pub enum ParsedExpression {
     Exp(Box<ParsedExpression>),
     Log10(Box<ParsedExpression>),
     Ln(Box<ParsedExpression>),
+    Acosh(Box<ParsedExpression>),
     Abs(Box<ParsedExpression>),
     Decay {
         kind: DecayKind,
@@ -165,6 +166,10 @@ impl ParsedExpression {
 
     pub fn new_ln(expression: ParsedExpression) -> Self {
         ParsedExpression::Ln(Box::new(expression))
+    }
+
+    pub fn new_acosh(expression: ParsedExpression) -> Self {
+        ParsedExpression::Acosh(Box::new(expression))
     }
 
     pub fn new_payload_id(path: JsonPath) -> Self {

--- a/lib/shard/src/query/conversions.rs
+++ b/lib/shard/src/query/conversions.rs
@@ -686,6 +686,9 @@ impl From<rest::Expression> for ExpressionInternal {
             rest::Expression::Ln(rest::LnExpression { ln: expr }) => {
                 ExpressionInternal::Ln(Box::new(ExpressionInternal::from(*expr)))
             }
+            rest::Expression::Acosh(rest::AcoshExpression { acosh: expr }) => {
+                ExpressionInternal::Acosh(Box::new(ExpressionInternal::from(*expr)))
+            }
             rest::Expression::Abs(rest::AbsExpression { abs: expr }) => {
                 ExpressionInternal::Abs(Box::new(ExpressionInternal::from(*expr)))
             }
@@ -832,6 +835,9 @@ impl TryFrom<grpc::Expression> for ExpressionInternal {
                 ExpressionInternal::Log10(Box::new((*expression).try_into()?))
             }
             Variant::Ln(expression) => ExpressionInternal::Ln(Box::new((*expression).try_into()?)),
+            Variant::Acosh(expression) => {
+                ExpressionInternal::Acosh(Box::new((*expression).try_into()?))
+            }
             Variant::LinDecay(decay_params) => {
                 try_from_decay_params(*decay_params, DecayKind::Lin)?
             }

--- a/lib/shard/src/query/formula.rs
+++ b/lib/shard/src/query/formula.rs
@@ -74,6 +74,7 @@ pub enum ExpressionInternal {
     Exp(Box<ExpressionInternal>),
     Log10(Box<ExpressionInternal>),
     Ln(Box<ExpressionInternal>),
+    Acosh(Box<ExpressionInternal>),
     Abs(Box<ExpressionInternal>),
     Decay {
         kind: DecayKind,
@@ -161,6 +162,9 @@ impl ExpressionInternal {
                 expression_internal.parse_and_convert(payload_vars, conditions)?,
             )),
             ExpressionInternal::Ln(expression_internal) => ParsedExpression::Ln(Box::new(
+                expression_internal.parse_and_convert(payload_vars, conditions)?,
+            )),
+            ExpressionInternal::Acosh(expression_internal) => ParsedExpression::Acosh(Box::new(
                 expression_internal.parse_and_convert(payload_vars, conditions)?,
             )),
             ExpressionInternal::Abs(expression_internal) => ParsedExpression::Abs(Box::new(

--- a/tests/openapi/test_query_formula.py
+++ b/tests/openapi/test_query_formula.py
@@ -1,5 +1,5 @@
 import pytest
-from math import isclose
+from math import acosh, isclose
 
 from .helpers.collection_setup import basic_collection_setup, drop_collection
 from .helpers.helpers import request_with_validation
@@ -44,6 +44,10 @@ def setup(on_disk_vectors, collection_name):
                 ],
             },
             lambda score, price: score + (price / (1.0 + abs(price))),
+        ),
+        (
+            {"acosh": {"sum": [1.0, {"abs": "price"}]}},
+            lambda score, price: acosh(1.0 + abs(price)),
         ),
     ],
 )


### PR DESCRIPTION
Closes #10186

Adds a unary `acosh` expression, parallel to `sqrt` / `ln` / `exp` / `log10`, so hyperbolic embeddings (Poincaré ball, Lorentz hyperboloid) can be rescored by exact geodesic distance without hand-expanding `ln(x + sqrt(x^2 - 1))` (which duplicates the argument subtree and loses precision near `x = 1`).

```json
{"acosh": <expression>}
```

### Semantics

- Evaluated in f64 via `f64::acosh` (numerically stable `ln(x + sqrt(x-1)·sqrt(x+1))` form).
- Domain is `x >= 1`; `acosh(1) == 0`. Inputs below `1` fail with the same `NonFiniteNumber` error as an invalid `sqrt` / `ln`:
  `Wrong input: The expression acosh(0.5) = NaN produced a non-finite number`
- No clamping for values marginally below `1` — callers add an epsilon, as the issue suggests.

### Surface

- REST: `AcoshExpression { acosh }` variant of `Expression` (+ regenerated OpenAPI)
- gRPC: `Expression.acosh = 20`
- Edge: FFI `Expression::acosh` constructor, Python `Expression.Acosh` + `.pyi` stub
- Internals: `ExpressionInternal::Acosh` → `ParsedExpression::Acosh`, unindexed-field extractor, gRPC unparse

### Validation

The issue's claims check out against `dev`: existing unary ops, error style, and the "not expressible today" point all hold. Ran the issue's Poincaré fixture end-to-end over REST and gRPC — Euclidean prefetch order `[1,2,3,4]`, `acosh` rescoring order `[2,1,4,3]`, scores `-0.8979416 / -1.0986123 / -1.736187 / -1.9371902` (match the issue's f64 reference within f32 precision).

### Tests

- `formula_scorer` unit cases: `acosh(1) == 0`, `acosh(cosh 2) == 2`, `acosh(0.5)` → `NonFiniteNumber`
- `tests/openapi/test_query_formula.py`: `acosh(1 + |price|)` case (also validates the regenerated schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)