### PR TITLE
feat: add a dedicated min operator to score formulas

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -15274,6 +15274,9 @@
             "$ref": "#/components/schemas/MaxExpression"
           },
           {
+            "$ref": "#/components/schemas/MinExpression"
+          },
+          {
             "$ref": "#/components/schemas/NegExpression"
           },
           {
@@ -15396,6 +15399,21 @@
         ],
         "properties": {
           "max": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Expression"
+            }
+          }
+        }
+      },
+      "MinExpression": {
+        "description": "Smallest of the given expressions. Requires at least one operand.",
+        "type": "object",
+        "required": [
+          "min"
+        ],
+        "properties": {
+          "min": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Expression"

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -351,6 +351,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("MultExpression.mult", ""),
             ("SumExpression.sum", ""),
             ("MaxExpression.max", ""),
+            ("MinExpression.min", ""),
             ("DivExpression.left", ""),
             ("DivExpression.right", ""),
             ("PowExpression.base", ""),

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -70,7 +70,8 @@ use crate::grpc::qdrant::{
 };
 use crate::grpc::{
     self, BinaryQuantizationEncoding, BinaryQuantizationQueryEncoding, DecayParamsExpression,
-    DivExpression, GeoDistance, MaxExpression, MultExpression, PowExpression, SumExpression,
+    DivExpression, GeoDistance, MaxExpression, MinExpression, MultExpression, PowExpression,
+    SumExpression,
 };
 use crate::rest::models::{CollectionsResponse, ShardKeysResponse, VersionInfo};
 use crate::rest::schema as rest;
@@ -3634,6 +3635,12 @@ fn unparse_expression(
         }),
         ParsedExpression::Max(exprs) => Variant::Max(MaxExpression {
             max: exprs
+                .into_iter()
+                .map(|expr| unparse_expression(expr, conditions))
+                .collect(),
+        }),
+        ParsedExpression::Min(exprs) => Variant::Min(MinExpression {
+            min: exprs
                 .into_iter()
                 .map(|expr| unparse_expression(expr, conditions))
                 .collect(),

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -980,6 +980,8 @@ message Expression {
     Expression acosh = 20;
     // Maximum
     MaxExpression max = 21;
+    // Minimum
+    MinExpression min = 22;
   }
 }
 
@@ -998,6 +1000,10 @@ message SumExpression {
 
 message MaxExpression {
   repeated Expression max = 1;
+}
+
+message MinExpression {
+  repeated Expression min = 1;
 }
 
 message DivExpression {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -6572,7 +6572,7 @@ pub struct Formula {
 pub struct Expression {
     #[prost(
         oneof = "expression::Variant",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22"
     )]
     #[validate(nested)]
     pub variant: ::core::option::Option<expression::Variant>,
@@ -6644,6 +6644,9 @@ pub mod expression {
         /// Maximum
         #[prost(message, tag = "21")]
         Max(super::MaxExpression),
+        /// Minimum
+        #[prost(message, tag = "22")]
+        Min(super::MinExpression),
     }
 }
 #[derive(serde::Serialize)]
@@ -6677,6 +6680,14 @@ pub struct MaxExpression {
     #[prost(message, repeated, tag = "1")]
     #[validate(nested)]
     pub max: ::prost::alloc::vec::Vec<Expression>,
+}
+#[derive(validator::Validate)]
+#[derive(serde::Serialize)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MinExpression {
+    #[prost(message, repeated, tag = "1")]
+    #[validate(nested)]
+    pub min: ::prost::alloc::vec::Vec<Expression>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -457,6 +457,7 @@ impl Validate for super::qdrant::expression::Variant {
             grpc::expression::Variant::Mult(mult_expression) => mult_expression.validate(),
             grpc::expression::Variant::Sum(sum_expression) => sum_expression.validate(),
             grpc::expression::Variant::Max(max_expression) => max_expression.validate(),
+            grpc::expression::Variant::Min(min_expression) => min_expression.validate(),
             grpc::expression::Variant::Div(div_expression) => div_expression.validate(),
             grpc::expression::Variant::Neg(expression) => expression.validate(),
             grpc::expression::Variant::Abs(expression) => expression.validate(),

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -938,6 +938,7 @@ pub enum Expression {
     Mult(MultExpression),
     Sum(SumExpression),
     Max(MaxExpression),
+    Min(MinExpression),
     Neg(NegExpression),
     Abs(AbsExpression),
     Div(DivExpression),
@@ -992,6 +993,13 @@ pub struct SumExpression {
 pub struct MaxExpression {
     #[validate(nested)]
     pub max: Vec<Expression>,
+}
+
+/// Smallest of the given expressions. Requires at least one operand.
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]
+pub struct MinExpression {
+    #[validate(nested)]
+    pub min: Vec<Expression>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -271,6 +271,7 @@ impl Validate for Expression {
             Expression::Mult(mult_expression) => mult_expression.validate(),
             Expression::Sum(sum_expression) => sum_expression.validate(),
             Expression::Max(max_expression) => max_expression.validate(),
+            Expression::Min(min_expression) => min_expression.validate(),
             Expression::Neg(neg_expression) => neg_expression.validate(),
             Expression::Abs(abs_expression) => abs_expression.validate(),
             Expression::Div(div_expression) => div_expression.validate(),

--- a/lib/collection/src/problems/unindexed_field.rs
+++ b/lib/collection/src/problems/unindexed_field.rs
@@ -474,7 +474,8 @@ impl<'a> Extractor<'a> {
                 }
                 return;
             }
-            ExpressionInternal::Max(expression_internals) => {
+            ExpressionInternal::Max(expression_internals)
+            | ExpressionInternal::Min(expression_internals) => {
                 for expr in expression_internals {
                     self.update_from_expression(expr);
                 }
@@ -696,6 +697,22 @@ mod tests {
             infer_index_from_field_condition(&condition),
             vec![FieldIndexType::KeywordPrefix],
         );
+    }
+
+    /// The walker shares one arm for `max` and `min`, so this pins down that `min` recurses too
+    /// rather than relying on the shared arm staying shared.
+    #[test]
+    fn min_operands_report_unindexed_payload_fields() {
+        let payload_schema = HashMap::new();
+
+        let mut extractor = Extractor::new(&payload_schema);
+        extractor.update_from_expression(&ExpressionInternal::Min(vec![
+            ExpressionInternal::Variable("$score".to_string()),
+            ExpressionInternal::Variable("popularity".to_string()),
+        ]));
+
+        let unindexed: Vec<_> = extractor.unindexed_schema().keys().cloned().collect();
+        assert_eq!(unindexed, vec![JsonPath::new("popularity")]);
     }
 
     /// Payload fields referenced inside `max` still need an index, so the walker must recurse

--- a/lib/edge/ffi/src/ops/formula.rs
+++ b/lib/edge/ffi/src/ops/formula.rs
@@ -221,6 +221,18 @@ impl Expression {
         })
     }
 
+    /// Smallest of `operands`. Requires at least one operand, for the same reason as
+    /// [`Expression::max`]: there is no identity element, so an empty list would otherwise
+    /// score every point with +infinity at query time.
+    #[uniffi::constructor]
+    pub fn min(operands: Vec<Arc<Expression>>) -> Result<Arc<Self>> {
+        require_non_empty("min", &operands)?;
+        let children: Vec<&Arc<Expression>> = operands.iter().collect();
+        Self::node(&children, || {
+            ExpressionInternal::Min(operands.iter().map(|e| e.inner.clone()).collect())
+        })
+    }
+
     /// Negation: `-expression`.
     #[uniffi::constructor]
     pub fn negate(expression: Arc<Expression>) -> Result<Arc<Self>> {
@@ -357,9 +369,9 @@ impl Expression {
 // ── Coverage map ────────────────────────────────────────────────────────────
 
 /// Compile-time map of the engine's formula-expression tree onto the
-/// Rejects a variadic operator given no operands. `max` has no identity element to fall back on,
-/// so an empty list would otherwise score every point with -infinity at query time; failing at
-/// build time points at the mistake instead.
+/// Rejects a variadic operator given no operands. `max` and `min` have no identity element to
+/// fall back on, so an empty list would otherwise score every point with -infinity or +infinity
+/// at query time; failing at build time points at the mistake instead.
 fn require_non_empty(operator: &str, operands: &[Arc<Expression>]) -> Result<()> {
     if operands.is_empty() {
         return Err(EdgeError::invalid_argument(format!(
@@ -397,6 +409,8 @@ fn assert_every_expression_is_mapped(e: ExpressionInternal) {
         ExpressionInternal::Sum(_) => {}
         // [`Expression::max`]
         ExpressionInternal::Max(_) => {}
+        // [`Expression::min`]
+        ExpressionInternal::Min(_) => {}
         // [`Expression::negate`]
         ExpressionInternal::Neg(_) => {}
         // [`Expression::div`]

--- a/lib/edge/ffi/tests/integration.rs
+++ b/lib/edge/ffi/tests/integration.rs
@@ -2846,6 +2846,93 @@ fn formula_empty_max_is_rejected() {
     );
 }
 
+/// `min` against a dominated constant pins every score to that constant, the mirror of the `max`
+/// floor test. A negative ceiling also distinguishes `min` from `sum`, which would instead
+/// subtract from each score.
+#[test]
+fn formula_min_clamps_scores_to_a_ceiling() {
+    use qdrant_edge_ffi::{Expression, Prefetch, QueryRequest, ScoringQuery};
+
+    let dir = tempfile::tempdir().expect("tempdir failed");
+    let path = dir.path().to_string_lossy().into_owned();
+    let shard: Arc<EdgeShard> = EdgeShard::load(path, Some(make_config())).expect("load failed");
+
+    let points = vec![
+        Point {
+            id: PointId::NumId { value: 1 },
+            vector: named_vec([0.1, 0.1, 0.1, 0.1]),
+            payload: None,
+        },
+        Point {
+            id: PointId::NumId { value: 2 },
+            vector: named_vec([0.09, 0.09, 0.09, 0.09]),
+            payload: None,
+        },
+    ];
+    let op = UpdateOperation::upsert_points(points, None, None).expect("upsert failed");
+    shard.update(op).expect("update failed");
+
+    const CEILING: f32 = -42.0;
+
+    let expression = Expression::min(vec![
+        Expression::variable("$score".to_string()),
+        Expression::constant(CEILING).expect("constant build failed"),
+    ])
+    .expect("expression build failed");
+
+    let hits = shard
+        .query(QueryRequest {
+            limit: 2,
+            offset: None,
+            query: Some(ScoringQuery::Formula {
+                expression,
+                defaults: HashMap::new(),
+            }),
+            prefetches: vec![Prefetch {
+                limit: 10,
+                query: Some(ScoringQuery::Vector {
+                    query: Query::Nearest {
+                        vector: NamedVector::Dense {
+                            values: vec![0.1, 0.1, 0.1, 0.1],
+                        },
+                        using: Some("vec".to_string()),
+                    },
+                }),
+                prefetches: vec![],
+                filter: None,
+                score_threshold: None,
+                params: None,
+            }],
+            with_vector: None,
+            with_payload: None,
+            filter: None,
+            score_threshold: None,
+            params: None,
+        })
+        .expect("formula query failed");
+
+    assert_eq!(hits.len(), 2, "both points should be re-scored");
+    for hit in &hits {
+        assert_eq!(
+            hit.score, CEILING,
+            "every score is above the ceiling, so min must return the ceiling itself"
+        );
+    }
+}
+
+/// An empty `min` is rejected for the same reason as an empty `max`: no identity element, so it
+/// would otherwise score every point with +infinity.
+#[test]
+fn formula_empty_min_is_rejected() {
+    use qdrant_edge_ffi::Expression;
+
+    let err = Expression::min(vec![]).expect_err("empty min must be rejected");
+    assert!(
+        matches!(err, EdgeError::InvalidArgument { .. }),
+        "expected InvalidArgument, got {err:?}"
+    );
+}
+
 /// Grouped query: one group per category, best hit each.
 #[test]
 fn query_groups_returns_one_group_per_key() {

--- a/lib/edge/python/qdrant_edge.pyi
+++ b/lib/edge/python/qdrant_edge.pyi
@@ -2484,6 +2484,11 @@ class Expression(Enum):
         ...
 
     @staticmethod
+    def Min(exprs: List["Expression"]) -> "Expression":
+        """Create a minimum expression. Requires at least one operand."""
+        ...
+
+    @staticmethod
     def Neg(expr: "Expression") -> "Expression":
         """Create a negation expression."""
         ...

--- a/lib/edge/python/src/types/formula/expression.rs
+++ b/lib/edge/python/src/types/formula/expression.rs
@@ -49,6 +49,10 @@ impl FromPyObject<'_, '_> for PyExpression {
                 ExpressionInternal::Max(PyExpression::peel_vec(exprs))
             }
 
+            PyExpressionInterface::Min { exprs } => {
+                ExpressionInternal::Min(PyExpression::peel_vec(exprs))
+            }
+
             PyExpressionInterface::Neg { expr } => ExpressionInternal::Neg(expr.into_box()),
 
             PyExpressionInterface::Div {
@@ -129,6 +133,10 @@ impl<'py> IntoPyObject<'py> for PyExpression {
             },
 
             ExpressionInternal::Max(exprs) => PyExpressionInterface::Max {
+                exprs: PyExpression::wrap_vec(exprs),
+            },
+
+            ExpressionInternal::Min(exprs) => PyExpressionInterface::Min {
                 exprs: PyExpression::wrap_vec(exprs),
             },
 
@@ -228,6 +236,10 @@ impl Repr for PyExpression {
 
             ExpressionInternal::Max(exprs) => {
                 ("Max", &[("exprs", &PyExpression::wrap_slice(exprs))])
+            }
+
+            ExpressionInternal::Min(exprs) => {
+                ("Min", &[("exprs", &PyExpression::wrap_slice(exprs))])
             }
 
             ExpressionInternal::Neg(expr) => ("Neg", &[("expr", PyExpression::wrap_ref(expr))]),

--- a/lib/edge/python/src/types/formula/expression_interface.rs
+++ b/lib/edge/python/src/types/formula/expression_interface.rs
@@ -46,6 +46,10 @@ pub enum PyExpressionInterface {
         exprs: Vec<PyExpression>,
     },
 
+    Min {
+        exprs: Vec<PyExpression>,
+    },
+
     Neg {
         expr: Boxed<PyExpression>,
     },
@@ -113,6 +117,7 @@ impl Repr for PyExpressionInterface {
             PyExpressionInterface::Mult { exprs } => ("Mult", &[("exprs", exprs)]),
             PyExpressionInterface::Sum { exprs } => ("Sum", &[("exprs", exprs)]),
             PyExpressionInterface::Max { exprs } => ("Max", &[("exprs", exprs)]),
+            PyExpressionInterface::Min { exprs } => ("Min", &[("exprs", exprs)]),
             PyExpressionInterface::Neg { expr } => ("Neg", &[("expr", expr)]),
 
             PyExpressionInterface::Div {

--- a/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/formula_scorer.rs
@@ -177,6 +177,14 @@ impl FormulaScorer<'_> {
                         Ok(acc.max(value))
                     })
             }
+            ParsedExpression::Min(expressions) => {
+                expressions
+                    .iter()
+                    .try_fold(PreciseScore::INFINITY, |acc, expr| {
+                        let value = self.eval_expression(expr, point_id)?;
+                        Ok(acc.min(value))
+                    })
+            }
             ParsedExpression::Div {
                 left,
                 right,
@@ -465,6 +473,36 @@ mod tests {
     ]), 85.0)]
     // A single operand is returned as-is
     #[case(ParsedExpression::Max(vec![ParsedExpression::new_score_id(1)]), 2.0)]
+    // `min` over the same mixed operands picks the smallest instead of the largest
+    #[case(ParsedExpression::Min(vec![
+        ParsedExpression::Constant(PreciseScoreOrdered::from(1.0)),
+        ParsedExpression::new_score_id(0),
+        ParsedExpression::new_payload_id(JsonPath::new(FIELD_NAME)),
+        ParsedExpression::new_condition_id(0),
+    ]), 1.0)]
+    #[case(ParsedExpression::Min(vec![ParsedExpression::new_score_id(1)]), 2.0)]
+    // Negative operands: min must not be confused by magnitude
+    #[case(ParsedExpression::Min(vec![
+        ParsedExpression::Constant(PreciseScoreOrdered::from(-10.0)),
+        ParsedExpression::Constant(PreciseScoreOrdered::from(-2.0)),
+    ]), -10.0)]
+    // Datetimes evaluate to seconds, so `min` picks the older of two dates.
+    #[case(ParsedExpression::Min(vec![
+        ParsedExpression::Datetime(DatetimeExpression::Constant("2025-03-18".parse().unwrap())),
+        ParsedExpression::Datetime(DatetimeExpression::Constant("2026-01-01".parse().unwrap())),
+    ]), "2025-03-18".parse::<DateTimePayloadType>().unwrap().timestamp() as PreciseScore / 1_000_000.0)]
+    // Nested sub-expressions are evaluated before comparing
+    #[case(ParsedExpression::Min(vec![
+        ParsedExpression::Mult(vec![
+            ParsedExpression::Constant(PreciseScoreOrdered::from(3.0)),
+            ParsedExpression::new_score_id(0),
+        ]),
+        ParsedExpression::new_score_id(1),
+    ]), 2.0)]
+    // max and min of the same single operand agree
+    #[case(ParsedExpression::Min(vec![
+        ParsedExpression::Constant(PreciseScoreOrdered::from(7.5)),
+    ]), 7.5)]
     // Negative operands: max must not be confused by magnitude
     #[case(ParsedExpression::Max(vec![
         ParsedExpression::Constant(PreciseScoreOrdered::from(-10.0)),
