### PR TITLE
docs: correct config.yaml comments for workers, gRPC, and HTTP timeouts

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -74,6 +74,9 @@ storage:
     # Number of WAL segments to create ahead of actual data requirement
     wal_segments_ahead: 0
 
+    # Number of closed WAL segments to keep
+    wal_retain_closed: 1
+
   # Normal node - receives all updates and answers all queries
   node_type: "Normal"
 
@@ -319,7 +322,8 @@ service:
   # Maximum size of POST data in a single request in megabytes
   max_request_size_mb: 32
 
-  # Number of parallel workers used for serving the api. If 0 - equal to the number of available cores.
+  # Number of parallel workers used for serving the api.
+  # If 0 - available cores minus one, with a minimum of 1.
   # If missing - Same as storage.max_search_threads
   max_workers: 0
 
@@ -329,9 +333,22 @@ service:
   # HTTP(S) port to bind the service on
   http_port: 6333
 
+  # Keep-alive timeout for incoming HTTP connections in seconds.
+  # Default: 5
+  # http_keep_alive_timeout_sec: 5
+
+  # Timeout for reading HTTP request data from clients in seconds.
+  # Default: 5
+  # http_client_request_timeout_sec: 5
+
+  # Timeout for client disconnect handling in seconds.
+  # Default: 5
+  # http_client_disconnect_timeout_sec: 5
+
   # gRPC port to bind the service on.
-  # If `null` - gRPC is disabled. Default: null
-  # Comment to disable gRPC:
+  # If `null` - gRPC is disabled. Default: 6334
+  # Commenting this key in an overlay does not disable gRPC; the base config
+  # still supplies 6334. Set `null` to disable.
   grpc_port: 6334
 
   # Enable CORS headers in REST API.


### PR DESCRIPTION
### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes

`config/config.yaml` comments did not match the code:

- `max_workers: 0` is available cores minus one, with a minimum of 1 (`src/settings.rs`), not all cores.
- `grpc_port` in this file is `6334`, not `null`. Commenting the key in an overlay does not disable gRPC; set `null` to disable.
- The three HTTP timeout keys already default to 5 and are asserted in `test_default_config`, but they were missing from the yaml. Added as commented examples.
- Documented `storage.wal.wal_retain_closed: 1` (existing serde default).

### How to test

```
cargo test --bin qdrant -- settings::tests::test_default_config
cargo +nightly fmt --all -- --check
```

### AI disclosure

- [AI] docs: correct config.yaml comments for workers, gRPC, and HTTP timeouts

Initial prompt:

```
Implement the next Qdrant first PR from contributions recon (2026-08-15).

Start: .cursor/scripts/lane.sh start qdrant qdrant config-yaml-comments --base dev
Work only in the printed worktree. Notes only at the printed notes path. Never touch the canonical clone. Read qdrant/PROCESS.md first.

No CLA/DCO. PRs must target dev, not master. After commit, strip injected Cursor Co-authored-by. PR body must disclose which commits are AI vs manual and include this prompt. Do not AI-write review replies.

Fix config/config.yaml only (maybe one line in src/settings.rs if you touch workers). Do not dump the gpu: section.
1. max_workers: 0 comment is wrong. Code is max(1, get_num_cpus() - 1) at src/settings.rs:420-426, not “equal to available cores”.
2. gRPC “Default: null” is wrong; the file ships grpc_port: 6334. Overlay “uncomment to enable” files do not unset the base key.
3. Add keys already defaulted to 5 and asserted in test_default_config but missing from yaml: http_keep_alive_timeout_sec, http_client_request_timeout_sec, http_client_disconnect_timeout_sec. Optional: storage.wal.wal_retain_closed: 1.

Test: cargo test --bin qdrant -- settings::tests::test_default_config
Fmt: cargo +nightly fmt --all -- --check
Then oss-patch-reviewer + oss-prepush-gate, push fork, open PR to qdrant/qdrant:dev, lane.sh finish.
```
