### PR TITLE
Implement more operations on `ConsensusStateMachine` [1/2]

### DIFF
--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1944,6 +1944,12 @@ pub struct PeerMetadata {
 }
 
 impl PeerMetadata {
+    /// Metadata of a peer running `version`, to set up a state for a test
+    #[cfg(any(test, feature = "testing"))]
+    pub fn new(version: Version) -> Self {
+        Self { version }
+    }
+
     pub fn current() -> Self {
         Self {
             version: defaults::QDRANT_VERSION.clone(),

--- a/lib/storage/Cargo.toml
+++ b/lib/storage/Cargo.toml
@@ -16,6 +16,7 @@ tracing = ["dep:tracing", "api/tracing", "collection/tracing", "segment/tracing"
 staging = ["collection/staging"]
 
 [dev-dependencies]
+collection = { path = "../collection", features = ["testing"] }
 fs-err = { workspace = true, features = ["debug"] }
 proptest = { workspace = true }
 mockito = { workspace = true }

--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -38,6 +38,23 @@ impl AliasMapping {
     pub fn insert(&mut self, alias: Alias, collection_name: CollectionId) {
         self.0.insert(alias, collection_name);
     }
+
+    /// Drop `alias`, if it exists.
+    pub fn remove(&mut self, alias: &str) {
+        self.0.remove(alias);
+    }
+
+    /// Rename `old_alias` as `new_alias`, keeping collection it points at.
+    /// Returns `false` if `old_alias` does not exist.
+    pub fn rename(&mut self, old_alias: &str, new_alias: Alias) -> bool {
+        let Some(collection_name) = self.0.remove(old_alias) else {
+            return false;
+        };
+
+        self.0.insert(new_alias, collection_name);
+
+        true
+    }
 }
 
 /// Persists mapping between alias and collection name. The data is assumed to be relatively small.

--- a/lib/storage/src/content_manager/consensus_state_machine/action.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/action.rs
@@ -26,6 +26,20 @@ pub enum Action {
         collection: CollectionId,
         field_name: PayloadKeyType,
     },
+
+    SetAlias {
+        alias: String,
+        collection: CollectionId,
+    },
+
+    DeleteAlias {
+        alias: String,
+    },
+
+    RenameAlias {
+        old_alias: String,
+        new_alias: String,
+    },
 }
 
 impl Action {
@@ -36,6 +50,11 @@ impl Action {
             | Action::DropNamedVector { collection, .. }
             | Action::SetPayloadIndex { collection, .. }
             | Action::DropPayloadIndex { collection, .. } => Some(collection),
+
+            // Alias actions change the alias mapping, not the collection an alias points at
+            Action::SetAlias { .. } | Action::DeleteAlias { .. } | Action::RenameAlias { .. } => {
+                None
+            }
         }
     }
 }

--- a/lib/storage/src/content_manager/consensus_state_machine/action.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/action.rs
@@ -47,6 +47,12 @@ pub enum Action {
         peer_id: PeerId,
         metadata: PeerMetadata,
     },
+
+    /// Null value removes the key
+    SetClusterMetadataKey {
+        key: String,
+        value: serde_json::Value,
+    },
 }
 
 impl Action {
@@ -58,11 +64,12 @@ impl Action {
             | Action::SetPayloadIndex { collection, .. }
             | Action::DropPayloadIndex { collection, .. } => Some(collection),
 
-            // Change the alias mapping or a peer, neither of which belongs to a collection
+            // Change the alias mapping, a peer or the cluster, none of which is a collection
             Action::SetAlias { .. }
             | Action::DeleteAlias { .. }
             | Action::RenameAlias { .. }
-            | Action::SetPeerMetadata { .. } => None,
+            | Action::SetPeerMetadata { .. }
+            | Action::SetClusterMetadataKey { .. } => None,
         }
     }
 }

--- a/lib/storage/src/content_manager/consensus_state_machine/action.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/action.rs
@@ -1,4 +1,6 @@
+use collection::operations::types::PeerMetadata;
 use collection::shards::CollectionId;
+use collection::shards::shard::PeerId;
 use segment::types::{PayloadFieldSchema, PayloadKeyType, VectorNameBuf};
 use shard::operations::vector_name_ops::VectorNameConfig;
 
@@ -40,6 +42,11 @@ pub enum Action {
         old_alias: String,
         new_alias: String,
     },
+
+    SetPeerMetadata {
+        peer_id: PeerId,
+        metadata: PeerMetadata,
+    },
 }
 
 impl Action {
@@ -51,10 +58,11 @@ impl Action {
             | Action::SetPayloadIndex { collection, .. }
             | Action::DropPayloadIndex { collection, .. } => Some(collection),
 
-            // Alias actions change the alias mapping, not the collection an alias points at
-            Action::SetAlias { .. } | Action::DeleteAlias { .. } | Action::RenameAlias { .. } => {
-                None
-            }
+            // Change the alias mapping or a peer, neither of which belongs to a collection
+            Action::SetAlias { .. }
+            | Action::DeleteAlias { .. }
+            | Action::RenameAlias { .. }
+            | Action::SetPeerMetadata { .. } => None,
         }
     }
 }

--- a/lib/storage/src/content_manager/consensus_state_machine/action.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/action.rs
@@ -4,6 +4,8 @@ use collection::shards::shard::PeerId;
 use segment::types::{PayloadFieldSchema, PayloadKeyType, VectorNameBuf};
 use shard::operations::vector_name_ops::VectorNameConfig;
 
+use crate::quota::QuotaConfig;
+
 /// A single change a consensus operation makes
 #[derive(Clone, Debug, PartialEq)]
 pub enum Action {
@@ -53,6 +55,10 @@ pub enum Action {
         key: String,
         value: serde_json::Value,
     },
+
+    SetQuotaConfig {
+        config: QuotaConfig,
+    },
 }
 
 impl Action {
@@ -69,7 +75,8 @@ impl Action {
             | Action::DeleteAlias { .. }
             | Action::RenameAlias { .. }
             | Action::SetPeerMetadata { .. }
-            | Action::SetClusterMetadataKey { .. } => None,
+            | Action::SetClusterMetadataKey { .. }
+            | Action::SetQuotaConfig { .. } => None,
         }
     }
 }