@@ -538,6 +576,17 @@ mod tests {
     ]), 0.0)]
     #[should_panic(expected = r#"NonFiniteNumber { expression: "log10(0) = -inf" }"#)]
     #[case(ParsedExpression::Max(vec![
+        ParsedExpression::Constant(PreciseScoreOrdered::from(5.0)),
+        ParsedExpression::new_log10(ParsedExpression::Constant(PreciseScoreOrdered::from(0.0))),
+    ]), 0.0)]
+    // Same for `min`, with the failure on either side of the finite operand.
+    #[should_panic(expected = r#"NonFiniteNumber { expression: "log10(0) = -inf" }"#)]
+    #[case(ParsedExpression::Min(vec![
+        ParsedExpression::new_log10(ParsedExpression::Constant(PreciseScoreOrdered::from(0.0))),
+        ParsedExpression::Constant(PreciseScoreOrdered::from(5.0)),
+    ]), 0.0)]
+    #[should_panic(expected = r#"NonFiniteNumber { expression: "log10(0) = -inf" }"#)]
+    #[case(ParsedExpression::Min(vec![
         ParsedExpression::Constant(PreciseScoreOrdered::from(5.0)),
         ParsedExpression::new_log10(ParsedExpression::Constant(PreciseScoreOrdered::from(0.0))),
     ]), 0.0)]

