### PR TITLE
[LiveReload] Preload `ReadOnlyFlags`

### DIFF
--- a/lib/common/common/src/stored_bitmask/format.rs
+++ b/lib/common/common/src/stored_bitmask/format.rs
@@ -8,7 +8,7 @@ use crate::bitvec::BitSlice;
 
 pub(super) const MAGIC: [u8; 4] = *b"QBMK";
 pub(super) const VERSION: u32 = 1;
-pub(super) const HEADER_SIZE: usize = size_of::<BitmaskHeader>();
+pub const HEADER_SIZE: usize = size_of::<BitmaskHeader>();
 
 /// Maximum logical length: every bit position must be representable as `u32`.
 pub(super) const MAX_LOGICAL_LEN: u64 = 1 << 32;

--- a/lib/common/common/src/stored_bitmask/mod.rs
+++ b/lib/common/common/src/stored_bitmask/mod.rs
@@ -17,7 +17,7 @@ mod read;
 mod tests;
 mod write;
 
-pub use format::BitmaskContent;
+pub use format::{BitmaskContent, HEADER_SIZE};
 pub use mutable::MutableStoredBitmask;
 pub use read::StoredBitmask;
 pub use write::save_bitmask;

--- a/lib/segment/src/common/flags/read_only_compact_flags.rs
+++ b/lib/segment/src/common/flags/read_only_compact_flags.rs
@@ -67,7 +67,8 @@ impl<S: UniversalRead> ReadOnlyCompactFlags<S> {
             Populate::Auto | Populate::No => {
                 Populate::Partial(ReadRange::new(0, stored_bitmask::HEADER_SIZE as u64))
             }
-            Populate::Blocking | Populate::PreferBackground => Populate::PreferBackground,
+            Populate::Blocking => Populate::Blocking,
+            Populate::PreferBackground => Populate::PreferBackground,
             partial @ Populate::Partial(_) => partial,
         };
 

--- a/lib/segment/src/common/flags/read_only_compact_flags.rs
+++ b/lib/segment/src/common/flags/read_only_compact_flags.rs
@@ -2,9 +2,10 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use common::mmap::AdviceSetting;
-use common::stored_bitmask::StoredBitmask;
+use common::stored_bitmask::{self, StoredBitmask};
 use common::universal_io::{
-    CachedReadFs, OkNotFound, OpenOptions, Populate, UniversalRead, UniversalReadFs,
+    CachedReadFs, OkNotFound, OkUnchanged, OpenOptions, Populate, ReadRange, UniversalRead,
+    UniversalReadFs,
 };
 use roaring::RoaringBitmap;
 
