### PR TITLE
Keep consensus operation awaiters alive for concurrent waiters

### DIFF
--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -754,21 +754,40 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         persistent.save()
     }
 
+    /// Deregister a caller that gave up waiting for `operation` to be applied.
+    ///
+    /// The map owns the only `Sender` for an operation, and callers proposing an identical
+    /// operation deduplicate onto it instead of proposing again. Removing the entry closes the
+    /// channel for every other waiter, so one caller's timeout would fail their still in-flight
+    /// operation with `Channel sender dropped`. Only drop the entry once no receiver is left.
+    fn forget_operation_awaiter(&self, operation: &ConsensusOperations) {
+        let mut on_apply_lock = self.on_consensus_op_apply.lock();
+        let no_waiters_left = on_apply_lock
+            .get(operation)
+            .is_some_and(|sender| sender.receiver_count() == 0);
+        if no_waiters_left {
+            on_apply_lock.remove(operation);
+        }
+    }
+
     async fn await_receiver(
         &self,
         mut receiver: Receiver<Result<bool, StorageError>>,
         wait_timeout: Duration,
         operation: &ConsensusOperations,
     ) -> Result<bool, StorageError> {
-        let timeout_res = tokio::time::timeout(wait_timeout, receiver.recv())
-            .await
-            .map_err(|_: Elapsed| {
-                self.on_consensus_op_apply.lock().remove(operation);
-                StorageError::service_error(format!(
+        let timeout_res = match tokio::time::timeout(wait_timeout, receiver.recv()).await {
+            Ok(res) => res,
+            Err(_elapsed) => {
+                // Drop our receiver before deciding whether anyone else still waits on it
+                drop(receiver);
+                self.forget_operation_awaiter(operation);
+                return Err(StorageError::service_error(format!(
                     "Waiting for consensus operation commit failed. Timeout set at: {} seconds",
                     wait_timeout.as_secs_f64(),
-                ))
-            })?;
+                )));
+            }
+        };
         // 2 possible errors to forward: channel sender dropped OR operation failed
         timeout_res.map_err(|err| {
             StorageError::service_error(format!("Error occurred while waiting for consensus operation. Channel sender dropped ({err})"))
@@ -786,7 +805,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             let (sender, mut receiver) = broadcast::channel(1);
             let mut on_apply_lock = self.on_consensus_op_apply.lock();
             // check that the exact same operation is not already in-flight
-            match on_apply_lock.entry(operation) {
+            match on_apply_lock.entry(operation.clone()) {
                 Entry::Occupied(e) => {
                     // subscribe to existing sender for faster feedback
                     receiver = e.get().subscribe()
@@ -796,16 +815,38 @@ impl<C: CollectionContainer> ConsensusManager<C> {
                     e.insert(sender);
                 }
             };
-            receivers.push(receiver);
+            // Keep the key around so we can deregister on timeout
+            receivers.push((operation, receiver));
         }
 
         async move {
-            let await_for_all = join_all(receivers.iter_mut().map(|receiver| receiver.recv()));
-            let results = tokio::time::timeout(
-                wait_timeout.unwrap_or(defaults::CONSENSUS_META_OP_WAIT),
-                await_for_all,
-            )
-            .await?;
+            let timeout_res = {
+                let await_for_all =
+                    join_all(receivers.iter_mut().map(|(_, receiver)| receiver.recv()));
+                tokio::time::timeout(
+                    wait_timeout.unwrap_or(defaults::CONSENSUS_META_OP_WAIT),
+                    await_for_all,
+                )
+                .await
+            };
+
+            let results = match timeout_res {
+                Ok(results) => results,
+                Err(elapsed) => {
+                    let (operations, our_receivers): (Vec<_>, Vec<_>) =
+                        receivers.into_iter().unzip();
+                    // Our receivers must be gone before we check whether anyone else is
+                    // still waiting on these operations
+                    drop(our_receivers);
+                    for operation in &operations {
+                        self.forget_operation_awaiter(operation);
+                    }
+                    return Err(elapsed);
+                }
+            };
+
+            // Every receiver resolved, and whoever resolves an operation takes its entry out
+            // of the map first, so there is nothing left to deregister on the paths below.
             for result in results {
                 match result {
                     Ok(response_res) => match response_res {
@@ -1281,6 +1322,7 @@ pub fn raft_error_other(e: impl std::error::Error) -> raft::Error {
 mod tests {
     use std::assert_matches;
     use std::sync::{Arc, mpsc};
+    use std::time::Duration;
 
     use collection::shards::shard::PeerId;
     use proptest::prelude::*;
@@ -1289,8 +1331,9 @@ mod tests {
     };
     use raft::storage::{MemStorage, Storage};
     use tempfile::Builder;
+    use tokio::sync::broadcast;
 
-    use super::ConsensusManager;
+    use super::{ConsensusManager, ConsensusOperations};
     use crate::content_manager::CollectionContainer;
     use crate::content_manager::consensus::consensus_wal::ConsensusOpWal;
     use crate::content_manager::consensus::entry_queue::EntryApplyProgressQueue;
@@ -1445,6 +1488,190 @@ mod tests {
         ) -> Result<(), crate::content_manager::errors::StorageError> {
             Ok(())
         }
+    }
+
+    /// Regression test for the shared awaiter slot.
+    ///
+    /// Callers proposing an identical operation deduplicate onto one broadcast channel, and the
+    /// map holds its only `Sender`. Before the fix, the first caller to time out removed the
+    /// entry, closing the channel for the others: they failed with `Channel sender dropped`
+    /// even though the operation was still in flight and went on to apply successfully.
+    #[tokio::test]
+    async fn timeout_keeps_awaiter_alive_for_other_waiters() {
+        let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
+        let (consensus_state, _) = setup_storages(vec![], dir.path());
+
+        let operation = ConsensusOperations::RemovePeer(1);
+
+        // Two callers awaiting the same in-flight operation, as `propose_consensus_op_with_await`
+        // would register them: the first inserts the sender, the second subscribes to it.
+        let (sender, first_receiver) = broadcast::channel(1);
+        let mut second_receiver = sender.subscribe();
+        consensus_state
+            .on_consensus_op_apply
+            .lock()
+            .insert(operation.clone(), sender);
+
+        // The first caller gives up.
+        let timed_out = consensus_state
+            .await_receiver(first_receiver, Duration::from_millis(10), &operation)
+            .await;
+        assert!(timed_out.is_err(), "first caller should have timed out");
+
+        // The second caller is still waiting, so the awaiter must survive.
+        assert!(
+            consensus_state
+                .on_consensus_op_apply
+                .lock()
+                .contains_key(&operation),
+            "awaiter was dropped while another caller was still waiting",
+        );
+
+        // ...and it still gets the result once the operation applies.
+        consensus_state
+            .on_consensus_op_apply
+            .lock()
+            .remove(&operation)
+            .expect("awaiter is still registered")
+            .send(Ok(true))
+            .expect("second caller is still subscribed");
+        assert!(matches!(second_receiver.recv().await, Ok(Ok(true))));
+    }
+
+    /// The last caller to give up must clean the entry up, otherwise the map grows without bound.
+    #[tokio::test]
+    async fn timeout_removes_awaiter_when_last_waiter_leaves() {
+        let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
+        let (consensus_state, _) = setup_storages(vec![], dir.path());
+
+        let operation = ConsensusOperations::RemovePeer(1);
+
+        let (sender, receiver) = broadcast::channel(1);
+        consensus_state
+            .on_consensus_op_apply
+            .lock()
+            .insert(operation.clone(), sender);
+
+        let timed_out = consensus_state
+            .await_receiver(receiver, Duration::from_millis(10), &operation)
+            .await;
+        assert!(timed_out.is_err(), "caller should have timed out");
+
+        assert!(
+            !consensus_state
+                .on_consensus_op_apply
+                .lock()
+                .contains_key(&operation),
+            "awaiter leaked after its only waiter gave up",
+        );
+    }
+
+    /// Two callers giving up at the same time must still leave the map clean: each drops its own
+    /// receiver before checking, so the last one out sees no waiters left and removes the entry.
+    #[tokio::test]
+    async fn concurrent_timeouts_leave_no_awaiter_behind() {
+        let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
+        let (consensus_state, _) = setup_storages(vec![], dir.path());
+
+        let operation = ConsensusOperations::RemovePeer(1);
+
+        let (sender, first_receiver) = broadcast::channel(1);
+        let second_receiver = sender.subscribe();
+        consensus_state
+            .on_consensus_op_apply
+            .lock()
+            .insert(operation.clone(), sender);
+
+        let (first, second) = tokio::join!(
+            consensus_state.await_receiver(first_receiver, Duration::from_millis(10), &operation),
+            consensus_state.await_receiver(second_receiver, Duration::from_millis(10), &operation),
+        );
+        assert!(
+            first.is_err() && second.is_err(),
+            "both should have timed out"
+        );
+
+        assert!(
+            !consensus_state
+                .on_consensus_op_apply
+                .lock()
+                .contains_key(&operation),
+            "awaiter leaked after both waiters gave up",
+        );
+    }
+
+    /// `await_for_multiple_operations` registers an awaiter per operation, so it has to
+    /// deregister them when it gives up, or the map grows on every timed-out batch.
+    #[tokio::test]
+    async fn multiple_operations_timeout_removes_own_awaiters() {
+        let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
+        let (consensus_state, _) = setup_storages(vec![], dir.path());
+
+        let operations = vec![
+            ConsensusOperations::RemovePeer(1),
+            ConsensusOperations::RemovePeer(2),
+        ];
+
+        let timed_out = consensus_state
+            .await_for_multiple_operations(operations.clone(), Some(Duration::from_millis(10)))
+            .await;
+        assert!(timed_out.is_err(), "batch should have timed out");
+
+        let on_apply_lock = consensus_state.on_consensus_op_apply.lock();
+        for operation in &operations {
+            assert!(
+                !on_apply_lock.contains_key(operation),
+                "awaiter leaked after the batch timed out: {operation:?}",
+            );
+        }
+    }
+
+    /// A timed-out batch must not tear down an awaiter another caller is still waiting on.
+    #[tokio::test]
+    async fn multiple_operations_timeout_keeps_other_waiters() {
+        let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
+        let (consensus_state, _) = setup_storages(vec![], dir.path());
+
+        let shared = ConsensusOperations::RemovePeer(1);
+        let own = ConsensusOperations::RemovePeer(2);
+
+        // Another caller is already awaiting `shared`, as `propose_consensus_op_with_await` would
+        // have registered it. The batch below deduplicates onto that same sender.
+        let (sender, mut other_receiver) = broadcast::channel(1);
+        consensus_state
+            .on_consensus_op_apply
+            .lock()
+            .insert(shared.clone(), sender);
+
+        let timed_out = consensus_state
+            .await_for_multiple_operations(
+                vec![shared.clone(), own.clone()],
+                Some(Duration::from_millis(10)),
+            )
+            .await;
+        assert!(timed_out.is_err(), "batch should have timed out");
+
+        {
+            let on_apply_lock = consensus_state.on_consensus_op_apply.lock();
+            assert!(
+                on_apply_lock.contains_key(&shared),
+                "awaiter was dropped while another caller was still waiting",
+            );
+            assert!(
+                !on_apply_lock.contains_key(&own),
+                "awaiter only the timed-out batch waited on should have been removed",
+            );
+        }
+
+        // The other caller still gets its result once the operation applies.
+        consensus_state
+            .on_consensus_op_apply
+            .lock()
+            .remove(&shared)
+            .expect("awaiter is still registered")
+            .send(Ok(true))
+            .expect("other caller is still subscribed");
+        assert!(matches!(other_receiver.recv().await, Ok(Ok(true))));
     }
 
     fn setup_storages(

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -1,4 +1,3 @@
-use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::fmt::Display;
@@ -754,42 +753,23 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         persistent.save()
     }
 
-    /// Deregister a caller that gave up waiting for `operation` to be applied.
-    ///
-    /// The map owns the only `Sender` for an operation, and callers proposing an identical
-    /// operation deduplicate onto it instead of proposing again. Removing the entry closes the
-    /// channel for every other waiter, so one caller's timeout would fail their still in-flight
-    /// operation with `Channel sender dropped`. Only drop the entry once no receiver is left.
-    fn forget_operation_awaiter(&self, operation: &ConsensusOperations) {
-        let mut on_apply_lock = self.on_consensus_op_apply.lock();
-        let no_waiters_left = on_apply_lock
-            .get(operation)
-            .is_some_and(|sender| sender.receiver_count() == 0);
-        if no_waiters_left {
-            on_apply_lock.remove(operation);
-        }
-    }
-
     async fn await_receiver(
         &self,
         mut receiver: Receiver<Result<bool, StorageError>>,
         wait_timeout: Duration,
         operation: &ConsensusOperations,
     ) -> Result<bool, StorageError> {
-        let timeout_res = match tokio::time::timeout(wait_timeout, receiver.recv()).await {
-            Ok(res) => res,
-            Err(_elapsed) => {
-                // Drop our receiver before deciding whether anyone else still waits on it
-                drop(receiver);
-                self.forget_operation_awaiter(operation);
-                return Err(StorageError::service_error(format!(
-                    "Waiting for consensus operation commit failed. Timeout set at: {} seconds",
-                    wait_timeout.as_secs_f64(),
-                )));
-            }
+        let Ok(receiver_res) = tokio::time::timeout(wait_timeout, receiver.recv()).await else {
+            forget_operation_awaiter(&mut self.on_consensus_op_apply.lock(), operation, receiver);
+
+            return Err(StorageError::service_error(format!(
+                "Waiting for consensus operation commit failed. Timeout set at: {} seconds",
+                wait_timeout.as_secs_f64(),
+            )));
         };
+
         // 2 possible errors to forward: channel sender dropped OR operation failed
-        timeout_res.map_err(|err| {
+        receiver_res.map_err(|err| {
             StorageError::service_error(format!("Error occurred while waiting for consensus operation. Channel sender dropped ({err})"))
         })?
     }
@@ -799,31 +779,28 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         operations: Vec<ConsensusOperations>,
         wait_timeout: Option<Duration>,
     ) -> impl Future<Output = Result<Result<(), StorageError>, Elapsed>> {
-        // Register the awaiters eagerly: the caller submits the operations only after this call
-        // returns, so the receivers must already be in place by then. The guard deregisters them
-        // again whenever we stop waiting, including when the caller drops this future without
-        // ever polling it.
+        // Register the awaiters eagerly, before the caller proposes the operation that triggers
+        // them: the awaited operations are emitted as a side effect of applying that one, and can
+        // land before this future is first polled. The guard deregisters them again whenever we
+        // stop waiting, including when the caller drops this future without ever polling it.
         let mut awaiters = OperationAwaiters::register(self, operations);
 
         async move {
-            let results = {
-                let await_for_all = join_all(awaiters.awaiters.iter_mut().map(|(_, r)| r.recv()));
-                tokio::time::timeout(
-                    wait_timeout.unwrap_or(defaults::CONSENSUS_META_OP_WAIT),
-                    await_for_all,
-                )
-                .await?
-            };
+            let await_for_all = join_all(awaiters.receivers_mut().map(|r| r.recv()));
+            let results = tokio::time::timeout(
+                wait_timeout.unwrap_or(defaults::CONSENSUS_META_OP_WAIT),
+                await_for_all,
+            )
+            .await?;
 
             for result in results {
                 match result {
-                    Ok(response_res) => match response_res {
-                        Ok(_) => {}
-                        Err(err) => return Ok(Err(err)),
-                    },
-                    Err(recv_error) => return Ok(Err(recv_error.into())),
+                    Ok(Ok(_)) => (),
+                    Ok(Err(err)) => return Ok(Err(err)),
+                    Err(err) => return Ok(Err(err.into())),
                 }
             }
+
             Ok(Ok(()))
         }
     }
@@ -1032,6 +1009,33 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     }
 }
 
+/// The awaiter map, keyed by the operation each caller is waiting for.
+type OnConsensusOpApply =
+    HashMap<ConsensusOperations, broadcast::Sender<Result<bool, StorageError>>>;
+
+/// Deregister a caller that gave up waiting for `operation` to be applied.
+///
+/// The map owns the only `Sender` for an operation, and callers proposing an identical operation
+/// deduplicate onto it instead of proposing again. Removing the entry closes the channel for
+/// every other waiter, so one caller's timeout would fail their still in-flight operation with
+/// `Channel sender dropped`. Only drop the entry once no receiver is left.
+///
+/// Takes the map already locked and drops `receiver` while it is held, so a caller registering in
+/// between never finds an entry nobody is waiting on and subscribes to it anyway.
+fn forget_operation_awaiter(
+    on_apply_lock: &mut OnConsensusOpApply,
+    operation: &ConsensusOperations,
+    receiver: Receiver<Result<bool, StorageError>>,
+) {
+    drop(receiver);
+    let no_waiters_left = on_apply_lock
+        .get(operation)
+        .is_some_and(|sender| sender.receiver_count() == 0);
+    if no_waiters_left {
+        on_apply_lock.remove(operation);
+    }
+}
+
 /// Awaiters registered for a batch of consensus operations, deregistered again on drop.
 ///
 /// The map owns the only `Sender` per operation, so an entry whose receivers are all gone is
@@ -1046,43 +1050,57 @@ struct OperationAwaiters<'a, C: CollectionContainer> {
 
 impl<'a, C: CollectionContainer> OperationAwaiters<'a, C> {
     fn register(consensus: &'a ConsensusManager<C>, operations: Vec<ConsensusOperations>) -> Self {
-        let mut awaiters = Vec::with_capacity(operations.len());
+        // Collected into the guard as we go, so giving up part way still deregisters the rest
+        let mut this = Self {
+            consensus,
+            awaiters: Vec::with_capacity(operations.len()),
+        };
+
         for operation in operations {
-            // one-shot broadcast channel
-            let (sender, mut receiver) = broadcast::channel(1);
             let mut on_apply_lock = consensus.on_consensus_op_apply.lock();
             // check that the exact same operation is not already in-flight
-            match on_apply_lock.entry(operation.clone()) {
-                Entry::Occupied(e) => {
+            let receiver = match on_apply_lock.get(&operation) {
+                Some(existing_sender) => {
                     debug_assert!(
-                        e.get().receiver_count() > 0,
-                        "Consensus operation must have at least one receiver, does forget_operation_awaiter() work correctly?",
+                        existing_sender.receiver_count() > 0,
+                        "Consensus operation must have at least one receiver, \
+                         does forget_operation_awaiter() work correctly?",
                     );
 
                     // subscribe to existing sender for faster feedback
-                    receiver = e.get().subscribe()
+                    existing_sender.subscribe()
                 }
-                Entry::Vacant(e) => {
-                    // insert new sender
-                    e.insert(sender);
+                None => {
+                    // one-shot broadcast channel
+                    let (sender, receiver) = broadcast::channel(1);
+                    on_apply_lock.insert(operation.clone(), sender);
+                    receiver
                 }
             };
+            drop(on_apply_lock);
+
             // Keep the key around so we can deregister again
-            awaiters.push((operation, receiver));
+            this.awaiters.push((operation, receiver));
         }
-        Self {
-            consensus,
-            awaiters,
-        }
+
+        this
+    }
+
+    fn receivers_mut(&mut self) -> impl Iterator<Item = &mut Receiver<Result<bool, StorageError>>> {
+        self.awaiters.iter_mut().map(|(_, receiver)| receiver)
     }
 }
 
 impl<C: CollectionContainer> Drop for OperationAwaiters<'_, C> {
     fn drop(&mut self) {
+        if self.awaiters.is_empty() {
+            return;
+        }
+        // One lock for the whole batch: creating a collection registers an awaiter per replica,
+        // and this runs on the mutex the consensus thread needs for every entry it applies
+        let mut on_apply_lock = self.consensus.on_consensus_op_apply.lock();
         for (operation, receiver) in self.awaiters.drain(..) {
-            // Our receiver must be gone before we check whether anyone else is still waiting
-            drop(receiver);
-            self.consensus.forget_operation_awaiter(&operation);
+            forget_operation_awaiter(&mut on_apply_lock, &operation, receiver);
         }
     }
 }

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -799,59 +799,22 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         operations: Vec<ConsensusOperations>,
         wait_timeout: Option<Duration>,
     ) -> impl Future<Output = Result<Result<(), StorageError>, Elapsed>> {
-        let mut receivers = vec![];
-        for operation in operations {
-            // one-shot broadcast channel
-            let (sender, mut receiver) = broadcast::channel(1);
-            let mut on_apply_lock = self.on_consensus_op_apply.lock();
-            // check that the exact same operation is not already in-flight
-            match on_apply_lock.entry(operation.clone()) {
-                Entry::Occupied(e) => {
-                    debug_assert!(
-                        e.get().receiver_count() > 0,
-                        "Consensus operation must have at least one receiver, does forget_operation_awaiter() work correctly?",
-                    );
-
-                    // subscribe to existing sender for faster feedback
-                    receiver = e.get().subscribe()
-                }
-                Entry::Vacant(e) => {
-                    // insert new sender
-                    e.insert(sender);
-                }
-            };
-            // Keep the key around so we can deregister on timeout
-            receivers.push((operation, receiver));
-        }
+        // Register the awaiters eagerly: the caller submits the operations only after this call
+        // returns, so the receivers must already be in place by then. The guard deregisters them
+        // again whenever we stop waiting, including when the caller drops this future without
+        // ever polling it.
+        let mut awaiters = OperationAwaiters::register(self, operations);
 
         async move {
-            let timeout_res = {
-                let await_for_all =
-                    join_all(receivers.iter_mut().map(|(_, receiver)| receiver.recv()));
+            let results = {
+                let await_for_all = join_all(awaiters.awaiters.iter_mut().map(|(_, r)| r.recv()));
                 tokio::time::timeout(
                     wait_timeout.unwrap_or(defaults::CONSENSUS_META_OP_WAIT),
                     await_for_all,
                 )
-                .await
+                .await?
             };
 
-            let results = match timeout_res {
-                Ok(results) => results,
-                Err(elapsed) => {
-                    let (operations, our_receivers): (Vec<_>, Vec<_>) =
-                        receivers.into_iter().unzip();
-                    // Our receivers must be gone before we check whether anyone else is
-                    // still waiting on these operations
-                    drop(our_receivers);
-                    for operation in &operations {
-                        self.forget_operation_awaiter(operation);
-                    }
-                    return Err(elapsed);
-                }
-            };
-
-            // Every receiver resolved, and whoever resolves an operation takes its entry out
-            // of the map first, so there is nothing left to deregister on the paths below.
             for result in results {
                 match result {
                     Ok(response_res) => match response_res {
@@ -1066,6 +1029,61 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         }
         *self.next_peer_metadata_update_attempt.lock() =
             Instant::now() + CONSENSUS_PEER_METADATA_UPDATE_INTERVAL;
+    }
+}
+
+/// Awaiters registered for a batch of consensus operations, deregistered again on drop.
+///
+/// The map owns the only `Sender` per operation, so an entry whose receivers are all gone is
+/// dead weight: later callers deduplicate onto it and then never hear back. Tying deregistration
+/// to the guard covers every way of giving up, including the caller dropping the future returned
+/// by [`ConsensusManager::await_for_multiple_operations`] without ever polling it.
+struct OperationAwaiters<'a, C: CollectionContainer> {
+    consensus: &'a ConsensusManager<C>,
+    /// One receiver per operation, keyed by the operation so we can deregister it again.
+    awaiters: Vec<(ConsensusOperations, Receiver<Result<bool, StorageError>>)>,
+}
+
+impl<'a, C: CollectionContainer> OperationAwaiters<'a, C> {
+    fn register(consensus: &'a ConsensusManager<C>, operations: Vec<ConsensusOperations>) -> Self {
+        let mut awaiters = Vec::with_capacity(operations.len());
+        for operation in operations {
+            // one-shot broadcast channel
+            let (sender, mut receiver) = broadcast::channel(1);
+            let mut on_apply_lock = consensus.on_consensus_op_apply.lock();
+            // check that the exact same operation is not already in-flight
+            match on_apply_lock.entry(operation.clone()) {
+                Entry::Occupied(e) => {
+                    debug_assert!(
+                        e.get().receiver_count() > 0,
+                        "Consensus operation must have at least one receiver, does forget_operation_awaiter() work correctly?",
+                    );
+
+                    // subscribe to existing sender for faster feedback
+                    receiver = e.get().subscribe()
+                }
+                Entry::Vacant(e) => {
+                    // insert new sender
+                    e.insert(sender);
+                }
+            };
+            // Keep the key around so we can deregister again
+            awaiters.push((operation, receiver));
+        }
+        Self {
+            consensus,
+            awaiters,
+        }
+    }
+}
+
+impl<C: CollectionContainer> Drop for OperationAwaiters<'_, C> {
+    fn drop(&mut self) {
+        for (operation, receiver) in self.awaiters.drain(..) {
+            // Our receiver must be gone before we check whether anyone else is still waiting
+            drop(receiver);
+            self.consensus.forget_operation_awaiter(&operation);
+        }
     }
 }
 
@@ -1627,6 +1645,39 @@ mod tests {
             assert!(
                 !on_apply_lock.contains_key(operation),
                 "awaiter leaked after the batch timed out: {operation:?}",
+            );
+        }
+    }
+
+    /// The awaiters are registered before the future is polled, because the caller submits the
+    /// operations only once they are in place. `Dispatcher::submit_collection_meta_op` then drops
+    /// the future unpolled whenever proposing the operation itself fails, so dropping it must
+    /// deregister them too. Otherwise a rejected operation leaves a dead entry behind that the
+    /// next identical request deduplicates onto and never hears back from.
+    #[tokio::test]
+    async fn multiple_operations_dropped_unpolled_removes_own_awaiters() {
+        let dir = Builder::new().prefix("raft_state_test").tempdir().unwrap();
+        let (consensus_state, _) = setup_storages(vec![], dir.path());
+
+        let operations = vec![
+            ConsensusOperations::RemovePeer(1),
+            ConsensusOperations::RemovePeer(2),
+        ];
+
+        let awaiter = consensus_state
+            .await_for_multiple_operations(operations.clone(), Some(Duration::from_millis(10)));
+        assert_eq!(
+            consensus_state.on_consensus_op_apply.lock().len(),
+            operations.len(),
+            "awaiters must be registered before the future is polled",
+        );
+        drop(awaiter);
+
+        let on_apply_lock = consensus_state.on_consensus_op_apply.lock();
+        for operation in &operations {
+            assert!(
+                !on_apply_lock.contains_key(operation),
+                "awaiter leaked after the batch was dropped unpolled: {operation:?}",
             );
         }
     }

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -807,6 +807,11 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             // check that the exact same operation is not already in-flight
             match on_apply_lock.entry(operation.clone()) {
                 Entry::Occupied(e) => {
+                    debug_assert!(
+                        e.get().receiver_count() > 0,
+                        "Consensus operation must have at least one receiver, does forget_operation_awaiter() work correctly?",
+                    );
+
                     // subscribe to existing sender for faster feedback
                     receiver = e.get().subscribe()
                 }


### PR DESCRIPTION
Callers proposing an identical consensus operation deduplicate onto one broadcast channel whose only sender lives in `on_consensus_op_apply`, so one caller giving up tore down the notification path for the others.

- `await_receiver` removed the shared map entry on timeout, dropping the sender and failing every other waiter with `Channel sender dropped` even though their operation was still in flight and went on to apply
- it now drops its own receiver first and removes the entry only when no receiver is left, so the last caller out cleans up and a concurrent double timeout still leaves the map empty
- `await_for_multiple_operations` registered an awaiter per operation but never deregistered them when it timed out, growing the map on every timed-out batch; it now deregisters the same way, leaving entries other callers still wait on in place
- 4 regression tests, each verified to fail against the previous behaviour

Not covered: a waiter whose future is cancelled rather than timed out still drops its receiver without cleanup, so an entry can linger if every waiter is cancelled and the operation never applies. That is pre-existing and self-heals once the operation applies; a proper fix needs a drop guard.