### PR TITLE
Move avg_vector_for_recommendation into segment, re-export from edge

### DIFF
--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -13,6 +13,7 @@ use segment::types::{
 };
 use segment::vector_storage::query::{
     ContextPair, ContextQuery, DiscoverQuery, FeedbackItem, NaiveFeedbackCoefficients, RecoQuery,
+    avg_vector_for_recommendation,
 };
 use serde::Serialize;
 use shard::query::query_enum::QueryEnum;
@@ -25,7 +26,6 @@ use crate::common::fetch_vectors::ReferencedVectors;
 use crate::lookup::WithLookup;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::universal_query::shard_query::MmrInternal;
-use crate::recommendations::avg_vector_for_recommendation;
 
 const DEFAULT_MMR_LAMBDA: f32 = 0.5;
 

--- a/lib/collection/src/recommendations.rs
+++ b/lib/collection/src/recommendations.rs
@@ -1,21 +1,17 @@
 use std::future::Future;
-use std::iter::Peekable;
 use std::sync::Arc;
 use std::time::Duration;
 
 use api::rest::RecommendStrategy;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
-use segment::data_types::vectors::{
-    DenseVector, NamedQuery, TypedMultiDenseVector, VectorElementType, VectorInternal, VectorRef,
-};
+use segment::data_types::vectors::{NamedQuery, VectorInternal};
 use segment::types::{
     Condition, ExtendedPointId, Filter, HasIdCondition, PointIdType, ScoredPoint,
 };
-use segment::vector_storage::query::RecoQuery;
+use segment::vector_storage::query::{RecoQuery, avg_vector_for_recommendation};
 use shard::query::query_enum::QueryEnum;
 use shard::search::CoreSearchRequestBatch;
-use sparse::common::sparse_vector::SparseVector;
 
 use crate::collection::Collection;
 use crate::common::batching::{batch_requests, empty_batch_results};
@@ -30,120 +26,6 @@ use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::types::{
     CollectionError, CollectionResult, CoreSearchRequest, RecommendRequestInternal, UsingVector,
 };
