### PR TITLE
docs: 11 parameter names in doc comments that the signatures do not have

### DIFF
--- a/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
@@ -397,7 +397,7 @@ impl<S: UniversalWrite> Bitmask<S> {
     ///
     /// # Arguments
     /// * `page_id` - The ID of the page to mark blocks on.
-    /// * `block_ranges` - An iterator over the ranges of blocks to mark, relative to the page start.
+    /// * `local_block_ranges` - An iterator over the ranges of blocks to mark, relative to the page start.
     /// * `used` - Whether the blocks should be marked as used or free.
     pub(crate) fn mark_blocks_batch(
         &mut self,

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -82,7 +82,7 @@ impl SegmentsSearcher {
     /// # Arguments
     /// * `search_result` - `[segment_size x batch_size]`
     /// * `limits` - `[batch_size]` - how many results to return for each batched request
-    /// * `further_searches` - `[segment_size x batch_size]` - whether we can search further in the segment
+    /// * `further_results` - `[segment_size x batch_size]` - whether we can search further in the segment
     ///
     /// Returns batch results aggregated by `[batch_size]` and list of queries, grouped by segment to re-run
     pub(crate) fn process_search_result_step1(
@@ -605,7 +605,7 @@ fn effective_limit(limit: usize, ef_limit: usize, poisson_sampling: usize) -> us
 /// * `segment` - Locked segment to search in
 /// * `request` - Batch of search requests
 /// * `use_sampling` - If true, try to use probabilistic sampling
-/// * `query_context` - Additional context for the search
+/// * `segment_query_context` - Additional context for the search
 ///
 /// # Returns
 ///

--- a/lib/quantization/src/encoded_vectors_pq.rs
+++ b/lib/quantization/src/encoded_vectors_pq.rs
@@ -62,7 +62,7 @@ impl<TStorage: EncodedStorage> EncodedVectorsPQ<TStorage> {
     /// * `storage_builder` - encoding result storage builder
     /// * `vector_parameters` - parameters of original vector data (dimension, distance, etc)
     /// * `chunk_size` - Max size of f32 chunk that replaced by centroid index (in original vector dimension)
-    /// * `max_threads` - Max allowed threads for kmeans and encodind process
+    /// * `max_kmeans_threads` - Max allowed threads for kmeans and encodind process
     /// * `stopped` - Atomic bool that indicates if encoding should be stopped
     #[allow(clippy::too_many_arguments)]
     pub fn encode<'a>(

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index/lifecycle.rs
@@ -26,7 +26,6 @@ impl MutableBoolIndex {
     ///
     /// # Arguments
     /// - `path` - The directory where the index files should live, must be exclusive to this index.
-    /// - `is_on_disk` - If the index should be kept on disk. Memory will be populated if false.
     /// - `create_if_missing` - If true, creates the index if it doesn't exist.
     pub fn open(path: &Path, create_if_missing: bool) -> OperationResult<Option<Self>> {
         let falses_dir = path.join(FALSES_DIRNAME);

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -481,7 +481,7 @@ impl Segment {
     /// # Arguments
     ///
     /// * `op_num` - sequential operation of the current operation
-    /// * `op` - operation to be wrapped. Should return `OperationResult` of bool (which is returned outside)
+    /// * `operation` - operation to be wrapped. Should return `OperationResult` of bool (which is returned outside)
     ///   and optionally new offset of the changed point.
     ///
     /// # Result
@@ -536,7 +536,7 @@ impl Segment {
     /// * `point_id` - external id of the point the operation targets; used for error correlation.
     /// * `op_point_offset` - If point offset is specified, handler will use point version for comparison.
     ///   Otherwise, it will be applied without version checks.
-    /// * `op` - operation to be wrapped. Should return `OperationResult` of bool (which is returned outside) and optionally new offset of the changed point.
+    /// * `operation` - operation to be wrapped. Should return `OperationResult` of bool (which is returned outside) and optionally new offset of the changed point.
     ///
     /// # Result
     ///

--- a/lib/shard/src/query/mmr/mod.rs
+++ b/lib/shard/src/query/mmr/mod.rs
@@ -28,12 +28,11 @@ use super::MmrInternal;
 ///
 /// # Arguments
 ///
-/// * `collection_params` - The parameters of the collection. Used to determine the right distance metric, or multivec config.
 /// * `points_with_vector` - The points with vectors.
 /// * `mmr` - The MMR parameters.
+/// * `distance` - The distance metric of the collection.
+/// * `multivector_config` - The multivector configuration of the collection, if any.
 /// * `limit` - The maximum number of points to return.
-/// * `search_runtime_handle` - The runtime handle for searching.
-/// * `timeout` - The timeout for the operation.
 /// * `hw_measurement_acc` - The hardware measurement accumulator.
 ///
 /// # Returns

--- a/lib/storage/src/content_manager/toc/point_ops.rs
+++ b/lib/storage/src/content_manager/toc/point_ops.rs
@@ -77,7 +77,7 @@ impl TableOfContent {
     /// # Arguments
     ///
     /// * `collection_name` - for what collection do we recommend
-    /// * `request` - [`RecommendRequestBatch`]
+    /// * `requests` - [`RecommendRequestBatch`]
     ///
     /// # Result
     ///


### PR DESCRIPTION
11 names across 7 files. Renames that did not reach the comment above them, and 3 arguments that were removed from a signature and left documented.

| where | the comment says | the signature has |
|---|---|---|
| `segments_searcher.rs:85` | `further_searches` | `further_results` |
| `segments_searcher.rs:608` | `query_context` | `segment_query_context` |
| `bitmask/mod.rs:400` | `block_ranges` | `local_block_ranges` |
| `segment_ops.rs:484` and `:539` | `op` | `operation` |
| `toc/point_ops.rs:80` | `request` | `requests` |
| `encoded_vectors_pq.rs:65` | `max_threads` | `max_kmeans_threads` |
| `bool_index/lifecycle.rs:29` | `is_on_disk` | no such argument |
| `mmr/mod.rs:31, 35, 36` | `collection_params`, `search_runtime_handle`, `timeout` | no such arguments |

`mmr_from_points_with_vector` takes `distance` and `multivector_config` where the comment still names `collection_params`, so that line became 2, and the list is now in signature order.

How I found them: a checker I wrote that compares each documented name against the signature under it. It read 49 of the 49 documented comments in this repository, and these were all it had to say.

Left alone on purpose: arguments with no documentation at all, `timeout` on `search_in_segment` and `count` and `meta_path` on `encode`. That is incompleteness rather than drift, and it would widen the change past what the title says.

## All Submissions:

- [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
- [x] Have you followed the guidelines in our [Contributing document](https://github.com/qdrant/qdrant/blob/master/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/qdrant/qdrant/pulls) for the same update/change?

The other 2 sections are left unticked because the diff is 11 lines inside `///` comments, with no code in it.