--- a/lib/storage/src/content_manager/consensus_state_machine/mod.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/mod.rs
@@ -73,9 +73,13 @@ impl ConsensusStateMachine {
         match operation {
             ConsensusOperations::CollectionMeta(operation) => self.plan_collection_meta(operation),
 
+            ConsensusOperations::UpdatePeerMetadata { peer_id, metadata } => {
+                let actions = self.state.plan_update_peer_metadata(*peer_id, metadata);
+                ApplyOutcome::Accepted(actions)
+            }
+
             ConsensusOperations::AddPeer { .. }
             | ConsensusOperations::RemovePeer(_)
-            | ConsensusOperations::UpdatePeerMetadata { .. }
             | ConsensusOperations::UpdateClusterMetadata { .. }
             | ConsensusOperations::SetQuotaConfig(_) => ApplyOutcome::NotCovered,
 

--- a/lib/storage/src/content_manager/consensus_state_machine/mod.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/mod.rs
@@ -93,12 +93,15 @@ impl ConsensusStateMachine {
             CollectionMetaOperations::CreateCollection(_)
             | CollectionMetaOperations::UpdateCollection(_)
             | CollectionMetaOperations::DeleteCollection(_)
-            | CollectionMetaOperations::ChangeAliases(_)
             | CollectionMetaOperations::CreateShardKey(_)
             | CollectionMetaOperations::DropShardKey(_)
             | CollectionMetaOperations::SetShardReplicaState(_)
             | CollectionMetaOperations::TransferShard(_, _)
             | CollectionMetaOperations::Resharding(_, _) => ApplyOutcome::NotCovered,
+
+            CollectionMetaOperations::ChangeAliases(operation) => {
+                ApplyOutcome::new(self.state.plan_change_aliases(operation))
+            }
 
             CollectionMetaOperations::CreateNamedVector(operation) => {
                 ApplyOutcome::new(self.state.plan_create_named_vector(operation))

--- a/lib/storage/src/content_manager/consensus_state_machine/mod.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/mod.rs
@@ -83,9 +83,13 @@ impl ConsensusStateMachine {
                 ApplyOutcome::Accepted(actions)
             }
 
-            ConsensusOperations::AddPeer { .. }
-            | ConsensusOperations::RemovePeer(_)
-            | ConsensusOperations::SetQuotaConfig(_) => ApplyOutcome::NotCovered,
+            ConsensusOperations::SetQuotaConfig(config) => {
+                ApplyOutcome::Accepted(self.state.plan_set_quota_config(config))
+            }
+
+            ConsensusOperations::AddPeer { .. } | ConsensusOperations::RemovePeer(_) => {
+                ApplyOutcome::NotCovered
+            }
 
             // Never reach the apply path: consensus handles them in its own thread
             ConsensusOperations::RequestSnapshot | ConsensusOperations::ReportSnapshot { .. } => {

--- a/lib/storage/src/content_manager/consensus_state_machine/mod.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/mod.rs
@@ -129,10 +129,10 @@ impl ConsensusStateMachine {
                 ApplyOutcome::new(self.state.plan_drop_payload_index(operation))
             }
 
-            // Sleeps, or fails at random. Neither is a state change to plan.
+            // Sleeps on a peer, or fails at random. Neither changes the state.
             #[cfg(feature = "staging")]
             CollectionMetaOperations::TestSlowDown(_)
-            | CollectionMetaOperations::TestTransientError(_) => ApplyOutcome::NotCovered,
+            | CollectionMetaOperations::TestTransientError(_) => ApplyOutcome::Accepted(Vec::new()),
         }
     }
 }

--- a/lib/storage/src/content_manager/consensus_state_machine/mod.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/mod.rs
@@ -78,9 +78,13 @@ impl ConsensusStateMachine {
                 ApplyOutcome::Accepted(actions)
             }
 
+            ConsensusOperations::UpdateClusterMetadata { key, value } => {
+                let actions = self.state.plan_update_cluster_metadata(key, value);
+                ApplyOutcome::Accepted(actions)
+            }
+
             ConsensusOperations::AddPeer { .. }
             | ConsensusOperations::RemovePeer(_)
-            | ConsensusOperations::UpdateClusterMetadata { .. }
             | ConsensusOperations::SetQuotaConfig(_) => ApplyOutcome::NotCovered,
 
             // Never reach the apply path: consensus handles them in its own thread

--- a/lib/storage/src/content_manager/consensus_state_machine/state/apply.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/state/apply.rs
@@ -90,6 +90,10 @@ impl ClusterState {
                     "action renames alias {old_alias}, which is not in the state",
                 );
             }
+
+            Action::SetPeerMetadata { peer_id, metadata } => {
+                self.peer_metadata_by_id.insert(*peer_id, metadata.clone());
+            }
         }
     }
 

--- a/lib/storage/src/content_manager/consensus_state_machine/state/apply.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/state/apply.rs
@@ -102,6 +102,10 @@ impl ClusterState {
                     self.cluster_metadata.insert(key.clone(), value.clone());
                 }
             }
+
+            Action::SetQuotaConfig { config } => {
+                self.quota_config = Some(*config);
+            }
         }
     }
 

--- a/lib/storage/src/content_manager/consensus_state_machine/state/apply.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/state/apply.rs
@@ -70,6 +70,26 @@ impl ClusterState {
 
                 state.payload_index_schema.schema.remove(field_name);
             }
+
+            Action::SetAlias { alias, collection } => {
+                self.aliases.insert(alias.clone(), collection.clone());
+            }
+
+            Action::DeleteAlias { alias } => {
+                self.aliases.remove(alias);
+            }
+
+            Action::RenameAlias {
+                old_alias,
+                new_alias,
+            } => {
+                let renamed = self.aliases.rename(old_alias, new_alias.clone());
+
+                debug_assert!(
+                    renamed,
+                    "action renames alias {old_alias}, which is not in the state",
+                );
+            }
         }
     }
 

--- a/lib/storage/src/content_manager/consensus_state_machine/state/apply.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/state/apply.rs
@@ -94,6 +94,14 @@ impl ClusterState {
             Action::SetPeerMetadata { peer_id, metadata } => {
                 self.peer_metadata_by_id.insert(*peer_id, metadata.clone());
             }
+
+            Action::SetClusterMetadataKey { key, value } => {
+                if value.is_null() {
+                    self.cluster_metadata.remove(key);
+                } else {
+                    self.cluster_metadata.insert(key.clone(), value.clone());
+                }
+            }
         }
     }
 

--- a/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
@@ -193,4 +193,10 @@ impl ClusterState {
             value: value.clone(),
         }]
     }
+
+    /// Emitted even when the config matches: `QuotaManager::set_config` also drops the limit
+    /// verdicts it recorded, so an operator raising a limit is served right away
+    pub fn plan_set_quota_config(&self, config: &QuotaConfig) -> Actions {
+        vec![Action::SetQuotaConfig { config: *config }]
+    }
 }

--- a/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
@@ -53,6 +53,82 @@ impl ClusterState {
         }])
     }
 
