### PR TITLE
Remove slow L1 turbo hnsw test

### DIFF
--- a/lib/segment/tests/integration/byte_storage_quantization_test.rs
+++ b/lib/segment/tests/integration/byte_storage_quantization_test.rs
@@ -219,15 +219,11 @@ fn sames_count(a: &[Vec<ScoredPointOffset>], b: &[Vec<ScoredPointOffset>]) -> us
     32, // ef
     70., // min_acc out of 100
 )]
-#[cfg_attr(
-    target_os = "windows",
-    test_attr(ignore = "slow on Windows, not OS-specific")
-)]
-#[case::nearest_turbo_turbo_manhattan(
+#[case::nearest_turbo_turbo_euclid(
     QueryVariant::Nearest,
     VectorStorageDatatype::Turbo4,
     QuantizationVariant::Turbo,
-    Distance::Manhattan,
+    Distance::Euclid,
     32, // dim
     32, // ef
     70., // min_acc out of 100


### PR DESCRIPTION
Test is very slow:

```
PASS [ 132.223s] segment::integration byte_storage_quantization_test::test_quantization_over_typed_storage_hnsw::case_16_nearest_turbo_turbo_manhattan
```

L1 metric is not so critical to be tested with hnsw, this PR replaces it with L2 metric.