### PR TITLE
Skip redundant ID resolutions

### DIFF
--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -594,17 +594,10 @@ impl LocalShard {
         deferred_behavior: DeferredBehavior,
     ) -> CollectionResult<AHashMap<ExtendedPointId, RecordInternal>> {
         if !with_payload.enable && !with_vector.is_enabled() {
-            let bare_record = |&id| {
-                let record = RecordInternal {
-                    id,
-                    payload: None,
-                    vector: None,
-                    shard_key: None,
-                    order_value: None,
-                };
-                (id, record)
-            };
-            return Ok(point_ids.iter().map(bare_record).collect());
+            return Ok(point_ids
+                .iter()
+                .map(|&id| (id, RecordInternal::new_empty(id)))
+                .collect());
         }
 
         tokio::time::timeout(

--- a/lib/collection/src/shards/local_shard/scroll.rs
+++ b/lib/collection/src/shards/local_shard/scroll.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use ahash::AHashMap;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::DeferredBehavior;
@@ -205,10 +206,8 @@ impl LocalShard {
         let with_payload = WithPayload::from(with_payload_interface);
         // update timeout
         let timeout = timeout.saturating_sub(start.elapsed());
-        let mut records_map = tokio::time::timeout(
-            timeout,
-            SegmentsSearcher::retrieve(
-                segments,
+        let mut records_map = self
+            .scroll_records(
                 &point_ids,
                 &with_payload,
                 with_vector,
@@ -216,10 +215,8 @@ impl LocalShard {
                 timeout,
                 hw_measurement_acc,
                 deferred_behavior,
-            ),
-        )
-        .await
-        .map_err(|_| CollectionError::timeout(timeout, "retrieve"))??;
+            )
+            .await?;
 
         drop(update_operation_lock);
 
@@ -414,11 +411,8 @@ impl LocalShard {
         // update timeout
         let timeout = timeout.saturating_sub(start.elapsed());
 
-        // Fetch with the requested vector and payload
-        let records_map = tokio::time::timeout(
-            timeout,
-            SegmentsSearcher::retrieve(
-                segments,
+        let records_map = self
+            .scroll_records(
                 &point_ids,
                 &with_payload,
                 with_vector,
@@ -426,10 +420,8 @@ impl LocalShard {
                 timeout,
                 hw_measurement_acc,
                 deferred_behavior,
-            ),
-        )
-        .await
-        .map_err(|_| CollectionError::timeout(timeout, "retrieve"))??;
+            )
+            .await?;
 
         drop(update_operation_lock);
 
@@ -572,10 +564,8 @@ impl LocalShard {
         let with_payload = WithPayload::from(with_payload_interface);
         // update timeout
         let timeout = timeout.saturating_sub(start.elapsed());
-        let records_map = tokio::time::timeout(
-            timeout,
-            SegmentsSearcher::retrieve(
-                segments,
+        let records_map = self
+            .scroll_records(
                 &selected_points,
                 &with_payload,
                 with_vector,
@@ -583,13 +573,54 @@ impl LocalShard {
                 timeout,
                 hw_measurement_acc,
                 DeferredBehavior::VisibleOnly,
-            ),
-        )
-        .await
-        .map_err(|_| CollectionError::timeout(timeout, "retrieve"))??;
+            )
+            .await?;
 
         drop(update_operation_lock);
 
         Ok(records_map.into_values().collect())
+    }
+
+    /// Records for scrolled ids; skips retrieval when neither payload nor vectors are requested.
+    #[allow(clippy::too_many_arguments)]
+    async fn scroll_records(
+        &self,
+        point_ids: &[ExtendedPointId],
+        with_payload: &WithPayload,
+        with_vector: &WithVector,
+        search_runtime_handle: &AdaptiveSearchHandle,
+        timeout: Duration,
+        hw_measurement_acc: HwMeasurementAcc,
+        deferred_behavior: DeferredBehavior,
+    ) -> CollectionResult<AHashMap<ExtendedPointId, RecordInternal>> {
+        if !with_payload.enable && !with_vector.is_enabled() {
+            let bare_record = |&id| {
+                let record = RecordInternal {
+                    id,
+                    payload: None,
+                    vector: None,
+                    shard_key: None,
+                    order_value: None,
+                };
+                (id, record)
+            };
+            return Ok(point_ids.iter().map(bare_record).collect());
+        }
+
+        tokio::time::timeout(
+            timeout,
+            SegmentsSearcher::retrieve(
+                self.segments.clone(),
+                point_ids,
+                with_payload,
+                with_vector,
+                search_runtime_handle,
+                timeout,
+                hw_measurement_acc,
+                deferred_behavior,
+            ),
+        )
+        .await
+        .map_err(|_| CollectionError::timeout(timeout, "retrieve"))?
     }
 }

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -12,7 +12,7 @@ use collection::operations::point_ops::{
 use collection::operations::shard_selector_internal::ShardSelectorInternal;
 use collection::operations::types::{
     CountRequestInternal, PointRequestInternal, RecommendRequestInternal, ScrollRequestInternal,
-    UpdateStatus,
+    ScrollResult, UpdateStatus,
 };
 use collection::recommendations::recommend_by;
 use collection::shards::replica_set::replica_set_state::{ReplicaSetState, ReplicaState};
@@ -504,6 +504,91 @@ async fn test_read_api_with_shards(shard_number: u32) {
 
     assert_eq!(result.next_page_offset, Some(2.into()));
     assert_eq!(result.points.len(), 2);
+}
+
+/// Scrolling without payload or vectors skips retrieval; the page must still match.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_scroll_without_payload_or_vectors() {
+    const KEY: &str = "price";
+
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
+    let collection = simple_collection_fixture(collection_dir.path(), 1).await;
+
+    let batch = BatchPersisted {
+        ids: (0..6).map(u64::into).collect_vec(),
+        vectors: BatchVectorStructPersisted::Single(vec![vec![1.0, 0.0, 0.0, 0.0]; 6]),
+        payloads: Some(
+            (0..6)
+                .map(|i| Some(Payload(Map::from_iter([(KEY.to_string(), i.into())]))))
+                .collect(),
+        ),
+    };
+    let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::from(batch),
+    ));
+    collection
+        .update_from_client_simple(
+            insert_points,
+            true,
+            None,
+            WriteOrdering::default(),
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+    collection
+        .create_payload_index_with_wait(
+            KEY.parse().unwrap(),
+            PayloadFieldSchema::FieldType(PayloadSchemaType::Integer),
+            true,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+
+    let order_by = OrderByInterface::Struct(OrderBy {
+        key: KEY.parse().unwrap(),
+        direction: Some(Direction::Desc),
+        start_from: None,
+    });
+    for order_by in [None, Some(order_by)] {
+        let scroll = |with_payload| {
+            collection.scroll_by(
+                ScrollRequestInternal {
+                    offset: None,
+                    limit: Some(4),
+                    filter: None,
+                    with_payload: Some(WithPayloadInterface::Bool(with_payload)),
+                    with_vector: false.into(),
+                    order_by: order_by.clone(),
+                },
+                None,
+                None,
+                &ShardSelectorInternal::All,
+                None,
+                HwMeasurementAcc::new(),
+            )
+        };
+        let full = scroll(true).await.unwrap();
+        let bare = scroll(false).await.unwrap();
+
+        assert_eq!(full.points.len(), 4);
+        assert!(full.points.iter().all(|point| point.payload.is_some()));
+        assert!(
+            bare.points
+                .iter()
+                .all(|point| point.payload.is_none() && point.vector.is_none())
+        );
+        assert_eq!(bare.next_page_offset, full.next_page_offset);
+        let page = |result: &ScrollResult| {
+            result
+                .points
+                .iter()
+                .map(|point| (point.id, point.order_value))
+                .collect_vec()
+        };
+        assert_eq!(page(&bare), page(&full));
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/lib/shard/src/query/planned_query.rs
+++ b/lib/shard/src/query/planned_query.rs
@@ -197,6 +197,17 @@ impl PlannedQuery {
             })),
         };
 
+        // Without rescoring the leaf is the final result: let it fetch payload
+        // and vectors itself instead of retrieving them again afterwards.
+        let requested = (with_vector, with_payload);
+        let nothing = (WithVector::from(false), WithPayloadInterface::from(false));
+        let ((leaf_with_vector, leaf_with_payload), (with_vector, with_payload)) =
+            if rescore_stages.is_none() {
+                (requested, nothing)
+            } else {
+                (nothing, requested)
+            };
+
         // Everything must come from a single source.
         let sources = vec![leaf_source_from_scoring_query(
             &mut self.searches,
@@ -206,6 +217,8 @@ impl PlannedQuery {
             params,
             score_threshold,
             filter,
+            leaf_with_vector,
+            leaf_with_payload,
         )?];
 
         // Root-level query without prefetches means we won't do any extra rescoring
@@ -334,6 +347,8 @@ fn recurse_prefetches(
                 params,
                 score_threshold.map(OrderedFloat::into_inner),
                 filter,
+                WithVector::from(false),
+                WithPayloadInterface::from(false),
             )?
         } else {
             // This has nested prefetches. Recurse into them
@@ -369,6 +384,7 @@ fn recurse_prefetches(
 /// does not act over prefetched points and will be executed over the segments directly.
 ///
 /// Only `Source::SearchesIdx` or `Source::ScrollsIdx` variants are returned.
+#[expect(clippy::too_many_arguments)]
 fn leaf_source_from_scoring_query(
     core_searches: &mut Vec<CoreSearchRequest>,
     scrolls: &mut Vec<QueryScrollRequestInternal>,
@@ -377,6 +393,8 @@ fn leaf_source_from_scoring_query(
     params: Option<SearchParams>,
     score_threshold: Option<f32>,
     filter: Option<Filter>,
+    with_vector: WithVector,
+    with_payload: WithPayloadInterface,
 ) -> OperationResult<Source> {
     let source = match query {
         Some(ScoringQuery::Vector(query_enum)) => {
@@ -386,8 +404,8 @@ fn leaf_source_from_scoring_query(
                 params,
                 limit,
                 offset: 0,
-                with_vector: Some(WithVector::from(false)),
-                with_payload: Some(WithPayloadInterface::from(false)),
+                with_vector: Some(with_vector),
+                with_payload: Some(with_payload),
                 score_threshold,
             };
 
@@ -405,8 +423,8 @@ fn leaf_source_from_scoring_query(
             let scroll = QueryScrollRequestInternal {
                 scroll_order: ScrollOrder::ByField(order_by),
                 filter,
-                with_vector: WithVector::from(false),
-                with_payload: WithPayloadInterface::from(false),
+                with_vector,
+                with_payload,
                 limit,
             };
 
@@ -424,8 +442,8 @@ fn leaf_source_from_scoring_query(
             let scroll = QueryScrollRequestInternal {
                 scroll_order: ScrollOrder::Random,
                 filter,
-                with_vector: WithVector::from(false),
-                with_payload: WithPayloadInterface::from(false),
+                with_vector,
+                with_payload,
                 limit,
             };
 
@@ -446,8 +464,8 @@ fn leaf_source_from_scoring_query(
                 query,
                 filter,
                 score_threshold,
-                with_vector: Some(WithVector::from(false)),
-                with_payload: Some(WithPayloadInterface::from(false)),
+                with_vector: Some(with_vector),
+                with_payload: Some(with_payload),
                 offset: 0,
                 params,
                 limit: candidates_limit,
@@ -462,8 +480,8 @@ fn leaf_source_from_scoring_query(
             let scroll = QueryScrollRequestInternal {
                 scroll_order: Default::default(),
                 filter,
-                with_vector: WithVector::from(false),
-                with_payload: WithPayloadInterface::from(false),
+                with_vector,
+                with_payload,
                 limit,
             };
 

--- a/lib/shard/src/query/planned_query.rs
+++ b/lib/shard/src/query/planned_query.rs
@@ -197,16 +197,25 @@ impl PlannedQuery {
             })),
         };
 
-        // Without rescoring the leaf is the final result: let it fetch payload
-        // and vectors itself instead of retrieving them again afterwards.
+        // A scroll leaf is the final result and retrieves payload and vectors once, for the
+        // merged page, so it can fetch them itself instead of resolving the ids again afterwards.
+        // A search leaf fetches them per segment before merging, which multiplies the I/O by
+        // the segment count, so it stays bare and the root plan retrieves for the final result.
+        // See: <https://github.com/qdrant/qdrant/pull/6279>
+        let leaf_fetches = match &query {
+            None | Some(ScoringQuery::OrderBy(_)) | Some(ScoringQuery::Sample(_)) => true,
+            Some(ScoringQuery::Vector(_))
+            | Some(ScoringQuery::Fusion(_))
+            | Some(ScoringQuery::Formula(_))
+            | Some(ScoringQuery::Mmr(_)) => false,
+        };
         let requested = (with_vector, with_payload);
         let nothing = (WithVector::from(false), WithPayloadInterface::from(false));
-        let ((leaf_with_vector, leaf_with_payload), (with_vector, with_payload)) =
-            if rescore_stages.is_none() {
-                (requested, nothing)
-            } else {
-                (nothing, requested)
-            };
+        let ((leaf_with_vector, leaf_with_payload), (with_vector, with_payload)) = if leaf_fetches {
+            (requested, nothing)
+        } else {
+            (nothing, requested)
+        };
 
         // Everything must come from a single source.
         let sources = vec![leaf_source_from_scoring_query(

--- a/lib/shard/src/query/tests.rs
+++ b/lib/shard/src/query/tests.rs
@@ -184,23 +184,63 @@ fn test_try_from_no_prefetch() {
             params: Some(SearchParams::default()),
             limit: 22,
             offset: 0,
-            with_vector: Some(WithVector::Bool(false)),
-            with_payload: Some(WithPayloadInterface::Bool(false)),
+            with_vector: Some(WithVector::Bool(true)),
+            with_payload: Some(WithPayloadInterface::Bool(true)),
             score_threshold: Some(0.5),
         }]
     );
 
+    // The leaf fetches payload and vectors, so the root plan does not.
     assert_eq!(
         planned_query.root_plans,
         vec![RootPlan {
-            with_payload: WithPayloadInterface::Bool(true),
-            with_vector: WithVector::Bool(true),
+            with_payload: WithPayloadInterface::Bool(false),
+            with_vector: WithVector::Bool(false),
             merge_plan: MergePlan {
                 sources: vec![Source::SearchesIdx(0)],
                 rescore_stages: None,
             },
         }]
     );
+}
+
+/// MMR without prefetches is rescored at collection level, so its candidates leaf must not
+/// fetch payload or vectors; the root plan fetches them for the final result.
+#[test]
+fn test_try_from_no_prefetch_mmr() {
+    let request = ShardQueryRequest {
+        prefetches: vec![],
+        query: Some(ScoringQuery::Mmr(MmrInternal {
+            vector: VectorInternal::Dense(vec![1.0, 2.0, 3.0]),
+            using: "dense".to_owned(),
+            lambda: OrderedFloat(0.5),
+            candidates_limit: 100,
+        })),
+        filter: None,
+        score_threshold: None,
+        limit: 10,
+        offset: 0,
+        params: None,
+        with_vector: WithVector::Bool(false),
+        with_payload: WithPayloadInterface::Bool(true),
+    };
+
+    let planned_query = PlannedQuery::try_from(vec![request]).unwrap();
+
+    let [search] = planned_query.searches.as_slice() else {
+        panic!("expected a single candidates search");
+    };
+    assert_eq!(search.with_vector, Some(WithVector::Bool(false)));
+    assert_eq!(search.with_payload, Some(WithPayloadInterface::Bool(false)));
+
+    let [root_plan] = planned_query.root_plans.as_slice() else {
+        panic!("expected a single root plan");
+    };
+    assert_eq!(
+        root_plan.with_vector,
+        WithVector::Selector(vec!["dense".to_owned()])
+    );
+    assert_eq!(root_plan.with_payload, WithPayloadInterface::Bool(true));
 }
 
 #[test]
@@ -583,7 +623,7 @@ fn test_from_batch_of_requests() {
             limit: 20,
             offset: 0,
             params: None,
-            with_payload: WithPayloadInterface::Bool(false),
+            with_payload: WithPayloadInterface::Bool(true),
             with_vector: WithVector::Bool(false),
         },
         // A double fusion query
@@ -620,6 +660,12 @@ fn test_from_batch_of_requests() {
     assert_eq!(planned_query.searches.len(), 3);
     assert_eq!(planned_query.scrolls.len(), 2);
     assert_eq!(planned_query.root_plans.len(), 3);
+
+    // The no-prefetch scroll fetches its own payload.
+    assert_eq!(
+        planned_query.scrolls[0].with_payload,
+        WithPayloadInterface::Bool(true)
+    );
 
     assert_eq!(
         planned_query.root_plans,

--- a/lib/shard/src/query/tests.rs
+++ b/lib/shard/src/query/tests.rs
@@ -184,18 +184,18 @@ fn test_try_from_no_prefetch() {
             params: Some(SearchParams::default()),
             limit: 22,
             offset: 0,
-            with_vector: Some(WithVector::Bool(true)),
-            with_payload: Some(WithPayloadInterface::Bool(true)),
+            with_vector: Some(WithVector::Bool(false)),
+            with_payload: Some(WithPayloadInterface::Bool(false)),
             score_threshold: Some(0.5),
         }]
     );
 
-    // The leaf fetches payload and vectors, so the root plan does not.
+    // A search leaf fetches per segment, so the root plan retrieves for the merged result.
     assert_eq!(
         planned_query.root_plans,
         vec![RootPlan {
-            with_payload: WithPayloadInterface::Bool(false),
-            with_vector: WithVector::Bool(false),
+            with_payload: WithPayloadInterface::Bool(true),
+            with_vector: WithVector::Bool(true),
             merge_plan: MergePlan {
                 sources: vec![Source::SearchesIdx(0)],
                 rescore_stages: None,

--- a/lib/shard/src/retrieve/record_internal.rs
+++ b/lib/shard/src/retrieve/record_internal.rs
@@ -21,7 +21,7 @@ pub struct RecordInternal {
 }
 
 impl RecordInternal {
-    pub fn new_empty(id: PointIdType) -> Self {
+    pub const fn new_empty(id: PointIdType) -> Self {
         Self {
             id,
             payload: None,


### PR DESCRIPTION
Follow up of <https://github.com/qdrant/qdrant/pull/10312>

Follows the spirit of removing redundant ID look-ups, but in other places.

Primarily prevents a retrieve call in cases where we don't have to retrieve anything.

I wanted to apply a similar change to `retrieve_over`. It resolves IDs three times and is a building block for many APIs. For example, it first resolves point IDs and versions, then it resolves again when actually retrieving. But removing this first step breaks deduplication. And so I decided not to bother with it.

I did not benchmark this. But it assumes less work is cheaper.

I'd recommend to review this per commit.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
