### PR TITLE
HNSW: stop exact-duplicate vectors from becoming a sink at level 0

### DIFF
--- a/lib/segment/src/index/hnsw_index/links_container.rs
+++ b/lib/segment/src/index/hnsw_index/links_container.rs
@@ -6,6 +6,30 @@ use common::types::{PointOffsetType, ScoreType, ScoredPointOffset};
 
 use crate::common::vector_utils::TrySetCapacityExact as _;
 
+/// Neighbour-selection ("not closer than base") test.
+///
+/// A candidate is dropped when an already selected link is closer to it than the
+/// target is. The comparison is strict, *except* between candidates that are
+/// exactly equidistant from the target: without that exception a group of
+/// byte-identical vectors is mutually non-pruning and fills every link slot,
+/// turning the group into a sink with no edges leaving it.
+///
+/// Restricting the non-strict comparison to `candidate_score == existing_score`
+/// keeps ordinary (non-duplicate) candidates unaffected: for them the equality
+/// case has measure zero.
+#[inline]
+fn is_redundant(
+    candidate_to_existing: ScoreType,
+    candidate_score: ScoreType,
+    existing_score: ScoreType,
+) -> bool {
+    if candidate_score == existing_score {
+        candidate_to_existing >= candidate_score
+    } else {
+        candidate_to_existing > candidate_score
+    }
+}
+
 pub struct LinksContainer {
     links: Vec<PointOffsetType>,
     /// Number of links that have been processed by the heuristic.
@@ -56,13 +80,20 @@ impl LinksContainer {
             self.processed_by_heuristic = 0;
             return;
         }
+        // Scores of the already selected links, to detect exact ties (see `is_redundant`).
+        let mut selected_scores: Vec<ScoreType> = Vec::with_capacity(level_m);
         'outer: for candidate in candidates {
-            for &existing in &self.links {
-                if score(candidate.idx, existing) > candidate.score {
+            for (&existing, &existing_score) in self.links.iter().zip(&selected_scores) {
+                if is_redundant(
+                    score(candidate.idx, existing),
+                    candidate.score,
+                    existing_score,
+                ) {
                     continue 'outer;
                 }
             }
             self.links.push(candidate.idx);
+            selected_scores.push(candidate.score);
             if self.links.len() >= level_m {
                 break;
             }
@@ -204,9 +235,11 @@ impl LinksContainer {
                 if candidate.order.is_some() && existing.order.is_some() {
                     continue; // See (A).
                 }
-                if score(candidate.idx, existing.idx)
-                    > candidate.cached_score(target_point_id, &mut score)
-                {
+                if is_redundant(
+                    score(candidate.idx, existing.idx),
+                    candidate.cached_score(target_point_id, &mut score),
+                    existing.cached_score(target_point_id, &mut score),
+                ) {
                     continue 'outer;
                 }
             }
@@ -388,6 +421,59 @@ mod tests {
             links_container.connect(id, 0, m, scorer);
         }
         assert_eq!(links_container.links(), &vec![1, 2, 3, 4, 5, 6]);
+    }
+
+    /// A group of byte-identical vectors must not consume each other's whole link
+    /// budget: every copy is equidistant from every other, so under a strictly
+    /// greater comparison none of them prunes any other and the group ends up as a
+    /// sink at level 0 with no edges leaving it.
+    #[test]
+    fn test_exact_duplicates_do_not_fill_the_link_list() {
+        const M: usize = 6;
+        const COPIES: usize = 8;
+
+        // Point 0 is the target. Points 1..=COPIES are byte-identical to it.
+        // The remaining points are ordinary neighbours, all a little further away.
+        let mut points: Vec<DenseVector> = vec![vec![0.0, 0.0]; COPIES + 1];
+        points.extend([
+            vec![1.0, 0.0],
+            vec![0.0, 1.0],
+            vec![-1.0, 0.0],
+            vec![0.0, -1.0],
+        ]);
+        let scorer = |a: PointOffsetType, b: PointOffsetType| {
+            -((points[a as usize][0] - points[b as usize][0]).powi(2)
+                + (points[a as usize][1] - points[b as usize][1]).powi(2))
+            .sqrt()
+        };
+
+        let mut candidates = FixedLengthPriorityQueue::new(points.len() - 1);
+        for id in 1..points.len() as PointOffsetType {
+            candidates.push(ScoredPointOffset {
+                idx: id,
+                score: scorer(0, id),
+            });
+        }
+
+        let mut container = LinksContainer::with_capacity(M);
+        container.fill_from_sorted_with_heuristic(candidates.into_iter_sorted(), M, scorer);
+
+        let copies = container
+            .links()
+            .iter()
+            .filter(|&&idx| idx as usize <= COPIES)
+            .count();
+        assert_eq!(
+            copies,
+            1,
+            "only one of {COPIES} identical copies should be kept, got {:?}",
+            container.links(),
+        );
+        assert!(
+            container.links().len() > 1,
+            "the rest of the budget should go to real neighbours, got {:?}",
+            container.links(),
+        );
     }
 
     #[test]


### PR DESCRIPTION
# HNSW: stop exact-duplicate vectors from becoming a sink at level 0

visualization of the idea: https://claude.ai/code/artifact/d4fe9051-34c6-4753-9587-f50556b2444e

### What this changes

One rule in the HNSW neighbour-selection heuristic (`LinksContainer`). A candidate is discarded when an
already-selected link is closer to it than the target is. That comparison is strict, so **byte-identical
vectors never prune each other**: every copy is exactly as close to every other copy as it is to the target,
so all of them survive and fill the whole link budget.

A group of *k* identical vectors therefore ends up linked only to itself — on LAION-2M the largest such group
(1 062 copies) had **100 % of its 33 984 level-0 links pointing back inside the group, and not one edge
leaving it**.

The fix makes the comparison non-strict *only between candidates that are exactly equidistant from the
target*. For distinct vectors that equality has measure zero, so ordinary data is unaffected.

### Why it matters — the damage is not local to the duplicates

The group becomes an absorbing state for the `ef_construct` beam search during construction. An unrelated
point being inserted walks in, cannot walk out (every neighbour is an identical copy with the identical
score, so nothing improves the result set), and the search terminates with a candidate list that is almost
entirely copies. The heuristic then correctly prunes all but one of them, and the new point is left with
**a single link — the one pointing into the sink**.

On LAION-2M that crippled **12 000–17 000 points to a mean out-degree of ~1.2** (against ~15.4 overall),
scattered across the dataset — they are not near the duplicate cluster, their greedy construction path just
happened to run into it. Max in-degree reached 17 798, and 24 445 points became unreachable.

### Measured effect

512-dim LAION CLIP embeddings, `m=16`, `ef_construct=100`, 2 000 queries against exact ground truth,
recall@10 scored on duplicate-group representatives (failed queries — those returning none of their true
top-10 — in brackets):

| ef | before | **after** | faiss `IndexHNSWFlat`, same data |
|---|---|---|---|
| 64 | 0.9105 (41) | **0.9442 (8)** | 0.9362 (17) |
| 128 | 0.9347 (34) | **0.9684 (4)** | 0.9603 (9) |
| 256 | 0.9473 (32) | **0.9806 (3)** | 0.9764 (5) |
| 512 | 0.9538 (31) | **0.9882 (2)** | 0.9819 (5) |
| 2048 | 0.9595 (31) | **0.9954 (0)** | 0.9914 (0) |

* A flat **~+3.4 recall points at every `ef`** — this is not a high-`ef` artefact.
* It lands on the ceiling: deleting every duplicate row from the dataset instead gives 0.9892 at ef=512, so
  the fix recovers essentially all of the loss without touching the data.
* The **failed-query plateau disappears**. Before, 31 queries stayed dead from ef=256 all the way to
  ef=2048 — extra `ef` could not rescue them because their neighbourhoods sat behind crippled nodes.
* Structurally at 2M: points crippled by a duplicate group 17 161 → 155, max in-degree 17 798 → 265,
  unreachable points 24 445 → 6 384.

### Cost: none measurable

Distance computations counted with `cpu_counter`, both variants built and measured back to back:

| ef | before | after | Δ work |
|---|---|---|---|
| 64 | 0.66 ms · 4 257 dist/q | 0.70 ms · 4 265 dist/q | +0.2 % |
| 512 | 3.23 ms · 20 236 dist/q | 3.16 ms · 20 329 dist/q | +0.5 % |
| 2048 | 11.35 ms · 61 790 dist/q | 10.41 ms · 62 134 dist/q | +0.6 % |

Same `ef` ⇒ same work to within 0.6 %. Wall-clock differences are inside this machine's run-to-run noise
(200K/ef=512, three runs each: before 2.08 / 2.02 / 1.98 ms/q, after 2.02 / 2.03 / 1.93 ms/q). Graph build
time is unchanged (429 s vs 442 s for 2M vectors on 4 threads).

At *matched recall* it is a large speed-up: reaching 0.9799 took ef=2048, 11.35 ms and 61 790 distance
computations before; after, ef=512 beats it at 3.16 ms and 20 329 computations.

It also removes a build-to-build lottery. Whether a duplicate group turns into a sink depends on the order
its copies happen to get linked, which the parallel build randomises: two unpatched 2M builds of identical
data gave 0.9538 and 0.9688 at ef=512 (spread 0.015), while two patched builds gave 0.9882 and 0.9891
(spread 0.0009).

### Note on the obvious simpler fix

Making the comparison non-strict unconditionally (`>=`) also removes the sink, but it over-prunes: once a
duplicate-of-the-target is in the list, every *legitimate* neighbour is exactly as close to that duplicate as
to the target and gets discarded too. The group's own out-degree then collapses to ~3. Restricting the
non-strict comparison to equidistant candidates keeps it at ~15 and gives slightly better recall
(0.9966 vs 0.9961 at ef=512 on the 200K subset).

### Remaining limitation

When a duplicate group is larger than `ef_construct`, its own members still end up sparsely linked — the
construction search never sees anything but copies, so there are no other candidates to keep. That no longer
harms anything else, and recall is at the ceiling, but deduplicating at ingest is still worthwhile for such
groups.

### Tests

`test_exact_duplicates_do_not_fill_the_link_list` is added and fails on the current rule
(all 6 slots taken by copies: `[5, 6, 2, 1, 3, 7]`), passes with the change. The existing
`test_connect_new_point_with_heuristic` — which asserts the optimised `connect_with_heuristic` still agrees
with the reference implementation — passes unchanged.

### Checklist

* [x] Targets `dev`
* [x] `cargo +nightly fmt --all`
* [x] `cargo +nightly clippy -p segment --all-features`
* [x] `cargo test -p segment --lib links_container` passes
* [x] New test for the changed behaviour

---

Base: `dev` @ `e45c248`. Apply with `git apply qdrant-duplicate-sink-fix.patch`.

Full investigation, reproduction harness and raw measurements:
https://github.com/generall/faiss-vs-qdrant/blob/claude/qdrant-edge-hnsw-accuracy-nhbikw/FINDINGS.md