+    /// Plan alias actions in order, each one reading what the actions before it did.
+    ///
+    /// `TableOfContent::update_aliases` validates and saves one action at a time, so an action
+    /// rejected in the middle keeps the ones before it. Here the whole operation is validated
+    /// first, and a rejected operation changes nothing.
+    pub fn plan_change_aliases(&self, op: &ChangeAliasesOperation) -> StorageResult<Actions> {
+        let ChangeAliasesOperation { actions } = op;
+
+        let mut aliases = self.aliases.clone();
+        let mut planned = Actions::new();
+
+        for action in actions {
+            match action {
+                AliasOperations::CreateAlias(action) => {
+                    let CreateAlias {
+                        collection_name,
+                        alias_name,
+                    } = &action.create_alias;
+
+                    // Collection has to exist under this name: an alias of an alias is rejected
+                    if !self.has_collection(collection_name) {
+                        return Err(StorageError::not_found(format!(
+                            "Collection `{collection_name}` doesn't exist!"
+                        )));
+                    }
+
+                    if self.has_collection(alias_name) {
+                        return Err(StorageError::already_exists(format!(
+                            "Collection `{alias_name}` already exists!"
+                        )));
+                    }
+
+                    aliases.insert(alias_name.clone(), collection_name.clone());
+
+                    planned.push(Action::SetAlias {
+                        alias: alias_name.clone(),
+                        collection: collection_name.clone(),
+                    });
+                }
+
+                AliasOperations::DeleteAlias(action) => {
+                    let DeleteAlias { alias_name } = &action.delete_alias;
+
+                    // Deleting an alias that does not exist is a no-op, not an error
+                    aliases.remove(alias_name);
+
+                    planned.push(Action::DeleteAlias {
+                        alias: alias_name.clone(),
+                    });
+                }
+
+                AliasOperations::RenameAlias(action) => {
+                    let RenameAlias {
+                        old_alias_name,
+                        new_alias_name,
+                    } = &action.rename_alias;
+
+                    // Rename reads the alias it removes, so a replay of an operation whose rename
+                    // landed is rejected, and the actions after the rename never apply
+                    if !aliases.rename(old_alias_name, new_alias_name.clone()) {
+                        return Err(StorageError::not_found(format!(
+                            "Alias {old_alias_name} does not exists!"
+                        )));
+                    }
+
+                    planned.push(Action::RenameAlias {
+                        old_alias: old_alias_name.clone(),
+                        new_alias: new_alias_name.clone(),
+                    });
+                }
+            }
+        }
+
+        Ok(planned)
+    }
+
     pub fn plan_create_payload_index(&self, op: &CreatePayloadIndex) -> StorageResult<Actions> {
         let CreatePayloadIndex {
             collection_name,

--- a/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
@@ -173,4 +173,24 @@ impl ClusterState {
             metadata: metadata.clone(),
         }]
     }
+
+    /// Null value removes the key, so the goal state is reached when the key is gone.
+    /// Nothing to validate: any key can hold any value.
+    pub fn plan_update_cluster_metadata(&self, key: &str, value: &serde_json::Value) -> Actions {
+        let current = self.cluster_metadata.get(key);
+
+        let applied = match value.is_null() {
+            true => current.is_none(),
+            false => current == Some(value),
+        };
+
+        if applied {
+            return Actions::new();
+        }
+
+        vec![Action::SetClusterMetadataKey {
+            key: key.to_string(),
+            value: value.clone(),
+        }]
+    }
 }

--- a/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
@@ -1,4 +1,6 @@
 use collection::collection::vector_name_schema;
+use collection::operations::types::PeerMetadata;
+use collection::shards::shard::PeerId;
 
 use super::*;
 use crate::content_manager::collection_meta_ops::*;
@@ -157,5 +159,18 @@ impl ClusterState {
             collection,
             field_name: field_name.clone(),
         }])
+    }
+
+    /// Metadata is an absolute value, so a peer that already has it needs no action.
+    /// Nothing to validate: any peer can report any metadata.
+    pub fn plan_update_peer_metadata(&self, peer_id: PeerId, metadata: &PeerMetadata) -> Actions {
+        if self.peer_metadata_by_id.get(&peer_id) == Some(metadata) {
+            return Actions::new();
+        }
+
+        vec![Action::SetPeerMetadata {
+            peer_id,
+            metadata: metadata.clone(),
+        }]
     }
 }

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/ops.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/ops.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use collection::operations::types::PeerMetadata;
 use segment::data_types::vector_name_config::*;
 use segment::types::*;
+use serde_json::{Value, json};
 
 use super::*;
 use crate::content_manager::collection_meta_ops::*;
@@ -589,6 +590,93 @@ fn update_peer_metadata_replay() {
 }
 
 #[test]
