### PR TITLE
Run model_testing harness gates on tmpfs

### DIFF
--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -949,6 +949,34 @@ mod tests {
     const SNAPSHOTS_OFF: bool = true;
     const SNAPSHOTS_ON: bool = false;
 
+    /// tmpfs root a run prefers over the platform temp dir: every gridstore storage preallocates
+    /// a 32 MB page, so a run occupies ~600 MB (~3 GB for the snapshot gate) and is unusably slow
+    /// on a copy-on-write filesystem (~30 s on tmpfs vs. not finishing in 7 min on btrfs).
+    const SHM_ROOT: &str = "/dev/shm";
+
+    /// Free space required at [`SHM_ROOT`], above the ~3 GB peak. Guards against the 64 MB
+    /// `/dev/shm` a container gets by default, where a run would die on `ENOSPC` partway through.
+    const SHM_MIN_AVAILABLE: u64 = 4 * 1024 * 1024 * 1024;
+
+    /// Create one run's storage dir, on tmpfs where possible. An explicit `TMPDIR` wins: it stays
+    /// the escape hatch for running these gates against a real filesystem.
+    fn create_storage_dir() -> tempfile::TempDir {
+        // Named prefix: a failing run leaks its dir for postmortem, and on tmpfs that leak is RAM.
+        let mut builder = tempfile::Builder::new();
+        let builder = builder.prefix("qdrant-model-testing-");
+        let shm = Path::new(SHM_ROOT);
+        let use_shm = !std::env::var_os("TMPDIR").is_some_and(|v| !v.is_empty())
+            && shm.is_dir()
+            && common::disk_usage::disk_usage(shm)
+                .is_some_and(|usage| usage.available >= SHM_MIN_AVAILABLE);
+        if use_shm {
+            builder.tempdir_in(shm)
+        } else {
+            builder.tempdir()
+        }
+        .expect("failed to create temp dir")
+    }
+
     /// Owns a run's storage dir. On a clean drop the dir is deleted (normal `TempDir`
     /// behaviour); if the test is unwinding from a panic the dir is leaked instead and its
     /// path printed, so the trace + data survive for postmortem reproduction with the seed.
@@ -974,7 +1002,8 @@ mod tests {
             {
                 let path = dir.keep(); // leak: do not delete on failure
                 eprintln!(
-                    "model_testing: {} FAILED (seed = {}), storage retained at {}",
+                    "model_testing: {} FAILED (seed = {}), storage retained at {} \
+                     (held in RAM when under {SHM_ROOT})",
                     self.name,
                     self.seed,
                     path.display(),
@@ -1001,9 +1030,12 @@ mod tests {
         disable_snapshots: bool,
         op_num: usize,
     ) {
-        let storage_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let storage_dir = create_storage_dir();
         let seed = rand::rng().random();
-        println!("model_testing: {name} seed = {seed}");
+        println!(
+            "model_testing: {name} seed = {seed}, storage = {}",
+            storage_dir.path().display(),
+        );
         let guard = StorageGuard {
             dir: Some(storage_dir),
             name,

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -950,13 +950,15 @@ mod tests {
     const SNAPSHOTS_ON: bool = false;
 
     /// tmpfs root a run prefers over the platform temp dir: every gridstore storage preallocates
-    /// a 32 MB page, so a run occupies ~600 MB (~3 GB for the snapshot gate) and is unusably slow
+    /// a 32 MB page, so a run occupies ~600 MB (~3.2 GB for the snapshot gate) and is unusably slow
     /// on a copy-on-write filesystem (~30 s on tmpfs vs. not finishing in 7 min on btrfs).
     const SHM_ROOT: &str = "/dev/shm";
 
-    /// Free space required at [`SHM_ROOT`], above the ~3 GB peak. Guards against the 64 MB
-    /// `/dev/shm` a container gets by default, where a run would die on `ENOSPC` partway through.
-    const SHM_MIN_AVAILABLE: u64 = 4 * 1024 * 1024 * 1024;
+    /// Free space required at [`SHM_ROOT`]. Sized against the 4.1-4.5 GB the five gates peak at
+    /// *together* (nextest runs them concurrently and none of them reserves capacity), not the
+    /// ~3.2 GB of a single gate. Also guards against the 64 MB `/dev/shm` a container gets by
+    /// default. Too small a mount means falling back to disk, not an `ENOSPC` mid-run.
+    const SHM_MIN_AVAILABLE: u64 = 6 * 1024 * 1024 * 1024;
 
     /// Create one run's storage dir, on tmpfs where possible. An explicit `TMPDIR` wins: it stays
     /// the escape hatch for running these gates against a real filesystem.

--- a/lib/collection/src/model_testing/mod.rs
+++ b/lib/collection/src/model_testing/mod.rs
@@ -1004,8 +1004,7 @@ mod tests {
             {
                 let path = dir.keep(); // leak: do not delete on failure
                 eprintln!(
-                    "model_testing: {} FAILED (seed = {}), storage retained at {} \
-                     (held in RAM when under {SHM_ROOT})",
+                    "model_testing: {} FAILED (seed = {}), storage retained at {}",
                     self.name,
                     self.seed,
                     path.display(),


### PR DESCRIPTION
The `model_testing::tests::harness*` gates are slow locally and unusable on some machines: a colleague reports the set finishing in ~30s on tmpfs but **not finishing after 7 minutes on btrfs**.

## Why

Not the op count. Every gridstore-backed storage in every segment preallocates a 32 MB page (`DEFAULT_PAGE_SIZE_BYTES`, `lib/blobstore/src/config.rs:12`), plus 32 MB WAL segments, so ~440 live points occupy ~600 MB and `harness_no_optimizer_snapshots` peaks at ~3.2 GB. That cost is per-segment, not per-op, so trimming op counts does not address it.

Measured solo, debug build, 2 runs each (wall seconds):

| gate | tmpfs | ext4 / NVMe |
|---|---|---|
| `no_optimizer_no_restarts` | 27.0 / 25.1 | 33.4 / 28.5 |
| `no_optimizer` | 43.1 / 40.5 | 58.5 / 60.6 |
| `no_optimizer_snapshots` | 54.0 / 52.8 | **336.9 / 98.2** |
| `no_restarts` | 15.9 / 18.9 | 23.4 / 23.4 |
| `harness` | 9.0 / 6.6 | 9.4 / 12.6 |

The snapshot gate runs at 24-47% CPU on ext4, i.e. purely waiting on IO. btrfs (CoW, `fallocate` reserving real space, slow mmap writeback) is worse still.

## Change

`create_storage_dir()` puts a run's storage under `/dev/shm` when `TMPDIR` is unset and at least 4 GiB is free, else falls back to the platform temp dir.

- The 6 GiB free-space gate is sized against the 4.1-4.5 GB the five gates peak at *together* (nextest runs them concurrently and none reserves capacity), not the ~3.2 GB of a single gate. It also covers the 64 MB `/dev/shm` a container gets by default. Too small a mount means falling back to disk, not an `ENOSPC` mid-run.
- An explicit `TMPDIR` wins, so running against a real filesystem stays one env var away. macOS always sets it, so behaviour there is unchanged.
- The seed line echoes the chosen root, and dirs get a `qdrant-model-testing-` prefix: `StorageGuard` leaks the dir on failure for postmortem, and on tmpfs that leak is GBs of RAM.

These gates cover harness rot, not durability, so trading real-disk timing for a usable runtime is the right call. The soak binary is untouched. This deliberately does not set `TMPDIR` globally for the suite: the fadvise eviction tests need a real filesystem.

## CI effect

Paired `rust-tests (ubuntu-latest)` samples, 6 baseline runs vs 3 PR runs (median seconds):

| gate | baseline | PR | ratio |
|---|---|---|---|
| `harness` | 22.7 | 13.7 | 0.61 |
| `harness_no_optimizer` | 84.1 | 62.5 | 0.74 |
| `harness_no_optimizer_snapshots` | 110.7 | 78.2 | 0.71 |
| `harness_no_restarts` | 33.6 | 27.6 | 0.82 |
| `harness_no_optimizer_no_restarts` | 59.2 | 55.9 | 0.94 |
| **total** | **314.5** | **252.6** | **0.80** |

Baseline totals `284, 287, 293, 336, 344, 360` vs PR `231, 253, 268`: disjoint, one-sided exact rank test p = 1/84 = 0.012.

Method: the baseline pools reruns of the dev-tip run (`6e638910d`, the commit CI actually merges against) with two older dev runs; their harness totals overlap, so dev drift did not move these gates. One PR run was dropped as an outlier machine (control tests at 0.57x typical). Comparability was checked with the median ratio of 139 non-harness tests >=5s.

-20% on CI is far below the local effect because GH runners have fast NVMe and 16 GB RAM, so the ~600 MB working set stays in page cache and only fsync costs. Suite total is unchanged within noise (786-830s vs 732-779s); these gates were never the critical path.

## Not in scope

- The snapshot gate still trips `SLOW`. That is cosmetic: no `slow-timeout` is set in `.config/nextest.toml`, so nothing is killed.
- Snapshot staging still goes to the platform temp dir, so on a non-tmpfs `/tmp` the snapshot gate keeps writing ~1.9 GB to disk. Redirecting it under `storage_path` was measured and rejected: it pushes the concurrent aggregate to 7.0 GB, which would force the threshold so high that most machines fall back to disk anyway.
- A test-only `DEFAULT_PAGE_SIZE_BYTES` override would cut the footprint ~30x and help every small-collection test on every filesystem, including the RAM this PR now spends. Left for a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
