### PR TITLE
Edge: seed appendable segment on load from existing segments' indexes

### DIFF
--- a/lib/edge/src/edge_shard/mod.rs
+++ b/lib/edge/src/edge_shard/mod.rs
@@ -9,13 +9,14 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use ::wal::WalOptions;
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::save_on_disk::SaveOnDisk;
 use fs_err as fs;
 use parking_lot::Mutex;
 use segment::common::operation_error::{OperationError, OperationResult};
-use segment::entry::ReadSegmentEntry as _;
-use segment::segment_constructor::{load_segment, normalize_segment_dir};
-use shard::files::{PAYLOAD_INDEX_CONFIG_FILE, SEGMENTS_PATH, WAL_PATH, segment_manifest_path};
+use segment::entry::{NonAppendableSegmentEntry as _, ReadSegmentEntry as _};
+use segment::segment_constructor::{build_segment, load_segment, normalize_segment_dir};
+use shard::files::{SEGMENTS_PATH, WAL_PATH, segment_manifest_path};
 use shard::operations::CollectionUpdateOperations;
 use shard::segment_holder::locked::LockedSegmentHolder;
 use shard::segment_holder::{FlushMode, SegmentHolder};
@@ -63,7 +64,7 @@ impl EdgeShard {
         config.save(path)?;
 
         let mut segments = SegmentHolder::default();
-        ensure_appendable_segment(&mut segments, path, &segments_path, &config)?;
+        ensure_appendable_segment(&mut segments, &segments_path, &config)?;
 
         let search_pool = build_segment_pool(
             "edge-search",
@@ -140,7 +141,7 @@ impl EdgeShard {
             }
         };
 
-        ensure_appendable_segment(&mut segments, path, &segments_path, &config)?;
+        ensure_appendable_segment(&mut segments, &segments_path, &config)?;
 
         let search_pool = build_segment_pool(
             "edge-search",
@@ -461,7 +462,6 @@ fn load_segments(segments_path: &Path) -> OperationResult<(SegmentHolder, Option
 
 fn ensure_appendable_segment(
     segments: &mut SegmentHolder,
-    path: &Path,
     segments_path: &Path,
     config: &EdgeConfig,
 ) -> OperationResult<()> {
@@ -469,21 +469,22 @@ fn ensure_appendable_segment(
         return Ok(());
     }
 
-    let payload_index_schema_path = path.join(PAYLOAD_INDEX_CONFIG_FILE);
-    let payload_index_schema = SaveOnDisk::load_or_init_default(&payload_index_schema_path)
-        .map_err(|err| {
-            OperationError::service_error(format!(
-                "failed to initialize payload index schema file {}: {err}",
-                payload_index_schema_path.display(),
-            ))
-        })?;
+    // Edge has no shard-level index schema; the segments are the source of truth. Seed the new
+    // segment with the union of indexes present in the loaded ones, like the optimizer does for
+    // its CoW segment via `replicate_field_indexes`.
+    let indexed_fields: HashMap<_, _> = segments
+        .iter()
+        .flat_map(|(_, segment)| segment.get().read().get_indexed_fields())
+        .collect();
 
-    segments.create_appendable_segment(
-        segments_path,
-        config.plain_segment_config(),
-        Arc::new(payload_index_schema),
-        None,
-    )?;
+    let (mut segment, token) =
+        build_segment(segments_path, &config.plain_segment_config(), None, true)?;
+    let hw_counter = HardwareCounterCell::disposable();
+    for (key, schema) in &indexed_fields {
+        segment.create_field_index(0, key, Some(schema), &hw_counter)?;
+    }
+    segments.sync_segment_manifest(Some(token))?;
+    segments.add_new(segment);
 
     debug_assert!(segments.has_appendable_segment());
     Ok(())

--- a/lib/edge/src/edge_shard/optimize.rs
+++ b/lib/edge/src/edge_shard/optimize.rs
@@ -163,18 +163,26 @@ mod tests {
 
     use fs_err as fs;
     use segment::data_types::vectors::{VectorInternal, VectorStructInternal};
-    use segment::types::{Distance, ExtendedPointId, WithPayloadInterface, WithVector};
-    use shard::operations::CollectionUpdateOperations::{PointOperation, VectorNameOperation};
-    use shard::operations::VectorNameOperations;
+    use segment::json_path::JsonPath;
+    use segment::types::{
+        Distance, ExtendedPointId, PayloadFieldSchema, PayloadSchemaType, WithPayloadInterface,
+        WithVector,
+    };
+    use shard::operations::CollectionUpdateOperations::{
+        FieldIndexOperation, PointOperation, VectorNameOperation,
+    };
     use shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
     use shard::operations::point_ops::PointOperations::{DeletePoints, UpsertPoints};
     use shard::operations::point_ops::{PointStructPersisted, VectorStructPersisted};
     use shard::operations::vector_name_ops::DeleteVectorName;
+    use shard::operations::{CreateIndex, FieldIndexOperations, VectorNameOperations};
     use shard::optimizers::config::default_segment_number;
     use uuid::Uuid;
 
     use crate::config::vectors::EdgeVectorParams;
-    use crate::{CountRequest, EdgeConfig, EdgeShard, RetrieveRequestBuilder};
+    use crate::{
+        CountRequest, EdgeConfig, EdgeOptimizersConfig, EdgeShard, RetrieveRequestBuilder,
+    };
 
     const VECTOR_NAME: &str = "edge-test-vector";
 
@@ -826,6 +834,83 @@ mod tests {
 
     /// Retrieve points by ID and verify each one is present with the correct
     /// vector value. Every test point was created with vector `[id as f32]`.
+    /// A shard loaded with only immutable segments gets a fresh appendable one that carries the
+    /// immutable segments' payload indexes, so writes stay indexed instead of falling back to
+    /// full scans until the next merge.
+    #[cfg_attr(target_os = "windows", ignore = "slow on Windows, not OS-specific")]
+    #[test]
+    fn appendable_segment_created_on_load_inherits_payload_indexes() {
+        let dir = tempfile::Builder::new()
+            .prefix("edge-load-inherit-indexes")
+            .tempdir()
+            .unwrap();
+
+        // Lowered indexing threshold makes the vacuum rebuild non-appendable.
+        let config = EdgeConfig {
+            optimizers: Some(EdgeOptimizersConfig {
+                deleted_threshold: Some(0.2),
+                vacuum_min_vector_number: Some(1),
+                indexing_threshold: Some(1),
+                ..EdgeOptimizersConfig::default()
+            }),
+            ..test_config()
+        };
+        let field: JsonPath = "k".parse().unwrap();
+        let schema = PayloadFieldSchema::FieldType(PayloadSchemaType::Integer);
+
+        let shard = EdgeShard::new(dir.path(), config).unwrap();
+        shard
+            .update(FieldIndexOperation(FieldIndexOperations::CreateIndex(
+                CreateIndex {
+                    field_name: field.clone(),
+                    field_schema: Some(schema.clone()),
+                },
+            )))
+            .unwrap();
+        let points = (1..=1000).map(point).collect::<Vec<_>>();
+        shard
+            .update(PointOperation(UpsertPoints(PointsList(points))))
+            .unwrap();
+        let deleted_ids = (1..=300).map(ExtendedPointId::NumId).collect();
+        shard
+            .update(PointOperation(DeletePoints { ids: deleted_ids }))
+            .unwrap();
+        assert!(shard.optimize().unwrap(), "expected a vacuum to run");
+
+        // Wipe the (empty) appendable CoW segment so the reload has to create one.
+        let appendable_dirs = shard
+            .segments
+            .read()
+            .iter()
+            .filter(|(_, segment)| segment.get().read().is_appendable())
+            .map(|(_, segment)| segment.get().read().data_path())
+            .collect::<Vec<_>>();
+        assert!(!appendable_dirs.is_empty());
+        drop(shard);
+        for segment_dir in appendable_dirs {
+            fs::remove_dir_all(segment_dir).unwrap();
+        }
+
+        let reopened = EdgeShard::load(dir.path(), None).unwrap();
+        assert_eq!(reopened.count(CountRequest::new()).unwrap(), 700);
+
+        let segments = reopened.segments.read();
+        let mut seen_appendable = false;
+        for (_, segment) in segments.iter() {
+            let segment = segment.get().read();
+            if segment.is_appendable() {
+                seen_appendable = true;
+            }
+            assert_eq!(
+                segment.get_indexed_fields().get(&field),
+                Some(&schema),
+                "segment {} lost the payload index",
+                segment.data_path().display(),
+            );
+        }
+        assert!(seen_appendable, "load must create an appendable segment");
+    }
+
     fn assert_points_retrievable_with_vectors(shard: &EdgeShard, ids: &[u64]) {
         let point_ids = ids
             .iter()


### PR DESCRIPTION
## What

`EdgeShard::load` on a shard tree with no appendable segment (externally built trees; Qdrant's own optimizer always leaves a CoW appendable segment behind) created the new appendable segment from a shard-root `payload_index.json` that nothing in edge ever writes — `CreateIndex` ops go straight to segments. So the new segment was always index-less, and since `IndexingOptimizer` replicates from the segment it optimizes, the appendable chain stayed unindexed until a merge happened to include an indexed immutable segment. Filters on the write path full-scanned.

Now `ensure_appendable_segment` builds the segment directly and seeds it with the union of `get_indexed_fields()` over the loaded segments — the same reconciliation `replicate_field_indexes` does for the optimizer's CoW segment. The shard-root `payload_index.json` is dropped from edge (segments are the source of truth there).

Edge-only; `shard`/`collection` untouched.

## Test

`appendable_segment_created_on_load_inherits_payload_indexes`: index + vacuum with a lowered indexing threshold → immutable indexed segment; delete the empty CoW appendable segment dir on disk; `load()`; every segment, including the freshly created appendable one, must carry the index. Fails with an empty seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
