### PR TITLE
[AI] fix: reject value 0 for filter_max_conditions and upsert_max_batchsize

### DIFF
--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1361,6 +1361,7 @@ pub struct StrictModeConfig {
 
     /// Max batchsize when upserting
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(range(min = 1))]
     pub upsert_max_batchsize: Option<usize>,
 
     /// Max batchsize when searching
@@ -1392,6 +1393,7 @@ pub struct StrictModeConfig {
 
     /// Max conditions a filter can have.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(range(min = 1))]
     pub filter_max_conditions: Option<usize>,
 
     /// Max size of a condition, eg. items in `MatchAny`.
@@ -4924,6 +4926,38 @@ mod tests {
             ..Default::default()
         };
         params.validate().unwrap();
+    }
+
+    #[test]
+    fn test_strict_mode_config_rejects_zero_filter_max_conditions() {
+        let config = StrictModeConfig {
+            filter_max_conditions: Some(0),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("filter_max_conditions"), "error was: {err}");
+
+        let config = StrictModeConfig {
+            filter_max_conditions: Some(1),
+            ..Default::default()
+        };
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn test_strict_mode_config_rejects_zero_upsert_max_batchsize() {
+        let config = StrictModeConfig {
+            upsert_max_batchsize: Some(0),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err().to_string();
+        assert!(err.contains("upsert_max_batchsize"), "error was: {err}");
+
+        let config = StrictModeConfig {
+            upsert_max_batchsize: Some(1),
+            ..Default::default()
+        };
+        config.validate().unwrap();
     }
 
     fn match_condition(key: &str, value: &str) -> Condition {

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1393,7 +1393,6 @@ pub struct StrictModeConfig {
 
     /// Max conditions a filter can have.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[validate(range(min = 1))]
     pub filter_max_conditions: Option<usize>,
 
     /// Max size of a condition, eg. items in `MatchAny`.
@@ -4926,22 +4925,6 @@ mod tests {
             ..Default::default()
         };
         params.validate().unwrap();
-    }
-
-    #[test]
-    fn test_strict_mode_config_rejects_zero_filter_max_conditions() {
-        let config = StrictModeConfig {
-            filter_max_conditions: Some(0),
-            ..Default::default()
-        };
-        let err = config.validate().unwrap_err().to_string();
-        assert!(err.contains("filter_max_conditions"), "error was: {err}");
-
-        let config = StrictModeConfig {
-            filter_max_conditions: Some(1),
-            ..Default::default()
-        };
-        config.validate().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## What
Fixes #9372 (partially — see below).

`StrictModeConfig` validates `max_query_limit`, `max_timeout`, and `max_points_count` with `#[validate(range(min = 1))]`, but `filter_max_conditions` and `upsert_max_batchsize` had no lower-bound check.

**Update:** as @timvisee pointed out in review, `filter_max_conditions = 0` is not actually a poisoned config — `check_filter_limits` (`lib/collection/src/operations/verification/mod.rs`) only runs when a request includes a filter at all, so `0` just means "no filtering allowed on this collection," which is a legitimate strict-mode policy. Unfiltered queries and upserts are unaffected. Reverted that half.

`upsert_max_batchsize = 0` is different: `check_limit_opt` (`lib/collection/src/operations/verification/update.rs`) compares every upsert's point count against the limit unconditionally, so `0` blocks every insert forever with no plausible intentional use at collection-creation time — that's the actual "poison pill" from the original issue. This half of the fix stands.

## Change
Adds `#[validate(range(min = 1))]` to `upsert_max_batchsize` only, in `lib/segment/src/types.rs`. It's validated through the existing `#[validate(nested)]` call sites in `lib/storage/src/content_manager/collection_meta_ops.rs`, so no other wiring changes were needed.

## Tests
`test_strict_mode_config_rejects_zero_upsert_max_batchsize`, modeled on the existing `test_search_params_rejects_zero_hnsw_ef`. Fails on `main` before this change, passes after.

Ran `cargo +nightly fmt -p segment -- --check` (clean) and `cargo clippy -p segment --lib` (no warnings).

## 🤖 Agent context
This commit was generated with an AI coding assistant (Claude Code). Prompt used: "add `#[validate(range(min = 1))]` to `filter_max_conditions` and `upsert_max_batchsize` in `StrictModeConfig` (lib/segment/src/types.rs), matching the existing validation on `max_query_limit`/`max_timeout`/`max_points_count`, and add tests modeled on `test_search_params_rejects_zero_hnsw_ef`." I reviewed the diff, confirmed the fields route through the same `#[validate(nested)]` call sites as the already-validated fields, and ran the fmt/clippy/test commands above myself.

The follow-up commit (dropping `filter_max_conditions`) was written manually after tracing through `check_filter_limits` and `check_limit_opt` in response to review feedback, not AI-generated.