### PR TITLE
Cleanup unused code

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12701,13 +12701,6 @@
             "enum": [
               "InRamMmap"
             ]
-          },
-          {
-            "description": "Placeholder storage: contains no data, all vectors reported as deleted. Used for newly created named vectors on immutable segments. No files on disk, reconstructed from config on load.",
-            "type": "string",
-            "enum": [
-              "Empty"
-            ]
           }
         ]
       },
@@ -12864,13 +12857,6 @@
             "type": "string",
             "enum": [
               "mmap"
-            ]
-          },
-          {
-            "description": "Placeholder storage: contains no data, all vectors reported as deleted. Used for newly created sparse named vectors on immutable segments.",
-            "type": "string",
-            "enum": [
-              "empty"
             ]
           }
         ]

--- a/lib/blobstore/src/error.rs
+++ b/lib/blobstore/src/error.rs
@@ -1,7 +1,7 @@
 use common::mmap;
 use common::universal_io::{IsNotFound, UniversalIoError};
 
-use crate::tracker::{PageId, PointOffset};
+use crate::tracker::PageId;
 
 #[derive(thiserror::Error, Debug)]
 pub enum BlobstoreError {
@@ -23,8 +23,6 @@ pub enum BlobstoreError {
     UnsupportedOperation { operation: String },
     #[error("Page {page_id} not found")]
     PageNotFound { page_id: PageId },
-    #[error("value {point_offset} not found")]
-    ValueNotFound { point_offset: PointOffset },
 }
 
 impl BlobstoreError {
@@ -58,8 +56,7 @@ impl IsNotFound for BlobstoreError {
             | BlobstoreError::FlushCancelled
             | BlobstoreError::ValidationError { .. }
             | BlobstoreError::UnsupportedOperation { .. }
-            | BlobstoreError::PageNotFound { .. }
-            | BlobstoreError::ValueNotFound { .. } => false,
+            | BlobstoreError::PageNotFound { .. } => false,
         }
     }
 }

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -7,7 +7,7 @@ use futures::{TryFutureExt, future};
 use itertools::{Either, Itertools};
 use rand::RngExt;
 use segment::common::reciprocal_rank_fusion::rrf_scoring;
-use segment::common::score_fusion::{ScoreFusion, score_fusion};
+use segment::common::score_fusion::score_fusion;
 use segment::data_types::vectors::VectorStructInternal;
 use segment::types::{Order, ScoredPoint, WithPayloadInterface, WithVector};
 use segment::utils::scored_point_ties::ScoredPointTies;
@@ -386,7 +386,7 @@ impl Collection {
                             .map(|w| w.iter().map(|f| f.into_inner()).collect::<Vec<_>>());
                         rrf_scoring(intermediates, *k, weights_slice.as_deref())?
                     }
-                    FusionInternal::Dbsf => score_fusion(intermediates, ScoreFusion::dbsf()),
+                    FusionInternal::Dbsf => score_fusion(intermediates),
                 };
                 if let Some(&score_threshold) = score_threshold.as_ref() {
                     fused = fused

--- a/lib/collection/src/operations/generalizer/update_persisted.rs
+++ b/lib/collection/src/operations/generalizer/update_persisted.rs
@@ -211,7 +211,7 @@ impl Generalizer for BatchPersisted {
                     multi
                         .iter()
                         .map(|v| {
-                            let dim = if v.is_empty() { 0 } else { v[0].len() };
+                            let dim = v.first().map_or(0, |v| v.len());
                             vec![vec![v.len() as f32, dim as f32]]
                         })
                         .collect(),
@@ -287,7 +287,7 @@ impl Generalizer for VectorStructPersisted {
                 VectorStructPersisted::Single(vec![dense.len() as f32])
             }
             VectorStructPersisted::MultiDense(multi) => {
-                let dim = if multi.is_empty() { 0 } else { multi[0].len() };
+                let dim = multi.first().map_or(0, |v| v.len());
                 VectorStructPersisted::MultiDense(vec![vec![multi.len() as f32, dim as f32]])
             }
             VectorStructPersisted::Named(named) => {
@@ -309,7 +309,7 @@ impl Generalizer for VectorPersisted {
                 SparseVector::new(vec![sparse.len() as DimId], vec![0.0]).unwrap(),
             ),
             VectorPersisted::MultiDense(multi) => {
-                let dim = if multi.is_empty() { 0 } else { multi[0].len() };
+                let dim = multi.first().map_or(0, |v| v.len());
                 VectorPersisted::MultiDense(vec![vec![multi.len() as f32, dim as f32]])
             }
         }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1154,9 +1154,6 @@ impl From<OperationError> for CollectionError {
                 error: description,
                 backtrace,
             },
-            OperationError::TypeError { .. } => Self::BadInput {
-                description: err.to_string(),
-            },
             OperationError::Cancelled { description } => Self::Cancelled { description },
             OperationError::TypeInferenceError { .. } => Self::BadInput {
                 description: err.to_string(),
@@ -1188,12 +1185,6 @@ impl From<OperationError> for CollectionError {
             OperationError::MissingMapIndexForFacet { .. } => Self::bad_input(err.to_string()),
             OperationError::VariableTypeError { .. } => Self::bad_input(err.to_string()),
             OperationError::NonFiniteNumber { .. } => Self::bad_input(err.to_string()),
-            // Normally handled by segment provisioning before reaching this conversion; if it
-            // leaks, stay transient so failed-operation recovery re-applies the operation.
-            OperationError::OutOfAppendableCapacity { .. } => Self::ServiceError {
-                error: err.to_string(),
-                backtrace: None,
-            },
         }
     }
 }

--- a/lib/collection/src/shards/local_shard/query.rs
+++ b/lib/collection/src/shards/local_shard/query.rs
@@ -10,7 +10,7 @@ use futures::future::BoxFuture;
 use ordered_float::OrderedFloat;
 use parking_lot::Mutex;
 use segment::common::reciprocal_rank_fusion::rrf_scoring;
-use segment::common::score_fusion::{ScoreFusion, score_fusion};
+use segment::common::score_fusion::score_fusion;
 use segment::types::{Filter, HasIdCondition, ScoredPoint, WithPayloadInterface, WithVector};
 use shard::query::planned_query::RescoreStages;
 use shard::search::CoreSearchRequestBatch;
@@ -434,7 +434,7 @@ impl LocalShard {
                     .map(|w| w.iter().map(|f| f.into_inner()).collect::<Vec<_>>());
                 rrf_scoring(sources, k, weights_slice.as_deref())?
             }
-            FusionInternal::Dbsf => score_fusion(sources, ScoreFusion::dbsf()),
+            FusionInternal::Dbsf => score_fusion(sources),
         };
 
         let top_fused: Vec<_> = if let Some(score_threshold) = score_threshold {

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -575,15 +575,15 @@ impl Inner {
                 }
             }
 
