### PR TITLE
add missing timeout parameter for get point API

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -4225,6 +4225,16 @@
             "schema": {
               "$ref": "#/components/schemas/ReadConsistency"
             }
+          },
+          {
+            "name": "timeout",
+            "in": "query",
+            "description": "If set, overrides global timeout for this request. Unit is seconds.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         ],
         "responses": {

--- a/openapi/openapi-points.ytt.yaml
+++ b/openapi/openapi-points.ytt.yaml
@@ -27,6 +27,13 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/ReadConsistency"
+        - name: timeout
+          in: query
+          description: If set, overrides global timeout for this request. Unit is seconds.
+          required: false
+          schema:
+            type: integer
+            minimum: 1
       responses: #@ response(reference("Record"))
 
   /collections/{collection_name}/points:

--- a/tests/openapi/test_basic_retrieve_api.py
+++ b/tests/openapi/test_basic_retrieve_api.py
@@ -20,6 +20,15 @@ def test_points_retrieve(collection_name):
     assert response.ok
 
     response = request_with_validation(
+        api='/collections/{collection_name}/points/{id}',
+        method="GET",
+        path_params={'collection_name': collection_name, 'id': 2},
+        query_params={'timeout': 1},
+    )
+    assert response.ok
+    assert response.json()['result']['id'] == 2
+
+    response = request_with_validation(
         api='/collections/{collection_name}/points',
         method="POST",
         path_params={'collection_name': collection_name},


### PR DESCRIPTION
### All Submissions:

> **⚠️ PRs must target the `dev` branch.** If your PR targets `master`, please change the base branch to `dev` before requesting a review.

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

No Rust sources changed in this PR (OpenAPI + one retrieve test). I did not run workspace clippy locally; disk on this machine was full enough that an earlier `cargo build --bins` hit ENOSPC. CI clippy should be a no-op for this diff.

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

## Summary

`GET /collections/{collection_name}/points/{id}` already accepts `Query<ReadParams>`, which includes `timeout`. The OpenAPI spec only listed `consistency`. `POST /collections/{collection_name}/points` already documents both.

This adds the same `timeout` query parameter (integer, minimum 1, same description as the POST retrieve) to the GET operation, regenerates `docs/redoc/master/openapi.json`, and extends the basic retrieve test so schema validation would fail if the parameter were missing.

## How to test

```bash
cargo +nightly fmt --all -- --check
cargo build --features "service_debug data-consistency-check staging" --locked
./target/debug/qdrant
# in another shell:
uv --project tests run pytest tests/openapi/test_basic_retrieve_api.py tests/openapi/test_validate_schema.py
```

CI `test-consistency` regenerates OpenAPI via `./tools/generate_openapi_models.sh` (`service_debug` only). Local ytt + `schema_generator` + schema2openapi + yq produced the same timeout-only JSON.

## AI disclosure

- [AI] add missing timeout parameter for get point API
- [manual] none

## Initial prompt

```
Implement Qdrant OpenAPI PR from contributions recon (2026-08-15).

Start: .cursor/scripts/lane.sh start qdrant qdrant openapi-get-point-timeout --base dev
Work only in the printed worktree. Notes only at the printed notes path. Never touch the canonical clone. Read qdrant/PROCESS.md.

PRs MUST target dev, not master. No CLA/DCO. After every commit, strip injected Cursor Co-authored-by (commit-tree, not --amend).
Repo AI policy: PR body must disclose which commits are AI vs manual (example: - [AI] … / - [manual] …) AND include this prompt. Do not AI-write review replies. You are responsible for the diff.

GET /collections/{name}/points/{id} handler already takes Query<ReadParams> including timeout (src/actix/api/retrieve_api.rs ~75-117). OpenAPI documents consistency only; POST /points documents both.

Edit openapi/openapi-points.ytt.yaml then run ./tools/generate_openapi_models.sh — CI test-consistency fails without generated drift.
Do not start claimed #9952 (VectorParams.size max) or #9872 (timeout minimum vs schema). Do not touch config.yaml / mmap rustdoc / SnapshotRecover (PRs #10232–#10234 already open).

Fmt: cargo +nightly fmt --all -- --check
Clippy (stronger than CONTRIBUTING): cargo clippy --workspace --all-targets --all-features -- -D warnings
Test: cargo build --features "service_debug data-consistency-check staging" --locked
Start ./target/debug/qdrant, then:
  uv --project tests run pytest tests/openapi/test_basic_retrieve_api.py tests/openapi/test_validate_schema.py

oss-patch-reviewer + oss-prepush-gate. Push fork. PR to qdrant/qdrant:dev. Verify commit + PR body have no Cursor trailer and DO have the AI disclosure + this prompt. lane.sh finish.
```
