### PR TITLE
Hide DRAM latency in quantized scoring with software prefetch

### DIFF
--- a/lib/common/common/src/lib.rs
+++ b/lib/common/common/src/lib.rs
@@ -35,6 +35,7 @@ pub mod mmap;
 pub mod num_traits;
 pub mod panic;
 pub mod persisted_hashmap;
+pub mod prefetch;
 pub mod process_counter;
 pub mod process_cpu_usage;
 pub mod progress_tracker;

--- a/lib/common/common/src/prefetch.rs
+++ b/lib/common/common/src/prefetch.rs
@@ -5,14 +5,18 @@
 const CACHE_LINE: usize = 64;
 
 /// Bytes of near (L1) prefetch lead; also the per-call cap of
-/// [`prefetch_slice`] / [`prefetch_slice_l2`]. ~1 KiB covers one uncontended
-/// DRAM fill at the scoring kernels' pace and is the most L1 can take without
-/// evicting data still being scored; the hardware prefetcher covers the tail
-/// of larger vectors.
+/// [`prefetch_slice`] / [`prefetch_slice_l2`], i.e. 16 cache lines per hinted
+/// vector. Measured: 16 hinted lines are exactly what trains the hardware
+/// stream prefetcher, which then covers the tail of larger vectors at L2 hit
+/// pace; hinting 32 lines regresses (Zen 5), so the cap is load-bearing.
 const NEAR_BYTES: usize = 1024;
 
-/// Bytes of far (L2) prefetch lead, sized to the ~3x longer fill latency when
-/// many threads queue on the memory controller.
+/// Bytes of far (L2) prefetch lead. The lead must cover the loaded memory
+/// latency — measured while the scoring kernel's own fills are in flight,
+/// ~2x the idle latency — at the kernel's consumption rate. 4 KiB sits at
+/// the measured knee of the fastest-consuming kernel that is still
+/// latency-bound (TurboQuant 4-bit, ~17 B/ns x ~250 ns loaded); shallower
+/// windows regress it, deeper ones measured no further gain.
 const FAR_BYTES: usize = 4096;
 
 /// Largest batch read without prefetch hints: in tiny batches every hint
@@ -27,8 +31,9 @@ pub const MAX_UNPREFETCHED_BATCH: usize = 2;
 /// complete.
 ///
 /// Sub-cache-line vectors get no far window (`far == 0`, callers skip the L2