@@ -60,8 +61,16 @@ impl<S: UniversalRead> ReadOnlyCompactFlags<S> {
     pub fn preopen(
         fs: &impl CachedReadFs<File = S>,
         directory: &Path,
-        populate: Populate,
+        mut populate: Populate,
     ) -> OperationResult<bool> {
+        populate = match populate {
+            Populate::Auto | Populate::No => {
+                Populate::Partial(ReadRange::new(0, stored_bitmask::HEADER_SIZE as u64))
+            }
+            Populate::Blocking | Populate::PreferBackground => Populate::PreferBackground,
+            partial @ Populate::Partial(_) => partial,
+        };
+
         Ok(fs
             .schedule_prefetch(
                 &directory.join(COMPACT_FLAGS_FILE),
@@ -119,6 +128,21 @@ impl<S: UniversalRead> ReadOnlyCompactFlags<S> {
         Ok(self.bitmap.get_or_init(|| bitmap))
     }
 
+    pub fn live_preload<Fs: CachedReadFs<File = S>>(&self, cached_fs: &Fs) -> OperationResult<()> {
+        let directory = self.directory.as_path();
+        let populate = if self.bitmap.get().is_some() {
+            Populate::PreferBackground
+        } else {
+            Populate::Partial(ReadRange::new(0, stored_bitmask::HEADER_SIZE as u64))
+        };
+        cached_fs.reschedule_prefetch(
+            &directory.join(COMPACT_FLAGS_FILE),
+            Some(open_options(populate)),
+            None,
+        )?;
+        Ok(())
+    }
+
     /// Refresh to the current on-disk state.
     ///
     /// The compact file is never mutated in place — every flush replaces it
@@ -132,12 +156,16 @@ impl<S: UniversalRead> ReadOnlyCompactFlags<S> {
     pub fn live_reload(&mut self, fs: &impl UniversalReadFs<File = S>) -> OperationResult<()> {
         // Once the flags exist their file always does, so absence here is a
         // genuine not-found (segment removed mid-reload), not a lazy file.
-        let storage = StoredBitmask::<S>::open(
+        let Some(storage) = StoredBitmask::<S>::open(
             fs,
             self.directory.join(COMPACT_FLAGS_FILE),
             open_options(Populate::No),
             Default::default(),
-        )?;
+        )
+        .ok_unchanged()?
+        else {
+            return Ok(());
+        };
 
         if let Some(bitmap) = self.bitmap.get_mut() {
             *bitmap = storage.read_ones()?;

--- a/lib/segment/src/common/flags/read_only_flags.rs
+++ b/lib/segment/src/common/flags/read_only_flags.rs
@@ -8,6 +8,7 @@ use super::read_only_compact_flags::ReadOnlyCompactFlags;
 use super::read_only_roaring_flags::ReadOnlyRoaringFlags;
 use super::roaring_flags::RoaringFlagsRead;
 use crate::common::operation_error::OperationResult;
+use crate::index::field_index::LiveReload;
 
 /// Read-only flags in either [storage mode](FlagsMode), serving the
 /// [`RoaringFlagsRead`] surface.
@@ -65,6 +66,33 @@ impl<S: UniversalRead> ReadOnlyFlags<S> {
         match self {
             Self::Dynamic(flags) => flags.live_reload(fs),
             Self::Compact(flags) => flags.live_reload(fs),
+        }
+    }
+}
+
+impl<S: UniversalRead> LiveReload for ReadOnlyFlags<S> {
+    type File = S;
+
+    fn live_preload<Fs: CachedReadFs<File = Self::File>>(
+        &self,
+        cached_fs: &Fs,
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyFlags::Dynamic(dynamic) => dynamic.live_preload(cached_fs),
+            ReadOnlyFlags::Compact(compact) => compact.live_preload(cached_fs),
+        }
+    }
+
+    fn live_reload<Fs: UniversalReadFs<File = Self::File>>(
+        &mut self,
+        fs: &Fs,
+        _deleted_points: &common::sorted_slice::SortedSlice<'_, common::types::PointOffsetType>,
+        _new_points: &common::sorted_slice::SortedSlice<'_, common::types::PointOffsetType>,
+        _hw_counter: &common::counter::hardware_counter::HardwareCounterCell,
+    ) -> OperationResult<()> {
+        match self {
+            ReadOnlyFlags::Dynamic(dynamic) => dynamic.live_reload(fs),
+            ReadOnlyFlags::Compact(compact) => compact.live_reload(fs),
         }
     }
 }

--- a/lib/segment/src/common/flags/read_only_roaring_flags.rs
+++ b/lib/segment/src/common/flags/read_only_roaring_flags.rs
@@ -5,7 +5,8 @@ use common::mmap::AdviceSetting;
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, OkNotFound, OpenOptions, Populate, TypedStorage, UniversalRead, UniversalReadFs,
+    CachedReadFs, OkNotFound, OkUnchanged, OpenOptions, Populate, TypedStorage, UioResult,
+    UniversalRead, UniversalReadFs,
 };
 use roaring::RoaringBitmap;
 
@@ -63,7 +64,7 @@ fn open_options(populate: Populate) -> OpenOptions {
 fn read_status_len<S: UniversalRead>(
     fs: &impl UniversalReadFs<File = S>,
     directory: &Path,
-) -> OperationResult<usize> {
+) -> UioResult<usize> {
     let file = fs.open(
         status_file(directory),
         open_options(Populate::No),
@@ -159,6 +160,32 @@ impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
         Ok(self.bitmap.get_or_init(|| bitmap))
     }
 
+    pub fn live_preload<Fs: CachedReadFs<File = S>>(&self, cached_fs: &Fs) -> OperationResult<()> {
+        let directory = self.directory.as_path();
+
+        // Bitslice
+        let populate = if self.bitmap.get().is_some() {
+            Populate::PreferBackground
+        } else {
+            Populate::No
+        };
+
+        cached_fs.reschedule_prefetch(
+            &directory.join(FLAGS_FILE),
+            Some(open_options(populate)),
+            None,
+        )?;
+
+        // Status file.
+        cached_fs.reschedule_prefetch(
+            &status_file(directory),
+            Some(open_options(Populate::PreferBackground)),
+            None,
+        )?;
+
+        Ok(())
+    }
+
     /// Refresh to the current on-disk state.
     ///
     /// Deliberately *not* an impl of [`LiveReload`][1]: this storage holds
@@ -178,26 +205,31 @@ impl<S: UniversalRead> ReadOnlyRoaringFlags<S> {
     ///
     /// [1]: crate::common::live_reload::LiveReload
     pub fn live_reload(&mut self, fs: &impl UniversalReadFs<File = S>) -> OperationResult<()> {
-        let storage = StoredBitSlice::<S>::open(
+        if let Some(storage) = StoredBitSlice::<S>::open(
             fs,
             self.directory.join(FLAGS_FILE),
             open_options(Populate::No),
             Default::default(),
-        )?;
+        )
+        .ok_unchanged()?
+        {
+            if let Some(bitmap) = self.bitmap.get_mut() {
+                *bitmap = RoaringBitmap::from_sorted_iter(
+                    storage.iter_ones()?.map(|i| i as PointOffsetType),
+                )
+                .expect("iter_ones iterates in sorted order");
+            }
 
-        if let Some(bitmap) = self.bitmap.get_mut() {
-            *bitmap =
-                RoaringBitmap::from_sorted_iter(storage.iter_ones()?.map(|i| i as PointOffsetType))
-                    .expect("iter_ones iterates in sorted order");
+            self.storage = storage;
         }
-
-        self.storage = storage;
 
         // The logical length grows as points are appended; refresh it so
         // length-driven readers (the null index's `iter_falses`) stay correct.
         // Once the index exists its status file always does, so absence here is
         // a genuine not-found (segment removed mid-reload), not a lazy file.
-        self.len = read_status_len::<S>(fs, &self.directory)?;
+        if let Some(new_len) = read_status_len(fs, &self.directory).ok_unchanged()? {
+            self.len = new_len;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
This PR implements `live_preload` and ajusts `live_reload` for `ReadOnlyFlags` and its downstream types.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>