### PR TITLE
Remove stale clippy allows and the obsolete large-error-threshold override

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,3 @@
-# For Rust 1.87 until fixed: <https://github.com/hyperium/tonic/issues/2253>
-large-error-threshold = 256
 
 disallowed-types = [
   # Use fs_err instead of std::fs and tokio::fs

--- a/lib/blobstore/src/tracker/append_only.rs
+++ b/lib/blobstore/src/tracker/append_only.rs
@@ -878,7 +878,6 @@ mod tests {
             vec![Some(pointer(2)), Some(pointer(3)),]
         );
         assert_eq!(tracker.get_range::<Random>(7..9).unwrap(), vec![None, None]);
-        #[allow(clippy::reversed_empty_ranges)]
         let empty = tracker.get_range::<Random>(3..3).unwrap();
         assert!(empty.is_empty());
     }

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -421,7 +421,6 @@ impl SegmentsSearcher {
     /// Byte-blob analogue of [`Self::retrieve`]: returns vectors as
     /// storage-native bytes ([`SegmentRecordRaw`]), avoiding a lossy
     /// quantization round-trip when relocating points during shard transfer.
-    #[allow(clippy::too_many_arguments)]
     pub async fn retrieve_raw(
         segments: LockedSegmentHolder,
         points: &[PointIdType],

--- a/lib/edge/ffi/tests/integration.rs
+++ b/lib/edge/ffi/tests/integration.rs
@@ -758,7 +758,6 @@ fn zero_vector_size_rejected_at_load() {
         .expect("vec field exists")
         .size = 0;
 
-    #[allow(clippy::err_expect)]
     let err = EdgeShard::load(path, Some(config))
         .err()
         .expect("load with size=0 should be rejected, not crash the engine");
@@ -999,7 +998,6 @@ fn oversized_hnsw_params_rejected_not_allocated() {
     ] {
         let dir = tempfile::tempdir().expect("tempdir failed");
         let path = dir.path().to_string_lossy().into_owned();
-        #[allow(clippy::err_expect)]
         let err = EdgeShard::load(path, Some(make(hnsw)))
             .err()
             .unwrap_or_else(|| panic!("{label}: load should be rejected, not allocated"));
@@ -1217,7 +1215,6 @@ fn nested_prefetch(depth: u32) -> qdrant_edge_ffi::Prefetch {
 /// Assert that `upsert_points` rejects `vector` eagerly (at the constructor,
 /// before any shard is involved) with `InvalidArgument`.
 fn assert_vector_rejected(vector: Vector) {
-    #[allow(clippy::err_expect)]
     let err = UpdateOperation::upsert_points(
         vec![Point {
             id: PointId::NumId { value: 1 },
@@ -3040,7 +3037,6 @@ fn create_and_delete_named_vector_field() {
     // Size bound is enforced at the boundary.
     // `.err().expect()` rather than `.expect_err()`: the Ok type involves a
     // non-`Debug` UniFFI object, so `expect_err` does not compile.
-    #[allow(clippy::err_expect)]
     let err = UpdateOperation::create_dense_vector("bad".to_string(), 0, Distance::Dot, None, None)
         .err()
         .expect("size 0 must be rejected");
@@ -3283,7 +3279,6 @@ fn lifecycle_additions_work() {
     // `create` on an occupied path must fail; on a fresh path it must work.
     // `.err().expect()`: see note above — the Ok type is a non-`Debug`
     // UniFFI object.
-    #[allow(clippy::err_expect)]
     let err = EdgeShard::create(path_string, make_config())
         .err()
         .expect("create over an existing shard must fail");

--- a/lib/segment/src/index/field_index/full_text_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/mod.rs
@@ -35,7 +35,6 @@ mod read_ops;
 /// [4]: crate::index::field_index::map_index::read_only::ReadOnlyMapIndex
 /// [5]: super::read_ops
 /// [6]: crate::index::field_index::field_index_base::read_only::ReadOnlyFieldIndex
-#[allow(clippy::large_enum_variant)]
 pub enum ReadOnlyFullTextIndex<S: UniversalRead> {
     /// Loads into RAM from appendable storage format
     Appendable(ReadOnlyAppendableFullTextIndex<S>),

--- a/lib/segment/src/index/field_index/geo_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/mod.rs
@@ -35,7 +35,6 @@ mod read_ops;
 /// [4]: super::on_disk_geo_index::OnDiskGeoIndex
 /// [5]: super::GeoIndex::new_gridstore
 /// [6]: super::GeoIndex::new_mmap
-#[allow(clippy::large_enum_variant)]
 pub enum ReadOnlyGeoIndex<S: UniversalRead> {
     /// Loads into RAM from appendable Gridstore storage format.
     Appendable(ReadOnlyAppendableGeoIndex<S>),

--- a/lib/segment/src/index/hnsw_index/graph_layers_batched.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_batched.rs
@@ -163,7 +163,6 @@ impl<S: UniversalRead> GraphLayersBatched<S> {
 
     /// Batched version of
     /// [`super::graph_layers::GraphLayersWithVectors::search_entry_with_vectors`].
-    #[allow(clippy::too_many_arguments)]
     fn search_entry_with_vectors(
         &self,
         entry_point: EntryPoint,

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/lifecycle.rs
@@ -175,7 +175,6 @@ impl<S: UniversalRead> ReadOnlyQuantizedVectors<S> {
     /// placement — a demoted pinned placement opens the lazy mmap loaders over the same
     /// flat files instead of the RAM ones, and a demoted cached placement skips the
     /// page-cache priming.
-    #[allow(clippy::too_many_arguments)]
     pub fn open(
         fs: &impl UniversalReadFs<File = S>,
         path: &Path,


### PR DESCRIPTION
Clippy hygiene, no behaviour change.

- Drop `large-error-threshold = 256` from `clippy.toml`: it was pinned for clippy 1.87 while tonic's `Status` was a large error type, and upstream boxed its contents in `5de7bad` (hyperium/tonic#2253), which is in the pinned 0.14.6 fork.
- Remove 11 `#[allow(clippy::...)]` that no longer suppress anything: `too_many_arguments` x3, `large_enum_variant` x2, `err_expect` x5, `reversed_empty_ranges` x1.
- Verified locally against the three `rust-lint.yml` steps (default, `--all-targets`, `--all-targets --all-features`), all green with `-D warnings`.
- Draft to confirm against CI, which covers configurations the local run does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)