### PR TITLE
perf: skip external-id resolution in search post-processing

### DIFF
--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -62,13 +62,13 @@ where
         )
     }
 
-    /// Like [`Self::retrieve`], but for callers that already hold the internal
-    /// offsets alongside the external ids (e.g. search post-processing, where
-    /// offsets come straight from the vector index). Skips the per-point
-    /// external→internal resolution entirely.
+    /// Builds the records for points whose internal offsets the caller already
+    /// holds, e.g. search post-processing, where the offsets come straight from
+    /// the vector index.
     ///
-    /// `resolved_ids` and `resolved_offsets` must be parallel arrays;
-    /// deferred filtering, if required, must already be applied by the caller.
+    /// `resolved_ids` and `resolved_offsets` are parallel arrays: each id is read
+    /// from the offset at the same index. The caller owns visibility — every pair
+    /// it passes is read as given.
     fn retrieve_resolved(
         &self,
         resolved_ids: Vec<PointIdType>,
@@ -288,16 +288,21 @@ where
             },
         )?;
 
-        // The deferred cutoff is applied directly by offset: the offsets are
-        // already known here, so there is no need to resolve the external ids
-        // back into offsets (`retrieve`'s first stage) just to filter them.
-        let deferred_cutoff = DeferredBehavior::VisibleOnly.apply(self.deferred_internal_id());
+        // Deferred versions never reach post-processing — they are excluded in the
+        // search path itself — so the offsets the index reports are read as they are.
+        debug_assert!(
+            {
+                let cutoff = DeferredBehavior::VisibleOnly.apply(self.deferred_internal_id());
+                internal_result
+                    .iter()
+                    .all(|scored| !cutoff.is_some_and(|cutoff| scored.idx >= cutoff))
+            },
+            "search returned a deferred point, which a query must not see",
+        );
+
         let (point_ids, scored_offsets): (Vec<_>, Vec<_>) = internal_result
             .into_iter()
             .filter_map(|scored_point_offset| {
-                if deferred_cutoff.is_some_and(|cutoff| scored_point_offset.idx >= cutoff) {
-                    return None;
-                }
                 let point_id = external_ids.get(&scored_point_offset.idx).copied();
                 // This can happen if a point was modified between retrieving and post-processing,
                 // but this function locks the segment so it can't be modified during execution.
@@ -310,9 +315,8 @@ where
             })
             .unzip();
 
