### PR TITLE
fix(segment): keep durably persisted points when their version entry is missing

### DIFF
--- a/lib/collection/tests/integration/main.rs
+++ b/lib/collection/tests/integration/main.rs
@@ -12,4 +12,5 @@ mod pagination_test;
 mod resharding_abort_deferred_points_test;
 mod snapshot_recovery_test;
 mod sparse_idf_test;
+mod torn_versions_write_test;
 mod wal_less_snapshot_clocks_test;

--- a/lib/collection/tests/integration/torn_versions_write_test.rs
+++ b/lib/collection/tests/integration/torn_versions_write_test.rs
@@ -1,0 +1,109 @@
+//! A torn write of a segment's point-versions file must not cost a point whose data is durable
+//! and whose operation the WAL no longer holds.
+
+use std::path::{Path, PathBuf};
+
+use collection::operations::CollectionUpdateOperations;
+use collection::operations::point_ops::{
+    BatchPersisted, BatchVectorStructPersisted, PointInsertOperationsInternal, PointOperations,
+    WriteOrdering,
+};
+use collection::operations::shard_selector_internal::ShardSelectorInternal;
+use collection::shards::local_shard::LocalShard;
+use collection::shards::shard_path;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use tempfile::Builder;
+
+use crate::common::{load_local_collection, simple_collection_fixture};
+
+const POINT_COUNT: u64 = 8;
+const VERSIONS_FILE: &str = "mutable_id_tracker.versions";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_torn_versions_write_keeps_point() {
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
+    let collection_path = collection_dir.path();
+    let snapshots_path = collection_path.join("snapshots");
+
+    let collection = simple_collection_fixture(collection_path, 1).await;
+
+    let ids = (0..POINT_COUNT).map(u64::into).collect();
+    let vectors = (0..POINT_COUNT)
+        .map(|i| vec![i as f32, 0.0, 1.0, 1.0])
+        .collect();
+    let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::PointsBatch(BatchPersisted {
+            ids,
+            vectors: BatchVectorStructPersisted::Single(vectors),
+            payloads: None,
+        }),
+    ));
+    collection
+        .update_from_client_simple(
+            insert_points,
+            true,
+            None,
+            WriteOrdering::default(),
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+    collection.stop_gracefully().await;
+
+    // Reloading replays the WAL and ends in a forced sync flush, so every point is durable on disk
+    // without depending on the flush worker's timer.
+    let collection =
+        load_local_collection("test".to_string(), collection_path, &snapshots_path).await;
+    collection.stop_gracefully().await;
+
+    let shard_path = shard_path(collection_path, 0);
+
+    // The flush worker acknowledges flushed operations and drops them from the WAL. Do it here so
+    // the state under test is the steady one, reached whenever a flush completes.
+    let wal_path = LocalShard::wal_path(&shard_path);
+    for entry in std::fs::read_dir(&wal_path).unwrap() {
+        std::fs::remove_file(entry.unwrap().path()).unwrap();
+    }
+
+    // Point versions are flushed last, as a dense array of one u64 per slot. Cutting its tail is
+    // what a kill part-way through the flush order leaves behind: a slot mapped, but versionless.
+    let versions_path = largest_versions_file(&LocalShard::segments_path(&shard_path));
+    let versions_len = std::fs::metadata(&versions_path).unwrap().len();
+    let slot = size_of::<u64>() as u64;
+    assert!(versions_len >= 2 * slot, "expected a segment with points");
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&versions_path)
+        .unwrap()
+        .set_len(versions_len - slot)
+        .unwrap();
+
+    let collection =
+        load_local_collection("test".to_string(), collection_path, &snapshots_path).await;
+    let points_count = collection
+        .info(&ShardSelectorInternal::All)
+        .await
+        .unwrap()
+        .points_count;
+    assert_eq!(
+        points_count,
+        Some(POINT_COUNT as usize),
+        "repair dropped a point that the WAL can no longer restore",
+    );
+    collection.stop_gracefully().await;
+}
+
+fn largest_versions_file(segments_path: &Path) -> PathBuf {
+    std::fs::read_dir(segments_path)
+        .unwrap()
+        .filter_map(|entry| {
+            let path = entry.unwrap().path().join(VERSIONS_FILE);
+            let len = path
+                .is_file()
+                .then(|| std::fs::metadata(&path).unwrap().len())?;
+            Some((len, path))
+        })
+        .max_by_key(|(len, _)| *len)
+        .expect("no mutable ID tracker in any segment")
+        .1
+}

