### PR TITLE
fix(common): pass file length to POSIX_FADV_NOREUSE in OneshotFile::open

### DIFF
--- a/lib/common/common/src/fs/fadvise.rs
+++ b/lib/common/common/src/fs/fadvise.rs
@@ -8,7 +8,23 @@ use nix::fcntl::{PosixFadviseAdvice, posix_fadvise};
 
 #[cfg(posix_fadvise_supported)]
 fn fadvise(f: &impl std::os::unix::io::AsFd, advise: PosixFadviseAdvice) -> io::Result<()> {
-    Ok(posix_fadvise(f, 0, 0, advise)?)
+    fadvise_with_len(f, advise, 0)
+}
+
+/// Call `posix_fadvise` with an explicit `len`.
+///
+/// `len = 0` means "to end of file" for most advice types, but the meaning is
+/// filesystem-specific for `POSIX_FADV_NOREUSE` on F2FS, where a zero-length
+/// request removes a previously-registered NOREUSE range and returns `ENOENT`
+/// when no range exists. Callers using `POSIX_FADV_NOREUSE` must pass the
+/// file's actual length instead.
+#[cfg(posix_fadvise_supported)]
+fn fadvise_with_len(
+    f: &impl std::os::unix::io::AsFd,
+    advise: PosixFadviseAdvice,
+    len: nix::libc::off_t,
+) -> io::Result<()> {
+    Ok(posix_fadvise(f, 0, len, advise)?)
 }
 
 /// For given file path, clear disk cache with `posix_fadvise`
@@ -44,11 +60,25 @@ pub struct OneshotFile {
 impl OneshotFile {
     /// Similar to [`File::open`].
     pub fn open(path: impl AsRef<Path>) -> io::Result<Self> {
-        let file = File::open(path.as_ref().to_path_buf())?;
+        let file = File::open(path.as_ref())?;
         #[cfg(posix_fadvise_supported)]
         {
             fadvise(&file, PosixFadviseAdvice::POSIX_FADV_SEQUENTIAL)?;
-            fadvise(&file, PosixFadviseAdvice::POSIX_FADV_NOREUSE)?;
+            // `POSIX_FADV_NOREUSE` is an advisory hint and must never abort
+            // loading on otherwise-valid data. `len = 0` has filesystem-
+            // specific semantics: on F2FS (used by Android) the kernel treats
+            // a zero-length request as "remove a previously-registered NOREUSE
+            // range" and returns `ENOENT` when no range exists. Pass the
+            // file's actual length so the advice covers the full file,
+            // skip the call for empty files (no range to advise on), and
+            // swallow any error so an unknown FS quirk cannot block
+            // shard loading.
+            let metadata = file.metadata()?;
+            if let Ok(len) = i64::try_from(metadata.len())
+                && len > 0
+            {
+                let _ = fadvise_with_len(&file, PosixFadviseAdvice::POSIX_FADV_NOREUSE, len);
+            }
         }
         Ok(Self { file: Some(file) })
     }
@@ -104,6 +134,80 @@ impl Drop for OneshotFile {
             #[cfg(posix_fadvise_supported)]
             let _ = fadvise(&file, PosixFadviseAdvice::POSIX_FADV_DONTNEED);
             let _ = file;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::Builder;
+
+    use super::*;
+
+    /// Smoke test: `OneshotFile::open` succeeds on a non-empty file. The
+    /// F2FS regression (where the `POSIX_FADV_NOREUSE` call returned `ENOENT`)
+    /// only reproduces on F2FS-backed filesystems, but the fix uses the
+    /// file's actual length on every platform, so we can at least confirm
+    /// the open path still works on a regular Linux fs.
+    #[test]
+    fn oneshot_file_open_succeeds_on_non_empty_file() {
+        let dir = Builder::new().prefix("fadvise").tempdir().unwrap();
+        let path = dir.path().join("data.bin");
+        {
+            let mut f = File::create(&path).unwrap();
+            f.write_all(b"hello world").unwrap();
+            f.sync_all().unwrap();
+        }
+        let mut file = OneshotFile::open(&path).expect("open should succeed");
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).unwrap();
+        assert_eq!(buf, b"hello world");
+    }
+
+    /// An empty file is handled by skipping the `POSIX_FADV_NOREUSE` call
+    /// entirely (no range to advise on). On F2FS, calling it with `len = 0`
+    /// would return `ENOENT`; skipping avoids that and any other FS-specific
+    /// zero-length semantics.
+    #[test]
+    fn oneshot_file_open_succeeds_on_empty_file() {
+        let dir = Builder::new().prefix("fadvise").tempdir().unwrap();
+        let path = dir.path().join("empty.bin");
+        File::create(&path).unwrap();
+        let mut file = OneshotFile::open(&path).expect("open should succeed on empty file");
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).unwrap();
+        assert!(buf.is_empty());
+    }
+
+    /// A larger file (multi-page) exercises the `len > 0` branch that triggers
+    /// the actual `posix_fadvise(fd, 0, file_len, NOREUSE)` call.
+    #[test]
+    fn oneshot_file_open_succeeds_on_multipage_file() {
+        let dir = Builder::new().prefix("fadvise").tempdir().unwrap();
+        let path = dir.path().join("big.bin");
+        let payload = vec![0u8; 256 * 1024];
+        std::fs::write(&path, &payload).unwrap();
+        let mut file = OneshotFile::open(&path).expect("open should succeed on multipage file");
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).unwrap();
+        assert_eq!(buf.len(), payload.len());
+    }
+
+    /// `OneshotFile::open` must not consume the file twice: opening the same
+    /// path twice produces two independent handles that each read the full
+    /// payload.
+    #[test]
+    fn oneshot_file_open_is_repeatable() {
+        let dir = Builder::new().prefix("fadvise").tempdir().unwrap();
+        let path = dir.path().join("repeat.bin");
+        std::fs::write(&path, b"abcdefghij").unwrap();
+        for _ in 0..3 {
+            let mut file = OneshotFile::open(&path).expect("open should succeed");
+            let mut buf = Vec::new();
+            file.read_to_end(&mut buf).unwrap();
+            assert_eq!(buf, b"abcdefghij");
         }
     }
 }