-/// hints): their far hints would fire only nanoseconds before the near ones,
-/// and under contention the too-early L2 installs get evicted before use.
+/// hints): kernels over such small codes consume faster than memory can
+/// deliver, so extra window depth measured no effect in either direction and
+/// the hints are pure issue overhead.
 #[inline]
 pub fn prefetch_windows(vector_size_bytes: usize) -> (usize, usize) {
     let near = (NEAR_BYTES / vector_size_bytes.max(1)).clamp(1, 8);
@@ -63,9 +68,11 @@ pub fn prefetch_slice(bytes: &[u8]) {
     let _ = bytes;
 }
 
-/// Like [`prefetch_slice`], but installs the lines into L2 instead of L1:
-/// early lines survive in L2 until use, while an equally early L1 install
-/// would evict data still being read.
+/// Like [`prefetch_slice`], but requests install no deeper than L2, so early
+/// lines wait there until use instead of displacing L1 data still being
+/// scored. Cores may ignore the level hint (measured: Zen 3 fills L1 for T1
+/// exactly as for T0; Zen 4/5, Intel and Apple stop at L2) — both behaviors
+/// are safe.
 #[inline(always)]
 pub fn prefetch_slice_l2(bytes: &[u8]) {
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
@@ -112,7 +119,7 @@ fn prefetch_read(ptr: *const u8) {
     }
 }
 
-/// Hint to pull the line holding `ptr` into L2, not L1 (`prefetcht1`).
+/// Hint to pull the line holding `ptr` no deeper than L2 (`prefetcht1`).
 /// Never faults, even on invalid addresses.
 #[cfg(target_arch = "x86_64")]
 #[inline(always)]
@@ -123,7 +130,7 @@ fn prefetch_read_l2(ptr: *const u8) {
     unsafe { _mm_prefetch::<_MM_HINT_T1>(ptr.cast::<i8>()) }
 }
 
-/// Hint to pull the line holding `ptr` into L2, not L1 (`prfm pldl2keep`).
+/// Hint to pull the line holding `ptr` no deeper than L2 (`prfm pldl2keep`).
 /// Never faults; inline asm because there is no stable `core::arch` prefetch
 /// intrinsic for aarch64.
 #[cfg(target_arch = "aarch64")]
@@ -137,5 +144,76 @@ fn prefetch_read_l2(ptr: *const u8) {
             ptr = in(reg) ptr,
             options(nostack, preserves_flags),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// L1 fill-buffer (MSHR) budget the near window must stay within, in
+    /// cache lines. 24 is the measured-safe envelope: the schedule's worst
+    /// band (115–146-byte codes, ~22–23.8 average lines in flight) benched
+    /// clean end-to-end, while cores with fewer buffers (Intel ~10-12 LFBs)
+    /// drop excess hints gracefully.
+    const MSHR_LINE_BUDGET: f64 = 24.0;
+
+    fn gcd(a: usize, b: usize) -> usize {
+        if b == 0 { a } else { gcd(b, a % b) }
+    }
+
+    /// Average cache lines one hint touches, exact over the cycle of in-line
+    /// offsets produced by packing vectors densely at `stride` bytes with
+    /// byte alignment (in-line offset of vector `i` is `i * stride % 64`).
+    fn avg_lines_per_hint(stride: usize, hint_bytes: usize) -> f64 {
+        let cycle = CACHE_LINE / gcd(stride, CACHE_LINE);
+        let total: usize = (0..cycle)
+            .map(|i| ((i * stride) % CACHE_LINE + hint_bytes).div_ceil(CACHE_LINE))
+            .sum();
+        total as f64 / cycle as f64
+    }
+
+    /// Sweeps every vector size up to 32 KiB and asserts the schedule invariants, most importantly that
+    /// the near (T0/L1) window can never keep more line fills in flight than
+    /// the MSHR budget — the bound is `near * lines_per_hint`, an over-count
+    /// since fills complete while the window slides, so a pass here is
+    /// conservative.
+    #[test]
+    fn window_schedule_stays_within_hardware_budgets() {
+        for size in 1..=32 * 1024 {
+            let (near, far) = prefetch_windows(size);
+            let hint_bytes = size.min(NEAR_BYTES);
+
+            assert!(
+                (1..=8).contains(&near),
+                "size {size}: near={near} outside [1, 8]"
+            );
+            if size < CACHE_LINE {
+                assert_eq!(far, 0, "size {size}: sub-line code but far={far}");
+            } else {
+                assert!(
+                    (near + 2..=16).contains(&far),
+                    "size {size}: far={far} outside [near+2, 16]"
+                );
+            }
+
+            assert!(
+                near * hint_bytes <= NEAR_BYTES,
+                "size {size}: near window holds {} bytes > {NEAR_BYTES}",
+                near * hint_bytes,
+            );
+            assert!(
+                far * hint_bytes <= FAR_BYTES,
+                "size {size}: far window holds {} bytes > {FAR_BYTES}",
+                far * hint_bytes,
+            );
+
+            let t0_lines = near as f64 * avg_lines_per_hint(size, hint_bytes);
+            assert!(
+                t0_lines <= MSHR_LINE_BUDGET,
+                "size {size}: near window keeps {t0_lines:.1} lines in \
+                 flight > budget {MSHR_LINE_BUDGET} (near={near})",
+            );
+        }
     }
 }

--- a/lib/common/common/src/prefetch.rs
+++ b/lib/common/common/src/prefetch.rs
@@ -1,32 +1,56 @@
 //! Best-effort software prefetch hints.
 
-/// Cache line size assumed for prefetching, in bytes.
-///
-/// Some aarch64 cores use 128-byte lines; issuing a hint per 64 bytes there is
-/// harmless (the second hint lands on an already-requested line).
+/// Cache line size assumed for prefetching, in bytes. On aarch64 cores with
+/// 128-byte lines the second hint per line is harmless.
 const CACHE_LINE: usize = 64;
 
-/// Upper bound on cache lines prefetched per [`prefetch_slice`] call.
-///
-/// Prefetching is meant to hide the latency of the first touch of scattered
-/// data; issuing hints for a large slice wastes line-fill buffer slots and can
-/// evict data that is still needed. 16 lines (1 KiB, i.e. a 256-dim f32
-/// vector) is enough to cover the hot prefix of a vector while the tail is
-/// pulled in by the hardware prefetcher during the sequential scoring scan.
-const MAX_PREFETCH_LINES: usize = 16;
+/// Bytes of near (L1) prefetch lead; also the per-call cap of
+/// [`prefetch_slice`] / [`prefetch_slice_l2`]. ~1 KiB covers one uncontended
+/// DRAM fill at the scoring kernels' pace and is the most L1 can take without
+/// evicting data still being scored; the hardware prefetcher covers the tail
+/// of larger vectors.
+const NEAR_BYTES: usize = 1024;
 
-/// Best-effort software prefetch (temporal, all cache levels) of the cache
-/// lines spanning `bytes`, capped at [`MAX_PREFETCH_LINES`].
+/// Bytes of far (L2) prefetch lead, sized to the ~3x longer fill latency when
+/// many threads queue on the memory controller.
+const FAR_BYTES: usize = 4096;
+
+/// Largest batch read without prefetch hints: in tiny batches every hint
+/// fires only moments before the read, too late to help. Deliberately not
+/// scaled with the near window — that would silently disable prefetch for
+/// common batch sizes (HNSW neighbor expansions) once the window is deep.
+pub const MAX_UNPREFETCHED_BATCH: usize = 2;
+
+/// Near (L1, [`prefetch_slice`]) and far (L2, [`prefetch_slice_l2`]) prefetch
+/// window sizes in vectors, covering a constant [`NEAR_BYTES`] / [`FAR_BYTES`]
+/// of lead — bytes, not vector counts, map to the time a fetch has to
+/// complete.
 ///
-/// Used to overlap the scattered-load latency of batch scoring. A prefetch is
-/// only a hint and never faults, so this is always safe.
-/// No-op on targets other than x86_64 and aarch64.
+/// Sub-cache-line vectors get no far window (`far == 0`, callers skip the L2
+/// hints): their far hints would fire only nanoseconds before the near ones,
+/// and under contention the too-early L2 installs get evicted before use.
+#[inline]
+pub fn prefetch_windows(vector_size_bytes: usize) -> (usize, usize) {
+    let near = (NEAR_BYTES / vector_size_bytes.max(1)).clamp(1, 8);
+
+    // Disable L2 far prefetch for small vectors.
+    if vector_size_bytes < CACHE_LINE {
+        return (near, 0);
+    }
+
+    let far = (FAR_BYTES / vector_size_bytes).clamp(near + 2, 16);
+    (near, far)
+}
+
+/// Best-effort prefetch (temporal, all cache levels) of the cache lines
+/// spanning `bytes`, capped at [`NEAR_BYTES`]. A prefetch is only a hint and
+/// never faults; no-op on targets other than x86_64 and aarch64.
 #[inline(always)]
 pub fn prefetch_slice(bytes: &[u8]) {
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     {
         let ptr = bytes.as_ptr();
-        let len = bytes.len().min(MAX_PREFETCH_LINES * CACHE_LINE);
+        let len = bytes.len().min(NEAR_BYTES);
         let mut offset = 0;
         while offset < len {
             // SAFETY: prefetch is a non-faulting hint; the computed address
@@ -39,11 +63,29 @@ pub fn prefetch_slice(bytes: &[u8]) {
     let _ = bytes;
 }
 
-/// Hint the CPU to pull the cache line holding `ptr` into all cache levels
-/// for a subsequent read (x86_64 `prefetcht0` / aarch64 `prfm pldl1keep`).
-///
-/// Safe to call with any pointer: a prefetch hint never faults, even on
-/// invalid addresses.
+/// Like [`prefetch_slice`], but installs the lines into L2 instead of L1:
+/// early lines survive in L2 until use, while an equally early L1 install
+/// would evict data still being read.
+#[inline(always)]
+pub fn prefetch_slice_l2(bytes: &[u8]) {
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    {
+        let ptr = bytes.as_ptr();
+        let len = bytes.len().min(NEAR_BYTES);
+        let mut offset = 0;
+        while offset < len {
+            // SAFETY: prefetch is a non-faulting hint; the computed address
+            // lies within a valid borrowed slice.
+            prefetch_read_l2(unsafe { ptr.add(offset) });
+            offset += CACHE_LINE;
+        }
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    let _ = bytes;
+}
+
+/// Hint to pull the line holding `ptr` into all cache levels (`prefetcht0`).
+/// Never faults, even on invalid addresses.
 #[cfg(target_arch = "x86_64")]
 #[inline(always)]
 fn prefetch_read(ptr: *const u8) {
@@ -53,12 +95,9 @@ fn prefetch_read(ptr: *const u8) {
     unsafe { _mm_prefetch::<_MM_HINT_T0>(ptr.cast::<i8>()) }
 }
 
-/// Hint the CPU to pull the cache line holding `ptr` into all cache levels
-/// for a subsequent read (x86_64 `prefetcht0` / aarch64 `prfm pldl1keep`).
-///
-/// Safe to call with any pointer: a prefetch hint never faults, even on
-/// invalid addresses. There is no stable `core::arch` prefetch intrinsic for
-/// aarch64 yet, hence inline asm.
+/// Hint to pull the line holding `ptr` into all cache levels
+/// (`prfm pldl1keep`). Never faults; inline asm because there is no stable
+/// `core::arch` prefetch intrinsic for aarch64.
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
 fn prefetch_read(ptr: *const u8) {
@@ -67,6 +106,34 @@ fn prefetch_read(ptr: *const u8) {
     unsafe {
         core::arch::asm!(
             "prfm pldl1keep, [{ptr}]",
+            ptr = in(reg) ptr,
+            options(nostack, preserves_flags),
+        )
+    }
+}
+
+/// Hint to pull the line holding `ptr` into L2, not L1 (`prefetcht1`).
+/// Never faults, even on invalid addresses.
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+fn prefetch_read_l2(ptr: *const u8) {
+    use std::arch::x86_64::{_MM_HINT_T1, _mm_prefetch};
+
+    // SAFETY: `_mm_prefetch` is a non-faulting hint for any address.
+    unsafe { _mm_prefetch::<_MM_HINT_T1>(ptr.cast::<i8>()) }
+}
+
+/// Hint to pull the line holding `ptr` into L2, not L1 (`prfm pldl2keep`).
+/// Never faults; inline asm because there is no stable `core::arch` prefetch
+/// intrinsic for aarch64.
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+fn prefetch_read_l2(ptr: *const u8) {
+    // SAFETY: `prfm` is a non-faulting hint for any address; it does not
+    // access memory architecturally, touch the stack, or clobber flags.
+    unsafe {
+        core::arch::asm!(
+            "prfm pldl2keep, [{ptr}]",
             ptr = in(reg) ptr,
             options(nostack, preserves_flags),
         )

--- a/lib/common/common/src/prefetch.rs
+++ b/lib/common/common/src/prefetch.rs
@@ -1,0 +1,74 @@
+//! Best-effort software prefetch hints.
+
+/// Cache line size assumed for prefetching, in bytes.
+///
+/// Some aarch64 cores use 128-byte lines; issuing a hint per 64 bytes there is
+/// harmless (the second hint lands on an already-requested line).
+const CACHE_LINE: usize = 64;
+
+/// Upper bound on cache lines prefetched per [`prefetch_slice`] call.
+///
+/// Prefetching is meant to hide the latency of the first touch of scattered
+/// data; issuing hints for a large slice wastes line-fill buffer slots and can
+/// evict data that is still needed. 16 lines (1 KiB, i.e. a 256-dim f32
+/// vector) is enough to cover the hot prefix of a vector while the tail is
+/// pulled in by the hardware prefetcher during the sequential scoring scan.
+const MAX_PREFETCH_LINES: usize = 16;
+
+/// Best-effort software prefetch (temporal, all cache levels) of the cache
+/// lines spanning `bytes`, capped at [`MAX_PREFETCH_LINES`].
+///
+/// Experimental: used to overlap the scattered-load latency of HNSW batch
+/// scoring. A prefetch is only a hint and never faults, so this is always safe.
+/// No-op on targets other than x86_64 and aarch64.
+#[inline(always)]
+pub fn prefetch_slice(bytes: &[u8]) {
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    {
+        let ptr = bytes.as_ptr();
+        let len = bytes.len().min(MAX_PREFETCH_LINES * CACHE_LINE);
+        let mut offset = 0;
+        while offset < len {
+            // SAFETY: prefetch is a non-faulting hint; the computed address
+            // lies within a valid borrowed slice.
+            prefetch_read(unsafe { ptr.add(offset) });
+            offset += CACHE_LINE;
+        }
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    let _ = bytes;
+}
+
+/// Hint the CPU to pull the cache line holding `ptr` into all cache levels
+/// for a subsequent read (x86_64 `prefetcht0` / aarch64 `prfm pldl1keep`).
+///
+/// Safe to call with any pointer: a prefetch hint never faults, even on
+/// invalid addresses.
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+fn prefetch_read(ptr: *const u8) {
+    use std::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+
+    // SAFETY: `_mm_prefetch` is a non-faulting hint for any address.
+    unsafe { _mm_prefetch::<_MM_HINT_T0>(ptr.cast::<i8>()) }
+}
+
+/// Hint the CPU to pull the cache line holding `ptr` into all cache levels
+/// for a subsequent read (x86_64 `prefetcht0` / aarch64 `prfm pldl1keep`).
+///
+/// Safe to call with any pointer: a prefetch hint never faults, even on
+/// invalid addresses. There is no stable `core::arch` prefetch intrinsic for
+/// aarch64 yet, hence inline asm.
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+fn prefetch_read(ptr: *const u8) {
+    // SAFETY: `prfm` is a non-faulting hint for any address; it does not
+    // access memory architecturally, touch the stack, or clobber flags.
+    unsafe {
+        core::arch::asm!(
+            "prfm pldl1keep, [{ptr}]",
+            ptr = in(reg) ptr,
+            options(nostack, preserves_flags),
+        )
+    }
+}

--- a/lib/common/common/src/prefetch.rs
+++ b/lib/common/common/src/prefetch.rs
@@ -18,8 +18,8 @@ const MAX_PREFETCH_LINES: usize = 16;
 /// Best-effort software prefetch (temporal, all cache levels) of the cache
 /// lines spanning `bytes`, capped at [`MAX_PREFETCH_LINES`].
 ///
-/// Experimental: used to overlap the scattered-load latency of HNSW batch
-/// scoring. A prefetch is only a hint and never faults, so this is always safe.
+/// Used to overlap the scattered-load latency of batch scoring. A prefetch is
+/// only a hint and never faults, so this is always safe.
 /// No-op on targets other than x86_64 and aarch64.
 #[inline(always)]
 pub fn prefetch_slice(bytes: &[u8]) {

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -13,6 +13,8 @@ use quantization::encoded_storage::default_for_each_batch;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::vector_utils::TrySetCapacityExact;
 use crate::vector_storage::VectorOffsetType;
+use crate::vector_storage::quantized::quantized_storage::prefetch_read;
+use crate::vector_storage::query_scorer::is_read_with_prefetch_efficient;
 use crate::vector_storage::volatile_chunked_vectors::VolatileChunkedVectors;
 
 #[derive(Debug)]
@@ -128,9 +130,32 @@ impl quantization::EncodedStorage for QuantizedRamStorage {
     fn for_each_batch(
         &self,
         offsets: &[PointOffsetType],
-        callback: impl FnMut(usize, Cow<'_, [u8]>),
+        mut callback: impl FnMut(usize, Cow<'_, [u8]>),
     ) {
-        default_for_each_batch(self, offsets, callback);
+        // Dense-ascending batches stream; the hardware prefetcher already
+        // covers them and software prefetch is pure overhead.
+        if is_read_with_prefetch_efficient(offsets) {
+            default_for_each_batch(self, offsets, callback);
+            return;
+        }
+
+        // Heap-resident vectors have the same random-access DRAM latency as
+        // the mmap-backed storage; prefetch a couple of vectors ahead of the
+        // scorer to hide it.
+        const PREFETCH_AHEAD: usize = 2;
+        for &offset in offsets.iter().take(PREFETCH_AHEAD) {
+            prefetch_read(self.vectors.get(offset as VectorOffsetType));
+        }
+
+        for (index, &offset) in offsets.iter().enumerate() {
+            if let Some(&upcoming) = offsets.get(index + PREFETCH_AHEAD) {
+                prefetch_read(self.vectors.get(upcoming as VectorOffsetType));
+            }
+            callback(
+                index,
+                Cow::Borrowed(self.vectors.get(offset as VectorOffsetType)),
+            );
+        }
     }
 
     fn files(&self) -> Vec<PathBuf> {

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap::MmapFlusher;
-use common::prefetch::prefetch_slice;
+use common::prefetch::{
+    MAX_UNPREFETCHED_BATCH, prefetch_slice, prefetch_slice_l2, prefetch_windows,
+};
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, OneshotFile, UniversalRead, UniversalReadFs};
 use fs_err as fs;
@@ -133,13 +135,9 @@ impl quantization::EncodedStorage for QuantizedRamStorage {
         mut callback: impl FnMut(usize, Cow<'_, [u8]>),
     ) {
         // Dense-ascending batches stream; the hardware prefetcher already
-        // covers them and software prefetch is pure overhead. Batches no
-        // longer than the window would only be prefetched right before use,
-        // too late to hide anything. Scoring two vectors takes about as long
-        // as a memory fetch (~80 ns), so a prefetch issued two vectors ahead
-        // arrives just in time; deeper windows benched neutral.
-        const PREFETCH_AHEAD: usize = 2;
-        if offsets.len() <= PREFETCH_AHEAD || is_read_with_prefetch_efficient(offsets) {
+        // covers them and software prefetch is pure overhead.
+        let (near, far) = prefetch_windows(self.vectors.vector_size_bytes());
+        if offsets.len() <= MAX_UNPREFETCHED_BATCH || is_read_with_prefetch_efficient(offsets) {
             default_for_each_batch(self, offsets, callback);
             return;
         }
@@ -147,12 +145,20 @@ impl quantization::EncodedStorage for QuantizedRamStorage {
         // Heap-resident vectors have the same random-access DRAM latency as
         // the mmap-backed storage; prefetch a couple of vectors ahead of the
         // scorer to hide it.
-        for &offset in offsets.iter().take(PREFETCH_AHEAD) {
+        for &offset in offsets.iter().take(far) {
+            prefetch_slice_l2(self.vectors.get(offset as VectorOffsetType));
+        }
+        for &offset in offsets.iter().take(near) {
             prefetch_slice(self.vectors.get(offset as VectorOffsetType));
         }
 
         for (index, &offset) in offsets.iter().enumerate() {
-            if let Some(&upcoming) = offsets.get(index + PREFETCH_AHEAD) {
+            if far > 0
+                && let Some(&upcoming) = offsets.get(index + far)
+            {
+                prefetch_slice_l2(self.vectors.get(upcoming as VectorOffsetType));
+            }
+            if let Some(&upcoming) = offsets.get(index + near) {
                 prefetch_slice(self.vectors.get(upcoming as VectorOffsetType));
             }
             callback(

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -135,7 +135,9 @@ impl quantization::EncodedStorage for QuantizedRamStorage {
         // Dense-ascending batches stream; the hardware prefetcher already
         // covers them and software prefetch is pure overhead. Batches no
         // longer than the window would only be prefetched right before use,
-        // too late to hide anything.
+        // too late to hide anything. Scoring two vectors takes about as long
+        // as a memory fetch (~80 ns), so a prefetch issued two vectors ahead
+        // arrives just in time; deeper windows benched neutral.
         const PREFETCH_AHEAD: usize = 2;
         if offsets.len() <= PREFETCH_AHEAD || is_read_with_prefetch_efficient(offsets) {
             default_for_each_batch(self, offsets, callback);

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -134,18 +134,20 @@ impl quantization::EncodedStorage for QuantizedRamStorage {
         offsets: &[PointOffsetType],
         mut callback: impl FnMut(usize, Cow<'_, [u8]>),
     ) {
-        // Dense-ascending batches stream; the hardware prefetcher already
-        // covers them and software prefetch is pure overhead.
-        let (near, far) = prefetch_windows(self.vectors.vector_size_bytes());
+        // Tiny batches gain nothing from hints, and dense-ascending batches
+        // stream — the hardware prefetcher already covers them and software
+        // prefetch is pure overhead.
         if offsets.len() <= MAX_UNPREFETCHED_BATCH || is_read_with_prefetch_efficient(offsets) {
             default_for_each_batch(self, offsets, callback);
             return;
         }
 
         // Heap-resident vectors have the same random-access DRAM latency as
-        // the mmap-backed storage; prefetch a couple of vectors ahead of the
-        // scorer to hide it.
-        for &offset in offsets.iter().take(far) {
+        // the mmap-backed storage; prefetch up to `far` vectors ahead of the
+        // scorer to hide it. Warm-up fills the initial windows: the first
+        // `near` vectors go straight to L1, the rest of the far window to L2.
+        let (near, far) = prefetch_windows(self.vectors.vector_size_bytes());
+        for &offset in offsets.iter().take(far).skip(near) {
             prefetch_slice_l2(self.vectors.get(offset as VectorOffsetType));
         }
         for &offset in offsets.iter().take(near) {

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap::MmapFlusher;
+use common::prefetch::prefetch_slice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, OneshotFile, UniversalRead, UniversalReadFs};
 use fs_err as fs;
@@ -13,7 +14,6 @@ use quantization::encoded_storage::default_for_each_batch;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::common::vector_utils::TrySetCapacityExact;
 use crate::vector_storage::VectorOffsetType;
-use crate::vector_storage::quantized::quantized_storage::prefetch_read;
 use crate::vector_storage::query_scorer::is_read_with_prefetch_efficient;
 use crate::vector_storage::volatile_chunked_vectors::VolatileChunkedVectors;
 
@@ -133,8 +133,11 @@ impl quantization::EncodedStorage for QuantizedRamStorage {
         mut callback: impl FnMut(usize, Cow<'_, [u8]>),
     ) {
         // Dense-ascending batches stream; the hardware prefetcher already
-        // covers them and software prefetch is pure overhead.
-        if is_read_with_prefetch_efficient(offsets) {
+        // covers them and software prefetch is pure overhead. Batches no
+        // longer than the window would only be prefetched right before use,
+        // too late to hide anything.
+        const PREFETCH_AHEAD: usize = 2;
+        if offsets.len() <= PREFETCH_AHEAD || is_read_with_prefetch_efficient(offsets) {
             default_for_each_batch(self, offsets, callback);
             return;
         }
@@ -142,14 +145,13 @@ impl quantization::EncodedStorage for QuantizedRamStorage {
         // Heap-resident vectors have the same random-access DRAM latency as
         // the mmap-backed storage; prefetch a couple of vectors ahead of the
         // scorer to hide it.
-        const PREFETCH_AHEAD: usize = 2;
         for &offset in offsets.iter().take(PREFETCH_AHEAD) {
-            prefetch_read(self.vectors.get(offset as VectorOffsetType));
+            prefetch_slice(self.vectors.get(offset as VectorOffsetType));
         }
 
         for (index, &offset) in offsets.iter().enumerate() {
             if let Some(&upcoming) = offsets.get(index + PREFETCH_AHEAD) {
-                prefetch_read(self.vectors.get(upcoming as VectorOffsetType));
+                prefetch_slice(self.vectors.get(upcoming as VectorOffsetType));
             }
             callback(
                 index,

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -9,6 +9,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::maybe_uninit::maybe_uninit_fill_from;
 use common::mmap::{AdviceSetting, MmapFlusher, advice};
+use common::prefetch::prefetch_slice;
 use common::types::PointOffsetType;
 use common::universal_io::{
     CachedReadFs, MmapFile, MmapFs, OpenOptions, Populate, ReadOnly, ReadRange, UioResult,
@@ -112,9 +113,12 @@ impl<S: UniversalRead> QuantizedStorage<S> {
 
             let batch_offset = VECTOR_READ_BATCH_SIZE * batch_idx;
 
-            if sequential {
-                // Dense-ascending batches stream; the hardware prefetcher
-                // already covers them and software prefetch is pure overhead.
+            // Dense-ascending batches stream; the hardware prefetcher already
+            // covers them and software prefetch is pure overhead. Batches no
+            // longer than the window would only be prefetched right before
+            // use, too late to hide anything.
+            const PREFETCH_AHEAD: usize = 2;
+            if sequential || vectors.len() <= PREFETCH_AHEAD {
                 for (vector_idx, vector) in vectors.iter().enumerate() {
                     f(batch_offset + vector_idx, vector);
                 }
@@ -122,14 +126,13 @@ impl<S: UniversalRead> QuantizedStorage<S> {
                 // The gathered `vectors` are borrowed straight from the mmap,
                 // so nothing has touched the bytes yet; without prefetch the
                 // scorer stalls on DRAM at the start of every cold vector.
-                const PREFETCH_AHEAD: usize = 2;
                 for vector in vectors.iter().take(PREFETCH_AHEAD) {
-                    prefetch_read(vector);
+                    prefetch_slice(vector);
                 }
 
                 for (vector_idx, vector) in vectors.iter().enumerate() {
                     if let Some(upcoming) = vectors.get(vector_idx + PREFETCH_AHEAD) {
-                        prefetch_read(upcoming);
+                        prefetch_slice(upcoming);
                     }
                     f(batch_offset + vector_idx, vector);
                 }
@@ -143,24 +146,6 @@ impl<S: UniversalRead> QuantizedStorage<S> {
 /// Open a file shortly for appending.
 fn open_append(path: &Path) -> std::io::Result<fs::File> {
     fs::OpenOptions::new().append(true).open(path)
-}
-
-/// Software-prefetch every cache line of `bytes` into L1.
-#[inline(always)]
-pub(super) fn prefetch_read(bytes: &[u8]) {
-    #[cfg(target_arch = "x86_64")]
-    {
-        use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
-        const CACHE_LINE_SIZE: usize = 64;
-        let mut offset = 0;
-        while offset < bytes.len() {
-            // SAFETY: the pointer stays inside `bytes`; prefetch never faults.
-            unsafe { _mm_prefetch::<_MM_HINT_T0>(bytes.as_ptr().add(offset).cast()) };
-            offset += CACHE_LINE_SIZE;
-        }
-    }
-    #[cfg(not(target_arch = "x86_64"))]
-    let _ = bytes;
 }
 
 pub struct QuantizedStorageBuilder<S> {

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -9,7 +9,9 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::{AccessPattern, Random, Sequential};
 use common::maybe_uninit::maybe_uninit_fill_from;
 use common::mmap::{AdviceSetting, MmapFlusher, advice};
-use common::prefetch::prefetch_slice;
+use common::prefetch::{
+    MAX_UNPREFETCHED_BATCH, prefetch_slice, prefetch_slice_l2, prefetch_windows,
+};
 use common::types::PointOffsetType;
 use common::universal_io::{
     CachedReadFs, MmapFile, MmapFs, OpenOptions, Populate, ReadOnly, ReadRange, UioResult,
@@ -100,6 +102,7 @@ impl<S: UniversalRead> QuantizedStorage<S> {
         }
 
         let mut vectors_buffer = [const { MaybeUninit::uninit() }; VECTOR_READ_BATCH_SIZE];
+        let (near, far) = prefetch_windows(self.quantized_vector_size.get());
 
         for (batch_idx, keys) in keys.chunks(VECTOR_READ_BATCH_SIZE).enumerate() {
             let sequential = is_read_with_prefetch_efficient(keys);
@@ -114,14 +117,8 @@ impl<S: UniversalRead> QuantizedStorage<S> {
             let batch_offset = VECTOR_READ_BATCH_SIZE * batch_idx;
 
             // Dense-ascending batches stream; the hardware prefetcher already
-            // covers them and software prefetch is pure overhead. Batches no
-            // longer than the window would only be prefetched right before
-            // use, too late to hide anything. Scoring two vectors takes about
-            // as long as a memory fetch (~80 ns), so a prefetch issued two
-            // vectors ahead arrives just in time; deeper windows benched
-            // neutral.
-            const PREFETCH_AHEAD: usize = 2;
-            if sequential || vectors.len() <= PREFETCH_AHEAD {
+            // covers them and software prefetch is pure overhead.
+            if sequential || vectors.len() <= MAX_UNPREFETCHED_BATCH {
                 for (vector_idx, vector) in vectors.iter().enumerate() {
                     f(batch_offset + vector_idx, vector);
                 }
@@ -129,12 +126,20 @@ impl<S: UniversalRead> QuantizedStorage<S> {
                 // The gathered `vectors` are borrowed straight from the mmap,
                 // so nothing has touched the bytes yet; without prefetch the
                 // scorer stalls on DRAM at the start of every cold vector.
-                for vector in vectors.iter().take(PREFETCH_AHEAD) {
+                for vector in vectors.iter().take(far) {
+                    prefetch_slice_l2(vector);
+                }
+                for vector in vectors.iter().take(near) {
                     prefetch_slice(vector);
                 }
 
                 for (vector_idx, vector) in vectors.iter().enumerate() {
-                    if let Some(upcoming) = vectors.get(vector_idx + PREFETCH_AHEAD) {
+                    if far > 0
+                        && let Some(upcoming) = vectors.get(vector_idx + far)
+                    {
+                        prefetch_slice_l2(upcoming);
+                    }
+                    if let Some(upcoming) = vectors.get(vector_idx + near) {
                         prefetch_slice(upcoming);
                     }
                     f(batch_offset + vector_idx, vector);

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -126,7 +126,7 @@ impl<S: UniversalRead> QuantizedStorage<S> {
                 // The gathered `vectors` are borrowed straight from the mmap,
                 // so nothing has touched the bytes yet; without prefetch the
                 // scorer stalls on DRAM at the start of every cold vector.
-                for vector in vectors.iter().take(far) {
+                for vector in vectors.iter().take(far).skip(near) {
                     prefetch_slice_l2(vector);
                 }
                 for vector in vectors.iter().take(near) {

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -101,7 +101,8 @@ impl<S: UniversalRead> QuantizedStorage<S> {
         let mut vectors_buffer = [const { MaybeUninit::uninit() }; VECTOR_READ_BATCH_SIZE];
 
         for (batch_idx, keys) in keys.chunks(VECTOR_READ_BATCH_SIZE).enumerate() {
-            let vectors = if is_read_with_prefetch_efficient(keys) {
+            let sequential = is_read_with_prefetch_efficient(keys);
+            let vectors = if sequential {
                 let iter = keys.iter().map(|&key| self.read_vector::<Sequential>(key));
                 maybe_uninit_fill_from(&mut vectors_buffer, iter).0
             } else {
@@ -111,19 +112,27 @@ impl<S: UniversalRead> QuantizedStorage<S> {
 
             let batch_offset = VECTOR_READ_BATCH_SIZE * batch_idx;
 
-            // The gathered `vectors` are borrowed straight from the mmap, so
-            // nothing has touched the bytes yet; without prefetch the scorer
-            // stalls on DRAM at the start of every cold vector.
-            const PREFETCH_AHEAD: usize = 2;
-            for vector in vectors.iter().take(PREFETCH_AHEAD) {
-                prefetch_read(vector);
-            }
-
-            for (vector_idx, vector) in vectors.iter().enumerate() {
-                if let Some(upcoming) = vectors.get(vector_idx + PREFETCH_AHEAD) {
-                    prefetch_read(upcoming);
+            if sequential {
+                // Dense-ascending batches stream; the hardware prefetcher
+                // already covers them and software prefetch is pure overhead.
+                for (vector_idx, vector) in vectors.iter().enumerate() {
+                    f(batch_offset + vector_idx, vector);
                 }
-                f(batch_offset + vector_idx, vector);
+            } else {
+                // The gathered `vectors` are borrowed straight from the mmap,
+                // so nothing has touched the bytes yet; without prefetch the
+                // scorer stalls on DRAM at the start of every cold vector.
+                const PREFETCH_AHEAD: usize = 2;
+                for vector in vectors.iter().take(PREFETCH_AHEAD) {
+                    prefetch_read(vector);
+                }
+
+                for (vector_idx, vector) in vectors.iter().enumerate() {
+                    if let Some(upcoming) = vectors.get(vector_idx + PREFETCH_AHEAD) {
+                        prefetch_read(upcoming);
+                    }
+                    f(batch_offset + vector_idx, vector);
+                }
             }
         }
 
@@ -138,7 +147,7 @@ fn open_append(path: &Path) -> std::io::Result<fs::File> {
 
 /// Software-prefetch every cache line of `bytes` into L1.
 #[inline(always)]
-fn prefetch_read(bytes: &[u8]) {
+pub(super) fn prefetch_read(bytes: &[u8]) {
     #[cfg(target_arch = "x86_64")]
     {
         use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -111,7 +111,18 @@ impl<S: UniversalRead> QuantizedStorage<S> {
 
             let batch_offset = VECTOR_READ_BATCH_SIZE * batch_idx;
 
+            // The gathered `vectors` are borrowed straight from the mmap, so
+            // nothing has touched the bytes yet; without prefetch the scorer
+            // stalls on DRAM at the start of every cold vector.
+            const PREFETCH_AHEAD: usize = 2;
+            for vector in vectors.iter().take(PREFETCH_AHEAD) {
+                prefetch_read(vector);
+            }
+
             for (vector_idx, vector) in vectors.iter().enumerate() {
+                if let Some(upcoming) = vectors.get(vector_idx + PREFETCH_AHEAD) {
+                    prefetch_read(upcoming);
+                }
                 f(batch_offset + vector_idx, vector);
             }
         }
@@ -123,6 +134,24 @@ impl<S: UniversalRead> QuantizedStorage<S> {
 /// Open a file shortly for appending.
 fn open_append(path: &Path) -> std::io::Result<fs::File> {
     fs::OpenOptions::new().append(true).open(path)
+}
+
+/// Software-prefetch every cache line of `bytes` into L1.
+#[inline(always)]
+fn prefetch_read(bytes: &[u8]) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+        const CACHE_LINE_SIZE: usize = 64;
+        let mut offset = 0;
+        while offset < bytes.len() {
+            // SAFETY: the pointer stays inside `bytes`; prefetch never faults.
+            unsafe { _mm_prefetch::<_MM_HINT_T0>(bytes.as_ptr().add(offset).cast()) };
+            offset += CACHE_LINE_SIZE;
+        }
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    let _ = bytes;
 }
 
 pub struct QuantizedStorageBuilder<S> {

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -116,7 +116,10 @@ impl<S: UniversalRead> QuantizedStorage<S> {
             // Dense-ascending batches stream; the hardware prefetcher already
             // covers them and software prefetch is pure overhead. Batches no
             // longer than the window would only be prefetched right before
-            // use, too late to hide anything.
+            // use, too late to hide anything. Scoring two vectors takes about
+            // as long as a memory fetch (~80 ns), so a prefetch issued two
+            // vectors ahead arrives just in time; deeper windows benched
+            // neutral.
             const PREFETCH_AHEAD: usize = 2;
             if sequential || vectors.len() <= PREFETCH_AHEAD {
                 for (vector_idx, vector) in vectors.iter().enumerate() {

--- a/lib/segment/src/vector_storage/volatile_chunked_vectors.rs
+++ b/lib/segment/src/vector_storage/volatile_chunked_vectors.rs
@@ -37,6 +37,11 @@ impl<T: Copy + Clone + Default> VolatileChunkedVectors<T> {
         self.len
     }
 
+    /// Size of one stored vector in bytes.
+    pub fn vector_size_bytes(&self) -> usize {
+        self.dim * mem::size_of::<T>()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }


### PR DESCRIPTION
This PR adds memory prefetching (`_mm_prefetch`) for quantized vector scoring with a random access pattern (HNSW). It covers all types of quantization: scalar, binary, and TurboQuant (both the `turbo4` datatype and quantization).

Multivectors are not covered by this PR.

# Results
<img width="1920" height="736" alt="image" src="https://github.com/user-attachments/assets/41e33fb9-711b-4503-bfb1-8f7df93ae1be" />

Speedup with prefetching, measured with random vectors on a Ryzen 5 5600x. Memory latency ~92ns single, ~135ns contended. Collection sizes are different, therefore a direct comparison between different dimensions is not always possible.

On Zen 5 (server), speedups of up to 150% have been measured (turbo 4bit, 1024d).

The exact performance gain is heavily dependent on the machine, collection and HNSW graph-shape. Denser HNSW-Graphs with many nodes/neighbors give better performance improvements.

# Why

When HNSW scores a batch of candidates, each quantized vector sits at a random memory address.
The CPU only learns that address the moment the scoring loop reaches it, so every vector that isn't cached starts with a full memory latency stall (~100–250 ns) before the scoring itself can even begin, and since quantized kernels are fast, those stalls end up **dominating search time**.

The CPU's own hardware prefetcher can't help for common dimension sizes, for two reasons:
1. It can't guess the next vector. Every new vector is a **cold start**.
2. Small vectors end before it gets going. The hardware prefetcher needs up to 16 sequential cache lines to reach full speed; quantized vectors at common dimensions are 9–17 lines. Each one is fetched at ramp-up pace, 3–4 memory latencies instead of one.

A software prefetch hint fixes both: it requests a vector's cache lines in parallel (one latency instead of 3–4) and does so early, while previous vectors are still being scored. By the time the vector is needed, it's already there.


| | DRAM latency (idle) | turbo4 | turbo1 | bq (1-bit) | bq2 (2-bit) | int8 |
|---|---:|---:|---:|---:|---:|---:|
| desktop / laptop | 109.5 ns | 31.3 ns | 24.6 ns | 5.7 ns | 8.5 ns | 23.3 ns |
| server | 128.4 ns | 45.1 ns | 37.0 ns | 8.5 ns | 11.3 ns | 27.9 ns |

This table shows the measured DRAM latency next to raw scoring time (median over selected dims 64–4096 and over the machines in each group).

Scoring a vector is **significantly cheaper** than fetching one from memory in every case. Without prefetching, the CPU spends most of its time _waiting_ instead of scoring.

In contended search scenarios, latency even goes up to ~1.5–2.5× of these values (over 300 ns on some machines, ~550 ns under full-machine stress). This explains why the performance improvements are higher in contended search scenario for mid-sized dimensions. Higher dimensional vectors see less improvement since the hardware prefetcher takes care of latencies for 4-8 bit quantizations (inside a vector) - and the between vector latency becomes less significant in comparison.

# How

`prefetch_windows()`, a new function deciding how much to prefetch, derives two lookahead windows:

- near window (up to 1 KiB ahead) -> into L1, needed _next_
- far window (up to 4 KiB ahead) -> into L2, needed _soon_. L2 is big enough that early arrivals don't evict data still in use.

Small vectors mean fast scoring, so the window automatically widens to more vectors prefetched (up to 8 near / 16 far), large vectors narrow it.

Each hint covers at most the first 16 cache lines of a vector.
That cap is doing two jobs: for vectors larger than 16 lines, 16 hinted lines are exactly what trains the hardware prefetcher, which then streams the rest of the vector automatically, and it keeps the number of parallel fetches within the CPU's miss-buffer budget (max memory level parallelism).