### PR TITLE
feat(edge): shard-open DX — clear(), ShardLocked, and an Unreadable load error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5692,6 +5692,7 @@ version = "0.8.0"
 dependencies = [
  "ahash",
  "edge",
+ "fs-err",
  "ordered-float 5.5.0",
  "parking_lot",
  "segment",

--- a/lib/edge/ffi/Cargo.toml
+++ b/lib/edge/ffi/Cargo.toml
@@ -58,3 +58,8 @@ tempfile = { workspace = true }
 
 [build-dependencies]
 uniffi = { version = "0.32", features = ["build"] }
+
+[dev-dependencies]
+# Integration tests fabricate/mutate scratch shard dirs; the workspace bans bare
+# `std::fs` (clippy `disallowed_methods`) in favour of `fs_err`.
+fs-err = { workspace = true }

--- a/lib/edge/ffi/src/error.rs
+++ b/lib/edge/ffi/src/error.rs
@@ -4,10 +4,15 @@ use segment::json_path::JsonPath;
 /// The error type returned from fallible `EdgeShard` operations and
 /// `UpdateOperation` constructors.
 ///
-/// Three branchable variants let Swift/Kotlin hosts pattern-match on the error
+/// Five branchable variants let Swift/Kotlin hosts pattern-match on the error
 /// category:
 ///
 /// - `ShardClosed` — the shard has been unloaded; reopen it via `load`.
+/// - `ShardLocked` — another live handle already holds the shard; recoverable,
+///   distinct from corruption (close the other handle or retry).
+/// - `Unreadable` — existing on-disk data is present but will not open (corrupt
+///   or inaccessible config, segments, or WAL); do **not** recreate over it —
+///   that destroys it.
 /// - `InvalidArgument` — host-supplied input was invalid; fix it and retry.
 /// - `OperationError` — any other engine failure (I/O, missing index, etc.).
 ///
@@ -24,6 +29,10 @@ use segment::json_path::JsonPath;
 ///     let shard = try EdgeShard.load(path: dataDir, config: nil)
 /// } catch EdgeError.shardClosed {
 ///     print("Shard is closed — reopen it first")
+/// } catch EdgeError.shardLocked {
+///     print("Another handle has this shard open — retry or close it first")
+/// } catch let EdgeError.unreadable(reason) {
+///     print("Store present but unreadable — do NOT overwrite: \(reason)")
 /// } catch let EdgeError.invalidArgument(reason) {
 ///     print("Bad input: \(reason)")
 /// } catch let error as EdgeError {
@@ -36,6 +45,10 @@ use segment::json_path::JsonPath;
 ///     val shard = EdgeShard.load(path = dataDir, config = null)
 /// } catch (e: EdgeException.ShardClosed) {
 ///     println("Shard is closed — reopen it first")
+/// } catch (e: EdgeException.ShardLocked) {
+///     println("Another handle has this shard open — retry or close it first")
+/// } catch (e: EdgeException.Unreadable) {
+///     println("Store present but unreadable — do NOT overwrite: ${e.reason}")
 /// } catch (e: EdgeException.InvalidArgument) {
 ///     println("Bad input: ${e.reason}")
 /// } catch (e: EdgeException.OperationException) {
@@ -47,6 +60,24 @@ pub enum EdgeError {
     /// The shard has been unloaded/disposed; reopen it via `load` to continue.
     #[error("shard is closed")]
     ShardClosed,
+
+    /// Another live handle already holds this shard (its write-ahead log is
+    /// locked). This is an ordinary, recoverable condition — a second isolate,
+    /// a store the app forgot to close, a provider rebuilt — and is explicitly
+    /// *not* corruption: close the other handle (or retry) and the shard opens.
+    /// Only [`EdgeShard::load`](crate::EdgeShard::load) returns it.
+    #[error("shard is already open by another handle")]
+    ShardLocked,
+
+    /// Existing on-disk shard data is present at the path but cannot be read —
+    /// a corrupt/unparseable or inaccessible `edge_config.json`, segments that
+    /// will not load, or a corrupt WAL (a *held* WAL lock is `ShardLocked`, not
+    /// this). The reaction differs from a fresh start: the caller must **not** recreate
+    /// over it (that would destroy recoverable data), so it is surfaced as its
+    /// own branchable category rather than a generic `OperationError`. Only
+    /// [`EdgeShard::load`](crate::EdgeShard::load) returns it.
+    #[error("{reason}")]
+    Unreadable { reason: String },
 
     /// Host-supplied input was invalid (bad UUID, out-of-range coordinate,
     /// malformed payload key/JSON, contradictory match filter, …). Fix the

--- a/lib/edge/ffi/src/shard.rs
+++ b/lib/edge/ffi/src/shard.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
+use segment::common::operation_error::OperationError;
 use segment::types::SegmentConfig;
 use shard::files::{clear_data, move_data};
 use shard::snapshots::snapshot_manifest::SnapshotManifest;
@@ -89,10 +90,13 @@ impl EdgeShard {
     ///
     /// # Errors
     ///
-    /// Returns an [`EdgeError::OperationError`] if the path is not writable,
-    /// the WAL cannot be opened, stored segments are incompatible with the
-    /// provided `config`, or the directory contains no segments and no
-    /// `config` was supplied.
+    /// - [`EdgeError::ShardLocked`] — another live handle already holds the
+    ///   shard's WAL lock; retry once it is released.
+    /// - [`EdgeError::Unreadable`] — existing on-disk data is present but cannot
+    ///   be read (corrupt, or not accessible). Do **not** recreate over it.
+    /// - [`EdgeError::OperationError`] — the path is not writable, the stored
+    ///   segments are incompatible with the provided `config`, or the directory
+    ///   contains no segments and no `config` was supplied.
     #[uniffi::constructor]
     pub fn load(path: String, config: Option<EdgeConfig>) -> Result<Arc<Self>> {
         // Reject config Edge can't honor (out-of-range vector size, unsupported
@@ -106,7 +110,8 @@ impl EdgeShard {
         let edge_config = config
             .map(SegmentConfig::from)
             .map(|sc| edge::EdgeConfig::from_segment_config(&sc));
-        let shard = edge::EdgeShard::load(&PathBuf::from(path), edge_config)?;
+        let shard = edge::EdgeShard::load(&PathBuf::from(path), edge_config)
+            .map_err(map_shard_load_error)?;
         Ok(Arc::new(Self {
             inner: RwLock::new(Some(shard)),
         }))
@@ -139,6 +144,25 @@ impl EdgeShard {
     /// Returns [`EdgeError::ShardClosed`] if the shard is unloaded.
     pub fn path(&self) -> Result<String> {
         self.with_shard(|shard| Ok(shard.path().to_string_lossy().into_owned()))
+    }
+
+    /// Deletes every point in the shard, leaving it loaded, its configuration
+    /// and payload indexes intact, and immediately writable again.
+    ///
+    /// This is the named, discoverable form of the match-all delete idiom
+    /// (`update(UpdateOperation::deletePointsByFilter(filter: /* empty */))`):
+    /// an empty filter matches every point. Prefer it to deleting the shard
+    /// directory when you want to reset a store's contents — the shard stays
+    /// open, so there is no reopen, no config to rebuild from scratch, and no
+    /// directory handling to get wrong. To discard a store *and* its files,
+    /// unload the shard and remove its directory instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EdgeError::ShardClosed`] if the shard is unloaded, or
+    /// [`EdgeError::OperationError`] if the delete fails to apply or persist.
+    pub fn clear(&self) -> Result<()> {
+        self.with_shard(|shard| Ok(shard.clear()?))
     }
 
     /// Flushes the write-ahead log and all segments to disk synchronously.
@@ -360,6 +384,10 @@ impl EdgeShard {
             move_data(unpack_dir.path(), &shard_path).map_err(|e| EdgeError::OperationError {
                 reason: format!("failed to move snapshot data into place: {e}"),
             })?;
+            // Load with a plain `?` (not `map_shard_load_error`) on purpose: the dir
+            // was just intentionally cleared and repopulated from the snapshot, so a
+            // `ShardLocked`/`Unreadable` category here would carry no host-actionable
+            // "another handle" / "don't overwrite" signal — a generic error is right.
             *guard = Some(edge::EdgeShard::load(&shard_path, None)?);
             return Ok(());
         }
@@ -397,4 +425,144 @@ impl EdgeShard {
 pub fn unpack_snapshot(snapshot_path: String, target_path: String) -> Result<()> {
     edge::EdgeShard::unpack_snapshot(&PathBuf::from(snapshot_path), &PathBuf::from(target_path))?;
     Ok(())
+}
+
+/// Maps the engine's shard-load error to the FFI error type, translating the
+/// one recoverable, expected failure — the shard's WAL is already held by
+/// another live handle — into a distinct [`EdgeError::ShardLocked`] so a
+/// consumer can retry or report "already open" without substring-matching a
+/// message itself.
+///
+/// The WAL takes an advisory `flock` on `<path>/wal` at open; a second handle
+/// fails with `io::ErrorKind::WouldBlock`, which the `wal` crate stringifies as
+/// `"Can't init WAL: Kind(WouldBlock)"` before it reaches this boundary — the
+/// error *kind* is lost to a string there, so this is the one place we must
+/// match on the message. The `load_of_locked_shard_reports_shard_locked`
+/// integration test pins the format so a future `wal` change can't silently
+/// demote this back to a generic `OperationError`.
+fn map_shard_load_error(err: OperationError) -> EdgeError {
+    // Typed load failures are classified by *variant*, before inspecting any
+    // message string — so a corrupt config whose on-disk path happens to contain
+    // "Can't init WAL"/"WouldBlock" can never fall into the WAL string check below
+    // and be misread as a held lock.
+    //
+    // `edge::EdgeShard::load` reports a failure to read existing on-disk config or
+    // segments as `InconsistentStorage`; surface it as the branchable `Unreadable`
+    // so a caller can tell "present but won't open" from "nothing here" and refuse
+    // to recreate over real data.
+    if let OperationError::InconsistentStorage { description } = &err {
+        return EdgeError::Unreadable {
+            reason: description.clone(),
+        };
+    }
+    // A provided config that contradicts intact, readable stored segments is a
+    // bad-argument case ("fix your config"), not do-not-overwrite: the data reads
+    // fine. `load` tags it as a typed `ValidationError`; surface it as
+    // `InvalidArgument` so a "recreate unless Unreadable" consumer does not clobber
+    // recoverable, config-mismatched data.
+    if let OperationError::ValidationError { description } = &err {
+        return EdgeError::InvalidArgument {
+            reason: description.clone(),
+        };
+    }
+    // The one unavoidable string boundary: WAL-open failures come from the
+    // third-party `wal` crate as a stringified io error, so the *kind* is lost and
+    // this is the only place we match on the message (see the note above the fn).
+    let msg = err.to_string();
+    if let Some((_, wal_detail)) = msg.split_once("Can't init WAL") {
+        // Match `WouldBlock` only in the io-error tail *after* the WAL prefix.
+        // `load` wraps the failure with the WAL path first, so checking the whole
+        // message would misclassify a corrupt WAL as `ShardLocked` when the shard
+        // path itself contains "WouldBlock".
+        if wal_detail.contains("WouldBlock") {
+            // Another live handle holds the WAL lock — recoverable.
+            return EdgeError::ShardLocked;
+        }
+        // A non-lock WAL-open failure. With existing shard data present (a
+        // corrupt/truncated WAL state file) this is "present but won't open" and
+        // must not be recreated over — left generic before, it would let a
+        // "recreate unless Unreadable" consumer clobber intact segments. NOTE: on a
+        // fresh path a non-lock WAL init failure (e.g. a filesystem that rejects
+        // the advisory lock) also lands here and is reported as `Unreadable` though
+        // no data exists — a benign mislabel (nothing to overwrite, and the caller
+        // is blocked either way). Separating the two needs the `wal` crate to
+        // preserve the io `ErrorKind` rather than stringifying it (upstream
+        // follow-up in `lib/shard/src/wal.rs`); that same typed kind would also
+        // retire the substring match here.
+        return EdgeError::Unreadable { reason: msg };
+    }
+    EdgeError::from(err)
+}
+
+#[cfg(test)]
+mod tests {
+    use segment::common::operation_error::OperationError;
+
+    use super::map_shard_load_error;
+    use crate::error::EdgeError;
+
+    /// A failure to read existing on-disk state is tagged `InconsistentStorage` by
+    /// `edge::load`; the classifier must map it to `Unreadable` by *variant*.
+    #[test]
+    fn inconsistent_storage_maps_to_unreadable() {
+        let err = OperationError::inconsistent_storage("corrupt edge_config.json");
+        assert!(
+            matches!(map_shard_load_error(err), EdgeError::Unreadable { .. }),
+            "InconsistentStorage must map to Unreadable",
+        );
+    }
+
+    /// Regression (P1): the typed `InconsistentStorage` arm runs *before* the WAL
+    /// string check, so a corrupt-config error whose text happens to contain the
+    /// WAL lock look-alikes ("Can't init WAL" … "WouldBlock" — e.g. echoed from a
+    /// shard path) must stay `Unreadable`, never be misread as a held lock. Before
+    /// the reorder this fell into the WAL branch and returned `ShardLocked`.
+    #[test]
+    fn inconsistent_storage_with_wal_lookalike_text_is_unreadable_not_locked() {
+        let err = OperationError::inconsistent_storage(
+            "failed to read /tmp/Can't init WAL WouldBlock/edge_config.json",
+        );
+        assert!(
+            matches!(map_shard_load_error(err), EdgeError::Unreadable { .. }),
+            "a typed InconsistentStorage must not fall into the WAL string check",
+        );
+    }
+
+    /// A provided config that contradicts intact stored segments is tagged
+    /// `ValidationError` by `edge::load`; the classifier must map it to
+    /// `InvalidArgument` ("fix your input"), not do-not-overwrite, not generic.
+    #[test]
+    fn validation_error_maps_to_invalid_argument() {
+        let err = OperationError::validation_error("config is incompatible with existing segments");
+        assert!(
+            matches!(map_shard_load_error(err), EdgeError::InvalidArgument { .. }),
+            "ValidationError must map to InvalidArgument",
+        );
+    }
+
+    /// A genuine held WAL lock surfaces from the `wal` crate as a stringified
+    /// `WouldBlock` in the io-error tail and must classify to `ShardLocked`.
+    #[test]
+    fn wal_wouldblock_tail_maps_to_shard_locked() {
+        let err = OperationError::service_error(
+            "failed to open WAL /data/wal: Can't init WAL: Kind(WouldBlock)",
+        );
+        assert!(
+            matches!(map_shard_load_error(err), EdgeError::ShardLocked),
+            "a WouldBlock WAL tail must map to ShardLocked",
+        );
+    }
+
+    /// A non-lock WAL-open failure (corrupt WAL state) has no `WouldBlock` in the
+    /// io tail and must classify to `Unreadable` (do-not-overwrite).
+    #[test]
+    fn wal_non_lock_failure_maps_to_unreadable() {
+        let err = OperationError::service_error(
+            "failed to open WAL /data/wal: Can't init WAL: unexpected end of file",
+        );
+        assert!(
+            matches!(map_shard_load_error(err), EdgeError::Unreadable { .. }),
+            "a non-lock WAL failure must map to Unreadable",
+        );
+    }
 }

--- a/lib/edge/ffi/tests/integration.rs
+++ b/lib/edge/ffi/tests/integration.rs
@@ -4502,3 +4502,265 @@ fn text_index_with_params_filters_with_stopwords() {
     // point matches even though every title contains it.
     assert_eq!(count_matching("point"), 0);
 }
+
+// ── Unreadable + ShardLocked + clear ──────────────────────────────────────────
+
+/// Existing on-disk data that is present but won't open surfaces as the distinct
+/// `Unreadable`, not a generic `OperationError`, so a caller can tell it apart
+/// from an empty path and refuse to recreate over recoverable data.
+#[test]
+fn load_of_corrupt_config_reports_unreadable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().to_str().unwrap().to_string();
+    {
+        let shard = EdgeShard::load(path.clone(), Some(make_config())).expect("load");
+        upsert_three(&shard);
+        shard.flush().expect("flush");
+        shard.unload().expect("unload");
+    }
+    // Corrupt the persisted config: the shard data is present, but load can't
+    // read it — must be `Unreadable`, never a silent empty-start.
+    fs_err::write(dir.path().join("edge_config.json"), b"{ this is not valid")
+        .expect("corrupt config");
+
+    let Err(err) = EdgeShard::load(path, None) else {
+        panic!("load must fail on a corrupt persisted config");
+    };
+    let EdgeError::Unreadable { reason } = err else {
+        panic!("expected Unreadable, got {err:?}");
+    };
+    assert!(
+        !reason.is_empty(),
+        "Unreadable must carry the underlying cause as `reason`",
+    );
+}
+
+/// Corrupt *segments* (not the config) — the data-safety-critical path — must
+/// also surface `Unreadable`. The `version.info` marker is left intact so the
+/// loader tries to open the segment (a marker-less dir is silently reclaimed);
+/// corrupting the segment metadata then fails the open.
+#[test]
+fn load_of_corrupt_segment_reports_unreadable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().to_str().unwrap().to_string();
+    {
+        let shard = EdgeShard::load(path.clone(), Some(make_config())).expect("load");
+        upsert_three(&shard);
+        shard.flush().expect("flush");
+        shard.unload().expect("unload");
+    }
+    // Find the persisted segment dir and corrupt its metadata, leaving
+    // `version.info` in place so the dir is opened rather than reclaimed.
+    let seg_dir = fs_err::read_dir(dir.path().join("segments"))
+        .expect("segments dir")
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .find(|p| p.is_dir())
+        .expect("a persisted segment dir");
+    fs_err::write(seg_dir.join("segment.json"), b"{ not valid segment json")
+        .expect("corrupt segment metadata");
+
+    let Err(err) = EdgeShard::load(path, None) else {
+        panic!("load must fail on a corrupt persisted segment");
+    };
+    assert!(
+        matches!(err, EdgeError::Unreadable { .. }),
+        "corrupt segments must be Unreadable (do-not-overwrite), got {err:?}",
+    );
+}
+
+/// The recoverable counter-case: when only the `edge_config.json` sidecar is
+/// missing but the segments are intact, `load(path, None)` must rebuild the
+/// config from the segments and reopen the data — NOT fail, and NOT be treated
+/// as empty. This is the "present but readable, do not overwrite" property that
+/// makes `Unreadable` meaningful.
+#[test]
+fn load_recovers_when_only_config_sidecar_is_deleted() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().to_str().unwrap().to_string();
+    {
+        let shard = EdgeShard::load(path.clone(), Some(make_config())).expect("load");
+        upsert_three(&shard);
+        shard.flush().expect("flush");
+        shard.unload().expect("unload");
+    }
+    fs_err::remove_file(dir.path().join("edge_config.json")).expect("remove config sidecar");
+
+    let shard = EdgeShard::load(path, None).expect("must recover config from segments");
+    assert_eq!(
+        shard.info().expect("info").points_count,
+        3,
+        "all points must survive a config-sidecar deletion",
+    );
+}
+
+/// A corrupt WAL (segments intact) is a *non-lock* WAL-open failure, distinct
+/// from `ShardLocked`. It must surface as `Unreadable` — a caller that recreates
+/// on any non-`Unreadable` error would otherwise clobber the intact segments.
+#[test]
+fn load_of_corrupt_wal_reports_unreadable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().to_str().unwrap().to_string();
+    {
+        let shard = EdgeShard::load(path.clone(), Some(make_config())).expect("load");
+        upsert_three(&shard);
+        shard.flush().expect("flush");
+        shard.unload().expect("unload");
+    }
+    // Scribble over every WAL file, leaving the segments untouched.
+    for entry in fs_err::read_dir(dir.path().join("wal"))
+        .expect("wal dir")
+        .filter_map(Result::ok)
+    {
+        if entry.path().is_file() {
+            fs_err::write(entry.path(), b"\x00\x01\x02 not a valid wal file")
+                .expect("corrupt wal file");
+        }
+    }
+
+    let Err(err) = EdgeShard::load(path, None) else {
+        panic!("load must fail on a corrupt WAL");
+    };
+    assert!(
+        matches!(err, EdgeError::Unreadable { .. }),
+        "corrupt WAL must be Unreadable (do-not-overwrite), got {err:?}",
+    );
+}
+
+/// Regression: a corrupt WAL must stay `Unreadable` even when the shard path
+/// itself contains the substring "WouldBlock" — the WAL-lock classification must
+/// match the io-error tail, not the path in the error's outer wrap.
+#[test]
+fn corrupt_wal_under_wouldblock_path_is_unreadable_not_locked() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let shard_dir = dir.path().join("WouldBlock");
+    fs_err::create_dir(&shard_dir).expect("create WouldBlock dir");
+    let path = shard_dir.to_str().unwrap().to_string();
+    {
+        let shard = EdgeShard::load(path.clone(), Some(make_config())).expect("load");
+        upsert_three(&shard);
+        shard.flush().expect("flush");
+        shard.unload().expect("unload");
+    }
+    for entry in fs_err::read_dir(shard_dir.join("wal"))
+        .expect("wal dir")
+        .filter_map(Result::ok)
+    {
+        if entry.path().is_file() {
+            fs_err::write(entry.path(), b"\x00\x01\x02 not a valid wal file")
+                .expect("corrupt wal file");
+        }
+    }
+
+    let Err(err) = EdgeShard::load(path, None) else {
+        panic!("load must fail on a corrupt WAL");
+    };
+    assert!(
+        matches!(err, EdgeError::Unreadable { .. }),
+        "corrupt WAL under a 'WouldBlock' path must be Unreadable, not ShardLocked; got {err:?}",
+    );
+}
+
+/// A second load of a shard another handle already holds fails with the distinct
+/// `ShardLocked`, not a generic `OperationError` (and not `Unreadable` — the data
+/// is fine, another handle just holds the WAL lock).
+#[test]
+fn load_of_locked_shard_reports_shard_locked() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().to_str().unwrap().to_string();
+
+    // First handle holds the WAL flock for its lifetime (not unloaded).
+    let s1 = EdgeShard::load(path.clone(), Some(make_config())).expect("first load");
+    upsert_three(&s1);
+
+    // `Arc<EdgeShard>` is not Debug, so `let...else` instead of `expect_err`.
+    let Err(err) = EdgeShard::load(path.clone(), None) else {
+        panic!("second load must fail while the first handle holds the shard");
+    };
+    assert!(
+        matches!(err, EdgeError::ShardLocked),
+        "expected ShardLocked, got {err:?}",
+    );
+
+    s1.unload().expect("unload");
+}
+
+/// A provided config that contradicts intact, readable stored segments is a
+/// bad-argument case, not do-not-overwrite: the data reads fine. It must surface
+/// as `InvalidArgument` ("fix your config") — never `Unreadable` (wrong advice,
+/// the data is fine) and never a silent empty-start (which would strand the
+/// mismatched data). This pins the last "data is present" branch of the
+/// do-not-overwrite contract at load.
+#[test]
+fn load_with_config_incompatible_with_segments_reports_invalid_argument() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().to_str().unwrap().to_string();
+    {
+        let shard = EdgeShard::load(path.clone(), Some(make_config())).expect("load");
+        upsert_three(&shard);
+        shard.flush().expect("flush");
+        shard.unload().expect("unload");
+    }
+    // Reopen with a config whose vector size (8) contradicts the stored data (4).
+    let mismatched = EdgeConfig {
+        vector_data: HashMap::from([(
+            "vec".to_string(),
+            VectorDataConfig {
+                size: 8,
+                distance: Distance::Dot,
+                quantization_config: None,
+                multivector_config: None,
+                datatype: None,
+                hnsw_config: None,
+            },
+        )]),
+        sparse_vector_data: HashMap::new(),
+    };
+
+    let Err(err) = EdgeShard::load(path, Some(mismatched)) else {
+        panic!("load must reject a config that contradicts stored segments");
+    };
+    assert!(
+        matches!(err, EdgeError::InvalidArgument { .. }),
+        "config-vs-stored-segments mismatch must be InvalidArgument (fix your config), \
+         not Unreadable and not a silent empty-start; got {err:?}",
+    );
+}
+
+/// `clear()` deletes every point, leaves the shard writable, and the empty state
+/// persists across a reload.
+#[test]
+fn clear_deletes_all_points_and_keeps_shard_writable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().to_str().unwrap().to_string();
+    let count = |shard: &EdgeShard| {
+        shard
+            .count(CountRequest {
+                filter: None,
+                exact: true,
+            })
+            .expect("count")
+    };
+
+    let shard = EdgeShard::load(path.clone(), Some(make_config())).expect("load");
+    upsert_three(&shard);
+    assert_eq!(count(&shard), 3);
+
+    shard.clear().expect("clear");
+    assert_eq!(count(&shard), 0, "clear() must remove every point");
+
+    // Still writable after clear.
+    upsert_three(&shard);
+    assert_eq!(count(&shard), 3, "shard must stay writable after clear()");
+
+    // Empty state persists across reload.
+    shard.clear().expect("clear again");
+    shard.flush().expect("flush");
+    shard.unload().expect("unload");
+    let reopened = EdgeShard::load(path, None).expect("reopen");
+    assert_eq!(
+        reopened.info().expect("info").points_count,
+        0,
+        "clear() must persist",
+    );
+}