--- a/lib/common/common/src/fs/fadvise.rs
+++ b/lib/common/common/src/fs/fadvise.rs
@@ -188,7 +188,7 @@ mod tests {
         let dir = Builder::new().prefix("fadvise").tempdir().unwrap();
         let path = dir.path().join("big.bin");
         let payload = vec![0u8; 256 * 1024];
-        std::fs::write(&path, &payload).unwrap();
+        fs_err::write(&path, &payload).unwrap();
         let mut file = OneshotFile::open(&path).expect("open should succeed on multipage file");
         let mut buf = Vec::new();
         file.read_to_end(&mut buf).unwrap();
@@ -202,7 +202,7 @@ mod tests {
     fn oneshot_file_open_is_repeatable() {
         let dir = Builder::new().prefix("fadvise").tempdir().unwrap();
         let path = dir.path().join("repeat.bin");
-        std::fs::write(&path, b"abcdefghij").unwrap();
+        fs_err::write(&path, b"abcdefghij").unwrap();
         for _ in 0..3 {
             let mut file = OneshotFile::open(&path).expect("open should succeed");
             let mut buf = Vec::new();


### PR DESCRIPTION
## Problem

Reproduces qdrant/qdrant#10307.

`OneshotFile::open` calls `posix_fadvise(fd, 0, 0, POSIX_FADV_NOREUSE)` and propagates the result with `?`. On F2FS-backed filesystems (used by Android), the kernel treats a zero-length `NOREUSE` request as "remove a previously-registered NOREUSE range" and returns `ENOENT` when no range exists. The error then aborts shard loading on an otherwise-valid file. The same shard loads fine on ext4.

## Root cause

The F2FS implementation of `POSIX_FADV_NOREUSE` interprets `len = 0` as a "remove range" request, while most filesystems (ext4, xfs, tmpfs) treat `len = 0` as "to end of file." The qdrant code path used `len = 0` for every fadvise call, so any F2FS shard load fails on the very first call.

## Fix

Three small changes in `lib/common/common/src/fs/fadvise.rs`:

1. **New private helper `fadvise_with_len(f, advise, len)`** that calls `posix_fadvise` with an explicit `len`. The existing `fadvise(f, advise)` now delegates to `fadvise_with_len(f, advise, 0)` so callers of the other advice types (`SEQUENTIAL`, `DONTNEED`) keep their original "to end of file" semantics.
2. **`OneshotFile::open` reads the file's actual length** via `file.metadata().len()`, converts it to `off_t`, and passes it to `POSIX_FADV_NOREUSE`. The advice now covers the full file on every filesystem.
3. **Defensive fallbacks** for the two edge cases the cross-model review surfaced:
   - Skip the `NOREUSE` call entirely for empty files (no range to advise on) and for files whose length does not fit in `off_t`.
   - Treat the `NOREUSE` call as non-fatal: it is an advisory hint and must never block loading of otherwise-valid data. The other advice types continue to propagate errors so genuine I/O failures remain visible.

## Why this is the right combination

The primary length fix matches what the issue reporter recommended. The "skip + non-fatal" fallback is defense in depth for any future filesystem that interprets `NOREUSE` differently — the call is a hint, not a requirement, and any failing hint should not be able to abort shard loading.

The cross-model review (10-model Tier A council) flagged both gaps in the original length-only fix; this PR implements all three layers.

## Tests

4 new unit tests in `lib/common/common/src/fs/fadvise.rs`:

- `oneshot_file_open_succeeds_on_non_empty_file` — the common case
- `oneshot_file_open_succeeds_on_empty_file` — empty file is now handled by skipping the NOREUSE call
- `oneshot_file_open_succeeds_on_multipage_file` — multi-page file exercises the `len > 0` branch that triggers the actual `posix_fadvise(fd, 0, file_len, NOREUSE)` call
- `oneshot_file_open_is_repeatable` — opening the same path three times still works

The F2FS bug itself only reproduces on an F2FS-backed filesystem, so these are smoke tests that confirm the open path does not regress on a regular Linux fs. The reporter's validation in the issue (`POSIX_FADV_NOREUSE` with the actual file length allows repeated shard reloads on F2FS) is the real verification.

## Scope

- **1 file changed**: `lib/common/common/src/fs/fadvise.rs`
- **+107 / -3 lines**
- No API changes, no public type changes. The new helper is `fn` (private), not `pub`.

Fixes #10307
