### PR TITLE
tests: restart reinit peer on the same port in readyz test

### DIFF
--- a/tests/consensus_tests/test_reinit_removed_peer.py
+++ b/tests/consensus_tests/test_reinit_removed_peer.py
@@ -141,6 +141,7 @@ def test_reinit_removed_peer_readyz_ignores_old_cluster(tmp_path: pathlib.Path):
 
     # Stop it again to inject the stale address below.
     reinit_peer_process = processes[1]
+    restart_port = reinit_peer_process.p2p_port
     reinit_peer_process.kill()
     processes.remove(reinit_peer_process)
 
@@ -170,8 +171,15 @@ def test_reinit_removed_peer_readyz_ignores_old_cluster(tmp_path: pathlib.Path):
     # still alive and reachable at the injected address. This peer's own
     # consensus can never reach `old_commit`, so `/readyz` must not depend
     # on it.
+    #
+    # Keep the same URI: restarting under a new one makes the peer announce
+    # its address change to every address-book entry, i.e. also to the old
+    # first peer, which then re-adds it to the *old* cluster as a learner and
+    # starts replicating its log to it. That is a different scenario, and it
+    # even overtakes this peer's own log if its last term was not persisted
+    # before the kill above.
     restart_api_uri, _restart_bootstrap_uri = start_first_peer(
-        removed_peer_dir, "removed_peer_restart.log",
+        removed_peer_dir, "removed_peer_restart.log", port=restart_port,
     )
 
     wait_for_peer_online(restart_api_uri)


### PR DESCRIPTION
Fixes the flaky `test_reinit_removed_peer_readyz_ignores_old_cluster` (`assert 13 < 12`).

## What happened

The test restarts the reinitialized single-voter peer via `start_first_peer(...)` without a port, i.e. on a fresh `--uri`. A changed URI makes `Consensus::recover()` announce the new address (`AddPeerToKnown`) to every address-book entry — including the old first peer the test injects. The old (single-node) cluster then proposes `AddLearnerNode(restarted peer)` and starts replicating its log to it.

Normally the restarted peer is at term 2 (self-elected during reinit) and drops the old leader's term-1 appends, so the test passes. In the failing run the reinit peer's `HardState{term: 2}` save had not completed before the test killed it (`Changing hard state … term: 2` with no `Saved state` after it; the WAL already held the term-2 entry). It restarted at term 1, accepted the old leader, truncated at index 5, took entries 6..13 (commit 13 > old commit 12), then applied `RemoveNode(self)` → `removed all voters` restart loop.

## Fix

Restart on the same p2p port (the suite's usual `restart_port = p.p2p_port` idiom). The scenario is a plain restart, so the URI should not change; then nothing is announced to the old cluster and the test only exercises the `/readyz` `conf_state` membership filter it was written for.

Not a product change: a *non-member* stale address only exists via the test's injection (applying `RemoveNode(x)` prunes `x` from the address book), so filtering `recover()` targets by `conf_state` would only guard an unreachable state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
