### PR TITLE
feat: add a dedicated max operator to score formulas

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -15257,6 +15257,9 @@
             "$ref": "#/components/schemas/SumExpression"
           },
           {
+            "$ref": "#/components/schemas/MaxExpression"
+          },
+          {
             "$ref": "#/components/schemas/NegExpression"
           },
           {
@@ -15364,6 +15367,21 @@
         ],
         "properties": {
           "sum": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Expression"
+            }
+          }
+        }
+      },
+      "MaxExpression": {
+        "description": "Largest of the given expressions. Requires at least one operand.",
+        "type": "object",
+        "required": [
+          "max"
+        ],
+        "properties": {
+          "max": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Expression"

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -350,6 +350,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("Expression.variant", ""),
             ("MultExpression.mult", ""),
             ("SumExpression.sum", ""),
+            ("MaxExpression.max", ""),
             ("DivExpression.left", ""),
             ("DivExpression.right", ""),
             ("PowExpression.base", ""),

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -70,7 +70,7 @@ use crate::grpc::qdrant::{
 };
 use crate::grpc::{
     self, BinaryQuantizationEncoding, BinaryQuantizationQueryEncoding, DecayParamsExpression,
-    DivExpression, GeoDistance, MultExpression, PowExpression, SumExpression,
+    DivExpression, GeoDistance, MaxExpression, MultExpression, PowExpression, SumExpression,
 };
 use crate::rest::models::{CollectionsResponse, ShardKeysResponse, VersionInfo};
 use crate::rest::schema as rest;
@@ -3628,6 +3628,12 @@ fn unparse_expression(
         }),
         ParsedExpression::Sum(exprs) => Variant::Sum(SumExpression {
             sum: exprs
+                .into_iter()
+                .map(|expr| unparse_expression(expr, conditions))
+                .collect(),
+        }),
+        ParsedExpression::Max(exprs) => Variant::Max(MaxExpression {
+            max: exprs
                 .into_iter()
                 .map(|expr| unparse_expression(expr, conditions))
                 .collect(),

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -978,6 +978,8 @@ message Expression {
     DecayParamsExpression lin_decay = 19;
     // Inverse hyperbolic cosine
     Expression acosh = 20;
+    // Maximum
+    MaxExpression max = 21;
   }
 }
 
@@ -992,6 +994,10 @@ message MultExpression {
 
 message SumExpression {
   repeated Expression sum = 1;
+}
+
+message MaxExpression {
+  repeated Expression max = 1;
 }
 
 message DivExpression {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -6572,7 +6572,7 @@ pub struct Formula {
 pub struct Expression {
     #[prost(
         oneof = "expression::Variant",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21"
     )]
     #[validate(nested)]
     pub variant: ::core::option::Option<expression::Variant>,
@@ -6641,6 +6641,9 @@ pub mod expression {
         /// Inverse hyperbolic cosine
         #[prost(message, tag = "20")]
         Acosh(::prost::alloc::boxed::Box<super::Expression>),
+        /// Maximum
+        #[prost(message, tag = "21")]
+        Max(super::MaxExpression),
     }
 }
 #[derive(serde::Serialize)]
@@ -6666,6 +6669,14 @@ pub struct SumExpression {
     #[prost(message, repeated, tag = "1")]
     #[validate(nested)]
     pub sum: ::prost::alloc::vec::Vec<Expression>,
+}
+#[derive(validator::Validate)]
+#[derive(serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MaxExpression {
+    #[prost(message, repeated, tag = "1")]
+    #[validate(nested)]
+    pub max: ::prost::alloc::vec::Vec<Expression>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -456,6 +456,7 @@ impl Validate for super::qdrant::expression::Variant {
             grpc::expression::Variant::DatetimeKey(_) => Ok(()),
             grpc::expression::Variant::Mult(mult_expression) => mult_expression.validate(),
             grpc::expression::Variant::Sum(sum_expression) => sum_expression.validate(),
+            grpc::expression::Variant::Max(max_expression) => max_expression.validate(),
             grpc::expression::Variant::Div(div_expression) => div_expression.validate(),
             grpc::expression::Variant::Neg(expression) => expression.validate(),
             grpc::expression::Variant::Abs(expression) => expression.validate(),

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -937,6 +937,7 @@ pub enum Expression {
     DatetimeKey(DatetimeKeyExpression),
     Mult(MultExpression),
     Sum(SumExpression),
+    Max(MaxExpression),
     Neg(NegExpression),
     Abs(AbsExpression),
     Div(DivExpression),
@@ -984,6 +985,13 @@ pub struct MultExpression {
 pub struct SumExpression {
     #[validate(nested)]
     pub sum: Vec<Expression>,
+}
+
+/// Largest of the given expressions. Requires at least one operand.
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]
+pub struct MaxExpression {
+    #[validate(nested)]
+    pub max: Vec<Expression>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -270,6 +270,7 @@ impl Validate for Expression {
             Expression::DatetimeKey(_) => Ok(()),
             Expression::Mult(mult_expression) => mult_expression.validate(),
             Expression::Sum(sum_expression) => sum_expression.validate(),
+            Expression::Max(max_expression) => max_expression.validate(),
             Expression::Neg(neg_expression) => neg_expression.validate(),
             Expression::Abs(abs_expression) => abs_expression.validate(),
             Expression::Div(div_expression) => div_expression.validate(),

--- a/lib/collection/src/problems/unindexed_field.rs
+++ b/lib/collection/src/problems/unindexed_field.rs
@@ -474,6 +474,12 @@ impl<'a> Extractor<'a> {
                 }
                 return;
             }
+            ExpressionInternal::Max(expression_internals) => {
+                for expr in expression_internals {
+                    self.update_from_expression(expr);
+                }
+                return;
+            }
             ExpressionInternal::Neg(expression_internal) => {
                 self.update_from_expression(expression_internal);
                 return;
@@ -690,6 +696,23 @@ mod tests {
             infer_index_from_field_condition(&condition),
             vec![FieldIndexType::KeywordPrefix],
         );
+    }
+
+    /// Payload fields referenced inside `max` still need an index, so the walker must recurse
+    /// into its operands the same way it does for `sum` and `mult`. Missing this would silently
+    /// stop suggesting indexes for any field used under a max.
+    #[test]
+    fn max_operands_report_unindexed_payload_fields() {
+        let payload_schema = HashMap::new();
+
+        let mut extractor = Extractor::new(&payload_schema);
+        extractor.update_from_expression(&ExpressionInternal::Max(vec![
+            ExpressionInternal::Variable("$score".to_string()),
+            ExpressionInternal::Variable("popularity".to_string()),
+        ]));
+
+        let unindexed: Vec<_> = extractor.unindexed_schema().keys().cloned().collect();
+        assert_eq!(unindexed, vec![JsonPath::new("popularity")]);
     }
 
     #[test]

--- a/lib/edge/ffi/src/ops/formula.rs
+++ b/lib/edge/ffi/src/ops/formula.rs
@@ -209,6 +209,18 @@ impl Expression {
         })
     }
 
+    /// Largest of `operands`. Requires at least one operand: unlike [`Expression::sum`]
+    /// and [`Expression::mult`], `max` has no identity element to fall back on, so an empty
+    /// list is rejected here rather than scoring every point with -infinity at query time.
+    #[uniffi::constructor]
+    pub fn max(operands: Vec<Arc<Expression>>) -> Result<Arc<Self>> {
+        require_non_empty("max", &operands)?;
+        let children: Vec<&Arc<Expression>> = operands.iter().collect();
+        Self::node(&children, || {
+            ExpressionInternal::Max(operands.iter().map(|e| e.inner.clone()).collect())
+        })
+    }
+
     /// Negation: `-expression`.
     #[uniffi::constructor]
     pub fn negate(expression: Arc<Expression>) -> Result<Arc<Self>> {
@@ -345,6 +357,18 @@ impl Expression {
 // ── Coverage map ────────────────────────────────────────────────────────────
 
 /// Compile-time map of the engine's formula-expression tree onto the
+/// Rejects a variadic operator given no operands. `max` has no identity element to fall back on,
+/// so an empty list would otherwise score every point with -infinity at query time; failing at
+/// build time points at the mistake instead.
+fn require_non_empty(operator: &str, operands: &[Arc<Expression>]) -> Result<()> {
+    if operands.is_empty() {
+        return Err(EdgeError::invalid_argument(format!(
+            "`{operator}` needs at least one operand"
+        )));
+    }
+    Ok(())
+}
+
 /// [`Expression`] constructors above — same contract as the maps in
 /// [`crate::update`], [`crate::ops::query`], and [`crate::filter`]: no
 /// wildcard arms, so a variant added to [`ExpressionInternal`] or the
@@ -371,6 +395,8 @@ fn assert_every_expression_is_mapped(e: ExpressionInternal) {
         ExpressionInternal::Mult(_) => {}
         // [`Expression::sum`]
         ExpressionInternal::Sum(_) => {}
+        // [`Expression::max`]
+        ExpressionInternal::Max(_) => {}
         // [`Expression::negate`]
         ExpressionInternal::Neg(_) => {}
         // [`Expression::div`]

--- a/lib/edge/ffi/tests/integration.rs
+++ b/lib/edge/ffi/tests/integration.rs
@@ -2760,6 +2760,92 @@ fn formula_rescoring_boosts_by_payload() {
     );
 }
 
+/// `max` against a dominating constant pins every score to that constant. Asserting the exact
+/// value distinguishes `max` from `sum`, which would instead add the constant to each score.
+#[test]
+fn formula_max_clamps_scores_to_a_floor() {
+    use qdrant_edge_ffi::{Expression, Prefetch, QueryRequest, ScoringQuery};
+
+    let dir = tempfile::tempdir().expect("tempdir failed");
+    let path = dir.path().to_string_lossy().into_owned();
+    let shard: Arc<EdgeShard> = EdgeShard::load(path, Some(make_config())).expect("load failed");
+
+    let points = vec![
+        Point {
+            id: PointId::NumId { value: 1 },
+            vector: named_vec([0.1, 0.1, 0.1, 0.1]),
+            payload: None,
+        },
+        Point {
+            id: PointId::NumId { value: 2 },
+            vector: named_vec([0.09, 0.09, 0.09, 0.09]),
+            payload: None,
+        },
+    ];
+    let op = UpdateOperation::upsert_points(points, None, None).expect("upsert failed");
+    shard.update(op).expect("update failed");
+
+    const FLOOR: f32 = 42.0;
+
+    let expression = Expression::max(vec![
+        Expression::variable("$score".to_string()),
+        Expression::constant(FLOOR).expect("constant build failed"),
+    ])
+    .expect("expression build failed");
+
+    let hits = shard
+        .query(QueryRequest {
+            limit: 2,
+            offset: None,
+            query: Some(ScoringQuery::Formula {
+                expression,
+                defaults: HashMap::new(),
+            }),
+            prefetches: vec![Prefetch {
+                limit: 10,
+                query: Some(ScoringQuery::Vector {
+                    query: Query::Nearest {
+                        vector: NamedVector::Dense {
+                            values: vec![0.1, 0.1, 0.1, 0.1],
+                        },
+                        using: Some("vec".to_string()),
+                    },
+                }),
+                prefetches: vec![],
+                filter: None,
+                score_threshold: None,
+                params: None,
+            }],
+            with_vector: None,
+            with_payload: None,
+            filter: None,
+            score_threshold: None,
+            params: None,
+        })
+        .expect("formula query failed");
+
+    assert_eq!(hits.len(), 2, "both points should be re-scored");
+    for hit in &hits {
+        assert_eq!(
+            hit.score, FLOOR,
+            "every score is below the floor, so max must return the floor itself"
+        );
+    }
+}
+
+/// An empty `max` has no identity element to fall back on, so building the query must fail rather
+/// than score every point with -infinity.
+#[test]
+fn formula_empty_max_is_rejected() {
+    use qdrant_edge_ffi::Expression;
+
+    let err = Expression::max(vec![]).expect_err("empty max must be rejected");
+    assert!(
+        matches!(err, EdgeError::InvalidArgument { .. }),
+        "expected InvalidArgument, got {err:?}"
+    );
+}
+
 /// Grouped query: one group per category, best hit each.
 #[test]
 fn query_groups_returns_one_group_per_key() {

--- a/lib/edge/python/qdrant_edge.pyi
+++ b/lib/edge/python/qdrant_edge.pyi
@@ -2479,6 +2479,11 @@ class Expression(Enum):
         ...
 
     @staticmethod
+    def Max(exprs: List["Expression"]) -> "Expression":
+        """Create a maximum expression. Requires at least one operand."""
+        ...
+
+    @staticmethod
     def Neg(expr: "Expression") -> "Expression":
         """Create a negation expression."""
         ...

--- a/lib/edge/python/src/types/formula/expression.rs
+++ b/lib/edge/python/src/types/formula/expression.rs
@@ -45,6 +45,10 @@ impl FromPyObject<'_, '_> for PyExpression {
                 ExpressionInternal::Sum(PyExpression::peel_vec(exprs))
             }
 
+            PyExpressionInterface::Max { exprs } => {
+                ExpressionInternal::Max(PyExpression::peel_vec(exprs))
+            }
+
             PyExpressionInterface::Neg { expr } => ExpressionInternal::Neg(expr.into_box()),
 
             PyExpressionInterface::Div {
@@ -121,6 +125,10 @@ impl<'py> IntoPyObject<'py> for PyExpression {
             },
 
             ExpressionInternal::Sum(exprs) => PyExpressionInterface::Sum {
+                exprs: PyExpression::wrap_vec(exprs),
+            },
+
+            ExpressionInternal::Max(exprs) => PyExpressionInterface::Max {
                 exprs: PyExpression::wrap_vec(exprs),
             },
 
@@ -216,6 +224,10 @@ impl Repr for PyExpression {
 
             ExpressionInternal::Sum(exprs) => {
                 ("Sum", &[("exprs", &PyExpression::wrap_slice(exprs))])
+            }
+
+            ExpressionInternal::Max(exprs) => {
+                ("Max", &[("exprs", &PyExpression::wrap_slice(exprs))])
             }
 
             ExpressionInternal::Neg(expr) => ("Neg", &[("expr", PyExpression::wrap_ref(expr))]),

--- a/lib/edge/python/src/types/formula/expression_interface.rs
+++ b/lib/edge/python/src/types/formula/expression_interface.rs
@@ -42,6 +42,10 @@ pub enum PyExpressionInterface {
         exprs: Vec<PyExpression>,
     },
 
+    Max {
+        exprs: Vec<PyExpression>,
+    },
+
     Neg {
         expr: Boxed<PyExpression>,
     },
@@ -108,6 +112,7 @@ impl Repr for PyExpressionInterface {
             PyExpressionInterface::DatetimeKey { path } => ("DatetimeKey", &[("path", path)]),
             PyExpressionInterface::Mult { exprs } => ("Mult", &[("exprs", exprs)]),
             PyExpressionInterface::Sum { exprs } => ("Sum", &[("exprs", exprs)]),
+            PyExpressionInterface::Max { exprs } => ("Max", &[("exprs", exprs)]),
             PyExpressionInterface::Neg { expr } => ("Neg", &[("expr", expr)]),
 
             PyExpressionInterface::Div {

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -470,6 +470,12 @@ mod tests {
         ParsedExpression::Constant(PreciseScoreOrdered::from(-10.0)),
         ParsedExpression::Constant(PreciseScoreOrdered::from(-2.0)),
     ]), -2.0)]
+    // Datetimes evaluate to seconds, so `max` picks the more recent of two dates. This is how
+    // you'd score on "whichever of these timestamps is newer".
+    #[case(ParsedExpression::Max(vec![
+        ParsedExpression::Datetime(DatetimeExpression::Constant("2025-03-18".parse().unwrap())),
+        ParsedExpression::Datetime(DatetimeExpression::Constant("2026-01-01".parse().unwrap())),
+    ]), "2026-01-01".parse::<DateTimePayloadType>().unwrap().timestamp() as PreciseScore / 1_000_000.0)]
     // Nested sub-expressions are evaluated before comparing
     #[case(ParsedExpression::Max(vec![
         ParsedExpression::Mult(vec![
@@ -521,6 +527,20 @@ mod tests {
         ParsedExpression::new_ln(ParsedExpression::Constant(PreciseScoreOrdered::from(0.0))),
         0.0
     )]
+    // A failing operand must fail the whole expression, not be quietly passed over in favour of
+    // a finite sibling. Checked with the failure both before and after the finite operand:
+    // `mult` short-circuits on zero and so can skip evaluating later operands, and `max` must
+    // not grow a similar shortcut that would swallow an error.
+    #[should_panic(expected = r#"NonFiniteNumber { expression: "log10(0) = -inf" }"#)]
+    #[case(ParsedExpression::Max(vec![
+        ParsedExpression::new_log10(ParsedExpression::Constant(PreciseScoreOrdered::from(0.0))),
+        ParsedExpression::Constant(PreciseScoreOrdered::from(5.0)),
+    ]), 0.0)]
+    #[should_panic(expected = r#"NonFiniteNumber { expression: "log10(0) = -inf" }"#)]
+    #[case(ParsedExpression::Max(vec![
+        ParsedExpression::Constant(PreciseScoreOrdered::from(5.0)),
+        ParsedExpression::new_log10(ParsedExpression::Constant(PreciseScoreOrdered::from(0.0))),
+    ]), 0.0)]
     #[should_panic(expected = r#"NonFiniteNumber { expression: "acosh(0.5) = NaN" }"#)]
     #[case(
         ParsedExpression::new_acosh(ParsedExpression::Constant(PreciseScoreOrdered::from(0.5))),

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -169,6 +169,14 @@ impl FormulaScorer<'_> {
                 let value = self.eval_expression(expr, point_id)?;
                 Ok(acc + value)
             }),
