### PR TITLE
Fix clippy warnings from Rust 1.98 beta

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -1067,7 +1067,7 @@ impl RecreateOptimizersState {
     fn request(&self) -> bool {
         let prev =
             self.state
-                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |state| match state {
+                .try_update(Ordering::AcqRel, Ordering::Acquire, |state| match state {
                     RECREATE_IDLE => Some(RECREATE_RUNNING),
                     RECREATE_RUNNING => Some(RECREATE_RUNNING_PENDING),
                     // Already queued, nothing to change.
@@ -1084,7 +1084,7 @@ impl RecreateOptimizersState {
     fn finish_run(&self) -> bool {
         let prev =
             self.state
-                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |state| match state {
+                .try_update(Ordering::AcqRel, Ordering::Acquire, |state| match state {
                     RECREATE_RUNNING_PENDING => Some(RECREATE_RUNNING),
                     RECREATE_RUNNING => Some(RECREATE_IDLE),
                     // Idle would mean finish_run was called without a running task.

--- a/lib/collection/src/profiling/slow_requests_collector.rs
+++ b/lib/collection/src/profiling/slow_requests_collector.rs
@@ -82,14 +82,13 @@ impl RequestsCollector {
                 .unwrap_or_else(|_| 0);
 
             // Atomically update if enough time has passed
-            let updated =
-                LAST_SEND_WARN.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |prev| {
-                    if now.saturating_sub(prev) >= WARN_INTERVAL_SECS {
-                        Some(now)
-                    } else {
-                        None
-                    }
-                });
+            let updated = LAST_SEND_WARN.try_update(Ordering::Relaxed, Ordering::Relaxed, |prev| {
+                if now.saturating_sub(prev) >= WARN_INTERVAL_SECS {
+                    Some(now)
+                } else {
+                    None
+                }
+            });
 
             if updated.is_err() {
                 return;

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -101,6 +101,7 @@ impl QueueProxyShard {
     ///
     /// This fails if the given `version` is not in bounds of our current WAL. If the given
     /// `version` is too old or too new, queue proxy creation is rejected.
+    #[allow(clippy::result_large_err)]
     pub async fn new_from_version(
         wrapped_shard: LocalShard,
         remote_shard: RemoteShard,

--- a/lib/common/io_bridge/src/pipeline/buffer.rs
+++ b/lib/common/io_bridge/src/pipeline/buffer.rs
@@ -151,7 +151,6 @@ async fn scatter_stream_into_buffer(
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use futures::StreamExt as _;
 
     use super::*;
 

--- a/lib/segment/src/id_tracker/mutable_id_tracker/update_only/mod.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/update_only/mod.rs
@@ -194,7 +194,11 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
         // entry boundaries stay visible to it.
         file.append_batch(
             committed_len,
-            versions_buffer.chunks_exact(VERSION_ELEMENT_SIZE as usize),
+            versions_buffer
+                .as_chunks::<{ VERSION_ELEMENT_SIZE as usize }>()
+                .0
+                .iter()
+                .map(|entry| entry.as_slice()),
         )?;
         (file.flusher())()?;
 

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -650,8 +650,10 @@ mod tests {
                 let decoded = match name.as_str() {
                     DENSE_NAME => VectorInternal::Dense(
                         bytes
-                            .chunks_exact(size_of::<f32>())
-                            .map(|chunk| f32::from_ne_bytes(chunk.try_into().unwrap()))
+                            .as_chunks::<{ size_of::<f32>() }>()
+                            .0
+                            .iter()
+                            .map(|chunk| f32::from_ne_bytes(*chunk))
                             .collect(),
                     ),
                     SPARSE_NAME => VectorInternal::Sparse(

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -822,6 +822,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     /// Wait and block until consensus reaches a `term` and actually applies the `commit`.
     ///
     /// Returns `false` if we have diverged commit/term for example, or if `timeout` elapsed first.
+    #[must_use]
     pub async fn wait_for_consensus_commit(
         &self,
         commit: u64,

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -821,16 +821,14 @@ impl<C: CollectionContainer> ConsensusManager<C> {
 
     /// Wait and block until consensus reaches a `term` and actually applies the `commit`.
     ///
-    /// # Errors
-    ///
-    /// Returns an error if we have diverged commit/term for example.
+    /// Returns `false` if we have diverged commit/term for example, or if `timeout` elapsed first.
     pub async fn wait_for_consensus_commit(
         &self,
         commit: u64,
         term: u64,
         consensus_tick: Duration,
         timeout: Duration,
-    ) -> Result<(), ()> {
+    ) -> bool {
         let start = Instant::now();
 
         // TODO: naive approach with spinlock for waiting on commit/term, find better way
@@ -840,20 +838,20 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             // Okay if on the same term and have at least the specified commit
             let is_ok = current_term == term && current_commit >= commit;
             if is_ok {
-                return Ok(());
+                return true;
             }
 
             // Fail if on a newer term
             let is_fail = current_term > term;
             if is_fail {
-                return Err(());
+                return false;
             }
 
             tokio::time::sleep(consensus_tick).await
         }
 
         // Fail on timeout
-        Err(())
+        false
     }
 
     /// Send operation to the consensus thread and listen for the result.

--- a/src/tonic/api/qdrant_internal_api.rs
+++ b/src/tonic/api/qdrant_internal_api.rs
@@ -75,8 +75,7 @@ impl QdrantInternal for QdrantInternalService {
         let ok = self
             .consensus_state
             .wait_for_consensus_commit(commit, term, consensus_tick, timeout)
-            .await
-            .is_ok();
+            .await;
         Ok(Response::new(WaitOnConsensusCommitResponse { ok }))
     }
 


### PR DESCRIPTION
Makes `cargo +beta clippy --workspace --all-targets --all-features -- -D warnings` pass on 1.98.0-beta.8. 
Stable 1.97 clippy and nightly fmt still pass.

- `io_bridge` buffer tests: drop `use futures::StreamExt as _;`, already in scope via `use super::*`
- 2x `chunks_exact(CONST)` -> `as_chunks::<{ CONST }>()` for [chunks_exact_to_as_chunks](https://rust-lang.github.io/rust-clippy/master/index.html?search=chunks_exact_to_as_chunks#chunks_exact_to_as_chunks)
- `#[allow(clippy::result_large_err)]` on `QueueProxyShard::new_from_version`, whose `Err` returns the `LocalShard`; same allow already on `ForwardProxyShard::new`
- `wait_for_consensus_commit` returns `bool` instead of `Result<(), ()>`, which `result_unit_err` now flags on `async fn`. Its only caller did `.is_ok()` on it
- 3x `Atomic::fetch_update` -> `try_update`. Not a 1.98 lint, but the old name is deprecated in 1.99 and the new one already exists at our 1.97 MSRV

Left for later: 1.99 flags `clone_on_copy` on all 29 `#[pyclass(from_py_object)]` `Copy` types, fixable only by a crate-level allow until pyo3 changes its codegen.
