### PR TITLE
[UIO] `UniversalRead::read_bytes_async` stubs

### DIFF
--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -162,6 +162,16 @@ impl UniversalRead for CachedSlice {
         Ok(self.get_range_bytes(start..end, align)?)
     }
 
+    async fn read_bytes_async<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        access_pattern: P,
+        align: usize,
+    ) -> UioResult<ACow<'_>> {
+        // TODO(uio): implement real async
+        self.read_bytes(range, access_pattern, align)
+    }
+
     fn len<T>(&self) -> UioResult<u64> {
         Ok(Self::len::<T>(self) as u64)
     }

--- a/lib/common/common/src/universal_io/error.rs
+++ b/lib/common/common/src/universal_io/error.rs
@@ -278,6 +278,9 @@ impl<Src, Dst: ?Sized> From<zerocopy::SizeError<Src, Dst>> for UniversalIoError 
 
 impl From<tokio::task::JoinError> for UniversalIoError {
     fn from(err: tokio::task::JoinError) -> Self {
+        if err.is_panic() {
+            return Self::TaskPanicked(err.to_string());
+        }
         Self::Io(io::Error::from(err))
     }
 }

--- a/lib/common/common/src/universal_io/error.rs
+++ b/lib/common/common/src/universal_io/error.rs
@@ -276,6 +276,12 @@ impl<Src, Dst: ?Sized> From<zerocopy::SizeError<Src, Dst>> for UniversalIoError 
     }
 }
 
+impl From<tokio::task::JoinError> for UniversalIoError {
+    fn from(err: tokio::task::JoinError) -> Self {
+        Self::Io(io::Error::from(err))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -206,11 +206,11 @@ impl UniversalRead for IoUringFile {
     async fn read_bytes_async<P: AccessPattern>(
         &self,
         range: Range<u64>,
-        _access_pattern: P,
+        access_pattern: P,
         align: usize,
     ) -> UioResult<ACow<'_>> {
         // TODO(uio): implement real async
-        self.read_bytes(range, _access_pattern, align)
+        self.read_bytes(range, access_pattern, align)
     }
 
     fn len<T>(&self) -> UioResult<u64> {

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -203,6 +203,16 @@ impl UniversalRead for IoUringFile {
         Ok(ACow::Owned(bytes))
     }
 
+    async fn read_bytes_async<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        _access_pattern: P,
+        align: usize,
+    ) -> UioResult<ACow<'_>> {
+        // TODO(uio): implement real async
+        self.read_bytes(range, _access_pattern, align)
+    }
+
     fn len<T>(&self) -> UioResult<u64> {
         let byte_len = self.file.metadata()?.len();
 

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -1,6 +1,7 @@
 mod pipeline;
 
 use std::borrow::Cow;
+use std::future::ready;
 use std::io::ErrorKind;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
@@ -210,6 +211,16 @@ impl UniversalRead for MmapFile {
         let mmap = self.as_bytes::<P>();
         let bytes = read_bytes(mmap, range)?;
         Ok(ACow::Borrowed(bytes))
+    }
+
+    fn read_bytes_async<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        access_pattern: P,
+        align: usize,
+    ) -> impl Future<Output = UioResult<ACow<'_>>> {
+        // No special async way of reading mmap
+        ready(self.read_bytes(range, access_pattern, align))
     }
 
     /// Override the default pipeline-based for better performance.

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -81,6 +81,16 @@ where
         Ok(bytes)
     }
 
+    async fn read_bytes_async<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        access_pattern: P,
+        align: usize,
+    ) -> UioResult<ACow<'_>> {
+        // TODO(uio): implement real async
+        self.read_bytes(range, access_pattern, align)
+    }
+
     fn read_whole<T: Item>(&self) -> UioResult<Cow<'_, [T]>> {
         self.prefill_if_uninit()?;
         let length = self.len::<T>()?;

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -107,6 +107,16 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
         align: usize,
     ) -> UioResult<ACow<'_>>;
 
+    /// Async-capable version of [`UniversalRead::read_bytes`].
+    ///
+    /// If backend allows it, uses async primitives.
+    fn read_bytes_async<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        access_pattern: P,
+        align: usize,
+    ) -> impl Future<Output = UioResult<ACow<'_>>>;
+
     /// Read the entire file in one logical access.
     ///
     /// Implementations may override this to avoid the two accesses that would

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -144,6 +144,16 @@ where
     }
 
     #[inline]
+    fn read_bytes_async<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        access_pattern: P,
+        align: usize,
+    ) -> impl Future<Output = UioResult<ACow<'_>>> {
+        self.0.read_bytes_async(range, access_pattern, align)
+    }
+
+    #[inline]
     fn read_whole<T: Item>(&self) -> UioResult<Cow<'_, [T]>> {
         self.0.read_whole()
     }

--- a/lib/common/io_bridge/src/cached/mod.rs
+++ b/lib/common/io_bridge/src/cached/mod.rs
@@ -211,6 +211,15 @@ where
         self.cache.read_bytes(range, access_pattern, align)
     }
 
+    fn read_bytes_async<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        access_pattern: P,
+        align: usize,
+    ) -> impl Future<Output = UioResult<ACow<'_>>> {
+        self.cache.read_bytes_async(range, access_pattern, align)
+    }
+
     fn read_whole<T: common::universal_io::Item>(&self) -> UioResult<std::borrow::Cow<'_, [T]>> {
         self.cache.read_whole()
     }

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -127,6 +127,20 @@ impl<A: AsyncRead + Clone> UniversalRead for BlobFile<A> {
         Ok(ACow::Owned(buf))
     }
 
+    async fn read_bytes_async<P: AccessPattern>(
+        &self,
+        range: Range<u64>,
+        _access_pattern: P,
+        align: usize,
+    ) -> UioResult<ACow<'_>> {
+        let buf = self
+            .runtime
+            .handle()
+            .spawn(read_into_byte_buffer::<A>(self, range, align))
+            .await??;
+        Ok(ACow::Owned(buf))
+    }
+
     fn read_whole<T: Item>(&self) -> UioResult<Cow<'_, [T]>> {
         let buf = self
             .runtime


### PR DESCRIPTION
## What
Adds an async interface for reading bytes from `UniversalRead` backends.

It bypasses `block_on` for `BlobFile`, and directly returns the future. For other backends, it's a basic that forwards to sync implementation.

## Why
It's the foundation to unlocking two new abilities:
1. Having an accurate signal of when reads are done, so that we know when `live_preload`/`preopen` is finished and we can start the apply step under a write lock (at least for `live_reload`).
2. Prefetching dependant ranges easily and efficiently. For example, in some cases we'll want to load graphlink's offsets, but we only know the right ranges after reading the header.