### PR TITLE
avoid building full SegmentInfo just to read segment_type in shard st…

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1200,8 +1200,7 @@ impl LocalShard {
                 // TODO: snapshotting also creates temp proxy segments. should differentiate.
                 let has_special_segment = segments
                     .iter()
-                    // `size_info` carries `segment_type` and cannot fail.
-                    .map(|(_, segment)| segment.get().read().size_info().segment_type)
+                    .map(|(_, segment)| segment.get().read().segment_type())
                     .any(|segment_type| segment_type == SegmentType::Special);
                 if has_special_segment {
                     Some((ShardStatus::Yellow, OptimizersStatus::Ok))


### PR DESCRIPTION
### All Submissions

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

### Description

`local_shard_status` decides whether a shard should report Yellow by checking if any segment is a proxy. Right now, it does that by calling `size_info()` for every segment and then reading only the `segment_type` field.

The problem is that `segment_type` is not actually computed by `size_info()` -- it is passed into it unchanged. Meanwhile, `size_info()` does a lot of extra work, including building per-vector statistics, allocating a HashMap, and calculating payload storage size. In this case, all of that work is immediately thrown away.

This change replaces `size_info().segment_type` with the existing `segment_type() g`etter. It returns the same value for normal, read-only, and proxy segments, so shard status behavior does not change. It simply avoids doing an expensive full size calculation when all we need is the segment type. 