+            ParsedExpression::Max(expressions) => {
+                expressions
+                    .iter()
+                    .try_fold(PreciseScore::NEG_INFINITY, |acc, expr| {
+                        let value = self.eval_expression(expr, point_id)?;
+                        Ok(acc.max(value))
+                    })
+            }
             ParsedExpression::Div {
                 left,
                 right,
@@ -449,6 +457,27 @@ mod tests {
     #[case(ParsedExpression::new_div(
         ParsedExpression::Constant(PreciseScoreOrdered::from(10.0)), ParsedExpression::new_score_id(0), None
     ), 10.0 / 1.0)]
+    #[case(ParsedExpression::Max(vec![
+        ParsedExpression::Constant(PreciseScoreOrdered::from(1.0)),
+        ParsedExpression::new_score_id(0),
+        ParsedExpression::new_payload_id(JsonPath::new(FIELD_NAME)),
+        ParsedExpression::new_condition_id(0),
+    ]), 85.0)]
+    // A single operand is returned as-is
+    #[case(ParsedExpression::Max(vec![ParsedExpression::new_score_id(1)]), 2.0)]
+    // Negative operands: max must not be confused by magnitude
+    #[case(ParsedExpression::Max(vec![
+        ParsedExpression::Constant(PreciseScoreOrdered::from(-10.0)),
+        ParsedExpression::Constant(PreciseScoreOrdered::from(-2.0)),
+    ]), -2.0)]
+    // Nested sub-expressions are evaluated before comparing
+    #[case(ParsedExpression::Max(vec![
+        ParsedExpression::Mult(vec![
+            ParsedExpression::Constant(PreciseScoreOrdered::from(3.0)),
+            ParsedExpression::new_score_id(0),
+        ]),
+        ParsedExpression::new_score_id(1),
+    ]), 3.0)]
     #[case(ParsedExpression::new_neg(ParsedExpression::Constant(PreciseScoreOrdered::from(10.0))), -10.0)]
     #[case(
         ParsedExpression::new_acosh(ParsedExpression::Constant(PreciseScoreOrdered::from(1.0))),