--- a/lib/edge/src/edge_shard/mod.rs
+++ b/lib/edge/src/edge_shard/mod.rs
@@ -108,7 +108,15 @@ impl EdgeShard {
     /// the default 32 MiB segment capacity is too large), set
     /// [`EdgeConfig::wal_options`] on the supplied config.
     pub fn load(path: &Path, config: Option<EdgeConfig>) -> OperationResult<Self> {
-        let resolved = resolve_initial_config(path, config)?;
+        // Reading existing on-disk state can fail in ways that all mean "present
+        // but won't open": a persisted `edge_config.json` that exists but can't be
+        // read or parsed (corrupt, or inaccessible — permission/`ENOTDIR`/`ELOOP`),
+        // and segments that won't load. Tag both so the FFI surfaces `Unreadable`
+        // and the caller refuses to recreate over recoverable data. The WAL open
+        // between them is left untagged here because the `wal` crate stringifies
+        // its error — the FFI classifies it (a held lock -> `ShardLocked`, a
+        // corrupt WAL -> `Unreadable`).
+        let resolved = resolve_initial_config(path, config).map_err(mark_unreadable)?;
 
         let wal_options = resolved
             .as_ref()
@@ -116,17 +124,27 @@ impl EdgeShard {
             .unwrap_or_default();
         let (wal, segments_path) = ensure_dirs_and_open_wal(path, wal_options)?;
 
-        let (mut segments, derived) = load_segments(&segments_path)?;
+        let (mut segments, derived) = load_segments(&segments_path).map_err(mark_unreadable)?;
 
         let config = match (resolved, derived) {
             (Some(resolved), Some(derived)) => {
                 let merged = resolved.fill_unspecified_from(&derived);
                 // The tunables converge to the merged config via the optimizers, but the vector
                 // definitions must actually match the stored data.
+                //
+                // Category: the data reads fine — it's the provided `config` that
+                // contradicts what's stored, so this is a bad-argument case ("fix
+                // your config"), NOT `Unreadable`. Do-not-overwrite would be the
+                // wrong advice here, but so is a generic error: a consumer following
+                // the "recreate unless `Unreadable`" contract would clobber intact,
+                // readable data on a mere config typo. Carried as a typed
+                // `ValidationError` so the FFI classifies it by variant into
+                // `InvalidArgument` ("fix your input, retry"), symmetric to the
+                // `InconsistentStorage`->`Unreadable` mapping.
                 merged
                     .check_compatible_with_segment_config(&derived.plain_segment_config())
                     .map_err(|err| {
-                        OperationError::service_error(format!(
+                        OperationError::validation_error(format!(
                             "config is incompatible with existing segments: {err}"
                         ))
                     })?;
@@ -343,6 +361,19 @@ fn ensure_dirs_and_open_wal(
     }
 
     Ok((wal, segments_path))
+}
+
+/// Tag an error from reading existing on-disk shard data so the FFI boundary
+/// classifies it as `EdgeError::Unreadable` — the caller must not recreate over
+/// data it cannot read. Covers both corrupt/unparseable data and the case where
+/// the path exists but cannot be accessed (permission, `ENOTDIR`, `ELOOP`, …):
+/// either way, overwriting would be the wrong reaction.
+///
+/// Carried as a typed [`OperationError::InconsistentStorage`] (not a marker
+/// string) so the FFI classifies it by variant and surfaces the underlying
+/// cause as the `reason`, with no internal sentinel text leaking to hosts.
+fn mark_unreadable(err: OperationError) -> OperationError {
+    OperationError::inconsistent_storage(err.to_string())
 }
 
 /// The provided → persisted layers of the config fallback chain (the derived-from-segments layer

--- a/lib/edge/src/edge_shard/update.rs
+++ b/lib/edge/src/edge_shard/update.rs
@@ -11,6 +11,20 @@ use crate::EdgeShard;
 use crate::config::vectors::{EdgeSparseVectorParams, EdgeVectorParams};
 
 impl EdgeShard {
+    /// Deletes every point in the shard, leaving it loaded and its configuration
+    /// and payload indexes intact. The shard stays open and immediately writable
+    /// — the in-place counterpart of deleting the shard directory. Equivalent to
+    /// applying a match-all `DeletePointsByFilter`, but as a named operation.
+    pub fn clear(&self) -> OperationResult<()> {
+        // A default (all-`None`) filter matches every point; the delete is
+        // written to the WAL and applied to the segments like any other op.
+        self.update(CollectionUpdateOperations::PointOperation(
+            shard::operations::point_ops::PointOperations::DeletePointsByFilter(
+                segment::types::Filter::default(),
+            ),
+        ))
+    }
+
     pub fn update(&self, operation: CollectionUpdateOperations) -> OperationResult<()> {
         // Reject a conflicting vector-name re-create before it reaches the WAL:
         // the segment-level create is idempotent, so re-creating an existing


### PR DESCRIPTION
## What

Three branchable, DX-focused additions to the Edge FFI, folding the "is a shard here, and would it open?" concerns into `load`'s own typed errors:

- **`clear()`** — a named match-all delete that empties a shard in place, keeping it loaded and writable (the in-place counterpart of deleting the directory).
- **`EdgeError::ShardLocked`** — `load` distinguishes "another live handle holds the WAL" (recoverable) from a generic failure.
- **`EdgeError::Unreadable { reason }`** — `load` distinguishes "existing on-disk data is present but won't open" (corrupt/inaccessible config, segments, or WAL) from "nothing here", so a consumer can refuse to recreate over recoverable data rather than silently clobber it.

## Why not `probe`

This replaces the earlier `probe(path) -> ShardPresence` read-only classifier (per @generall's review): a separate advisory path re-deriving `load`'s decision is a second source of truth that can disagree with `load` (TOCTOU). Folding the one real distinction — *empty* vs *present-but-broken* — into `load`'s error type keeps a single code path: the failed open **is** the classification.

Classification lives in `edge::load` (it tags its read-existing-state failures as `InconsistentStorage`); the FFI translates by variant. A **held** WAL lock stays `ShardLocked`, not `Unreadable`.

## Tests

`Unreadable` is covered on all three data-safety paths — corrupt config, corrupt segments (version marker intact), corrupt WAL — plus the recoverable counter-case (config sidecar deleted → recovers from segments). `ShardLocked` and `clear()` keep their tests.