--- a/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
+++ b/lib/segment/src/index/query_optimization/rescore_formula/parsed_formula.rs
@@ -66,6 +66,7 @@ pub enum ParsedExpression {
     Mult(Vec<ParsedExpression>),
     Sum(Vec<ParsedExpression>),
     Max(Vec<ParsedExpression>),
+    Min(Vec<ParsedExpression>),
     Div {
         left: Box<ParsedExpression>,
         right: Box<ParsedExpression>,

--- a/lib/shard/src/query/conversions.rs
+++ b/lib/shard/src/query/conversions.rs
@@ -654,6 +654,9 @@ impl From<rest::Expression> for ExpressionInternal {
             rest::Expression::Max(rest::MaxExpression { max: exprs }) => {
                 ExpressionInternal::Max(exprs.into_iter().map(ExpressionInternal::from).collect())
             }
+            rest::Expression::Min(rest::MinExpression { min: exprs }) => {
+                ExpressionInternal::Min(exprs.into_iter().map(ExpressionInternal::from).collect())
+            }
             rest::Expression::Neg(rest::NegExpression { neg: expr }) => {
                 ExpressionInternal::Neg(Box::new(ExpressionInternal::from(*expr)))
             }
@@ -799,6 +802,13 @@ impl TryFrom<grpc::Expression> for ExpressionInternal {
                     .try_collect()?;
                 ExpressionInternal::Max(max)
             }
+            Variant::Min(grpc::MinExpression { min }) => {
+                let min = min
+                    .into_iter()
+                    .map(ExpressionInternal::try_from)
+                    .try_collect()?;
+                ExpressionInternal::Min(min)
+            }
             Variant::Div(div) => {
                 let grpc::DivExpression {
                     left,
@@ -925,6 +935,25 @@ mod formula_grpc_roundtrip_tests {
         assert_roundtrips(ParsedExpression::Max(vec![
             ParsedExpression::new_score_id(0),
             constant(0.5),
+        ]));
+    }
+
+    #[test]
+    fn min_survives_grpc_roundtrip() {
+        assert_roundtrips(ParsedExpression::Min(vec![
+            ParsedExpression::new_score_id(0),
+            constant(0.5),
+        ]));
+    }
+
+    /// `max` and `min` share the same shape, so a copy-paste slip in either unparse arm would
+    /// send one operator's operands out under the other's tag. Nesting them in each other pins
+    /// the two arms apart.
+    #[test]
+    fn max_and_min_do_not_swap_in_grpc_roundtrip() {
+        assert_roundtrips(ParsedExpression::Max(vec![
+            ParsedExpression::Min(vec![constant(1.0), ParsedExpression::new_score_id(0)]),
+            ParsedExpression::Min(vec![constant(2.0), ParsedExpression::new_score_id(1)]),
         ]));
     }
 

--- a/lib/shard/src/query/formula.rs
+++ b/lib/shard/src/query/formula.rs
@@ -61,6 +61,7 @@ pub enum ExpressionInternal {
     Mult(Vec<ExpressionInternal>),
     Sum(Vec<ExpressionInternal>),
     Max(Vec<ExpressionInternal>),
+    Min(Vec<ExpressionInternal>),
     Neg(Box<ExpressionInternal>),
     Div {
         left: Box<ExpressionInternal>,
@@ -140,6 +141,9 @@ impl ExpressionInternal {
             ExpressionInternal::Max(expression_internals) => ParsedExpression::Max(
                 parse_non_empty_operands("max", expression_internals, payload_vars, conditions)?,
             ),
+            ExpressionInternal::Min(expression_internals) => ParsedExpression::Min(
+                parse_non_empty_operands("min", expression_internals, payload_vars, conditions)?,
+            ),
             ExpressionInternal::Neg(expression_internal) => ParsedExpression::new_neg(
                 expression_internal.parse_and_convert(payload_vars, conditions)?,
             ),
@@ -204,9 +208,9 @@ impl ExpressionInternal {
 }
 
 /// Parses the operands of a variadic operator which has no identity element to fall back on when
-/// given nothing. `sum` and `mult` can define the empty case as `0` and `1`, but `max` cannot:
-/// folding over no operands would yield -inf, and score every point with a non-finite value
-/// instead of reporting the mistake.
+/// given nothing. `sum` and `mult` can define the empty case as `0` and `1`, but `max` and `min`
+/// cannot: folding over no operands would yield -inf or +inf, and score every point with a
+/// non-finite value instead of reporting the mistake.
 fn parse_non_empty_operands(
     operator: &str,
     operands: Vec<ExpressionInternal>,
@@ -255,6 +259,49 @@ mod tests {
         assert!(
             message.contains("max"),
             "error should name the operator, got {message:?}"
+        );
+    }
+
+    #[test]
+    fn empty_min_is_rejected() {
+        let err = parse(ExpressionInternal::Min(vec![])).unwrap_err();
+        assert!(
+            matches!(err, OperationError::ValidationError { .. }),
+            "expected a validation error, got {err:?}"
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains("min"),
+            "error should name the operator, got {message:?}"
+        );
+    }
+
+    #[test]
+    fn single_operand_min_is_accepted() {
+        let parsed = parse(ExpressionInternal::Min(vec![ExpressionInternal::Constant(
+            1.0,
+        )]))
+        .unwrap();
+        assert_eq!(
+            parsed.formula,
+            ParsedExpression::Min(vec![ParsedExpression::Constant(PreciseScoreOrdered::from(
+                1.0
+            ))])
+        );
+    }
+
+    /// Payload variables and conditions nested inside `min` must still be collected, otherwise
+    /// the scorer would have no retriever for them.
+    #[test]
+    fn min_collects_nested_payload_vars() {
+        let parsed = parse(ExpressionInternal::Min(vec![
+            ExpressionInternal::Variable("popularity".to_string()),
+            ExpressionInternal::Variable("$score".to_string()),
+        ]))
+        .unwrap();
+        assert_eq!(
+            parsed.payload_vars,
+            HashSet::from([JsonPath::new("popularity")])
         );
     }
 

--- a/tests/openapi/test_query_formula.py
+++ b/tests/openapi/test_query_formula.py
@@ -58,6 +58,20 @@ def setup(on_disk_vectors, collection_name):
             {"max": [{"mult": ["$score", 3.0]}, "price", 0.0]},
             lambda score, price: max(3.0 * score, price, 0.0),
         ),
+        (
+            {"min": ["$score", "price"]},
+            lambda score, price: min(score, price),
+        ),
+        # More than two operands, and nested sub-expressions
+        (
+            {"min": [{"mult": ["$score", 3.0]}, "price", 0.0]},
+            lambda score, price: min(3.0 * score, price, 0.0),
+        ),
+        # max and min of the same operands bracket the operands from both sides
+        (
+            {"sum": [{"max": ["$score", "price"]}, {"min": ["$score", "price"]}]},
+            lambda score, price: max(score, price) + min(score, price),
+        ),
     ],
 )
 def test_formula(collection_name, formula, expecting):
@@ -238,3 +252,68 @@ def test_empty_max_is_rejected(collection_name):
     )
     assert not response.ok, response.json()
     assert response.status_code == 400, response.json()
+
+
+def test_empty_min_is_rejected(collection_name):
+    """Same as the empty `max` case: no identity element, so it must be rejected rather than
+    silently scoring every point as +infinity."""
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "prefetch": {"query": 8},
+            "query": {"formula": {"min": []}},
+        },
+    )
+    assert not response.ok, response.json()
+    assert response.status_code == 400, response.json()
+
+
+def test_min_matches_the_arithmetic_workaround(collection_name):
+    """The identity for a minimum is (a + b - |a - b|) / 2, the sign flip of the max one.
+
+    Same reasoning as the `max` case: `min` must be a drop-in replacement for formulas
+    already written out by hand.
+    """
+    point_id = 8
+    boosted = {"mult": [3.0, "$score"]}
+
+    workaround = {
+        "mult": [
+            0.5,
+            {
+                "sum": [
+                    boosted,
+                    "price",
+                    {"neg": {"abs": {"sum": [boosted, {"neg": "price"}]}}},
+                ]
+            },
+        ]
+    }
+    direct = {"min": [boosted, "price"]}
+
+    def scores_for(formula):
+        response = request_with_validation(
+            api="/collections/{collection_name}/points/query",
+            method="POST",
+            path_params={"collection_name": collection_name},
+            body={
+                "prefetch": {"query": point_id},
+                "query": {"formula": formula, "defaults": {"price": 0.0}},
+                "limit": 10,
+            },
+        )
+        assert response.ok, response.json()
+        return {
+            point["id"]: point["score"] for point in response.json()["result"]["points"]
+        }
+
+    workaround_scores = scores_for(workaround)
+    direct_scores = scores_for(direct)
+
+    assert workaround_scores.keys() == direct_scores.keys()
+    for point_id, expected in workaround_scores.items():
+        assert isclose(direct_scores[point_id], expected, rel_tol=1e-5), (
+            f"point {point_id}: min gave {direct_scores[point_id]}, workaround gave {expected}"
+        )


### PR DESCRIPTION
Follow-up to #10287, which added `max`. Same plumbing, opposite fold.

## Why

#10287 added `max`; this is its counterpart. The obvious use is putting a ceiling on something.

Say you rank by vector similarity and add a popularity boost from a payload field:

```
score = similarity + 0.1 * log_views
```

One viral document now outranks everything regardless of what it says. So cap the boost:

```
score = similarity + min(2.0, 0.1 * log_views)
```

```json
{"sum": ["$score", {"min": [2.0, {"mult": [0.1, "log_views"]}]}]}
```

Popularity lifts a result by at most 2.0, and relevance decides the rest.

Having both operators also gives you a clamp, `max(lo, min(hi, x))`, for pinning a value into a range before you blend it with other signals.

### You could already do this

`min(a, b) = -max(-a, -b)`, and it costs the same — `neg` evaluates its child once, so each operand is still evaluated exactly once. So this PR is about ergonomics, not speed:

- It reads badly. The cap above becomes `{"neg": {"max": [{"neg": 2.0}, {"neg": {"mult": [0.1, "log_views"]}}]}}`.
- Forget the outer `neg` and you get `-min(a, b)`: every score sign-flipped, ranking inverted, no error.
- Anyone who finds `max` in the docs will look for `min` next.

## Decisions

All mirror #10287, and both guard helpers it added already took an `operator: &str`, so `min` reuses them unchanged:

- **Variadic**, like `sum`, `mult` and `max`.
- **Empty list is an error**, via `parse_non_empty_operands("min", ...)`. `min: []` would fold to `+inf` and score every point with a non-finite value. The Edge FFI rejects it at construction time too.
- **No `is_finite` check** — `min` can't turn finite inputs into a non-finite value, so it follows `sum` and `max`.
- **Proto field 22**, since 21 went to `max`.

The `unindexed_field` walker now shares one arm for `Max | Min` since the bodies are identical, with a test pinning `min` separately so a later split can't silently drop it.

## Worth knowing

`min` is more exposed to missing prefetch scores than `max` is. A point that isn't in a prefetch's results scores `0.0`, and with the positive similarities cosine normally gives, that `0.0` is below everything — so `min` returns it every time:

```
min($score[0], $score[1])   id=1 -> 0.0       (really 0.99875, missing from prefetch 1)
max($score[0], $score[1])   id=1 -> 0.99875   (unaffected)
```

And "not in the results" usually means "didn't make the top N", not "scored badly" — the point might be rank N+1. So a multi-prefetch `min` can turn a truncation artifact into a zero. Set a [default](https://qdrant.tech/documentation/search/search-relevance/) to opt out:

```json
"query": {
  "formula":  {"min": ["$score[0]", "$score[1]"]},
  "defaults": {"$score[1]": 1e30}
}
```

`defaults` goes beside `formula`, not inside it, and the key needs the `$`. Both mistakes are ignored rather than rejected, so the only way to confirm it applied is to run the query without it and check the scores changed.

## Tests

Mirrors of the `max` set with min semantics: negative operands, datetimes picking the older date, a failing operand on either side of a finite one (`min` must not grow a `mult`-style short-circuit that swallows errors), equivalence with the arithmetic identity, and empty-list rejection at every entry point.

Two are new to having both operators. `max_and_min_do_not_swap_in_grpc_roundtrip` nests each inside the other, so a copy-paste slip sending one operator's operands out under the other's tag fails — that otherwise only shows up on multi-node clusters. And a `sum` of `max` and `min` over the same operands in the REST tests pins both directions at once.

Verified locally: 49 segment, 28 shard, 4 collection, 12 Edge FFI, clippy clean, plus a manual run against a local server.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