--- a/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
@@ -65,6 +65,7 @@ pub enum ParsedExpression {
     // Nested
     Mult(Vec<ParsedExpression>),
     Sum(Vec<ParsedExpression>),
+    Max(Vec<ParsedExpression>),
     Div {
         left: Box<ParsedExpression>,
         right: Box<ParsedExpression>,

--- a/lib/shard/src/query/conversions.rs
+++ b/lib/shard/src/query/conversions.rs
@@ -651,6 +651,9 @@ impl From<rest::Expression> for ExpressionInternal {
             rest::Expression::Sum(rest::SumExpression { sum: exprs }) => {
                 ExpressionInternal::Sum(exprs.into_iter().map(ExpressionInternal::from).collect())
             }
+            rest::Expression::Max(rest::MaxExpression { max: exprs }) => {
+                ExpressionInternal::Max(exprs.into_iter().map(ExpressionInternal::from).collect())
+            }
             rest::Expression::Neg(rest::NegExpression { neg: expr }) => {
                 ExpressionInternal::Neg(Box::new(ExpressionInternal::from(*expr)))
             }
@@ -789,6 +792,13 @@ impl TryFrom<grpc::Expression> for ExpressionInternal {
                     .try_collect()?;
                 ExpressionInternal::Sum(sum)
             }
+            Variant::Max(grpc::MaxExpression { max }) => {
+                let max = max
+                    .into_iter()
+                    .map(ExpressionInternal::try_from)
+                    .try_collect()?;
+                ExpressionInternal::Max(max)
+            }
             Variant::Div(div) => {
                 let grpc::DivExpression {
                     left,
@@ -875,4 +885,58 @@ fn try_from_decay_params(
         midpoint,
         scale,
     })
+}
+
+#[cfg(test)]
+mod formula_grpc_roundtrip_tests {
+    use std::collections::HashMap;
+
+    use segment::index::query_optimization::rescore_formula::parsed_formula::{
+        ParsedExpression, PreciseScoreOrdered,
+    };
+
+    use super::*;
+
+    /// A parsed formula is unparsed back to gRPC when a query is forwarded to another shard, so
+    /// every expression variant must survive the round trip. A missing arm in
+    /// `unparse_expression` only shows up on multi-node clusters, which unit tests of the scorer
+    /// alone would never catch.
+    fn assert_roundtrips(formula: ParsedExpression) {
+        let original = ParsedFormula {
+            payload_vars: Default::default(),
+            conditions: Vec::new(),
+            defaults: HashMap::new(),
+            formula: formula.clone(),
+        };
+
+        let unparsed = grpc::Formula::from_parsed(original);
+        let internal = FormulaInternal::try_from(unparsed).unwrap();
+        let reparsed = ParsedFormula::try_from(internal).unwrap();
+
+        assert_eq!(reparsed.formula, formula);
+    }
+
+    fn constant(value: f64) -> ParsedExpression {
+        ParsedExpression::Constant(PreciseScoreOrdered::from(value))
+    }
+
+    #[test]
+    fn max_survives_grpc_roundtrip() {
+        assert_roundtrips(ParsedExpression::Max(vec![
+            ParsedExpression::new_score_id(0),
+            constant(0.5),
+        ]));
+    }
+
+    /// `max` nested inside other operators must round trip too, not just at the formula root.
+    #[test]
+    fn nested_max_survives_grpc_roundtrip() {
+        assert_roundtrips(ParsedExpression::Mult(vec![
+            constant(2.0),
+            ParsedExpression::Max(vec![
+                ParsedExpression::Mult(vec![constant(3.0), ParsedExpression::new_score_id(0)]),
+                ParsedExpression::new_score_id(1),
+            ]),
+        ]));
+    }
 }

--- a/lib/shard/src/query/formula.rs
+++ b/lib/shard/src/query/formula.rs
@@ -60,6 +60,7 @@ pub enum ExpressionInternal {
     DatetimeKey(JsonPath),
     Mult(Vec<ExpressionInternal>),
     Sum(Vec<ExpressionInternal>),
+    Max(Vec<ExpressionInternal>),
     Neg(Box<ExpressionInternal>),
     Div {
         left: Box<ExpressionInternal>,
@@ -136,6 +137,9 @@ impl ExpressionInternal {
                     .map(|expr| expr.parse_and_convert(payload_vars, conditions))
                     .try_collect()?,
             ),
+            ExpressionInternal::Max(expression_internals) => ParsedExpression::Max(
+                parse_non_empty_operands("max", expression_internals, payload_vars, conditions)?,
+            ),
             ExpressionInternal::Neg(expression_internal) => ParsedExpression::new_neg(
                 expression_internal.parse_and_convert(payload_vars, conditions)?,
             ),
@@ -199,6 +203,87 @@ impl ExpressionInternal {
     }
 }
 
+/// Parses the operands of a variadic operator which has no identity element to fall back on when
+/// given nothing. `sum` and `mult` can define the empty case as `0` and `1`, but `max` cannot:
+/// folding over no operands would yield -inf, and score every point with a non-finite value
+/// instead of reporting the mistake.
+fn parse_non_empty_operands(
+    operator: &str,
+    operands: Vec<ExpressionInternal>,
+    payload_vars: &mut HashSet<JsonPath>,
+    conditions: &mut Vec<Condition>,
+) -> OperationResult<Vec<ParsedExpression>> {
+    if operands.is_empty() {
+        return Err(OperationError::validation_error(format!(
+            "`{operator}` needs at least one operand"
+        )));
+    }
+
+    operands
+        .into_iter()
+        .map(|expr| expr.parse_and_convert(payload_vars, conditions))
+        .try_collect()
+}
+
 fn failed_to_parse(what: &str, value: &str, message: impl fmt::Display) -> OperationError {
     OperationError::validation_error(format!("failed to parse {what} {value}: {message}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(expression: ExpressionInternal) -> OperationResult<ParsedFormula> {
+        FormulaInternal {
+            formula: expression,
+            defaults: HashMap::new(),
+        }
+        .try_into()
+    }
+
+    /// `sum` and `mult` have identity elements for the empty case (0 and 1), but `max` and `min`
+    /// do not: folding over nothing would silently yield ±infinity. Reject it at parse time
+    /// instead, which covers every entry point (REST, gRPC and the Edge FFI).
+    #[test]
+    fn empty_max_is_rejected() {
+        let err = parse(ExpressionInternal::Max(vec![])).unwrap_err();
+        assert!(
+            matches!(err, OperationError::ValidationError { .. }),
+            "expected a validation error, got {err:?}"
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains("max"),
+            "error should name the operator, got {message:?}"
+        );
+    }
+
+    #[test]
+    fn single_operand_max_is_accepted() {
+        let parsed = parse(ExpressionInternal::Max(vec![ExpressionInternal::Constant(
+            1.0,
+        )]))
+        .unwrap();
+        assert_eq!(
+            parsed.formula,
+            ParsedExpression::Max(vec![ParsedExpression::Constant(PreciseScoreOrdered::from(
+                1.0
+            ))])
+        );
+    }
+
+    /// Payload variables and conditions nested inside `max` must still be collected, otherwise
+    /// the scorer would have no retriever for them.
+    #[test]
+    fn max_collects_nested_payload_vars() {
+        let parsed = parse(ExpressionInternal::Max(vec![
+            ExpressionInternal::Variable("popularity".to_string()),
+            ExpressionInternal::Variable("$score".to_string()),
+        ]))
+        .unwrap();
+        assert_eq!(
+            parsed.payload_vars,
+            HashSet::from([JsonPath::new("popularity")])
+        );
+    }
 }

--- a/tests/openapi/test_query_formula.py
+++ b/tests/openapi/test_query_formula.py
@@ -49,6 +49,15 @@ def setup(on_disk_vectors, collection_name):
             {"acosh": {"sum": [1.0, {"abs": "price"}]}},
             lambda score, price: acosh(1.0 + abs(price)),
         ),
+        (
+            {"max": ["$score", "price"]},
+            lambda score, price: max(score, price),
+        ),
+        # More than two operands, and nested sub-expressions
+        (
+            {"max": [{"mult": ["$score", 3.0]}, "price", 0.0]},
+            lambda score, price: max(3.0 * score, price, 0.0),
+        ),
     ],
 )
 def test_formula(collection_name, formula, expecting):
@@ -164,3 +173,68 @@ def test_formula_with_score_threshold(collection_name):
         assert p.get("score") >= threshold - 1e-8, (
             f"Point {p.get('id')} with score {p.get('score')} is below threshold {threshold}"
         )
+
+
+def test_max_matches_the_arithmetic_workaround(collection_name):
+    """Before `max` existed, users had to spell it as (a + b + |a - b|) / 2.
+
+    Both forms must produce identical scores, otherwise `max` is not a drop-in replacement
+    for the formulas already in the wild.
+    """
+    point_id = 8
+    boosted = {"mult": [3.0, "$score"]}
+
+    workaround = {
+        "mult": [
+            0.5,
+            {
+                "sum": [
+                    boosted,
+                    "price",
+                    {"abs": {"sum": [boosted, {"neg": "price"}]}},
+                ]
+            },
+        ]
+    }
+    direct = {"max": [boosted, "price"]}
+
+    def scores_for(formula):
+        response = request_with_validation(
+            api="/collections/{collection_name}/points/query",
+            method="POST",
+            path_params={"collection_name": collection_name},
+            body={
+                "prefetch": {"query": point_id},
+                "query": {"formula": formula, "defaults": {"price": 0.0}},
+                "limit": 10,
+            },
+        )
+        assert response.ok, response.json()
+        return {
+            point["id"]: point["score"] for point in response.json()["result"]["points"]
+        }
+
+    workaround_scores = scores_for(workaround)
+    direct_scores = scores_for(direct)
+
+    assert workaround_scores.keys() == direct_scores.keys()
+    for point_id, expected in workaround_scores.items():
+        assert isclose(direct_scores[point_id], expected, rel_tol=1e-5), (
+            f"point {point_id}: max gave {direct_scores[point_id]}, workaround gave {expected}"
+        )
+
+
+def test_empty_max_is_rejected(collection_name):
+    """`sum: []` is 0 and `mult: []` is 1, but the max of nothing has no sensible value,
+    so it must be rejected rather than silently scoring every point as -infinity."""
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "prefetch": {"query": 8},
+            "query": {"formula": {"max": []}},
+        },
+    )
+    assert not response.ok, response.json()
+    assert response.status_code == 400, response.json()