-
-fn avg_vectors<'a>(
-    vectors: impl IntoIterator<Item = VectorRef<'a>>,
-) -> CollectionResult<VectorInternal> {
-    let mut avg_dense = DenseVector::default();
-    let mut avg_sparse = SparseVector::default();
-    let mut avg_multi: Option<TypedMultiDenseVector<VectorElementType>> = None;
-    let mut dense_count = 0;
-    let mut sparse_count = 0;
-    let mut multi_count = 0;
-    for vector in vectors {
-        match vector {
-            VectorRef::Dense(vector) => {
-                dense_count += 1;
-                for i in 0..vector.len() {
-                    if i >= avg_dense.len() {
-                        avg_dense.push(vector[i])
-                    } else {
-                        avg_dense[i] += vector[i];
-                    }
-                }
-            }
-            VectorRef::Sparse(vector) => {
-                sparse_count += 1;
-                avg_sparse = vector.combine_aggregate(&avg_sparse, |v1, v2| v1 + v2);
-            }
-            VectorRef::MultiDense(vector) => {
-                multi_count += 1;
-                avg_multi = Some(avg_multi.map_or_else(
-                    || vector.to_owned(),
-                    |mut avg_multi| {
-                        avg_multi
-                            .flattened_vectors
-                            .extend_from_slice(vector.flattened_vectors);
-                        avg_multi
-                    },
-                ));
-            }
-        }
-    }
-
-    match (dense_count, sparse_count, multi_count) {
-        // TODO(sparse): what if vectors iterator is empty? We added CollectionError::BadRequest,
-        // but it's not clear if it's the best solution.
-        // Currently it's hard to return an zeroed vector, because we don't know its type: dense or sparse.
-        (0, 0, 0) => Err(CollectionError::bad_input(
-            "Positive vectors should not be empty with `average` strategy".to_owned(),
-        )),
-        (_, 0, 0) => {
-            for item in &mut avg_dense {
-                *item /= dense_count as VectorElementType;
-            }
-            Ok(VectorInternal::from(avg_dense))
-        }
-        (0, _, 0) => {
-            for item in &mut avg_sparse.values {
-                *item /= sparse_count as VectorElementType;
-            }
-            Ok(VectorInternal::from(avg_sparse))
-        }
-        (0, 0, _) => match avg_multi {
-            Some(avg_multi) => Ok(VectorInternal::from(avg_multi)),
-            None => Err(CollectionError::bad_input(
-                "Positive vectors should not be empty with `average` strategy".to_owned(),
-            )),
-        },
-        (_, _, _) => Err(CollectionError::bad_input(
-            "Can't average vectors with different types".to_owned(),
-        )),
-    }
-}
-
-fn merge_positive_and_negative_avg(
-    positive: VectorInternal,
-    negative: VectorInternal,
-) -> CollectionResult<VectorInternal> {
-    match (positive, negative) {
-        (VectorInternal::Dense(positive), VectorInternal::Dense(negative)) => {
-            let vector: DenseVector = positive
-                .iter()
-                .zip(negative.iter())
-                .map(|(pos, neg)| pos + pos - neg)
-                .collect();
-            Ok(vector.into())
-        }
-        (VectorInternal::Sparse(positive), VectorInternal::Sparse(negative)) => Ok(positive
-            .combine_aggregate(&negative, |pos, neg| pos + pos - neg)
-            .into()),
-        (VectorInternal::MultiDense(mut positive), VectorInternal::MultiDense(negative)) => {
-            // merge positive and negative vectors as concatenated vectors with negative vectors negated
-            positive.flattened_vectors.extend(negative.flattened_vectors.into_iter().map(|x| -x));
-            Ok(VectorInternal::MultiDense(positive))
-        },
-        _ => Err(CollectionError::bad_input(
-            "Positive and negative vectors should be of the same type, either all dense or all sparse or all multi".to_owned(),
-        )),
-    }
-}
-
-pub fn avg_vector_for_recommendation<'a>(
-    positive: impl IntoIterator<Item = VectorRef<'a>>,
-    mut negative: Peekable<impl Iterator<Item = VectorRef<'a>>>,
-) -> CollectionResult<VectorInternal> {
-    let avg_positive = avg_vectors(positive)?;
-
-    let search_vector = if negative.peek().is_none() {
-        avg_positive
-    } else {
-        let avg_negative = avg_vectors(negative)?;
-        merge_positive_and_negative_avg(avg_positive, avg_negative)?
-    };
-
-    Ok(search_vector)
-}
 
 #[allow(clippy::too_many_arguments)]
 pub async fn recommend_by<F, Fut>(
@@ -469,49 +351,5 @@ fn recommend_by_custom_score(
         with_payload,
         with_vector,
         score_threshold,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use segment::data_types::vectors::{VectorInternal, VectorRef};
-    use sparse::common::sparse_vector::SparseVector;
-
-    use super::avg_vectors;
-
-    #[test]
-    fn test_avg_vectors() {
-        let vectors: Vec<VectorInternal> = vec![
-            vec![1.0, 2.0, 3.0].into(),
-            vec![1.0, 2.0, 3.0].into(),
-            vec![1.0, 2.0, 3.0].into(),
-        ];
-        assert_eq!(
-            avg_vectors(vectors.iter().map(VectorRef::from)).unwrap(),
-            vec![1.0, 2.0, 3.0].into(),
-        );
-
-        let vectors: Vec<VectorInternal> = vec![
-            SparseVector::new(vec![0, 1, 2], vec![0.0, 0.1, 0.2])
-                .unwrap()
-                .into(),
-            SparseVector::new(vec![0, 1, 2], vec![0.0, 1.0, 2.0])
-                .unwrap()
-                .into(),
-        ];
-        assert_eq!(
-            avg_vectors(vectors.iter().map(VectorRef::from)).unwrap(),
-            SparseVector::new(vec![0, 1, 2], vec![0.0, 0.55, 1.1])
-                .unwrap()
-                .into(),
-        );
-
-        let vectors: Vec<VectorInternal> = vec![
-            vec![1.0, 2.0, 3.0].into(),
-            SparseVector::new(vec![0, 1, 2], vec![0.0, 0.1, 0.2])
-                .unwrap()
-                .into(),
-        ];
-        assert!(avg_vectors(vectors.iter().map(VectorRef::from)).is_err());
     }
 }

--- a/lib/edge/src/reexports.rs
+++ b/lib/edge/src/reexports.rs
@@ -39,6 +39,7 @@ mod reexports_from_qdrant_crates {
         ContextPair, ContextQuery, DiscoverQuery, FeedbackItem,
         NaiveFeedbackCoefficients as NaiveFeedbackStrategy,
         NaiveFeedbackQuery as FeedbackNaiveQuery, RecoQuery as RecommendQuery,
+        avg_vector_for_recommendation,
     };
     pub use shard::operations::payload_ops::{DeletePayloadOp, PayloadOps, SetPayloadOp};
     pub use shard::operations::point_ops::{
@@ -66,7 +67,7 @@ pub use reexports_from_qdrant_crates::*;
 
 /// TODO: We need to do something these duplicates of Vector/Point structures
 mod todo_to_clean_up {
-    pub use segment::data_types::vectors::{VectorInternal, VectorStructInternal};
+    pub use segment::data_types::vectors::{VectorInternal, VectorRef, VectorStructInternal};
     pub use shard::operations::point_ops::{
         PointStructPersisted, VectorPersisted, VectorStructPersisted,
     };

--- a/lib/segment/src/vector_storage/query/mod.rs
+++ b/lib/segment/src/vector_storage/query/mod.rs
@@ -11,7 +11,9 @@ mod reco_query;
 pub use context_query::{ContextPair, ContextQuery};
 pub use discover_query::DiscoverQuery;
 pub use feedback_query::{FeedbackItem, NaiveFeedbackCoefficients, NaiveFeedbackQuery};
-pub use reco_query::{RecoBestScoreQuery, RecoQuery, RecoSumScoresQuery};
+pub use reco_query::{
+    RecoBestScoreQuery, RecoQuery, RecoSumScoresQuery, avg_vector_for_recommendation,
+};
 
 pub trait TransformInto<Output, T = DenseVector, U = DenseVector> {
     /// Change the underlying type of the query, or just process it in some way.

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -1,13 +1,17 @@
 use std::hash::Hash;
+use std::iter::Peekable;
 
 use common::math::scaled_fast_sigmoid;
 use common::types::ScoreType;
 use itertools::Itertools;
 use serde::Serialize;
+use sparse::common::sparse_vector::SparseVector;
 
 use super::{Query, TransformInto};
-use crate::common::operation_error::OperationResult;
-use crate::data_types::vectors::{QueryVector, VectorInternal};
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::data_types::vectors::{
+    DenseVector, QueryVector, TypedMultiDenseVector, VectorElementType, VectorInternal, VectorRef,
+};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Hash)]
 pub struct RecoQuery<T> {
@@ -131,6 +135,128 @@ impl<T> Query<T> for RecoSumScoresQuery<T> {
     }
 }
 
+/// The query vector of the `average_vector` recommend strategy:
+/// `avg(positives)` when there are no negatives, else
+/// `avg(positives) + (avg(positives) - avg(negatives))`.
+///
+/// All examples must be of one kind (all dense, all sparse or all multi); an
+/// empty positive set or mixed kinds is a validation error.
+pub fn avg_vector_for_recommendation<'a>(
+    positive: impl IntoIterator<Item = VectorRef<'a>>,
+    mut negative: Peekable<impl Iterator<Item = VectorRef<'a>>>,
+) -> OperationResult<VectorInternal> {
+    let avg_positive = avg_vectors(positive)?;
+
+    let search_vector = if negative.peek().is_none() {
+        avg_positive
+    } else {
+        let avg_negative = avg_vectors(negative)?;
+        merge_positive_and_negative_avg(avg_positive, avg_negative)?
+    };
+
+    Ok(search_vector)
+}
+
+fn avg_vectors<'a>(
+    vectors: impl IntoIterator<Item = VectorRef<'a>>,
+) -> OperationResult<VectorInternal> {
+    let mut avg_dense = DenseVector::default();
+    let mut avg_sparse = SparseVector::default();
+    let mut avg_multi: Option<TypedMultiDenseVector<VectorElementType>> = None;
+    let mut dense_count = 0;
+    let mut sparse_count = 0;
+    let mut multi_count = 0;
+    for vector in vectors {
+        match vector {
+            VectorRef::Dense(vector) => {
+                dense_count += 1;
+                for i in 0..vector.len() {
+                    if i >= avg_dense.len() {
+                        avg_dense.push(vector[i])
+                    } else {
+                        avg_dense[i] += vector[i];
+                    }
+                }
+            }
+            VectorRef::Sparse(vector) => {
+                sparse_count += 1;
+                avg_sparse = vector.combine_aggregate(&avg_sparse, |v1, v2| v1 + v2);
+            }
+            VectorRef::MultiDense(vector) => {
+                multi_count += 1;
+                avg_multi = Some(avg_multi.map_or_else(
+                    || vector.to_owned(),
+                    |mut avg_multi| {
+                        avg_multi
+                            .flattened_vectors
+                            .extend_from_slice(vector.flattened_vectors);
+                        avg_multi
+                    },
+                ));
+            }
+        }
+    }
+
+    match (dense_count, sparse_count, multi_count) {
+        // TODO(sparse): what if vectors iterator is empty? We return a validation error,
+        // but it's not clear if it's the best solution.
+        // Currently it's hard to return an zeroed vector, because we don't know its type: dense or sparse.
+        (0, 0, 0) => Err(OperationError::validation_error(
+            "Positive vectors should not be empty with `average` strategy",
+        )),
+        (_, 0, 0) => {
+            for item in &mut avg_dense {
+                *item /= dense_count as VectorElementType;
+            }
+            Ok(VectorInternal::from(avg_dense))
+        }
+        (0, _, 0) => {
+            for item in &mut avg_sparse.values {
+                *item /= sparse_count as VectorElementType;
+            }
+            Ok(VectorInternal::from(avg_sparse))
+        }
+        (0, 0, _) => match avg_multi {
+            Some(avg_multi) => Ok(VectorInternal::from(avg_multi)),
+            None => Err(OperationError::validation_error(
+                "Positive vectors should not be empty with `average` strategy",
+            )),
+        },
+        (_, _, _) => Err(OperationError::validation_error(
+            "Can't average vectors with different types",
+        )),
+    }
+}
+
+fn merge_positive_and_negative_avg(
+    positive: VectorInternal,
+    negative: VectorInternal,
+) -> OperationResult<VectorInternal> {
+    match (positive, negative) {
+        (VectorInternal::Dense(positive), VectorInternal::Dense(negative)) => {
+            let vector: DenseVector = positive
+                .iter()
+                .zip(negative.iter())
+                .map(|(pos, neg)| pos + pos - neg)
+                .collect();
+            Ok(vector.into())
+        }
+        (VectorInternal::Sparse(positive), VectorInternal::Sparse(negative)) => Ok(positive
+            .combine_aggregate(&negative, |pos, neg| pos + pos - neg)
+            .into()),
+        (VectorInternal::MultiDense(mut positive), VectorInternal::MultiDense(negative)) => {
+            // merge positive and negative vectors as concatenated vectors with negative vectors negated
+            positive
+                .flattened_vectors
+                .extend(negative.flattened_vectors.into_iter().map(|x| -x));
+            Ok(VectorInternal::MultiDense(positive))
+        }
+        _ => Err(OperationError::validation_error(
+            "Positive and negative vectors should be of the same type, either all dense or all sparse or all multi",
+        )),
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::cmp::Ordering;
@@ -139,7 +265,10 @@ mod test {
     use common::types::ScoreType;
     use proptest::prelude::*;
     use rstest::rstest;
+    use sparse::common::sparse_vector::SparseVector;
 
+    use super::{avg_vector_for_recommendation, avg_vectors};
+    use crate::data_types::vectors::{VectorInternal, VectorRef};
     use crate::vector_storage::query::{Query, RecoBestScoreQuery, RecoQuery};
 
     enum Chosen {
@@ -261,5 +390,63 @@ mod test {
 
             assert_ne!(ordering, std::cmp::Ordering::Less);
         }
+    }
+
+    #[test]
+    fn test_avg_vectors() {
+        let vectors: Vec<VectorInternal> = vec![
+            vec![1.0, 2.0, 3.0].into(),
+            vec![1.0, 2.0, 3.0].into(),
+            vec![1.0, 2.0, 3.0].into(),
+        ];
+        assert_eq!(
+            avg_vectors(vectors.iter().map(VectorRef::from)).unwrap(),
+            vec![1.0, 2.0, 3.0].into(),
+        );
+
+        let vectors: Vec<VectorInternal> = vec![
+            SparseVector::new(vec![0, 1, 2], vec![0.0, 0.1, 0.2])
+                .unwrap()
+                .into(),
+            SparseVector::new(vec![0, 1, 2], vec![0.0, 1.0, 2.0])
+                .unwrap()
+                .into(),
+        ];
+        assert_eq!(
+            avg_vectors(vectors.iter().map(VectorRef::from)).unwrap(),
+            SparseVector::new(vec![0, 1, 2], vec![0.0, 0.55, 1.1])
+                .unwrap()
+                .into(),
+        );
+
+        let vectors: Vec<VectorInternal> = vec![
+            vec![1.0, 2.0, 3.0].into(),
+            SparseVector::new(vec![0, 1, 2], vec![0.0, 0.1, 0.2])
+                .unwrap()
+                .into(),
+        ];
+        assert!(avg_vectors(vectors.iter().map(VectorRef::from)).is_err());
+    }
+
+    #[test]
+    fn test_avg_vector_for_recommendation() {
+        let positives: Vec<VectorInternal> = vec![vec![1.0, 0.0].into(), vec![0.0, 1.0].into()];
+        let negatives: Vec<VectorInternal> = vec![vec![0.0, 1.0].into()];
+
+        // No negatives: the plain average.
+        let vector = avg_vector_for_recommendation(
+            positives.iter().map(VectorRef::from),
+            std::iter::empty().peekable(),
+        )
+        .unwrap();
+        assert_eq!(vector, vec![0.5, 0.5].into());
+
+        // With negatives: avg_pos + (avg_pos - avg_neg) = [0.5, 0.5] + ([0.5, 0.5] - [0, 1]).
+        let vector = avg_vector_for_recommendation(
+            positives.iter().map(VectorRef::from),
+            negatives.iter().map(VectorRef::from).peekable(),
+        )
+        .unwrap();
+        assert_eq!(vector, vec![1.0, 0.0].into());
     }
 }


### PR DESCRIPTION
The `average_vector` recommend strategy folds the examples into one query
vector (`avg(pos)`, or `avg(pos) + (avg(pos) - avg(neg))`). That fold lived in
`collection::recommendations`, though it only touches segment/sparse types
(`VectorRef`, `VectorInternal`, `SparseVector::combine_aggregate`,
`TypedMultiDenseVector`). Edge-based consumers — the serverless search worker
(qdrant/qdrant-serverless#46) — had to re-implement it, because the
`collection` crate is the whole node layer.

This moves `avg_vector_for_recommendation` (+ its private `avg_vectors` /
`merge_positive_and_negative_avg`) next to `RecoQuery` in
`segment::vector_storage::query`, returning `OperationResult` (the validation
errors map to `CollectionError::BadInput` through the existing `From`, so
HTTP/gRPC behaviour is unchanged), keeps the two `collection` call sites on it,
and re-exports it — plus `VectorRef`, which callers need to build the
iterators — from edge. No behaviour change; the existing test moves along and
one for the fold itself is added.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally? (`cargo test -p segment --lib -- reco_query`, `cargo clippy -p segment -p edge -p collection`, nightly fmt on the touched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
