### PR TITLE
Run CI tests with TMPDIR on tmpfs

### DIFF
--- a/.github/workflows/rust-gpu.yml
+++ b/.github/workflows/rust-gpu.yml
@@ -33,6 +33,9 @@ jobs:
         /usr/bin/vulkaninfo --summary
     - name: Build
       run: cargo build --workspace --tests --features "gpu" --locked
+    # See the same step in rust.yml; this job is Linux-only so it needs no condition.
+    - name: Put test temp files on tmpfs
+      run: echo "TMPDIR=/dev/shm" >> "$GITHUB_ENV"
     - name: Run tests
       # Profile "ci" is configured in .config/nextest.toml
       run: cargo nextest run --workspace --features "gpu" --profile ci --locked

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,13 @@ jobs:
       uses: taiki-e/install-action@3a0adc33ab45d7b9b9da91822dd2b3c0151704be # nextest
     - name: Build
       run: cargo build --workspace --tests --locked
+    # `/dev/shm` is tmpfs. The `model_testing` harness gates preallocate 32 MB gridstore pages
+    # per storage per segment and peak around 4.5 GB across the five of them, so on a disk-backed
+    # temp dir they are dominated by IO. Linux only: macOS and Windows have no `/dev/shm`.
+    - name: Put test temp files on tmpfs
+      if: matrix.os == 'ubuntu-latest'
+      run: echo "TMPDIR=/dev/shm" >> "$GITHUB_ENV"
+      shell: bash
     - name: Run tests
       # Profile "ci" is configured in .config/nextest.toml
       run: cargo nextest run --workspace --profile ci --locked


### PR DESCRIPTION
`TMPDIR=/dev/shm` on the Linux test jobs, guarded by `matrix.os == 'ubuntu-latest'` in `rust.yml` (`rust-gpu.yml` is Linux-only already).

Configuration-level alternative to #10263, which solved the same problem by probing for `/dev/shm` inside the test code.

The `model_testing` gates are IO-bound, not op-bound: every gridstore-backed storage in every segment preallocates a 32 MB page (`DEFAULT_PAGE_SIZE_BYTES`, `lib/blobstore/src/config.rs:12`) plus 32 MB WAL segments, so ~440 live points occupy ~600 MB and the five gates peak at 4.1-4.5 GB together.

On a disk-backed temp dir that preallocation, plus flush and snapshot traffic, dominates their runtime.

Measured on CI from the nextest per-test times in the `rust-tests (ubuntu-latest)` logs: 3 runs of this branch against 7 runs of `dev` and other non-tmpfs branches from the same day at the same code, plus #10263 for reference.

The CPU-bound suites are unchanged across all groups (`quantization::integration` + `segment::integration` sum: 1559-1602s baseline, 1588-1604s here), so the runners are comparable.

| metric | baseline (n=7) | #10263 (n=3) | this PR (n=3) |
|---|---|---|---|
| 5 `model_testing` gates | 348s [305-364] | 284s | **244s (-30%)** |
| all other tests | 2708s [2605-2742] | 2748s | 2627s (-3.0%) |
| sum of per-test times | 3056s [2910-3091] | 3032s | 2871s (-6.1%) |
| nextest wall time | 814s [771-858] | 790s | 750s (-7.8%) |
| job wall time, incl. build | 1087s [1047-1139] | 1051s | 1022s (-6.0%) |

Per gate, mean [range] over the same runs:

| gate | baseline (n=7) | #10263 (n=3) | this PR (n=3) | delta |
|---|---|---|---|---|
| `harness` | 26.2s [17.6-32.2] | 21.4s | 21.5s [17.5-25.4] | -18% |
| `harness_no_optimizer` | 97.0s [90.8-110.0] | 81.6s | 70.8s [66.3-77.6] | -27%, disjoint |
| `harness_no_optimizer_no_restarts` | 60.8s [50.8-72.2] | 53.4s | 51.6s [45.1-61.9] | -15% |
| `harness_no_optimizer_snapshots` | 127.0s [102.1-165.0] | 94.3s | 72.0s [45.3-102.9] | -43% |
| `harness_no_restarts` | 36.8s [24.8-48.6] | 33.2s | 28.4s [22.3-32.2] | -23% |
| all five | 347.8s [305.2-363.6] | 283.8s | 244.3s [226.9-278.3] | -30%, disjoint |

Only `no_optimizer` and the total separate cleanly at n=3; the snapshot gate has the largest
absolute win and the widest spread on both arms, so the individual percentages carry error bars.

Every sample of this branch is below every baseline sample on all rows except "all other tests", where one baseline run on a faster runner overlaps (p = 0.008, Mann-Whitney, for the separated rows).

Outside the gates, the wins are confined to IO-bound tests:

- `wal` -48%, `disk_cache` -71%, `edge` -56%, `storage` -63%
- CPU-bound suites flat: `segment::integration` +0.6%, `quantization::integration` -0.4%, `blobstore` -0.8%

Trade-offs vs #10263:

- CI only. Developers on a non-tmpfs `/tmp` need to export `TMPDIR` themselves; #10263 gave them the speedup by default.
- Applies to every test, not just these five. Two tests already detect tmpfs and return early, so they would stop covering anything on CI: `lib/common/common/src/universal_io/mmap/mod.rs:698` (`POSIX_FADV_DONTNEED` cannot evict tmpfs pages) and `lib/common/common/src/universal_io/tests.rs:126` (tmpfs rejects `O_DIRECT`). Both already skip on any dev machine whose `/tmp` is tmpfs, so CI is currently their only real coverage. If that matters, they should pin their own temp dir to a real filesystem, the way `lib/shard/src/quota/manager/enforce.rs` already does.
- Whole-suite peak `/dev/shm` usage is 4.6 GB against the ~8 GB a GitHub runner provides.

Not in scope: a test-only `DEFAULT_PAGE_SIZE_BYTES` override would cut the footprint ~30x and help every small-collection test on every filesystem, rather than hiding the IO behind RAM.