-            if batch.batch.is_empty() {
+            let Some(last) = batch.batch.last() else {
                 break;
-            }
+            };
 
             // Send the current batch and prefetch the next one concurrently. This overlaps the
             // network round-trip with the WAL read for the next batch.
             // Note: this temporarily holds two batches in memory (~2x MAX_BATCH_BYTES).
             let is_last = batch.reached_end;
-            let next_from = batch.batch.last().unwrap().0 + 1;
+            let next_from = last.0 + 1;
             let (send_result, read_result) = tokio::join!(
                 self.send_wal_batch(&batch, is_last),
                 self.read_wal_batch(next_from),

--- a/lib/common/common/src/mmap/mmap_rw.rs
+++ b/lib/common/common/src/mmap/mmap_rw.rs
@@ -465,15 +465,12 @@ pub enum Error {
     SizeMultiple(usize, usize),
     #[error("{0}")]
     Io(#[from] std::io::Error),
-    #[error("File not found: {0}")]
-    MissingFile(String),
 }
 
 impl crate::universal_io::IsNotFound for Error {
     fn is_not_found(&self) -> bool {
         match self {
             Self::Io(err) => err.is_not_found(),
-            Self::MissingFile(_) => true,
             Self::SizeExact(..) | Self::SizeLess(..) | Self::SizeMultiple(..) => false,
         }
     }

--- a/lib/edge/src/read_view/ops/query.rs
+++ b/lib/edge/src/read_view/ops/query.rs
@@ -8,7 +8,7 @@ use common::types::{DeferredBehavior, ScoreType};
 use ordered_float::OrderedFloat;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::common::reciprocal_rank_fusion::rrf_scoring;
-use segment::common::score_fusion::{ScoreFusion, score_fusion};
+use segment::common::score_fusion::score_fusion;
 use segment::data_types::query_context::FormulaContext;
 use segment::entry::ReadSegmentEntry;
 use segment::index::query_optimization::rescore_formula::parsed_formula::ParsedFormula;
@@ -301,7 +301,7 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
                     .map(|w| w.iter().map(|f| f.into_inner()).collect::<Vec<_>>());
                 rrf_scoring(sources, k, weights_slice.as_deref())?
             }
-            FusionInternal::Dbsf => score_fusion(sources, ScoreFusion::dbsf()),
+            FusionInternal::Dbsf => score_fusion(sources),
         };
 
         let top_fused: Vec<_> = if let Some(score_threshold) = score_threshold {

--- a/lib/quantization/src/lib.rs
+++ b/lib/quantization/src/lib.rs
@@ -20,7 +20,6 @@ pub use encoded_vectors_u8::{EncodedQueryU8, EncodedVectorsU8};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum EncodingError {
-    IOError(String),
     EncodingError(String),
     ArgumentsError(String),
     Stopped,
@@ -29,7 +28,6 @@ pub enum EncodingError {
 impl Display for EncodingError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            EncodingError::IOError(description) => write!(f, "IOError: {description}"),
             EncodingError::EncodingError(description) => {
                 write!(f, "EncodingError: {description}")
             }

--- a/lib/segment/src/common/operation_error.rs
+++ b/lib/segment/src/common/operation_error.rs
@@ -42,13 +42,6 @@ pub enum OperationError {
     VectorNameNotExists { received_name: VectorNameBuf },
     #[error("No point with id {missed_point_id}")]
     PointIdError { missed_point_id: PointIdType },
-    #[error(
-        "Payload type does not match with previously given for field {field_name}. Expected: {expected_type}"
-    )]
-    TypeError {
-        field_name: PayloadKeyType,
-        expected_type: String,
-    },
     #[error("Unable to infer type for the field '{field_name}'. Please specify `field_type`")]
     TypeInferenceError { field_name: PayloadKeyType },
     /// Service Error prevents further update of the collection until it is fixed.
@@ -95,13 +88,6 @@ pub enum OperationError {
     },
     #[error("The expression {expression} produced a non-finite number")]
     NonFiniteNumber { expression: String },
-    /// All appendable segments reached `max_segment_size`, so there is no valid destination for
-    /// new or moved points. Recoverable by provisioning a fresh appendable segment and re-applying
-    /// the operation; already-applied points are skipped by their point version.
-    #[error(
-        "All appendable segments reached the maximum segment size of {max_segment_size_bytes} bytes"
-    )]
-    OutOfAppendableCapacity { max_segment_size_bytes: usize },
 }
 
 impl OperationError {
@@ -163,7 +149,7 @@ impl OperationError {
 }
 
 /// `FileNotFound` only ever originates from sources that carry a structured path
-/// ([`UniversalIoError::NotFound`], [`MmapError::MissingFile`]); a raw io NotFound is a
+/// ([`UniversalIoError::NotFound`]); a raw io NotFound is a
 /// plain `ServiceError` — universal-io wraps not-found at the call site
 /// (`UniversalIoError::extract_not_found`), so classify there, not here.
 impl IsNotFound for OperationError {
@@ -175,7 +161,6 @@ impl IsNotFound for OperationError {
             | Self::MalformedPayloadBlob { .. }
             | Self::VectorNameNotExists { .. }
             | Self::PointIdError { .. }
-            | Self::TypeError { .. }
             | Self::TypeInferenceError { .. }
             | Self::ServiceError { .. }
             | Self::InconsistentStorage { .. }
@@ -188,8 +173,7 @@ impl IsNotFound for OperationError {
             | Self::MissingRangeIndexForOrderBy { .. }
             | Self::MissingMapIndexForFacet { .. }
             | Self::VariableTypeError { .. }
-            | Self::NonFiniteNumber { .. }
-            | Self::OutOfAppendableCapacity { .. } => false,
+            | Self::NonFiniteNumber { .. } => false,
         }
     }
 }
@@ -216,15 +200,9 @@ impl From<DecompressionError> for OperationError {
 
 impl From<MmapError> for OperationError {
     fn from(err: MmapError) -> Self {
-        match err {
-            // `MissingFile` is the only mmap error with a structured path; an io NotFound
-            // is deliberately left as a service error (see `IsNotFound for OperationError`).
-            MmapError::MissingFile(path) => Self::FileNotFound { path: path.into() },
-            err @ (MmapError::SizeExact(..)
-            | MmapError::SizeLess(..)
-            | MmapError::SizeMultiple(..)
-            | MmapError::Io(_)) => Self::service_error(err.to_string()),
-        }
+        // An io NotFound is deliberately left as a service error
+        // (see `IsNotFound for OperationError`).
+        Self::service_error(err.to_string())
     }
 }
 
@@ -328,8 +306,7 @@ impl From<geohash::GeohashError> for OperationError {
 impl From<quantization::EncodingError> for OperationError {
     fn from(err: quantization::EncodingError) -> Self {
         match err {
-            quantization::EncodingError::IOError(err)
-            | quantization::EncodingError::EncodingError(err)
+            quantization::EncodingError::EncodingError(err)
             | quantization::EncodingError::ArgumentsError(err) => {
                 Self::service_error(format!("Quantization encoding error: {err}"))
             }
@@ -386,7 +363,6 @@ impl From<BlobstoreError> for OperationError {
                 }
             },
             BlobstoreError::PageNotFound { .. } => Self::service_error(err.to_string()),
-            BlobstoreError::ValueNotFound { .. } => Self::service_error(err.to_string()),
         }
     }
 }
@@ -443,10 +419,6 @@ mod tests {
         });
         assert!(err.is_not_found());
         assert!(err.to_string().contains("segments/0/deleted.bin"));
-
-        let err = OperationError::from(MmapError::MissingFile("matrix.dat".to_string()));
-        assert!(err.is_not_found());
-        assert!(err.to_string().contains("matrix.dat"));
 
         let err = OperationError::from(BlobstoreError::UniversalIo(UniversalIoError::NotFound {
             path: "page_0.dat".into(),

--- a/lib/segment/src/common/operation_time_statistics.rs
+++ b/lib/segment/src/common/operation_time_statistics.rs
@@ -275,13 +275,6 @@ impl OperationDurationsAggregator {
 
     pub fn get_statistics(&self, detail: TelemetryDetail) -> OperationDurationStatistics {
         let duration_micros_histogram = if detail.histograms {
-            let mut duration_micros_histogram =
-                Vec::with_capacity(DEFAULT_BUCKET_BOUNDARIES_MICROS.len());
-            let mut cumulative_count = 0;
-            for (&count, &le) in self.buckets.iter().zip(&DEFAULT_BUCKET_BOUNDARIES_MICROS) {
-                cumulative_count += count;
-                duration_micros_histogram.push((le, cumulative_count));
-            }
             convert_histogram(&DEFAULT_BUCKET_BOUNDARIES_MICROS, &self.buckets)
         } else {
             Vec::new()

--- a/lib/segment/src/common/operation_time_statistics.rs
+++ b/lib/segment/src/common/operation_time_statistics.rs
@@ -81,7 +81,7 @@ pub struct OperationDurationsAggregator {
     min_value: Option<f32>,
     max_value: Option<f32>,
     total_value: u64,
-    last_response_date: Option<DateTime<Utc>>,
+    last_response_date: DateTime<Utc>,
 
     /// The non-cumulative count of operations in each bucket.
     /// The total operations count (aka the last bucket, or `{le="+Inf"}` in Prometheus terms) is
@@ -234,7 +234,7 @@ impl OperationDurationsAggregator {
             min_value: None,
             max_value: None,
             total_value: 0,
-            last_response_date: Some(Utc::now().round_subsecs(2)),
+            last_response_date: Utc::now().round_subsecs(2),
             buckets: smallvec::smallvec![0; DEFAULT_BUCKET_BOUNDARIES_MICROS.len()],
         }))
     }
@@ -270,7 +270,7 @@ impl OperationDurationsAggregator {
             self.fail_count += 1;
         }
 
-        self.last_response_date = Some(Utc::now().round_subsecs(2));
+        self.last_response_date = Utc::now().round_subsecs(2);
     }
 
     pub fn get_statistics(&self, detail: TelemetryDetail) -> OperationDurationStatistics {
@@ -296,7 +296,7 @@ impl OperationDurationsAggregator {
             min_duration_micros: detailed.then_some(self.min_value).flatten(),
             max_duration_micros: detailed.then_some(self.max_value).flatten(),
             total_duration_micros: detailed.then_some(self.total_value),
-            last_responded: detailed.then_some(self.last_response_date).flatten(),
+            last_responded: detailed.then_some(self.last_response_date),
             duration_micros_histogram,
         }
     }

--- a/lib/segment/src/common/score_fusion.rs
+++ b/lib/segment/src/common/score_fusion.rs
@@ -1,84 +1,21 @@
-use std::iter;
-
 use ahash::AHashMap;
 use common::types::ScoreType;
-use itertools::{Itertools, MinMaxResult};
-use ordered_float::OrderedFloat;
+use itertools::Itertools;
 
-use crate::types::{Order, PointIdType, ScoredPoint};
+use crate::types::{PointIdType, ScoredPoint};
 
-pub struct ScoreFusion {
-    /// Defines how to combine the scores of the same point in different lists
-    pub method: Aggregation,
-    /// Defines how to normalize the scores in each list
-    pub norm: Normalization,
-    /// Multipliers for each list of scores
-    pub weights: Vec<f32>,
-    /// Final ordering of the results
-    pub order: Order,
-}
-
-impl ScoreFusion {
-    /// Params for the distribution-based score fusion
-    pub fn dbsf() -> Self {
-        Self {
-            method: Aggregation::Sum,
-            norm: Normalization::Distr,
-            weights: vec![],
-            order: Order::LargeBetter,
-        }
-    }
-}
-
-/// Defines how to combine the scores of the same point in different lists
-pub enum Aggregation {
-    /// Sums the scores
-    Sum,
-}
-
-pub enum Normalization {
-    /// Uses the minimum and maximum scores as extremes
-    MinMax,
-    /// Uses the 3rd standard deviation as extremes
-    Distr,
-}
-
-pub fn score_fusion(
-    all_results: impl IntoIterator<Item = Vec<ScoredPoint>>,
-    params: ScoreFusion,
-) -> Vec<ScoredPoint> {
-    let ScoreFusion {
-        method,
-        norm,
-        weights,
-        order,
-    } = params;
-
-    let weights = weights.into_iter().chain(iter::repeat(1.0));
-
+/// Distribution-based score fusion.
+pub fn score_fusion(all_results: impl IntoIterator<Item = Vec<ScoredPoint>>) -> Vec<ScoredPoint> {
     all_results
         .into_iter()
         // normalize
-        .map(|points| match norm {
-            Normalization::MinMax => min_max_norm(points),
-            Normalization::Distr => distr_norm(points),
-        })
-        // weight each list of points
-        .zip(weights)
-        .flat_map(|(points, weight)| {
-            points.into_iter().map(move |p| ScoredPoint {
-                score: p.score * weight,
-                ..p
-            })
-        })
+        .flat_map(distr_norm)
         // combine to deduplicate
         .fold(
             AHashMap::<PointIdType, ScoredPoint>::new(),
             |mut acc, point| {
                 acc.entry(point.id)
-                    .and_modify(|entry| match method {
-                        Aggregation::Sum => entry.score += point.score,
-                    })
+                    .and_modify(|entry| entry.score += point.score)
                     .or_insert(point);
 
                 acc
@@ -86,10 +23,7 @@ pub fn score_fusion(
         )
         // sort and return
         .into_values()
-        .sorted_by(|a, b| match order {
-            Order::SmallBetter => a.cmp(b),
-            Order::LargeBetter => b.cmp(a),
-        })
+        .sorted_by(|a, b| b.cmp(a))
         .collect()
 }
 
@@ -106,15 +40,6 @@ fn norm(mut points: Vec<ScoredPoint>, min: ScoreType, max: ScoreType) -> Vec<Sco
     });
 
     points
-}
-
-pub fn min_max_norm(points: Vec<ScoredPoint>) -> Vec<ScoredPoint> {
-    let (min, max) = match points.iter().map(|p| OrderedFloat(p.score)).minmax() {
-        MinMaxResult::NoElements | MinMaxResult::OneElement(_) => return points,
-        MinMaxResult::MinMax(min, max) => (min.0, max.0),
-    };
-
-    norm(points, min, max)
 }
 
 /// Welford's method for stable one-pass mean and variance calculation.

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
@@ -96,15 +96,11 @@ impl<S: UniversalReadExt> ReadOnlyBoolIndex<S> {
     /// When they *are* set the bitmaps are materialized too (deriving the
     /// counts is what materialized them), so this rereads them for free.
     pub(super) fn refresh_counts(&mut self) -> OperationResult<()> {
-        if self.counts.get().is_none() {
+        let Some(counts) = self.counts.get_mut() else {
             return Ok(());
-        }
+        };
 
-        let counts = Self::derive_counts(&self.storage)?;
-        *self
-            .counts
-            .get_mut()
-            .expect("counts are set, just checked above") = counts;
+        *counts = Self::derive_counts(&self.storage)?;
 
         Ok(())
     }

--- a/lib/segment/src/index/field_index/geo_hash.rs
+++ b/lib/segment/src/index/field_index/geo_hash.rs
@@ -208,12 +208,9 @@ impl From<GeoPoint> for Coord<f64> {
 }
 
 pub fn common_hash_prefix(geo_hashes: &[GeoHash]) -> Option<GeoHash> {
-    if geo_hashes.is_empty() {
-        return None;
-    }
-    let first = &geo_hashes[0];
+    let (first, rest) = geo_hashes.split_first()?;
     let mut prefix: usize = first.len();
-    for geo_hash in geo_hashes.iter().skip(1) {
+    for geo_hash in rest {
         for i in 0..prefix {
             if first[i] != geo_hash[i] {
                 prefix = i;

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -113,11 +113,9 @@ impl GraphLayersBuilder {
         points: &[PointOffsetType],
         q: f32,
     ) -> f32 {
-        if points.is_empty() {
+        let Some(&max_point_id) = points.iter().max() else {
             return 1.0;
-        }
-
-        let max_point_id = *points.iter().max().unwrap();
+        };
 
         let mut visited: BitVec = BitVec::repeat(false, max_point_id as usize + 1);
         let mut point_selection: BitVec = BitVec::repeat(false, max_point_id as usize + 1);

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -118,15 +118,12 @@ impl ValueChecker for FieldCondition {
             is_null,
         } = self;
 
-        if values_count.is_some() {
-            self.values_count
-                .as_ref()
-                .unwrap()
-                .check_count_from(payload)
-        } else if is_empty.is_some() {
-            check_is_empty(is_empty.unwrap(), payload)
-        } else if is_null.is_some() {
-            check_is_null(is_null.unwrap(), payload)
+        if let Some(values_count) = values_count {
+            values_count.check_count_from(payload)
+        } else if let Some(is_empty) = is_empty {
+            check_is_empty(*is_empty, payload)
+        } else if let Some(is_null) = is_null {
+            check_is_null(*is_null, payload)
         } else {
             self._check(payload)
         }

--- a/lib/segment/src/segment_constructor/segment_constructor_base/vector_storage.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/vector_storage.rs
@@ -131,19 +131,6 @@ pub(crate) fn open_vector_storage(
             AdviceSetting::from(Advice::Normal),
             true,
         ),
-
-        // Empty placeholder storage, no files on disk
-        VectorStorageType::Empty => {
-            use crate::vector_storage::dense::empty_dense_vector_storage::new_empty_dense_vector_storage;
-            Ok(new_empty_dense_vector_storage(
-                vector_config.size,
-                vector_config.distance,
-                vector_config.datatype.unwrap_or_default(),
-                vector_config.storage_type.is_on_disk(),
-                vector_config.multivector_config,
-                0, // num_points set after id_tracker is loaded
-            ))
-        }
     }
 }
 
@@ -155,10 +142,6 @@ pub(crate) fn create_sparse_vector_storage(
         SparseVectorStorageType::Mmap => {
             let mmap_storage = MmapSparseVectorStorage::open_or_create(path)?;
             Ok(VectorStorageEnum::SparseMmap(mmap_storage))
-        }
-        SparseVectorStorageType::Empty => {
-            use crate::vector_storage::sparse::empty_sparse_vector_storage::new_empty_sparse_vector_storage;
-            Ok(new_empty_sparse_vector_storage(0))
         }
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2019,10 +2019,6 @@ pub enum VectorStorageType {
     /// Storage in a single mmap file, not appendable
     /// Pre-fetched into RAM on load
     InRamMmap,
-    /// Placeholder storage: contains no data, all vectors reported as deleted.
-    /// Used for newly created named vectors on immutable segments.
-    /// No files on disk, reconstructed from config on load.
-    Empty,
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -2124,9 +2120,6 @@ impl VectorStorageType {
             Self::Memory => Memory::Pinned,
             Self::Mmap | Self::ChunkedMmap => Memory::Cold,
             Self::InRamChunkedMmap | Self::InRamMmap => Memory::Cached,
-            // Empty storage has no data; report the safe placement, consistent with
-            // `is_on_disk`
-            Self::Empty => Memory::Cold,
         }
     }
 
@@ -2135,17 +2128,7 @@ impl VectorStorageType {
         match self {
             Self::Memory | Self::InRamChunkedMmap | Self::InRamMmap => false,
             Self::Mmap | Self::ChunkedMmap => true,
-            // Empty storage has no actual data; report based on what the
-            // runtime EmptyDenseVectorStorage was configured with.
-            // This fallback returns true to be safe, but callers that need
-            // the real on-disk status should check the storage instance.
-            Self::Empty => true,
         }
-    }
-
-    /// Whether this is a placeholder empty storage type
-    pub fn is_empty(&self) -> bool {
-        matches!(self, Self::Empty)
     }
 }
 
@@ -2186,7 +2169,6 @@ impl VectorDataConfig {
             VectorStorageType::ChunkedMmap => true,
             VectorStorageType::InRamChunkedMmap => true,
             VectorStorageType::InRamMmap => false,
-            VectorStorageType::Empty => false,
         };
         is_index_appendable && is_storage_appendable
     }
@@ -2253,18 +2235,15 @@ pub enum SparseVectorStorageType {
     /// Storage in memory maps (gridstore storage)
     #[default]
     Mmap,
-    /// Placeholder storage: contains no data, all vectors reported as deleted.
-    /// Used for newly created sparse named vectors on immutable segments.
-    Empty,
 }
 
 impl SparseVectorStorageType {
     /// Whether this storage type is a mmap on disk
     pub fn is_on_disk(&self) -> bool {
         match self {
-            // Both options are on disk, but we keep it explicit for the case if someone adds a new
-            // storage type in the future
-            Self::Mmap | Self::Empty => true,
+            // On disk; kept explicit for the case if someone adds a new storage
+            // type in the future.
+            Self::Mmap => true,
         }
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -3759,11 +3759,11 @@ impl FieldCondition {
     }
 
     fn input_size(&self) -> usize {
-        if self.r#match.is_none() {
+        let Some(r#match) = &self.r#match else {
             return 0;
-        }
+        };
 
-        match self.r#match.as_ref().unwrap() {
+        match r#match {
             Match::Any(match_any) => match_any.any.len(),
             Match::Except(match_except) => match_except.except.len(),
             Match::Value(_) => 0,

--- a/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vector_storage.rs
@@ -45,7 +45,7 @@ where
 {
     vectors_path: PathBuf,
     deleted_path: PathBuf,
-    vectors: Option<ImmutableDenseVectors<T, S>>,
+    vectors: ImmutableDenseVectors<T, S>,
     distance: Distance,
     populated: bool,
     fs: S::Fs,
@@ -59,9 +59,7 @@ where
     /// Populate all pages in the mmap.
     /// Block until all pages are populated.
     pub fn populate(&self) {
-        if let Some(mmap_store) = &self.vectors {
-            mmap_store.populate();
-        }
+        self.vectors.populate();
     }
 
     /// Drop disk cache.
@@ -74,9 +72,7 @@ where
             populated: _,
             fs: _,
         } = self;
-        if let Some(vectors) = vectors {
-            vectors.clear_cache()?;
-        }
+        vectors.clear_cache()?;
         Ok(())
     }
 }
@@ -230,7 +226,7 @@ where
     let storage = DenseVectorStorageImpl {
         vectors_path,
         deleted_path,
-        vectors: Some(vectors),
+        vectors,
         distance,
         populated: populate,
         fs,
@@ -245,13 +241,11 @@ where
     S: UniversalRead,
 {
     fn vector_dim(&self) -> usize {
-        self.vectors.as_ref().unwrap().dim()
+        self.vectors.dim()
     }
 
     fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]> {
         self.vectors
-            .as_ref()
-            .unwrap()
             .get_vector_opt::<P>(key)
             .unwrap_or_else(|| panic!("vector not found: {key}"))
     }
@@ -261,8 +255,7 @@ where
         keys: &[PointOffsetType],
         f: F,
     ) -> OperationResult<()> {
-        let mmap_store = self.vectors.as_ref().unwrap();
-        mmap_store.for_each_in_batch(keys, f)
+        self.vectors.for_each_in_batch(keys, f)
     }
 
     fn read_dense_bytes<P: AccessPattern, U: Copy>(
@@ -276,8 +269,6 @@ where
         let (user_data, point_offsets): (Vec<U>, Vec<PointOffsetType>) = keys.into_iter().unzip();
 
         self.vectors
-            .as_ref()
-            .unwrap()
             .for_each_in_batch(&point_offsets, |idx, vector| {
                 callback(
                     user_data[idx],
@@ -299,7 +290,7 @@ where
         stopped: &AtomicBool,
     ) -> OperationResult<Range<PointOffsetType>> {
         let dim = self.vector_dim();
-        let start_index = self.vectors.as_ref().unwrap().num_vectors() as PointOffsetType;
+        let start_index = self.vectors.num_vectors() as PointOffsetType;
         let mut end_index = start_index;
 
         // Extend vectors file, write other vectors into it
@@ -328,24 +319,23 @@ where
             .sync_data()?;
 
         // Load store with updated files
-        self.vectors.replace(ImmutableDenseVectors::open(
+        self.vectors = ImmutableDenseVectors::open(
             &self.fs,
             &self.vectors_path,
             &self.deleted_path,
             dim,
             Populate::No, // No need to populate
-        )?);
+        )?;
 
         // Flush deleted flags into store
         // We must do that in the updated store, and cannot do it in the previous loop. That is
         // because the file backing delete storage must be resized, and for that we'd need to know
         // the exact number of vectors beforehand. When opening the store it is done automatically.
-        let store = self.vectors.as_mut().unwrap();
         for id in deleted_ids {
             check_process_stopped(stopped)?;
-            store.delete(id);
+            self.vectors.delete(id);
         }
-        store.flusher()()?;
+        self.vectors.flusher()()?;
 
         Ok(start_index..end_index)
     }
@@ -373,13 +363,11 @@ where
     }
 
     fn total_vector_count(&self) -> usize {
-        self.vectors.as_ref().unwrap().num_vectors()
+        self.vectors.num_vectors()
     }
 
     fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
         self.vectors
-            .as_ref()
-            .unwrap()
             .get_vector_opt::<P>(key)
             .map(|vector| T::slice_to_float_cow(vector).into())
             .expect("Vector not found")
@@ -396,8 +384,6 @@ where
         let (user_data, point_offsets): (Vec<U>, Vec<PointOffsetType>) = keys.into_iter().unzip();
 
         self.vectors
-            .as_ref()
-            .unwrap()
             .for_each_in_batch(&point_offsets, |idx, vector| {
                 let vector = CowVector::from(T::slice_to_float_cow(Cow::Borrowed(vector)));
                 callback(user_data[idx], point_offsets[idx], vector);
@@ -407,22 +393,20 @@ where
 
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.vectors
-            .as_ref()
-            .unwrap()
             .get_vector_opt::<P>(key)
             .map(|vector| T::slice_to_float_cow(vector).into())
     }
 
     fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
-        self.vectors.as_ref().unwrap().is_deleted_vector(key)
+        self.vectors.is_deleted_vector(key)
     }
 
     fn deleted_vector_count(&self) -> usize {
-        self.vectors.as_ref().unwrap().deleted_count
+        self.vectors.deleted_count
     }
 
     fn deleted_vector_bitslice(&self) -> &BitSlice {
-        self.vectors.as_ref().unwrap().deleted_vector_bitslice()
+        self.vectors.deleted_vector_bitslice()
     }
 
     fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
@@ -449,13 +433,8 @@ where
     }
 
     fn flusher(&self) -> Flusher {
-        match &self.vectors {
-            Some(mmap_store) => {
-                let mmap_flusher = mmap_store.flusher();
-                Box::new(move || mmap_flusher().map_err(OperationError::from))
-            }
-            None => Box::new(|| Ok(())),
-        }
+        let mmap_flusher = self.vectors.flusher();
+        Box::new(move || mmap_flusher().map_err(OperationError::from))
     }
 
     fn files(&self) -> Vec<PathBuf> {
@@ -469,7 +448,7 @@ where
     }
 
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
-        Ok(self.vectors.as_mut().unwrap().delete(key))
+        Ok(self.vectors.delete(key))
     }
 }
 

--- a/lib/segment/src/vector_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/read_only/lifecycle.rs
@@ -26,7 +26,7 @@ fn storage_type_params(storage_type: VectorStorageType) -> Option<(AdviceSetting
         VectorStorageType::InRamMmap => (AdviceSetting::from(Advice::Normal), true, false),
         VectorStorageType::ChunkedMmap => (AdviceSetting::Global, false, true),
         VectorStorageType::InRamChunkedMmap => (AdviceSetting::from(Advice::Normal), true, true),
-        VectorStorageType::Memory | VectorStorageType::Empty => return None,
+        VectorStorageType::Memory => return None,
     };
 
     let populate = match populate {

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -148,20 +148,19 @@ mod tests {
             .collect()
     }
 
-    /// `Memory` and `Empty` storage types are a no-op: nothing to open read-only.
+    /// The `Memory` storage type is a no-op: nothing to open read-only.
     #[test]
-    fn open_memory_and_empty_are_noop() {
+    fn open_memory_is_noop() {
         let dir = Builder::new().prefix("disp_noop").tempdir().unwrap();
-        for storage_type in [VectorStorageType::Memory, VectorStorageType::Empty] {
-            let opened = VectorStorageReadEnum::<MmapFile>::open(
-                &MmapFs,
-                &dense_config(storage_type, None),
-                dir.path(),
-                None,
-            )
-            .unwrap();
-            assert!(opened.is_none(), "{storage_type:?} should be a no-op");
-        }
+        let storage_type = VectorStorageType::Memory;
+        let opened = VectorStorageReadEnum::<MmapFile>::open(
+            &MmapFs,
+            &dense_config(storage_type, None),
+            dir.path(),
+            None,
+        )
+        .unwrap();
+        assert!(opened.is_none(), "{storage_type:?} should be a no-op");
     }
 
     /// `ChunkedMmap` single-dense routes to the chunked read-only storage.
@@ -650,8 +649,7 @@ mod tests {
                 }
                 VectorStorageType::InRamMmap
                 | VectorStorageType::InRamChunkedMmap
-                | VectorStorageType::Memory
-                | VectorStorageType::Empty => {
+                | VectorStorageType::Memory => {
                     unreachable!("unexpected storage type {storage_type:?}")
                 }
             }
@@ -672,8 +670,7 @@ mod tests {
                 }
                 VectorStorageType::Memory
                 | VectorStorageType::InRamChunkedMmap
-                | VectorStorageType::InRamMmap
-                | VectorStorageType::Empty => false,
+                | VectorStorageType::InRamMmap => false,
             };
             assert!(
                 routed,

--- a/lib/segment/src/vector_storage/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/update_only/mod.rs
@@ -78,15 +78,13 @@ impl<S: UniversalAppend + 'static> UpdateOnlyVectorStorage<S> {
     /// if it is not there yet.
     ///
     /// Fails for a storage type an update-only segment cannot have: the mmap
-    /// ones are immutable, built whole rather than appended to, and the empty
-    /// placeholder has no files at all.
+    /// ones are immutable, built whole rather than appended to.
     pub fn open(fs: S::Fs, path: &Path, config: &VectorDataConfig) -> OperationResult<Self> {
         match config.storage_type {
             VectorStorageType::ChunkedMmap | VectorStorageType::InRamChunkedMmap => {}
             storage_type @ (VectorStorageType::Mmap
             | VectorStorageType::InRamMmap
-            | VectorStorageType::Memory
-            | VectorStorageType::Empty) => {
+            | VectorStorageType::Memory) => {
                 return Err(OperationError::service_error(format!(
                     "Cannot open a {storage_type:?} vector storage for appending: it is not an \
                      appendable storage type",

--- a/lib/shard/src/optimizers/config_mismatch_optimizer.rs
+++ b/lib/shard/src/optimizers/config_mismatch_optimizer.rs
@@ -100,8 +100,7 @@ impl ConfigMismatchOptimizer {
                         }
                     }
 
-                    if !vector_data.storage_type.is_empty()
-                        && let Some(required_memory) = self.requested_vectors_memory(vector_name)
+                    if let Some(required_memory) = self.requested_vectors_memory(vector_name)
                         && required_memory.is_on_disk() != vector_data.storage_type.is_on_disk()
                     {
                         return true;

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -1271,12 +1271,12 @@ impl SegmentHolder {
     pub fn remove_segment_if_not_needed(&mut self, segment_id: SegmentId) -> OperationResult<bool> {
         let tmp_segment = {
             let mut segments = self.remove(&[segment_id]);
-            if segments.is_empty() {
+            let Some(segment) = segments.pop() else {
                 // Seems like segment is already removed, ignore
                 return Ok(false);
-            }
-            assert_eq!(segments.len(), 1, "expected exactly one segment");
-            segments.pop().unwrap()
+            };
+            assert!(segments.is_empty(), "expected exactly one segment");
+            segment
         };
 
         // Append a temp segment to collection if it is not empty or there is no other appendable segment

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -37,7 +37,6 @@ impl From<StorageError> for Status {
             StorageError::ServiceError { .. } => tonic::Code::Internal,
             StorageError::BadRequest { .. } => tonic::Code::InvalidArgument,
             StorageError::StandaloneMode { .. } => tonic::Code::Unimplemented,
-            StorageError::Locked { .. } => tonic::Code::FailedPrecondition,
             StorageError::Timeout { .. } => tonic::Code::DeadlineExceeded,
             StorageError::AlreadyExists { .. } => tonic::Code::AlreadyExists,
             StorageError::ChecksumMismatch { .. } => tonic::Code::DataLoss,

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -28,8 +28,6 @@ pub enum StorageError {
     // operation requires distributed mode, but node runs standalone
     #[error("{description}")]
     StandaloneMode { description: String },
-    #[error("Storage locked: {description}")]
-    Locked { description: String },
     #[error("Timeout: {description}")]
     Timeout { description: String },
     #[error("Checksum mismatch: expected {expected}, actual {actual}")]

--- a/lib/wal/tests/process_crash.rs
+++ b/lib/wal/tests/process_crash.rs
@@ -24,10 +24,8 @@ const EXIT_CODE: i32 = 42;
 #[test]
 fn process_crash() {
     let vars: HashMap<String, String> = env::vars().collect();
-    if vars.contains_key("SEED") && vars.contains_key("SEGMENT_PATH") {
-        let seed: usize = vars["SEED"].parse().unwrap();
-        let path = vars["SEGMENT_PATH"].clone();
-        subprocess(path, seed);
+    if let (Some(seed), Some(path)) = (vars.get("SEED"), vars.get("SEGMENT_PATH")) {
+        subprocess(path.clone(), seed.parse().unwrap());
     } else {
         test()
     }

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -227,7 +227,6 @@ impl HttpError {
             StorageError::ServiceError { .. } => {}
             StorageError::BadRequest { .. } => {}
             StorageError::StandaloneMode { .. } => {}
-            StorageError::Locked { .. } => {}
             StorageError::Timeout { .. } => {}
             StorageError::ChecksumMismatch { .. } => {}
             StorageError::Forbidden { .. } => {}
@@ -249,7 +248,6 @@ impl ResponseError for HttpError {
             StorageError::ServiceError { .. } => http::StatusCode::INTERNAL_SERVER_ERROR,
             StorageError::BadRequest { .. } => http::StatusCode::BAD_REQUEST,
             StorageError::StandaloneMode { .. } => http::StatusCode::METHOD_NOT_ALLOWED,
-            StorageError::Locked { .. } => http::StatusCode::FORBIDDEN,
             StorageError::Timeout { .. } => http::StatusCode::REQUEST_TIMEOUT,
             StorageError::AlreadyExists { .. } => http::StatusCode::CONFLICT,
             StorageError::ChecksumMismatch { .. } => http::StatusCode::BAD_REQUEST,

--- a/src/actix/web_ui.rs
+++ b/src/actix/web_ui.rs
@@ -65,13 +65,11 @@ mod tests {
         let mut settings = Settings::new(None).unwrap();
         settings.service.static_content_dir = Some(static_dir.clone());
 
-        let maybe_static_folder = web_ui_folder(&settings);
-        if maybe_static_folder.is_none() {
+        let Some(static_folder) = web_ui_folder(&settings) else {
             println!("Skipping test because the static folder was not found.");
             return;
-        }
+        };
 
-        let static_folder = maybe_static_folder.unwrap();
         let srv = test::init_service(App::new().service(web_ui_factory(&static_folder))).await;
 
         // Index path (no trailing slash)

--- a/src/common/collections.rs
+++ b/src/common/collections.rs
@@ -258,10 +258,9 @@ pub async fn do_update_collection_cluster(
         "update_collection_cluster",
     )?;
 
-    if dispatcher.consensus_state().is_none() {
+    let Some(consensus_state) = dispatcher.consensus_state() else {
         return Err(StorageError::standalone_mode());
-    }
-    let consensus_state = dispatcher.consensus_state().unwrap();
+    };
 
     let get_all_peer_ids = || {
         consensus_state


### PR DESCRIPTION
Remove unused enum variants, collapse options that are never `None`, etc.
See commit descriptions for details.