### PR TITLE
[AI] fix: reject unreasonably large shard_number instead of crashing

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -147,7 +147,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("CreateCollection.optimizers_config", ""),
             ("CreateCollection.vectors_config", ""),
             ("CreateCollection.quantization_config", ""),
-            ("CreateCollection.shard_number", "range(min = 1)"),
+            ("CreateCollection.shard_number", "range(min = 1, max = 65536)"),
             ("CreateCollection.replication_factor", "range(min = 1)"),
             ("CreateCollection.write_consistency_factor", "range(min = 1)"),
             ("CreateCollection.strict_mode_config", ""),

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1205,7 +1205,7 @@ pub struct CreateCollection {
     /// Number of shards in the collection, default is 1 for standalone, otherwise
     /// equal to the number of nodes. Minimum is 1
     #[prost(uint32, optional, tag = "7")]
-    #[validate(range(min = 1))]
+    #[validate(range(min = 1, max = 65536))]
     pub shard_number: ::core::option::Option<u32>,
     /// Deprecated: use `payload.memory` instead.
     /// If true - point's payload will not be stored in memory

--- a/lib/storage/src/content_manager/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/collection_meta_ops.rs
@@ -123,13 +123,15 @@ pub struct CreateCollection {
     /// Number of shards in collection.
     ///  - Default is 1 for standalone, otherwise equal to the number of nodes
     ///  - Minimum is 1
+    ///  - Maximum is 65536
     ///
     /// For custom sharding:
     /// Number of shards in collection per shard group.
     ///  - Default is 1, meaning that each shard key will be mapped to a single shard
     ///  - Minimum is 1
+    ///  - Maximum is 65536
     #[serde(default)]
-    #[validate(range(min = 1))]
+    #[validate(range(min = 1, max = 65536))]
     pub shard_number: Option<u32>,
     /// Sharding method
     /// Default is Auto - points are distributed across all available shards
@@ -555,5 +557,49 @@ impl From<CollectionConfigInternal> for CreateCollection {
             uuid,
             metadata,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn create_collection_with_shard_number(shard_number: u32) -> CreateCollection {
+        serde_json::from_value(json!({
+            "vectors": {"size": 4, "distance": "Cosine"},
+            "shard_number": shard_number,
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn test_shard_number_above_upper_bound_rejected() {
+        // An unreasonably large shard_number must be rejected up front instead of
+        // reaching the shard allocation path and exhausting resources.
+        let create_collection = create_collection_with_shard_number(u32::MAX);
+        assert!(
+            create_collection.validate().is_err(),
+            "shard_number = u32::MAX should fail validation"
+        );
+    }
+
+    #[test]
+    fn test_shard_number_at_upper_bound_accepted() {
+        let create_collection = create_collection_with_shard_number(65536);
+        assert!(
+            create_collection.validate().is_ok(),
+            "shard_number = 65536 is within the allowed range"
+        );
+    }
+
+    #[test]
+    fn test_shard_number_just_above_upper_bound_rejected() {
+        let create_collection = create_collection_with_shard_number(65537);
+        assert!(
+            create_collection.validate().is_err(),
+            "shard_number = 65537 exceeds the allowed range"
+        );
     }
 }


### PR DESCRIPTION
### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

**What this does and why**

`shard_number` on `CreateCollection` was only validated with a lower bound (`range(min = 1)`), so a syntactically valid but unreasonable value like `2147483647` (INT_MAX) passed validation and reached the shard allocation path. The server then attempts to allocate resources for 2+ billion shards and becomes unresponsive (`#9520`).

`replication_factor` and `write_consistency_factor` have the same lower-bound-only pattern, but this PR only touches `shard_number`, since that's the field that directly drives eager allocation and is the one reported as crashing.

**Fix**

Added an upper bound to `shard_number`'s validation, mirroring the existing `range(min = 1, max = 65536)` pattern already used for `VectorParams.size` in the same `lib/api/build.rs` file (that same bound is a precedented "reasonable positive limit" in this codebase, not a number I invented for this PR):

- `lib/storage/src/content_manager/collection_meta_ops.rs`: `CreateCollection.shard_number`'s `#[validate(range(...))]` attribute, and its doc comment.
- `lib/api/build.rs`: the matching gRPC-side validation config, which regenerates `lib/api/src/grpc/qdrant.rs` (included in this PR as the generated output of that change) so the gRPC API path gets the same protection as REST.

Fixes #9520

**Testing**

Added `test_shard_number_above_upper_bound_rejected`, `test_shard_number_at_upper_bound_accepted`, and `test_shard_number_just_above_upper_bound_rejected` in `collection_meta_ops.rs`, deserializing the exact JSON shape from the bug report and asserting `.validate()` on the resulting `CreateCollection`.

```
$ cargo test -p storage --lib content_manager::collection_meta_ops::tests
running 3 tests
test content_manager::collection_meta_ops::tests::test_shard_number_above_upper_bound_rejected ... ok
test content_manager::collection_meta_ops::tests::test_shard_number_just_above_upper_bound_rejected ... ok
test content_manager::collection_meta_ops::tests::test_shard_number_at_upper_bound_accepted ... ok
test result: ok. 3 passed; 0 failed
```

Also ran `cargo +nightly fmt --all -- --check` (clean) and `cargo clippy -p storage -p api --all-features` (no warnings) on the touched packages.

### AI disclosure

This PR was written by Claude (Anthropic's Claude Code), at the direction of a human contributor who asked it to find and fix a real, tractable, unclaimed open-source issue. Claude searched this repo's open unassigned bug reports, selected #9520, traced the validation code from the REST struct through to the gRPC-generated equivalent, wrote the fix and the three tests above, and ran the project's required fmt/clippy checks. The commit is marked `[AI]` per this repo's AI contribution policy. The contributor reviewed the diff and reasoning before submission and is able to answer questions about it.
