### PR TITLE
Latency probe tool (Quantization + DRAM)

### DIFF
--- a/lib/segment/examples/hwpf_threshold_probe.rs
+++ b/lib/segment/examples/hwpf_threshold_probe.rs
@@ -232,8 +232,14 @@ fn install_probe(
     let floor = med[1]; // T0 documented "all levels" everywhere = the L1 floor
     let dram_gap = base - floor;
 
-    println!("\n{:>6} {:>12} {:>12}  verdict (heuristic)", "hint", "ns/hop", "vs t0");
-    println!("{:>6} {:>12.1} {:>12}  DRAM baseline (no hint)", "none", base, "-");
+    println!(
+        "\n{:>6} {:>12} {:>12}  verdict (heuristic)",
+        "hint", "ns/hop", "vs t0"
+    );
+    println!(
+        "{:>6} {:>12.1} {:>12}  DRAM baseline (no hint)",
+        "none", base, "-"
+    );
     for m in 1..4 {
         let d = med[m] - floor;
         let verdict = if m == 1 {
@@ -313,9 +319,8 @@ fn main() {
                 order.swap(i, rng.below(i + 1));
             }
             // one run per page at a random in-page offset that fits K lines
-            let start_of = |page: u32, off: usize| {
-                (page as usize * lines_per_page + off) * words_per_line
-            };
+            let start_of =
+                |page: u32, off: usize| (page as usize * lines_per_page + off) * words_per_line;
             let mut starts: Vec<u32> = Vec::with_capacity(pages);
             for &page in &order {
                 let off = rng.below(lines_per_page - k + 1);

--- a/lib/segment/examples/hwpf_threshold_probe.rs
+++ b/lib/segment/examples/hwpf_threshold_probe.rs
@@ -1,0 +1,396 @@
+//! Measures how many sequential cache-line accesses it takes before the
+//! hardware prefetcher engages — the stream detector's training threshold.
+//!
+//! Method: a dependent pointer chase over short runs of K consecutive cache
+//! lines. One run per 4 KiB page (so runs never collide, never cross a page
+//! boundary, and no page carries prefetcher training left over from another
+//! run), pages visited in shuffled order, every run visited exactly once.
+//! Each hop depends on the previous load, so the chase has zero memory-level
+//! parallelism — any cheapening of a run's later lines can only come from
+//! the hardware prefetcher running ahead of the chain. A streaming pass over
+//! the whole buffer between chain build and timing evicts the build's writes.
+//!
+//! Reading the output: the marginal cost of extending a run by one line is
+//! ~full DRAM latency while the prefetcher is asleep, and collapses once it
+//! has trained and runs ahead. The knee position is the training threshold
+//! (plus the prefetcher's first-fetch lead).
+//!
+//! Usage:
+//!   cargo build -p segment --profile perf --example hwpf_threshold_probe
+//!   ./target/perf/examples/hwpf_threshold_probe
+//! Env: PROBE_MB (512) buffer size, PROBE_ROUNDS (3),
+//!      PROBE_LINE (64) cache line size in bytes (128 for Apple L2),
+//!      PROBE_MAX_K (32) longest run in lines,
+//!      PROBE_SW_PREFIX (0) issue software prefetches (prefetcht0) for the
+//!      first N lines of each run right before chasing it. Compare K > N
+//!      rows against PROBE_SW_PREFIX=0 and =K: if the tail lines stay cheap
+//!      the hardware prefetcher continues past a software-prefetched prefix;
+//!      if the staircase reappears after line N it starts cold there.
+//!
+//! Install-level mode (PROBE_INSTALL=1): instead of the threshold probe,
+//! measure which cache level each prefetch hint actually fills. A dependent
+//! chase over single random lines (one per page), where each line is hinted
+//! W hops ahead of its demand load; by arrival the fill is long complete, so
+//! the per-hop cost is the hit latency at whatever level the hint installed
+//! into. Modes: no hint (DRAM baseline), T0, T1, T2. If T1 matches T0 the
+//! core fills L1 for both (documented Zen 3 behavior); a T1 a few ns above
+//! T0 but far below baseline means the L1-exclusion is honored (documented
+//! Zen 4+/Intel). Env: PROBE_INSTALL_W (64) hint lead in hops,
+//! PROBE_INSTALL_MULS (16) dependent multiplies pacing each hop so
+//! outstanding fills stay well under the MSHR count.
+
+use std::hint::black_box;
+use std::time::Instant;
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+/// xorshift64* — deterministic, dependency-free
+struct Rng(u64);
+impl Rng {
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+/// Non-faulting prefetch into all cache levels; no-op off x86_64/aarch64.
+#[inline(always)]
+fn prefetch(ptr: *const u64) {
+    #[cfg(target_arch = "x86_64")]
+    // SAFETY: prefetch is a non-faulting hint for any address.
+    unsafe {
+        std::arch::x86_64::_mm_prefetch::<{ std::arch::x86_64::_MM_HINT_T0 }>(ptr.cast::<i8>())
+    }
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: `prfm` is a non-faulting hint; no memory access, stack use,
+    // or flag clobber.
+    unsafe {
+        core::arch::asm!(
+            "prfm pldl1keep, [{ptr}]",
+            ptr = in(reg) ptr,
+            options(nostack, preserves_flags),
+        )
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    let _ = ptr;
+}
+
+/// Non-faulting prefetch into L2 and higher (`prefetcht1` / `pldl2keep`).
+#[inline(always)]
+fn prefetch_l2(ptr: *const u64) {
+    #[cfg(target_arch = "x86_64")]
+    // SAFETY: prefetch is a non-faulting hint for any address.
+    unsafe {
+        std::arch::x86_64::_mm_prefetch::<{ std::arch::x86_64::_MM_HINT_T1 }>(ptr.cast::<i8>())
+    }
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: `prfm` is a non-faulting hint; no memory access, stack use,
+    // or flag clobber.
+    unsafe {
+        core::arch::asm!(
+            "prfm pldl2keep, [{ptr}]",
+            ptr = in(reg) ptr,
+            options(nostack, preserves_flags),
+        )
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    let _ = ptr;
+}
+
+/// Non-faulting prefetch into L3 and higher (`prefetcht2` / `pldl3keep`).
+#[inline(always)]
+fn prefetch_l3(ptr: *const u64) {
+    #[cfg(target_arch = "x86_64")]
+    // SAFETY: prefetch is a non-faulting hint for any address.
+    unsafe {
+        std::arch::x86_64::_mm_prefetch::<{ std::arch::x86_64::_MM_HINT_T2 }>(ptr.cast::<i8>())
+    }
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: `prfm` is a non-faulting hint; no memory access, stack use,
+    // or flag clobber.
+    unsafe {
+        core::arch::asm!(
+            "prfm pldl3keep, [{ptr}]",
+            ptr = in(reg) ptr,
+            options(nostack, preserves_flags),
+        )
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    let _ = ptr;
+}
+
+/// One timed chase pass for the install-level probe. `hint` is issued for
+/// the line `w` hops ahead of its demand load; `muls` dependent multiplies
+/// gate every hop's address so hops never overlap and outstanding fills stay
+/// low. Returns ns per hop.
+fn install_chase(
+    buf: &[u64],
+    starts: &[u32],
+    w: usize,
+    muls: usize,
+    hint: impl Fn(*const u64),
+) -> f64 {
+    let pages = starts.len();
+    let ptr = buf.as_ptr();
+    // Opaque runtime zero: `j & zero` below cannot be constant-folded by the
+    // compiler (value unknown) and is no dependency-breaking idiom for the
+    // hardware, so the delay chain genuinely gates every hop's address.
+    let zero = black_box(0u64);
+    let mut idx = starts[0] as u64;
+    let t = Instant::now();
+    for i in 0..pages {
+        if i + w < pages {
+            // SAFETY: starts holds in-bounds word indices.
+            hint(unsafe { ptr.add(*starts.get_unchecked(i + w) as usize) });
+        }
+        let mut j = idx;
+        for _ in 0..muls {
+            // Multiply mixed with xor-shift: unlike a pure affine chain,
+            // consecutive iterations cannot be composed into one constant
+            // operation, so all `muls` steps stay on the dependency path.
+            j = j.wrapping_mul(0x2545_F491_4F6C_DD1D) ^ (j >> 32);
+        }
+        let adj = j & zero;
+        idx = unsafe { *buf.get_unchecked((idx.wrapping_add(adj)) as usize) };
+    }
+    black_box(idx);
+    t.elapsed().as_nanos() as f64 / pages as f64
+}
+
+fn install_probe(
+    buf: &mut [u64],
+    pages: usize,
+    lines_per_page: usize,
+    words_per_line: usize,
+    rounds: usize,
+) {
+    let w = env_usize("PROBE_INSTALL_W", 64);
+    let muls = env_usize("PROBE_INSTALL_MULS", 16);
+    let words = buf.len();
+    println!(
+        "== prefetch install-level probe: {pages} random lines (one per page), \
+         hint {w} hops ahead, {muls} pacing multiplies per hop, {rounds} rounds =="
+    );
+
+    let mut rng = Rng(0xD1B5_4A32_D192_ED03);
+    let mut order: Vec<u32> = (0..pages as u32).collect();
+    const MODES: [&str; 4] = ["none", "t0", "t1", "t2"];
+    let mut per_mode: [Vec<f64>; 4] = [const { Vec::new() }; 4];
+
+    for round in 0..rounds {
+        for i in (1..order.len()).rev() {
+            order.swap(i, rng.below(i + 1));
+        }
+        let mut starts: Vec<u32> = Vec::with_capacity(pages);
+        for &page in &order {
+            let off = rng.below(lines_per_page);
+            starts.push(((page as usize * lines_per_page + off) * words_per_line) as u32);
+        }
+        for r in 0..pages {
+            buf[starts[r] as usize] = starts[(r + 1) % pages] as u64;
+        }
+        // Rotate mode order per round: within-round drift (clock ramp, DRAM
+        // state) otherwise biases whichever mode always runs last.
+        for m in (0..MODES.len()).map(|i| (i + round) % MODES.len()) {
+            // evict whatever the build or the previous mode left cached
+            let mut acc = 0u64;
+            for i in (0..words).step_by(words_per_line) {
+                acc = acc.wrapping_add(unsafe { *buf.get_unchecked(i) });
+            }
+            black_box(acc);
+
+            let ns = match m {
+                1 => install_chase(buf, &starts, w, muls, prefetch),
+                2 => install_chase(buf, &starts, w, muls, prefetch_l2),
+                3 => install_chase(buf, &starts, w, muls, prefetch_l3),
+                _ => install_chase(buf, &starts, w, muls, |p| {
+                    black_box(p);
+                }),
+            };
+            per_mode[m].push(ns);
+        }
+    }
+
+    let mut med = [0.0f64; 4];
+    for (m, v) in per_mode.iter_mut().enumerate() {
+        v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        med[m] = v[v.len() / 2];
+    }
+    let base = med[0];
+    let floor = med[1]; // T0 documented "all levels" everywhere = the L1 floor
+    let dram_gap = base - floor;
+
+    println!("\n{:>6} {:>12} {:>12}  verdict (heuristic)", "hint", "ns/hop", "vs t0");
+    println!("{:>6} {:>12.1} {:>12}  DRAM baseline (no hint)", "none", base, "-");
+    for m in 1..4 {
+        let d = med[m] - floor;
+        let verdict = if m == 1 {
+            "L1 floor by definition (docs: fills all levels)"
+        } else if d <= 1.2 {
+            "fills L1 (behaves like T0)"
+        } else if d <= 10.0 {
+            "skips L1, installs to L2"
+        } else if d < 0.6 * dram_gap {
+            "installs to L3 only"
+        } else {
+            "not installed (= no hint)"
+        };
+        println!("{:>6} {:>12.1} {:>+11.1}  {verdict}", MODES[m], med[m], d);
+    }
+    println!(
+        "\nnote: thresholds are heuristic (L1-vs-L2 gap is ~2-5 ns depending on \
+         clock); trust the raw deltas. DRAM gap here: {dram_gap:.1} ns."
+    );
+    // ~3 cycles per dependent multiply; even at 6 GHz that is 0.5 ns each.
+    if floor < muls as f64 * 0.5 {
+        println!(
+            "WARNING: t0 floor {floor:.1} ns < expected pacing (~{} ns): the \
+             delay chain got compiled out — outstanding fills may exceed small \
+             MSHR counts and inflate the t0 floor on Intel-class cores.",
+            muls as f64 * 0.5
+        );
+    }
+}
+
+fn main() {
+    let mb = env_usize("PROBE_MB", 512);
+    let rounds = env_usize("PROBE_ROUNDS", 3);
+    let line = env_usize("PROBE_LINE", 64);
+    let max_k = env_usize("PROBE_MAX_K", 32);
+    let sw_prefix = env_usize("PROBE_SW_PREFIX", 0);
+    assert!(line % 8 == 0 && line >= 64);
+    let words = mb * 1024 * 1024 / 8;
+    let words_per_line = line / 8;
+    let lines_per_page = 4096 / line;
+    let pages = mb * 1024 * 1024 / 4096;
+
+    let install = env_usize("PROBE_INSTALL", 0) == 1;
+    if !install {
+        println!(
+            "== hw-prefetcher training threshold probe: buffer {mb} MiB, \
+             line {line} B, one run per page ({pages} runs), {rounds} rounds, \
+             sw prefix {sw_prefix} lines =="
+        );
+    }
+
+    let mut buf: Vec<u64> = vec![0u64; words];
+    for i in (0..words).step_by(4096 / 8) {
+        buf[i] = 1; // fault every page in before timing
+    }
+
+    if install {
+        install_probe(&mut buf, pages, lines_per_page, words_per_line, rounds);
+        return;
+    }
+
+    let ks: Vec<usize> = [1usize, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24, 28, 32]
+        .into_iter()
+        .filter(|&k| k <= max_k && k <= lines_per_page)
+        .collect();
+
+    let mut rng = Rng(0x9E37_79B9_7F4A_7C15);
+    let mut med_run_ns: Vec<(usize, f64)> = Vec::new();
+
+    // reusable shuffled page order (reshuffled per round)
+    let mut order: Vec<u32> = (0..pages as u32).collect();
+
+    for &k in &ks {
+        let mut per_round = Vec::new();
+        for _ in 0..rounds {
+            for i in (1..order.len()).rev() {
+                order.swap(i, rng.below(i + 1));
+            }
+            // one run per page at a random in-page offset that fits K lines
+            let start_of = |page: u32, off: usize| {
+                (page as usize * lines_per_page + off) * words_per_line
+            };
+            let mut starts: Vec<u32> = Vec::with_capacity(pages);
+            for &page in &order {
+                let off = rng.below(lines_per_page - k + 1);
+                starts.push(start_of(page, off) as u32);
+            }
+            for r in 0..pages {
+                let s = starts[r] as usize;
+                for j in 0..k - 1 {
+                    buf[s + j * words_per_line] = (s + (j + 1) * words_per_line) as u64;
+                }
+                buf[s + (k - 1) * words_per_line] = starts[(r + 1) % pages] as u64;
+            }
+            // evict the build's writes: stream-read every line once
+            let mut acc = 0u64;
+            for i in (0..words).step_by(words_per_line) {
+                acc = acc.wrapping_add(unsafe { *buf.get_unchecked(i) });
+            }
+            black_box(acc);
+
+            // timed per-run chase: every run visited exactly once. The next
+            // run's start comes from the chain's own last hop (not starts[]),
+            // so runs stay fully serialized like the original flat chain;
+            // the software-prefetch prefix is issued the moment a run's start
+            // address becomes known, i.e. with zero lead.
+            let ptr = buf.as_ptr();
+            let p = sw_prefix.min(k);
+            let mut idx = starts[0] as u64;
+            let t = Instant::now();
+            for _ in 0..pages {
+                let s = idx as usize;
+                for j in 0..p {
+                    // SAFETY: address lies within the buffer; prefetch never
+                    // faults regardless.
+                    prefetch(unsafe { ptr.add(s + j * words_per_line) });
+                }
+                for _ in 0..k {
+                    idx = unsafe { *buf.get_unchecked(idx as usize) };
+                }
+            }
+            black_box(idx);
+            per_round.push(t.elapsed().as_nanos() as f64 / pages as f64);
+        }
+        per_round.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        med_run_ns.push((k, per_round[per_round.len() / 2]));
+    }
+
+    let base = med_run_ns[0].1;
+    println!("\nbase random-line latency (K=1): {base:.1} ns");
+    println!(
+        "\n{:>3} {:>12} {:>16} {:>10}",
+        "K", "ns/run", "marginal ns/line", "vs base"
+    );
+    let mut knee: Option<usize> = None;
+    for w in med_run_ns.windows(2) {
+        let (k0, t0) = w[0];
+        let (k1, t1) = w[1];
+        let marginal = (t1 - t0) / (k1 - k0) as f64;
+        let ratio = marginal / base;
+        println!("{k1:>3} {t1:>12.1} {marginal:>16.1} {ratio:>9.2}x");
+        if knee.is_none() && ratio < 0.5 {
+            knee = Some(k0);
+        }
+    }
+    match knee {
+        Some(t) => println!(
+            "\n=> marginal line cost first drops below 0.5x base after line ~{t}: \
+             the hw prefetcher trains on about {t} sequential misses"
+        ),
+        None => println!(
+            "\n=> no marginal collapse up to K={max_k}: no stream prefetcher \
+             engaged in this pattern (or its lead never catches a dependent chase)"
+        ),
+    }
+    println!(
+        "note: dependent chase gives the prefetcher ~1 latency per line to run \
+         ahead — this measures the training threshold, not its steady-state lead"
+    );
+}

--- a/lib/segment/examples/latency_kernel_probe.rs
+++ b/lib/segment/examples/latency_kernel_probe.rs
@@ -231,6 +231,9 @@ struct KernelCell {
     datatype: Datatype,
     dim: usize,
     vec_bytes: usize,
+    /// Size of the code buffer the timed loop cycles over — printed so
+    /// cache residency is auditable against the machine's private L1+L2.
+    ws_bytes: usize,
     ns_per_vec: f64,
     bytes_per_ns: f64,
 }
@@ -296,7 +299,7 @@ fn measure_kernel(datatype: Datatype, dim: usize, secs: u64, rng: &mut SmallRng)
     let stopped = AtomicBool::new(false);
     let hw = HardwareCounterCell::new();
 
-    let (vec_bytes, ns_per_vec) = match datatype {
+    let (vec_bytes, ns_per_vec, ws_bytes) = match datatype {
         Datatype::Turbo4 | Datatype::Turbo1 => {
             let bits = match datatype {
                 Datatype::Turbo4 => TQBits::Bits4,
@@ -324,7 +327,7 @@ fn measure_kernel(datatype: Datatype, dim: usize, secs: u64, rng: &mut SmallRng)
             let ns = run_rate(&buf, vec_bytes, count, secs, rng, |bytes| {
                 quantizer.score_precomputed(&query, bytes)
             });
-            (vec_bytes, ns)
+            (vec_bytes, ns, buf.len())
         }
         Datatype::Bq | Datatype::Bq2 => {
             let encoding = match datatype {
@@ -356,7 +359,7 @@ fn measure_kernel(datatype: Datatype, dim: usize, secs: u64, rng: &mut SmallRng)
             let ns = run_rate(&buf, vec_bytes, count, secs, rng, |bytes| {
                 encoded.score(&query, bytes, &hw)
             });
-            (vec_bytes, ns)
+            (vec_bytes, ns, buf.len())
         }
         Datatype::Int8 => {
             let qsize = encoded_vectors_u8::get_quantized_vector_size(&params);
@@ -382,7 +385,7 @@ fn measure_kernel(datatype: Datatype, dim: usize, secs: u64, rng: &mut SmallRng)
             let ns = run_rate(&buf, vec_bytes, count, secs, rng, |bytes| {
                 encoded.score(&query, bytes, &hw)
             });
-            (vec_bytes, ns)
+            (vec_bytes, ns, buf.len())
         }
     };
 
@@ -390,6 +393,7 @@ fn measure_kernel(datatype: Datatype, dim: usize, secs: u64, rng: &mut SmallRng)
         datatype,
         dim,
         vec_bytes,
+        ws_bytes,
         ns_per_vec,
         bytes_per_ns: vec_bytes as f64 / ns_per_vec,
     }
@@ -408,10 +412,11 @@ fn measure_kernels(
         .map(|(datatype, dim)| {
             let cell = measure_kernel(datatype, dim, secs, rng);
             println!(
-                "{prefix}{:7} dim {:4}  code {:4} B  {:7.2} ns/vec  {:5.1} B/ns",
+                "{prefix}{:7} dim {:4}  code {:4} B  ws {:3} KiB  {:7.2} ns/vec  {:5.1} B/ns",
                 cell.datatype.label(),
                 cell.dim,
                 cell.vec_bytes,
+                cell.ws_bytes / 1024,
                 cell.ns_per_vec,
                 cell.bytes_per_ns
             );

--- a/lib/segment/examples/latency_kernel_probe.rs
+++ b/lib/segment/examples/latency_kernel_probe.rs
@@ -1,0 +1,501 @@
+//! Measures the two hardware inputs of the prefetch-window formula
+//! `look-ahead bytes ≈ memory latency × kernel consumption rate`, so
+//! per-machine prefetch look-ahead constants can be checked instead of
+//! trusted from one calibration box.
+//!
+//! Part A — memory latency: dependent pointer chase over a single random
+//! cycle of cache lines in a buffer far larger than L3 (default 512 MiB).
+//! Each hop's address depends on the previous load, so nothing overlaps and
+//! ns/hop is the full load-to-use latency, including TLB effects — the same
+//! conditions a scoring loop's first-touch loads see. A small L3-resident
+//! control buffer sanity-checks the methodology.
+//!
+//! Part B — kernel consumption rates: the production scoring kernels
+//! (TurboQuant 4-bit and 1-bit, binary 1-bit and 2-bit with u128 words,
+//! int8 scalar) over a cache-resident working set, in production batch shape. Warm data means no
+//! memory stalls: the measured ns/vector is pure compute + loop glue, i.e.
+//! the consumption rate the formula needs.
+//!
+//! Part C — the same two measurements under load: background aggressor
+//! threads (default: all remaining cores) each issue batches of independent
+//! random cache-line reads over their own DRAM-sized buffers — the scattered,
+//! high-MLP traffic shape of contended candidate fills, deliberately not
+//! streaming (which would measure the bandwidth wall instead of queueing).
+//! Loaded latency × loaded kernel rate gives the look-ahead required under
+//! contention; idle inputs alone can under-size it.
+//!
+//! The final table multiplies latency and rate into a predicted look-ahead
+//! per code size — idle and loaded — next to a reference two-level window
+//! schedule (1 KiB near / 4 KiB far).
+//!
+//! Usage:
+//!   cargo run -p segment --profile perf --example latency_kernel_probe
+//! Env: PROBE_LAT_MB (512), PROBE_HOPS (16777216), PROBE_ROUNDS (3),
+//!      PROBE_KERNEL_SECS (2), PROBE_DIMS (64,128,512,768,1024,2048,4096),
+//!      PROBE_TYPES (turbo4,turbo1,bq,bq2,int8),
+//!      PROBE_LOAD_THREADS (cores - 1; 0 skips part C), PROBE_LOAD_MB (128)
+
+use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Barrier};
+use std::time::{Duration, Instant};
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use quantization::encoded_storage::{EncodedStorage, TestEncodedStorageBuilder};
+use quantization::encoded_vectors_binary::{self, EncodedVectorsBin, Encoding, QueryEncoding};
+use quantization::encoded_vectors_u8::{self, EncodedVectorsU8, ScalarQuantizationMethod};
+use quantization::turboquant::quantization::TurboQuantizer;
+use quantization::turboquant::{TQBits, TQMode, TQRotation};
+use quantization::{DistanceType, EncodedVectors, VectorParameters};
+use rand::prelude::*;
+use rand::rngs::SmallRng;
+
+const SEED: u64 = 42;
+const CACHE_LINE: usize = 64;
+/// Mirrors `VECTOR_READ_BATCH_SIZE`: production scores candidates in batches.
+const BATCH: usize = 64;
+
+/// Reference two-level prefetch schedule the final table compares against:
+/// a near (L1) window covering `NEAR_BYTES` and a far (L2) window covering
+/// `FAR_BYTES` of look-ahead, both expressed in whole vectors, with no far
+/// window for sub-cache-line codes. Kept local so this tool stands alone;
+/// update it if the production schedule changes.
+const NEAR_BYTES: usize = 1024;
+const FAR_BYTES: usize = 4096;
+
+fn reference_windows(vector_size_bytes: usize) -> (usize, usize) {
+    let near = (NEAR_BYTES / vector_size_bytes.max(1)).clamp(1, 8);
+    if vector_size_bytes < CACHE_LINE {
+        return (near, 0);
+    }
+    let far = (FAR_BYTES / vector_size_bytes).clamp(near + 2, 16);
+    (near, far)
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name).ok().map_or(default, |value| {
+        value
+            .parse()
+            .unwrap_or_else(|_| panic!("{name} must be an integer, got {value:?}"))
+    })
+}
+
+/// One random cycle through all cache lines of a `mb` MiB buffer: buf holds
+/// one u64 next-line index at the start of each 64-B line.
+fn build_chase(mb: usize, rng: &mut SmallRng) -> Vec<u64> {
+    let lines = mb * 1024 * 1024 / CACHE_LINE;
+    let mut order: Vec<u32> = (0..lines as u32).collect();
+    order.shuffle(rng);
+    let mut buf = vec![0u64; lines * (CACHE_LINE / 8)];
+    for k in 0..lines {
+        let from = order[k] as usize;
+        let to = order[(k + 1) % lines];
+        buf[from * (CACHE_LINE / 8)] = u64::from(to);
+    }
+    buf
+}
+
+/// ns per dependent load. The chain forces one full memory round trip per hop.
+fn chase_ns_per_hop(buf: &[u64], hops: usize) -> f64 {
+    let mut cur: u64 = 0;
+    let start = Instant::now();
+    for _ in 0..hops {
+        cur = buf[cur as usize * (CACHE_LINE / 8)];
+    }
+    let elapsed = start.elapsed();
+    black_box(cur);
+    elapsed.as_secs_f64() * 1e9 / hops as f64
+}
+
+fn measure_chase(buf: &[u64], label: &str, hops: usize, rounds: usize) -> f64 {
+    chase_ns_per_hop(buf, hops / 4); // warm-up: page-in + TLB/predictor settle
+    let mut samples: Vec<f64> = (0..rounds).map(|_| chase_ns_per_hop(buf, hops)).collect();
+    samples.sort_by(f64::total_cmp);
+    for (idx, ns) in samples.iter().enumerate() {
+        println!("latency {label} round{idx}: {ns:.1} ns/hop");
+    }
+    samples[samples.len() / 2]
+}
+
+fn measure_latency(mb: usize, hops: usize, rounds: usize, rng: &mut SmallRng) -> f64 {
+    let buf = build_chase(mb, rng);
+    measure_chase(&buf, &format!("{mb}MiB"), hops, rounds)
+}
+
+/// Background memory aggressors: each thread issues batches of 8 independent
+/// random cache-line reads over its own private buffer — many misses in
+/// flight per thread (scattered candidate-fill shape), unlike a dependent
+/// chase (1 miss) or streaming (HW-prefetched bandwidth).
+struct LoadGen {
+    stop: Arc<AtomicBool>,
+    handles: Vec<std::thread::JoinHandle<u64>>,
+    started: Instant,
+}
+
+fn start_load(threads: usize, mb: usize) -> LoadGen {
+    let stop = Arc::new(AtomicBool::new(false));
+    // +1: the main thread also waits for all buffers to be paged in before
+    // any loaded measurement starts.
+    let barrier = Arc::new(Barrier::new(threads + 1));
+    let handles = (0..threads)
+        .map(|tid| {
+            let stop = Arc::clone(&stop);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                let words = mb * 1024 * 1024 / 8;
+                let lines = words / (CACHE_LINE / 8);
+                assert!(
+                    lines.is_power_of_two(),
+                    "PROBE_LOAD_MB must be a power of two"
+                );
+                // Distinct written values force real physical pages (an
+                // untouched zeroed allocation would alias the kernel's shared
+                // zero page and turn every "miss" into a cache hit).
+                let buf: Vec<u64> = (0..words).map(|w| w as u64).collect();
+                // 8 xorshift streams -> 8 independent loads per batch.
+                let mut states: [u64; 8] = std::array::from_fn(|lane| {
+                    SEED ^ ((tid * 8 + lane) as u64).wrapping_mul(0x9e3779b97f4a7c15) | 1
+                });
+                let mut acc = 0u64;
+                let mut touched = 0u64;
+                barrier.wait();
+                while !stop.load(Ordering::Relaxed) {
+                    for _ in 0..64 {
+                        for state in &mut states {
+                            *state ^= *state << 13;
+                            *state ^= *state >> 7;
+                            *state ^= *state << 17;
+                            let line = (*state as usize) & (lines - 1);
+                            acc = acc.wrapping_add(buf[line * (CACHE_LINE / 8)]);
+                        }
+                        touched += 8;
+                    }
+                }
+                black_box(acc);
+                touched
+            })
+        })
+        .collect();
+    barrier.wait();
+    LoadGen {
+        stop,
+        handles,
+        started: Instant::now(),
+    }
+}
+
+impl LoadGen {
+    /// Stops the aggressors and returns their aggregate read bandwidth in
+    /// GB/s — context for how close to the wall the loaded numbers were taken.
+    fn stop(self) -> f64 {
+        self.stop.store(true, Ordering::Relaxed);
+        let elapsed = self.started.elapsed().as_secs_f64();
+        let touched: u64 = self.handles.into_iter().map(|h| h.join().unwrap()).sum();
+        touched as f64 * CACHE_LINE as f64 / elapsed / 1e9
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Datatype {
+    Turbo4,
+    Turbo1,
+    Bq,
+    Bq2,
+    Int8,
+}
+
+impl Datatype {
+    fn label(self) -> &'static str {
+        match self {
+            Datatype::Turbo4 => "turbo4",
+            Datatype::Turbo1 => "turbo1",
+            Datatype::Bq => "bq",
+            Datatype::Bq2 => "bq2",
+            Datatype::Int8 => "int8",
+        }
+    }
+
+    fn parse(name: &str) -> Self {
+        match name {
+            "turbo4" => Datatype::Turbo4,
+            "turbo1" => Datatype::Turbo1,
+            "bq" => Datatype::Bq,
+            "bq2" => Datatype::Bq2,
+            "int8" => Datatype::Int8,
+            other => panic!("PROBE_TYPES entry {other:?}, expected turbo4|turbo1|bq|bq2|int8"),
+        }
+    }
+}
+
+struct KernelCell {
+    datatype: Datatype,
+    dim: usize,
+    vec_bytes: usize,
+    ns_per_vec: f64,
+    bytes_per_ns: f64,
+}
+
+fn random_vec(rng: &mut SmallRng, dim: usize) -> Vec<f32> {
+    (0..dim).map(|_| rng.random::<f32>() - 0.5).collect()
+}
+
+/// Working set capped at 256 KiB so it settles into L1/L2 after warm-up;
+/// power-of-two count for mask indexing.
+fn working_set_count(vec_bytes: usize) -> usize {
+    (256 * 1024 / vec_bytes).clamp(64, 1024).next_power_of_two() / 2
+}
+
+/// The shared timing loop: score random ids from a flat cache-resident code
+/// buffer in production batch shape, return ns per scored vector.
+fn run_rate(
+    buf: &[u8],
+    vec_bytes: usize,
+    count: usize,
+    secs: u64,
+    rng: &mut SmallRng,
+    score: impl Fn(&[u8]) -> f32,
+) -> f64 {
+    let ids: Vec<u32> = (0..1 << 16)
+        .map(|_| (rng.random::<u64>() as usize & (count - 1)) as u32)
+        .collect();
+    let run = |deadline: Instant| -> (u64, f64) {
+        let start = Instant::now();
+        let mut scored: u64 = 0;
+        let mut acc: f32 = 0.0;
+        'outer: loop {
+            for (batch_idx, batch) in ids.chunks(BATCH).enumerate() {
+                for &id in batch {
+                    let at = id as usize * vec_bytes;
+                    acc += score(&buf[at..at + vec_bytes]);
+                }
+                scored += batch.len() as u64;
+                if batch_idx % 64 == 0 && Instant::now() >= deadline {
+                    break 'outer;
+                }
+            }
+        }
+        black_box(acc);
+        (scored, start.elapsed().as_secs_f64())
+    };
+
+    run(Instant::now() + Duration::from_millis(200)); // warm caches + branch predictors
+    let (scored, elapsed) = run(Instant::now() + Duration::from_secs(secs));
+    elapsed * 1e9 / scored as f64
+}
+
+/// Pure consumption rate of one production scoring kernel: cache-resident
+/// codes, batch loop shape, no prefetch hints (hints on resident data are
+/// near-free and would only blur the compute measurement).
+fn measure_kernel(datatype: Datatype, dim: usize, secs: u64, rng: &mut SmallRng) -> KernelCell {
+    let params = VectorParameters {
+        dim,
+        deprecated_count: None,
+        distance_type: DistanceType::Dot,
+        invert: false,
+    };
+    let stopped = AtomicBool::new(false);
+    let hw = HardwareCounterCell::new();
+
+    let (vec_bytes, ns_per_vec) = match datatype {
+        Datatype::Turbo4 | Datatype::Turbo1 => {
+            let bits = match datatype {
+                Datatype::Turbo4 => TQBits::Bits4,
+                Datatype::Turbo1 => TQBits::Bits1,
+                Datatype::Bq | Datatype::Bq2 | Datatype::Int8 => unreachable!(),
+            };
+            let quantizer = TurboQuantizer::new(
+                dim,
+                bits,
+                TQMode::Normal,
+                DistanceType::Dot,
+                TQRotation::Unpadded,
+                None,
+            );
+            let mut pad_buf = vec![0.0f64; quantizer.get_padded_dim()];
+            let vec_bytes = quantizer
+                .quantize(&random_vec(rng, dim), &mut pad_buf)
+                .len();
+            let count = working_set_count(vec_bytes);
+            let mut buf: Vec<u8> = Vec::with_capacity(count * vec_bytes);
+            for _ in 0..count {
+                buf.extend_from_slice(&quantizer.quantize(&random_vec(rng, dim), &mut pad_buf));
+            }
+            let query = quantizer.precompute_query(&random_vec(rng, dim));
+            let ns = run_rate(&buf, vec_bytes, count, secs, rng, |bytes| {
+                quantizer.score_precomputed(&query, bytes)
+            });
+            (vec_bytes, ns)
+        }
+        Datatype::Bq | Datatype::Bq2 => {
+            let encoding = match datatype {
+                Datatype::Bq => Encoding::OneBit,
+                Datatype::Bq2 => Encoding::TwoBits,
+                Datatype::Turbo4 | Datatype::Turbo1 | Datatype::Int8 => unreachable!(),
+            };
+            let qsize = encoded_vectors_binary::get_quantized_vector_size_from_params::<u128>(
+                dim, encoding,
+            );
+            let count = working_set_count(qsize);
+            let samples: Vec<Vec<f32>> = (0..count).map(|_| random_vec(rng, dim)).collect();
+            let encoded = EncodedVectorsBin::<u128, _>::encode(
+                samples.iter(),
+                TestEncodedStorageBuilder::new(None, qsize),
+                &params,
+                encoding,
+                QueryEncoding::SameAsStorage,
+                None,
+                &stopped,
+            )
+            .unwrap();
+            let vec_bytes = encoded.quantized_vector_size();
+            let mut buf: Vec<u8> = Vec::with_capacity(count * vec_bytes);
+            for i in 0..count {
+                buf.extend_from_slice(&encoded.storage().get_vector_data(i as u32));
+            }
+            let query = encoded.encode_query(&random_vec(rng, dim));
+            let ns = run_rate(&buf, vec_bytes, count, secs, rng, |bytes| {
+                encoded.score(&query, bytes, &hw)
+            });
+            (vec_bytes, ns)
+        }
+        Datatype::Int8 => {
+            let qsize = encoded_vectors_u8::get_quantized_vector_size(&params);
+            let count = working_set_count(qsize);
+            let samples: Vec<Vec<f32>> = (0..count).map(|_| random_vec(rng, dim)).collect();
+            let encoded = EncodedVectorsU8::encode(
+                samples.iter(),
+                TestEncodedStorageBuilder::new(None, qsize),
+                &params,
+                count,
+                None,
+                ScalarQuantizationMethod::Int8,
+                None,
+                &stopped,
+            )
+            .unwrap();
+            let vec_bytes = encoded.quantized_vector_size();
+            let mut buf: Vec<u8> = Vec::with_capacity(count * vec_bytes);
+            for i in 0..count {
+                buf.extend_from_slice(&encoded.storage().get_vector_data(i as u32));
+            }
+            let query = encoded.encode_query(&random_vec(rng, dim));
+            let ns = run_rate(&buf, vec_bytes, count, secs, rng, |bytes| {
+                encoded.score(&query, bytes, &hw)
+            });
+            (vec_bytes, ns)
+        }
+    };
+
+    KernelCell {
+        datatype,
+        dim,
+        vec_bytes,
+        ns_per_vec,
+        bytes_per_ns: vec_bytes as f64 / ns_per_vec,
+    }
+}
+
+fn measure_kernels(
+    types: &[Datatype],
+    dims: &[usize],
+    secs: u64,
+    rng: &mut SmallRng,
+    prefix: &str,
+) -> Vec<KernelCell> {
+    types
+        .iter()
+        .flat_map(|&datatype| dims.iter().map(move |&dim| (datatype, dim)))
+        .map(|(datatype, dim)| {
+            let cell = measure_kernel(datatype, dim, secs, rng);
+            println!(
+                "{prefix}{:7} dim {:4}  code {:4} B  {:7.2} ns/vec  {:5.1} B/ns",
+                cell.datatype.label(),
+                cell.dim,
+                cell.vec_bytes,
+                cell.ns_per_vec,
+                cell.bytes_per_ns
+            );
+            cell
+        })
+        .collect()
+}
+
+fn main() {
+    let lat_mb = env_usize("PROBE_LAT_MB", 512);
+    let hops = env_usize("PROBE_HOPS", 16 * 1024 * 1024);
+    let rounds = env_usize("PROBE_ROUNDS", 3);
+    let kernel_secs = env_usize("PROBE_KERNEL_SECS", 2) as u64;
+    let dims: Vec<usize> = std::env::var("PROBE_DIMS")
+        .unwrap_or_else(|_| "64,128,512,768,1024,2048,4096".to_string())
+        .split(',')
+        .map(|d| d.trim().parse().expect("PROBE_DIMS must be integers"))
+        .collect();
+    let types: Vec<Datatype> = std::env::var("PROBE_TYPES")
+        .unwrap_or_else(|_| "turbo4,turbo1,bq,bq2,int8".to_string())
+        .split(',')
+        .map(|name| Datatype::parse(name.trim()))
+        .collect();
+    let mut rng = SmallRng::seed_from_u64(SEED);
+
+    println!("== part A: dependent-load memory latency ==");
+    let l3_control = measure_latency(4, hops, rounds, &mut rng);
+    let dram_buf = build_chase(lat_mb, &mut rng);
+    let dram = measure_chase(&dram_buf, &format!("{lat_mb}MiB"), hops, rounds);
+    println!("control(4MiB, ~L3): {l3_control:.1} ns   DRAM({lat_mb}MiB): {dram:.1} ns");
+
+    println!("\n== part B: kernel consumption rates (cache-resident) ==");
+    let cells = measure_kernels(&types, &dims, kernel_secs, &mut rng, "");
+
+    let load_threads = env_usize(
+        "PROBE_LOAD_THREADS",
+        std::thread::available_parallelism().map_or(0, |n| n.get().saturating_sub(1)),
+    );
+    let load_mb = env_usize("PROBE_LOAD_MB", 128);
+    let loaded = (load_threads > 0).then(|| {
+        println!(
+            "\n== part C: loaded latency + kernel rates ({load_threads} aggressor threads x {load_mb} MiB, scattered reads) =="
+        );
+        let load = start_load(load_threads, load_mb);
+        let dram_loaded = measure_chase(&dram_buf, "loaded", hops, rounds);
+        let loaded_cells = measure_kernels(&types, &dims, kernel_secs, &mut rng, "loaded ");
+        let gbps = load.stop();
+        println!(
+            "loaded DRAM: {dram_loaded:.1} ns (idle {dram:.1} ns, x{:.2});  aggressor read bandwidth {gbps:.1} GB/s aggregate",
+            dram_loaded / dram,
+        );
+        (dram_loaded, loaded_cells)
+    });
+
+    println!("\n== formula check: predicted look-ahead = latency x rate ==");
+    println!(
+        "reference schedule: NEAR_BYTES={NEAR_BYTES} FAR_BYTES={FAR_BYTES}; coverage = eff_near x ns_per_vec / latency (<1 -> near alone too shallow)"
+    );
+    println!(
+        "type,dim,code_bytes,eff_near,eff_far,idle_need_bytes,idle_coverage,loaded_need_bytes,loaded_coverage"
+    );
+    for (idx, cell) in cells.iter().enumerate() {
+        let (near, far) = reference_windows(cell.vec_bytes);
+        let coverage =
+            |lat: f64, c: &KernelCell| (near as f64 * c.ns_per_vec / lat, lat * c.bytes_per_ns);
+        let (idle_cov, idle_need) = coverage(dram, cell);
+        let (loaded_need, loaded_cov) = match &loaded {
+            Some((lat, loaded_cells)) => {
+                let (cov, need) = coverage(*lat, &loaded_cells[idx]);
+                (format!("{need:.0}"), format!("{cov:.2}"))
+            }
+            None => ("-".to_string(), "-".to_string()),
+        };
+        println!(
+            "{},{},{},{},{},{:.0},{:.2},{},{}",
+            cell.datatype.label(),
+            cell.dim,
+            cell.vec_bytes,
+            near,
+            far,
+            idle_need,
+            idle_cov,
+            loaded_need,
+            loaded_cov,
+        );
+    }
+}


### PR DESCRIPTION
A small test program that measures two things about the machine it runs on: 
 - how long the computer takes to fetch data from main memory (DRAM latency)
 - how fast each of our quantization scoring methods (turbo1, turbo4, binary 1-bit and 2-bit, int8) consumes the vectors without any DRAM access (everything in cache).
 
It runs the checks twice: once on a quiet machine, and once while all the other cores are kept busy, since a busy machine behaves differently.

Based on this we can calculate how many bytes we need to pre-fetch from memory in advance to not starve the CPU during scoring.

It can be run using the following command

```
cargo run -p segment --profile perf --example latency_kernel_probe
```
When running it, the machine it runs on should be quiet and not run anything heavy.