-        // The offsets ride along from the index — hand them to
-        // `retrieve_resolved`, so no per-point external→internal lookup
-        // happens on the search path.
+        // The offsets ride along from the index, so no per-point external->internal
+        // lookup happens on the search path.
         let point_offsets: Vec<_> = scored_offsets.iter().map(|scored| scored.idx).collect();
         let mut segment_records = self.retrieve_resolved(
             point_ids.clone(),

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -53,8 +53,8 @@ where
             },
         )?;
         self.retrieve_resolved(
-            resolved_ids,
-            resolved_offsets,
+            &resolved_ids,
+            &resolved_offsets,
             with_payload,
             with_vector,
             hw_counter,
@@ -71,8 +71,8 @@ where
     /// it passes is read as given.
     fn retrieve_resolved(
         &self,
-        resolved_ids: Vec<PointIdType>,
-        resolved_offsets: Vec<PointOffsetType>,
+        resolved_ids: &[PointIdType],
+        resolved_offsets: &[PointOffsetType],
         with_payload: &WithPayload,
         with_vector: &WithVector,
         hw_counter: &HardwareCounterCell,
@@ -96,7 +96,7 @@ where
             .collect();
 
         for vector_name in self.requested_vector_names(with_vector) {
-            let keys = resolved_keys(&resolved_ids, &resolved_offsets, is_stopped);
+            let keys = resolved_keys(resolved_ids, resolved_offsets, is_stopped);
             self.vectors_by_offsets(vector_name, keys, hw_counter, |id, _offset, vector| {
                 if let Some(record) = records.get_mut(&id) {
                     record
@@ -176,7 +176,7 @@ where
         }
 
         let payloads =
-            self.requested_payloads_raw(resolved_ids, resolved_offsets, is_stopped, hw_counter)?;
+            self.requested_payloads_raw(&resolved_ids, &resolved_offsets, is_stopped, hw_counter)?;
         for (id, payload) in payloads {
             if let Some(record) = records.get_mut(&id) {
                 record.payload = Some(payload);
@@ -206,8 +206,8 @@ where
     /// already-resolved offsets. Empty when payload wasn't requested.
     fn requested_payloads(
         &self,
-        resolved_ids: Vec<ExtendedPointId>,
-        resolved_offsets: Vec<PointOffsetType>,
+        resolved_ids: &[ExtendedPointId],
+        resolved_offsets: &[PointOffsetType],
         with_payload: &WithPayload,
         is_stopped: &AtomicBool,
         hw_counter: &HardwareCounterCell,
@@ -217,7 +217,7 @@ where
         }
 
         let mut payloads = Vec::with_capacity(resolved_ids.len());
-        let point_offsets = resolved_ids.into_iter().zip(resolved_offsets);
+        let point_offsets = resolved_keys(resolved_ids, resolved_offsets, is_stopped);
 
         self.read_payloads::<Random, _>(
             point_offsets,
@@ -245,13 +245,13 @@ where
     /// payload".
     fn requested_payloads_raw(
         &self,
-        resolved_ids: Vec<ExtendedPointId>,
-        resolved_offsets: Vec<PointOffsetType>,
+        resolved_ids: &[ExtendedPointId],
+        resolved_offsets: &[PointOffsetType],
         is_stopped: &AtomicBool,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<(ExtendedPointId, RawPayload)>> {
         let mut payloads = Vec::with_capacity(resolved_ids.len());
-        let point_offsets = resolved_ids.into_iter().zip(resolved_offsets);
+        let point_offsets = resolved_keys(resolved_ids, resolved_offsets, is_stopped);
 
         self.read_payloads_raw::<Random, _>(
             point_offsets,
@@ -319,8 +319,8 @@ where
         // lookup happens on the search path.
         let point_offsets: Vec<_> = scored_offsets.iter().map(|scored| scored.idx).collect();
         let mut segment_records = self.retrieve_resolved(
-            point_ids.clone(),
-            point_offsets,
+            &point_ids,
+            &point_offsets,
             with_payload,
             with_vector,
             hw_counter,

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -52,6 +52,33 @@ where
                 resolved_offsets.push(offset);
             },
         )?;
+        self.retrieve_resolved(
+            resolved_ids,
+            resolved_offsets,
+            with_payload,
+            with_vector,
+            hw_counter,
+            is_stopped,
+        )
+    }
+
+    /// Like [`Self::retrieve`], but for callers that already hold the internal
+    /// offsets alongside the external ids (e.g. search post-processing, where
+    /// offsets come straight from the vector index). Skips the per-point
+    /// external→internal resolution entirely.
+    ///
+    /// `resolved_ids` and `resolved_offsets` must be parallel arrays;
+    /// deferred filtering, if required, must already be applied by the caller.
+    fn retrieve_resolved(
+        &self,
+        resolved_ids: Vec<PointIdType>,
+        resolved_offsets: Vec<PointOffsetType>,
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
+        hw_counter: &HardwareCounterCell,
+        is_stopped: &AtomicBool,
+    ) -> OperationResult<AHashMap<ExtendedPointId, SegmentRecord>> {
+        debug_assert_eq!(resolved_ids.len(), resolved_offsets.len());
 
         // One blank record per resolved point; `vectors` is `Some` only when
         // vectors were requested, so the `WithVector::Bool(false)` path needs
@@ -261,9 +288,16 @@ where
             },
         )?;
 
+        // The deferred cutoff is applied directly by offset: the offsets are
+        // already known here, so there is no need to resolve the external ids
+        // back into offsets (`retrieve`'s first stage) just to filter them.
+        let deferred_cutoff = DeferredBehavior::VisibleOnly.apply(self.deferred_internal_id());
         let (point_ids, scored_offsets): (Vec<_>, Vec<_>) = internal_result
             .into_iter()
             .filter_map(|scored_point_offset| {
+                if deferred_cutoff.is_some_and(|cutoff| scored_point_offset.idx >= cutoff) {
+                    return None;
+                }
                 let point_id = external_ids.get(&scored_point_offset.idx).copied();
                 // This can happen if a point was modified between retrieving and post-processing,
                 // but this function locks the segment so it can't be modified during execution.
@@ -276,13 +310,17 @@ where
             })
             .unzip();
 
-        let mut segment_records = self.retrieve(
-            &point_ids,
+        // The offsets ride along from the index — hand them to
+        // `retrieve_resolved`, so no per-point external→internal lookup
+        // happens on the search path.
+        let point_offsets: Vec<_> = scored_offsets.iter().map(|scored| scored.idx).collect();
+        let mut segment_records = self.retrieve_resolved(
+            point_ids.clone(),
+            point_offsets,
             with_payload,
             with_vector,
             hw_counter,
             is_stopped,
-            DeferredBehavior::VisibleOnly,
         )?;
 
         let mut versions = AHashMap::with_capacity(scored_offsets.len());


### PR DESCRIPTION
# perf: skip external-id resolution in search post-processing

Part of #10311.

## What

`process_search_result` hands its scored points to `retrieve()`, which resolves
every external id back into an internal offset. The offsets are already known
at that point — they come straight from the vector index as
`ScoredPointOffset` — so each request performs `top_k * segments` redundant
`external -> internal` lookups.

`retrieve()` is split into resolution + `retrieve_resolved()`; the search path
calls the latter with the offsets it already holds, and applies the deferred
cutoff by offset instead of resolving ids just to filter them.

## Why it survived this long

The cost depends on the id tracker being mutable: a freshly optimized segment
resolves through a BTree, a restarted node maps an immutable tracker and
resolves in constant time. The effect appears right after ingestion or
optimization and disappears after a restart — so a benchmark that loads data,
restarts, and only then measures never sees it.

## Compatibility

`retrieve()` keeps its `deferred_behavior` parameter and applies it during
resolution exactly as before, so **behaviour is unchanged for every other
caller**. `retrieve_resolved()` is private and its doc states that deferred
filtering is the caller's responsibility; the only caller that skips resolution
applies the cutoff itself, by offset. There is no double filtering.

## Measurements

Measured on current `dev`: `glove-100-angular`, 1.18M points, `dim=100`, 21
segments, `m=16`, `ef=128`, fixed 800 QPS, search pool pinned to 15 threads,
process CPU time per request, three runs each:

| build | ms CPU / request |
|---|---|
| `dev` | 6.82 / 6.83 / 6.82 |
| `dev` + this patch | 6.31 / 6.30 / 6.30 |

**≈8% less CPU per search request** on a many-segment collection.

On a 1.18.x cluster the same round trip additionally showed up as ~15-24%
higher median latency right after ingestion, disappearing after a node restart
— the mutable-vs-immutable id tracker effect described above.

## Testing

`cargo nextest run -p segment` over the search and deferred-point suites:
87/87 pass, including `test_deferred_point_read_operations`,
`test_deferred_point_sparse`, `test_dense_deferred_point_segment_combinations`
and `test_deferred_point_facets`. `cargo clippy --all-targets` clean.