+fn update_cluster_metadata() {
+    let mut machine = state_machine(ClusterState::default());
+    let outcome = machine.apply(&update_cluster_metadata_op("region", json!("eu")));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("a new metadata key should be accepted, got {outcome:?}");
+    };
+
+    assert!(matches!(
+        actions.as_slice(),
+        [Action::SetClusterMetadataKey { .. }],
+    ));
+
+    assert_eq!(
+        machine.state().cluster_metadata.get("region"),
+        Some(&json!("eu")),
+    );
+}
+
+#[test]
+fn update_cluster_metadata_replace() {
+    let mut machine = state_machine(cluster_metadata_state("region", json!("eu")));
+    let outcome = machine.apply(&update_cluster_metadata_op("region", json!("us")));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("another value for a key should be accepted, got {outcome:?}");
+    };
+
+    assert!(matches!(
+        actions.as_slice(),
+        [Action::SetClusterMetadataKey { .. }],
+    ));
+
+    assert_eq!(
+        machine.state().cluster_metadata.get("region"),
+        Some(&json!("us")),
+    );
+}
+
+#[test]
+fn update_cluster_metadata_replay() {
+    let state = cluster_metadata_state("region", json!("eu"));
+
+    let mut machine = state_machine(state.clone());
+    let outcome = machine.apply(&update_cluster_metadata_op("region", json!("eu")));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("replay of an applied key should be accepted, got {outcome:?}");
+    };
+
+    assert!(actions.is_empty());
+    assert_eq!(machine.state(), &state);
+}
+
+#[test]
+fn update_cluster_metadata_remove() {
+    let mut machine = state_machine(cluster_metadata_state("region", json!("eu")));
+    let outcome = machine.apply(&update_cluster_metadata_op("region", Value::Null));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("a null value should be accepted, got {outcome:?}");
+    };
+
+    assert!(matches!(
+        actions.as_slice(),
+        [Action::SetClusterMetadataKey { .. }],
+    ));
+
+    assert!(machine.state().cluster_metadata.get("region").is_none());
+}
+
+#[test]
+fn update_cluster_metadata_remove_missing() {
+    let state = ClusterState::default();
+
+    let mut machine = state_machine(state.clone());
+    let outcome = machine.apply(&update_cluster_metadata_op("region", Value::Null));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("removing a key that does not exist should be accepted, got {outcome:?}");
+    };
+
+    assert!(actions.is_empty());
+    assert_eq!(machine.state(), &state);
+}
+
+#[test]
 fn reject_missing_collection() {
     let mut machine = state_machine(ClusterState::default());
     let outcome = machine.apply(&create_named_vector_op("text", dense(4, Distance::Cosine)));
@@ -782,6 +870,20 @@ fn update_peer_metadata_op(peer_id: PeerId, version: &str) -> ConsensusOperation
 
 fn peer_metadata(version: &str) -> PeerMetadata {
     PeerMetadata::new(version.parse().expect("valid version"))
+}
+
+fn cluster_metadata_state(key: &str, value: Value) -> ClusterState {
+    ClusterState {
+        cluster_metadata: HashMap::from([(key.into(), value)]),
+        ..Default::default()
+    }
+}
+
+fn update_cluster_metadata_op(key: &str, value: Value) -> ConsensusOperations {
+    ConsensusOperations::UpdateClusterMetadata {
+        key: key.into(),
+        value,
+    }
 }
 
 fn field_name(field: &str) -> PayloadKeyType {

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/ops.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/ops.rs
@@ -32,6 +32,217 @@ fn nop() {
 }
 
 #[test]
+fn create_alias() {
+    let state = cluster_state(Vec::new());
+
+    let mut machine = state_machine(state);
+    let outcome = machine.apply(&change_aliases_op(vec![create_alias_action(
+        "alias", COLLECTION,
+    )]));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("creating an alias should be accepted, got {outcome:?}");
+    };
+
+    assert!(matches!(actions.as_slice(), [Action::SetAlias { .. }]));
+
+    let aliases = &machine.state().aliases;
+
+    assert_eq!(aliases.get("alias").map(String::as_str), Some(COLLECTION));
+}
+
+#[test]
+fn create_alias_replay() {
+    let mut state = cluster_state(Vec::new());
+    state.aliases.insert("alias".into(), COLLECTION.into());
+
+    let mut machine = state_machine(state.clone());
+    let outcome = machine.apply(&change_aliases_op(vec![create_alias_action(
+        "alias", COLLECTION,
+    )]));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("replay of an applied alias should be accepted, got {outcome:?}");
+    };
+
+    assert!(matches!(actions.as_slice(), [Action::SetAlias { .. }]));
+
+    assert_eq!(machine.state(), &state, "replay should not change anything");
+}
+
+#[test]
+fn create_alias_reject_missing_collection() {
+    let state = cluster_state(Vec::new());
+
+    let mut machine = state_machine(state.clone());
+    let outcome = machine.apply(&change_aliases_op(vec![create_alias_action(
+        "alias", "missing",
+    )]));
+
+    assert!(matches!(
+        outcome,
+        ApplyOutcome::Rejected(StorageError::NotFound { .. })
+    ));
+
+    assert_eq!(machine.state(), &state);
+}
+
+#[test]
+fn create_alias_reject_alias_target() {
+    let mut state = cluster_state(Vec::new());
+    state.aliases.insert("alias".into(), COLLECTION.into());
+
+    let mut machine = state_machine(state.clone());
+    let outcome = machine.apply(&change_aliases_op(vec![create_alias_action(
+        "other", "alias",
+    )]));
+
+    // An alias of an alias is rejected: the target is not resolved
+    assert!(matches!(
+        outcome,
+        ApplyOutcome::Rejected(StorageError::NotFound { .. })
+    ));
+
+    assert_eq!(machine.state(), &state);
+}
+
+#[test]
+fn create_alias_reject_collection_name() {
+    let state = cluster_state(Vec::new());
+
+    let mut machine = state_machine(state.clone());
+    let outcome = machine.apply(&change_aliases_op(vec![create_alias_action(
+        COLLECTION, COLLECTION,
+    )]));
+
+    assert!(matches!(
+        outcome,
+        ApplyOutcome::Rejected(StorageError::AlreadyExists { .. })
+    ));
+
+    assert_eq!(machine.state(), &state);
+}
+
+#[test]
+fn delete_alias() {
+    let mut state = cluster_state(Vec::new());
+    state.aliases.insert("alias".into(), COLLECTION.into());
+
+    let mut machine = state_machine(state);
+    let outcome = machine.apply(&change_aliases_op(vec![delete_alias_action("alias")]));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("deleting an alias should be accepted, got {outcome:?}");
+    };
+
+    assert!(matches!(actions.as_slice(), [Action::DeleteAlias { .. }]));
+
+    assert!(machine.state().aliases.get("alias").is_none());
+}
+
+#[test]
+fn delete_alias_missing() {
+    let state = cluster_state(Vec::new());
+
+    let mut machine = state_machine(state.clone());
+    let outcome = machine.apply(&change_aliases_op(vec![delete_alias_action("alias")]));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("deleting an alias that does not exist should be accepted, got {outcome:?}");
+    };
+
+    // Action is emitted even if state already matches
+    assert!(matches!(actions.as_slice(), [Action::DeleteAlias { .. }]));
+
+    assert_eq!(machine.state(), &state);
+}
+
+#[test]
+fn rename_alias() {
+    let mut state = cluster_state(Vec::new());
+    state.aliases.insert("alias".into(), COLLECTION.into());
+
+    let mut machine = state_machine(state);
+    let outcome = machine.apply(&change_aliases_op(vec![rename_alias_action(
+        "alias", "other",
+    )]));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("renaming an alias should be accepted, got {outcome:?}");
+    };
+
+    assert!(matches!(actions.as_slice(), [Action::RenameAlias { .. }]));
+
+    let aliases = &machine.state().aliases;
+
+    assert!(aliases.get("alias").is_none());
+    assert_eq!(aliases.get("other").map(String::as_str), Some(COLLECTION));
+}
+
+#[test]
+fn rename_alias_reject_missing() {
+    let state = cluster_state(Vec::new());
+
+    let mut machine = state_machine(state.clone());
+    let outcome = machine.apply(&change_aliases_op(vec![rename_alias_action(
+        "alias", "other",
+    )]));
+
+    assert!(matches!(
+        outcome,
+        ApplyOutcome::Rejected(StorageError::NotFound { .. })
+    ));
+
+    assert_eq!(machine.state(), &state);
+}
+
+#[test]
+fn change_aliases_in_order() {
+    let state = cluster_state(Vec::new());
+
+    let mut machine = state_machine(state);
+    let outcome = machine.apply(&change_aliases_op(vec![
+        create_alias_action("alias", COLLECTION),
+        rename_alias_action("alias", "other"),
+    ]));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("renaming an alias the operation just created should be accepted, got {outcome:?}");
+    };
+
+    assert!(matches!(
+        actions.as_slice(),
+        [Action::SetAlias { .. }, Action::RenameAlias { .. }],
+    ));
+
+    let aliases = &machine.state().aliases;
+
+    assert!(aliases.get("alias").is_none());
+    assert_eq!(aliases.get("other").map(String::as_str), Some(COLLECTION));
+}
+
+#[test]
+fn change_aliases_reject_whole_operation() {
+    let mut state = cluster_state(Vec::new());
+    state.aliases.insert("alias".into(), COLLECTION.into());
+
+    let mut machine = state_machine(state.clone());
+    let outcome = machine.apply(&change_aliases_op(vec![
+        delete_alias_action("alias"),
+        create_alias_action("other", "missing"),
+    ]));
+
+    assert!(matches!(
+        outcome,
+        ApplyOutcome::Rejected(StorageError::NotFound { .. })
+    ));
+
+    // `TableOfContent::update_aliases` saves each action as it goes,
+    // so it drops the alias and rejects the operation after that
+    assert_eq!(machine.state(), &state);
+}
+
+#[test]
 fn create_named_vector_dense() {
     let machine = create_named_vector_impl(dense(4, Distance::Cosine));
 
@@ -409,6 +620,35 @@ fn cluster_state_with_index(field: &str, field_type: PayloadSchemaType) -> Clust
 
 fn collection_meta_op(op: CollectionMetaOperations) -> ConsensusOperations {
     ConsensusOperations::CollectionMeta(Box::new(op))
+}
+
+fn change_aliases_op(actions: Vec<AliasOperations>) -> ConsensusOperations {
+    collection_meta_op(CollectionMetaOperations::ChangeAliases(
+        ChangeAliasesOperation { actions },
+    ))
+}
+
+fn create_alias_action(alias: &str, collection: &str) -> AliasOperations {
+    CreateAlias {
+        collection_name: collection.into(),
+        alias_name: alias.into(),
+    }
+    .into()
+}
+
+fn delete_alias_action(alias: &str) -> AliasOperations {
+    DeleteAlias {
+        alias_name: alias.into(),
+    }
+    .into()
+}
+
+fn rename_alias_action(old_alias: &str, new_alias: &str) -> AliasOperations {
+    RenameAlias {
+        old_alias_name: old_alias.into(),
+        new_alias_name: new_alias.into(),
+    }
+    .into()
 }
 
 fn create_named_vector_op(vector_name: &str, config: VectorNameConfig) -> ConsensusOperations {

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/ops.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/ops.rs
@@ -13,6 +13,7 @@ use crate::content_manager::collection_meta_ops::*;
 use crate::content_manager::consensus_ops::ConsensusOperations;
 use crate::content_manager::consensus_state_machine::*;
 use crate::content_manager::errors::StorageError;
+use crate::quota::QuotaConfig;
 
 const COLLECTION: &str = "alpha";
 
@@ -677,6 +678,68 @@ fn update_cluster_metadata_remove_missing() {
 }
 
 #[test]
+fn set_quota_config() {
+    let mut machine = state_machine(ClusterState::default());
+    let outcome = machine.apply(&ConsensusOperations::SetQuotaConfig(quota_config(true)));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("a quota config should be accepted, got {outcome:?}");
+    };
+
+    assert!(matches!(
+        actions.as_slice(),
+        [Action::SetQuotaConfig { .. }],
+    ));
+
+    assert_eq!(machine.state().quota_config, Some(quota_config(true)));
+}
+
+#[test]
+fn set_quota_config_replace() {
+    let state = ClusterState {
+        quota_config: Some(quota_config(true)),
+        ..Default::default()
+    };
+
+    let mut machine = state_machine(state);
+    let outcome = machine.apply(&ConsensusOperations::SetQuotaConfig(quota_config(false)));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("another quota config should be accepted, got {outcome:?}");
+    };
+
+    assert!(matches!(
+        actions.as_slice(),
+        [Action::SetQuotaConfig { .. }],
+    ));
+
+    assert_eq!(machine.state().quota_config, Some(quota_config(false)));
+}
+
+#[test]
+fn set_quota_config_replay() {
+    let state = ClusterState {
+        quota_config: Some(quota_config(true)),
+        ..Default::default()
+    };
+
+    let mut machine = state_machine(state.clone());
+    let outcome = machine.apply(&ConsensusOperations::SetQuotaConfig(quota_config(true)));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("replay of an applied quota config should be accepted, got {outcome:?}");
+    };
+
+    // Action is emitted even if state already matches: applying it also drops recorded verdicts
+    assert!(matches!(
+        actions.as_slice(),
+        [Action::SetQuotaConfig { .. }],
+    ));
+
+    assert_eq!(machine.state(), &state);
+}
+
+#[test]
 fn reject_missing_collection() {
     let mut machine = state_machine(ClusterState::default());
     let outcome = machine.apply(&create_named_vector_op("text", dense(4, Distance::Cosine)));
@@ -883,6 +946,15 @@ fn update_cluster_metadata_op(key: &str, value: Value) -> ConsensusOperations {
     ConsensusOperations::UpdateClusterMetadata {
         key: key.into(),
         value,
+    }
+}
+
+fn quota_config(enabled: bool) -> QuotaConfig {
+    QuotaConfig {
+        enabled,
+        max_resident_memory_percent: None,
+        max_disk_usage_percent: None,
+        release_margin_percent: None,
     }
 }
 

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/ops.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/ops.rs
@@ -739,6 +739,43 @@ fn set_quota_config_replay() {
     assert_eq!(machine.state(), &state);
 }
 
+#[cfg(feature = "staging")]
+#[test]
+fn test_slow_down() {
+    let operation = CollectionMetaOperations::TestSlowDown(TestSlowDown {
+        peer_id: Some(PEER_ID),
+        duration_ms: 10,
+    });
+
+    staging_operation_changes_nothing(operation);
+}
+
+#[cfg(feature = "staging")]
+#[test]
+fn test_transient_error() {
+    let operation = CollectionMetaOperations::TestTransientError(TestTransientError {
+        peer_id: Some(PEER_ID),
+        failure_probability_percent: 100,
+    });
+
+    staging_operation_changes_nothing(operation);
+}
+
+#[cfg(feature = "staging")]
+fn staging_operation_changes_nothing(operation: CollectionMetaOperations) {
+    let state = cluster_state(Vec::new());
+
+    let mut machine = state_machine(state.clone());
+    let outcome = machine.apply(&collection_meta_op(operation));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("a staging operation should be accepted, got {outcome:?}");
+    };
+
+    assert!(actions.is_empty());
+    assert_eq!(machine.state(), &state);
+}
+
 #[test]
 fn reject_missing_collection() {
     let mut machine = state_machine(ClusterState::default());

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/ops.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/ops.rs
@@ -659,7 +659,7 @@ fn update_cluster_metadata_remove() {
         [Action::SetClusterMetadataKey { .. }],
     ));
 
