### PR TITLE
gitignore: ignore lib/edge/publish/target

### DIFF
--- a/lib/edge/publish/.gitignore
+++ b/lib/edge/publish/.gitignore
@@ -1,3 +1,4 @@
 /Cargo.lock
+/target
 /examples/target
 /qdrant-edge


### PR DESCRIPTION
`amalgamate.py` builds the generated `qdrant-edge` crate in place, leaving a Cargo target directory at `lib/edge/publish/target`. `lib/edge/publish/.gitignore` covered `/examples/target` and `/qdrant-edge` but not that one, so anyone who has run the amalgamation sees ~32k untracked files there — which a path-wide `git add lib/edge` will happily stage.

One line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
