### PR TITLE
[UpdateOnly] Honor upsert update_mode in the batch writer

### DIFF
--- a/lib/edge/src/update_only/apply.rs
+++ b/lib/edge/src/update_only/apply.rs
@@ -33,8 +33,12 @@ pub struct UpdateBatchOutcome {
     /// Points already at or beyond the batch's version, left untouched — what
     /// makes a replayed batch a no-op.
     pub skipped: usize,
+    /// Points every naming operation's update mode rejected, left untouched —
+    /// how many ids of an `insert_only` upsert were already taken.
+    pub rejected: usize,
     /// Points an operation named that no segment holds and the batch did not
-    /// create — a payload update to a point that is not there.
+    /// create — a payload update, or an `update_only` upsert, to a point that
+    /// is not there.
     pub missing: usize,
     /// One record per touched point, in first-touched order: what happened
     /// to it, and which slots it vacated where.
@@ -69,8 +73,23 @@ pub enum PointApplyKind {
     Deleted,
     /// Left untouched: already at or beyond the batch's version.
     Skipped,
+    /// Left untouched: every operation naming it was rejected by its update
+    /// mode.
+    Rejected,
     /// Named by an operation, held by no segment, not created by the batch.
     Missing,
+}
+
+impl PointApplyKind {
+    /// Whether the point's previous slots have to stop resolving: a point the
+    /// batch rewrote or removed must not keep serving from where it used to
+    /// sit. The kinds that write nothing leave every slot alone.
+    fn retires_slots(self) -> bool {
+        match self {
+            Self::Stored | Self::Deleted => true,
+            Self::Skipped | Self::Rejected | Self::Missing => false,
+        }
+    }
 }
 
 /// One copy of a point: where it lives, and at what version.
@@ -156,6 +175,10 @@ impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S> {
                     outcome.skipped += 1;
                     PointApplyKind::Skipped
                 }
+                PointAction::Rejected => {
+                    outcome.rejected += 1;
+                    PointApplyKind::Rejected
+                }
                 PointAction::Missing => {
                     outcome.missing += 1;
                     PointApplyKind::Missing
@@ -178,7 +201,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S> {
                 superseded: None,
             };
 
-            if matches!(kind, PointApplyKind::Stored | PointApplyKind::Deleted) {
+            if kind.retires_slots() {
                 for (segment, internal_id) in slots {
                     // The copy a stored point leaves behind in the write target
                     // needs no retirement: appending the point records a mapping

--- a/lib/edge/src/update_only/batch/mutation.rs
+++ b/lib/edge/src/update_only/batch/mutation.rs
@@ -7,6 +7,7 @@ use segment::data_types::named_vectors::NamedVectors;
 use segment::data_types::segment_record::NamedVectorBytesOwned;
 use segment::json_path::JsonPath;
 use segment::types::{Payload, PayloadKeyType, PointIdType, SeqNumberType, VectorNameBuf};
+use shard::operations::point_ops::UpdateMode;
 
 /// The vectors an operation carries, in the form the operation carried them:
 /// storage-native bytes travel to the new slot untouched, decoded vectors are
@@ -25,6 +26,9 @@ pub enum PointMutation {
     Replace {
         vectors: OperationVectors,
         payload: Payload,
+        /// The upsert's update mode, deciding whether it applies to a point
+        /// that already exists, one that does not, or both.
+        mode: UpdateMode,
     },
     /// The point is removed.
     Delete,
@@ -46,6 +50,41 @@ pub enum PointMutation {
 }
 
 impl PointMutation {
+    /// Whether this mutation applies at all, given whether the point exists
+    /// where this mutation sits in the fold. Only a conditional upsert can
+    /// answer `false` — every other mutation applies unconditionally.
+    ///
+    /// Existence is the whole condition: an upsert carrying a real filter is
+    /// rejected when the batch is built, so nothing here has to read payload.
+    fn applies(&self, exists: bool) -> bool {
+        match self {
+            Self::Replace {
+                mode,
+                vectors: _,
+                payload: _,
+            } => match mode {
+                UpdateMode::Upsert => true,
+                UpdateMode::InsertOnly => !exists,
+                UpdateMode::UpdateOnly => exists,
+            },
+            Self::Delete
+            | Self::UpdateVectors(_)
+            | Self::DeleteVectors(_)
+            | Self::SetPayload { .. }
+            | Self::OverwritePayload(_)
+            | Self::DeletePayload(_)
+            | Self::ClearPayload => true,
+        }
+    }
+
+    /// Whether this mutation applies whatever the point's current existence.
+    /// Only such a mutation may discard the mutations before it while the
+    /// batch is folded: a conditional one may turn out not to apply, and the
+    /// mutations it would have superseded then have to still be there.
+    fn always_applies(&self) -> bool {
+        self.applies(true) && self.applies(false)
+    }
+
     /// Whether this mutation makes every mutation before it irrelevant:
     /// nothing of the point as it stood survives, so neither the earlier
     /// mutations nor the stored point itself need to be looked at.
@@ -80,7 +119,7 @@ impl PointUpdates {
     }
 
     pub(super) fn push(&mut self, version: SeqNumberType, mutation: PointMutation) {
-        if mutation.discards_stored_point() {
+        if mutation.always_applies() && mutation.discards_stored_point() {
             self.mutations.clear();
         }
         self.version = self.version.max(version);
@@ -92,29 +131,59 @@ impl PointUpdates {
         self.version
     }
 
-    /// Whether applying these mutations requires reading the point as it is
-    /// stored today. False exactly when the first surviving mutation replaces
-    /// or removes the point.
-    pub fn needs_stored_point(&self) -> bool {
+    /// Whether any mutation applies at all, given whether a segment holds the
+    /// point today. `false` means every operation naming it was rejected by
+    /// its update mode — an `insert_only` upsert of a point that is already
+    /// there, or an `update_only` upsert of one that is not — and the point
+    /// must be left exactly as it stands.
+    ///
+    /// Answering against the point's existence *before* the batch is enough:
+    /// for existence to flip mid-fold some mutation has to have applied, which
+    /// is what this asks in the first place.
+    ///
+    /// [`materialize`](Self::materialize) assumes this is `true`; call it on a
+    /// point this rejects and it rewrites the point unchanged into a fresh
+    /// slot.
+    pub fn applies_any(&self, exists: bool) -> bool {
         self.mutations
-            .first()
-            .is_none_or(|mutation| !mutation.discards_stored_point())
+            .iter()
+            .any(|mutation| mutation.applies(exists))
     }
 
-    /// Fold the mutations onto `stored` — the point as it stands, absent when
-    /// no segment holds it — into the point to store.
+    /// Whether applying these mutations to a point some segment holds requires
+    /// reading it as it is stored today. False exactly when the first mutation
+    /// that applies replaces or removes the point — or when none applies.
+    ///
+    /// Only asked about points a segment holds: one that does not exist has
+    /// nothing to read. So the mutations are judged against `exists = true`,
+    /// which is what makes an `insert_only` upsert of an existing point free —
+    /// it is dropped, and the point it would have overwritten is never read.
+    pub fn needs_stored_point(&self) -> bool {
+        self.mutations
+            .iter()
+            .find(|mutation| mutation.applies(true))
+            .is_some_and(|mutation| !mutation.discards_stored_point())
+    }
+
+    /// Fold the mutations onto `stored` — the point as it stands — into the
+    /// point to store. `exists` says whether a segment holds the point;
+    /// `stored` carries its content, and is absent both when the point does
+    /// not exist and when [`needs_stored_point`](Self::needs_stored_point)
+    /// said the fold would discard it unread.
     ///
     /// `Ok(None)` means the batch leaves nothing to store: the point ends up
     /// deleted, or an operation that can only modify an existing point named
     /// one that does not exist.
+    ///
+    /// Only meaningful for a point [`applies_any`](Self::applies_any) accepts.
     pub fn materialize(
         self,
         id: PointIdType,
+        mut exists: bool,
         stored: Option<StoredPoint>,
     ) -> OperationResult<Option<FullyQualifiedPoint>> {
         let Self { version, mutations } = self;
 
-        let mut exists = stored.is_some();
         let (mut stored_vectors, mut payload) = match stored {
             Some(stored) => {
                 let StoredPoint {
@@ -132,10 +201,19 @@ impl PointUpdates {
         let mut updated_vectors = NamedVectors::default();
 
         for mutation in mutations {
+            // An upsert whose update mode does not match the point as it
+            // stands here in the fold leaves everything before it in place —
+            // including a point an earlier mutation of this very batch
+            // created, which is what an `insert_only` upsert has to see.
+            if !mutation.applies(exists) {
+                continue;
+            }
+
             match mutation {
                 PointMutation::Replace {
                     vectors,
                     payload: replacement,
+                    mode: _,
                 } => {
                     exists = true;
                     stored_vectors.clear();

--- a/lib/edge/src/update_only/batch/mutation.rs
+++ b/lib/edge/src/update_only/batch/mutation.rs
@@ -50,12 +50,12 @@ pub enum PointMutation {
 }
 
 impl PointMutation {
-    /// Whether this mutation applies at all, given whether the point exists
-    /// where this mutation sits in the fold. Only a conditional upsert can
-    /// answer `false` — every other mutation applies unconditionally.
+    /// Whether this mutation applies, given whether the point exists where
+    /// this mutation sits in the fold. Only a conditional upsert can answer
+    /// `false` — every other mutation applies unconditionally.
     ///
-    /// Existence is the whole condition: an upsert carrying a real filter is
-    /// rejected when the batch is built, so nothing here has to read payload.
+    /// Decided from `exists` alone, never from the point's content: an upsert
+    /// whose condition is more than existence never reaches a mutation.
     fn applies(&self, exists: bool) -> bool {
         match self {
             Self::Replace {
@@ -150,14 +150,14 @@ impl PointUpdates {
             .any(|mutation| mutation.applies(exists))
     }
 
-    /// Whether applying these mutations to a point some segment holds requires
-    /// reading it as it is stored today. False exactly when the first mutation
-    /// that applies replaces or removes the point — or when none applies.
+    /// Whether folding these mutations reads the point as it is stored today.
+    /// False exactly when the first mutation that applies replaces or removes
+    /// the point, and when none applies at all.
     ///
-    /// Only asked about points a segment holds: one that does not exist has
-    /// nothing to read. So the mutations are judged against `exists = true`,
-    /// which is what makes an `insert_only` upsert of an existing point free —
-    /// it is dropped, and the point it would have overwritten is never read.
+    /// Answers for a point some segment holds — one that does not exist has
+    /// nothing to read either way. So an `insert_only` upsert of an existing
+    /// point answers `false`: it is dropped, and the point it would have
+    /// overwritten is never fetched.
     pub fn needs_stored_point(&self) -> bool {
         self.mutations
             .iter()

--- a/lib/edge/src/update_only/batch/mutation.rs
+++ b/lib/edge/src/update_only/batch/mutation.rs
@@ -77,14 +77,6 @@ impl PointMutation {
         }
     }
 
-    /// Whether this mutation applies whatever the point's current existence.
-    /// Only such a mutation may discard the mutations before it while the
-    /// batch is folded: a conditional one may turn out not to apply, and the
-    /// mutations it would have superseded then have to still be there.
-    fn always_applies(&self) -> bool {
-        self.applies(true) && self.applies(false)
-    }
-
     /// Whether this mutation makes every mutation before it irrelevant:
     /// nothing of the point as it stood survives, so neither the earlier
     /// mutations nor the stored point itself need to be looked at.
@@ -119,7 +111,10 @@ impl PointUpdates {
     }
 
     pub(super) fn push(&mut self, version: SeqNumberType, mutation: PointMutation) {
-        if mutation.always_applies() && mutation.discards_stored_point() {
+        // Only a mutation that applies whatever the point's existence may
+        // discard the ones before it: a conditional upsert may turn out not to
+        // apply, and what it would have superseded then has to still be there.
+        if mutation.applies(true) && mutation.applies(false) && mutation.discards_stored_point() {
             self.mutations.clear();
         }
         self.version = self.version.max(version);
@@ -131,15 +126,9 @@ impl PointUpdates {
         self.version
     }
 
-    /// Whether any mutation applies at all, given whether a segment holds the
-    /// point today. `false` means every operation naming it was rejected by
-    /// its update mode — an `insert_only` upsert of a point that is already
-    /// there, or an `update_only` upsert of one that is not — and the point
-    /// must be left exactly as it stands.
-    ///
-    /// Answering against the point's existence *before* the batch is enough:
-    /// for existence to flip mid-fold some mutation has to have applied, which
-    /// is what this asks in the first place.
+    /// Whether any mutation applies, given whether a segment holds the point
+    /// today. `false` means every operation naming it was rejected by its
+    /// update mode, and the point must be left exactly as it stands.
     ///
     /// [`materialize`](Self::materialize) assumes this is `true`; call it on a
     /// point this rejects and it rewrites the point unchanged into a fresh

--- a/lib/edge/src/update_only/batch/plan.rs
+++ b/lib/edge/src/update_only/batch/plan.rs
@@ -3,11 +3,12 @@
 use ahash::AHashMap;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::data_types::named_vectors::NamedVectors;
-use segment::types::{PointIdType, SeqNumberType};
+use segment::types::{Filter, PointIdType, SeqNumberType};
 use shard::operations::CollectionUpdateOperations;
 use shard::operations::payload_ops::PayloadOps;
 use shard::operations::point_ops::{
-    PointOperations, PointStructPersisted, PointStructRawPersisted,
+    ConditionalInsertOperationInternal, PointInsertOperationsInternal, PointOperations,
+    PointStructPersisted, PointStructRawPersisted, UpdateMode,
 };
 use shard::operations::vector_ops::{PointVectorsPersisted, VectorOperations};
 
@@ -27,8 +28,8 @@ impl UpdateBatchPlan {
     /// operation-number order; the fold is order-sensitive.
     ///
     /// Rejects everything outside the writer's contract: operations that
-    /// select points by filter, point sync, conditional upserts, and the
-    /// schema-level operations.
+    /// select points by filter — a conditional upsert carrying a real
+    /// condition included — point sync, and the schema-level operations.
     pub fn build(
         operations: impl IntoIterator<Item = (SeqNumberType, CollectionUpdateOperations)>,
     ) -> OperationResult<Self> {
@@ -76,6 +77,37 @@ impl UpdateBatchPlan {
         }
     }
 
+    /// Fold an upsert's points in under `mode`, which decides whether each of
+    /// them applies to a point that already exists, one that does not, or
+    /// both.
+    fn push_upsert(
+        &mut self,
+        op_num: SeqNumberType,
+        points: PointInsertOperationsInternal,
+        mode: UpdateMode,
+    ) {
+        for point in points.into_point_vec() {
+            // Decode before destructuring: `get_vectors` reads the still-owned
+            // `vector` field, and taking the payload by value afterwards saves
+            // a clone of it.
+            let vectors = OperationVectors::Decoded(point.get_vectors().into_owned());
+            let PointStructPersisted {
+                id,
+                vector: _,
+                payload,
+            } = point;
+            self.push(
+                id,
+                op_num,
+                PointMutation::Replace {
+                    vectors,
+                    payload: payload.unwrap_or_default(),
+                    mode,
+                },
+            );
+        }
+    }
+
     fn push_point_operation(
         &mut self,
         op_num: SeqNumberType,
@@ -83,25 +115,26 @@ impl UpdateBatchPlan {
     ) -> OperationResult<()> {
         match operation {
             PointOperations::UpsertPoints(operation) => {
-                for point in operation.into_point_vec() {
-                    // Decode before destructuring: `get_vectors` reads the
-                    // still-owned `vector` field, and taking the payload by
-                    // value afterwards saves a clone of it.
-                    let vectors = OperationVectors::Decoded(point.get_vectors().into_owned());
-                    let PointStructPersisted {
-                        id,
-                        vector: _,
-                        payload,
-                    } = point;
-                    self.push(
-                        id,
-                        op_num,
-                        PointMutation::Replace {
-                            vectors,
-                            payload: payload.unwrap_or_default(),
-                        },
-                    );
+                self.push_upsert(op_num, operation, UpdateMode::Upsert);
+            }
+            PointOperations::UpsertPointsConditional(operation) => {
+                let ConditionalInsertOperationInternal {
+                    points_op,
+                    condition,
+                    update_mode,
+                } = operation;
+                // Whether a point exists is the whole condition the accepted
+                // modes need, and the batch locates every point it touches
+                // anyway. A real condition would mean querying payload
+                // indexes, which the writer never fetches.
+                //
+                // Rejected for `insert_only` too, even though the apply path
+                // ignores the condition in that mode: silently dropping a
+                // condition the caller wrote is worse than refusing it.
+                if condition != Filter::default() {
+                    return Err(unsupported("conditional upserts with a filter condition"));
                 }
+                self.push_upsert(op_num, points_op, update_mode.unwrap_or_default());
             }
             PointOperations::UpsertPointsRaw(points) => {
                 for mut point in points {
@@ -119,6 +152,7 @@ impl UpdateBatchPlan {
                         PointMutation::Replace {
                             vectors: OperationVectors::Raw(vectors),
                             payload: payload.unwrap_or_default(),
+                            mode: UpdateMode::Upsert,
                         },
                     );
                 }
@@ -127,9 +161,6 @@ impl UpdateBatchPlan {
                 for id in ids {
                     self.push(id, op_num, PointMutation::Delete);
                 }
-            }
-            PointOperations::UpsertPointsConditional(_) => {
-                return Err(unsupported("conditional upserts"));
             }
             PointOperations::DeletePointsByFilter(_) => {
                 return Err(unsupported("deleting points by filter"));

--- a/lib/edge/src/update_only/batch/plan.rs
+++ b/lib/edge/src/update_only/batch/plan.rs
@@ -123,14 +123,11 @@ impl UpdateBatchPlan {
                     condition,
                     update_mode,
                 } = operation;
-                // Whether a point exists is the whole condition the accepted
-                // modes need, and the batch locates every point it touches
-                // anyway. A real condition would mean querying payload
-                // indexes, which the writer never fetches.
-                //
-                // Rejected for `insert_only` too, even though the apply path
-                // ignores the condition in that mode: silently dropping a
-                // condition the caller wrote is worse than refusing it.
+                // Existence is the whole gate the accepted modes need, and the
+                // batch locates every point it touches anyway. A real
+                // condition needs payload indexes the writer never fetches —
+                // rejected for `insert_only` too, whose apply path ignores it,
+                // so a condition the caller wrote is never silently dropped.
                 if condition != Filter::default() {
                     return Err(unsupported("conditional upserts with a filter condition"));
                 }

--- a/lib/edge/src/update_only/batch/tests.rs
+++ b/lib/edge/src/update_only/batch/tests.rs
@@ -1,8 +1,11 @@
 use segment::payload_json;
-use segment::types::{Payload, PointIdType};
+use segment::types::{Condition, Filter, HasIdCondition, Payload, PointIdType};
 use shard::operations::CollectionUpdateOperations;
 use shard::operations::payload_ops::{PayloadOps, SetPayloadOp};
-use shard::operations::point_ops::{PointOperations, PointStructPersisted, VectorStructPersisted};
+use shard::operations::point_ops::{
+    ConditionalInsertOperationInternal, PointOperations, PointStructPersisted, UpdateMode,
+    VectorStructPersisted,
+};
 
 use super::UpdateBatchPlan;
 
@@ -10,14 +13,32 @@ fn point_id(id: u64) -> PointIdType {
     PointIdType::NumId(id)
 }
 
+fn point(id: u64, payload: Payload) -> PointStructPersisted {
+    PointStructPersisted {
+        id: point_id(id),
+        vector: VectorStructPersisted::Single(vec![1.0, 0.0]),
+        payload: Some(payload),
+    }
+}
+
 fn upsert(id: u64, payload: Payload) -> CollectionUpdateOperations {
     CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-        vec![PointStructPersisted {
-            id: point_id(id),
-            vector: VectorStructPersisted::Single(vec![1.0, 0.0]),
-            payload: Some(payload),
-        }]
-        .into(),
+        vec![point(id, payload)].into(),
+    ))
+}
+
+fn conditional_upsert(
+    id: u64,
+    payload: Payload,
+    mode: UpdateMode,
+    condition: Filter,
+) -> CollectionUpdateOperations {
+    CollectionUpdateOperations::PointOperation(PointOperations::UpsertPointsConditional(
+        ConditionalInsertOperationInternal {
+            points_op: vec![point(id, payload)].into(),
+            condition,
+            update_mode: Some(mode),
+        },
     ))
 }
 
@@ -54,7 +75,7 @@ fn folds_operations_on_the_same_point() {
     assert_eq!(id, point_id(7));
     assert_eq!(updates.version(), 2);
 
-    let point = updates.materialize(id, None).unwrap().unwrap();
+    let point = updates.materialize(id, false, None).unwrap().unwrap();
     assert_eq!(point.version, 2);
     assert_eq!(point.payload, payload_json! { "a": 1, "b": 2 });
 }
@@ -83,7 +104,7 @@ fn delete_discards_preceding_operations() {
     assert_eq!(plan.point_ids_needing_stored_point().count(), 0);
 
     let (id, updates) = plan.into_point_updates().next().unwrap();
-    assert!(updates.materialize(id, None).unwrap().is_none());
+    assert!(updates.materialize(id, false, None).unwrap().is_none());
 }
 
 /// ... and an upsert after a delete brings the point back.
@@ -93,8 +114,108 @@ fn upsert_after_delete_recreates_the_point() {
         UpdateBatchPlan::build([(1, delete(7)), (2, upsert(7, payload_json! { "a": 1 }))]).unwrap();
 
     let (id, updates) = plan.into_point_updates().next().unwrap();
-    let point = updates.materialize(id, None).unwrap().unwrap();
+    let point = updates.materialize(id, false, None).unwrap().unwrap();
     assert_eq!(point.payload, payload_json! { "a": 1 });
+}
+
+/// An `insert_only` upsert of a point that is already there applies nothing —
+/// and the point it would have overwritten is never read.
+#[test]
+fn insert_only_upsert_leaves_an_existing_point_alone() {
+    let plan = UpdateBatchPlan::build([(
+        1,
+        conditional_upsert(
+            7,
+            payload_json! { "a": 1 },
+            UpdateMode::InsertOnly,
+            Filter::default(),
+        ),
+    )])
+    .unwrap();
+
+    assert_eq!(plan.point_ids_needing_stored_point().count(), 0);
+
+    let (id, updates) = plan.into_point_updates().next().unwrap();
+    assert!(!updates.applies_any(true));
+    // ...and the same operation does create the point when it is not there.
+    assert!(updates.applies_any(false));
+    assert_eq!(
+        updates
+            .materialize(id, false, None)
+            .unwrap()
+            .unwrap()
+            .payload,
+        payload_json! { "a": 1 },
+    );
+}
+
+/// An `update_only` upsert of a point no segment holds applies nothing.
+#[test]
+fn update_only_upsert_does_not_create_a_missing_point() {
+    let plan = UpdateBatchPlan::build([(
+        1,
+        conditional_upsert(
+            7,
+            payload_json! { "a": 1 },
+            UpdateMode::UpdateOnly,
+            Filter::default(),
+        ),
+    )])
+    .unwrap();
+
+    let (_id, updates) = plan.into_point_updates().next().unwrap();
+    assert!(!updates.applies_any(false));
+    assert!(updates.applies_any(true));
+}
+
+/// The condition is judged where the upsert sits in the fold, not against the
+/// state the batch started from: a point an earlier operation of the same
+/// batch created counts as existing, so an `insert_only` upsert after it does
+/// not overwrite it. That mirrors the leader, which resolves each operation
+/// only after the ones before it were applied.
+#[test]
+fn insert_only_upsert_does_not_overwrite_what_the_batch_just_created() {
+    let plan = UpdateBatchPlan::build([
+        (1, upsert(7, payload_json! { "a": 1 })),
+        (
+            2,
+            conditional_upsert(
+                7,
+                payload_json! { "a": 2 },
+                UpdateMode::InsertOnly,
+                Filter::default(),
+            ),
+        ),
+    ])
+    .unwrap();
+
+    let (id, updates) = plan.into_point_updates().next().unwrap();
+    // The conditional upsert may not apply, so it may not discard the plain
+    // upsert it follows.
+    assert!(updates.applies_any(false));
+
+    let point = updates.materialize(id, false, None).unwrap().unwrap();
+    assert_eq!(point.payload, payload_json! { "a": 1 });
+    assert_eq!(point.version, 2);
+}
+
+/// A conditional upsert carrying a real condition needs payload indexes the
+/// writer never fetches, so it is rejected rather than silently applied as if
+/// the condition held.
+#[test]
+fn rejects_conditional_upsert_with_a_condition() {
+    let condition = Filter::new_must(Condition::HasId(HasIdCondition::from(
+        [point_id(7)].into_iter().collect::<ahash::AHashSet<_>>(),
+    )));
+
+    for mode in [
+        UpdateMode::Upsert,
+        UpdateMode::InsertOnly,
+        UpdateMode::UpdateOnly,
+    ] {
+        let operation = conditional_upsert(7, payload_json! { "a": 1 }, mode, condition.clone());
+        assert!(UpdateBatchPlan::build([(1, operation)]).is_err());
+    }
 }
 
 /// Filter-selected operations are rejected up front, not silently applied to

--- a/lib/edge/src/update_only/batch/tests.rs
+++ b/lib/edge/src/update_only/batch/tests.rs
@@ -149,25 +149,6 @@ fn insert_only_upsert_leaves_an_existing_point_alone() {
     );
 }
 
-/// An `update_only` upsert of a point no segment holds applies nothing.
-#[test]
-fn update_only_upsert_does_not_create_a_missing_point() {
-    let plan = UpdateBatchPlan::build([(
-        1,
-        conditional_upsert(
-            7,
-            payload_json! { "a": 1 },
-            UpdateMode::UpdateOnly,
-            Filter::default(),
-        ),
-    )])
-    .unwrap();
-
-    let (_id, updates) = plan.into_point_updates().next().unwrap();
-    assert!(!updates.applies_any(false));
-    assert!(updates.applies_any(true));
-}
-
 /// The condition is judged where the upsert sits in the fold, not against the
 /// state the batch started from: a point an earlier operation of the same
 /// batch created counts as existing, so an `insert_only` upsert after it does

--- a/lib/edge/src/update_only/mod.rs
+++ b/lib/edge/src/update_only/mod.rs
@@ -10,7 +10,12 @@
 //! * writers are opened once, at shard open, next to the segments they resume
 //!   from; the store components only on the first point actually stored. Every
 //!   lookup is one batched pass per component over the whole point set;
-//! * there is no WAL: a batch is durable when the storages are flushed.
+//! * there is no WAL: a batch is durable when the storages are flushed;
+//! * an upsert's `update_mode` is honored off the same lookup: whether a point
+//!   exists is what locating it already answers, so `insert_only` costs
+//!   nothing beyond a plain upsert — and less, since the points it rejects are
+//!   never read. A conditional upsert carrying a real filter is rejected:
+//!   evaluating one needs payload indexes the writer never fetches.
 //!
 //! Storage is append-only throughout. Updating a point appends it in full and
 //! retires its old copy; a deletion writes no point data at all — it records

--- a/lib/edge/src/update_only/preview.rs
+++ b/lib/edge/src/update_only/preview.rs
@@ -56,8 +56,13 @@ pub enum PointAction {
     /// Left untouched: the stored copy is already at or beyond the batch's
     /// version, so re-applying would move the point backwards.
     Skip,
+    /// Left untouched: every operation naming the point was rejected by its
+    /// update mode — an `insert_only` upsert of a point that is already
+    /// there. Nothing is written and no slot is retired.
+    Rejected,
     /// An operation that can only modify an existing point named one that no
-    /// segment holds; there is nothing to write.
+    /// segment holds; there is nothing to write. An `update_only` upsert of a
+    /// point that does not exist lands here.
     Missing,
 }
 
@@ -86,6 +91,7 @@ pub(super) fn resolve_batch<S: UniversalRead + 'static>(
             .map(|location| location.slots.clone())
             .unwrap_or_default();
 
+        let exists = current.is_some();
         // Already applied: the stored point is at or beyond this batch's
         // version, so re-applying would move it backwards.
         let already_applied = current
@@ -94,10 +100,19 @@ pub(super) fn resolve_batch<S: UniversalRead + 'static>(
 
         let action = if already_applied {
             PointAction::Skip
+        } else if !updates.applies_any(exists) {
+            // Every operation was rejected by its update mode. A rejected
+            // `update_only` upsert is the `Missing` case — an operation that
+            // can only modify an existing point, naming one that is not there.
+            if exists {
+                PointAction::Rejected
+            } else {
+                PointAction::Missing
+            }
         } else {
-            match updates.materialize(id, stored.remove(&id))? {
+            match updates.materialize(id, exists, stored.remove(&id))? {
                 Some(point) => PointAction::Store(Box::new(point)),
-                None if current.is_some() => PointAction::Delete,
+                None if exists => PointAction::Delete,
                 None => PointAction::Missing,
             }
         };

--- a/lib/edge/src/update_only/tests.rs
+++ b/lib/edge/src/update_only/tests.rs
@@ -197,11 +197,13 @@ mod store {
     use common::universal_io::MmapFs;
     use segment::payload_json;
     use segment::payload_storage::update_only::UpdateOnlyPayloadStorage;
-    use segment::types::{WithPayloadInterface, WithVector};
+    use segment::types::{Filter, Payload, WithPayloadInterface, WithVector};
     use shard::files::SEGMENTS_PATH;
     use shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
-    use shard::operations::point_ops::PointOperations::UpsertPoints;
-    use shard::operations::point_ops::PointStructPersisted;
+    use shard::operations::point_ops::PointOperations::{UpsertPoints, UpsertPointsConditional};
+    use shard::operations::point_ops::{
+        ConditionalInsertOperationInternal, PointStructPersisted, UpdateMode,
+    };
 
     use super::*;
     use crate::RetrieveRequestBuilder;
@@ -230,6 +232,39 @@ mod store {
         points: Vec<PointStructPersisted>,
     ) -> [(SeqNumberType, CollectionUpdateOperations); 1] {
         [(op_num, PointOperation(UpsertPoints(PointsList(points))))]
+    }
+
+    /// A batch of one conditional upsert with the empty condition — existence
+    /// is the whole gate, which is what the writer accepts.
+    fn conditional_batch(
+        op_num: SeqNumberType,
+        points: Vec<PointStructPersisted>,
+        update_mode: UpdateMode,
+    ) -> [(SeqNumberType, CollectionUpdateOperations); 1] {
+        [(
+            op_num,
+            PointOperation(UpsertPointsConditional(
+                ConditionalInsertOperationInternal {
+                    points_op: PointsList(points),
+                    condition: Filter::default(),
+                    update_mode: Some(update_mode),
+                },
+            )),
+        )]
+    }
+
+    fn insert_only_batch(
+        op_num: SeqNumberType,
+        points: Vec<PointStructPersisted>,
+    ) -> [(SeqNumberType, CollectionUpdateOperations); 1] {
+        conditional_batch(op_num, points, UpdateMode::InsertOnly)
+    }
+
+    fn update_only_batch(
+        op_num: SeqNumberType,
+        points: Vec<PointStructPersisted>,
+    ) -> [(SeqNumberType, CollectionUpdateOperations); 1] {
+        conditional_batch(op_num, points, UpdateMode::UpdateOnly)
     }
 
     /// A batch of stores against the appendable segment: a new point (with a
@@ -420,5 +455,111 @@ mod store {
                 .to_vec(),
         );
         assert_follower_vectors(&follower, &[11, 12]);
+    }
+
+    /// An `insert_only` batch over a mix of taken and free ids: the free ones
+    /// are created, the taken ones keep the leader's point untouched — no
+    /// rewrite, no tombstone, no version bump — and the run reports which was
+    /// which.
+    #[test]
+    fn insert_only_batch_creates_only_the_free_ids() {
+        let dir = leader_with_ten_points("edge-update-insert-only");
+        recreate_payload_storages_append_only(dir.path());
+
+        // Point 5 is taken; giving the rejected upsert a vector the fixture
+        // would never produce makes an accidental overwrite visible.
+        let taken = PointStructPersisted {
+            vector: point(50).vector,
+            payload: Some(payload_json! { "kind": "rejected" }),
+            ..point(5)
+        };
+        let free = PointStructPersisted {
+            payload: Some(payload_json! { "kind": "fresh" }),
+            ..point(11)
+        };
+
+        let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+        let (writer, outcome) = writer
+            .apply_batch(insert_only_batch(100, vec![taken.clone(), free]))
+            .unwrap();
+
+        assert_eq!(outcome.stored, 1);
+        assert_eq!(outcome.rejected, 1);
+        assert_eq!(outcome.deleted, 0);
+        assert_eq!(outcome.skipped, 0);
+        assert_eq!(outcome.missing, 0);
+
+        let [rejected, created] = &outcome.points[..] else {
+            panic!("expected one record per touched point");
+        };
+        assert_eq!(rejected.id, ExtendedPointId::NumId(5));
+        assert_eq!(rejected.kind, PointApplyKind::Rejected);
+        // A rejected point keeps every slot it had: nothing was written that
+        // could supersede them.
+        assert!(rejected.tombstoned.is_empty());
+        assert_eq!(rejected.superseded, None);
+        assert_eq!(created.id, ExtendedPointId::NumId(11));
+        assert_eq!(created.kind, PointApplyKind::Stored);
+
+        let follower = open_follower(dir.path());
+        assert_eq!(exact_count(&follower), 11);
+        // Point 5 still reads as the leader wrote it, payload included.
+        assert_follower_vectors(&follower, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        let results = follower
+            .retrieve(
+                RetrieveRequestBuilder::new(vec![ExtendedPointId::NumId(5)])
+                    .with_payload(WithPayloadInterface::Bool(true))
+                    .build(),
+            )
+            .unwrap();
+        assert_eq!(results[0].payload, Some(Payload::default()));
+
+        // The id it just created is now taken, so replaying the same batch
+        // through the same writer rejects both.
+        let (_writer, replayed) = writer
+            .apply_batch(insert_only_batch(101, vec![taken, point(11)]))
+            .unwrap();
+        assert_eq!(replayed.stored, 0);
+        assert_eq!(replayed.rejected, 2);
+    }
+
+    /// An `update_only` batch is the mirror image: ids no segment holds are
+    /// reported missing rather than created.
+    #[test]
+    fn update_only_batch_does_not_create_missing_ids() {
+        let dir = leader_with_ten_points("edge-update-update-only");
+        recreate_payload_storages_append_only(dir.path());
+
+        let existing = PointStructPersisted {
+            payload: Some(payload_json! { "kind": "updated" }),
+            ..point(5)
+        };
+
+        let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
+        let (_writer, outcome) = writer
+            .apply_batch(update_only_batch(100, vec![existing, point(11)]))
+            .unwrap();
+
+        assert_eq!(outcome.stored, 1);
+        assert_eq!(outcome.missing, 1);
+        assert_eq!(outcome.rejected, 0);
+
+        let follower = open_follower(dir.path());
+        assert_eq!(exact_count(&follower), 10);
+        assert_eq!(
+            scrolled_ids(&follower),
+            (1..=10).map(ExtendedPointId::NumId).collect::<Vec<_>>(),
+        );
+        let results = follower
+            .retrieve(
+                RetrieveRequestBuilder::new(vec![ExtendedPointId::NumId(5)])
+                    .with_payload(WithPayloadInterface::Bool(true))
+                    .build(),
+            )
+            .unwrap();
+        assert_eq!(
+            results[0].payload,
+            Some(payload_json! { "kind": "updated" })
+        );
     }
 }

--- a/lib/edge/src/update_only/tests.rs
+++ b/lib/edge/src/update_only/tests.rs
@@ -253,20 +253,6 @@ mod store {
         )]
     }
 
-    fn insert_only_batch(
-        op_num: SeqNumberType,
-        points: Vec<PointStructPersisted>,
-    ) -> [(SeqNumberType, CollectionUpdateOperations); 1] {
-        conditional_batch(op_num, points, UpdateMode::InsertOnly)
-    }
-
-    fn update_only_batch(
-        op_num: SeqNumberType,
-        points: Vec<PointStructPersisted>,
-    ) -> [(SeqNumberType, CollectionUpdateOperations); 1] {
-        conditional_batch(op_num, points, UpdateMode::UpdateOnly)
-    }
-
     /// A batch of stores against the appendable segment: a new point (with a
     /// payload) and a rewrite of an existing one, appended by the writer and read
     /// back through an ordinary follower.
@@ -480,7 +466,11 @@ mod store {
 
         let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
         let (writer, outcome) = writer
-            .apply_batch(insert_only_batch(100, vec![taken.clone(), free]))
+            .apply_batch(conditional_batch(
+                100,
+                vec![taken.clone(), free],
+                UpdateMode::InsertOnly,
+            ))
             .unwrap();
 
         assert_eq!(outcome.stored, 1);
@@ -517,7 +507,11 @@ mod store {
         // The id it just created is now taken, so replaying the same batch
         // through the same writer rejects both.
         let (_writer, replayed) = writer
-            .apply_batch(insert_only_batch(101, vec![taken, point(11)]))
+            .apply_batch(conditional_batch(
+                101,
+                vec![taken, point(11)],
+                UpdateMode::InsertOnly,
+            ))
             .unwrap();
         assert_eq!(replayed.stored, 0);
         assert_eq!(replayed.rejected, 2);
@@ -537,7 +531,11 @@ mod store {
 
         let writer = UpdateOnlyEdgeShard::<MmapFile>::open_mmap(dir.path()).unwrap();
         let (_writer, outcome) = writer
-            .apply_batch(update_only_batch(100, vec![existing, point(11)]))
+            .apply_batch(conditional_batch(
+                100,
+                vec![existing, point(11)],
+                UpdateMode::UpdateOnly,
+            ))
             .unwrap();
 
         assert_eq!(outcome.stored, 1);

--- a/lib/edge/tools/shard_update/src/main.rs
+++ b/lib/edge/tools/shard_update/src/main.rs
@@ -68,12 +68,11 @@ use common::universal_io::{
 };
 use edge::external::uuid::Uuid;
 use edge::{
-    ConditionalInsertOperation, Filter, FullyQualifiedPoint, ManifestSegmentEnumerator,
-    PAYLOAD_INDEX_CONFIG_FILE, Payload, PayloadConfig, PayloadFieldSchema, PayloadSchemaParams,
-    PayloadSchemaType, PointAction, PointApplyKind, PointApplyRecord, PointId,
-    PointInsertOperations, PointOperations, PointStructPersisted, SegmentConfig, SegmentConfigInfo,
-    SparseVector, UpdateMode, UpdateOnlyEdgeShard, UpdateOperation, VectorPersisted,
-    VectorStructPersisted, get_payload_index_path,
+    FullyQualifiedPoint, ManifestSegmentEnumerator, PAYLOAD_INDEX_CONFIG_FILE, Payload,
+    PayloadConfig, PayloadFieldSchema, PayloadSchemaParams, PayloadSchemaType, PointAction,
+    PointApplyKind, PointApplyRecord, PointId, PointOperations, PointStructPersisted,
+    SegmentConfig, SegmentConfigInfo, SparseVector, UpdateOnlyEdgeShard, UpdateOperation,
+    VectorPersisted, VectorStructPersisted, get_payload_index_path,
 };
 use io_bridge_object_store::backends::aws::{AwsConfig, AwsCredentials};
 use io_bridge_object_store::backends::gcp::{GcsConfig, GcsCredentials};
@@ -95,28 +94,6 @@ enum Backend {
     Aws,
     /// Google Cloud Storage.
     Gcs,
-}
-
-/// Which points of the generated upsert are written, mirroring the
-/// `update_mode` of the REST/gRPC upsert.
-#[derive(Clone, Copy, Debug, ValueEnum)]
-enum UpdateModeArg {
-    /// Write every id: overwrite the ones that exist, create the rest.
-    Upsert,
-    /// Write only ids no segment holds; leave the ones that exist alone.
-    InsertOnly,
-    /// Write only ids that already exist; do not create the rest.
-    UpdateOnly,
-}
-
-impl From<UpdateModeArg> for UpdateMode {
-    fn from(mode: UpdateModeArg) -> Self {
-        match mode {
-            UpdateModeArg::Upsert => UpdateMode::Upsert,
-            UpdateModeArg::InsertOnly => UpdateMode::InsertOnly,
-            UpdateModeArg::UpdateOnly => UpdateMode::UpdateOnly,
-        }
-    }
 }
 
 #[derive(Parser, Debug)]
@@ -146,10 +123,6 @@ struct Cli {
     /// UUIDs. Ids no segment holds are created rather than overwritten.
     #[arg(long, value_delimiter = ',', required = true)]
     ids: Vec<String>,
-
-    /// Update mode of the generated upsert.
-    #[arg(long, value_enum, default_value = "upsert")]
-    update_mode: UpdateModeArg,
 
     /// Operation number recorded as the new points' version. A point whose
     /// stored version is at or beyond this is reported as skipped — the
@@ -491,7 +464,7 @@ fn log_preview_point(point: &edge::PointPreview) {
              re-run with a higher --op-num to overwrite",
         ),
         PointAction::Rejected => {
-            log::info!("point {id}: already there — rejected by --update-mode, left untouched",);
+            log::info!("point {id}: already there — rejected by the upsert's update mode");
         }
         PointAction::Missing => {
             log::info!("point {id}: names a point no segment holds — nothing to do");
@@ -501,12 +474,7 @@ fn log_preview_point(point: &edge::PointPreview) {
 
 /// Generate the random upsert batch off the shard's schema, logging each
 /// point's shape.
-fn generate_batch(
-    schema: &ShardSchema,
-    ids: &[PointId],
-    seed: u64,
-    mode: UpdateMode,
-) -> UpdateOperation {
+fn generate_batch(schema: &ShardSchema, ids: &[PointId], seed: u64) -> UpdateOperation {
     let mut rng = StdRng::seed_from_u64(seed);
     let points: Vec<PointStructPersisted> = ids
         .iter()
@@ -540,21 +508,7 @@ fn generate_batch(
         })
         .collect();
 
-    let points = PointInsertOperations::PointsList(points);
-    let operation = match mode {
-        UpdateMode::Upsert => PointOperations::UpsertPoints(points),
-        // The writer accepts a conditional upsert only with an empty
-        // condition — existence is the whole condition it can answer.
-        UpdateMode::InsertOnly | UpdateMode::UpdateOnly => {
-            PointOperations::UpsertPointsConditional(ConditionalInsertOperation {
-                points_op: points,
-                condition: Filter::default(),
-                update_mode: Some(mode),
-            })
-        }
-    };
-
-    UpdateOperation::PointOperation(operation)
+    UpdateOperation::PointOperation(PointOperations::UpsertPoints(points.into()))
 }
 
 /// Generate the random batch, resolve it against the open shard, and log what
@@ -566,9 +520,8 @@ fn dry_run<S: UniversalAppend + 'static>(
     ids: &[PointId],
     op_num: u64,
     seed: u64,
-    mode: UpdateMode,
 ) -> Result<()> {
-    let operation = generate_batch(schema, ids, seed, mode);
+    let operation = generate_batch(schema, ids, seed);
 
     let preview = shard
         .preview_batch([(op_num, operation)])
@@ -600,7 +553,7 @@ fn dry_run<S: UniversalAppend + 'static>(
 
     log::info!(
         "summary: {stored} point(s) would be appended to the write target, \
-         {skipped} skipped, {rejected} rejected by --update-mode",
+         {skipped} skipped, {rejected} rejected by their update mode",
     );
     for (segment, count) in &tombstones {
         log::info!("summary: segment {segment} would receive {count} tombstone(s)");
@@ -621,12 +574,11 @@ fn apply_run<S: UniversalAppend + 'static>(
     ids: &[PointId],
     mut op_num: u64,
     mut seed: u64,
-    mode: UpdateMode,
     interactive: bool,
 ) -> Result<()> {
     let mut ids = ids.to_vec();
     loop {
-        let operation = generate_batch(schema, &ids, seed, mode);
+        let operation = generate_batch(schema, &ids, seed);
 
         let (returned, outcome) = shard
             .apply_batch([(op_num, operation)])
@@ -694,7 +646,7 @@ fn log_apply_record(record: &PointApplyRecord) {
             log::info!("point {id}: skipped — already at or beyond this op-num");
         }
         PointApplyKind::Rejected => {
-            log::info!("point {id}: already there — rejected by --update-mode");
+            log::info!("point {id}: already there — rejected by its update mode");
         }
         PointApplyKind::Missing => {
             log::info!("point {id}: no segment holds it — nothing to do");
@@ -821,24 +773,9 @@ fn run_local(cli: &Cli, ids: &[PointId]) -> Result<()> {
 
     let schema = read_schema(&shard, &common::universal_io::MmapFs, &path)?;
     if cli.apply {
-        apply_run(
-            shard,
-            &schema,
-            ids,
-            cli.op_num,
-            cli.seed,
-            cli.update_mode.into(),
-            cli.interactive,
-        )
+        apply_run(shard, &schema, ids, cli.op_num, cli.seed, cli.interactive)
     } else {
-        dry_run(
-            &shard,
-            &schema,
-            ids,
-            cli.op_num,
-            cli.seed,
-            cli.update_mode.into(),
-        )
+        dry_run(&shard, &schema, ids, cli.op_num, cli.seed)
     }
 }
 
@@ -871,24 +808,9 @@ where
 
     let schema = read_schema(&shard, &cached_fs, &prefix)?;
     if cli.apply {
-        apply_run(
-            shard,
-            &schema,
-            ids,
-            cli.op_num,
-            cli.seed,
-            cli.update_mode.into(),
-            cli.interactive,
-        )
+        apply_run(shard, &schema, ids, cli.op_num, cli.seed, cli.interactive)
     } else {
-        dry_run(
-            &shard,
-            &schema,
-            ids,
-            cli.op_num,
-            cli.seed,
-            cli.update_mode.into(),
-        )
+        dry_run(&shard, &schema, ids, cli.op_num, cli.seed)
     }
 }
 

--- a/lib/edge/tools/shard_update/src/main.rs
+++ b/lib/edge/tools/shard_update/src/main.rs
@@ -68,11 +68,12 @@ use common::universal_io::{
 };
 use edge::external::uuid::Uuid;
 use edge::{
-    FullyQualifiedPoint, ManifestSegmentEnumerator, PAYLOAD_INDEX_CONFIG_FILE, Payload,
-    PayloadConfig, PayloadFieldSchema, PayloadSchemaParams, PayloadSchemaType, PointAction,
-    PointApplyKind, PointApplyRecord, PointId, PointOperations, PointStructPersisted,
-    SegmentConfig, SegmentConfigInfo, SparseVector, UpdateOnlyEdgeShard, UpdateOperation,
-    VectorPersisted, VectorStructPersisted, get_payload_index_path,
+    ConditionalInsertOperation, Filter, FullyQualifiedPoint, ManifestSegmentEnumerator,
+    PAYLOAD_INDEX_CONFIG_FILE, Payload, PayloadConfig, PayloadFieldSchema, PayloadSchemaParams,
+    PayloadSchemaType, PointAction, PointApplyKind, PointApplyRecord, PointId,
+    PointInsertOperations, PointOperations, PointStructPersisted, SegmentConfig, SegmentConfigInfo,
+    SparseVector, UpdateMode, UpdateOnlyEdgeShard, UpdateOperation, VectorPersisted,
+    VectorStructPersisted, get_payload_index_path,
 };
 use io_bridge_object_store::backends::aws::{AwsConfig, AwsCredentials};
 use io_bridge_object_store::backends::gcp::{GcsConfig, GcsCredentials};
@@ -94,6 +95,28 @@ enum Backend {
     Aws,
     /// Google Cloud Storage.
     Gcs,
+}
+
+/// Which points of the generated upsert are written, mirroring the
+/// `update_mode` of the REST/gRPC upsert.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum UpdateModeArg {
+    /// Write every id: overwrite the ones that exist, create the rest.
+    Upsert,
+    /// Write only ids no segment holds; leave the ones that exist alone.
+    InsertOnly,
+    /// Write only ids that already exist; do not create the rest.
+    UpdateOnly,
+}
+
+impl From<UpdateModeArg> for UpdateMode {
+    fn from(mode: UpdateModeArg) -> Self {
+        match mode {
+            UpdateModeArg::Upsert => UpdateMode::Upsert,
+            UpdateModeArg::InsertOnly => UpdateMode::InsertOnly,
+            UpdateModeArg::UpdateOnly => UpdateMode::UpdateOnly,
+        }
+    }
 }
 
 #[derive(Parser, Debug)]
@@ -123,6 +146,10 @@ struct Cli {
     /// UUIDs. Ids no segment holds are created rather than overwritten.
     #[arg(long, value_delimiter = ',', required = true)]
     ids: Vec<String>,
+
+    /// Update mode of the generated upsert.
+    #[arg(long, value_enum, default_value = "upsert")]
+    update_mode: UpdateModeArg,
 
     /// Operation number recorded as the new points' version. A point whose
     /// stored version is at or beyond this is reported as skipped — the
@@ -463,6 +490,9 @@ fn log_preview_point(point: &edge::PointPreview) {
             "point {id}: already at or beyond version — skipped (replay no-op); \
              re-run with a higher --op-num to overwrite",
         ),
+        PointAction::Rejected => {
+            log::info!("point {id}: already there — rejected by --update-mode, left untouched",);
+        }
         PointAction::Missing => {
             log::info!("point {id}: names a point no segment holds — nothing to do");
         }
@@ -471,7 +501,12 @@ fn log_preview_point(point: &edge::PointPreview) {
 
 /// Generate the random upsert batch off the shard's schema, logging each
 /// point's shape.
-fn generate_batch(schema: &ShardSchema, ids: &[PointId], seed: u64) -> UpdateOperation {
+fn generate_batch(
+    schema: &ShardSchema,
+    ids: &[PointId],
+    seed: u64,
+    mode: UpdateMode,
+) -> UpdateOperation {
     let mut rng = StdRng::seed_from_u64(seed);
     let points: Vec<PointStructPersisted> = ids
         .iter()
@@ -505,7 +540,21 @@ fn generate_batch(schema: &ShardSchema, ids: &[PointId], seed: u64) -> UpdateOpe
         })
         .collect();
 
-    UpdateOperation::PointOperation(PointOperations::UpsertPoints(points.into()))
+    let points = PointInsertOperations::PointsList(points);
+    let operation = match mode {
+        UpdateMode::Upsert => PointOperations::UpsertPoints(points),
+        // The writer accepts a conditional upsert only with an empty
+        // condition — existence is the whole condition it can answer.
+        UpdateMode::InsertOnly | UpdateMode::UpdateOnly => {
+            PointOperations::UpsertPointsConditional(ConditionalInsertOperation {
+                points_op: points,
+                condition: Filter::default(),
+                update_mode: Some(mode),
+            })
+        }
+    };
+
+    UpdateOperation::PointOperation(operation)
 }
 
 /// Generate the random batch, resolve it against the open shard, and log what
@@ -517,8 +566,9 @@ fn dry_run<S: UniversalAppend + 'static>(
     ids: &[PointId],
     op_num: u64,
     seed: u64,
+    mode: UpdateMode,
 ) -> Result<()> {
-    let operation = generate_batch(schema, ids, seed);
+    let operation = generate_batch(schema, ids, seed, mode);
 
     let preview = shard
         .preview_batch([(op_num, operation)])
@@ -526,6 +576,7 @@ fn dry_run<S: UniversalAppend + 'static>(
 
     let mut stored = 0usize;
     let mut skipped = 0usize;
+    let mut rejected = 0usize;
     let mut tombstones: HashMap<Uuid, usize> = HashMap::new();
     for point in &preview.points {
         log_preview_point(point);
@@ -542,12 +593,14 @@ fn dry_run<S: UniversalAppend + 'static>(
                 }
             }
             PointAction::Skip => skipped += 1,
+            PointAction::Rejected => rejected += 1,
             PointAction::Missing => {}
         }
     }
 
     log::info!(
-        "summary: {stored} point(s) would be appended to the write target, {skipped} skipped",
+        "summary: {stored} point(s) would be appended to the write target, \
+         {skipped} skipped, {rejected} rejected by --update-mode",
     );
     for (segment, count) in &tombstones {
         log::info!("summary: segment {segment} would receive {count} tombstone(s)");
@@ -568,11 +621,12 @@ fn apply_run<S: UniversalAppend + 'static>(
     ids: &[PointId],
     mut op_num: u64,
     mut seed: u64,
+    mode: UpdateMode,
     interactive: bool,
 ) -> Result<()> {
     let mut ids = ids.to_vec();
     loop {
-        let operation = generate_batch(schema, &ids, seed);
+        let operation = generate_batch(schema, &ids, seed, mode);
 
         let (returned, outcome) = shard
             .apply_batch([(op_num, operation)])
@@ -580,10 +634,12 @@ fn apply_run<S: UniversalAppend + 'static>(
         shard = returned;
 
         log::info!(
-            "applied at op-num {op_num}: {} stored, {} deleted, {} skipped, {} missing",
+            "applied at op-num {op_num}: {} stored, {} deleted, {} skipped, \
+             {} rejected, {} missing",
             outcome.stored,
             outcome.deleted,
             outcome.skipped,
+            outcome.rejected,
             outcome.missing,
         );
         for record in &outcome.points {
@@ -636,6 +692,9 @@ fn log_apply_record(record: &PointApplyRecord) {
         }
         PointApplyKind::Skipped => {
             log::info!("point {id}: skipped — already at or beyond this op-num");
+        }
+        PointApplyKind::Rejected => {
+            log::info!("point {id}: already there — rejected by --update-mode");
         }
         PointApplyKind::Missing => {
             log::info!("point {id}: no segment holds it — nothing to do");
@@ -762,9 +821,24 @@ fn run_local(cli: &Cli, ids: &[PointId]) -> Result<()> {
 
     let schema = read_schema(&shard, &common::universal_io::MmapFs, &path)?;
     if cli.apply {
-        apply_run(shard, &schema, ids, cli.op_num, cli.seed, cli.interactive)
+        apply_run(
+            shard,
+            &schema,
+            ids,
+            cli.op_num,
+            cli.seed,
+            cli.update_mode.into(),
+            cli.interactive,
+        )
     } else {
-        dry_run(&shard, &schema, ids, cli.op_num, cli.seed)
+        dry_run(
+            &shard,
+            &schema,
+            ids,
+            cli.op_num,
+            cli.seed,
+            cli.update_mode.into(),
+        )
     }
 }
 
@@ -797,9 +871,24 @@ where
 
     let schema = read_schema(&shard, &cached_fs, &prefix)?;
     if cli.apply {
-        apply_run(shard, &schema, ids, cli.op_num, cli.seed, cli.interactive)
+        apply_run(
+            shard,
+            &schema,
+            ids,
+            cli.op_num,
+            cli.seed,
+            cli.update_mode.into(),
+            cli.interactive,
+        )
     } else {
-        dry_run(&shard, &schema, ids, cli.op_num, cli.seed)
+        dry_run(
+            &shard,
+            &schema,
+            ids,
+            cli.op_num,
+            cli.seed,
+            cli.update_mode.into(),
+        )
     }
 }
 


### PR DESCRIPTION
## What

`UpdateBatchPlan::build` rejected every `UpsertPointsConditional`. This accepts the ones whose condition is empty — `update_mode=insert_only` and `update_mode=update_only`, exactly what the REST/gRPC path synthesizes when a caller passes a mode without a filter (`src/common/update.rs`).

Existence is the whole gate those modes need, and `locate_points` already answers it for every point a batch touches, so this rides on the lookup the batch does anyway. A conditional upsert carrying a real filter is still rejected: evaluating one means querying payload indexes, which the writer never fetches.

Why this was missing rather than broken: `LocalShard::submit_update` resolves conditional upserts to plain id-based ones *before* the WAL, so a WAL-fed writer never sees one. A serverless updater ingesting client operations directly has no such stage, and got a hard error instead.

## Semantics

The gate is evaluated per mutation **at its position in the fold**, not against the state the batch started from:

```
op 10: upsert A
op 11: upsert A, insert_only   →  dropped; A keeps op 10's content
```

That mirrors the leader, where op 11 resolves only after op 10 was applied. It follows that a conditional upsert may not discard the mutations before it the way a plain upsert does — it may turn out not to apply, and then they still have to be there.

Per-point outcome, on top of the existing `stored` / `deleted` / `skipped` / `missing`:

| case | action |
|---|---|
| `insert_only`, id free | `Stored` |
| `insert_only`, id taken | `Rejected` (new) — no write, no tombstone, no version bump |
| `update_only`, id taken | `Stored` |
| `update_only`, id free | `Missing` — the existing meaning: an operation that can only modify an existing point, naming one that is not there |

## Cost

Rejecting an upsert also means never reading the point it would have overwritten. `needs_stored_point` now asks whether the *first mutation that applies to an existing point* discards it, instead of looking at the first mutation unconditionally — so an `insert_only` batch pays nothing for the ids that are already taken, which on this workload is most of them. Without that, every rejected id would cost a full vector+payload read from object storage for a write that never happens.

## Notes

- `materialize` takes `exists` explicitly now. It used to infer it from `stored.is_some()`, which conflated "we read the point" with "the point is there" — fine while only mutations that keep the stored point cared, wrong as soon as a mutation both discards it and depends on existence. The `update_only` end-to-end test catches this.
- `insert_only` **with** a filter is rejected, though mainline `retain_conditional_upsert_points` ignores the condition entirely in that mode. Silently dropping a condition the caller wrote seemed worse than refusing it; happy to mirror mainline instead if you'd rather the two agree.
- `edge-shard-update` grows `--update-mode {upsert,insert-only,update-only}` so this is exercisable against real object storage, and reports the rejected count in both the dry run and the apply.

## Test plan

- `cargo test -p edge --lib` — 67 pass. New: fold-level tests for both modes, the same-batch ordering case above, and rejection of a real condition across all three modes; end-to-end tests applying `insert_only` / `update_only` batches over a leader-written directory and reading the result back through an ordinary follower.
- `cargo clippy -p edge -p edge-shard-update --all-targets -- -D warnings`, `cargo +nightly fmt --check`, `sg scan` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
