### PR TITLE
Reject .. in collection names

### DIFF
--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -702,15 +702,24 @@ mod tests {
             "good collection request should not error on validation"
         );
 
-        // Collection name validation must not be strict on non-creation
+        // Collection name validation must not be strict on non-creation. On Windows a
+        // backslash is a path separator, so there the same name is a path — it is rejected,
+        // and no existing collection can carry it (see `check_plain_dir_name`).
         let bad_request = UpdateCollection {
             collection_name: "no\\path".into(),
             ..Default::default()
         };
-        assert!(
-            bad_request.validate().is_ok(),
-            "good collection request should not error on validation"
-        );
+        if cfg!(windows) {
+            assert!(
+                bad_request.validate().is_err(),
+                "backslash collection name is a path on Windows and must error on validation"
+            );
+        } else {
+            assert!(
+                bad_request.validate().is_ok(),
+                "good collection request should not error on validation"
+            );
+        }
 
         // Collection name validation must not be strict on non-creation
         let bad_request = UpdateCollection {

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -704,7 +704,9 @@ mod tests {
 
         // Collection name validation must not be strict on non-creation. On Windows a
         // backslash is a path separator, so there the same name is a path — it is rejected,
-        // and no existing collection can carry it (see `check_plain_dir_name`).
+        // Collection name validation must not be strict on non-creation.
+        // Backslash is a path separator on Windows and rejected in collection names there,
+        // so that `no\path` can't be interpreted as a path (see `check_plain_dir_name`).
         let bad_request = UpdateCollection {
             collection_name: "no\\path".into(),
             ..Default::default()

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::path::Path;
 
 use serde::Serialize;
 use validator::{Validate, ValidationError, ValidationErrors, ValidationErrorsKind};
@@ -107,11 +108,31 @@ fn check_invalid_name_chars(value: &str, kind: &str) -> Result<(), ValidationErr
     Err(err)
 }
 
-/// Validate the collection name contains no illegal characters
+/// Reject names that are not a plain, single path component.
 ///
-/// This does not check the length of the name.
+/// The name is joined onto a storage directory on disk, so a dot segment (`.`, `..`) — or
+/// anything else `Path::file_name` does not return verbatim, such as the empty string — would
+/// resolve outside (or to) the parent directory instead of a subdirectory of it. Same predicate
+/// as the snapshot name check in `collection::common::snapshots_manager`.
+fn check_plain_dir_name(value: &str, kind: &str) -> Result<(), ValidationError> {
+    if Path::new(value).file_name() != Some(value.as_ref()) {
+        let mut err = ValidationError::new("invalid_path_component");
+        err.add_param(Cow::from("value"), &value);
+        err.message.replace(
+            format!("{kind} cannot be {value:?}, it is used as a directory name on disk").into(),
+        );
+        return Err(err);
+    }
+    Ok(())
+}
+
+/// Validate the collection name contains no illegal characters and stays a plain directory name
+/// on disk: dot segments (`.`, `..`) and the empty string are rejected.
+///
+/// This does not check the maximum length of the name.
 pub fn validate_collection_name(value: &str) -> Result<(), ValidationError> {
-    check_invalid_name_chars(value, "collection name")
+    check_invalid_name_chars(value, "collection name")?;
+    check_plain_dir_name(value, "collection name")
 }
 
 /// Validate a named vector identifier.
@@ -141,21 +162,23 @@ pub fn validate_vector_name(value: &str) -> Result<(), ValidationError> {
 /// were supported pre Qdrant 1.5. More specifically, this only disallows characters that could
 /// never have been used on both Linux and Windows filesystems.
 ///
-/// This does not check the length of the name.
+/// Dot segments (`.`, `..`) and the empty string are rejected here as well: they were never
+/// usable as directory names, so no pre-existing collection can carry such a name.
+///
+/// This does not check the maximum length of the name.
 pub fn validate_collection_name_legacy(value: &str) -> Result<(), ValidationError> {
     // Disallowed characters on both Linux/Windows, sourced from: <https://stackoverflow.com/a/31976060/1000145>
     const INVALID_CHARS: [char; 2] = ['/', '\0'];
 
-    match INVALID_CHARS.into_iter().find(|c| value.contains(*c)) {
-        Some(c) => {
-            let mut err = ValidationError::new("does_not_contain");
-            err.add_param(Cow::from("pattern"), &c);
-            err.message
-                .replace(format!("collection name cannot contain \"{c}\" char").into());
-            Err(err)
-        }
-        None => Ok(()),
+    if let Some(c) = INVALID_CHARS.into_iter().find(|c| value.contains(*c)) {
+        let mut err = ValidationError::new("does_not_contain");
+        err.add_param(Cow::from("pattern"), &c);
+        err.message
+            .replace(format!("collection name cannot contain \"{c}\" char").into());
+        return Err(err);
     }
+
+    check_plain_dir_name(value, "collection name")
 }
 
 /// Validate a polygon has at least 4 points and is closed.
@@ -399,18 +422,61 @@ mod tests {
     #[test]
     fn test_validate_collection_name() {
         assert!(validate_collection_name("test_collection").is_ok());
-        assert!(validate_collection_name("").is_ok());
         assert!(validate_collection_name("no/path").is_err());
         assert!(validate_collection_name("no*path").is_err());
         assert!(validate_collection_name("?").is_err());
         assert!(validate_collection_name("\0").is_err());
 
         assert!(validate_collection_name_legacy("test_collection").is_ok());
-        assert!(validate_collection_name_legacy("").is_ok());
         assert!(validate_collection_name_legacy("no/path").is_err());
         assert!(validate_collection_name_legacy("no*path").is_ok());
         assert!(validate_collection_name_legacy("?").is_ok());
         assert!(validate_collection_name_legacy("\0").is_err());
+    }
+
+    /// Collection names become directory components on disk
+    /// (`storage/collections/<name>`, `snapshots/<name>`), so a name that resolves outside the
+    /// parent directory must be rejected — by the legacy validator too, since a traversing name
+    /// was never usable as a directory and thus cannot refer to a pre-existing collection.
+    ///
+    /// Mirrors `TRAVERSING_NAMES` in `collection::common::snapshots_manager`.
+    #[test]
+    fn test_validate_collection_name_rejects_traversal() {
+        const TRAVERSING_NAMES: &[&str] = &[
+            "/collections/other-collection",
+            "/etc/passwd",
+            "other-collection/nested",
+            "../other-collection",
+            "./other-collection",
+            "..",
+            ".",
+            "",
+        ];
+
+        for name in TRAVERSING_NAMES {
+            assert!(
+                validate_collection_name(name).is_err(),
+                "collection name {name:?} escapes the collections directory and must be rejected",
+            );
+            assert!(
+                validate_collection_name_legacy(name).is_err(),
+                "collection name {name:?} escapes the collections directory and must be rejected \
+                 by the legacy validator",
+            );
+        }
+
+        // Names merely containing dots do not traverse and must stay valid, so existing
+        // collections with such names remain reachable.
+        for name in ["v1.2", ".hidden", "..dots", "..."] {
+            assert!(
+                validate_collection_name(name).is_ok(),
+                "collection name {name:?} does not traverse and must stay valid",
+            );
+            assert!(
+                validate_collection_name_legacy(name).is_ok(),
+                "collection name {name:?} does not traverse and must stay valid",
+            );
+        }
     }
 
     #[test]

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -110,10 +110,13 @@ fn check_invalid_name_chars(value: &str, kind: &str) -> Result<(), ValidationErr
 
 /// Reject names that are not a plain, single path component.
 ///
-/// The name is joined onto a storage directory on disk, so a dot segment (`.`, `..`) — or
-/// anything else `Path::file_name` does not return verbatim, such as the empty string — would
-/// resolve outside (or to) the parent directory instead of a subdirectory of it. Same predicate
-/// as the snapshot name check in `collection::common::snapshots_manager`.
+/// Name is used as the name of a storage directory on disk.
+/// It must not contain path separators or dot-segments (`.`, `..`),
+/// so that it won't be interpreted as a path.
+///
+/// `Path::file_name` is a simple way to check this: it returns the whole path
+/// only when it's a simple name with no restricted components.
+/// Same check is used in `collection::common::snapshots_manager`.
 fn check_plain_dir_name(value: &str, kind: &str) -> Result<(), ValidationError> {
     if Path::new(value).file_name() != Some(value.as_ref()) {
         let mut err = ValidationError::new("invalid_path_component");

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -465,6 +465,31 @@ mod tests {
             );
         }
 
+        // On Windows, backslashes are separators and drive prefixes re-root the joined path,
+        // so these names are paths there too. The legacy character list deliberately allows
+        // `\` and `:`, so containment rests on the plain-name check alone. No existing
+        // collection can carry such a name on Windows — they were never valid directory
+        // names there. (The strict validator rejects `\` and `:` on every platform.)
+        #[cfg(windows)]
+        for name in ["..\\other-collection", "a\\b", "C:", "C:other"] {
+            assert!(
+                validate_collection_name_legacy(name).is_err(),
+                "collection name {name:?} is a path on Windows and must be rejected by the \
+                 legacy validator",
+            );
+        }
+
+        // On Unix, a backslash is a plain character: the same name is a single path component
+        // and must stay valid, so existing collections keep working.
+        #[cfg(unix)]
+        for name in ["no\\path", "C:"] {
+            assert!(
+                validate_collection_name_legacy(name).is_ok(),
+                "collection name {name:?} is a single path component on Unix and must stay \
+                 valid for the legacy validator",
+            );
+        }
+
         // Names merely containing dots do not traverse and must stay valid, so existing
         // collections with such names remain reachable.
         for name in ["v1.2", ".hidden", "..dots", "..."] {


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/security/advisories/GHSA-jwrp-6pff-wg9c>

Collection names are used as directory components on disk (storage/collections/<name>, snapshots/<name>). Apply the same plain-file-name predicate already used for snapshot names, so names like ".." and "." no longer resolve outside the parent directory.

Applied to the legacy validator too: dot segments were never usable as directory names, so no existing collection can be locked out by this.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
