### PR TITLE
fix: token-aware Text and Phrase matching on unindexed payload fields

### DIFF
--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -1,10 +1,13 @@
 //! Contains functions for interpreting filter queries and defining if given points pass the conditions
 
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use ordered_float::OrderedFloat;
 use serde_json::Value;
 
+use crate::data_types::index::TextIndexParams;
+use crate::index::field_index::full_text_index::tokenizers::{Tokenizer, TokenizerTextKind};
 use crate::types::{
     AnyVariants, CheckGeoPoint, DateTimePayloadType, FieldCondition, FloatPayloadType,
     GeoBoundingBox, GeoPoint, GeoPolygon, GeoRadius, Match, MatchAny, MatchExcept, MatchPhrase,
@@ -17,6 +20,51 @@ use crate::types::{
 /// For sets smaller than this threshold iterating outperforms hashing.
 /// For more information see <https://github.com/qdrant/qdrant/pull/3525>.
 pub const INDEXSET_ITER_THRESHOLD: usize = 13;
+
+/// Default tokenizer for unindexed text/phrase filters. Matches
+/// [`TextIndexParams::default`] (Word tokenizer, lowercase on).
+static DEFAULT_UNINDEXED_TEXT_TOKENIZER: LazyLock<Tokenizer> =
+    LazyLock::new(|| Tokenizer::new_from_text_index_params(&TextIndexParams::default()));
+
+fn collect_unindexed_document_tokens(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    DEFAULT_UNINDEXED_TEXT_TOKENIZER.tokenize(TokenizerTextKind::Document, text, |token| {
+        tokens.push(token.into_owned());
+    });
+    tokens
+}
+
+fn collect_unindexed_query_tokens(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    DEFAULT_UNINDEXED_TEXT_TOKENIZER.tokenize(TokenizerTextKind::Query, text, |token| {
+        tokens.push(token.into_owned());
+    });
+    tokens
+}
+
+fn unindexed_text_match(stored: &str, query: &str) -> bool {
+    let document_tokens = collect_unindexed_document_tokens(stored);
+    let query_tokens = collect_unindexed_query_tokens(query);
+    if query_tokens.is_empty() {
+        return false;
+    }
+    query_tokens.iter().all(|query_token| {
+        document_tokens
+            .iter()
+            .any(|document_token| document_token == query_token)
+    })
+}
+
+fn unindexed_phrase_match(stored: &str, phrase: &str) -> bool {
+    let document_tokens = collect_unindexed_document_tokens(stored);
+    let phrase_tokens = collect_unindexed_query_tokens(phrase);
+    if phrase_tokens.is_empty() {
+        return false;
+    }
+    document_tokens
+        .windows(phrase_tokens.len())
+        .any(|window| window == phrase_tokens.as_slice())
+}
 
 pub trait ValueChecker {
     fn check_match(&self, payload: &Value) -> bool;
@@ -171,16 +219,22 @@ impl ValueChecker for Match {
                 }
                 _ => false,
             },
-            Match::Text(MatchText { text }) | Match::Phrase(MatchPhrase { phrase: text }) => {
-                match payload {
-                    Value::String(stored) => stored.contains(text),
-                    Value::Null
-                    | Value::Bool(_)
-                    | Value::Number(_)
-                    | Value::Array(_)
-                    | Value::Object(_) => false,
-                }
-            }
+            Match::Text(MatchText { text }) => match payload {
+                Value::String(stored) => unindexed_text_match(stored, text),
+                Value::Null
+                | Value::Bool(_)
+                | Value::Number(_)
+                | Value::Array(_)
+                | Value::Object(_) => false,
+            },
+            Match::Phrase(MatchPhrase { phrase }) => match payload {
+                Value::String(stored) => unindexed_phrase_match(stored, phrase),
+                Value::Null
+                | Value::Bool(_)
+                | Value::Number(_)
+                | Value::Array(_)
+                | Value::Object(_) => false,
+            },
             Match::TextAny(MatchTextAny { text_any }) => match payload {
                 Value::String(stored) => text_any
                     .split_whitespace()

--- a/lib/segment/tests/integration/main.rs
+++ b/lib/segment/tests/integration/main.rs
@@ -26,3 +26,4 @@ mod segment_tests;
 mod sparse_discover_test;
 mod sparse_idf_corpus_test;
 mod sparse_vector_index_search_tests;
+mod unindexed_text_match_test;

--- a/lib/segment/tests/integration/unindexed_text_match_test.rs
+++ b/lib/segment/tests/integration/unindexed_text_match_test.rs
@@ -1,0 +1,37 @@
+use segment::payload_storage::condition_checker::ValueChecker;
+use segment::types::{Match, MatchPhrase, MatchText};
+use serde_json::Value;
+
+/// Regression for <https://github.com/qdrant/qdrant/issues/10182>
+#[test]
+fn test_unindexed_text_uses_token_matching_not_substring() {
+    let text_match = |query: &str, stored: &str| {
+        Match::Text(MatchText {
+            text: query.to_string(),
+        })
+        .check_match(&Value::String(stored.to_string()))
+    };
+
+    // "good" is a substring of "goodness" but not a whole token
+    assert!(!text_match("good", "goodness only"));
+    assert!(text_match("good", "good cheap stuff"));
+    assert!(text_match("good cheap", "cheap hardware good"));
+    assert!(!text_match("good cheap", "cheap hardware"));
+}
+
+/// Regression for <https://github.com/qdrant/qdrant/issues/10182>
+#[test]
+fn test_unindexed_phrase_requires_token_order() {
+    let phrase_match = |phrase: &str, stored: &str| {
+        Match::Phrase(MatchPhrase {
+            phrase: phrase.to_string(),
+        })
+        .check_match(&Value::String(stored.to_string()))
+    };
+
+    assert!(phrase_match("alpha beta", "foo alpha beta bar"));
+    assert!(!phrase_match("alpha beta", "beta alpha"));
+    assert!(!phrase_match("alpha beta", "alphabeta"));
+    assert!(!phrase_match("good", "goodness only"));
+    assert!(phrase_match("good", "goodness only good"));
+}


### PR DESCRIPTION
### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there are no other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you would like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

## Summary

Unindexed `Match::Text` and `Match::Phrase` filters used the same `String::contains` path in `condition_checker.rs`, so both could match across token boundaries or inside a token (for example, `"good"` matching `"goodness"`).

I split the arms and route both through the default Word tokenizer (`TextIndexParams::default`) for best-effort parity with indexed fields:
- **Text**: every query token must appear as a whole document token (order-independent)
- **Phrase**: query tokens must appear consecutively in document token order

Fixes #10182

## AI disclosure

- [AI] fix: token-aware Text and Phrase matching on unindexed payload fields

## Verification

- before, on current `dev`: `Match::Phrase { phrase: "alpha beta" }` matched `"xxalpha betaxx"` as a raw substring; `Match::Text { text: "good" }` matched `"goodness only"`
- after: `cargo test -p segment --test integration unindexed_text` — 2 passed
- after: `cargo clippy -p segment --test integration -- -D warnings` — clean