### PR TITLE
docs(collection): align SnapshotRecover.priority rustdoc with SnapshotPriority

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -14203,7 +14203,7 @@
             "format": "uri"
           },
           "priority": {
-            "description": "Defines which data should be used as a source of truth if there are other replicas in the cluster. If set to `Snapshot`, the snapshot will be used as a source of truth, and the current state will be overwritten. If set to `Replica`, the current state will be used as a source of truth, and after recovery if will be synchronized with the snapshot.",
+            "description": "Defines which data should be used as a source of truth if there are other replicas in the cluster. If set to `Snapshot`, the snapshot will be used as a source of truth, and the current state will be overwritten. If set to `Replica`, the current state will be used as a source of truth, and after recovery it will be synchronized from other replicas.",
             "default": null,
             "anyOf": [
               {

--- a/lib/collection/src/operations/snapshot_ops.rs
+++ b/lib/collection/src/operations/snapshot_ops.rs
@@ -70,7 +70,7 @@ pub struct SnapshotRecover {
 
     /// Defines which data should be used as a source of truth if there are other replicas in the cluster.
     /// If set to `Snapshot`, the snapshot will be used as a source of truth, and the current state will be overwritten.
-    /// If set to `Replica`, the current state will be used as a source of truth, and after recovery if will be synchronized with the snapshot.
+    /// If set to `Replica`, the current state will be used as a source of truth, and after recovery it will be synchronized from other replicas.
     #[serde(default)]
     pub priority: Option<SnapshotPriority>,
 


### PR DESCRIPTION
### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

`SnapshotPriority` already documents `Replica` as prefer existing data over the snapshot. The `SnapshotRecover.priority` field rustdoc said the opposite for the follow-up step (`synchronized with the snapshot`) and had a typo (`if will`). Recovery transfers from another replica onto this peer, so the field docs now say that.

OpenAPI description is generated from this rustdoc (`docs/redoc/master/openapi.json`) so it is updated in the same commit.

### How to test

Comment-only. No unit test asserts this wording.

```
cargo +nightly fmt --all -- --check
```

CI `test-consistency` regenerates OpenAPI from rustdoc and diffs `docs/redoc/master/openapi.json`.

### AI disclosure

- [AI] docs(collection): align SnapshotRecover.priority rustdoc with SnapshotPriority

Initial prompt:

```
Fix Qdrant SnapshotRecover.priority rustdoc (old #8) — XS, no CLA
One file, field docs contradict the enum plus a typo. Even smaller than mmap. Independent of #1 and of mmap.
```