-    assert!(machine.state().cluster_metadata.get("region").is_none());
+    assert!(!machine.state().cluster_metadata.contains_key("region"));
 }
 
 #[test]

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/ops.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/ops.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 
+use collection::operations::types::PeerMetadata;
 use segment::data_types::vector_name_config::*;
 use segment::types::*;
 
@@ -521,6 +522,73 @@ fn drop_payload_index_missing() {
 }
 
 #[test]
+fn update_peer_metadata() {
+    let mut machine = state_machine(ClusterState::default());
+    let outcome = machine.apply(&update_peer_metadata_op(PEER_ID, "1.15.0"));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("metadata of a peer without any should be accepted, got {outcome:?}");
+    };
+
+    assert!(matches!(
+        actions.as_slice(),
+        [Action::SetPeerMetadata { .. }],
+    ));
+
+    assert_eq!(
+        machine.state().peer_metadata_by_id.get(&PEER_ID),
+        Some(&peer_metadata("1.15.0")),
+    );
+}
+
+#[test]
+fn update_peer_metadata_replace() {
+    let mut state = ClusterState::default();
+
+    state
+        .peer_metadata_by_id
+        .insert(PEER_ID, peer_metadata("1.14.0"));
+
+    let mut machine = state_machine(state);
+    let outcome = machine.apply(&update_peer_metadata_op(PEER_ID, "1.15.0"));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("a peer reporting a new version should be accepted, got {outcome:?}");
+    };
+
+    assert!(matches!(
+        actions.as_slice(),
+        [Action::SetPeerMetadata { .. }],
+    ));
+
+    assert_eq!(
+        machine.state().peer_metadata_by_id.get(&PEER_ID),
+        Some(&peer_metadata("1.15.0")),
+    );
+}
+
+#[test]
+fn update_peer_metadata_replay() {
+    let mut state = ClusterState::default();
+
+    state
+        .peer_metadata_by_id
+        .insert(PEER_ID, peer_metadata("1.15.0"));
+
+    let mut machine = state_machine(state.clone());
+    let outcome = machine.apply(&update_peer_metadata_op(PEER_ID, "1.15.0"));
+
+    let ApplyOutcome::Accepted(actions) = outcome else {
+        panic!("replay of applied metadata should be accepted, got {outcome:?}");
+    };
+
+    // Nothing left to do: metadata is absolute and the applier only writes it
+    assert!(actions.is_empty());
+
+    assert_eq!(machine.state(), &state);
+}
+
+#[test]
 fn reject_missing_collection() {
     let mut machine = state_machine(ClusterState::default());
     let outcome = machine.apply(&create_named_vector_op("text", dense(4, Distance::Cosine)));
@@ -703,6 +771,17 @@ fn drop_payload_index_op(field: &str) -> ConsensusOperations {
             field_name: field_name(field),
         },
     ))
