### PR TITLE
Fix clippy warnings from Rust 1.98 beta

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -1067,7 +1067,7 @@ impl RecreateOptimizersState {
     fn request(&self) -> bool {
         let prev =
             self.state
-                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |state| match state {
+                .try_update(Ordering::AcqRel, Ordering::Acquire, |state| match state {
                     RECREATE_IDLE => Some(RECREATE_RUNNING),
                     RECREATE_RUNNING => Some(RECREATE_RUNNING_PENDING),
                     // Already queued, nothing to change.
@@ -1084,7 +1084,7 @@ impl RecreateOptimizersState {
     fn finish_run(&self) -> bool {
         let prev =
             self.state
-                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |state| match state {
+                .try_update(Ordering::AcqRel, Ordering::Acquire, |state| match state {
                     RECREATE_RUNNING_PENDING => Some(RECREATE_RUNNING),
                     RECREATE_RUNNING => Some(RECREATE_IDLE),
                     // Idle would mean finish_run was called without a running task.

--- a/lib/collection/src/profiling/slow_requests_collector.rs
+++ b/lib/collection/src/profiling/slow_requests_collector.rs
@@ -82,14 +82,13 @@ impl RequestsCollector {
                 .unwrap_or_else(|_| 0);
 
             // Atomically update if enough time has passed
-            let updated =
-                LAST_SEND_WARN.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |prev| {
-                    if now.saturating_sub(prev) >= WARN_INTERVAL_SECS {
-                        Some(now)
-                    } else {
-                        None
-                    }
-                });
+            let updated = LAST_SEND_WARN.try_update(Ordering::Relaxed, Ordering::Relaxed, |prev| {
+                if now.saturating_sub(prev) >= WARN_INTERVAL_SECS {
+                    Some(now)
+                } else {
+                    None
+                }
+            });
 
             if updated.is_err() {
                 return;

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -101,6 +101,7 @@ impl QueueProxyShard {
     ///
     /// This fails if the given `version` is not in bounds of our current WAL. If the given
     /// `version` is too old or too new, queue proxy creation is rejected.
+    #[allow(clippy::result_large_err)]
     pub async fn new_from_version(
         wrapped_shard: LocalShard,
         remote_shard: RemoteShard,

--- a/lib/common/io_bridge/src/pipeline/buffer.rs
+++ b/lib/common/io_bridge/src/pipeline/buffer.rs
@@ -151,7 +151,6 @@ async fn scatter_stream_into_buffer(
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use futures::StreamExt as _;
 
     use super::*;
 

--- a/lib/segment/src/id_tracker/mutable_id_tracker/update_only/mod.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/update_only/mod.rs
@@ -194,7 +194,11 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
         // entry boundaries stay visible to it.
         file.append_batch(
             committed_len,
-            versions_buffer.chunks_exact(VERSION_ELEMENT_SIZE as usize),
+            versions_buffer
+                .as_chunks::<{ VERSION_ELEMENT_SIZE as usize }>()
+                .0
+                .iter()
+                .map(|entry| entry.as_slice()),
         )?;
         (file.flusher())()?;
 

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -650,8 +650,10 @@ mod tests {
                 let decoded = match name.as_str() {
                     DENSE_NAME => VectorInternal::Dense(
                         bytes
-                            .chunks_exact(size_of::<f32>())
-                            .map(|chunk| f32::from_ne_bytes(chunk.try_into().unwrap()))
+                            .as_chunks::<{ size_of::<f32>() }>()
+                            .0
+                            .iter()
+                            .map(|chunk| f32::from_ne_bytes(*chunk))
                             .collect(),
                     ),
                     SPARSE_NAME => VectorInternal::Sparse(

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -824,6 +824,8 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     /// # Errors
     ///
     /// Returns an error if we have diverged commit/term for example.
+    // The only caller wants success or failure, there is nothing to carry in an error type.
+    #[allow(clippy::result_unit_err)]
     pub async fn wait_for_consensus_commit(
         &self,
         commit: u64,


### PR DESCRIPTION
`cargo +beta clippy --workspace --all-targets --all-features -- -D warnings` (rustc 1.98.0-beta.8) is clean with this. Stable clippy (1.97) and nightly `cargo fmt --check` still pass.

## Real fixes

* `io_bridge` buffer tests: dropped `use futures::StreamExt as _;`, the parent module's import already arrives through `use super::*`.
* Two `chunks_exact(CONST)` sites rewritten as `as_chunks::<{ CONST }>()` for the new `chunks_exact_to_as_chunks` lint (`as_chunks` is stable since 1.88, below our 1.97 MSRV). The `read_view` site also loses a `try_into().unwrap()` because the chunk is already `&[u8; 4]`.

## Suppressions

* `result_large_err` on `QueueProxyShard::new_from_version`, whose `Err` hands the `LocalShard` back to the caller. Mirrors the allow already sitting on `ForwardProxyShard::new`.
* `result_unit_err` now reaches `async fn`, which flags `wait_for_consensus_commit`. Its single caller does `.is_ok()`, so switching the signature to `bool` would silence it honestly too if that is preferred over the allow.

## Looking ahead to 1.99

Not required here, but included because the fix is free at our MSRV: the three `Atomic::fetch_update` calls are migrated to `try_update`, the name it is renamed to in 1.99. The new name already exists in 1.97, and the old one is deprecated next release.

One 1.99 lint is left alone: `#[pyclass(from_py_object)]` expands to a `clone()` of the wrapped value, tripping `clone_on_copy` for all 29 `Copy` types the Python bindings expose. The span points at the attribute, so silencing it means either 29 attributes or a crate-level allow, and pyo3 0.29.2 is the latest release so there is nothing upstream to pick up yet. Worth revisiting when 1.99 gets closer.

## Verification

* `cargo +1.98.0-beta clippy --workspace --all-targets --all-features -- -D warnings`: clean
* `cargo clippy --workspace --all-targets --all-features -- -D warnings` (1.97): clean
* `cargo +nightly fmt --all --check`: clean
* `cargo test -p segment --lib mutable_id_tracker`: 53 passed
