### PR TITLE
Propagate numeric index read errors

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs
@@ -4,8 +4,7 @@ use std::path::PathBuf;
 
 use common::generic_consts::{Random, Sequential};
 use common::universal_io::{
-    OkNotFound, OpenOptions, ReadRange, UniversalIoError, UioResult, UniversalRead,
-    UniversalReadFs,
+    OkNotFound, OpenOptions, ReadRange, UioResult, UniversalIoError, UniversalRead, UniversalReadFs,
 };
 use posting_list::{PostingList, PostingListView};
 use zerocopy::FromBytes;

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/read_ops.rs
@@ -45,8 +45,8 @@ where
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         _hw_counter: &HardwareCounterCell,
-    ) -> bool {
-        self.point_to_values.check_values_any(idx, |v| check_fn(v))
+    ) -> OperationResult<bool> {
+        Ok(self.point_to_values.check_values_any(idx, |v| check_fn(v)))
     }
 
     fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {

--- a/lib/segment/src/index/field_index/numeric_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/numeric_index/lifecycle.rs
@@ -100,7 +100,7 @@ where
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
-    ) -> bool {
+    ) -> OperationResult<bool> {
         self.inner.check_values_any(idx, check_fn, hw_counter)
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/read_ops.rs
@@ -24,8 +24,8 @@ where
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         _hw_counter: &HardwareCounterCell,
-    ) -> bool {
-        self.in_memory_index.check_values_any(idx, check_fn)
+    ) -> OperationResult<bool> {
+        Ok(self.in_memory_index.check_values_any(idx, check_fn))
     }
 
     fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_ops.rs
@@ -104,8 +104,8 @@ where
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         _hw_counter: &HardwareCounterCell,
-    ) -> bool {
-        self.in_memory_index.check_values_any(idx, check_fn)
+    ) -> OperationResult<bool> {
+        Ok(self.in_memory_index.check_values_any(idx, check_fn))
     }
 
     fn get_values(&self, idx: PointOffsetType) -> Option<Box<dyn Iterator<Item = T> + '_>> {

--- a/lib/segment/src/index/field_index/numeric_index/numeric_index_read.rs
+++ b/lib/segment/src/index/field_index/numeric_index/numeric_index_read.rs
@@ -25,15 +25,14 @@ use crate::telemetry::PayloadIndexTelemetry;
 /// [`NumericIndexInner`]: super::NumericIndexInner
 pub trait NumericIndexRead<T: Encodable + Numericable + Default + StoredValue> {
     /// Hardware counter is used only by the mmap-backed variant; in-memory
-    /// variants ignore it. Returns `false` if the mmap read fails (matches
-    /// the legacy enum dispatcher behavior — see the FIXME on
-    /// [`super::NumericIndexInner::check_values_any`]).
+    /// variants ignore it. Read errors from the mmap-backed variant are
+    /// propagated so callers do not silently lose matching points.
     fn check_values_any(
         &self,
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
-    ) -> bool;
+    ) -> OperationResult<bool>;
 
     /// Batched counterpart of [`Self::check_values_any`].
     fn for_each_matching_value<I, F, M, U>(
@@ -50,7 +49,7 @@ pub trait NumericIndexRead<T: Encodable + Numericable + Default + StoredValue> {
         M: FnMut(U, bool),
     {
         for (tag, idx) in items {
-            on_match(tag, self.check_values_any(idx, &check_fn, hw_counter));
+            on_match(tag, self.check_values_any(idx, &check_fn, hw_counter)?);
         }
         Ok(())
     }

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/read_ops.rs
@@ -26,18 +26,16 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
-    ) -> bool {
-        // FIXME: don't silently ignore error — propagate it once
-        // [`NumericIndexRead::check_values_any`] returns `OperationResult`.
+    ) -> OperationResult<bool> {
         let hw_counter = ConditionedCounter::always(hw_counter);
 
         if self.storage.deleted.is_active(idx) {
-            self.storage
+            Ok(self
+                .storage
                 .point_to_values
-                .check_values_any(idx, |v| check_fn(v), &hw_counter)
-                .unwrap_or(false)
+                .check_values_any(idx, |v| check_fn(v), &hw_counter)?)
         } else {
-            false
+            Ok(false)
         }
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/query.rs
+++ b/lib/segment/src/index/field_index/numeric_index/query.rs
@@ -362,11 +362,11 @@ where
     type Error = OperationError;
 
     fn check(&self, point_id: PointOffsetType) -> OperationResult<bool> {
-        Ok(self.index.check_values_any(
+        self.index.check_values_any(
             point_id,
             |value| self.typed_range.check_range(*value),
             &self.hw_counter,
-        ))
+        )
     }
 
     fn check_batched<K: CheckItem>(

--- a/lib/segment/src/index/field_index/numeric_index/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_only/read_ops.rs
@@ -34,7 +34,7 @@ where
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
-    ) -> bool {
+    ) -> OperationResult<bool> {
         self.inner.check_values_any(idx, check_fn, hw_counter)
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/read_ops.rs
@@ -32,7 +32,7 @@ where
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
-    ) -> bool {
+    ) -> OperationResult<bool> {
         match self {
             ReadOnlyNumericIndexInner::Appendable(index) => {
                 index.check_values_any(idx, check_fn, hw_counter)

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_ops.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_ops.rs
@@ -30,9 +30,7 @@ where
         idx: PointOffsetType,
         check_fn: impl Fn(&T) -> bool,
         hw_counter: &HardwareCounterCell,
-    ) -> bool {
-        // FIXME: don't silently ignore mmap-read errors; promote the trait
-        // method's return type to `OperationResult<bool>` and propagate.
+    ) -> OperationResult<bool> {
         match self {
             NumericIndexInner::Mutable(index) => index.check_values_any(idx, check_fn, hw_counter),
             NumericIndexInner::Immutable(index) => {


### PR DESCRIPTION
Closes #10180\n\nSummary:\n- Propagate storage errors from numeric index check_values_any calls.\n- Update wrapper implementations and query handling to preserve OperationResult errors.\n\nTests:\n- cargo check -p segment passed.\n- cargo fmt -p segment completed successfully.