+}
+
+fn update_peer_metadata_op(peer_id: PeerId, version: &str) -> ConsensusOperations {
+    ConsensusOperations::UpdatePeerMetadata {
+        peer_id,
+        metadata: peer_metadata(version),
+    }
+}
+
+fn peer_metadata(version: &str) -> PeerMetadata {
+    PeerMetadata::new(version.parse().expect("valid version"))
 }
 
 fn field_name(field: &str) -> PayloadKeyType {

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/prop.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/prop.rs
@@ -1,6 +1,7 @@
 //! Proptest generators for cluster state and consensus operations
 
 use collection::collection_state;
+use collection::operations::types::PeerMetadata;
 use collection::shards::CollectionId;
 use proptest::prelude::*;
 use segment::data_types::modifier::Modifier;
@@ -13,6 +14,7 @@ use crate::content_manager::alias_mapping::AliasMapping;
 use crate::content_manager::collection_meta_ops::*;
 use crate::content_manager::consensus_ops::ConsensusOperations;
 use crate::content_manager::consensus_state_machine::*;
+use crate::types::PeerMetadataById;
 
 const COLLECTION_NAMES: &[&str] = &["alpha", "beta", "gamma"];
 const MISSING_COLLECTION_NAME: &str = "missing";
@@ -22,6 +24,10 @@ const DANGLING_ALIAS_NAME: &str = "dangling";
 
 const VECTOR_NAMES: &[&str] = &["", "text", "image"];
 const FIELD_NAMES: &[&str] = &["city", "count", "nested.key"];
+
+/// This node, and one other peer
+const PEER_IDS: &[PeerId] = &[PEER_ID, 43];
+const PEER_VERSIONS: &[&str] = &["1.14.0", "1.15.0"];
 
 pub fn arb_state_and_operation() -> impl Strategy<Value = (ClusterState, ConsensusOperations)> {
     arb_cluster_state().prop_flat_map(|state| {
@@ -45,12 +51,31 @@ pub fn arb_cluster_state() -> impl Strategy<Value = ClusterState> {
     collections.prop_flat_map(|collections| {
         let names = collections.keys().cloned().collect();
 
-        (Just(collections), arb_aliases(names)).prop_map(|(collections, aliases)| ClusterState {
-            collections,
-            aliases,
-            ..Default::default()
-        })
+        (
+            Just(collections),
+            arb_aliases(names),
+            arb_peer_metadata_by_id(),
+        )
+            .prop_map(|(collections, aliases, peer_metadata_by_id)| ClusterState {
+                collections,
+                aliases,
+                peer_metadata_by_id,
+                ..Default::default()
+            })
     })
+}
+
+fn arb_peer_metadata_by_id() -> impl Strategy<Value = PeerMetadataById> {
+    proptest::collection::hash_map(arb_peer_id(), arb_peer_metadata(), 0..3)
+}
+
+fn arb_peer_id() -> impl Strategy<Value = PeerId> {
+    proptest::sample::select(PEER_IDS)
+}
+
+fn arb_peer_metadata() -> impl Strategy<Value = PeerMetadata> {
+    proptest::sample::select(PEER_VERSIONS)
+        .prop_map(|version| PeerMetadata::new(version.parse().expect("valid version")))
 }
 
 fn arb_collection_state() -> impl Strategy<Value = collection_state::State> {
@@ -92,8 +117,18 @@ fn arb_aliases(collections: Vec<CollectionId>) -> impl Strategy<Value = AliasMap
 }
 
 pub fn arb_consensus_operation(
-    mut collection_names: Vec<String>,
+    collection_names: Vec<String>,
 ) -> impl Strategy<Value = ConsensusOperations> {
+    let collection_meta = arb_collection_meta_operation(collection_names)
+        .prop_map(|operation| ConsensusOperations::CollectionMeta(Box::new(operation)));
+
+    // Weighted by how many operations each arm covers, so one operation is as likely as another
+    prop_oneof![6 => collection_meta, 1 => arb_update_peer_metadata()]
+}
+
+fn arb_collection_meta_operation(
+    mut collection_names: Vec<String>,
+) -> impl Strategy<Value = CollectionMetaOperations> {
     collection_names.push(MISSING_COLLECTION_NAME.into());
 
     prop_oneof![
@@ -104,7 +139,12 @@ pub fn arb_consensus_operation(
         arb_create_payload_index(collection_names.clone()),
         arb_drop_payload_index(collection_names.clone()),
     ]
-    .prop_map(|operation| ConsensusOperations::CollectionMeta(Box::new(operation)))
+}
+
+fn arb_update_peer_metadata() -> impl Strategy<Value = ConsensusOperations> {
+    (arb_peer_id(), arb_peer_metadata()).prop_map(|(peer_id, metadata)| {
+        ConsensusOperations::UpdatePeerMetadata { peer_id, metadata }
+    })
 }
 
 fn arb_collection_name(names: Vec<String>) -> impl Strategy<Value = String> {

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/prop.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/prop.rs
@@ -16,6 +16,7 @@ use crate::content_manager::alias_mapping::AliasMapping;
 use crate::content_manager::collection_meta_ops::*;
 use crate::content_manager::consensus_ops::ConsensusOperations;
 use crate::content_manager::consensus_state_machine::*;
+use crate::quota::QuotaConfig;
 use crate::types::PeerMetadataById;
 
 const COLLECTION_NAMES: &[&str] = &["alpha", "beta", "gamma"];
@@ -60,14 +61,18 @@ pub fn arb_cluster_state() -> impl Strategy<Value = ClusterState> {
             arb_aliases(names),
             arb_peer_metadata_by_id(),
             arb_cluster_metadata(),
+            proptest::option::of(arb_quota_config()),
         )
             .prop_map(
-                |(collections, aliases, peer_metadata_by_id, cluster_metadata)| ClusterState {
-                    collections,
-                    aliases,
-                    peer_metadata_by_id,
-                    cluster_metadata,
-                    ..Default::default()
+                |(collections, aliases, peer_metadata_by_id, cluster_metadata, quota_config)| {
+                    ClusterState {
+                        collections,
+                        aliases,
+                        peer_metadata_by_id,
+                        cluster_metadata,
+                        quota_config,
+                        ..Default::default()
+                    }
                 },
             )
     })
@@ -101,6 +106,21 @@ fn arb_metadata_value() -> impl Strategy<Value = serde_json::Value> {
         Just(serde_json::json!(2)),
         Just(serde_json::json!(true)),
     ]
+}
+
+/// Quota config varying two of its fields: no covered operation reads any of them
+fn arb_quota_config() -> impl Strategy<Value = QuotaConfig> {
+    let enabled = proptest::bool::ANY;
+    let max_resident_memory_percent = proptest::option::of(Just(90));
+
+    (enabled, max_resident_memory_percent).prop_map(|(enabled, max_resident_memory_percent)| {
+        QuotaConfig {
+            enabled,
+            max_resident_memory_percent,
+            max_disk_usage_percent: None,
+            release_margin_percent: None,
+        }
+    })
 }
 
 fn arb_collection_state() -> impl Strategy<Value = collection_state::State> {
@@ -152,6 +172,7 @@ pub fn arb_consensus_operation(
         6 => collection_meta,
         1 => arb_update_peer_metadata(),
         1 => arb_update_cluster_metadata(),
+        1 => arb_quota_config().prop_map(ConsensusOperations::SetQuotaConfig),
     ]
 }
 

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/prop.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/prop.rs
@@ -66,9 +66,9 @@ pub fn arb_cluster_state() -> impl Strategy<Value = ClusterState> {
             .prop_map(
                 |(collections, aliases, peer_metadata_by_id, cluster_metadata, quota_config)| {
                     ClusterState {
+                        peer_metadata_by_id,
                         collections,
                         aliases,
-                        peer_metadata_by_id,
                         cluster_metadata,
                         quota_config,
                         ..Default::default()

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/prop.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/prop.rs
@@ -98,6 +98,7 @@ pub fn arb_consensus_operation(
 
     prop_oneof![
         Just(CollectionMetaOperations::Nop { token: 0 }),
+        arb_change_aliases(collection_names.clone()),
         arb_create_named_vector(collection_names.clone()),
         arb_delete_named_vector(collection_names.clone()),
         arb_create_payload_index(collection_names.clone()),
@@ -108,6 +109,49 @@ pub fn arb_consensus_operation(
 
 fn arb_collection_name(names: Vec<String>) -> impl Strategy<Value = String> {
     proptest::sample::select(names)
+}
+
+fn arb_change_aliases(collections: Vec<String>) -> impl Strategy<Value = CollectionMetaOperations> {
+    let actions = proptest::collection::vec(arb_alias_operation(collections), 1..3);
+
+    actions.prop_map(|actions| {
+        CollectionMetaOperations::ChangeAliases(ChangeAliasesOperation { actions })
+    })
+}
+
+fn arb_alias_operation(collections: Vec<String>) -> impl Strategy<Value = AliasOperations> {
+    let create = (arb_alias_name(), arb_collection_name(collections)).prop_map(
+        |(alias_name, collection_name)| {
+            CreateAlias {
+                collection_name,
+                alias_name,
+            }
+            .into()
+        },
+    );
+
+    let delete = arb_alias_name().prop_map(|alias_name| DeleteAlias { alias_name }.into());
+
+    let rename =
+        (arb_alias_name(), arb_alias_name()).prop_map(|(old_alias_name, new_alias_name)| {
+            RenameAlias {
+                old_alias_name,
+                new_alias_name,
+            }
+            .into()
+        });
+
+    prop_oneof![create, delete, rename]
+}
+
+fn arb_alias_name() -> impl Strategy<Value = String> {
+    let names: Vec<_> = ALIAS_NAMES
+        .iter()
+        .chain([&DANGLING_ALIAS_NAME])
+        .copied()
+        .collect();
+
+    proptest::sample::select(names).prop_map(String::from)
 }
 
 fn arb_create_named_vector(

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/prop.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/prop.rs
@@ -1,5 +1,7 @@
 //! Proptest generators for cluster state and consensus operations
 
+use std::collections::HashMap;
+
 use collection::collection_state;
 use collection::operations::types::PeerMetadata;
 use collection::shards::CollectionId;
@@ -29,6 +31,8 @@ const FIELD_NAMES: &[&str] = &["city", "count", "nested.key"];
 const PEER_IDS: &[PeerId] = &[PEER_ID, 43];
 const PEER_VERSIONS: &[&str] = &["1.14.0", "1.15.0"];
 
+const METADATA_KEYS: &[&str] = &["region", "tier"];
+
 pub fn arb_state_and_operation() -> impl Strategy<Value = (ClusterState, ConsensusOperations)> {
     arb_cluster_state().prop_flat_map(|state| {
         let collections = state.collections.keys().cloned();
@@ -55,13 +59,17 @@ pub fn arb_cluster_state() -> impl Strategy<Value = ClusterState> {
             Just(collections),
             arb_aliases(names),
             arb_peer_metadata_by_id(),
+            arb_cluster_metadata(),
         )
-            .prop_map(|(collections, aliases, peer_metadata_by_id)| ClusterState {
-                collections,
-                aliases,
-                peer_metadata_by_id,
-                ..Default::default()
-            })
+            .prop_map(
+                |(collections, aliases, peer_metadata_by_id, cluster_metadata)| ClusterState {
+                    collections,
+                    aliases,
+                    peer_metadata_by_id,
+                    cluster_metadata,
+                    ..Default::default()
+                },
+            )
     })
 }
 
@@ -76,6 +84,23 @@ fn arb_peer_id() -> impl Strategy<Value = PeerId> {
 fn arb_peer_metadata() -> impl Strategy<Value = PeerMetadata> {
     proptest::sample::select(PEER_VERSIONS)
         .prop_map(|version| PeerMetadata::new(version.parse().expect("valid version")))
+}
+
+/// Cluster metadata never holds a null value: that is how a key is removed
+fn arb_cluster_metadata() -> impl Strategy<Value = HashMap<String, serde_json::Value>> {
+    proptest::collection::hash_map(arb_metadata_key(), arb_metadata_value(), 0..2)
+}
+
+fn arb_metadata_key() -> impl Strategy<Value = String> {
+    proptest::sample::select(METADATA_KEYS).prop_map(String::from)
+}
+
+fn arb_metadata_value() -> impl Strategy<Value = serde_json::Value> {
+    prop_oneof![
+        Just(serde_json::json!("eu")),
+        Just(serde_json::json!(2)),
+        Just(serde_json::json!(true)),
+    ]
 }
 
 fn arb_collection_state() -> impl Strategy<Value = collection_state::State> {
@@ -123,7 +148,11 @@ pub fn arb_consensus_operation(
         .prop_map(|operation| ConsensusOperations::CollectionMeta(Box::new(operation)));
 
     // Weighted by how many operations each arm covers, so one operation is as likely as another
-    prop_oneof![6 => collection_meta, 1 => arb_update_peer_metadata()]
+    prop_oneof![
+        6 => collection_meta,
+        1 => arb_update_peer_metadata(),
+        1 => arb_update_cluster_metadata(),
+    ]
 }
 
 fn arb_collection_meta_operation(
@@ -145,6 +174,13 @@ fn arb_update_peer_metadata() -> impl Strategy<Value = ConsensusOperations> {
     (arb_peer_id(), arb_peer_metadata()).prop_map(|(peer_id, metadata)| {
         ConsensusOperations::UpdatePeerMetadata { peer_id, metadata }
     })
+}
+
+fn arb_update_cluster_metadata() -> impl Strategy<Value = ConsensusOperations> {
+    let value = prop_oneof![arb_metadata_value(), Just(serde_json::Value::Null)];
+
+    (arb_metadata_key(), value)
+        .prop_map(|(key, value)| ConsensusOperations::UpdateClusterMetadata { key, value })
 }
 
 fn arb_collection_name(names: Vec<String>) -> impl Strategy<Value = String> {

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/replay.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/replay.rs
@@ -4,6 +4,7 @@ use proptest::prelude::*;
 
 use super::prop::*;
 use super::*;
+use crate::content_manager::collection_meta_ops::{AliasOperations, ChangeAliasesOperation};
 
 proptest! {
     /// Accepted operation changes the state only through its own actions.
@@ -65,6 +66,10 @@ proptest! {
     /// complete. Rejecting any earlier would make the partial state permanent.
     #[test]
     fn replay_after_crash_converges((state, operation) in arb_state_and_operation()) {
+        if replay_may_diverge(&operation) {
+            return Ok(());
+        }
+
         let mut uncrashed = state_machine(state.clone());
 
         let ApplyOutcome::Accepted(actions) = uncrashed.apply(&operation) else {
@@ -116,4 +121,27 @@ proptest! {
 /// Apply `operation` without modifying `state`
 fn apply(state: &ClusterState, operation: &ConsensusOperations) -> ApplyOutcome {
     state_machine(state.clone()).apply(operation)
+}
+
+/// Whether replay of `operation` is allowed to end up anywhere but the goal state.
+///
+/// `RenameAlias` reads the alias it removes, so replaying an operation whose rename landed either
+/// rejects it, leaving the actions after the rename unapplied, or renames the alias that a later
+/// action put back. `TableOfContent::update_aliases` behaves the same way, and the machine
+/// reproduces it. A lone rename converges: its rejection comes after the last action.
+fn replay_may_diverge(operation: &ConsensusOperations) -> bool {
+    let ConsensusOperations::CollectionMeta(operation) = operation else {
+        return false;
+    };
+
+    let CollectionMetaOperations::ChangeAliases(ChangeAliasesOperation { actions }) = &**operation
+    else {
+        return false;
+    };
+
+    let renames = actions
+        .iter()
+        .any(|action| matches!(action, AliasOperations::RenameAlias(_)));
+
+    renames && actions.len() > 1
 }


### PR DESCRIPTION
Implement `ChangeAliases`, `UpdatePeerMetadata`, `UpdateClusterMetadata`, `SetQuotaConfig` and `TestSlowDown`/`TestTransientError` operations.

**TODO:**
- [x] de-slop and cleanup PR
- [x] implement `TestSlowDown` and `TestTransientError` properly
- see #10339

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