--- a/lib/collection/tests/integration/torn_versions_write_test.rs
+++ b/lib/collection/tests/integration/torn_versions_write_test.rs
@@ -12,6 +12,7 @@ use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::shards::local_shard::LocalShard;
 use collection::shards::shard_path;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
+use fs_err as fs;
 use tempfile::Builder;
 
 use crate::common::{load_local_collection, simple_collection_fixture};
@@ -61,17 +62,17 @@ async fn test_torn_versions_write_keeps_point() {
     // The flush worker acknowledges flushed operations and drops them from the WAL. Do it here so
     // the state under test is the steady one, reached whenever a flush completes.
     let wal_path = LocalShard::wal_path(&shard_path);
-    for entry in std::fs::read_dir(&wal_path).unwrap() {
-        std::fs::remove_file(entry.unwrap().path()).unwrap();
+    for entry in fs::read_dir(&wal_path).unwrap() {
+        fs::remove_file(entry.unwrap().path()).unwrap();
     }
 
     // Point versions are flushed last, as a dense array of one u64 per slot. Cutting its tail is
     // what a kill part-way through the flush order leaves behind: a slot mapped, but versionless.
     let versions_path = largest_versions_file(&LocalShard::segments_path(&shard_path));
-    let versions_len = std::fs::metadata(&versions_path).unwrap().len();
+    let versions_len = fs::metadata(&versions_path).unwrap().len();
     let slot = size_of::<u64>() as u64;
     assert!(versions_len >= 2 * slot, "expected a segment with points");
-    std::fs::OpenOptions::new()
+    fs::OpenOptions::new()
         .write(true)
         .open(&versions_path)
         .unwrap()
@@ -94,13 +95,11 @@ async fn test_torn_versions_write_keeps_point() {
 }
 
 fn largest_versions_file(segments_path: &Path) -> PathBuf {
-    std::fs::read_dir(segments_path)
+    fs::read_dir(segments_path)
         .unwrap()
         .filter_map(|entry| {
             let path = entry.unwrap().path().join(VERSIONS_FILE);
-            let len = path
-                .is_file()
-                .then(|| std::fs::metadata(&path).unwrap().len())?;
+            let len = path.is_file().then(|| fs::metadata(&path).unwrap().len())?;
             Some((len, path))
         })
         .max_by_key(|(len, _)| *len)

--- a/lib/segment/src/id_tracker/id_tracker_base/mod.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/mod.rs
@@ -8,6 +8,6 @@ pub mod read_only_tracker_enum;
 pub use point_mappings_ref::{PointMappingsGuard, PointMappingsRefEnum};
 pub use tracker_enum::IdTrackerEnum;
 pub use trait_def::{
-    DELETED_POINT_VERSION, IdTracker, IdTrackerRead, default_external_ids_batch,
-    default_internal_versions_batch,
+    DELETED_POINT_VERSION, IdTracker, IdTrackerInconsistencies, IdTrackerRead,
+    default_external_ids_batch, default_internal_versions_batch,
 };

--- a/lib/segment/src/id_tracker/id_tracker_base/tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/tracker_enum.rs
@@ -287,12 +287,24 @@ impl IdTracker for IdTrackerEnum {
         }
     }
 
-    fn fix_inconsistencies(&mut self) -> OperationResult<Vec<PointOffsetType>> {
+    fn try_set_missing_version(
+        &mut self,
+        internal_id: PointOffsetType,
+        version: SeqNumberType,
+    ) -> OperationResult<bool> {
         match self {
-            IdTrackerEnum::MutableIdTracker(id_tracker) => id_tracker.fix_inconsistencies(),
-            IdTrackerEnum::ImmutableIdTracker(id_tracker) => id_tracker.fix_inconsistencies(),
-            IdTrackerEnum::InMemoryIdTracker(id_tracker) => id_tracker.fix_inconsistencies(),
-            IdTrackerEnum::DiskIdTracker(id_tracker) => id_tracker.fix_inconsistencies(),
+            IdTrackerEnum::MutableIdTracker(id_tracker) => {
+                id_tracker.try_set_missing_version(internal_id, version)
+            }
+            IdTrackerEnum::ImmutableIdTracker(id_tracker) => {
+                id_tracker.try_set_missing_version(internal_id, version)
+            }
+            IdTrackerEnum::InMemoryIdTracker(id_tracker) => {
+                id_tracker.try_set_missing_version(internal_id, version)
+            }
+            IdTrackerEnum::DiskIdTracker(id_tracker) => {
+                id_tracker.try_set_missing_version(internal_id, version)
+            }
         }
     }
 

--- a/lib/segment/src/id_tracker/id_tracker_base/trait_def.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/trait_def.rs
@@ -22,6 +22,18 @@ const SEED: u64 = 0b101100001101111000111001010100101000101100110100101001000111
 /// It does not mean a point with this version is always deleted.
 pub const DELETED_POINT_VERSION: SeqNumberType = 0;
 
+/// Points whose id mapping and version entry disagree, as found by
+/// [`IdTrackerRead::find_inconsistencies`].
+#[derive(Debug, Default)]
+pub struct IdTrackerInconsistencies {
+    /// Mapped points with no version entry, as `(internal id, external id)`.
+    pub versionless: Vec<(PointOffsetType, PointIdType)>,
+
+    /// Points with a non-deleted version but no mapping. Their leftovers must be cleaned from
+    /// the rest of the segment.
+    pub unmapped: Vec<PointOffsetType>,
+}
+
 /// Trait for point ids tracker.
 ///
 /// This tracker is used to convert external (i.e. user-facing) point id into internal point id
@@ -54,45 +66,18 @@ pub trait IdTracker: IdTrackerRead + fmt::Debug {
     /// Flush points versions to disk
     fn versions_flusher(&self) -> Flusher;
 
-    /// Finds inconsistencies between id mapping and versions storage.
-    /// It might happen that point doesn't have version due to un-flushed WAL.
-    /// This method makes those points usable again.
+    /// Give a mapped point that has no version entry the given version, if this tracker can
+    /// extend its version list. Returns whether the version was set.
     ///
-    /// Returns a list of internal ids, that have non-zero versions, but are missing in the id mapping.
-    /// Those points should be removed from all other parts of the segment.
-    fn fix_inconsistencies(&mut self) -> OperationResult<Vec<PointOffsetType>> {
-        // Points with mapping, but no version.
-        // Can happen if insertion didn't complete.
-        // We need to remove mapping and assume the point is going to be re-inserted by WAL.
-        let mut to_remove = Vec::new();
-
-        // Points with version, but no mapping.
-        // Can happen if point was deleted, but version (and likely the storage) wasn't cleaned up.
-        // We return those points to the caller to clean up the storage.
-        let mut to_return = Vec::new();
-
-        for (internal_id, version) in self.iter_internal_versions()? {
-            if version != DELETED_POINT_VERSION && self.external_id(internal_id).is_none() {
-                to_return.push(internal_id);
-            }
-        }
-
-        for internal_id in self.point_mappings().iter_internal() {
-            if self.internal_version(internal_id).is_none() {
-                if let Some(external_id) = self.external_id(internal_id) {
-                    to_remove.push(external_id);
-                    to_return.push(internal_id);
-                } else {
-                    debug_assert!(false, "internal id {internal_id} has no external id");
-                }
-            }
-        }
-        for external_id in to_remove {
-            self.drop(external_id)?;
-            #[cfg(debug_assertions)]
-            log::debug!("dropped mapping for point {external_id} without version");
-        }
-        Ok(to_return)
+    /// Only the trackers of appendable segments can grow their versions; the immutable and
+    /// disk-resident ones size theirs with the mappings at build time and refuse to extend.
+    /// The caller falls back to dropping the point when this returns `false`.
+    fn try_set_missing_version(
+        &mut self,
+        _internal_id: PointOffsetType,
+        _version: SeqNumberType,
+    ) -> OperationResult<bool> {
+        Ok(false)
     }
 
     fn files(&self) -> Vec<PathBuf>;
@@ -240,6 +225,38 @@ pub trait IdTrackerRead {
     fn iter_internal_versions(
         &self,
     ) -> OperationResult<Box<dyn Iterator<Item = (PointOffsetType, SeqNumberType)> + '_>>;
+
+    /// Find points whose mapping and version disagree, without changing anything.
+    ///
+    /// Flush writes mappings before versions, so both halves can be missing after a crash. What
+    /// to do about them depends on segment data the tracker cannot see, so the decision is left
+    /// to [`Segment::check_consistency_and_repair`](crate::segment::Segment::check_consistency_and_repair).
+    fn find_inconsistencies(&self) -> OperationResult<IdTrackerInconsistencies> {
+        let mut inconsistencies = IdTrackerInconsistencies::default();
+
+        // Points with a version, but no mapping.
+        // Can happen if point was deleted, but version (and likely the storage) wasn't cleaned up.
+        for (internal_id, version) in self.iter_internal_versions()? {
+            if version != DELETED_POINT_VERSION && self.external_id(internal_id).is_none() {
+                inconsistencies.unmapped.push(internal_id);
+            }
+        }
+
+        // Points with a mapping, but no version.
+        // Either an insert that never reached the versions flush, or a version entry that was
+        // lost after it did.
+        for internal_id in self.point_mappings().iter_internal() {
+            if self.internal_version(internal_id).is_none() {
+                if let Some(external_id) = self.external_id(internal_id) {
+                    inconsistencies.versionless.push((internal_id, external_id));
+                } else {
+                    debug_assert!(false, "internal id {internal_id} has no external id");
+                }
+            }
+        }
+
+        Ok(inconsistencies)
+    }
 
     /// Internal-id threshold above which points are hidden from reads.
     ///

--- a/lib/segment/src/id_tracker/in_memory_id_tracker.rs
+++ b/lib/segment/src/id_tracker/in_memory_id_tracker.rs
@@ -164,6 +164,15 @@ impl IdTracker for InMemoryIdTracker {
         Ok(())
     }
 
+    fn try_set_missing_version(
+        &mut self,
+        internal_id: PointOffsetType,
+        version: SeqNumberType,
+    ) -> OperationResult<bool> {
+        self.set_internal_version(internal_id, version)?;
+        Ok(self.internal_version(internal_id).is_some())
+    }
+
     fn set_link(
         &mut self,
         external_id: PointIdType,

--- a/lib/segment/src/id_tracker/mutable_id_tracker/mod.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/mod.rs
@@ -281,6 +281,15 @@ impl IdTracker for MutableIdTracker {
         Ok(())
     }
 
+    fn try_set_missing_version(
+        &mut self,
+        internal_id: PointOffsetType,
+        version: SeqNumberType,
+    ) -> OperationResult<bool> {
+        self.set_internal_version(internal_id, version)?;
+        Ok(true)
+    }
+
     fn set_link(
         &mut self,
         external_id: PointIdType,

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
@@ -4,8 +4,7 @@ use std::path::PathBuf;
 
 use common::generic_consts::{Random, Sequential};
 use common::universal_io::{
-    OkNotFound, OpenOptions, ReadRange, UniversalIoError, UioResult, UniversalRead,
-    UniversalReadFs,
+    OkNotFound, OpenOptions, ReadRange, UioResult, UniversalIoError, UniversalRead, UniversalReadFs,
 };
 use posting_list::{PostingList, PostingListView};
 use zerocopy::FromBytes;

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -22,7 +22,7 @@ use crate::data_types::named_vectors::NamedVectors;
 use crate::data_types::tiny_map::TinyMap;
 use crate::entry::entry_point::StorageSegmentEntry as _;
 use crate::entry::{NonAppendableSegmentEntry as _, ReadSegmentEntry};
-use crate::id_tracker::{IdTracker, IdTrackerRead};
+use crate::id_tracker::{IdTracker, IdTrackerInconsistencies, IdTrackerRead};
 use crate::index::{PayloadIndex, PayloadIndexRead, VectorIndex};
 use crate::types::{
     Payload, PayloadFieldSchema, PayloadKeyType, PointIdType, SegmentState, SeqNumberType,
@@ -765,10 +765,65 @@ impl Segment {
     }
 
     /// Check consistency of the segment's data and repair it if possible.
-    /// Removes partially persisted points.
+    ///
+    /// Flush writes the id mapping first, then vectors and payloads, then the point versions, so
+    /// an interrupted flush can leave a point mapped but versionless, and can leave a version
+    /// behind for a point that has no mapping any more.
+    ///
+    /// A versionless point whose vectors are not durable never got past the vectors flush, so the
+    /// segment state file was never updated for it either and its operation is above the
+    /// persisted segment version. WAL replay is guaranteed to still hold it, and the point is
+    /// dropped here so replay can insert it cleanly.
+    ///
+    /// A versionless point whose vectors are durable is the opposite case: its data survived the
+    /// vectors flush, so its operation can be covered by the persisted segment version and can
+    /// already be gone from the WAL. Dropping it would destroy the only copy, so it is kept and
+    /// given the persisted segment version. That version is never above its real one, so replay
+    /// still corrects it wherever the WAL does hold the operation.
     pub fn check_consistency_and_repair(&mut self) -> OperationResult<()> {
-        // Get rid of mappingless points.
-        let ids_to_clean = self.fix_id_tracker_inconsistencies()?;
+        let IdTrackerInconsistencies {
+            versionless,
+            unmapped: mut ids_to_clean,
+        } = self.id_tracker.borrow().find_inconsistencies()?;
+
+        let mut restored = 0;
+        if !versionless.is_empty() {
+            // Only what a completed flush left behind can be trusted here.
+            let persisted_version = *self.persisted_version.lock();
+
+            // Resolved before the tracker is borrowed, the storages may reach into it.
+            let checked: Vec<_> = versionless
+                .into_iter()
+                .map(|(internal_id, external_id)| {
+                    let durable = self.has_durable_vector_data(internal_id);
+                    (internal_id, external_id, durable)
+                })
+                .collect();
+
+            let mut id_tracker = self.id_tracker.borrow_mut();
+            for (internal_id, external_id, durable) in checked {
+                let restored_version = match persisted_version {
+                    Some(version) if durable => {
+                        id_tracker.try_set_missing_version(internal_id, version)?
+                    }
+                    _ => false,
+                };
+
+                if restored_version {
+                    restored += 1;
+                } else {
+                    id_tracker.drop(external_id)?;
+                    ids_to_clean.push(internal_id);
+                }
+            }
+        }
+
+        if restored > 0 {
+            log::warn!(
+                "Restored the point version of {restored} points with durable data in segment {:?}, their version entries were missing",
+                self.data_path(),
+            );
+        }
 
         // There are some leftovers to clean from segment.
         // After that we need to set internal version to 0, so that
@@ -776,18 +831,17 @@ impl Segment {
 
         // This is internal operation, no hw measurement needed
         let disposable_hw_counter = HardwareCounterCell::disposable();
+        let repaired = restored > 0 || !ids_to_clean.is_empty();
         if !ids_to_clean.is_empty() {
-            log::debug!(
-                "Cleaning up {} points with version but no mapping in segment {:?}",
+            log::warn!(
+                "Cleaning up {} partially persisted points in segment {:?}, assuming their recovery by WAL",
                 ids_to_clean.len(),
-                self.data_path()
+                self.data_path(),
             );
 
             for internal_id in ids_to_clean {
                 self.delete_point_internal(internal_id, None, &disposable_hw_counter)?;
             }
-
-            self.flush(true)?;
 
             // We do not drop version here, because it is already not loaded into memory.
             // There are no explicit mapping between internal ID and version, so all dangling
@@ -796,7 +850,26 @@ impl Segment {
             // They will also be deleted by the next optimization.
         }
 
+        if repaired {
+            self.flush(true)?;
+        }
+
         Ok(())
+    }
+
+    /// Whether any vector storage of this segment holds live data for this internal id.
+    ///
+    /// Vectors are flushed after the id mapping and before the point versions, so live data in a
+    /// slot means the flush that wrote its mapping got at least as far as the vectors. A slot no
+    /// storage ever received is prefilled as deleted when the segment is opened
+    /// (`prefill_vector_storage`), which is what an insert cut short after the mapping flush
+    /// looks like here.
+    fn has_durable_vector_data(&self, internal_id: PointOffsetType) -> bool {
+        self.vector_data.values().any(|data| {
+            let storage = data.vector_storage.borrow();
+            (internal_id as usize) < storage.total_vector_count()
+                && !storage.is_deleted_vector(internal_id)
+        })
     }
 
     /// Update all payload/field indices to match `desired_schemas`
@@ -944,12 +1017,6 @@ impl Segment {
 
     pub fn total_point_count(&self) -> usize {
         self.id_tracker.borrow().total_point_count()
-    }
-
-    /// Fixes inconsistencies in the ID tracker, if any.
-    /// Returns list of IDs without mappings which should be removed from segment
-    pub fn fix_id_tracker_inconsistencies(&mut self) -> OperationResult<Vec<PointOffsetType>> {
-        self.id_tracker.borrow_mut().fix_inconsistencies()
     }
 }
 

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -509,6 +509,55 @@ fn test_check_consistency() {
     );
 }
 
+/// A torn write of the point versions file must not cost us a point whose data is all durable.
+#[test]
+fn test_repair_keeps_point_with_torn_versions_write() {
+    init_logger();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let mut segment = build_simple_segment(dir.path(), 4, Distance::Dot).unwrap();
+    let segment_path = segment.segment_path.clone();
+
+    let vec1 = vec![1.0, 0.0, 0.0, 0.0];
+    segment
+        .upsert_point(100, 1.into(), only_default_vector(&vec1), &hw_counter)
+        .unwrap();
+    let vec2 = vec![0.0, 1.0, 0.0, 0.0];
+    segment
+        .upsert_point(101, 2.into(), only_default_vector(&vec2), &hw_counter)
+        .unwrap();
+    segment.flush(true).unwrap();
+    drop(segment);
+
+    // Versions are flushed last, as a dense array of one u64 per slot. Dropping its tail slot is
+    // what a kill part-way through the flush order leaves on disk: mapped, but versionless.
+    let versions_path = segment_path.join("mutable_id_tracker.versions");
+    assert!(versions_path.is_file(), "expected a mutable ID tracker");
+    let versions_len = fs::metadata(&versions_path).unwrap().len();
+    File::options()
+        .write(true)
+        .open(&versions_path)
+        .unwrap()
+        .set_len(versions_len - size_of::<u64>() as u64)
+        .unwrap();
+
+    let mut segment =
+        load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
+    segment.check_consistency_and_repair().unwrap();
+
+    assert!(
+        segment.has_point(2.into(), DeferredBehavior::VisibleOnly),
+        "repair dropped a point whose vectors and mapping were both persisted",
+    );
+    assert!(
+        segment
+            .vector(DEFAULT_VECTOR_NAME, 2.into(), &hw_counter)
+            .is_ok()
+    );
+    assert!(segment.has_point(1.into(), DeferredBehavior::VisibleOnly));
+}
+
 #[test]
 fn test_point_vector_count() {
     init_logger();

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -50,6 +50,7 @@ use crate::types::{
     WithVector,
 };
 use crate::utils::maybe_arc::MaybeArc;
+use crate::vector_storage::VectorStorageRead as _;
 use crate::vector_storage::query::{FeedbackItem, NaiveFeedbackCoefficients, NaiveFeedbackQuery};
 
 fn init_logger() {
@@ -507,6 +508,49 @@ fn test_check_consistency() {
         segment.with_view(|v| v.vector_by_offset(DEFAULT_VECTOR_NAME, internal_id, &hw_counter)),
         Ok(None)
     );
+}
+
+/// A mapping that got past the mapping flush but not the vectors flush is an insert that never
+/// completed. Its operation is above the persisted segment version, so the WAL still holds it and
+/// repair has to drop the point rather than resurrect one without vectors.
+#[test]
+fn test_repair_drops_point_without_durable_vectors() {
+    init_logger();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let mut segment = build_simple_segment(dir.path(), 4, Distance::Dot).unwrap();
+    let segment_path = segment.segment_path.clone();
+
+    let vec1 = vec![1.0, 0.0, 0.0, 0.0];
+    segment
+        .upsert_point(100, 1.into(), only_default_vector(&vec1), &hw_counter)
+        .unwrap();
+    segment.flush(true).unwrap();
+
+    // Flush runs the mapping flusher first and the vectors flusher after it. Running just the
+    // first one is what a kill in between leaves on disk: a mapping for a slot that no vector
+    // storage holds data for.
+    let orphan_internal_id = segment.vector_data[DEFAULT_VECTOR_NAME]
+        .vector_storage
+        .borrow()
+        .total_vector_count() as PointOffsetType;
+    {
+        let mut id_tracker = segment.id_tracker.borrow_mut();
+        id_tracker.set_link(2.into(), orphan_internal_id).unwrap();
+        id_tracker.mapping_flusher()().unwrap();
+    }
+    drop(segment);
+
+    let mut segment =
+        load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
+    segment.check_consistency_and_repair().unwrap();
+
+    assert!(
+        !segment.has_point(2.into(), DeferredBehavior::VisibleOnly),
+        "repair kept a point whose vectors never reached disk",
+    );
+    assert!(segment.has_point(1.into(), DeferredBehavior::VisibleOnly));
 }
 
 /// A torn write of the point versions file must not cost us a point whose data is all durable.


### PR DESCRIPTION
Repair deleted durable points on an unchecked assumption about the WAL; this makes it check. First commit is @tellet-q's repro, drop it if it lands separately.

## The bug

Flush writes the id mapping, then vectors and payloads, then the point versions, then `segment.json`. A mapped point with no version entry was read as an insert cut short: dropped, and its data destroyed by `delete_point_internal` + `flush(true)`, because "the point is going to be re-inserted by WAL". Nothing checked that.

It holds only while the flush never completed: no `segment.json` update means no acknowledge, so the operation is still in the WAL. Once the flush completed, the acknowledge moved past the operation and dropping the point destroys the only copy.

The versions file cannot separate the two cases, a missing entry is just a shorter dense array. The vectors flush can: it runs between the mapping and the versions.

## Example

Segment holds points 1 and 2 in slots 0 and 1. Flush at version 101 completes, the shard acknowledges and truncates the WAL. A point inserted at op 102 then gets its mapping flushed and the process is killed before the vectors flush. Restart also finds the versions file one slot short.

| slot | mapping | vector data | version entry | before | after |
|---|---|---|---|---|---|
| 1 | yes | live | missing | dropped, point lost for good | kept at version 101 |
| 2 | yes | prefilled deleted | missing | dropped | dropped, replay of op 102 re-inserts it |

## Why assigning a version is safe

`W` is the point's real version, the last operation that modified it. `V` is the persisted segment version, which is what repair assigns.

1. Assigning below `W` is harmless. Replay re-applies every operation above the assigned version, upserts and deletes are idempotent, and the point ends at `W`.
2. Assigning above `W` is the direction that loses data: it makes replay skip an operation the point's durable data does not reflect.
3. `V` cannot lose anything that way. No operation in `(W, V]` touches this point, that is what `W` being its latest version means, so skipping them changes nothing about it.
4. `V >= W` whenever the point is kept. `segment.json` holding `V` means a completed flush persisted everything the segment had applied up to `V`, and live vector data in the slot means this point was part of what that flush persisted.
5. If the guard is fooled and the flush was in fact interrupted, so `W > V`, the assignment understates. The acknowledge never passed `V`, so the WAL still holds everything above it and replay restores `W`.
6. A stale copy cannot be promoted. A point moved to another segment is soft-deleted in this one, so `is_deleted_vector` keeps it out of the kept branch.

## The fix

- `find_inconsistencies` replaces `fix_inconsistencies`: the tracker reports, the segment decides, since only the segment sees the storages and the persisted version.
- The guard tests `!is_deleted_vector(slot)`, not the storage extent. `prefill_vector_storage` pads every storage up to the id tracker's point count at open, so the extent alone attests to nothing.
- Immutable and disk trackers cannot extend their version list, both `debug_assert!` on it, so `try_set_missing_version` returns false and optimized segments keep the old path.
- Both outcomes log at `warn!` with counts. This class of loss was invisible in production.

## Framing

A fsynced versions file does not lose a committed tail entry on its own, and the repro cuts it by hand. The reachable route to the same state is an acknowledge that ran ahead of durability, the bug class of #9536, #10201, #10203 and #10204. This is not a new data-loss hole, it is the amplifier that turns any such hole into silent permanent deletion instead of a recoverable inconsistency.

## Tests

Both repro tests are red before and green after. `test_repair_drops_point_without_durable_vectors` runs only the mapping flusher, which is what a kill between the two flushers leaves, and asserts the point is still dropped, so the replay path is untouched. `segment`, `collection` and `shard` suites green, all three clippy configurations clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)