### PR DESCRIPTION
## Why

`max(3 * $score[0], $score[1])` before:

```json
{"mult": [0.5, {"sum": [
  {"mult": [3.0, "$score[0]"]}, "$score[1]",
  {"abs": {"sum": [{"mult": [3.0, "$score[0]"]}, {"neg": "$score[1]"}]}}
]}]}
```

after:

```json
{"max": [{"mult": [3.0, "$score[0]"]}, "$score[1]"]}
```

You had to know and use `max(a,b) = (a + b + |a - b|) / 2`: the `/ 2` is easy to miss & hurts further composition, it only works for two operands at a time, and each operand appears twice, so the scorer evaluates every sub-tree twice per candidate point.

It comes up when ranking one query against several variants of a field and taking each point's best match rather than its total — one prefetch per variant, `mult` for the weights, `max` to pick. Summing across variants was already `sum`; best-of was the gap.

## Decisions

**Variadic**, like `sum` and `mult`, so `max(a, b, c)` doesn't need nesting.

**Empty list is an error.** `sum: []` can reasonably be `0` and `mult: []` can be `1`, but `max` has no identity element — folding over nothing gives `-inf` and would silently score every point with a non-finite value. Rejected in `ExpressionInternal::parse_and_convert`, which REST, gRPC and Edge all pass through. The Edge FFI also rejects at construction time, matching how it already handles non-finite constants.

