### PR TITLE
Don't re-apply committed entries already applied during consensus start

### DIFF
--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -359,6 +359,11 @@ impl Consensus {
 
         // Before consensus has started apply any unapplied committed entries
         // They might have not been applied due to unplanned Qdrant shutdown
+        //
+        // Note: this advances the applied index tracked in persistent state past the `applied`
+        // index the Raft node was configured with above. The first `Ready` re-delivers the
+        // entries applied here. `handle_committed_entries` skips them by consulting the
+        // persisted applied index.
         let _stop_consensus = state_ref.apply_entries(&mut node)?;
 
         if force_compact_wal {
@@ -1208,7 +1213,24 @@ fn handle_committed_entries(
 ) -> anyhow::Result<bool> {
     let mut stop_consensus = false;
     if let (Some(first), Some(last)) = (entries.first(), entries.last()) {
-        state.set_unapplied_entries(first.index, last.index)?;
+        // Raft delivers committed entries starting right after the `applied` index the node
+        // was constructed with, which does not account for the entries applied during catch-up
+        // in `Consensus::new`. The first `Ready` after a (re)start therefore re-delivers
+        // entries that are already applied. We never want to apply an entry twice.
+        let first_unapplied = state
+            .last_applied_entry()
+            .map_or(first.index, |applied| cmp::max(first.index, applied + 1));
+
+        if first_unapplied > first.index {
+            log::debug!(
+                "Skipping committed entries up to {} which are already applied",
+                first_unapplied - 1,
+            );
+        }
+
+        if first_unapplied <= last.index {
+            state.set_unapplied_entries(first_unapplied, last.index)?;
+        }
         stop_consensus = state.apply_entries(raw_node)?;
     }
     Ok(stop_consensus)

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -313,13 +313,15 @@ impl Consensus {
         }
 
         // raft will not return entries to the application smaller or equal to `applied`
-        let last_applied = state_ref.last_applied_entry().unwrap_or_default();
-        let raft_config = Config {
+        let mut raft_config = Config {
             id: state_ref.this_peer_id(),
-            applied: last_applied,
+            applied: state_ref.last_applied_entry().unwrap_or_default(),
+            batch_append: true,
             ..Default::default()
         };
+
         raft_config.validate()?;
+
         // State might be initialized but the node might be shutdown without actually syncing or committing anything.
         if state_ref.is_new_deployment() || reinit {
             let leader_established_in_ms =
@@ -351,20 +353,29 @@ impl Consensus {
             if bootstrap_peer.is_some() || uri.is_some() {
                 log::debug!("Local raft state found - bootstrap and uri cli arguments were ignored")
             }
+
             log::debug!("Local raft state found - skipping initialization");
         };
 
         let mut node = Node::new(&raft_config, state_ref.clone(), logger)?;
-        node.set_batch_append(true);
 
-        // Before consensus has started apply any unapplied committed entries
-        // They might have not been applied due to unplanned Qdrant shutdown
-        //
-        // Note: this advances the applied index tracked in persistent state past the `applied`
-        // index the Raft node was configured with above. The first `Ready` re-delivers the
-        // entries applied here. `handle_committed_entries` skips them by consulting the
-        // persisted applied index.
+        // (Re-)apply any committed, but unapplied entries before starting consensus.
+        // This might happen if Qdrant was stopped or crashed before or while applying an operation.
+        // Applying during startup allows us to catch service errors early,
+        // before starting consensus thread.
         let _stop_consensus = state_ref.apply_entries(&mut node)?;
+
+        // Node was created with older `applied` index, and `apply_entries` does *not* update it.
+        // On first `Ready` Raft would once again return entries applied above to the application,
+        // and we would apply them a second time.
+        //
+        // `applied` can only be set when node is created and can't be updated manually,
+        // so we have to re-create the node with updated index.
+        let applied = state_ref.last_applied_entry().unwrap_or_default();
+        if raft_config.applied < applied {
+            raft_config.applied = applied;
+            node = Node::new(&raft_config, state_ref.clone(), logger)?;
+        }
 
         if force_compact_wal {
             // Making sure that the WAL will be compacted on start
@@ -1213,24 +1224,7 @@ fn handle_committed_entries(
 ) -> anyhow::Result<bool> {
     let mut stop_consensus = false;
     if let (Some(first), Some(last)) = (entries.first(), entries.last()) {
-        // Raft delivers committed entries starting right after the `applied` index the node
-        // was constructed with, which does not account for the entries applied during catch-up
-        // in `Consensus::new`. The first `Ready` after a (re)start therefore re-delivers
-        // entries that are already applied. We never want to apply an entry twice.
-        let first_unapplied = state
-            .last_applied_entry()
-            .map_or(first.index, |applied| cmp::max(first.index, applied + 1));
-
-        if first_unapplied > first.index {
-            log::debug!(
-                "Skipping committed entries up to {} which are already applied",
-                first_unapplied - 1,
-            );
-        }
-
-        if first_unapplied <= last.index {
-            state.set_unapplied_entries(first_unapplied, last.index)?;
-        }
+        state.set_unapplied_entries(first.index, last.index)?;
         stop_consensus = state.apply_entries(raw_node)?;
     }
     Ok(stop_consensus)


### PR DESCRIPTION
Attempts to fix a flaky consensus test which I've already seen multiple times.

Example failure: https://github.com/qdrant/qdrant/actions/runs/32313963620/job/96262369800?pr=10269#step:11:755

I believe the goal should be for operations to be idempotent. But that on it's own doesn't eliminate this change.

---

Raft delivers committed entries starting right after the `applied` index the node was constructed with, which does not account for the entries applied by the catch-up in `Consensus::new`. The first `Ready` after a (re)start therefore re-delivered entries that were already applied, and `handle_committed_entries` reset the apply-progress queue backwards and applied them a second time.

Applying is not guaranteed to be idempotent. This made `test_consensus_restart_on_transient_error` flaky: on every consensus thread restart the poisoned entry rolled its failure probability twice (once in catch-up, once on re-delivery), turning per-attempt recovery from 0.7 into 0.49 and inflating the chance of exhausting the 600s recovery timeout from ~0.002% to ~0.2% per run. Seen in CI where a restart attempt passed the roll in catch-up, then failed the re-applied roll 27ms later and escalated into the 256s/300s backoff tiers.

Skip the already-applied prefix of a delivered batch by consulting the persisted applied index. A batch that is entirely applied becomes a no-op. The stop-consensus path is unaffected: a conf entry that stops consensus is never marked applied, so it is never skipped.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?