### PR TITLE
fix(collection): route top-level is_empty count through exact path

### DIFF
--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -701,11 +701,23 @@ impl LocalShard {
 /// currently route through the approximate-count path whose estimate is
 /// systematically biased low (qdrant/qdrant#10120); the count endpoint
 /// should fall back to the exact path for them.
+///
+/// `should` and `must_not` are deserialized through `MaybeOneOrMany`, which
+/// preserves `[]` as `Some(vec![])`. An empty `must_not` is a no-op at
+/// filter evaluation, and an empty `should` matches nothing — neither
+/// changes the result of a `must: [IsEmpty]` filter against the exact
+/// path, so neither should disqualify the helper.
+///
+/// `min_should` disqualifies unconditionally: it changes the boolean
+/// semantics of the filter and the count path needs to be re-evaluated
+/// on the approximate side, so we keep the conservative behaviour.
 fn is_top_level_is_empty(filter: Option<&Filter>) -> bool {
     let Some(filter) = filter else {
         return false;
     };
-    if filter.should.is_some() || filter.must_not.is_some() || filter.min_should.is_some() {
+    let has_non_empty_should = filter.should.as_deref().is_some_and(|s| !s.is_empty());
+    let has_non_empty_must_not = filter.must_not.as_deref().is_some_and(|m| !m.is_empty());
+    if has_non_empty_should || has_non_empty_must_not || filter.min_should.is_some() {
         return false;
     }
     match filter.must.as_deref() {
@@ -716,8 +728,9 @@ fn is_top_level_is_empty(filter: Option<&Filter>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use segment::types::{FieldCondition, PayloadField};
+
+    use super::*;
 
     fn cond_is_empty() -> Condition {
         Condition::IsEmpty(IsEmptyCondition {
@@ -768,6 +781,47 @@ mod tests {
         // must: [IsEmpty], must_not: [Match]
         let mut filter = Filter::new_must(cond_is_empty());
         filter.must_not = Some(vec![cond_match()]);
+        assert!(!is_top_level_is_empty(Some(&filter)));
+    }
+
+    /// An empty `should: []` is a no-op (the deserializer preserves `[]` as
+    /// `Some(vec![])` via `MaybeOneOrMany`), so the helper must still
+    /// recognise the request as a top-level `is_empty` and force exact.
+    #[test]
+    fn is_top_level_is_empty_allows_empty_should() {
+        let mut filter = Filter::new_must(cond_is_empty());
+        filter.should = Some(vec![]);
+        assert!(is_top_level_is_empty(Some(&filter)));
+    }
+
+    /// Same as above for `must_not: []`. The exact bug CodeRabbit flagged
+    /// on PR #10348: `must_not: []` was treated as a non-empty clause and
+    /// caused the helper to fall through to the approximate path.
+    #[test]
+    fn is_top_level_is_empty_allows_empty_must_not() {
+        let mut filter = Filter::new_must(cond_is_empty());
+        filter.must_not = Some(vec![]);
+        assert!(is_top_level_is_empty(Some(&filter)));
+    }
+
+    /// Both empty at once still matches.
+    #[test]
+    fn is_top_level_is_empty_allows_empty_should_and_must_not() {
+        let mut filter = Filter::new_must(cond_is_empty());
+        filter.should = Some(vec![]);
+        filter.must_not = Some(vec![]);
+        assert!(is_top_level_is_empty(Some(&filter)));
+    }
+
+    /// `min_should` changes the boolean semantics of the filter and is
+    /// rejected unconditionally, even if its inner conditions are empty.
+    #[test]
+    fn is_top_level_is_empty_rejects_min_should() {
+        let mut filter = Filter::new_must(cond_is_empty());
+        filter.min_should = Some(segment::types::MinShould {
+            conditions: vec![cond_match()],
+            min_count: 1,
+        });
         assert!(!is_top_level_is_empty(Some(&filter)));
     }
 }

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -7,7 +7,8 @@ use common::types::DeferredBehavior;
 use segment::data_types::facets::{FacetParams, FacetResponse};
 use segment::data_types::order_by::OrderBy;
 use segment::types::{
-    ExtendedPointId, Filter, ScoredPoint, WithPayload, WithPayloadInterface, WithVector,
+    Condition, ExtendedPointId, Filter, IsEmptyCondition, ScoredPoint, WithPayload,
+    WithPayloadInterface, WithVector,
 };
 use shard::count::CountRequestInternal;
 use shard::retrieve::record_internal::RecordInternal;
@@ -399,7 +400,16 @@ impl ShardOperation for LocalShard {
         })?;
         let start_time = Instant::now();
         let cpu_utilization = hw_measurement_acc.cpu_utilization();
-        let result: CollectionResult<usize> = if request.exact {
+        // A top-level `is_empty` cardinality is currently off by ~35% on
+        // common data (e.g. 80% field presence → ~35% undercount). The
+        // simpler and safer fix is to fall back to the exact path: the
+        // "field has no value" set is the null-index's bread and butter
+        // (it is exact for `is_null`), and routing the approximate count
+        // through it is a follow-up.
+        //
+        // See: qdrant/qdrant#10120
+        let force_exact = !request.exact && is_top_level_is_empty(request.filter.as_ref());
+        let result: CollectionResult<usize> = if request.exact || force_exact {
             let timeout = self.timeout_or_default_search_timeout(timeout);
             match tokio::time::timeout(
                 timeout,
@@ -684,5 +694,80 @@ impl LocalShard {
             deferred_behavior,
         )
         .await
+    }
+}
+
+/// True when the filter is a top-level `is_empty` condition. Such filters
+/// currently route through the approximate-count path whose estimate is
+/// systematically biased low (qdrant/qdrant#10120); the count endpoint
+/// should fall back to the exact path for them.
+fn is_top_level_is_empty(filter: Option<&Filter>) -> bool {
+    let Some(filter) = filter else {
+        return false;
+    };
+    if filter.should.is_some() || filter.must_not.is_some() || filter.min_should.is_some() {
+        return false;
+    }
+    match filter.must.as_deref() {
+        Some([Condition::IsEmpty(_)]) => true,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use segment::types::{FieldCondition, PayloadField};
+
+    fn cond_is_empty() -> Condition {
+        Condition::IsEmpty(IsEmptyCondition {
+            is_empty: segment::types::PayloadField {
+                key: "kw".parse().unwrap(),
+            },
+        })
+    }
+
+    fn cond_match() -> Condition {
+        Condition::Field(FieldCondition::new_match(
+            "kw".parse().unwrap(),
+            segment::types::Match::Value(segment::types::MatchValue {
+                value: segment::types::ValueVariants::String("red".to_string()),
+            }),
+        ))
+    }
+
+    #[test]
+    fn is_top_level_is_empty_matches_single_is_empty() {
+        let filter = Filter::new_must(cond_is_empty());
+        assert!(is_top_level_is_empty(Some(&filter)));
+    }
+
+    #[test]
+    fn is_top_level_is_empty_rejects_none() {
+        assert!(!is_top_level_is_empty(None));
+    }
+
+    #[test]
+    fn is_top_level_is_empty_rejects_composite_filters() {
+        // must: [IsEmpty, Match] — composite, not pure IsEmpty
+        let mut filter = Filter::new_must(cond_is_empty());
+        filter.must = Some(vec![cond_is_empty(), cond_match()]);
+        assert!(!is_top_level_is_empty(Some(&filter)));
+    }
+
+    #[test]
+    fn is_top_level_is_empty_rejects_should() {
+        // should: [Match] with must: [IsEmpty]
+        let mut filter = Filter::new_must(cond_is_empty());
+        filter.should = Some(vec![cond_match()]);
+        assert!(!is_top_level_is_empty(Some(&filter)));
+    }
+
+    #[test]
+    fn is_top_level_is_empty_rejects_must_not() {
+        // must: [IsEmpty], must_not: [Match]
+        let mut filter = Filter::new_must(cond_is_empty());
+        filter.must_not = Some(vec![cond_match()]);
+        assert!(!is_top_level_is_empty(Some(&filter)));
     }
 }


### PR DESCRIPTION
## Problem

Reproduces qdrant/qdrant#10120.

`count exact=false is_empty` on a keyword-indexed field returns a stable ~35% under-count at steady state. For 200 points with 80% field presence, `exact=true` returns 40 but `exact=false` returns 25. `is_null` on the same collection returns identical correct values on both paths, which isolates the bug to the `is_empty` cardinality estimator.

The OpenAPI spec documents that approximate counts are "faster but might be unreliable during indexing" — at steady state (after indexing completes), `is_empty` should not be systematically biased by 35%.

## Root cause (partial)

The segment-level cardinality pipeline for `is_empty` falls through to a generic `(min=0, exp=TOTAL/2, max=TOTAL)` estimate in `query_estimator.rs`. The per-field `condition_cardinality` in `filtering.rs` is supposed to refine this via the null-index's `total - has_values` exact count, but the count code path returns the unrefined generic estimate. The exact mechanism — why the null-index's `Some(estimation)` does not reach the final `exp` — is in the segment/shard-level cardinality combination, not directly observable from a single-file reading.

I attempted two paths to fix the underlying estimator:

1. **Route through the null-index directly in `condition_cardinality`.** The blocker is that `field_indexes` is `IndexesMap<F>` where `F: FieldIndexRead`, and the `FieldIndex` enum wrapper used in the writable struct payload index is not in the read view's type — you cannot downcast from `F: FieldIndexRead` to `NullIndex` to call its `estimate_cardinality` directly without a new trait method. This would require a `FieldIndexRead::estimate_is_empty_cardinality` extension.
2. **Add a new trait method for is_empty cardinality.** Cleaner but a larger change.

Both would require deeper refactoring than the scope of this PR.

## Fix

Fall back to the exact path for the affected filter shape, mirroring the approach the issue reporter flagged as the safe alternative ("fall back to `exact=true` for `is_empty` when the indexed estimate cannot be made exact"). The cost is that the exact path iterates segments via `read_filtered` rather than consulting a cardinality estimator, but the null-index-driven `is_null` cardinality is already exact via the same exact path, so this is a documented cost paid only for the broken shape.

The trigger is narrow: only a top-level single `Condition::IsEmpty(_)` in the `must` clause, with no `should`, `must_not`, or `min_should`. Any composite filter that mixes `is_empty` with another condition continues to use the approximate path; extending the trigger there is a follow-up.

## Tests

5 new unit tests in `lib/collection/src/shards/local_shard/shard_ops.rs`:

- `is_top_level_is_empty_matches_single_is_empty` — `must: [IsEmpty("kw")]` returns true
- `is_top_level_is_empty_rejects_none` — no filter returns false
- `is_top_level_is_empty_rejects_composite_filters` — `must: [IsEmpty, Match]` returns false
- `is_top_level_is_empty_rejects_should` — `must: [IsEmpty]` with `should: [Match]` returns false
- `is_top_level_is_empty_rejects_must_not` — `must: [IsEmpty]` with `must_not: [Match]` returns false

Existing `cargo test -p collection --lib shard_ops` shows 5/5 passing. `cargo test -p shard --lib` (149 tests) and `cargo test -p storage --lib` (79 tests) all pass.

## Scope

- **1 file changed**: `lib/collection/src/shards/local_shard/shard_ops.rs`
- **+87 / -2 lines** (5 new tests + the predicate function + the count call site)
- No API change, no public type change, no behavior change for non-`is_empty` filters

## Cross-model review

I ran the patch through a 10-model Tier A consult before opening the PR. Consensus:

- The stopgap is correct and the trade-off is acceptable
- One reviewer (gpt-5.3-codex) noted I should also gate on `min_should` — applied
- Several reviewers identified that the proper fix lives in the segment-level estimator; documenting that as a follow-up

## Future improvement

The right architectural fix is a new `FieldIndexRead::estimate_is_empty_cardinality` trait method that the segment-level estimator consults, with a fallback for the read view. This would restore the approximate path's performance for the broken shape while making the estimator's contract explicit. Tracking that as a follow-up to this PR.

Fixes #10120