**No `is_finite` check on the result.** `log10`, `exp` and `div` need one because they can turn finite inputs into a non-finite value. `max` can't, so it follows `sum`.

**Proto field 21**, since 20 went to `acosh`.

## Worth knowing

A point that isn't in a prefetch's results scores `0.0`. With BM25 or normal cosine scores that's fine — `0.0` is smaller than everything, so `max` ignores it.

It only causes trouble when an operand can be negative, because then that `0.0` beats every real score:

```
max($score[0], $score[1])   id=1 -> 0.0    (really -1.0, but missing from prefetch 1)
                            id=2 -> -0.99  (the better match, now second)
```

Dot products and opposed cosine vectors can be negative on their own. The more common way to get there is a distance metric. Euclid and Manhattan arrive as positive distances, so they're safe as-is — but results sort highest-first, which puts the farthest point on top. The fix for that is `{"neg": "$score"}`, and that's what makes the operands negative.

So the thing to check isn't which metric you picked, it's whether anything feeding the `max` can go below zero.

To fix it, set a [default](https://qdrant.tech/documentation/search/search-relevance/) for that index: `"defaults": {"$score[1]": -1e30}`. The value is in the units of the variable, not your final score. And `-1e30` isn't a magic number — with `exp_decay` a missing `0.0` means "distance zero" and decays to `1.0`, the best score there is, so there you'd want a big positive number instead.

Two spots are easy to miss, both covered by tests: `unparse_expression` (a missing arm breaks only multi-node clusters) and `unindexed_field.rs` (handling `max` without recursing silently stops suggesting indexes for fields used under it).

`min` follows in a stacked PR reusing the same plumbing.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

