### PR TITLE
docs(segment): fix leftover mmap_* rustdoc after on_disk rename

### DIFF
--- a/lib/segment/src/index/field_index/geo_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/mod.rs
@@ -32,7 +32,7 @@ mod read_ops;
 /// [1]: super::GeoIndex
 /// [2]: super::mutable_geo_index::MutableGeoIndex
 /// [3]: super::immutable_geo_index::ImmutableGeoIndex
-/// [4]: super::mmap_geo_index::OnDiskGeoIndex
+/// [4]: super::on_disk_geo_index::OnDiskGeoIndex
 /// [5]: super::GeoIndex::new_gridstore
 /// [6]: super::GeoIndex::new_mmap
 #[allow(clippy::large_enum_variant)]

--- a/lib/segment/src/payload_storage/read_only/mod.rs
+++ b/lib/segment/src/payload_storage/read_only/mod.rs
@@ -7,7 +7,7 @@ use common::universal_io::UniversalRead;
 
 use crate::types::Payload;
 
-/// Read-only counterpart to [`super::mmap_payload_storage::MmapPayloadStorage`].
+/// Read-only counterpart to [`super::payload_storage_impl::PayloadStorageImpl`].
 ///
 /// Backed by a [`BlobstoreReader`] over generic [`UniversalRead`] instead of a
 /// writable [`blobstore::Blobstore`]. Unlike the read-only field indexes there


### PR DESCRIPTION
Two rustdoc comments still point at `mmap_*` modules that were renamed. Documentation only, no code change.

- `geo_index/read_only/mod.rs`: footnote `[4]` linked `super::mmap_geo_index::OnDiskGeoIndex`. The type lives in `on_disk_geo_index` (already imported in this file).
- `payload_storage/read_only/mod.rs`: called the writable counterpart `mmap_payload_storage::MmapPayloadStorage`. That module does not exist; the writer is `payload_storage_impl::PayloadStorageImpl` (same target as `update_only` and `read_only/lifecycle.rs`).

Left alone on purpose: `geo_index/read_ops.rs` (`#9909`) and `numeric_index_read.rs` (`#10181` / `#9909`). Same leftover class, different files those PRs already edit.

`RUSTDOCFLAGS='-W rustdoc::broken_intra_doc_links' cargo doc -p segment --no-deps --locked` no longer warns on these two paths. `cargo +nightly fmt --check` on the two files passes.

### All Submissions

- [x] Targets the `dev` branch (branched from `dev`).
- [x] Followed the Contributing guidelines.
- [x] Checked there are no other open PRs for this change.

### How to test

```bash
RUSTDOCFLAGS='-W rustdoc::broken_intra_doc_links' cargo doc -p segment --no-deps --locked
cargo +nightly fmt --check -- lib/segment/src/index/field_index/geo_index/read_only/mod.rs lib/segment/src/payload_storage/read_only/mod.rs
```

### AI disclosure (per CONTRIBUTING.md)

Commits:
- [AI] docs(segment): fix leftover mmap_* rustdoc after on_disk rename

Prompt/intent: fix the leftover mmap rustdoc (same class as merged #9794). Two comment lines only; skip the files #10181 and #9909 already own.
