### PR TITLE
build(deps): disable unused default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,15 +1546,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpp_demangle"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,11 +1971,6 @@ name = "duplicate"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e92f10a49176cbffacaedabfaa11d51db1ea0f80a83c26e1873b43cd1742c24"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "proc-macro2-diagnostics",
-]
 
 [[package]]
 name = "dyn-clone"
@@ -1997,15 +1983,6 @@ name = "dyn_size_of"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a742b95783b1f45b900129082cbc47717b6a77ee8d17eea70a8ea62462f5de3"
-
-[[package]]
-name = "earcut"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "ecdsa"
@@ -2743,7 +2720,6 @@ version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30eb1fdc57c1e5cfd11826fe0caec4b9dc7901f3758263bb506228d88c8d9e9a"
 dependencies = [
- "earcut",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
@@ -2755,7 +2731,6 @@ dependencies = [
  "robust",
  "rstar",
  "sif-itree",
- "spade",
 ]
 
 [[package]]
@@ -2766,10 +2741,8 @@ checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
  "approx",
  "num-traits",
- "rayon",
  "rstar",
  "serde",
- "spade",
 ]
 
 [[package]]
@@ -3306,9 +3279,6 @@ name = "i_key_sort"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c4d36ff9fb73dc62e163e25a07523ca5c2126660fb2485cdecf063e59b58f29"
-dependencies = [
- "rayon",
-]
 
 [[package]]
 name = "i_overlay"
@@ -3320,7 +3290,6 @@ dependencies = [
  "i_key_sort",
  "i_shape",
  "i_tree",
- "rayon",
 ]
 
 [[package]]
@@ -3884,14 +3853,12 @@ dependencies = [
  "js-sys",
  "p256",
  "p384",
- "pem",
  "rand 0.8.5",
  "rsa",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "signature",
- "simple_asn1",
  "zeroize",
 ]
 
@@ -4796,16 +4763,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64",
- "serde_core",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5187,18 +5144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "version_check",
 ]
 
 [[package]]
@@ -7131,18 +7076,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
-name = "simple_asn1"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 2.0.20",
- "time",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7226,18 +7159,6 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "spade"
-version = "2.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb313e1c8afee5b5647e00ee0fe6855e3d529eb863a0fdae1d60006c4d1e9990"
-dependencies = [
- "hashbrown 0.15.5",
- "num-traits",
- "robust",
- "smallvec",
 ]
 
 [[package]]
@@ -7455,7 +7376,6 @@ version = "12.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b237cfbe320601dd24b4ac817a5b68bb28f5508e33f08d42be0682cadc8ac9"
 dependencies = [
- "cpp_demangle",
  "rustc-demangle",
  "symbolic-common 12.17.2",
 ]
@@ -7579,7 +7499,6 @@ checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
- "xattr",
 ]
 
 [[package]]
@@ -9277,16 +9196,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ rustls-pki-types = "1.14.0"
 rustls-pemfile = "2.2.0"
 prometheus = { version = "0.14.0", default-features = false }
 validator = { workspace = true }
-jsonwebtoken = { version = "11.0", features = ["rust_crypto"] }
+jsonwebtoken = { version = "11.0", default-features = false, features = ["rust_crypto"] }
 tempfile = { workspace = true }
 
 # Consensus related crates
@@ -221,6 +221,7 @@ clap = { version = "4.6.1", features = ["derive", "env"] }
 core_affinity = "0.8.3"
 criterion = "0.8.2"
 data-encoding = "2.11.0"
+duplicate = { version = "2.0.1", default-features = false }
 ecow = { version = "0.3.0", features = ["serde"] }
 env_logger = "0.11"
 fnv = "1.0"
@@ -255,7 +256,7 @@ ordered-float = { version = "5.3.0", features = ["serde", "schemars", "bytemuck"
 rayon = "1.12.0"
 parking_lot = { version = "0.12.5", features = ["arc_lock", "deadlock_detection", "serde"] }
 ph = "0.8.5"
-pprof = { version = "0.15.0", features = ["flamegraph", "prost-codec"] }
+pprof = { version = "0.15.0", default-features = false, features = ["flamegraph", "prost-codec"] }
 proptest = { version = "1.11.0", default-features = false, features = ["std"] }
 prost = "0.14.0"
 prost-types = "0.14.0"
@@ -294,7 +295,7 @@ strum = { version = "0.28.0", features = ["derive"] }
 stumpalo = "1.0.0"
 sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 tap = "1.0.1"
-tar = "0.4.46"
+tar = { version = "0.4.46", default-features = false }
 tempfile = "3.27.0"
 tinyvec = { version = "1.11.0", features = ["alloc", "latest_stable_rust"] }
 tokio = { version = "1.52.3", features = ["full"] }

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -58,7 +58,7 @@ zerocopy = { workspace = true }
 [dev-dependencies]
 common = { path = ".", features = ["testing"] }
 criterion = { workspace = true }
-duplicate = "2.0.1"
+duplicate = { workspace = true }
 fs-err = { workspace = true, features = ["debug"] }
 rstest = { workspace = true }
 static_assertions = "1.1.0"

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -70,7 +70,7 @@ atomicwrites = { workspace = true }
 memmap2 = { workspace = true }
 schemars = { workspace = true }
 log = { workspace = true }
-geo = "0.33.1"
+geo = { version = "0.33.1", default-features = false }
 geohash = "0.13.2"
 num-traits = { workspace = true }
 num-derive = "0.5.1"
@@ -121,7 +121,7 @@ macro_rules_attribute = "0.2.2"
 nom = "8.0.0"
 half = { workspace = true }
 roaring = { workspace = true }
-duplicate = "2.0.1"
+duplicate = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.18", default-features = false }

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -37,7 +37,7 @@ zerocopy = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 dataset = { path = "../common/dataset" }
-duplicate = "2.0.1"
+duplicate = { workspace = true }
 fs-err = { workspace = true, features = ["debug"] }
 indicatif = { workspace = true }
 sha2 = { workspace = true }


### PR DESCRIPTION
Drops 6 crates from the release build (591 -> 585) and 7 from the workspace test build (744 -> 737), without touching any source file.

Each one was picked by flipping `default-features = false` on every external dep that currently builds with defaults on, diffing `cargo tree`, and keeping only the deps whose dropped features are unused:

- `geo`: only `Contains`/`Intersects`/`Haversine`/`Point`/`Polygon` are used, no triangulation, so `spade` (21k LoC) and `earcut` go
- `jsonwebtoken`: the JWT path is HS256 `from_secret` only, no PEM keys, so `pem` and `simple_asn1` go
- `tar`: `xattr` is reachable only through `unpack_xattrs`, which `Archive::new` defaults to false and nothing sets
- `duplicate`: every `duplicate_item` passes an explicit module name, so `module_disambiguation` is unused, and `pretty_errors` only prettifies macro errors (`proc-macro2-diagnostics`). Also promoted to a workspace dependency
- `pprof`: no C++ frames to demangle, so `cpp_demangle` goes (dev only)

The `Cargo.lock` diff is removals only, no version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
