### PR TITLE
Persist proxy segment changes across restart, don't stall WAL ack's

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -11885,8 +11885,13 @@
             "default": false,
             "type": "boolean"
           },
+          "persist_proxy_segments": {
+            "description": "Persist proxy segment changes on disk. Prevents pinning the WAL while proxy segments are open. Replays the persisted changes on startup to guarantee data consistency. Required for serverless deployments where storage and compute is separated.",
+            "default": false,
+            "type": "boolean"
+          },
           "serverless_compatible": {
-            "description": "Serverless-compatible deployment mode. Automatically enables [`Self::write_segment_manifest`], [`Self::append_only_mutations`], [`Self::compact_bitmask`] and [`Self::append_only_storages`].\n\nNote that this will only be applied when passed into [`init_feature_flags`].",
+            "description": "Serverless-compatible deployment mode. Implies [`Self::write_segment_manifest`], [`Self::append_only_mutations`], [`Self::compact_bitmask`], [`Self::append_only_storages`] and [`Self::persist_proxy_segments`].\n\nNote that this will only be applied when passed into [`init_feature_flags`].",
             "default": false,
             "type": "boolean"
           }

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -49,6 +49,7 @@ use parking_lot::Mutex as ParkingMutex;
 use segment::common::operation_error::OperationResult;
 use segment::entry::ReadSegmentEntry as _;
 use segment::index::field_index::{CardinalityEstimation, EstimationMerge};
+use segment::pending_changes::PersistedProxyChanges;
 use segment::segment_constructor::{build_segment, load_segment, normalize_segment_dir};
 use segment::types::{
     Filter, PayloadIndexInfo, PayloadKeyType, PointIdType, SegmentConfig, SegmentType,
@@ -458,7 +459,10 @@ impl LocalShard {
                     // Buffered proxy state that made it to disk doesn't hold back the WAL
                     // acknowledge, so it must be recovered here before WAL replay to create a
                     // consistent view of the segment.
-                    segment::pending_changes::recover_pending_changes(&mut segment)?;
+                    segment::pending_changes::recover_pending_changes(
+                        &mut segment,
+                        PersistedProxyChanges::Replay,
+                    )?;
 
                     if rebuild_payload_index {
                         segment.update_all_field_indices(

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -371,6 +371,7 @@ impl LocalShard {
         shared_storage_config: Arc<SharedStorageConfig>,
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         rebuild_payload_index: bool,
+        persisted_proxy_changes: PersistedProxyChanges,
         update_runtime: Handle,
         search_runtime: AdaptiveSearchHandle,
         optimizer_resource_budget: ResourceBudget,
@@ -459,9 +460,11 @@ impl LocalShard {
                     // Buffered proxy state that made it to disk doesn't hold back the WAL
                     // acknowledge, so it must be recovered here before WAL replay to create a
                     // consistent view of the segment.
+                    // Skipped when loading a mirror of another writer's segment files, such as a
+                    // recovered partial snapshot, which must not diverge from the writer's.
                     segment::pending_changes::recover_pending_changes(
                         &mut segment,
-                        PersistedProxyChanges::Replay,
+                        persisted_proxy_changes,
                     )?;
 
                     if rebuild_payload_index {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -454,6 +454,12 @@ impl LocalShard {
 
                     segment.check_consistency_and_repair()?;
 
+                    // Replay pending changes persisted by proxy segment, then remove them.
+                    // Buffered proxy state that made it to disk doesn't hold back the WAL
+                    // acknowledge, so it must be recovered here before WAL replay to create a
+                    // consistent view of the segment.
+                    segment::pending_changes::recover_pending_changes(&mut segment)?;
+
                     if rebuild_payload_index {
                         segment.update_all_field_indices(
                             &payload_index_schema.read().schema.clone(),

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -72,7 +72,9 @@ use self::disk_usage_watcher::DiskUsageWatcher;
 use super::update_tracker::UpdateTracker;
 use crate::collection::payload_index_schema::PayloadIndexSchema;
 use crate::collection_manager::collection_updater::CollectionUpdater;
-use crate::collection_manager::holders::segment_holder::{LockedSegment, SegmentHolder};
+use crate::collection_manager::holders::segment_holder::{
+    LockedSegment, PostFlushOutcome, SegmentHolder,
+};
 use crate::collection_manager::optimizers::TrackerLog;
 use crate::collection_manager::optimizers::segment_optimizer::plan_optimizations;
 use crate::collection_manager::segments_searcher::SegmentsSearcher;
@@ -457,13 +459,15 @@ impl LocalShard {
 
                     segment.check_consistency_and_repair()?;
 
-                    // Replay pending changes persisted by proxy segment, then remove them.
-                    // Buffered proxy state that made it to disk doesn't hold back the WAL
-                    // acknowledge, so it must be recovered here before WAL replay to create a
-                    // consistent view of the segment.
+                    // Replay pending changes persisted by proxy segment. Buffered proxy state
+                    // that made it to disk doesn't hold back the WAL acknowledge, so it must be
+                    // recovered here before WAL replay to create a consistent view of the
+                    // segment. The log files are only safe to remove once the segment durably
+                    // persists past `recovered.ready_at`; that is deferred to a post-flush action
+                    // registered once this segment has joined the holder, below.
                     // Skipped when loading a mirror of another writer's segment files, such as a
                     // recovered partial snapshot, which must not diverge from the writer's.
-                    segment::pending_changes::recover_pending_changes(
+                    let recovered = segment::pending_changes::recover_pending_changes(
                         &mut segment,
                         persisted_proxy_changes,
                     )?;
@@ -478,7 +482,7 @@ impl LocalShard {
                     // but are missing from the segment (e.g. after crash between config update and shard update)
                     segment.update_all_vector_names(&desired_vectors)?;
 
-                    CollectionResult::Ok(Some(segment))
+                    CollectionResult::Ok(Some((segment, recovered)))
                 });
                 AbortOnDropHandle::new(handle)
             })
@@ -492,11 +496,26 @@ impl LocalShard {
         let mut segment_holder = SegmentHolder::builder();
 
         while let Some(result) = segment_stream.next().await {
-            let Some(segment) = result?? else {
+            let Some((segment, recovered)) = result?? else {
                 continue;
             };
 
             segment_holder.add_new(segment);
+
+            // Defer removing the pending changes log files until a future flush proves the
+            // replayed operations durable; see `RecoveredPendingChanges::log_files`.
+            if !recovered.log_files.is_empty() {
+                segment_holder.register_post_flush_action(
+                    recovered.ready_at,
+                    recovered.ready_at,
+                    move || {
+                        for path in &recovered.log_files {
+                            fs::remove_file(path)?;
+                        }
+                        Ok(PostFlushOutcome::Done)
+                    },
+                );
+            }
         }
         drop(segment_stream); // release `payload_index_schema` from borrow checker
 

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -452,6 +452,7 @@ impl LocalShard {
                         uuid,
                         deferred_internal_id,
                         &AtomicBool::new(false),
+                        false,
                     )?;
 
                     segment.check_consistency_and_repair()?;

--- a/lib/collection/src/shards/local_shard/snapshot_tests.rs
+++ b/lib/collection/src/shards/local_shard/snapshot_tests.rs
@@ -83,9 +83,10 @@ fn test_snapshot_all() {
 /// as `active`.
 #[test]
 fn test_snapshot_includes_segment_manifest() {
-    let mut flags = FeatureFlags::default();
-    flags.write_segment_manifest = true;
-    init_feature_flags(flags);
+    init_feature_flags(FeatureFlags {
+        write_segment_manifest: true,
+        ..Default::default()
+    });
 
     // Another test in this process may have initialized the feature flags first; the manifest is
     // only written when the flag is actually enabled.

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -20,6 +20,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use common::types::DeferredBehavior;
 use replica_set_state::{ReplicaSetState, ReplicaState};
+use segment::pending_changes::PersistedProxyChanges;
 use segment::types::{ExtendedPointId, Filter, SeqNumberType, ShardKey, StrictModeConfig};
 use serde::{Deserialize, Serialize};
 use shard::operations::optimization::{
@@ -304,6 +305,7 @@ impl ShardReplicaSet {
                     shared_storage_config.clone(),
                     payload_index_schema.clone(),
                     true,
+                    PersistedProxyChanges::Replay,
                     update_runtime.clone(),
                     search_runtime.clone(),
                     optimizer_resource_budget.clone(),

--- a/lib/collection/src/shards/replica_set/snapshots.rs
+++ b/lib/collection/src/shards/replica_set/snapshots.rs
@@ -336,6 +336,7 @@ impl ShardReplicaSet {
                 self.shared_storage_config.clone(),
                 self.payload_index_schema.clone(),
                 recovery_type.is_full(),
+                recovery_type.persisted_proxy_changes(),
                 self.update_runtime.clone(),
                 self.search_runtime.clone(),
                 self.optimizer_resource_budget.clone(),

--- a/lib/collection/src/tests/fix_payload_indices.rs
+++ b/lib/collection/src/tests/fix_payload_indices.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
+use segment::pending_changes::PersistedProxyChanges;
 use segment::types::{PayloadFieldSchema, PayloadSchemaType};
 use tempfile::Builder;
 use tokio::runtime::Handle;
@@ -96,6 +97,7 @@ async fn test_fix_payload_indices() {
         Arc::new(Default::default()),
         payload_index_schema,
         true,
+        PersistedProxyChanges::Replay,
         update_runtime.clone(),
         current_runtime,
         ResourceBudget::default(),

--- a/lib/collection/src/tests/segment_manifest.rs
+++ b/lib/collection/src/tests/segment_manifest.rs
@@ -18,9 +18,10 @@ use crate::tests::fixtures::create_collection_config;
 /// (next to the `segments/` directory) listing the shard's segments as `active`.
 #[tokio::test]
 async fn writes_segment_manifest_when_flag_enabled() {
-    let mut flags = FeatureFlags::default();
-    flags.write_segment_manifest = true;
-    init_feature_flags(flags);
+    init_feature_flags(FeatureFlags {
+        write_segment_manifest: true,
+        ..Default::default()
+    });
 
     let collection_dir = Builder::new().prefix("segment-manifest").tempdir().unwrap();
     let payload_schema_dir = Builder::new().prefix("payload-schema").tempdir().unwrap();

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -1752,3 +1752,194 @@ async fn test_malformed_multivector_raw_upsert_is_skipped_on_wal_replay() {
 
     assert_bad_op_skipped_on_wal_replay(config, valid_upsert, malformed_raw_upsert).await;
 }
+
+/// End-to-end crash recovery through the persisted pending changes of proxy segments.
+///
+/// A delete buffered in a proxy segment used to hold back acknowledging the WAL: the buffer was
+/// in memory only, so the delete had to stay replayable. With the pending changes log the flush
+/// persists the buffer, the WAL is acknowledged past the delete, and a restart recovers the
+/// delete from the log instead of the WAL.
+///
+/// This simulates the crash: buffer a delete in proxies, flush, acknowledge the WAL up to the
+/// flushed version, then drop the shard without ever propagating the proxies. On load the delete
+/// must come back through pending changes recovery — the WAL no longer holds it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_proxy_pending_changes_crash_recovery() {
+    use shard::proxy_segment::UnsyncedProxySegment;
+
+    let _ = env_logger::builder().is_test(true).try_init();
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+
+    let config = create_collection_config();
+    let collection_name = "test".to_string();
+
+    let update_runtime = Handle::current();
+    let current_runtime: AdaptiveSearchHandle = AdaptiveSearchHandle::current_for_tests();
+
+    let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+    let payload_index_schema =
+        Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
+    let shard = LocalShard::build(
+        0,
+        collection_name.clone(),
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        Arc::new(Default::default()),
+        payload_index_schema.clone(),
+        update_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+        config.optimizer_config.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Keep flushing and WAL acknowledging under the test's control
+    shard.stop_flush_worker().await;
+
+    let hw_acc = HwMeasurementAcc::new();
+
+    // Insert points; WAL indices: fake operation at 0, then one entry per upsert (1..=total)
+    let total_points = 10u64;
+    for i in 0..total_points {
+        let point = PointStructPersisted {
+            id: i.into(),
+            vector: VectorStructInternal::from(vec![1.0, 2.0, 3.0, 4.0]).into(),
+            payload: None,
+        };
+        let op = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+            PointInsertOperationsInternal::PointsList(vec![point]),
+        ));
+        shard
+            .update(op.into(), WaitUntil::Visible, None, hw_acc.clone())
+            .await
+            .unwrap();
+    }
+
+    // Wrap every segment in a proxy, as the optimizer and snapshots do
+    {
+        let segments = shard.segments();
+        let segments_read = segments.upgradable_read();
+        let segment_ids = segments_read.segment_ids();
+        let mut proxies = Vec::new();
+        for segment_id in segment_ids {
+            let locked_segment = segments_read.get(segment_id).unwrap().clone();
+            proxies.push((
+                segment_id,
+                UnsyncedProxySegment::new(locked_segment).unwrap(),
+            ));
+        }
+        let mut segments_write = parking_lot::RwLockUpgradableReadGuard::upgrade(segments_read);
+        for (segment_id, proxy) in proxies {
+            segments_write
+                .replace(segment_id, proxy.finalize())
+                .unwrap();
+        }
+    }
+
+    // Delete two points; all segments are proxies, so the deletes are only buffered in memory.
+    // The second delete exists because the WAL acknowledge never passes the very last entry, so
+    // the last operation is always replayed; the delete under test must not be the last one for
+    // this test to prove it is recovered from the pending changes log rather than the WAL.
+    let delete_op_num = total_points + 1;
+    for point_id in [3, 5] {
+        shard
+            .update(
+                delete_point_operation(point_id).into(),
+                WaitUntil::Visible,
+                None,
+                hw_acc.clone(),
+            )
+            .await
+            .unwrap();
+    }
+
+    // Flushing persists the buffered deletes into the pending changes logs, so the full version
+    // including the deletes can be acknowledged in the WAL
+    let flushed_version = shard
+        .segments()
+        .read()
+        .flush_all(FlushMode::Sync, true)
+        .unwrap();
+    assert_eq!(
+        flushed_version,
+        delete_op_num + 1,
+        "proxy segments must not hold back the WAL acknowledge once flushed",
+    );
+
+    // A pending changes log must exist in at least one segment directory
+    let has_pending_changes_log = |segments_path: &std::path::Path| {
+        fs_err::read_dir(segments_path)
+            .unwrap()
+            .flatten()
+            .filter(|entry| entry.path().is_dir())
+            .any(|entry| {
+                !segment::pending_changes::list_pending_changes_log_files(&entry.path()).is_empty()
+            })
+    };
+    let segments_path = LocalShard::segments_path(collection_dir.path());
+    assert!(has_pending_changes_log(&segments_path));
+
+    // "Crash": stop the shard while the proxies still hold the delete; they are never
+    // propagated into their wrapped segments
+    shard.stop_gracefully().await;
+
+    // Acknowledge the WAL up to the flushed version, as the flush worker does
+    {
+        let wal_path = LocalShard::wal_path(collection_dir.path());
+        let mut raw_wal: SerdeWal<String> =
+            SerdeWal::new(&wal_path, (&config.wal_config).into()).unwrap();
+        raw_wal.ack(flushed_version).unwrap();
+        assert!(
+            raw_wal.first_index() > delete_op_num,
+            "test setup must acknowledge the WAL past the first delete operation",
+        );
+    }
+
+    // "Restart": the delete is not in the WAL anymore, it must be recovered from the pending
+    // changes logs
+    let shard = LocalShard::load(
+        0,
+        collection_name,
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        config.optimizer_config.clone(),
+        Arc::new(Default::default()),
+        payload_index_schema,
+        false,
+        update_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+    )
+    .await
+    .unwrap();
+
+    let retrieved = shard
+        .retrieve(
+            Arc::new(PointRequestInternal {
+                ids: (0..total_points).map(PointIdType::from).collect(),
+                with_payload: None,
+                with_vector: WithVector::Bool(false),
+            }),
+            &WithPayload::default(),
+            &WithVector::Bool(false),
+            &current_runtime,
+            None,
+            hw_acc.clone(),
+            DeferredBehavior::VisibleOnly,
+        )
+        .await
+        .unwrap();
+    let retrieved_ids: Vec<_> = retrieved.iter().map(|point| point.id).collect();
+    assert!(
+        !retrieved_ids.contains(&3.into()),
+        "deleted point must stay deleted after restart: {retrieved_ids:?}",
+    );
+    assert!(!retrieved_ids.contains(&5.into()));
+    assert_eq!(retrieved_ids.len() as u64, total_points - 2);
+
+    // Recovery replayed and removed the pending changes logs
+    assert!(!has_pending_changes_log(&segments_path));
+}

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -6,6 +6,7 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use common::save_on_disk::SaveOnDisk;
 use common::types::DeferredBehavior;
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, VectorStructInternal};
+use segment::pending_changes::PersistedProxyChanges;
 use segment::types::{
     Distance, MultiVectorConfig, PayloadFieldSchema, PayloadSchemaType, PointIdType, RawPayload,
     WithPayload, WithVector,
@@ -133,6 +134,7 @@ async fn test_delete_from_indexed_payload() {
         Arc::new(Default::default()),
         payload_index_schema.clone(),
         true,
+        PersistedProxyChanges::Replay,
         update_runtime.clone(),
         current_runtime.clone(),
         ResourceBudget::default(),
@@ -165,6 +167,7 @@ async fn test_delete_from_indexed_payload() {
         Arc::new(Default::default()),
         payload_index_schema,
         true,
+        PersistedProxyChanges::Replay,
         update_runtime.clone(),
         current_runtime,
         ResourceBudget::default(),
@@ -272,6 +275,7 @@ async fn test_partial_flush_recovery() {
         Arc::new(Default::default()),
         payload_index_schema,
         true,
+        PersistedProxyChanges::Replay,
         update_runtime.clone(),
         current_runtime,
         ResourceBudget::default(),
@@ -557,6 +561,7 @@ async fn test_wal_replay_loads_pending_to_queue() {
         shared_storage_config,
         payload_index_schema,
         false,
+        PersistedProxyChanges::Replay,
         update_runtime.clone(),
         current_runtime.clone(),
         ResourceBudget::default(),
@@ -712,6 +717,7 @@ async fn test_wal_replay_is_synchronous_without_prevent_unoptimized() {
         shared_storage_config,
         payload_index_schema,
         false,
+        PersistedProxyChanges::Replay,
         update_runtime.clone(),
         current_runtime.clone(),
         ResourceBudget::default(),
@@ -843,6 +849,7 @@ async fn test_wal_replay_tolerates_corrupt_tail_entry() {
         shared_storage_config,
         payload_index_schema,
         false,
+        PersistedProxyChanges::Replay,
         update_runtime.clone(),
         current_runtime.clone(),
         ResourceBudget::default(),
@@ -990,6 +997,7 @@ async fn test_wal_replay_truncated_past_applied_seq() {
         shared_storage_config,
         payload_index_schema,
         false,
+        PersistedProxyChanges::Replay,
         update_runtime.clone(),
         current_runtime.clone(),
         ResourceBudget::default(),
@@ -1135,6 +1143,7 @@ async fn test_wal_replay_with_smaller_queue_size() {
         Arc::new(shared_storage_config),
         payload_index_schema,
         false,
+        PersistedProxyChanges::Replay,
         update_runtime.clone(),
         current_runtime.clone(),
         ResourceBudget::default(),
@@ -1320,6 +1329,7 @@ async fn test_filter_ops_resolved_to_ids_in_wal() {
         Arc::new(Default::default()),
         payload_index_schema,
         true,
+        PersistedProxyChanges::Replay,
         update_runtime.clone(),
         current_runtime.clone(),
         ResourceBudget::default(),
@@ -1442,6 +1452,7 @@ async fn test_old_wal_filter_op_replays_with_apply_semantics() {
         Arc::new(Default::default()),
         payload_index_schema,
         true,
+        PersistedProxyChanges::Replay,
         update_runtime.clone(),
         current_runtime.clone(),
         ResourceBudget::default(),
@@ -1550,6 +1561,7 @@ async fn assert_bad_op_skipped_on_wal_replay(
         Arc::new(Default::default()),
         payload_index_schema,
         true,
+        PersistedProxyChanges::Replay,
         update_runtime,
         current_runtime.clone(),
         ResourceBudget::default(),
@@ -1898,6 +1910,37 @@ async fn test_proxy_pending_changes_crash_recovery() {
         );
     }
 
+    // Loading while ignoring persisted proxy changes, as partial snapshot recovery does, must
+    // leave the segments and the logs untouched: the first delete is not replayed (and no longer
+    // in the WAL), only the second one comes back through the always replayed last WAL entry
+    let shard = LocalShard::load(
+        0,
+        collection_name.clone(),
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        config.optimizer_config.clone(),
+        Arc::new(Default::default()),
+        payload_index_schema.clone(),
+        false,
+        PersistedProxyChanges::Ignore,
+        update_runtime.clone(),
+        current_runtime.clone(),
+        ResourceBudget::default(),
+    )
+    .await
+    .unwrap();
+    let points_count = shard.info().await.unwrap().points_count.unwrap_or(0);
+    assert_eq!(
+        points_count as u64,
+        total_points - 1,
+        "ignored persisted proxy changes must not be replayed",
+    );
+    assert!(
+        has_pending_changes_log(&segments_path),
+        "ignored pending changes logs must stay in place",
+    );
+    shard.stop_gracefully().await;
+
     // "Restart": the delete is not in the WAL anymore, it must be recovered from the pending
     // changes logs
     let shard = LocalShard::load(
@@ -1909,6 +1952,7 @@ async fn test_proxy_pending_changes_crash_recovery() {
         Arc::new(Default::default()),
         payload_index_schema,
         false,
+        PersistedProxyChanges::Replay,
         update_runtime.clone(),
         current_runtime.clone(),
         ResourceBudget::default(),

--- a/lib/collection/src/tests/wal_recovery_test.rs
+++ b/lib/collection/src/tests/wal_recovery_test.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::flags::{FeatureFlags, init_feature_flags};
 use common::save_on_disk::SaveOnDisk;
 use common::types::DeferredBehavior;
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, VectorStructInternal};
@@ -1778,6 +1779,11 @@ async fn test_malformed_multivector_raw_upsert_is_skipped_on_wal_replay() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_proxy_pending_changes_crash_recovery() {
     use shard::proxy_segment::UnsyncedProxySegment;
+
+    init_feature_flags(FeatureFlags {
+        persist_proxy_segments: true,
+        ..Default::default()
+    });
 
     let _ = env_logger::builder().is_test(true).try_init();
     let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -75,9 +75,14 @@ pub struct FeatureFlags {
     /// Read on the sending side only: nodes accept raw payloads regardless.
     pub transfer_raw_payloads: bool,
 
-    /// Serverless-compatible deployment mode. Automatically enables [`Self::write_segment_manifest`],
-    /// [`Self::append_only_mutations`], [`Self::compact_bitmask`] and
-    /// [`Self::append_only_storages`].
+    /// Persist proxy segment changes on disk. Prevents pinning the WAL while proxy segments are
+    /// open. Replays the persisted changes on startup to guarantee data consistency. Required for
+    /// serverless deployments where storage and compute is separated.
+    pub persist_proxy_segments: bool,
+
+    /// Serverless-compatible deployment mode. Implies [`Self::write_segment_manifest`],
+    /// [`Self::append_only_mutations`], [`Self::compact_bitmask`], [`Self::append_only_storages`]
+    /// and [`Self::persist_proxy_segments`].
     ///
     /// Note that this will only be applied when passed into [`init_feature_flags`].
     serverless_compatible: bool,
@@ -98,6 +103,7 @@ impl Default for FeatureFlags {
             append_only_storages: false,
             transfer_raw_points: false,
             transfer_raw_payloads: false,
+            persist_proxy_segments: false,
             serverless_compatible: false,
         }
     }
@@ -133,6 +139,7 @@ impl FeatureFlags {
             // version that understands them, so they can only be switched on a release later.
             transfer_raw_points: false,
             transfer_raw_payloads: false,
+            persist_proxy_segments: true,
             serverless_compatible: false,
         }
     }
@@ -150,6 +157,7 @@ impl FeatureFlags {
             self.append_only_mutations = true;
             self.compact_bitmask = true;
             self.append_only_storages = true;
+            self.persist_proxy_segments = true;
         }
 
         // Append-only storages cannot rewrite slots.
@@ -209,6 +217,7 @@ mod tests {
         assert!(flags.append_only_mutations);
         assert!(flags.compact_bitmask);
         assert!(flags.append_only_storages);
+        assert!(flags.persist_proxy_segments);
     }
 
     #[test]
@@ -224,6 +233,7 @@ mod tests {
         assert!(flags.append_only_mutations);
         assert!(flags.compact_bitmask);
         assert!(flags.append_only_storages);
+        assert!(flags.persist_proxy_segments);
     }
 
     #[test]

--- a/lib/common/common/src/flags.rs
+++ b/lib/common/common/src/flags.rs
@@ -12,7 +12,7 @@ pub struct FeatureFlags {
     /// Magic feature flag that enables all features.
     ///
     /// Note that this will only be applied to all flags when passed into [`init_feature_flags`].
-    all: bool,
+    pub all: bool,
 
     /// Use incremental HNSW building.
     ///
@@ -85,7 +85,7 @@ pub struct FeatureFlags {
     /// and [`Self::persist_proxy_segments`].
     ///
     /// Note that this will only be applied when passed into [`init_feature_flags`].
-    serverless_compatible: bool,
+    pub serverless_compatible: bool,
 }
 
 impl Default for FeatureFlags {

--- a/lib/edge/src/edge_shard/mod.rs
+++ b/lib/edge/src/edge_shard/mod.rs
@@ -454,6 +454,16 @@ fn load_segments(segments_path: &Path) -> OperationResult<(SegmentHolder, Option
             ))
         })?;
 
+        // Replay pending changes persisted by proxy segments onto this segment, then remove
+        // them. Buffered proxy state that made it to disk does not hold back the WAL
+        // acknowledge, so it must be recovered here, before WAL replay.
+        segment::pending_changes::recover_pending_changes(&mut segment).map_err(|err| {
+            OperationError::service_error(format!(
+                "failed to recover pending proxy changes of segment {}: {err}",
+                segment_path.display(),
+            ))
+        })?;
+
         segments.add_new(segment);
     }
 

--- a/lib/edge/src/edge_shard/mod.rs
+++ b/lib/edge/src/edge_shard/mod.rs
@@ -15,6 +15,7 @@ use fs_err as fs;
 use parking_lot::Mutex;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::entry::{NonAppendableSegmentEntry as _, ReadSegmentEntry as _};
+use segment::pending_changes::PersistedProxyChanges;
 use segment::segment_constructor::{build_segment, load_segment, normalize_segment_dir};
 use shard::files::{SEGMENTS_PATH, WAL_PATH, segment_manifest_path};
 use shard::operations::CollectionUpdateOperations;
@@ -457,7 +458,11 @@ fn load_segments(segments_path: &Path) -> OperationResult<(SegmentHolder, Option
         // Replay pending changes persisted by proxy segments onto this segment, then remove
         // them. Buffered proxy state that made it to disk does not hold back the WAL
         // acknowledge, so it must be recovered here, before WAL replay.
-        segment::pending_changes::recover_pending_changes(&mut segment).map_err(|err| {
+        segment::pending_changes::recover_pending_changes(
+            &mut segment,
+            PersistedProxyChanges::Replay,
+        )
+        .map_err(|err| {
             OperationError::service_error(format!(
                 "failed to recover pending proxy changes of segment {}: {err}",
                 segment_path.display(),

--- a/lib/edge/src/edge_shard/mod.rs
+++ b/lib/edge/src/edge_shard/mod.rs
@@ -428,13 +428,19 @@ fn load_segments(segments_path: &Path) -> OperationResult<(SegmentHolder, Option
     segment_dirs.sort_unstable_by_key(|(segment_uuid, _)| *segment_uuid);
 
     for (segment_uuid, segment_path) in segment_dirs {
-        let mut segment = load_segment(&segment_path, segment_uuid, None, &AtomicBool::new(false))
-            .map_err(|err| {
-                OperationError::service_error(format!(
-                    "failed to load segment {}: {err}",
-                    segment_path.display(),
-                ))
-            })?;
+        let mut segment = load_segment(
+            &segment_path,
+            segment_uuid,
+            None,
+            &AtomicBool::new(false),
+            false,
+        )
+        .map_err(|err| {
+            OperationError::service_error(format!(
+                "failed to load segment {}: {err}",
+                segment_path.display(),
+            ))
+        })?;
 
         let segment_cfg = segment.config();
         if let Some(acc) = derived.as_ref() {

--- a/lib/edge/src/edge_shard/mod.rs
+++ b/lib/edge/src/edge_shard/mod.rs
@@ -8,7 +8,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
-use ::wal::WalOptions;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::save_on_disk::SaveOnDisk;
 use fs_err as fs;
@@ -20,10 +19,11 @@ use segment::segment_constructor::{build_segment, load_segment, normalize_segmen
 use shard::files::{SEGMENTS_PATH, WAL_PATH, segment_manifest_path};
 use shard::operations::CollectionUpdateOperations;
 use shard::segment_holder::locked::LockedSegmentHolder;
-use shard::segment_holder::{FlushMode, SegmentHolder};
+use shard::segment_holder::{FlushMode, PostFlushOutcome, SegmentHolder};
 use shard::segment_manifest::SegmentsManifest;
 use shard::wal::SerdeWal;
 use uuid::Uuid;
+use wal::WalOptions;
 
 use crate::config::optimizers::EdgeOptimizersConfig;
 use crate::config::shard::{EDGE_CONFIG_FILE, EdgeConfig};
@@ -461,10 +461,12 @@ fn load_segments(segments_path: &Path) -> OperationResult<(SegmentHolder, Option
             ))
         })?;
 
-        // Replay pending changes persisted by proxy segments onto this segment, then remove
-        // them. Buffered proxy state that made it to disk does not hold back the WAL
-        // acknowledge, so it must be recovered here, before WAL replay.
-        segment::pending_changes::recover_pending_changes(
+        // Replay pending changes persisted by proxy segments onto this segment. Buffered proxy
+        // state that made it to disk does not hold back the WAL acknowledge, so it must be
+        // recovered here, before WAL replay. The log files are only safe to remove once the
+        // segment durably persists past `recovered.ready_at`; that is deferred to a post-flush
+        // action.
+        let recovered = segment::pending_changes::recover_pending_changes(
             &mut segment,
             PersistedProxyChanges::Replay,
         )
@@ -476,6 +478,19 @@ fn load_segments(segments_path: &Path) -> OperationResult<(SegmentHolder, Option
         })?;
 
         segments.add_new(segment);
+
+        if !recovered.log_files.is_empty() {
+            segments.register_post_flush_action(
+                recovered.ready_at,
+                recovered.ready_at,
+                move || {
+                    for path in &recovered.log_files {
+                        fs::remove_file(path)?;
+                    }
+                    Ok(PostFlushOutcome::Done)
+                },
+            );
+        }
     }
 
     Ok((segments, derived))

--- a/lib/segment/src/index/struct_payload_index/tests.rs
+++ b/lib/segment/src/index/struct_payload_index/tests.rs
@@ -88,6 +88,7 @@ fn test_load_payload_index() {
         Uuid::nil(),
         None,
         &AtomicBool::new(false),
+        false,
     )
     .unwrap();
 
@@ -152,8 +153,14 @@ fn create_field_index_persists_index_data_with_config() {
         "create_field_index must durably commit the config",
     );
 
-    let segment = load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false))
-        .expect("segment must load after simulated crash");
+    let segment = load_segment(
+        &segment_path,
+        Uuid::nil(),
+        None,
+        &AtomicBool::new(false),
+        false,
+    )
+    .expect("segment must load after simulated crash");
 
     // Queried before any replay on purpose: the index data itself must be complete,
     // not repaired by re-applied operations.
@@ -223,8 +230,14 @@ fn switch_incompatible_index_type_survives_crash() {
         "the durable config must list the new index schema",
     );
 
-    let segment = load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false))
-        .expect("segment must load after simulated crash");
+    let segment = load_segment(
+        &segment_path,
+        Uuid::nil(),
+        None,
+        &AtomicBool::new(false),
+        false,
+    )
+    .expect("segment must load after simulated crash");
 
     // Queried before any replay on purpose: the new index data must be complete.
     let filter = Filter::new_must(Condition::Field(FieldCondition::new_match(

--- a/lib/segment/src/lib.rs
+++ b/lib/segment/src/lib.rs
@@ -5,6 +5,7 @@ pub mod fixtures;
 pub mod id_tracker;
 pub mod index;
 pub mod payload_storage;
+pub mod pending_changes;
 pub mod segment;
 pub mod segment_constructor;
 pub mod spaces;

--- a/lib/segment/src/pending_changes/change.rs
+++ b/lib/segment/src/pending_changes/change.rs
@@ -1,13 +1,20 @@
 //! Types describing a single pending operation buffered by a proxy segment.
+//!
+//! A proxy segment blocks writes to its wrapped segment and instead buffers point deletes,
+//! payload index changes and vector name changes. Each buffered operation carries the version
+//! (operation number) it was issued with, so it can later be applied to the actual segment
+//! through the regular version-gated segment operations — applying an operation that the
+//! segment has already seen is silently skipped, making replay idempotent.
 
 use ahash::AHashMap;
+use serde::{Deserialize, Serialize};
 
-use crate::types::{PayloadFieldSchema, PointIdType, SeqNumberType};
+use crate::types::{PayloadFieldSchema, PayloadKeyType, PointIdType, SeqNumberType, VectorNameBuf};
 
 pub type DeletedPoints = AHashMap<PointIdType, ProxyDeletedPoint>;
 
 /// Point version information of points to delete from a wrapped proxy segment.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProxyDeletedPoint {
     /// Version the point had in the wrapped segment when the delete was scheduled.
     /// We use it to determine if some other proxy segment should move the point again with
@@ -20,7 +27,7 @@ pub struct ProxyDeletedPoint {
 }
 
 /// A pending payload index change buffered by a proxy segment.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ProxyIndexChange {
     Create(PayloadFieldSchema, SeqNumberType),
     Delete(SeqNumberType),
@@ -33,6 +40,44 @@ impl ProxyIndexChange {
             ProxyIndexChange::Create(_, version) => *version,
             ProxyIndexChange::Delete(version) => *version,
             ProxyIndexChange::DeleteIfIncompatible(version, _) => *version,
+        }
+    }
+}
+
+/// A single pending operation registered on a proxy segment, in the shape it is persisted to the
+/// pending changes log file.
+///
+/// The variants mirror the per-type buffers of [`PendingChanges`]: point deletes, payload index
+/// changes and vector name changes. Every variant carries the operation version, so replaying an
+/// entry goes through the same version-gated segment operations as the original write.
+///
+/// [`PendingChanges`]: super::PendingChanges
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum PendingChange {
+    /// Delete the given point from the wrapped segment.
+    DeletePoint {
+        point_id: PointIdType,
+        versions: ProxyDeletedPoint,
+    },
+    /// Create or delete a payload index on the wrapped segment.
+    IndexChange {
+        field_name: PayloadKeyType,
+        change: ProxyIndexChange,
+    },
+    /// Create or delete a named vector on the wrapped segment.
+    VectorNameChange {
+        vector_name: VectorNameBuf,
+        intent: super::IntendedVector,
+    },
+}
+
+impl PendingChange {
+    /// Version of the operation that caused this pending change.
+    pub fn version(&self) -> SeqNumberType {
+        match self {
+            PendingChange::DeletePoint { versions, .. } => versions.operation_version,
+            PendingChange::IndexChange { change, .. } => change.version(),
+            PendingChange::VectorNameChange { intent, .. } => intent.version(),
         }
     }
 }

--- a/lib/segment/src/pending_changes/change.rs
+++ b/lib/segment/src/pending_changes/change.rs
@@ -1,0 +1,38 @@
+//! Types describing a single pending operation buffered by a proxy segment.
+
+use ahash::AHashMap;
+
+use crate::types::{PayloadFieldSchema, PointIdType, SeqNumberType};
+
+pub type DeletedPoints = AHashMap<PointIdType, ProxyDeletedPoint>;
+
+/// Point version information of points to delete from a wrapped proxy segment.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProxyDeletedPoint {
+    /// Version the point had in the wrapped segment when the delete was scheduled.
+    /// We use it to determine if some other proxy segment should move the point again with
+    /// `move_if_exists` if it has newer point data.
+    pub local_version: SeqNumberType,
+    /// Version of the operation that caused the delete to be scheduled.
+    /// We use it for the delete operations when propagating them to the wrapped or optimized
+    /// segment.
+    pub operation_version: SeqNumberType,
+}
+
+/// A pending payload index change buffered by a proxy segment.
+#[derive(Debug, Clone)]
+pub enum ProxyIndexChange {
+    Create(PayloadFieldSchema, SeqNumberType),
+    Delete(SeqNumberType),
+    DeleteIfIncompatible(SeqNumberType, PayloadFieldSchema),
+}
+
+impl ProxyIndexChange {
+    pub fn version(&self) -> SeqNumberType {
+        match self {
+            ProxyIndexChange::Create(_, version) => *version,
+            ProxyIndexChange::Delete(version) => *version,
+            ProxyIndexChange::DeleteIfIncompatible(version, _) => *version,
+        }
+    }
+}

--- a/lib/segment/src/pending_changes/index_changes.rs
+++ b/lib/segment/src/pending_changes/index_changes.rs
@@ -1,0 +1,55 @@
+//! Pending payload index changes buffered by a proxy segment.
+
+use ahash::AHashMap;
+use itertools::Itertools as _;
+
+use super::change::ProxyIndexChange;
+use crate::types::PayloadKeyType;
+
+#[derive(Debug, Default)]
+pub struct ProxyIndexChanges {
+    changes: AHashMap<PayloadKeyType, ProxyIndexChange>,
+}
+
+impl ProxyIndexChanges {
+    pub fn insert(&mut self, key: PayloadKeyType, change: ProxyIndexChange) {
+        self.changes.insert(key, change);
+    }
+
+    pub fn remove(&mut self, key: &PayloadKeyType) {
+        self.changes.remove(key);
+    }
+
+    pub fn len(&self) -> usize {
+        self.changes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.changes.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.changes.clear();
+    }
+
+    /// Iterate over proxy index changes in order of version.
+    ///
+    /// Index changes must be applied in order because changes with an old version will silently be
+    /// rejected.
+    pub fn iter_ordered(&self) -> impl Iterator<Item = (&PayloadKeyType, &ProxyIndexChange)> {
+        self.changes
+            .iter()
+            .sorted_by_key(|(_, change)| change.version())
+    }
+
+    /// Iterate over proxy index changes in arbitrary order.
+    pub fn iter_unordered(&self) -> impl Iterator<Item = (&PayloadKeyType, &ProxyIndexChange)> {
+        self.changes.iter()
+    }
+
+    pub fn merge(&mut self, other: &Self) {
+        for (key, change) in &other.changes {
+            self.changes.insert(key.clone(), change.clone());
+        }
+    }
+}

--- a/lib/segment/src/pending_changes/log_file.rs
+++ b/lib/segment/src/pending_changes/log_file.rs
@@ -1,0 +1,328 @@
+//! Append-only log file storing the pending changes of a proxy segment.
+//!
+//! ## File format
+//!
+//! The file is a sequence of length-prefixed entries, simply concatenated:
+//!
+//! +---------------------+------------------------------------+
+//! | entry length: u32   | JSON-serialized [`PendingChange`]  |
+//! +---------------------+------------------------------------+
+//!
+//! Entries are only ever appended. Each append serializes all new entries into a single buffer
+//! and writes it with a single write call on a file opened in append mode, so growing the file
+//! and writing the data happen in one operation. A crash can therefore only ever leave a
+//! partially written entry at the very end of the file, which [`load_changes`] detects and
+//! truncates — the operations it held were never durable, so they were never acknowledged in the
+//! WAL and will simply be replayed from there.
+//!
+//! This mirrors the mutable ID tracker mappings storage.
+
+use std::cmp::Ordering;
+use std::io::{BufReader, Write as _};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicU64;
+
+use byteorder::{LittleEndian, ReadBytesExt as _, WriteBytesExt as _};
+use common::fs::{OneshotFile, sync_parent_dir};
+use fs_err::File;
+use parking_lot::Mutex;
+
+use super::change::PendingChange;
+use crate::common::operation_error::{OperationError, OperationResult};
+
+/// File name of the pending changes log of the first (inner most) proxy layer.
+///
+/// Additional proxy layers append a numeric suffix: the second layer writes to
+/// `pending_changes.log.1`, the third to `pending_changes.log.2`, and so on. See
+/// [`pending_changes_log_path`].
+pub const PENDING_CHANGES_LOG_FILE: &str = "pending_changes.log";
+
+/// Sanity limit for a single log entry, to not trust a corrupted length prefix.
+const MAX_ENTRY_SIZE: u32 = 32 * 1024 * 1024;
+
+/// Path of the pending changes log file for the given proxy `level` inside `segment_path`.
+///
+/// The first (inner most) proxy layer gets no suffix, each further layer gets its level as a
+/// numeric suffix.
+pub fn pending_changes_log_path(segment_path: &Path, level: usize) -> PathBuf {
+    if level == 0 {
+        segment_path.join(PENDING_CHANGES_LOG_FILE)
+    } else {
+        segment_path.join(format!("{PENDING_CHANGES_LOG_FILE}.{level}"))
+    }
+}
+
+/// List all pending changes log files inside the given segment directory, ordered by proxy level
+/// (inner most first).
+///
+/// Levels are not necessarily contiguous: a proxy layer that never persisted any change does not
+/// create a file, while a layer above it may have. The listing is therefore based on the actual
+/// directory contents rather than probing levels until the first gap.
+pub fn list_pending_changes_log_files(segment_path: &Path) -> Vec<PathBuf> {
+    let Ok(dir) = fs_err::read_dir(segment_path) else {
+        return Vec::new();
+    };
+
+    let mut files: Vec<(usize, PathBuf)> = dir
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let file_name = entry.file_name();
+            let level = parse_log_file_level(file_name.to_str()?)?;
+            entry.path().is_file().then(|| (level, entry.path()))
+        })
+        .collect();
+    files.sort_unstable_by_key(|(level, _)| *level);
+    files.into_iter().map(|(_, path)| path).collect()
+}
+
+/// Parse the proxy level from a pending changes log file name, if it is one.
+fn parse_log_file_level(file_name: &str) -> Option<usize> {
+    if file_name == PENDING_CHANGES_LOG_FILE {
+        return Some(0);
+    }
+    let suffix = file_name
+        .strip_prefix(PENDING_CHANGES_LOG_FILE)?
+        .strip_prefix('.')?;
+    // Higher levels always carry an explicit non-zero suffix, level 0 never does
+    let level: usize = suffix.parse().ok()?;
+    (level > 0).then_some(level)
+}
+
+/// Store new pending changes, appending them to the given log file.
+///
+/// `expected_len` is the shared valid length of the file in bytes; everything past it is not
+/// durable and may be garbage from an earlier failed append. It is read fresh on every call and
+/// bumped after the appended entries have been fsynced, so a later append (or a retry after a
+/// failure) starts exactly after the last durable entry.
+pub(super) fn store_changes(
+    path: &Path,
+    changes: &[PendingChange],
+    expected_len: &AtomicU64,
+) -> OperationResult<()> {
+    let is_new_file = !path.exists();
+
+    // Create or open file in append mode to write new changes to the end
+    let file = File::options().create(true).append(true).open(path)?;
+
+    // Ensure correct file length to not corrupt entries when appending
+    let file_len = file
+        .metadata()
+        .map_err(|err| {
+            OperationError::service_error(format!(
+                "Failed to get pending changes log file size: {err}"
+            ))
+        })?
+        .len();
+    let file_start_appending = expected_len.load(std::sync::atomic::Ordering::Relaxed);
+    match file_len.cmp(&file_start_appending) {
+        // File size is what we expect, continue normally
+        Ordering::Equal => {}
+        // File is larger than expected, previous append might not have completed properly
+        // Clean up by truncating to what we expect, then append
+        // May happen if system is out of disk space and the file cannot be grown
+        Ordering::Greater => {
+            file.set_len(file_start_appending).map_err(|err| {
+                OperationError::service_error(format!(
+                    "Failed to truncate pending changes log file that is too large: {err}"
+                ))
+            })?;
+        }
+        // File is smaller than expected, indicates a bug we cannot recover from
+        Ordering::Less => {
+            return Err(OperationError::service_error(format!(
+                "Pending changes log file size is less than expected, cannot append new changes (file size: {file_len}, expected: {file_start_appending})",
+            )));
+        }
+    }
+
+    // Serialize all entries into a single buffer so appending them is a single call that both
+    // grows the file and writes into it, protecting against torn writes in the middle
+    let mut buffer = Vec::new();
+    for change in changes {
+        write_entry(&mut buffer, change)?;
+    }
+
+    let mut file = file;
+    file.write_all(&buffer).map_err(|err| {
+        OperationError::service_error(format!(
+            "Failed to persist pending changes log ({}): {err}",
+            path.display(),
+        ))
+    })?;
+
+    // Explicitly fsync file contents to ensure durability
+    file.sync_all().map_err(|err| {
+        OperationError::service_error(format!("Failed to fsync pending changes log: {err}"))
+    })?;
+
+    // Make sure a newly created file has its directory entry persisted as well
+    if is_new_file {
+        sync_parent_dir(path)?;
+    }
+
+    // Update expected file length to append after these entries next time
+    expected_len.store(
+        file_start_appending + buffer.len() as u64,
+        std::sync::atomic::Ordering::Relaxed,
+    );
+
+    Ok(())
+}
+
+/// Pending changes loaded from a log file.
+pub(super) struct LoadedChanges {
+    /// All entries of the file, in append order.
+    pub changes: Vec<PendingChange>,
+    /// Length of the valid part of the file in bytes.
+    ///
+    /// If the file held a partially written entry at the end it has been truncated away, and this
+    /// reflects the truncated length.
+    pub valid_len: u64,
+}
+
+/// Load all pending changes from the given log file.
+///
+/// If the file ends with a partially written entry — the result of a crash in the middle of an
+/// append — that entry is truncated from the file. The operations it held were never durable, so
+/// they were never acknowledged in the WAL, and are recovered by regular WAL replay instead.
+///
+/// A malformed entry that is *not* at the end of the file cannot be explained by a torn append
+/// and is reported as a hard error: entries after it may have been acknowledged in the WAL, so
+/// silently dropping them would lose acknowledged operations.
+pub(super) fn load_changes(path: &Path) -> OperationResult<LoadedChanges> {
+    let file = OneshotFile::open(path)?;
+    let file_len = file.metadata()?.len();
+    let mut reader = BufReader::new(file);
+
+    let mut changes = Vec::new();
+    let mut valid_len: u64 = 0;
+
+    loop {
+        match read_entry(&mut reader, file_len - valid_len) {
+            ReadEntry::Change(change, entry_bytes) => {
+                valid_len += entry_bytes;
+                changes.push(change);
+            }
+            ReadEntry::EndOfFile => break,
+            // A torn entry at the end of the file, truncate it below
+            ReadEntry::Truncated => break,
+            ReadEntry::Err(err) => {
+                return Err(OperationError::service_error(format!(
+                    "Malformed entry in pending changes log at offset {valid_len} ({}): {err}",
+                    path.display(),
+                )));
+            }
+        }
+    }
+
+    reader.into_inner().drop_cache()?;
+
+    // If the file holds a partial entry at the end, truncate the file
+    // It can happen on crash while appending. We must truncate the file here to not corrupt new
+    // entries we append after it
+    debug_assert!(
+        valid_len <= file_len,
+        "cannot read past the end of the file"
+    );
+    if valid_len < file_len {
+        log::warn!(
+            "Pending changes log ends with incomplete entry, removing last {} bytes and assuming automatic recovery by WAL ({})",
+            file_len - valid_len,
+            path.display(),
+        );
+        let file = File::options().write(true).truncate(false).open(path)?;
+        file.set_len(valid_len)?;
+        file.sync_all()?;
+    }
+
+    Ok(LoadedChanges { changes, valid_len })
+}
+
+/// Result of reading a single entry from a pending changes log.
+enum ReadEntry {
+    /// A complete, valid entry, and the number of bytes it takes in the file.
+    Change(PendingChange, u64),
+    /// The reader was exactly at the end of the file.
+    EndOfFile,
+    /// The file ends with a partially written entry.
+    Truncated,
+    /// The entry is malformed even though the file holds all its bytes.
+    Err(std::io::Error),
+}
+
+/// Read a single entry from the given reader, with `remaining` bytes left in the file.
+fn read_entry(reader: &mut impl std::io::Read, remaining: u64) -> ReadEntry {
+    if remaining == 0 {
+        return ReadEntry::EndOfFile;
+    }
+    if remaining < size_of::<u32>() as u64 {
+        return ReadEntry::Truncated;
+    }
+
+    let entry_len = match reader.read_u32::<LittleEndian>() {
+        Ok(entry_len) => entry_len,
+        Err(err) => return ReadEntry::Err(err),
+    };
+
+    // If the length prefix points past the end of the file the entry is torn, no matter whether
+    // the prefix itself is garbage or the payload just did not make it to disk
+    if u64::from(entry_len) > remaining - size_of::<u32>() as u64 {
+        return ReadEntry::Truncated;
+    }
+    if entry_len > MAX_ENTRY_SIZE {
+        return ReadEntry::Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("entry length {entry_len} exceeds sanity limit {MAX_ENTRY_SIZE}"),
+        ));
+    }
+
+    let mut payload = vec![0; entry_len as usize];
+    if let Err(err) = reader.read_exact(&mut payload) {
+        return ReadEntry::Err(err);
+    }
+
+    let entry_bytes = size_of::<u32>() as u64 + u64::from(entry_len);
+
+    match serde_json::from_slice(&payload) {
+        Ok(change) => ReadEntry::Change(change, entry_bytes),
+        // The payload bytes are all present but malformed; only a torn write of the very last
+        // entry can explain that, anything before it is corruption
+        Err(err) if entry_bytes == remaining => {
+            log::warn!("Pending changes log ends with malformed entry, truncating: {err}");
+            ReadEntry::Truncated
+        }
+        Err(err) => ReadEntry::Err(err.into()),
+    }
+}
+
+/// Serialize a single entry and write it into the given writer.
+fn write_entry(writer: &mut Vec<u8>, change: &PendingChange) -> OperationResult<()> {
+    let payload = serde_json::to_vec(change).map_err(|err| {
+        OperationError::service_error(format!("Failed to serialize pending change: {err}"))
+    })?;
+    debug_assert!(payload.len() <= MAX_ENTRY_SIZE as usize);
+    writer.write_u32::<LittleEndian>(payload.len() as u32)?;
+    writer.extend_from_slice(&payload);
+    Ok(())
+}
+
+/// Drop persisted entries from the pending buffer after they have been stored.
+///
+/// Counts how many entries at the front of `pending` match the just-persisted `changes` and
+/// drains them. With concurrent flushers it is possible that the beginning of the lists doesn't
+/// match. Since replaying an entry twice is harmless (all operations are version gated) it is not
+/// a problem, and we can store everything again in the next iteration.
+pub(super) fn reconcile_persisted_changes(
+    pending: &Mutex<Vec<PendingChange>>,
+    changes: &[PendingChange],
+) {
+    let mut pending = pending.lock();
+
+    let count = pending
+        .iter()
+        .zip(changes)
+        .take_while(|(pending, persisted)| pending == persisted)
+        .count();
+
+    pending.drain(0..count);
+}

--- a/lib/segment/src/pending_changes/log_file.rs
+++ b/lib/segment/src/pending_changes/log_file.rs
@@ -137,11 +137,20 @@ pub(super) fn store_changes(
         // Clean up by truncating to what we expect, then append
         // May happen if system is out of disk space and the file cannot be grown
         Ordering::Greater => {
-            file.set_len(file_start_appending).map_err(|err| {
-                OperationError::service_error(format!(
-                    "Failed to truncate pending changes log file that is too large: {err}"
-                ))
-            })?;
+            // `file` is opened in append-only mode, which on Windows grants `FILE_APPEND_DATA`
+            // but not `FILE_WRITE_DATA`/`GENERIC_WRITE`. `set_len` needs the latter (it calls
+            // `SetEndOfFile`), so truncate through a separate, plainly-writable handle instead;
+            // POSIX has no such distinction and this is equivalent there.
+            File::options()
+                .write(true)
+                .truncate(false)
+                .open(path)
+                .and_then(|file| file.set_len(file_start_appending))
+                .map_err(|err| {
+                    OperationError::service_error(format!(
+                        "Failed to truncate pending changes log file that is too large: {err}"
+                    ))
+                })?;
         }
         // File is smaller than expected, indicates a bug we cannot recover from
         Ordering::Less => {

--- a/lib/segment/src/pending_changes/log_file.rs
+++ b/lib/segment/src/pending_changes/log_file.rs
@@ -38,27 +38,27 @@ use uuid::Uuid;
 use super::change::PendingChange;
 use crate::common::operation_error::{OperationError, OperationResult};
 
-/// File name template of a pending changes log file.
+/// File name prefix of a pending changes log file.
 ///
-/// Every actual file also carries a level suffix  and a random ID.
-/// See [`pending_changes_log_path`] for the full naming scheme.
-pub const LOG_FILE_TEMPLATE: &str = "pending_changes.log";
+/// Every actual file also carries a level, a random ID and the [`LOG_FILE_EXTENSION`], e.g.
+/// `proxy_changes.0.<uuid>.dat`. See [`pending_changes_log_path`] for the full naming scheme.
+pub const LOG_FILE_PREFIX: &str = "proxy_changes";
+
+/// File name extension of a pending changes log file.
+const LOG_FILE_EXTENSION: &str = "dat";
 
 /// Sanity limit for a single log entry, to not trust a corrupted length prefix.
 const MAX_ENTRY_SIZE: u32 = 32 * 1024 * 1024;
 
-/// Path of the pending changes log file, includes `level` and `id`.
+/// Path of the pending changes log file, includes `level` and `id`: `proxy_changes.<level>.<id>.dat`.
 ///
-/// The first (inner most) proxy layer gets no level suffix, each further layer
-/// gets its level as a numeric suffix; every layer also carries `id` as a
-/// further suffix. `id` must be a random UUID for a brand new proxy (see
-/// `PendingChanges::new`). A reopened proxy must retain the same UUID.
+/// The level is always included, even for the first (inner most) proxy layer at level 0. `id`
+/// must be a random UUID for a brand new proxy (see `PendingChanges::new`). A reopened proxy must
+/// retain the same UUID.
 pub fn pending_changes_log_path(segment_path: &Path, level: usize, id: Uuid) -> PathBuf {
-    if level == 0 {
-        segment_path.join(format!("{LOG_FILE_TEMPLATE}-{id}"))
-    } else {
-        segment_path.join(format!("{LOG_FILE_TEMPLATE}.{level}-{id}"))
-    }
+    segment_path.join(format!(
+        "{LOG_FILE_PREFIX}.{level}.{id}.{LOG_FILE_EXTENSION}"
+    ))
 }
 
 /// List all pending changes log files inside the given segment directory, ordered by proxy level
@@ -87,24 +87,19 @@ pub fn list_pending_changes_log_files(segment_path: &Path) -> Vec<PathBuf> {
 
 /// Parse the proxy level from a pending changes log file name, if it is one.
 pub(super) fn parse_log_file_level(file_name: &str) -> Option<usize> {
-    let rest = file_name.strip_prefix(LOG_FILE_TEMPLATE)?;
+    let rest = file_name
+        .strip_prefix(LOG_FILE_PREFIX)?
+        .strip_prefix('.')?
+        .strip_suffix(LOG_FILE_EXTENSION)?
+        .strip_suffix('.')?;
 
-    // The level prefix (empty, or `.<level>`) never contains a `-`, so the first one always marks
-    // the boundary with the ID suffix (which may contain further ones of its own)
-    let (level_part, id_part) = rest.split_once('-')?;
+    // The level never contains a `.`, so the first one always marks the boundary with the UUID
+    // (which is only ever hyphenated, never dotted)
+    let (level_str, id_str) = rest.split_once('.')?;
+    let level: usize = level_str.parse().ok()?;
 
-    let level: usize = if level_part.is_empty() {
-        0
-    } else {
-        // Higher levels always carry an explicit non-zero suffix, level 0 never does
-        match level_part.strip_prefix('.')?.parse().ok()? {
-            0 => return None,
-            level => level,
-        }
-    };
-
-    // Reject anything whose suffix isn't actually a valid ID, e.g. an unrelated `.bak` file
-    Uuid::parse_str(id_part).ok()?;
+    // Reject anything whose id isn't actually a valid UUID, e.g. an unrelated file
+    Uuid::parse_str(id_str).ok()?;
 
     Some(level)
 }

--- a/lib/segment/src/pending_changes/log_file.rs
+++ b/lib/segment/src/pending_changes/log_file.rs
@@ -16,6 +16,13 @@
 //! WAL and will simply be replayed from there.
 //!
 //! This mirrors the mutable ID tracker mappings storage.
+//!
+//! ## File naming
+//!
+//! Every proxy gets a random ID assigned, which is included in the changes log
+//! file name. When a segment is unproxied and proxied again, it will get a new
+//! ID. This way different proxy instances can be uniquely identified on disk
+//! for serverless deployments.
 
 use std::cmp::Ordering;
 use std::io::{BufReader, Write as _};
@@ -26,29 +33,31 @@ use byteorder::{LittleEndian, ReadBytesExt as _, WriteBytesExt as _};
 use common::fs::{OneshotFile, sync_parent_dir};
 use fs_err::File;
 use parking_lot::Mutex;
+use uuid::Uuid;
 
 use super::change::PendingChange;
 use crate::common::operation_error::{OperationError, OperationResult};
 
-/// File name of the pending changes log of the first (inner most) proxy layer.
+/// File name template of a pending changes log file.
 ///
-/// Additional proxy layers append a numeric suffix: the second layer writes to
-/// `pending_changes.log.1`, the third to `pending_changes.log.2`, and so on. See
-/// [`pending_changes_log_path`].
-pub const PENDING_CHANGES_LOG_FILE: &str = "pending_changes.log";
+/// Every actual file also carries a level suffix  and a random ID.
+/// See [`pending_changes_log_path`] for the full naming scheme.
+pub const LOG_FILE_TEMPLATE: &str = "pending_changes.log";
 
 /// Sanity limit for a single log entry, to not trust a corrupted length prefix.
 const MAX_ENTRY_SIZE: u32 = 32 * 1024 * 1024;
 
-/// Path of the pending changes log file for the given proxy `level` inside `segment_path`.
+/// Path of the pending changes log file, includes `level` and `id`.
 ///
-/// The first (inner most) proxy layer gets no suffix, each further layer gets its level as a
-/// numeric suffix.
-pub fn pending_changes_log_path(segment_path: &Path, level: usize) -> PathBuf {
+/// The first (inner most) proxy layer gets no level suffix, each further layer
+/// gets its level as a numeric suffix; every layer also carries `id` as a
+/// further suffix. `id` must be a random UUID for a brand new proxy (see
+/// `PendingChanges::new`). A reopened proxy must retain the same UUID.
+pub fn pending_changes_log_path(segment_path: &Path, level: usize, id: Uuid) -> PathBuf {
     if level == 0 {
-        segment_path.join(PENDING_CHANGES_LOG_FILE)
+        segment_path.join(format!("{LOG_FILE_TEMPLATE}-{id}"))
     } else {
-        segment_path.join(format!("{PENDING_CHANGES_LOG_FILE}.{level}"))
+        segment_path.join(format!("{LOG_FILE_TEMPLATE}.{level}-{id}"))
     }
 }
 
@@ -56,8 +65,9 @@ pub fn pending_changes_log_path(segment_path: &Path, level: usize) -> PathBuf {
 /// (inner most first).
 ///
 /// Levels are not necessarily contiguous: a proxy layer that never persisted any change does not
-/// create a file, while a layer above it may have. The listing is therefore based on the actual
-/// directory contents rather than probing levels until the first gap.
+/// create a file, while a layer above it may have. It is possible for multiple
+/// files to exist on a single level, if an unwrapped proxy failed to clean up
+/// its log file for example. In that case both are expected to be applied.
 pub fn list_pending_changes_log_files(segment_path: &Path) -> Vec<PathBuf> {
     let Ok(dir) = fs_err::read_dir(segment_path) else {
         return Vec::new();
@@ -76,16 +86,27 @@ pub fn list_pending_changes_log_files(segment_path: &Path) -> Vec<PathBuf> {
 }
 
 /// Parse the proxy level from a pending changes log file name, if it is one.
-fn parse_log_file_level(file_name: &str) -> Option<usize> {
-    if file_name == PENDING_CHANGES_LOG_FILE {
-        return Some(0);
-    }
-    let suffix = file_name
-        .strip_prefix(PENDING_CHANGES_LOG_FILE)?
-        .strip_prefix('.')?;
-    // Higher levels always carry an explicit non-zero suffix, level 0 never does
-    let level: usize = suffix.parse().ok()?;
-    (level > 0).then_some(level)
+pub(super) fn parse_log_file_level(file_name: &str) -> Option<usize> {
+    let rest = file_name.strip_prefix(LOG_FILE_TEMPLATE)?;
+
+    // The level prefix (empty, or `.<level>`) never contains a `-`, so the first one always marks
+    // the boundary with the ID suffix (which may contain further ones of its own)
+    let (level_part, id_part) = rest.split_once('-')?;
+
+    let level: usize = if level_part.is_empty() {
+        0
+    } else {
+        // Higher levels always carry an explicit non-zero suffix, level 0 never does
+        match level_part.strip_prefix('.')?.parse().ok()? {
+            0 => return None,
+            level => level,
+        }
+    };
+
+    // Reject anything whose suffix isn't actually a valid ID, e.g. an unrelated `.bak` file
+    Uuid::parse_str(id_part).ok()?;
+
+    Some(level)
 }
 
 /// Store new pending changes, appending them to the given log file.

--- a/lib/segment/src/pending_changes/mod.rs
+++ b/lib/segment/src/pending_changes/mod.rs
@@ -8,12 +8,15 @@
 //!
 //! Persisting the pending changes means a proxy segment does not hold back acknowledging the WAL:
 //! everything the proxy buffers is durable once flushed, so on a restart the buffered state does
-//! not need to be recovered by replaying the WAL. All operations are version gated, so replaying
+//! not need to be recovered by replaying the WAL. Instead of reconstructing proxy segments on
+//! restart, the pending changes log is replayed directly onto the actual segment before regular
+//! WAL replay (see [`recover_pending_changes`]). All operations are version gated, so replaying
 //! an entry the segment already applied is a no-op, and replaying a stale file is harmless.
 //!
 //! Proxy segments can be layered (an optimization and a snapshot both proxy the same segment).
 //! Each layer persists into its own log file: the inner most layer gets no suffix, each layer
-//! above it gets its level as a numeric suffix.
+//! above it gets its level as a numeric suffix. On restart the files are replayed inner most
+//! first, matching the order in which the layers received their operations.
 
 mod change;
 mod index_changes;
@@ -24,7 +27,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use common::is_alive_lock::IsAliveLock;
+use fs_err as fs;
 use parking_lot::Mutex;
 
 pub use self::change::{DeletedPoints, PendingChange, ProxyDeletedPoint, ProxyIndexChange};
@@ -34,8 +39,10 @@ pub use self::log_file::{
 };
 pub use self::vector_name_changes::{IntendedVector, ProxyVectorNameChanges};
 use crate::common::Flusher;
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::vector_name_config::VectorNameConfig;
+use crate::entry::entry_point::{NonAppendableSegmentEntry, StorageSegmentEntry as _};
+use crate::segment::Segment;
 use crate::types::{PayloadKeyType, PointIdType, SegmentConfig, SeqNumberType, VectorNameBuf};
 
 /// Manages the pending changes of a single proxy segment layer.
@@ -49,9 +56,9 @@ use crate::types::{PayloadKeyType, PointIdType, SegmentConfig, SeqNumberType, Ve
 /// The log file deliberately outlives the component: when a proxy segment is unwrapped its
 /// buffered changes are propagated to the wrapped segment in memory, but deleting the log before
 /// the wrapped segment has flushed those changes would not be crash safe. The file is cleaned up
-/// on restart and when the segment directory is dropped, and a new proxy on the same segment
-/// adopts and appends to it (see [`Self::open`]). Replaying a stale file is safe because all
-/// operations are version gated.
+/// on restart (see [`recover_pending_changes`]) and when the segment directory is dropped, and a
+/// new proxy on the same segment adopts and appends to it (see [`Self::open`]). Replaying a stale
+/// file is safe because all operations are version gated.
 #[derive(Debug)]
 pub struct PendingChanges {
     /// Points which should no longer be used from the wrapped segment.
@@ -114,7 +121,8 @@ impl PendingChanges {
     ///
     /// This restores the buffered state of the proxy layer that wrote the file, as if every entry
     /// were registered again in order. Use this only when the entries are *not* applied to the
-    /// wrapped segment; the regular restart path replays them onto the segment directly instead.
+    /// wrapped segment; the regular restart path replays them onto the segment directly instead
+    /// (see [`recover_pending_changes`]).
     pub fn load(segment_path: &Path, level: usize) -> OperationResult<Self> {
         Self::open_impl(segment_path, level, true)
     }
@@ -353,4 +361,114 @@ impl PendingChanges {
             Ok(())
         }))
     }
+}
+
+/// Apply a single pending change to the given segment, through the regular version-gated segment
+/// operations.
+pub fn apply_change<S>(segment: &mut S, change: &PendingChange) -> OperationResult<()>
+where
+    S: NonAppendableSegmentEntry + ?Sized,
+{
+    // Internal operation, no need to measure hardware IO
+    let hw_counter = HardwareCounterCell::disposable();
+
+    match change {
+        PendingChange::DeletePoint { point_id, versions } => {
+            // Note:
+            // The delete may have an older version than the point currently has in the segment.
+            // Such deletes are ignored because the point in the segment is considered to be
+            // newer. This is possible because different proxy segments can share state through a
+            // common write segment.
+            // See: <https://github.com/qdrant/qdrant/pull/7208>
+            segment.delete_point(versions.operation_version, *point_id, &hw_counter)?;
+        }
+        PendingChange::IndexChange { field_name, change } => match change {
+            ProxyIndexChange::Create(schema, version) => {
+                segment.create_field_index(*version, field_name, Some(schema), &hw_counter)?;
+            }
+            ProxyIndexChange::Delete(version) => {
+                segment.delete_field_index(*version, field_name)?;
+            }
+            ProxyIndexChange::DeleteIfIncompatible(version, schema) => {
+                segment.delete_field_index_if_incompatible(*version, field_name, schema)?;
+            }
+        },
+        PendingChange::VectorNameChange {
+            vector_name,
+            intent,
+        } => match intent {
+            IntendedVector::Absent { version } => {
+                segment.delete_vector_name(*version, vector_name)?;
+            }
+            IntendedVector::Present {
+                config,
+                version,
+                supersedes_wrapped,
+            } => {
+                if *supersedes_wrapped {
+                    // `create_vector_name` is idempotent and would silently keep the segment's
+                    // stale storage. Clear it first so the new schema actually takes effect.
+                    segment.delete_vector_name(*version, vector_name)?;
+                }
+                segment.create_vector_name(*version, vector_name, config)?;
+            }
+        },
+    }
+
+    Ok(())
+}
+
+/// Recover pending changes left on disk by proxy segments, before regular WAL replay
+///
+/// If the segment directory holds pending changes log files, the proxy segments that wrote them
+/// did not propagate their buffered state into this segment before the process stopped. Instead
+/// of reconstructing the proxies, replay all logged operations directly onto the segment: inner
+/// most layer first, each file in append order. All operations are version gated, so entries the
+/// segment already applied (e.g. because a proxy did propagate before unwrapping, leaving the
+/// file behind) are silently skipped.
+///
+/// The segment is force-flushed afterwards, making the replayed operations durable, and only then
+/// are the log files removed. Must be called before regular WAL replay, which recovers everything
+/// past what segments (including these logs) have durably applied.
+///
+/// This is necessary because proxy changes that are persisted on disk are also acknowledged in the
+/// WAL. It means that on restart we expect all those changes to be visible in the segment to get a
+/// consistent read view. Since the processes that required a proxy are not running anymore we
+/// don't reconstruct the proxies, instead we just apply the changes directly to the segment.
+///
+/// Returns the number of replayed log entries.
+pub fn recover_pending_changes(segment: &mut Segment) -> OperationResult<usize> {
+    let log_files = list_pending_changes_log_files(&segment.segment_path);
+    if log_files.is_empty() {
+        return Ok(0);
+    }
+
+    let mut replayed = 0;
+    for path in &log_files {
+        let loaded = log_file::load_changes(path)?;
+        log::info!(
+            "Replaying {} pending proxy changes onto segment ({})",
+            loaded.changes.len(),
+            path.display(),
+        );
+        for change in &loaded.changes {
+            apply_change(segment, change).map_err(|err| {
+                OperationError::service_error(format!(
+                    "Failed to replay pending change from {}: {err}",
+                    path.display(),
+                ))
+            })?;
+        }
+        replayed += loaded.changes.len();
+    }
+
+    // Persist the replayed operations before removing the log files; a crash in between just
+    // means the files are replayed again, which is a version-gated no-op
+    segment.flush(true)?;
+
+    for path in log_files {
+        fs::remove_file(path)?;
+    }
+
+    Ok(replayed)
 }

--- a/lib/segment/src/pending_changes/mod.rs
+++ b/lib/segment/src/pending_changes/mod.rs
@@ -1,0 +1,13 @@
+//! Pending changes buffered by a proxy segment.
+//!
+//! A proxy segment wraps another segment, prevents any writes to it, and buffers a small set of
+//! operations instead: point deletes, payload index changes and vector name changes. This module
+//! holds the types describing those buffered operations.
+
+mod change;
+mod index_changes;
+mod vector_name_changes;
+
+pub use self::change::{DeletedPoints, ProxyDeletedPoint, ProxyIndexChange};
+pub use self::index_changes::ProxyIndexChanges;
+pub use self::vector_name_changes::{IntendedVector, ProxyVectorNameChanges};

--- a/lib/segment/src/pending_changes/mod.rs
+++ b/lib/segment/src/pending_changes/mod.rs
@@ -23,6 +23,9 @@ mod index_changes;
 mod log_file;
 mod vector_name_changes;
 
+#[cfg(test)]
+mod tests;
+
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/lib/segment/src/pending_changes/mod.rs
+++ b/lib/segment/src/pending_changes/mod.rs
@@ -2,12 +2,13 @@
 //!
 //! A proxy segment wraps another segment, prevents any writes to it, and buffers a small set of
 //! operations instead: point deletes, payload index changes and vector name changes. This module
-//! holds the types describing those buffered operations.
+//! holds the types describing those buffered operations, including [`PendingChange`], the shape
+//! in which a single buffered operation is persisted to disk.
 
 mod change;
 mod index_changes;
 mod vector_name_changes;
 
-pub use self::change::{DeletedPoints, ProxyDeletedPoint, ProxyIndexChange};
+pub use self::change::{DeletedPoints, PendingChange, ProxyDeletedPoint, ProxyIndexChange};
 pub use self::index_changes::ProxyIndexChanges;
 pub use self::vector_name_changes::{IntendedVector, ProxyVectorNameChanges};

--- a/lib/segment/src/pending_changes/mod.rs
+++ b/lib/segment/src/pending_changes/mod.rs
@@ -421,6 +421,26 @@ where
     Ok(())
 }
 
+/// Whether persisted pending proxy changes are replayed onto a segment when it is loaded.
+///
+/// See [`recover_pending_changes`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PersistedProxyChanges {
+    /// Replay all persisted pending proxy changes onto the segment and remove their log files.
+    ///
+    /// The default: on a regular load this recovers the buffered state of proxies that did not
+    /// propagate it into the segment before the process stopped.
+    #[default]
+    Replay,
+    /// Do not replay persisted pending proxy changes, leave the segment and the log files
+    /// untouched.
+    ///
+    /// For segment files that mirror those of another writer, such as a partial snapshot
+    /// recovered from it: replaying would mutate the segment files and remove the logs, making
+    /// the local copy diverge from what the writer's manifest describes.
+    Ignore,
+}
+
 /// Recover pending changes left on disk by proxy segments, before regular WAL replay
 ///
 /// If the segment directory holds pending changes log files, the proxy segments that wrote them
@@ -439,11 +459,29 @@ where
 /// consistent read view. Since the processes that required a proxy are not running anymore we
 /// don't reconstruct the proxies, instead we just apply the changes directly to the segment.
 ///
+/// With [`PersistedProxyChanges::Ignore`] nothing is replayed and the log files are left as they
+/// are; see there for when that is appropriate.
+///
 /// Returns the number of replayed log entries.
-pub fn recover_pending_changes(segment: &mut Segment) -> OperationResult<usize> {
+pub fn recover_pending_changes(
+    segment: &mut Segment,
+    persisted_proxy_changes: PersistedProxyChanges,
+) -> OperationResult<usize> {
     let log_files = list_pending_changes_log_files(&segment.segment_path);
     if log_files.is_empty() {
         return Ok(0);
+    }
+
+    match persisted_proxy_changes {
+        PersistedProxyChanges::Replay => {}
+        PersistedProxyChanges::Ignore => {
+            log::debug!(
+                "Ignoring {} persisted pending proxy changes log(s) of segment {}, not replaying them",
+                log_files.len(),
+                segment.segment_path.display(),
+            );
+            return Ok(0);
+        }
     }
 
     let mut replayed = 0;

--- a/lib/segment/src/pending_changes/mod.rs
+++ b/lib/segment/src/pending_changes/mod.rs
@@ -427,17 +427,10 @@ where
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum PersistedProxyChanges {
     /// Replay all persisted pending proxy changes onto the segment and remove their log files.
-    ///
-    /// The default: on a regular load this recovers the buffered state of proxies that did not
-    /// propagate it into the segment before the process stopped.
     #[default]
     Replay,
     /// Do not replay persisted pending proxy changes, leave the segment and the log files
     /// untouched.
-    ///
-    /// For segment files that mirror those of another writer, such as a partial snapshot
-    /// recovered from it: replaying would mutate the segment files and remove the logs, making
-    /// the local copy diverge from what the writer's manifest describes.
     Ignore,
 }
 

--- a/lib/segment/src/pending_changes/mod.rs
+++ b/lib/segment/src/pending_changes/mod.rs
@@ -1,14 +1,356 @@
-//! Pending changes buffered by a proxy segment.
+//! Pending changes of a proxy segment, buffered in memory and persisted to disk.
 //!
 //! A proxy segment wraps another segment, prevents any writes to it, and buffers a small set of
 //! operations instead: point deletes, payload index changes and vector name changes. This module
-//! holds the types describing those buffered operations, including [`PendingChange`], the shape
-//! in which a single buffered operation is persisted to disk.
+//! provides [`PendingChanges`], the component managing those buffered operations for one proxy
+//! layer, including their persistence into an append-only log file inside the wrapped segment's
+//! directory (see `log_file.rs`).
+//!
+//! Persisting the pending changes means a proxy segment does not hold back acknowledging the WAL:
+//! everything the proxy buffers is durable once flushed, so on a restart the buffered state does
+//! not need to be recovered by replaying the WAL. All operations are version gated, so replaying
+//! an entry the segment already applied is a no-op, and replaying a stale file is harmless.
+//!
+//! Proxy segments can be layered (an optimization and a snapshot both proxy the same segment).
+//! Each layer persists into its own log file: the inner most layer gets no suffix, each layer
+//! above it gets its level as a numeric suffix.
 
 mod change;
 mod index_changes;
+mod log_file;
 mod vector_name_changes;
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use common::is_alive_lock::IsAliveLock;
+use parking_lot::Mutex;
 
 pub use self::change::{DeletedPoints, PendingChange, ProxyDeletedPoint, ProxyIndexChange};
 pub use self::index_changes::ProxyIndexChanges;
+pub use self::log_file::{
+    PENDING_CHANGES_LOG_FILE, list_pending_changes_log_files, pending_changes_log_path,
+};
 pub use self::vector_name_changes::{IntendedVector, ProxyVectorNameChanges};
+use crate::common::Flusher;
+use crate::common::operation_error::OperationResult;
+use crate::data_types::vector_name_config::VectorNameConfig;
+use crate::types::{PayloadKeyType, PointIdType, SegmentConfig, SeqNumberType, VectorNameBuf};
+
+/// Manages the pending changes of a single proxy segment layer.
+///
+/// Keeps an in-memory buffer per operation type — point deletes, payload index changes and vector
+/// name changes — which the proxy segment serves its reads from, plus a single buffer of all
+/// registered operations that still have to be persisted. [`Self::flusher`] persists that buffer
+/// into an append-only log file in the wrapped segment's directory; hook it into the regular
+/// segment flush.
+///
+/// The log file deliberately outlives the component: when a proxy segment is unwrapped its
+/// buffered changes are propagated to the wrapped segment in memory, but deleting the log before
+/// the wrapped segment has flushed those changes would not be crash safe. The file is cleaned up
+/// on restart and when the segment directory is dropped, and a new proxy on the same segment
+/// adopts and appends to it (see [`Self::open`]). Replaying a stale file is safe because all
+/// operations are version gated.
+#[derive(Debug)]
+pub struct PendingChanges {
+    /// Points which should no longer be used from the wrapped segment.
+    deleted_points: DeletedPoints,
+    /// Pending payload index changes, per field key.
+    changed_indexes: ProxyIndexChanges,
+    /// Pending vector name changes, per vector name.
+    changed_vector_names: ProxyVectorNameChanges,
+
+    /// All registered operations that are not persisted to the log file yet, in registration
+    /// order.
+    ///
+    /// Deliberately not cleared when the proxy propagates its changes to the wrapped segment:
+    /// [`Self::persisted_version`] promises that every registered operation it covers is durable
+    /// in the log, and propagation only makes the operations durable once the wrapped segment
+    /// flushes. A flusher captured before propagation may thus persist entries that are also
+    /// applied to the wrapped segment; replaying such an entry is a version-gated no-op.
+    pending_persist: Arc<Mutex<Vec<PendingChange>>>,
+
+    /// Path of the pending changes log file, inside the wrapped segment's directory.
+    path: PathBuf,
+
+    /// Proxy layer this component belongs to; determines the log file suffix.
+    level: usize,
+
+    /// Expected length of the log file in bytes.
+    ///
+    /// Initialized on open, and bumped after each successful flush. Pending changes are appended
+    /// to the file after this offset. If the file on disk is longer it probably indicates a
+    /// partial flush, if it is shorter we hit some kind of a bug.
+    expected_file_len: Arc<AtomicU64>,
+
+    /// Highest operation version covered by the log file.
+    ///
+    /// Every operation registered on the proxy with a version at or below this is either durably
+    /// persisted in the log file, or was a no-op that does not need recovery. The proxy reports
+    /// this through its `persistent_version`, which is what allows the WAL to be acknowledged
+    /// past operations that only live in a proxy buffer.
+    persisted_version: Arc<AtomicU64>,
+
+    /// Marks captured flushers dead once this component is dropped, so they never append to a
+    /// segment directory that may be going away.
+    is_alive_lock: IsAliveLock,
+}
+
+impl PendingChanges {
+    /// Open the pending changes for the proxy layer `level` on the segment at `segment_path`.
+    ///
+    /// If a log file for this layer already exists — left behind by a previous proxy on the same
+    /// segment, which propagated its buffered changes to the segment before unwrapping — it is
+    /// adopted: new changes are appended after its existing entries, and
+    /// [`Self::persisted_version`] starts at the highest version the file holds. The existing
+    /// entries are *not* loaded into the in-memory buffers, as they are already applied to the
+    /// wrapped segment.
+    pub fn open(segment_path: &Path, level: usize) -> OperationResult<Self> {
+        Self::open_impl(segment_path, level, false)
+    }
+
+    /// Like [`Self::open`], but also reconstruct the in-memory buffers from the log file.
+    ///
+    /// This restores the buffered state of the proxy layer that wrote the file, as if every entry
+    /// were registered again in order. Use this only when the entries are *not* applied to the
+    /// wrapped segment; the regular restart path replays them onto the segment directly instead.
+    pub fn load(segment_path: &Path, level: usize) -> OperationResult<Self> {
+        Self::open_impl(segment_path, level, true)
+    }
+
+    fn open_impl(
+        segment_path: &Path,
+        level: usize,
+        reconstruct_buffers: bool,
+    ) -> OperationResult<Self> {
+        let path = pending_changes_log_path(segment_path, level);
+
+        let mut changes = Self {
+            deleted_points: DeletedPoints::default(),
+            changed_indexes: ProxyIndexChanges::default(),
+            changed_vector_names: ProxyVectorNameChanges::default(),
+            pending_persist: Default::default(),
+            path: path.clone(),
+            level,
+            expected_file_len: Arc::new(AtomicU64::new(0)),
+            persisted_version: Arc::new(AtomicU64::new(0)),
+            is_alive_lock: IsAliveLock::new(),
+        };
+
+        if path.is_file() {
+            // Read all entries, truncating a torn entry at the end of the file if there is one
+            let loaded = log_file::load_changes(&path)?;
+            let max_version = loaded
+                .changes
+                .iter()
+                .map(PendingChange::version)
+                .max()
+                .unwrap_or(0);
+            changes
+                .expected_file_len
+                .store(loaded.valid_len, Ordering::Relaxed);
+            changes
+                .persisted_version
+                .store(max_version, Ordering::Relaxed);
+
+            if reconstruct_buffers {
+                for change in loaded.changes {
+                    changes.reconstruct_change(change);
+                }
+            }
+        }
+
+        Ok(changes)
+    }
+
+    /// Re-insert a change loaded from the log file into the in-memory buffers.
+    fn reconstruct_change(&mut self, change: PendingChange) {
+        match change {
+            PendingChange::DeletePoint { point_id, versions } => {
+                self.deleted_points.insert(point_id, versions);
+            }
+            PendingChange::IndexChange { field_name, change } => {
+                self.changed_indexes.insert(field_name, change);
+            }
+            PendingChange::VectorNameChange {
+                vector_name,
+                intent,
+            } => {
+                self.changed_vector_names.insert_intent(vector_name, intent);
+            }
+        }
+    }
+
+    /// Proxy layer this component belongs to.
+    pub fn level(&self) -> usize {
+        self.level
+    }
+
+    /// Path of the pending changes log file.
+    pub fn log_path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Register a pending point delete.
+    ///
+    /// Returns the previously registered delete for this point, if any.
+    pub fn register_delete_point(
+        &mut self,
+        point_id: PointIdType,
+        versions: ProxyDeletedPoint,
+    ) -> Option<ProxyDeletedPoint> {
+        let previous = self.deleted_points.insert(point_id, versions);
+        self.pending_persist
+            .lock()
+            .push(PendingChange::DeletePoint { point_id, versions });
+        previous
+    }
+
+    /// Register a pending payload index change.
+    pub fn register_index_change(&mut self, field_name: PayloadKeyType, change: ProxyIndexChange) {
+        self.changed_indexes
+            .insert(field_name.clone(), change.clone());
+        self.pending_persist
+            .lock()
+            .push(PendingChange::IndexChange { field_name, change });
+    }
+
+    /// Register a pending vector name creation.
+    ///
+    /// `wrapped_config` is the segment config of the wrapped segment; see
+    /// [`ProxyVectorNameChanges::record_create`] for how it is used to decide whether the wrapped
+    /// segment's existing data for this name must be cleared when the change is applied.
+    pub fn register_vector_name_create(
+        &mut self,
+        vector_name: VectorNameBuf,
+        config: VectorNameConfig,
+        version: SeqNumberType,
+        wrapped_config: &SegmentConfig,
+    ) {
+        let intent = self.changed_vector_names.record_create(
+            vector_name.clone(),
+            config,
+            version,
+            wrapped_config,
+        );
+        self.pending_persist
+            .lock()
+            .push(PendingChange::VectorNameChange {
+                vector_name,
+                intent,
+            });
+    }
+
+    /// Register a pending vector name deletion.
+    pub fn register_vector_name_delete(
+        &mut self,
+        vector_name: VectorNameBuf,
+        version: SeqNumberType,
+    ) {
+        self.changed_vector_names
+            .record_delete(vector_name.clone(), version);
+        self.pending_persist
+            .lock()
+            .push(PendingChange::VectorNameChange {
+                vector_name,
+                intent: IntendedVector::Absent { version },
+            });
+    }
+
+    /// Pending point deletes.
+    pub fn deleted_points(&self) -> &DeletedPoints {
+        &self.deleted_points
+    }
+
+    /// Pending payload index changes.
+    pub fn index_changes(&self) -> &ProxyIndexChanges {
+        &self.changed_indexes
+    }
+
+    /// Pending vector name changes.
+    pub fn vector_name_changes(&self) -> &ProxyVectorNameChanges {
+        &self.changed_vector_names
+    }
+
+    /// Clear the pending point deletes, after they have been propagated to the wrapped segment.
+    pub fn clear_deleted_points(&mut self) {
+        self.deleted_points.clear();
+    }
+
+    /// Clear the pending payload index changes, after they have been propagated to the wrapped
+    /// segment.
+    pub fn clear_index_changes(&mut self) {
+        self.changed_indexes.clear();
+    }
+
+    /// Clear the pending vector name changes, after they have been propagated to the wrapped
+    /// segment.
+    pub fn clear_vector_name_changes(&mut self) {
+        self.changed_vector_names.clear();
+    }
+
+    /// Highest operation version covered by the log file.
+    ///
+    /// Every operation registered with a version at or below this is either durably persisted in
+    /// the log file, or was a no-op that does not need recovery.
+    pub fn persisted_version(&self) -> SeqNumberType {
+        self.persisted_version.load(Ordering::Relaxed)
+    }
+
+    /// Get a flusher persisting all currently pending operations to the log file.
+    ///
+    /// `target_version` must be the current version of the proxy segment: the highest operation
+    /// version registered so far, including operations that did not buffer anything (e.g. a
+    /// delete for a point the wrapped segment does not have). After the flusher ran,
+    /// [`Self::persisted_version`] covers it.
+    ///
+    /// Returns `None` if there is nothing to persist and `target_version` is already covered.
+    pub fn flusher(&self, target_version: SeqNumberType) -> Option<Flusher> {
+        let changes = {
+            let pending_persist = self.pending_persist.lock();
+            if pending_persist.is_empty()
+                && self.persisted_version.load(Ordering::Relaxed) >= target_version
+            {
+                return None;
+            }
+            pending_persist.clone()
+        };
+
+        let path = self.path.clone();
+        let is_alive_handle = self.is_alive_lock.handle();
+        let pending_persist_weak = Arc::downgrade(&self.pending_persist);
+        let expected_file_len = self.expected_file_len.clone();
+        let persisted_version = self.persisted_version.clone();
+
+        Some(Box::new(move || {
+            let (Some(_is_alive_guard), Some(pending_persist)) = (
+                is_alive_handle.lock_if_alive(),
+                pending_persist_weak.upgrade(),
+            ) else {
+                // Proxy segment is dropped, skip flush
+                log::debug!("Proxy segment was dropped, skip pending changes flush");
+                return Ok(());
+            };
+
+            if !changes.is_empty() {
+                log_file::store_changes(&path, &changes, &expected_file_len)?;
+                log_file::reconcile_persisted_changes(&pending_persist, &changes);
+            }
+
+            // Only advance the covered version once the entries are durable. Operations
+            // registered after this flusher was captured are not covered: they have a higher
+            // version than the target captured with the entries.
+            let batch_version = changes
+                .iter()
+                .map(PendingChange::version)
+                .max()
+                .map_or(target_version, |max_version| {
+                    max_version.max(target_version)
+                });
+            persisted_version.fetch_max(batch_version, Ordering::Relaxed);
+
+            Ok(())
+        }))
+    }
+}

--- a/lib/segment/src/pending_changes/mod.rs
+++ b/lib/segment/src/pending_changes/mod.rs
@@ -14,9 +14,11 @@
 //! an entry the segment already applied is a no-op, and replaying a stale file is harmless.
 //!
 //! Proxy segments can be layered (an optimization and a snapshot both proxy the same segment).
-//! Each layer persists into its own log file: the inner most layer gets no suffix, each layer
-//! above it gets its level as a numeric suffix. On restart the files are replayed inner most
-//! first, matching the order in which the layers received their operations.
+//! Each layer persists into its own log file, named after its level plus a
+//! random ID generated when the proxy is created. On restart all files found in
+//! the segment directory are replayed level by level (level 0 fully before level
+//! 1, and so on), and by version within a level, so multiple files left behind
+//! on the same level are still applied in the right order.
 
 mod change;
 mod index_changes;
@@ -33,11 +35,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::is_alive_lock::IsAliveLock;
 use parking_lot::Mutex;
+use uuid::Uuid;
 
 pub use self::change::{DeletedPoints, PendingChange, ProxyDeletedPoint, ProxyIndexChange};
 pub use self::index_changes::ProxyIndexChanges;
 pub use self::log_file::{
-    PENDING_CHANGES_LOG_FILE, list_pending_changes_log_files, pending_changes_log_path,
+    LOG_FILE_TEMPLATE, list_pending_changes_log_files, pending_changes_log_path,
 };
 pub use self::vector_name_changes::{IntendedVector, ProxyVectorNameChanges};
 use crate::common::Flusher;
@@ -57,10 +60,7 @@ use crate::types::{PayloadKeyType, PointIdType, SegmentConfig, SeqNumberType, Ve
 ///
 /// The log file deliberately outlives the component: when a proxy segment is unwrapped its
 /// buffered changes are propagated to the wrapped segment in memory, but deleting the log before
-/// the wrapped segment has flushed those changes would not be crash safe. The file is eventually
-/// cleaned up after a restart (see [`recover_pending_changes`]) and when the segment directory is
-/// dropped, and a new proxy on the same segment adopts and appends to it (see [`Self::open`]).
-/// Replaying a stale file is safe because all operations are version gated.
+/// the wrapped segment has flushed those changes would not be crash safe.
 #[derive(Debug)]
 pub struct PendingChanges {
     /// Points which should no longer be used from the wrapped segment.
@@ -107,50 +107,39 @@ pub struct PendingChanges {
 }
 
 impl PendingChanges {
-    /// Open the pending changes for the proxy layer `level` on the segment at `segment_path`.
+    /// Open a new pending changes log for the proxy layer `level` on the segment at `segment_path`.
     ///
-    /// If a log file for this layer already exists — left behind by a previous proxy on the same
-    /// segment, which propagated its buffered changes to the segment before unwrapping — it is
-    /// adopted: new changes are appended after its existing entries, and
-    /// [`Self::persisted_version`] starts at the highest version the file holds. The existing
-    /// entries are *not* loaded into the in-memory buffers, as they are already applied to the
-    /// wrapped segment.
-    pub fn open(segment_path: &Path, level: usize) -> OperationResult<Self> {
-        Self::open_impl(segment_path, level, false)
+    /// Uses a random ID.
+    pub fn new(segment_path: &Path, level: usize) -> OperationResult<Self> {
+        let path = pending_changes_log_path(segment_path, level, Uuid::new_v4());
+        Ok(Self::empty(path, level))
     }
 
-    /// Like [`Self::open`], but also reconstruct the in-memory buffers from the log file.
+    /// Reopen the pending changes log at its exact `path`, reconstructing the in-memory buffers
+    /// from it as if every entry were registered again in order.
     ///
-    /// This restores the buffered state of the proxy layer that wrote the file, as if every entry
-    /// were registered again in order. Use this only when the entries are *not* applied to the
-    /// wrapped segment; the regular restart path replays them onto the segment directly instead
-    /// (see [`recover_pending_changes`]).
-    pub fn load(segment_path: &Path, level: usize) -> OperationResult<Self> {
-        Self::open_impl(segment_path, level, true)
-    }
+    /// Unlike [`Self::open`], this targets one specific file rather than creating a new one.
+    /// `path` must be exactly the log file of the proxy generation being resumed. New changes will
+    /// keep appending to the same file.
+    ///
+    /// Must only be used when entries are not yet applied to the wrapped segment.
+    pub fn load(path: &Path) -> OperationResult<Self> {
+        let level = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(log_file::parse_log_file_level)
+            .ok_or_else(|| {
+                OperationError::service_error(format!(
+                    "Not a pending changes log file path: {}",
+                    path.display(),
+                ))
+            })?;
 
-    fn open_impl(
-        segment_path: &Path,
-        level: usize,
-        reconstruct_buffers: bool,
-    ) -> OperationResult<Self> {
-        let path = pending_changes_log_path(segment_path, level);
-
-        let mut changes = Self {
-            deleted_points: DeletedPoints::default(),
-            changed_indexes: ProxyIndexChanges::default(),
-            changed_vector_names: ProxyVectorNameChanges::default(),
-            pending_persist: Default::default(),
-            path: path.clone(),
-            level,
-            expected_file_len: Arc::new(AtomicU64::new(0)),
-            persisted_version: Arc::new(AtomicU64::new(0)),
-            is_alive_lock: IsAliveLock::new(),
-        };
+        let mut changes = Self::empty(path.to_path_buf(), level);
 
         if path.is_file() {
             // Read all entries, truncating a torn entry at the end of the file if there is one
-            let loaded = log_file::load_changes(&path)?;
+            let loaded = log_file::load_changes(path)?;
             let max_version = loaded
                 .changes
                 .iter()
@@ -164,14 +153,27 @@ impl PendingChanges {
                 .persisted_version
                 .store(max_version, Ordering::Relaxed);
 
-            if reconstruct_buffers {
-                for change in loaded.changes {
-                    changes.reconstruct_change(change);
-                }
+            for change in loaded.changes {
+                changes.reconstruct_change(change);
             }
         }
 
         Ok(changes)
+    }
+
+    /// Build an empty instance targeting `path`, with nothing loaded or persisted yet.
+    fn empty(path: PathBuf, level: usize) -> Self {
+        Self {
+            deleted_points: DeletedPoints::default(),
+            changed_indexes: ProxyIndexChanges::default(),
+            changed_vector_names: ProxyVectorNameChanges::default(),
+            pending_persist: Default::default(),
+            path,
+            level,
+            expected_file_len: Arc::new(AtomicU64::new(0)),
+            persisted_version: Arc::new(AtomicU64::new(0)),
+            is_alive_lock: IsAliveLock::new(),
+        }
     }
 
     /// Re-insert a change loaded from the log file into the in-memory buffers.
@@ -451,10 +453,12 @@ pub struct RecoveredPendingChanges {
 ///
 /// If the segment directory holds pending changes log files, the proxy segments that wrote them
 /// did not propagate their buffered state into this segment before the process stopped. Instead
-/// of reconstructing the proxies, replay all logged operations directly onto the segment: inner
-/// most layer first, each file in append order. All operations are version gated, so entries the
-/// segment already applied (e.g. because a proxy did propagate before unwrapping, leaving the
-/// file behind) are silently skipped.
+/// of reconstructing the proxies, replay all logged operations directly onto the segment.
+///
+/// Replay order is level first, then operation version: every level-0 file is fully replayed
+/// before any level-1 file, matching the order of proxy laters. It is possible a level has
+/// multiple files if a unproxy failed to clean it up. In that case all files are replayed by
+/// version order.
 ///
 /// Must be called before regular WAL replay, which recovers everything past what segments
 /// (including these logs) have durably applied.
@@ -472,7 +476,7 @@ pub struct RecoveredPendingChanges {
 ///
 /// With [`PersistedProxyChanges::Ignore`] nothing is replayed and the log files are left as they
 /// are; see there for when that is appropriate.
-#[must_use = "Should clean up log files after segment flush"]
+#[must_use = "should clean up log files after segment flush"]
 pub fn recover_pending_changes(
     segment: &mut Segment,
     persisted_proxy_changes: PersistedProxyChanges,
@@ -494,15 +498,42 @@ pub fn recover_pending_changes(
         }
     }
 
-    let mut replayed = 0;
+    // Load every file, tagged with its level and the version it starts at, then order whole
+    // files for replay: level first, then by that starting version, see above.
+    let mut files = Vec::with_capacity(log_files.len());
     for path in &log_files {
-        let loaded = log_file::load_changes(path)?;
-        log::info!(
-            "Replaying {} pending proxy changes onto segment ({})",
-            loaded.changes.len(),
+        let level = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(log_file::parse_log_file_level)
+            .ok_or_else(|| {
+                OperationError::service_error(format!(
+                    "Not a pending changes log file path: {}",
+                    path.display(),
+                ))
+            })?;
+        let changes = log_file::load_changes(path)?.changes;
+        let start_version = changes
+            .iter()
+            .map(PendingChange::version)
+            .min()
+            .unwrap_or(0);
+        log::debug!(
+            "Loaded {} pending proxy changes from {} (level {level})",
+            changes.len(),
             path.display(),
         );
-        for change in &loaded.changes {
+        files.push((level, start_version, path, changes));
+    }
+    files.sort_by_key(|(level, start_version, ..)| (*level, *start_version));
+
+    let replayed: usize = files.iter().map(|(.., changes)| changes.len()).sum();
+    log::info!(
+        "Replaying {replayed} pending proxy changes onto segment ({})",
+        segment.segment_path.display(),
+    );
+    for (_, _, path, changes) in &files {
+        for change in changes {
             apply_change(segment, change).map_err(|err| {
                 OperationError::service_error(format!(
                     "Failed to replay pending change from {}: {err}",
@@ -510,7 +541,6 @@ pub fn recover_pending_changes(
                 ))
             })?;
         }
-        replayed += loaded.changes.len();
     }
 
     Ok(RecoveredPendingChanges {

--- a/lib/segment/src/pending_changes/mod.rs
+++ b/lib/segment/src/pending_changes/mod.rs
@@ -32,7 +32,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::is_alive_lock::IsAliveLock;
-use fs_err as fs;
 use parking_lot::Mutex;
 
 pub use self::change::{DeletedPoints, PendingChange, ProxyDeletedPoint, ProxyIndexChange};
@@ -58,10 +57,10 @@ use crate::types::{PayloadKeyType, PointIdType, SegmentConfig, SeqNumberType, Ve
 ///
 /// The log file deliberately outlives the component: when a proxy segment is unwrapped its
 /// buffered changes are propagated to the wrapped segment in memory, but deleting the log before
-/// the wrapped segment has flushed those changes would not be crash safe. The file is cleaned up
-/// on restart (see [`recover_pending_changes`]) and when the segment directory is dropped, and a
-/// new proxy on the same segment adopts and appends to it (see [`Self::open`]). Replaying a stale
-/// file is safe because all operations are version gated.
+/// the wrapped segment has flushed those changes would not be crash safe. The file is eventually
+/// cleaned up after a restart (see [`recover_pending_changes`]) and when the segment directory is
+/// dropped, and a new proxy on the same segment adopts and appends to it (see [`Self::open`]).
+/// Replaying a stale file is safe because all operations are version gated.
 #[derive(Debug)]
 pub struct PendingChanges {
     /// Points which should no longer be used from the wrapped segment.
@@ -426,12 +425,26 @@ where
 /// See [`recover_pending_changes`].
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum PersistedProxyChanges {
-    /// Replay all persisted pending proxy changes onto the segment and remove their log files.
+    /// Replay all persisted pending proxy changes onto the segment; their log files can be
+    /// removed once the segment durably persists past the replay, see
+    /// [`RecoveredPendingChanges`].
     #[default]
     Replay,
     /// Do not replay persisted pending proxy changes, leave the segment and the log files
     /// untouched.
     Ignore,
+}
+
+/// What [`recover_pending_changes`] leaves to clean up.
+#[derive(Debug, Default)]
+pub struct RecoveredPendingChanges {
+    /// Number of replayed log entries, across all layers.
+    pub replayed: usize,
+    /// Log files that are safe to remove once the segment durably persists at or past
+    /// `ready_at`. Removing them before that is unsafe, see [`recover_pending_changes`].
+    pub log_files: Vec<PathBuf>,
+    /// Flush version after which log files can be safely removed.
+    pub ready_at: SeqNumberType,
 }
 
 /// Recover pending changes left on disk by proxy segments, before regular WAL replay
@@ -443,26 +456,30 @@ pub enum PersistedProxyChanges {
 /// segment already applied (e.g. because a proxy did propagate before unwrapping, leaving the
 /// file behind) are silently skipped.
 ///
-/// The segment is force-flushed afterwards, making the replayed operations durable, and only then
-/// are the log files removed. Must be called before regular WAL replay, which recovers everything
-/// past what segments (including these logs) have durably applied.
+/// Must be called before regular WAL replay, which recovers everything past what segments
+/// (including these logs) have durably applied.
 ///
 /// This is necessary because proxy changes that are persisted on disk are also acknowledged in the
 /// WAL. It means that on restart we expect all those changes to be visible in the segment to get a
 /// consistent read view. Since the processes that required a proxy are not running anymore we
 /// don't reconstruct the proxies, instead we just apply the changes directly to the segment.
 ///
+/// The replayed operations are only applied in memory here; nothing is flushed. The returned
+/// [`RecoveredPendingChanges::log_files`] must not be removed until the segment durably persists
+/// past [`RecoveredPendingChanges::ready_at`] — the caller is expected to defer that, e.g. by
+/// registering it as a post-flush action on the segment's `SegmentHolder` once the segment has
+/// joined one.
+///
 /// With [`PersistedProxyChanges::Ignore`] nothing is replayed and the log files are left as they
 /// are; see there for when that is appropriate.
-///
-/// Returns the number of replayed log entries.
+#[must_use = "Should clean up log files after segment flush"]
 pub fn recover_pending_changes(
     segment: &mut Segment,
     persisted_proxy_changes: PersistedProxyChanges,
-) -> OperationResult<usize> {
+) -> OperationResult<RecoveredPendingChanges> {
     let log_files = list_pending_changes_log_files(&segment.segment_path);
     if log_files.is_empty() {
-        return Ok(0);
+        return Ok(RecoveredPendingChanges::default());
     }
 
     match persisted_proxy_changes {
@@ -473,7 +490,7 @@ pub fn recover_pending_changes(
                 log_files.len(),
                 segment.segment_path.display(),
             );
-            return Ok(0);
+            return Ok(RecoveredPendingChanges::default());
         }
     }
 
@@ -496,13 +513,9 @@ pub fn recover_pending_changes(
         replayed += loaded.changes.len();
     }
 
-    // Persist the replayed operations before removing the log files; a crash in between just
-    // means the files are replayed again, which is a version-gated no-op
-    segment.flush(true)?;
-
-    for path in log_files {
-        fs::remove_file(path)?;
-    }
-
-    Ok(replayed)
+    Ok(RecoveredPendingChanges {
+        replayed,
+        ready_at: segment.version(),
+        log_files,
+    })
 }

--- a/lib/segment/src/pending_changes/mod.rs
+++ b/lib/segment/src/pending_changes/mod.rs
@@ -40,7 +40,7 @@ use uuid::Uuid;
 pub use self::change::{DeletedPoints, PendingChange, ProxyDeletedPoint, ProxyIndexChange};
 pub use self::index_changes::ProxyIndexChanges;
 pub use self::log_file::{
-    LOG_FILE_TEMPLATE, list_pending_changes_log_files, pending_changes_log_path,
+    LOG_FILE_PREFIX, list_pending_changes_log_files, pending_changes_log_path,
 };
 pub use self::vector_name_changes::{IntendedVector, ProxyVectorNameChanges};
 use crate::common::Flusher;
@@ -118,7 +118,7 @@ impl PendingChanges {
     /// Reopen the pending changes log at its exact `path`, reconstructing the in-memory buffers
     /// from it as if every entry were registered again in order.
     ///
-    /// Unlike [`Self::open`], this targets one specific file rather than creating a new one.
+    /// Unlike [`Self::new`], this targets one specific file rather than creating a new one.
     /// `path` must be exactly the log file of the proxy generation being resumed. New changes will
     /// keep appending to the same file.
     ///
@@ -456,9 +456,9 @@ pub struct RecoveredPendingChanges {
 /// of reconstructing the proxies, replay all logged operations directly onto the segment.
 ///
 /// Replay order is level first, then operation version: every level-0 file is fully replayed
-/// before any level-1 file, matching the order of proxy laters. It is possible a level has
-/// multiple files if a unproxy failed to clean it up. In that case all files are replayed by
-/// version order.
+/// before any level-1 file, matching the order the proxy layers were created in. A level may have
+/// multiple files if an unproxy failed to clean one up; in that case they are replayed in version
+/// order.
 ///
 /// Must be called before regular WAL replay, which recovers everything past what segments
 /// (including these logs) have durably applied.

--- a/lib/segment/src/pending_changes/tests.rs
+++ b/lib/segment/src/pending_changes/tests.rs
@@ -402,7 +402,7 @@ fn test_recover_pending_changes() {
     // The segment itself never saw the operations
     assert!(segment.has_point(2.into(), common::types::DeferredBehavior::VisibleOnly));
 
-    let replayed = recover_pending_changes(&mut segment).unwrap();
+    let replayed = recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
     assert_eq!(replayed, 2);
 
     assert!(!segment.has_point(2.into(), common::types::DeferredBehavior::VisibleOnly));
@@ -413,7 +413,10 @@ fn test_recover_pending_changes() {
     assert!(list_pending_changes_log_files(&segment_dir).is_empty());
 
     // Running again is a no-op
-    assert_eq!(recover_pending_changes(&mut segment).unwrap(), 0);
+    assert_eq!(
+        recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap(),
+        0
+    );
 
     // Deleting a point again with the same version is silently skipped
     assert!(
@@ -421,6 +424,40 @@ fn test_recover_pending_changes() {
             .delete_point(segment_version + 1, 2.into(), &hw_counter)
             .unwrap()
     );
+}
+
+#[test]
+fn test_recover_ignore_leaves_log_untouched() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let mut segment = build_segment(dir.path());
+    let segment_dir = segment.data_path();
+    let segment_version = segment.version();
+
+    let mut pending_changes = PendingChanges::open(&segment_dir, 0).unwrap();
+    pending_changes.register_delete_point(
+        2.into(),
+        ProxyDeletedPoint {
+            local_version: 2,
+            operation_version: segment_version + 1,
+        },
+    );
+    pending_changes.flusher(segment_version + 1).unwrap()().unwrap();
+    let log_path = pending_changes.log_path().to_path_buf();
+    let log_len = fs::metadata(&log_path).unwrap().len();
+    drop(pending_changes);
+
+    // Ignoring must neither touch the segment nor the log file
+    let replayed = recover_pending_changes(&mut segment, PersistedProxyChanges::Ignore).unwrap();
+    assert_eq!(replayed, 0);
+    assert!(segment.has_point(2.into(), common::types::DeferredBehavior::VisibleOnly));
+    assert_eq!(segment.version(), segment_version);
+    assert_eq!(fs::metadata(&log_path).unwrap().len(), log_len);
+
+    // A later replaying load still recovers the change
+    let replayed = recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
+    assert_eq!(replayed, 1);
+    assert!(!segment.has_point(2.into(), common::types::DeferredBehavior::VisibleOnly));
+    assert!(!log_path.is_file());
 }
 
 #[test]
@@ -450,7 +487,7 @@ fn test_recover_stale_log_is_noop() {
     let point_count = segment.available_point_count();
 
     // Replaying the stale log must not change anything, and must clean up the file
-    recover_pending_changes(&mut segment).unwrap();
+    recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
     assert_eq!(segment.available_point_count(), point_count);
     assert_eq!(segment.version(), op_version);
     assert!(list_pending_changes_log_files(&segment_dir).is_empty());
@@ -495,7 +532,7 @@ fn test_recover_multiple_levels_in_order() {
     outer.flusher(segment_version + 4).unwrap()().unwrap();
     drop(outer);
 
-    let replayed = recover_pending_changes(&mut segment).unwrap();
+    let replayed = recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
     assert_eq!(replayed, 4);
 
     assert!(!segment.has_point(1.into(), common::types::DeferredBehavior::VisibleOnly));
@@ -528,7 +565,7 @@ fn test_recover_vector_name_changes() {
     pending_changes.flusher(segment_version + 1).unwrap()().unwrap();
     drop(pending_changes);
 
-    recover_pending_changes(&mut segment).unwrap();
+    recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
 
     assert!(
         segment

--- a/lib/segment/src/pending_changes/tests.rs
+++ b/lib/segment/src/pending_changes/tests.rs
@@ -1,0 +1,563 @@
+use std::path::Path;
+
+use common::counter::hardware_counter::HardwareCounterCell;
+use fs_err as fs;
+use tempfile::Builder;
+
+use super::*;
+use crate::data_types::vectors::only_default_vector;
+use crate::entry::ReadSegmentEntry as _;
+use crate::entry::entry_point::SegmentEntry as _;
+use crate::segment_constructor::simple_segment_constructor::build_simple_segment;
+use crate::types::{Distance, PayloadFieldSchema, PayloadSchemaType};
+
+fn keyword_schema() -> PayloadFieldSchema {
+    PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword)
+}
+
+fn field(name: &str) -> PayloadKeyType {
+    name.parse().unwrap()
+}
+
+fn delete_change(point_id: u64, version: SeqNumberType) -> PendingChange {
+    PendingChange::DeletePoint {
+        point_id: point_id.into(),
+        versions: ProxyDeletedPoint {
+            local_version: version,
+            operation_version: version,
+        },
+    }
+}
+
+/// Build a segment with points 1..=5 at versions 1..=5, flushed to disk.
+fn build_segment(path: &Path) -> Segment {
+    let hw_counter = HardwareCounterCell::new();
+    let mut segment = build_simple_segment(path, 4, Distance::Dot).unwrap();
+    for point_id in 1..=5u64 {
+        segment
+            .upsert_point(
+                point_id,
+                point_id.into(),
+                only_default_vector(&[1.0, 0.0, 1.0, 1.0]),
+                &hw_counter,
+            )
+            .unwrap();
+    }
+    segment.flush(true).unwrap();
+    segment
+}
+
+#[test]
+fn test_log_path_levels() {
+    let segment_path = Path::new("/some/segment");
+    assert_eq!(
+        pending_changes_log_path(segment_path, 0),
+        segment_path.join("pending_changes.log"),
+    );
+    assert_eq!(
+        pending_changes_log_path(segment_path, 1),
+        segment_path.join("pending_changes.log.1"),
+    );
+    assert_eq!(
+        pending_changes_log_path(segment_path, 2),
+        segment_path.join("pending_changes.log.2"),
+    );
+}
+
+#[test]
+fn test_list_log_files_ordered_and_gap_tolerant() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    assert!(list_pending_changes_log_files(dir.path()).is_empty());
+
+    // A proxy layer that never persisted anything leaves no file; levels may have gaps
+    fs::write(pending_changes_log_path(dir.path(), 2), b"").unwrap();
+    fs::write(pending_changes_log_path(dir.path(), 0), b"").unwrap();
+    // Unrelated files are not picked up
+    fs::write(dir.path().join("pending_changes.log.bak"), b"").unwrap();
+    fs::write(dir.path().join("segment.json"), b"").unwrap();
+
+    let files = list_pending_changes_log_files(dir.path());
+    assert_eq!(
+        files,
+        vec![
+            pending_changes_log_path(dir.path(), 0),
+            pending_changes_log_path(dir.path(), 2),
+        ],
+    );
+}
+
+#[test]
+fn test_register_flush_load_roundtrip() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let segment = build_segment(dir.path());
+    let segment_dir = segment.data_path();
+    let segment_config = segment.config().clone();
+
+    let mut pending_changes = PendingChanges::open(&segment_dir, 0).unwrap();
+    assert_eq!(pending_changes.persisted_version(), 0);
+
+    // Register one operation of each type
+    pending_changes.register_delete_point(
+        2.into(),
+        ProxyDeletedPoint {
+            local_version: 2,
+            operation_version: 10,
+        },
+    );
+    pending_changes.register_index_change(
+        field("color"),
+        ProxyIndexChange::Create(keyword_schema(), 11),
+    );
+    pending_changes.register_index_change(field("price"), ProxyIndexChange::Delete(12));
+    // An existing vector name with a different schema must supersede the wrapped data
+    pending_changes.register_vector_name_create(
+        "".into(),
+        VectorNameConfig::dense(crate::data_types::vector_name_config::DenseVectorConfig {
+            size: 8,
+            distance: Distance::Cosine,
+            multivector_config: None,
+            datatype: None,
+        }),
+        13,
+        &segment_config,
+    );
+    pending_changes.register_vector_name_delete("other".into(), 14);
+
+    // Nothing is persisted yet
+    assert!(!pending_changes.log_path().is_file());
+
+    let flusher = pending_changes.flusher(14).unwrap();
+    flusher().unwrap();
+
+    assert!(pending_changes.log_path().is_file());
+    assert_eq!(pending_changes.persisted_version(), 14);
+
+    // The pending buffer is drained, a new flusher has nothing to do
+    assert!(pending_changes.flusher(14).is_none());
+
+    // Reconstruct the in-memory state from the log file
+    let loaded = PendingChanges::load(&segment_dir, 0).unwrap();
+    assert_eq!(loaded.persisted_version(), 14);
+    assert_eq!(loaded.deleted_points(), pending_changes.deleted_points());
+    assert_eq!(loaded.index_changes().len(), 2);
+    assert_eq!(
+        loaded
+            .index_changes()
+            .iter_ordered()
+            .map(|(field_name, change)| (field_name.clone(), change.clone()))
+            .collect::<Vec<_>>(),
+        pending_changes
+            .index_changes()
+            .iter_ordered()
+            .map(|(field_name, change)| (field_name.clone(), change.clone()))
+            .collect::<Vec<_>>(),
+    );
+    let intent = loaded.vector_name_changes().get("").unwrap();
+    assert!(
+        matches!(
+            intent,
+            IntendedVector::Present {
+                version: 13,
+                supersedes_wrapped: true,
+                ..
+            },
+        ),
+        "existing vector name with different schema must supersede wrapped data: {intent:?}",
+    );
+    assert_eq!(
+        loaded.vector_name_changes().get("other").unwrap(),
+        &IntendedVector::Absent { version: 14 },
+    );
+
+    // Plain open adopts the file without loading the buffers
+    let adopted = PendingChanges::open(&segment_dir, 0).unwrap();
+    assert_eq!(adopted.persisted_version(), 14);
+    assert!(adopted.deleted_points().is_empty());
+    assert!(adopted.index_changes().is_empty());
+    assert!(adopted.vector_name_changes().is_empty());
+}
+
+#[test]
+fn test_flusher_covers_version_without_changes() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let pending_changes = PendingChanges::open(dir.path(), 0).unwrap();
+
+    // Nothing registered and version 0 already covered
+    assert!(pending_changes.flusher(0).is_none());
+
+    // An operation that buffered nothing (e.g. a delete for an absent point) must still be
+    // covered by the persisted version once flushed, without creating a log file
+    let flusher = pending_changes.flusher(7).unwrap();
+    flusher().unwrap();
+    assert_eq!(pending_changes.persisted_version(), 7);
+    assert!(!pending_changes.log_path().is_file());
+
+    assert!(pending_changes.flusher(7).is_none());
+}
+
+#[test]
+fn test_register_during_flush_is_not_lost_nor_covered() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut pending_changes = PendingChanges::open(dir.path(), 0).unwrap();
+    pending_changes.register_delete_point(
+        1.into(),
+        ProxyDeletedPoint {
+            local_version: 1,
+            operation_version: 10,
+        },
+    );
+
+    // Capture a flusher, then register another operation before it runs
+    let flusher = pending_changes.flusher(10).unwrap();
+    pending_changes.register_delete_point(
+        2.into(),
+        ProxyDeletedPoint {
+            local_version: 2,
+            operation_version: 11,
+        },
+    );
+    flusher().unwrap();
+
+    // The captured operation is persisted and covered, the raced-in one is neither
+    assert_eq!(pending_changes.persisted_version(), 10);
+
+    let flusher = pending_changes.flusher(11).unwrap();
+    flusher().unwrap();
+    assert_eq!(pending_changes.persisted_version(), 11);
+
+    let loaded = PendingChanges::load(dir.path(), 0).unwrap();
+    assert_eq!(loaded.deleted_points().len(), 2);
+}
+
+#[test]
+fn test_flusher_skipped_after_drop() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut pending_changes = PendingChanges::open(dir.path(), 0).unwrap();
+    pending_changes.register_delete_point(
+        1.into(),
+        ProxyDeletedPoint {
+            local_version: 1,
+            operation_version: 10,
+        },
+    );
+
+    let log_path = pending_changes.log_path().to_path_buf();
+    let flusher = pending_changes.flusher(10).unwrap();
+    drop(pending_changes);
+
+    // A flusher captured before the component was dropped must be a no-op
+    flusher().unwrap();
+    assert!(!log_path.is_file());
+}
+
+#[test]
+fn test_torn_tail_is_truncated() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut pending_changes = PendingChanges::open(dir.path(), 0).unwrap();
+    pending_changes.register_delete_point(
+        1.into(),
+        ProxyDeletedPoint {
+            local_version: 1,
+            operation_version: 10,
+        },
+    );
+    pending_changes.flusher(10).unwrap()().unwrap();
+
+    let log_path = pending_changes.log_path().to_path_buf();
+    let intact_len = fs::metadata(&log_path).unwrap().len();
+    drop(pending_changes);
+
+    // A partially written length prefix
+    let mut mangled = fs::read(&log_path).unwrap();
+    mangled.extend_from_slice(&[0xAB, 0xCD]);
+    fs::write(&log_path, &mangled).unwrap();
+
+    let loaded = PendingChanges::load(dir.path(), 0).unwrap();
+    assert_eq!(loaded.deleted_points().len(), 1);
+    assert_eq!(loaded.persisted_version(), 10);
+    assert_eq!(fs::metadata(&log_path).unwrap().len(), intact_len);
+
+    // A full length prefix whose payload did not make it to disk
+    let mut mangled = fs::read(&log_path).unwrap();
+    mangled.extend_from_slice(&100u32.to_le_bytes());
+    mangled.extend_from_slice(b"partial");
+    fs::write(&log_path, &mangled).unwrap();
+
+    let loaded = PendingChanges::load(dir.path(), 0).unwrap();
+    assert_eq!(loaded.deleted_points().len(), 1);
+    assert_eq!(fs::metadata(&log_path).unwrap().len(), intact_len);
+
+    // Appending after truncation must work and keep the intact entry
+    let mut adopted = PendingChanges::open(dir.path(), 0).unwrap();
+    adopted.register_delete_point(
+        2.into(),
+        ProxyDeletedPoint {
+            local_version: 2,
+            operation_version: 11,
+        },
+    );
+    adopted.flusher(11).unwrap()().unwrap();
+
+    let loaded = PendingChanges::load(dir.path(), 0).unwrap();
+    assert_eq!(loaded.deleted_points().len(), 2);
+    assert_eq!(loaded.persisted_version(), 11);
+}
+
+#[test]
+fn test_corruption_in_middle_is_error() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut pending_changes = PendingChanges::open(dir.path(), 0).unwrap();
+    pending_changes.register_delete_point(
+        1.into(),
+        ProxyDeletedPoint {
+            local_version: 1,
+            operation_version: 10,
+        },
+    );
+    pending_changes.register_delete_point(
+        2.into(),
+        ProxyDeletedPoint {
+            local_version: 2,
+            operation_version: 11,
+        },
+    );
+    pending_changes.flusher(11).unwrap()().unwrap();
+
+    let log_path = pending_changes.log_path().to_path_buf();
+    drop(pending_changes);
+
+    // Corrupt the payload of the first entry; entries after it may have been acknowledged in the
+    // WAL, so this must not be silently truncated away
+    let mut mangled = fs::read(&log_path).unwrap();
+    mangled[4] = b'X';
+    fs::write(&log_path, &mangled).unwrap();
+
+    assert!(PendingChanges::load(dir.path(), 0).is_err());
+}
+
+#[test]
+fn test_adopted_log_is_appended() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut pending_changes = PendingChanges::open(dir.path(), 0).unwrap();
+    pending_changes.register_delete_point(
+        1.into(),
+        ProxyDeletedPoint {
+            local_version: 1,
+            operation_version: 10,
+        },
+    );
+    pending_changes.flusher(10).unwrap()().unwrap();
+    drop(pending_changes);
+
+    // A new proxy on the same segment adopts the log file and appends to it
+    let mut adopted = PendingChanges::open(dir.path(), 0).unwrap();
+    assert_eq!(adopted.persisted_version(), 10);
+    assert!(adopted.deleted_points().is_empty());
+
+    adopted.register_delete_point(
+        2.into(),
+        ProxyDeletedPoint {
+            local_version: 2,
+            operation_version: 20,
+        },
+    );
+    adopted.flusher(20).unwrap()().unwrap();
+    assert_eq!(adopted.persisted_version(), 20);
+
+    let loaded = PendingChanges::load(dir.path(), 0).unwrap();
+    assert_eq!(loaded.deleted_points().len(), 2);
+    assert_eq!(loaded.persisted_version(), 20);
+}
+
+#[test]
+fn test_recover_pending_changes() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let mut segment = build_segment(dir.path());
+    let segment_dir = segment.data_path();
+    let segment_version = segment.version();
+
+    let mut pending_changes = PendingChanges::open(&segment_dir, 0).unwrap();
+    pending_changes.register_delete_point(
+        2.into(),
+        ProxyDeletedPoint {
+            local_version: 2,
+            operation_version: segment_version + 1,
+        },
+    );
+    pending_changes.register_index_change(
+        field("color"),
+        ProxyIndexChange::Create(keyword_schema(), segment_version + 2),
+    );
+    pending_changes.flusher(segment_version + 2).unwrap()().unwrap();
+    drop(pending_changes);
+
+    // The segment itself never saw the operations
+    assert!(segment.has_point(2.into(), common::types::DeferredBehavior::VisibleOnly));
+
+    let replayed = recover_pending_changes(&mut segment).unwrap();
+    assert_eq!(replayed, 2);
+
+    assert!(!segment.has_point(2.into(), common::types::DeferredBehavior::VisibleOnly));
+    assert!(segment.get_indexed_fields().contains_key(&field("color")));
+    assert_eq!(segment.version(), segment_version + 2);
+    // The segment was flushed before the log was removed
+    assert_eq!(segment.persistent_version(), segment_version + 2);
+    assert!(list_pending_changes_log_files(&segment_dir).is_empty());
+
+    // Running again is a no-op
+    assert_eq!(recover_pending_changes(&mut segment).unwrap(), 0);
+
+    // Deleting a point again with the same version is silently skipped
+    assert!(
+        !segment
+            .delete_point(segment_version + 1, 2.into(), &hw_counter)
+            .unwrap()
+    );
+}
+
+#[test]
+fn test_recover_stale_log_is_noop() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let mut segment = build_segment(dir.path());
+    let segment_dir = segment.data_path();
+    let op_version = segment.version() + 1;
+
+    // The operation is already applied to the segment, e.g. because a proxy propagated its
+    // changes before unwrapping and left the log file behind
+    let mut pending_changes = PendingChanges::open(&segment_dir, 0).unwrap();
+    pending_changes.register_delete_point(
+        3.into(),
+        ProxyDeletedPoint {
+            local_version: 3,
+            operation_version: op_version,
+        },
+    );
+    pending_changes.flusher(op_version).unwrap()().unwrap();
+    drop(pending_changes);
+
+    segment
+        .delete_point(op_version, 3.into(), &hw_counter)
+        .unwrap();
+    let point_count = segment.available_point_count();
+
+    // Replaying the stale log must not change anything, and must clean up the file
+    recover_pending_changes(&mut segment).unwrap();
+    assert_eq!(segment.available_point_count(), point_count);
+    assert_eq!(segment.version(), op_version);
+    assert!(list_pending_changes_log_files(&segment_dir).is_empty());
+}
+
+#[test]
+fn test_recover_multiple_levels_in_order() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let mut segment = build_segment(dir.path());
+    let segment_dir = segment.data_path();
+    let segment_version = segment.version();
+
+    // Inner most proxy layer deleted point 1, the layer above later deleted point 2 and
+    // re-created the index the inner layer deleted
+    let mut inner = PendingChanges::open(&segment_dir, 0).unwrap();
+    inner.register_delete_point(
+        1.into(),
+        ProxyDeletedPoint {
+            local_version: 1,
+            operation_version: segment_version + 1,
+        },
+    );
+    inner.register_index_change(
+        field("color"),
+        ProxyIndexChange::Delete(segment_version + 2),
+    );
+    inner.flusher(segment_version + 2).unwrap()().unwrap();
+    drop(inner);
+
+    let mut outer = PendingChanges::open(&segment_dir, 1).unwrap();
+    outer.register_delete_point(
+        2.into(),
+        ProxyDeletedPoint {
+            local_version: 2,
+            operation_version: segment_version + 3,
+        },
+    );
+    outer.register_index_change(
+        field("color"),
+        ProxyIndexChange::Create(keyword_schema(), segment_version + 4),
+    );
+    outer.flusher(segment_version + 4).unwrap()().unwrap();
+    drop(outer);
+
+    let replayed = recover_pending_changes(&mut segment).unwrap();
+    assert_eq!(replayed, 4);
+
+    assert!(!segment.has_point(1.into(), common::types::DeferredBehavior::VisibleOnly));
+    assert!(!segment.has_point(2.into(), common::types::DeferredBehavior::VisibleOnly));
+    // The outer (newer) index create must win over the inner delete
+    assert!(segment.get_indexed_fields().contains_key(&field("color")));
+    assert_eq!(segment.version(), segment_version + 4);
+    assert!(list_pending_changes_log_files(&segment_dir).is_empty());
+}
+
+#[test]
+fn test_recover_vector_name_changes() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let mut segment = build_segment(dir.path());
+    let segment_dir = segment.data_path();
+    let segment_version = segment.version();
+    let segment_config = segment.config().clone();
+
+    let mut pending_changes = PendingChanges::open(&segment_dir, 0).unwrap();
+    // Create a brand new sparse vector name
+    pending_changes.register_vector_name_create(
+        "sparse_new".into(),
+        VectorNameConfig::sparse(crate::data_types::vector_name_config::SparseVectorConfig {
+            modifier: None,
+            datatype: None,
+        }),
+        segment_version + 1,
+        &segment_config,
+    );
+    pending_changes.flusher(segment_version + 1).unwrap()().unwrap();
+    drop(pending_changes);
+
+    recover_pending_changes(&mut segment).unwrap();
+
+    assert!(
+        segment
+            .vector_names()
+            .iter()
+            .any(|name| name == "sparse_new"),
+        "replayed vector name create must be applied: {:?}",
+        segment.vector_names(),
+    );
+    assert!(list_pending_changes_log_files(&segment_dir).is_empty());
+}
+
+#[test]
+fn test_pending_change_version() {
+    assert_eq!(delete_change(1, 42).version(), 42);
+    assert_eq!(
+        PendingChange::IndexChange {
+            field_name: field("color"),
+            change: ProxyIndexChange::Create(keyword_schema(), 43),
+        }
+        .version(),
+        43,
+    );
+    assert_eq!(
+        PendingChange::VectorNameChange {
+            vector_name: "v".into(),
+            intent: IntendedVector::Absent { version: 44 },
+        }
+        .version(),
+        44,
+    );
+}

--- a/lib/segment/src/pending_changes/tests.rs
+++ b/lib/segment/src/pending_changes/tests.rs
@@ -52,18 +52,12 @@ fn build_segment(path: &Path) -> Segment {
 fn test_log_path_levels() {
     let segment_path = Path::new("/some/segment");
     let id = Uuid::nil();
-    assert_eq!(
-        pending_changes_log_path(segment_path, 0, id),
-        segment_path.join(format!("pending_changes.log-{id}")),
-    );
-    assert_eq!(
-        pending_changes_log_path(segment_path, 1, id),
-        segment_path.join(format!("pending_changes.log.1-{id}")),
-    );
-    assert_eq!(
-        pending_changes_log_path(segment_path, 2, id),
-        segment_path.join(format!("pending_changes.log.2-{id}")),
-    );
+    for level in 0..3 {
+        assert_eq!(
+            pending_changes_log_path(segment_path, level, id),
+            segment_path.join(format!("proxy_changes.{level}.{id}.dat")),
+        );
+    }
 }
 
 #[test]
@@ -88,7 +82,7 @@ fn test_list_log_files_ordered_and_gap_tolerant() {
     fs::write(&level_2, b"").unwrap();
     fs::write(&level_0, b"").unwrap();
     // Unrelated files are not picked up
-    fs::write(dir.path().join("pending_changes.log.bak"), b"").unwrap();
+    fs::write(dir.path().join("proxy_changes.bak"), b"").unwrap();
     fs::write(dir.path().join("segment.json"), b"").unwrap();
 
     let files = list_pending_changes_log_files(dir.path());

--- a/lib/segment/src/pending_changes/tests.rs
+++ b/lib/segment/src/pending_changes/tests.rs
@@ -402,21 +402,33 @@ fn test_recover_pending_changes() {
     // The segment itself never saw the operations
     assert!(segment.has_point(2.into(), common::types::DeferredBehavior::VisibleOnly));
 
-    let replayed = recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
-    assert_eq!(replayed, 2);
+    let recovered = recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
+    assert_eq!(recovered.replayed, 2);
+    assert_eq!(recovered.ready_at, segment_version + 2);
 
     assert!(!segment.has_point(2.into(), common::types::DeferredBehavior::VisibleOnly));
     assert!(segment.get_indexed_fields().contains_key(&field("color")));
     assert_eq!(segment.version(), segment_version + 2);
-    // The segment was flushed before the log was removed
+    // Recovery does not flush; the log files must survive until the segment durably persists
+    // past `ready_at`
+    assert_eq!(segment.persistent_version(), segment_version);
+    assert_eq!(
+        list_pending_changes_log_files(&segment_dir),
+        recovered.log_files,
+    );
+
+    // Once the segment durably persists past `ready_at`, the log files are safe to remove
+    segment.flush(true).unwrap();
     assert_eq!(segment.persistent_version(), segment_version + 2);
+    for path in &recovered.log_files {
+        fs::remove_file(path).unwrap();
+    }
     assert!(list_pending_changes_log_files(&segment_dir).is_empty());
 
     // Running again is a no-op
-    assert_eq!(
-        recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap(),
-        0
-    );
+    let recovered = recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
+    assert_eq!(recovered.replayed, 0);
+    assert!(recovered.log_files.is_empty());
 
     // Deleting a point again with the same version is silently skipped
     assert!(
@@ -447,16 +459,23 @@ fn test_recover_ignore_leaves_log_untouched() {
     drop(pending_changes);
 
     // Ignoring must neither touch the segment nor the log file
-    let replayed = recover_pending_changes(&mut segment, PersistedProxyChanges::Ignore).unwrap();
-    assert_eq!(replayed, 0);
+    let recovered = recover_pending_changes(&mut segment, PersistedProxyChanges::Ignore).unwrap();
+    assert_eq!(recovered.replayed, 0);
+    assert!(recovered.log_files.is_empty());
     assert!(segment.has_point(2.into(), common::types::DeferredBehavior::VisibleOnly));
     assert_eq!(segment.version(), segment_version);
     assert_eq!(fs::metadata(&log_path).unwrap().len(), log_len);
 
     // A later replaying load still recovers the change
-    let replayed = recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
-    assert_eq!(replayed, 1);
+    let recovered = recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
+    assert_eq!(recovered.replayed, 1);
     assert!(!segment.has_point(2.into(), common::types::DeferredBehavior::VisibleOnly));
+    assert_eq!(recovered.log_files, vec![log_path.clone()]);
+    // The log file removal is deferred to the caller, not done here
+    assert!(log_path.is_file());
+
+    segment.flush(true).unwrap();
+    fs::remove_file(&log_path).unwrap();
     assert!(!log_path.is_file());
 }
 
@@ -486,10 +505,20 @@ fn test_recover_stale_log_is_noop() {
         .unwrap();
     let point_count = segment.available_point_count();
 
-    // Replaying the stale log must not change anything, and must clean up the file
-    recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
+    // Replaying the stale log must not change anything; the file is left for the caller to
+    // remove once the segment is durable past `ready_at`
+    let recovered = recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
     assert_eq!(segment.available_point_count(), point_count);
     assert_eq!(segment.version(), op_version);
+    assert_eq!(
+        list_pending_changes_log_files(&segment_dir),
+        recovered.log_files,
+    );
+
+    segment.flush(true).unwrap();
+    for path in &recovered.log_files {
+        fs::remove_file(path).unwrap();
+    }
     assert!(list_pending_changes_log_files(&segment_dir).is_empty());
 }
 
@@ -532,14 +561,20 @@ fn test_recover_multiple_levels_in_order() {
     outer.flusher(segment_version + 4).unwrap()().unwrap();
     drop(outer);
 
-    let replayed = recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
-    assert_eq!(replayed, 4);
+    let recovered = recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
+    assert_eq!(recovered.replayed, 4);
 
     assert!(!segment.has_point(1.into(), common::types::DeferredBehavior::VisibleOnly));
     assert!(!segment.has_point(2.into(), common::types::DeferredBehavior::VisibleOnly));
     // The outer (newer) index create must win over the inner delete
     assert!(segment.get_indexed_fields().contains_key(&field("color")));
     assert_eq!(segment.version(), segment_version + 4);
+    assert_eq!(recovered.ready_at, segment_version + 4);
+
+    segment.flush(true).unwrap();
+    for path in &recovered.log_files {
+        fs::remove_file(path).unwrap();
+    }
     assert!(list_pending_changes_log_files(&segment_dir).is_empty());
 }
 
@@ -565,7 +600,7 @@ fn test_recover_vector_name_changes() {
     pending_changes.flusher(segment_version + 1).unwrap()().unwrap();
     drop(pending_changes);
 
-    recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
+    let recovered = recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
 
     assert!(
         segment
@@ -575,6 +610,11 @@ fn test_recover_vector_name_changes() {
         "replayed vector name create must be applied: {:?}",
         segment.vector_names(),
     );
+
+    segment.flush(true).unwrap();
+    for path in &recovered.log_files {
+        fs::remove_file(path).unwrap();
+    }
     assert!(list_pending_changes_log_files(&segment_dir).is_empty());
 }
 

--- a/lib/segment/src/pending_changes/tests.rs
+++ b/lib/segment/src/pending_changes/tests.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use common::counter::hardware_counter::HardwareCounterCell;
 use fs_err as fs;
 use tempfile::Builder;
+use uuid::Uuid;
 
 use super::*;
 use crate::data_types::vectors::only_default_vector;
@@ -50,17 +51,28 @@ fn build_segment(path: &Path) -> Segment {
 #[test]
 fn test_log_path_levels() {
     let segment_path = Path::new("/some/segment");
+    let id = Uuid::nil();
     assert_eq!(
-        pending_changes_log_path(segment_path, 0),
-        segment_path.join("pending_changes.log"),
+        pending_changes_log_path(segment_path, 0, id),
+        segment_path.join(format!("pending_changes.log-{id}")),
     );
     assert_eq!(
-        pending_changes_log_path(segment_path, 1),
-        segment_path.join("pending_changes.log.1"),
+        pending_changes_log_path(segment_path, 1, id),
+        segment_path.join(format!("pending_changes.log.1-{id}")),
     );
     assert_eq!(
-        pending_changes_log_path(segment_path, 2),
-        segment_path.join("pending_changes.log.2"),
+        pending_changes_log_path(segment_path, 2, id),
+        segment_path.join(format!("pending_changes.log.2-{id}")),
+    );
+}
+
+#[test]
+fn test_log_path_unique_id_per_call() {
+    let segment_path = Path::new("/some/segment");
+    assert_ne!(
+        pending_changes_log_path(segment_path, 0, Uuid::new_v4()),
+        pending_changes_log_path(segment_path, 0, Uuid::new_v4()),
+        "two different ids at the same level must not collide",
     );
 }
 
@@ -71,20 +83,34 @@ fn test_list_log_files_ordered_and_gap_tolerant() {
     assert!(list_pending_changes_log_files(dir.path()).is_empty());
 
     // A proxy layer that never persisted anything leaves no file; levels may have gaps
-    fs::write(pending_changes_log_path(dir.path(), 2), b"").unwrap();
-    fs::write(pending_changes_log_path(dir.path(), 0), b"").unwrap();
+    let level_2 = pending_changes_log_path(dir.path(), 2, Uuid::new_v4());
+    let level_0 = pending_changes_log_path(dir.path(), 0, Uuid::new_v4());
+    fs::write(&level_2, b"").unwrap();
+    fs::write(&level_0, b"").unwrap();
     // Unrelated files are not picked up
     fs::write(dir.path().join("pending_changes.log.bak"), b"").unwrap();
     fs::write(dir.path().join("segment.json"), b"").unwrap();
 
     let files = list_pending_changes_log_files(dir.path());
-    assert_eq!(
-        files,
-        vec![
-            pending_changes_log_path(dir.path(), 0),
-            pending_changes_log_path(dir.path(), 2),
-        ],
-    );
+    assert_eq!(files, vec![level_0, level_2]);
+}
+
+#[test]
+fn test_list_log_files_multiple_generations_same_level() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    // An unwrapped proxy's log file not cleaned up yet, and a new proxy at the same level, both
+    // exist side by side under their own unique names
+    let older = pending_changes_log_path(dir.path(), 0, Uuid::new_v4());
+    let newer = pending_changes_log_path(dir.path(), 0, Uuid::new_v4());
+    fs::write(&older, b"").unwrap();
+    fs::write(&newer, b"").unwrap();
+
+    let mut files = list_pending_changes_log_files(dir.path());
+    files.sort();
+    let mut expected = vec![older, newer];
+    expected.sort();
+    assert_eq!(files, expected);
 }
 
 #[test]
@@ -94,7 +120,7 @@ fn test_register_flush_load_roundtrip() {
     let segment_dir = segment.data_path();
     let segment_config = segment.config().clone();
 
-    let mut pending_changes = PendingChanges::open(&segment_dir, 0).unwrap();
+    let mut pending_changes = PendingChanges::new(&segment_dir, 0).unwrap();
     assert_eq!(pending_changes.persisted_version(), 0);
 
     // Register one operation of each type
@@ -137,7 +163,7 @@ fn test_register_flush_load_roundtrip() {
     assert!(pending_changes.flusher(14).is_none());
 
     // Reconstruct the in-memory state from the log file
-    let loaded = PendingChanges::load(&segment_dir, 0).unwrap();
+    let loaded = PendingChanges::load(pending_changes.log_path()).unwrap();
     assert_eq!(loaded.persisted_version(), 14);
     assert_eq!(loaded.deleted_points(), pending_changes.deleted_points());
     assert_eq!(loaded.index_changes().len(), 2);
@@ -170,19 +196,20 @@ fn test_register_flush_load_roundtrip() {
         &IntendedVector::Absent { version: 14 },
     );
 
-    // Plain open adopts the file without loading the buffers
-    let adopted = PendingChanges::open(&segment_dir, 0).unwrap();
-    assert_eq!(adopted.persisted_version(), 14);
-    assert!(adopted.deleted_points().is_empty());
-    assert!(adopted.index_changes().is_empty());
-    assert!(adopted.vector_name_changes().is_empty());
+    // A further plain open never adopts the file: it always starts a new, uniquely named one
+    let fresh = PendingChanges::new(&segment_dir, 0).unwrap();
+    assert_ne!(fresh.log_path(), pending_changes.log_path());
+    assert_eq!(fresh.persisted_version(), 0);
+    assert!(fresh.deleted_points().is_empty());
+    assert!(fresh.index_changes().is_empty());
+    assert!(fresh.vector_name_changes().is_empty());
 }
 
 #[test]
 fn test_flusher_covers_version_without_changes() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
-    let pending_changes = PendingChanges::open(dir.path(), 0).unwrap();
+    let pending_changes = PendingChanges::new(dir.path(), 0).unwrap();
 
     // Nothing registered and version 0 already covered
     assert!(pending_changes.flusher(0).is_none());
@@ -201,7 +228,7 @@ fn test_flusher_covers_version_without_changes() {
 fn test_register_during_flush_is_not_lost_nor_covered() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
-    let mut pending_changes = PendingChanges::open(dir.path(), 0).unwrap();
+    let mut pending_changes = PendingChanges::new(dir.path(), 0).unwrap();
     pending_changes.register_delete_point(
         1.into(),
         ProxyDeletedPoint {
@@ -228,7 +255,7 @@ fn test_register_during_flush_is_not_lost_nor_covered() {
     flusher().unwrap();
     assert_eq!(pending_changes.persisted_version(), 11);
 
-    let loaded = PendingChanges::load(dir.path(), 0).unwrap();
+    let loaded = PendingChanges::load(pending_changes.log_path()).unwrap();
     assert_eq!(loaded.deleted_points().len(), 2);
 }
 
@@ -236,7 +263,7 @@ fn test_register_during_flush_is_not_lost_nor_covered() {
 fn test_flusher_skipped_after_drop() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
-    let mut pending_changes = PendingChanges::open(dir.path(), 0).unwrap();
+    let mut pending_changes = PendingChanges::new(dir.path(), 0).unwrap();
     pending_changes.register_delete_point(
         1.into(),
         ProxyDeletedPoint {
@@ -258,7 +285,7 @@ fn test_flusher_skipped_after_drop() {
 fn test_torn_tail_is_truncated() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
-    let mut pending_changes = PendingChanges::open(dir.path(), 0).unwrap();
+    let mut pending_changes = PendingChanges::new(dir.path(), 0).unwrap();
     pending_changes.register_delete_point(
         1.into(),
         ProxyDeletedPoint {
@@ -277,7 +304,7 @@ fn test_torn_tail_is_truncated() {
     mangled.extend_from_slice(&[0xAB, 0xCD]);
     fs::write(&log_path, &mangled).unwrap();
 
-    let loaded = PendingChanges::load(dir.path(), 0).unwrap();
+    let loaded = PendingChanges::load(&log_path).unwrap();
     assert_eq!(loaded.deleted_points().len(), 1);
     assert_eq!(loaded.persisted_version(), 10);
     assert_eq!(fs::metadata(&log_path).unwrap().len(), intact_len);
@@ -288,22 +315,23 @@ fn test_torn_tail_is_truncated() {
     mangled.extend_from_slice(b"partial");
     fs::write(&log_path, &mangled).unwrap();
 
-    let loaded = PendingChanges::load(dir.path(), 0).unwrap();
+    let loaded = PendingChanges::load(&log_path).unwrap();
     assert_eq!(loaded.deleted_points().len(), 1);
     assert_eq!(fs::metadata(&log_path).unwrap().len(), intact_len);
 
-    // Appending after truncation must work and keep the intact entry
-    let mut adopted = PendingChanges::open(dir.path(), 0).unwrap();
-    adopted.register_delete_point(
+    // Appending after truncation must work and keep the intact entry. This resumes the exact
+    // same file rather than opening a new one, unlike a brand new proxy would.
+    let mut resumed = PendingChanges::load(&log_path).unwrap();
+    resumed.register_delete_point(
         2.into(),
         ProxyDeletedPoint {
             local_version: 2,
             operation_version: 11,
         },
     );
-    adopted.flusher(11).unwrap()().unwrap();
+    resumed.flusher(11).unwrap()().unwrap();
 
-    let loaded = PendingChanges::load(dir.path(), 0).unwrap();
+    let loaded = PendingChanges::load(&log_path).unwrap();
     assert_eq!(loaded.deleted_points().len(), 2);
     assert_eq!(loaded.persisted_version(), 11);
 }
@@ -312,7 +340,7 @@ fn test_torn_tail_is_truncated() {
 fn test_corruption_in_middle_is_error() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
-    let mut pending_changes = PendingChanges::open(dir.path(), 0).unwrap();
+    let mut pending_changes = PendingChanges::new(dir.path(), 0).unwrap();
     pending_changes.register_delete_point(
         1.into(),
         ProxyDeletedPoint {
@@ -338,14 +366,59 @@ fn test_corruption_in_middle_is_error() {
     mangled[4] = b'X';
     fs::write(&log_path, &mangled).unwrap();
 
-    assert!(PendingChanges::load(dir.path(), 0).is_err());
+    assert!(PendingChanges::load(&log_path).is_err());
 }
 
 #[test]
-fn test_adopted_log_is_appended() {
+fn test_new_proxy_never_adopts_old_log() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
 
-    let mut pending_changes = PendingChanges::open(dir.path(), 0).unwrap();
+    let mut first = PendingChanges::new(dir.path(), 0).unwrap();
+    first.register_delete_point(
+        1.into(),
+        ProxyDeletedPoint {
+            local_version: 1,
+            operation_version: 10,
+        },
+    );
+    first.flusher(10).unwrap()().unwrap();
+    let first_log_path = first.log_path().to_path_buf();
+    drop(first);
+
+    // A new proxy on the same segment (e.g. after the first one unwrapped) never adopts the old
+    // log file: it starts a new, uniquely named one and leaves the old file untouched
+    let mut second = PendingChanges::new(dir.path(), 0).unwrap();
+    assert_ne!(second.log_path(), first_log_path);
+    assert_eq!(second.persisted_version(), 0);
+    assert!(second.deleted_points().is_empty());
+
+    second.register_delete_point(
+        2.into(),
+        ProxyDeletedPoint {
+            local_version: 2,
+            operation_version: 20,
+        },
+    );
+    second.flusher(20).unwrap()().unwrap();
+    assert_eq!(second.persisted_version(), 20);
+
+    // Both log files coexist, each still holding just its own proxy's entries
+    let loaded_first = PendingChanges::load(&first_log_path).unwrap();
+    assert_eq!(loaded_first.deleted_points().len(), 1);
+    assert_eq!(loaded_first.persisted_version(), 10);
+
+    let loaded_second = PendingChanges::load(second.log_path()).unwrap();
+    assert_eq!(loaded_second.deleted_points().len(), 1);
+    assert_eq!(loaded_second.persisted_version(), 20);
+
+    assert_eq!(list_pending_changes_log_files(dir.path()).len(), 2);
+}
+
+#[test]
+fn test_load_resumes_same_log_name() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+
+    let mut pending_changes = PendingChanges::new(dir.path(), 0).unwrap();
     pending_changes.register_delete_point(
         1.into(),
         ProxyDeletedPoint {
@@ -354,24 +427,25 @@ fn test_adopted_log_is_appended() {
         },
     );
     pending_changes.flusher(10).unwrap()().unwrap();
+    let log_path = pending_changes.log_path().to_path_buf();
     drop(pending_changes);
 
-    // A new proxy on the same segment adopts the log file and appends to it
-    let mut adopted = PendingChanges::open(dir.path(), 0).unwrap();
-    assert_eq!(adopted.persisted_version(), 10);
-    assert!(adopted.deleted_points().is_empty());
-
-    adopted.register_delete_point(
+    // Loading the same proxy's exact file and storing again must keep using that same file name
+    let mut resumed = PendingChanges::load(&log_path).unwrap();
+    assert_eq!(resumed.log_path(), log_path);
+    resumed.register_delete_point(
         2.into(),
         ProxyDeletedPoint {
             local_version: 2,
             operation_version: 20,
         },
     );
-    adopted.flusher(20).unwrap()().unwrap();
-    assert_eq!(adopted.persisted_version(), 20);
+    resumed.flusher(20).unwrap()().unwrap();
 
-    let loaded = PendingChanges::load(dir.path(), 0).unwrap();
+    assert_eq!(resumed.log_path(), log_path);
+    assert_eq!(list_pending_changes_log_files(dir.path()), vec![log_path]);
+
+    let loaded = PendingChanges::load(resumed.log_path()).unwrap();
     assert_eq!(loaded.deleted_points().len(), 2);
     assert_eq!(loaded.persisted_version(), 20);
 }
@@ -384,7 +458,7 @@ fn test_recover_pending_changes() {
     let segment_dir = segment.data_path();
     let segment_version = segment.version();
 
-    let mut pending_changes = PendingChanges::open(&segment_dir, 0).unwrap();
+    let mut pending_changes = PendingChanges::new(&segment_dir, 0).unwrap();
     pending_changes.register_delete_point(
         2.into(),
         ProxyDeletedPoint {
@@ -445,7 +519,7 @@ fn test_recover_ignore_leaves_log_untouched() {
     let segment_dir = segment.data_path();
     let segment_version = segment.version();
 
-    let mut pending_changes = PendingChanges::open(&segment_dir, 0).unwrap();
+    let mut pending_changes = PendingChanges::new(&segment_dir, 0).unwrap();
     pending_changes.register_delete_point(
         2.into(),
         ProxyDeletedPoint {
@@ -489,7 +563,7 @@ fn test_recover_stale_log_is_noop() {
 
     // The operation is already applied to the segment, e.g. because a proxy propagated its
     // changes before unwrapping and left the log file behind
-    let mut pending_changes = PendingChanges::open(&segment_dir, 0).unwrap();
+    let mut pending_changes = PendingChanges::new(&segment_dir, 0).unwrap();
     pending_changes.register_delete_point(
         3.into(),
         ProxyDeletedPoint {
@@ -531,7 +605,7 @@ fn test_recover_multiple_levels_in_order() {
 
     // Inner most proxy layer deleted point 1, the layer above later deleted point 2 and
     // re-created the index the inner layer deleted
-    let mut inner = PendingChanges::open(&segment_dir, 0).unwrap();
+    let mut inner = PendingChanges::new(&segment_dir, 0).unwrap();
     inner.register_delete_point(
         1.into(),
         ProxyDeletedPoint {
@@ -546,7 +620,7 @@ fn test_recover_multiple_levels_in_order() {
     inner.flusher(segment_version + 2).unwrap()().unwrap();
     drop(inner);
 
-    let mut outer = PendingChanges::open(&segment_dir, 1).unwrap();
+    let mut outer = PendingChanges::new(&segment_dir, 1).unwrap();
     outer.register_delete_point(
         2.into(),
         ProxyDeletedPoint {
@@ -578,6 +652,54 @@ fn test_recover_multiple_levels_in_order() {
     assert!(list_pending_changes_log_files(&segment_dir).is_empty());
 }
 
+/// Two proxy generations at the *same* level (e.g. a proxy that unwrapped without its log being
+/// cleaned up yet, followed by a new proxy that never adopts it) are not chronologically ordered
+/// by file discovery. Recovery must still replay them in the correct order.
+#[test]
+fn test_recover_same_level_multiple_generations_replayed_in_version_order() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let mut segment = build_segment(dir.path());
+    let segment_dir = segment.data_path();
+    let segment_version = segment.version();
+
+    // First proxy generation at level 0 creates the "color" index, then unwraps without the
+    // segment ever flushing, leaving its log file behind
+    let mut first = PendingChanges::new(&segment_dir, 0).unwrap();
+    first.register_index_change(
+        field("color"),
+        ProxyIndexChange::Create(keyword_schema(), segment_version + 1),
+    );
+    first.flusher(segment_version + 1).unwrap()().unwrap();
+    drop(first);
+
+    // A second proxy generation at the very same level starts fresh (it does not adopt the first
+    // one's file) and later creates a different index
+    let mut second = PendingChanges::new(&segment_dir, 0).unwrap();
+    second.register_index_change(
+        field("size"),
+        ProxyIndexChange::Create(keyword_schema(), segment_version + 2),
+    );
+    second.flusher(segment_version + 2).unwrap()().unwrap();
+    drop(second);
+
+    assert_eq!(list_pending_changes_log_files(&segment_dir).len(), 2);
+
+    // Both changes must be applied. Replaying the newer (second generation) change before the
+    // older (first generation) one would bump the segment's global version past it, silently and
+    // permanently skipping it, even though it targets a different field entirely.
+    let recovered = recover_pending_changes(&mut segment, PersistedProxyChanges::Replay).unwrap();
+    assert_eq!(recovered.replayed, 2);
+    assert!(segment.get_indexed_fields().contains_key(&field("color")));
+    assert!(segment.get_indexed_fields().contains_key(&field("size")));
+    assert_eq!(segment.version(), segment_version + 2);
+
+    segment.flush(true).unwrap();
+    for path in &recovered.log_files {
+        fs::remove_file(path).unwrap();
+    }
+    assert!(list_pending_changes_log_files(&segment_dir).is_empty());
+}
+
 #[test]
 fn test_recover_vector_name_changes() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
@@ -586,7 +708,7 @@ fn test_recover_vector_name_changes() {
     let segment_version = segment.version();
     let segment_config = segment.config().clone();
 
-    let mut pending_changes = PendingChanges::open(&segment_dir, 0).unwrap();
+    let mut pending_changes = PendingChanges::new(&segment_dir, 0).unwrap();
     // Create a brand new sparse vector name
     pending_changes.register_vector_name_create(
         "sparse_new".into(),

--- a/lib/segment/src/pending_changes/vector_name_changes.rs
+++ b/lib/segment/src/pending_changes/vector_name_changes.rs
@@ -92,7 +92,7 @@ pub struct ProxyVectorNameChanges {
 }
 
 impl ProxyVectorNameChanges {
-    /// Record a `Create` intent for `vector_name`.
+    /// Record a `Create` intent for `vector_name`, and return the recorded intent.
     ///
     /// `wrapped_config` is the segment config the proxy is wrapping; it is used
     /// to decide whether the wrapped segment already carries this name with a
@@ -106,7 +106,7 @@ impl ProxyVectorNameChanges {
         config: VectorNameConfig,
         version: SeqNumberType,
         wrapped_config: &SegmentConfig,
-    ) {
+    ) -> IntendedVector {
         // Carry forward an earlier "tainted" flag: a previous `Absent` (or a
         // previous `Present { supersedes_wrapped: true }`) means the wrapped
         // data has already been logically discarded by this proxy, so even a
@@ -118,20 +118,32 @@ impl ProxyVectorNameChanges {
         let supersedes_wrapped =
             previous_taints || wrapped_carries_stale_schema(wrapped_config, &vector_name, &config);
 
-        self.intent.insert(
-            vector_name,
-            IntendedVector::Present {
-                config,
-                version,
-                supersedes_wrapped,
-            },
-        );
+        let intent = IntendedVector::Present {
+            config,
+            version,
+            supersedes_wrapped,
+        };
+        self.intent.insert(vector_name, intent.clone());
+        intent
     }
 
     /// Record a `Delete` intent for `vector_name`.
     pub fn record_delete(&mut self, vector_name: VectorNameBuf, version: SeqNumberType) {
         self.intent
             .insert(vector_name, IntendedVector::Absent { version });
+    }
+
+    /// Insert an already-computed intent for `vector_name` as-is.
+    ///
+    /// Used to reconstruct the buffer from a persisted pending changes log, where the intent —
+    /// including its `supersedes_wrapped` flag — was computed when the change was first recorded.
+    pub fn insert_intent(&mut self, vector_name: VectorNameBuf, intent: IntendedVector) {
+        self.intent.insert(vector_name, intent);
+    }
+
+    /// Get the recorded intent for `vector_name`, if any.
+    pub fn get(&self, vector_name: &VectorName) -> Option<&IntendedVector> {
+        self.intent.get(vector_name)
     }
 
     pub fn is_empty(&self) -> bool {

--- a/lib/segment/src/pending_changes/vector_name_changes.rs
+++ b/lib/segment/src/pending_changes/vector_name_changes.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use ahash::{AHashMap, AHashSet};
 use itertools::Itertools as _;
+use serde::{Deserialize, Serialize};
 
 use crate::data_types::vector_name_config::{
     DenseVectorConfig, SparseVectorConfig, VectorNameConfig,
@@ -45,7 +46,7 @@ impl CustomIdCheckerCondition for AlwaysFalseChecker {
 /// stale storage from the wrapped segment. The intent representation keeps
 /// enough information that the apply path can clear that stale storage before
 /// installing the new schema.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum IntendedVector {
     /// The vector should exist with this configuration once the proxy drains.
     Present {

--- a/lib/segment/src/pending_changes/vector_name_changes.rs
+++ b/lib/segment/src/pending_changes/vector_name_changes.rs
@@ -1,4 +1,4 @@
-//! Pending vector-schema changes recorded in a [`super::ProxySegment`].
+//! Pending vector-schema changes recorded in a proxy segment.
 //!
 //! See [`IntendedVector`] for the rationale behind the intent representation
 //! and [`ProxyVectorNameChanges`] for the per-proxy buffer.
@@ -8,11 +8,12 @@ use std::sync::Arc;
 
 use ahash::{AHashMap, AHashSet};
 use itertools::Itertools as _;
-use segment::data_types::vector_name_config::{
+
+use crate::data_types::vector_name_config::{
     DenseVectorConfig, SparseVectorConfig, VectorNameConfig,
 };
-use segment::index::field_index::CardinalityEstimation;
-use segment::types::{
+use crate::index::field_index::CardinalityEstimation;
+use crate::types::{
     Condition, CustomIdCheckerCondition, ExtendedPointId, Filter, SegmentConfig, SeqNumberType,
     SparseVectorDataConfig, VectorDataConfig, VectorName, VectorNameBuf, WithVector,
 };
@@ -34,7 +35,7 @@ impl CustomIdCheckerCondition for AlwaysFalseChecker {
     }
 }
 
-/// Desired end-state of a single named vector inside a [`super::ProxySegment`].
+/// Desired end-state of a single named vector inside a proxy segment.
 ///
 /// `ProxyVectorNameChanges` records, for each name touched in the proxy, the
 /// final state we want the wrapped/optimised segment to converge to once the

--- a/lib/segment/src/segment/snapshot.rs
+++ b/lib/segment/src/segment/snapshot.rs
@@ -17,6 +17,7 @@ use crate::entry::snapshot_entry::SnapshotEntry;
 use crate::id_tracker::IdTracker;
 use crate::index::{PayloadIndex, VectorIndex};
 use crate::payload_storage::PayloadStorage;
+use crate::pending_changes::list_pending_changes_log_files;
 use crate::segment::{SEGMENT_STATE_FILE, SNAPSHOT_FILES_PATH, SNAPSHOT_PATH, Segment};
 use crate::types::SnapshotFormat;
 use crate::utils::path::strip_prefix;
@@ -174,13 +175,20 @@ impl Segment {
                 (file, FileVersion::from(version))
             });
 
+        // Pending proxy changes logs, if any proxy segment persisted buffered changes for this
+        // segment. Carried in snapshots so recovery replays them onto the segment.
+        let pending_changes_files = list_pending_changes_log_files(&self.segment_path)
+            .into_iter()
+            .map(|file| (file, FileVersion::Unversioned));
+
         let mut file_versions = HashMap::with_capacity(files.len());
 
         let files = files
             .chain(vector_storage_files)
             .chain(payload_storage_files)
             .chain(immutable_files)
-            .chain(payload_index_files);
+            .chain(payload_index_files)
+            .chain(pending_changes_files);
 
         for (path, version) in files {
             // All segment files should be contained within segment directory
@@ -347,6 +355,14 @@ pub fn snapshot_files(
     let version_file_path = segment.segment_path.join(VERSION_FILE);
     tar.blocking_append_file(&version_file_path, Path::new(VERSION_FILE))
         .map_err(|err| failed_to_add("segment version file", &version_file_path, err))?;
+
+    // Pending proxy changes logs, if any proxy segment persisted buffered changes for this
+    // segment; replayed onto the segment when it is loaded on recovery
+    for file in list_pending_changes_log_files(&segment.segment_path) {
+        let stripped_path = strip_prefix(&file, &segment.segment_path)?;
+        tar.blocking_append_file(&file, stripped_path)
+            .map_err(|err| failed_to_add("pending changes log file", &file, err))?;
+    }
 
     Ok(())
 }

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -285,8 +285,14 @@ fn test_snapshot(#[case] format: SnapshotFormat) {
     assert!(entry.path().is_dir());
     assert_eq!(entry.file_name(), segment_id);
 
-    let restored_segment =
-        load_segment(&entry.path(), Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
+    let restored_segment = load_segment(
+        &entry.path(),
+        Uuid::nil(),
+        None,
+        &AtomicBool::new(false),
+        false,
+    )
+    .unwrap();
 
     // validate restored snapshot is the same as original segment
     assert_eq!(
@@ -392,8 +398,14 @@ fn test_snapshot_streamable_without_files_wrapper() {
 
     assert!(segment_path.is_dir());
 
-    let restored_segment =
-        load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
+    let restored_segment = load_segment(
+        &segment_path,
+        Uuid::nil(),
+        None,
+        &AtomicBool::new(false),
+        false,
+    )
+    .unwrap();
 
     assert_eq!(
         segment.total_point_count(),
@@ -2076,7 +2088,8 @@ fn test_dense_deferred_points() {
     drop(segment);
 
     // Reopen segment to ensure deferred points are loaded correctly from disk
-    let segment = load_segment(&path, Uuid::nil(), Some(13), &AtomicBool::new(false)).unwrap();
+    let segment =
+        load_segment(&path, Uuid::nil(), Some(13), &AtomicBool::new(false), false).unwrap();
 
     // Deferred points should still be the same after reopening
     assert!(

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -2832,7 +2832,14 @@ fn test_flush_of_unfinished_operation_reloads_dirty() {
     .expect("flush must not fail");
     drop(segment);
 
-    let reloaded = load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
+    let reloaded = load_segment(
+        &segment_path,
+        Uuid::nil(),
+        None,
+        &AtomicBool::new(false),
+        false,
+    )
+    .unwrap();
 
     // Coming back at 10 would make the segment look clean, and the WAL replay of operation 10
     // would sit in memory with nothing left to flush it.

--- a/lib/segment/src/segment/tests/test_immutable_payload_index_files.rs
+++ b/lib/segment/src/segment/tests/test_immutable_payload_index_files.rs
@@ -445,8 +445,14 @@ fn payload_index_files_are_immutable_after_build() {
     // an index state that still answers queries correctly given the runtime
     // deletion bitvec.
     drop(segment);
-    let mut reloaded =
-        load_segment(&segment_path, segment_uuid, None, &AtomicBool::new(false)).unwrap();
+    let mut reloaded = load_segment(
+        &segment_path,
+        segment_uuid,
+        None,
+        &AtomicBool::new(false),
+        false,
+    )
+    .unwrap();
     let after_reload = snapshot_dir(&payload_index_dir);
     assert_snapshots_equal(&baseline, &after_reload, "after reload");
     assert_query_counts(&reloaded, &live, &queries, "after reload");
@@ -558,6 +564,7 @@ fn snapshot_roundtrip_recovers_block_index_sidecars(#[case] format: crate::types
         uuid::Uuid::nil(),
         None,
         &AtomicBool::new(false),
+        false,
     )
     .unwrap();
 

--- a/lib/segment/src/segment/tests/test_vector_name_ops.rs
+++ b/lib/segment/src/segment/tests/test_vector_name_ops.rs
@@ -421,7 +421,7 @@ fn test_persistence_after_create_with_data() {
     drop(segment);
 
     let stopped = AtomicBool::new(false);
-    let loaded = load_segment(&segment_path, segment_uuid, None, &stopped).unwrap();
+    let loaded = load_segment(&segment_path, segment_uuid, None, &stopped, false).unwrap();
 
     // Config persisted
     assert_eq!(loaded.segment_config.vector_data["persisted"].size, new_dim);
@@ -525,7 +525,7 @@ fn check_recreate_does_not_resurrect(
     drop(segment);
 
     let stopped = AtomicBool::new(false);
-    let loaded = load_segment(&segment_path, segment_uuid, None, &stopped).unwrap();
+    let loaded = load_segment(&segment_path, segment_uuid, None, &stopped, false).unwrap();
     let v2 = loaded.vector("v2", new_point, &hw).unwrap();
     assert!(
         v2.is_none(),
@@ -575,7 +575,7 @@ fn test_persistence_after_delete_with_data() {
     drop(segment);
 
     let stopped = AtomicBool::new(false);
-    let loaded = load_segment(&segment_path, segment_uuid, None, &stopped).unwrap();
+    let loaded = load_segment(&segment_path, segment_uuid, None, &stopped, false).unwrap();
 
     assert!(!loaded.segment_config.vector_data.contains_key("temp"));
     assert_eq!(loaded.available_point_count(), NUM_POINTS + 1);

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -536,6 +536,7 @@ impl SegmentBuilder {
             segments_path,
             Uuid::new_v4(),
             None,
+            true,
             ResourcePermit::dummy(get_num_indexing_threads(0) as u32),
             &AtomicBool::new(false),
             &mut rand::rng(),
@@ -545,12 +546,18 @@ impl SegmentBuilder {
         .unwrap()
     }
 
+    /// Build the segment.
+    ///
+    /// If `ready` is false, the version will not be stored, so the segment is skipped on
+    /// restart. The caller is then responsible for saving the version manually, once it is
+    /// safe to do so, to make the segment ready.
     #[allow(clippy::too_many_arguments)]
     pub fn build<R: Rng + ?Sized>(
         self,
         segments_path: &Path,
         segment_uuid: Uuid,
         deferred_internal_id: Option<PointOffsetType>,
+        ready: bool,
         permit: ResourcePermit,
         stopped: &AtomicBool,
         rng: &mut R,
@@ -812,8 +819,10 @@ impl SegmentBuilder {
                 temp_dir.path(),
             )?;
 
-            // After version is saved, segment can be loaded on restart
-            SegmentVersion::save(temp_dir.path())?;
+            // Postpone until ready: this segment may still be missing pending proxy changes
+            if ready {
+                SegmentVersion::save(temp_dir.path())?;
+            }
             // All temp data is evicted from RAM
             temp_dir
         };
@@ -828,6 +837,7 @@ impl SegmentBuilder {
             segment_uuid,
             deferred_internal_id,
             stopped,
+            true, // ignore_missing_version: reloaded here before the version save above, if postponed
         )
     }
 

--- a/lib/segment/src/segment_constructor/segment_constructor_base/segment.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/segment.rs
@@ -106,48 +106,61 @@ pub fn normalize_segment_dir(path: &Path) -> OperationResult<Option<(PathBuf, Uu
 /// Preferably, the `uuid` should match the last component of `path`.
 /// In production use [`normalize_segment_dir`] to obtain correct path and UUID.
 /// In tests it is acceptable to pass an arbitrary UUID, e.g., [`Uuid::nil()`].
+///
+/// `ignore_missing_version` controls whether a missing version file is tolerated instead of
+/// an error. Pass `false` unless reloading a segment this same process just built with
+/// `ready: false` (see `SegmentBuilder::build`), whose version file is intentionally not yet
+/// written.
 pub fn load_segment(
     path: &Path,
     uuid: Uuid,
     deferred_internal_id: Option<PointOffsetType>,
     stopped: &AtomicBool,
+    ignore_missing_version: bool,
 ) -> OperationResult<Segment> {
     let total_started = Instant::now();
 
-    let stored_version = SegmentVersion::load_universal(&MmapFs, path)?.ok_or_else(|| {
-        OperationError::service_error(format!(
-            "Segment version file not found in segment: {}",
-            path.display()
-        ))
-    })?;
+    let stored_version = SegmentVersion::load_universal(&MmapFs, path)?;
 
-    let app_version = SegmentVersion::current();
+    match stored_version {
+        Some(stored_version) => {
+            let app_version = SegmentVersion::current();
 
-    if stored_version != app_version {
-        info!("Migrating segment {stored_version} -> {app_version}");
+            if stored_version != app_version {
+                info!("Migrating segment {stored_version} -> {app_version}");
 
-        if stored_version > app_version {
+                if stored_version > app_version {
+                    return Err(OperationError::service_error(format!(
+                        "Data version {stored_version} is newer than application version {app_version}. \
+                        Please upgrade the application. Compatibility is not guaranteed."
+                    )));
+                }
+
+                if stored_version.major == 0 && stored_version.minor < 3 {
+                    return Err(OperationError::service_error(format!(
+                        "Segment version({stored_version}) is not compatible with current version({app_version})"
+                    )));
+                }
+
+                if stored_version.major == 0 && stored_version.minor == 3 {
+                    let segment_state = load_segment_state_v3(path)?;
+                    Segment::save_state(&segment_state, path)?;
+                } else if stored_version.major == 0 && stored_version.minor <= 5 {
+                    let segment_state = load_segment_state_v5(path)?;
+                    Segment::save_state(&segment_state, path)?;
+                }
+
+                SegmentVersion::save(path)?
+            }
+        }
+        None if !ignore_missing_version => {
             return Err(OperationError::service_error(format!(
-                "Data version {stored_version} is newer than application version {app_version}. \
-                Please upgrade the application. Compatibility is not guaranteed."
+                "Segment version file not found in segment: {}",
+                path.display()
             )));
         }
-
-        if stored_version.major == 0 && stored_version.minor < 3 {
-            return Err(OperationError::service_error(format!(
-                "Segment version({stored_version}) is not compatible with current version({app_version})"
-            )));
-        }
-
-        if stored_version.major == 0 && stored_version.minor == 3 {
-            let segment_state = load_segment_state_v3(path)?;
-            Segment::save_state(&segment_state, path)?;
-        } else if stored_version.major == 0 && stored_version.minor <= 5 {
-            let segment_state = load_segment_state_v5(path)?;
-            Segment::save_state(&segment_state, path)?;
-        }
-
-        SegmentVersion::save(path)?
+        // Freshly built by this process (`ready: false`); nothing to migrate yet.
+        None => {}
     }
 
     let started = Instant::now();

--- a/lib/segment/tests/append_only_storages.rs
+++ b/lib/segment/tests/append_only_storages.rs
@@ -134,8 +134,14 @@ fn append_only_storages_serve_the_ordinary_write_paths() {
     drop(segment);
 
     // Everything survives a reload through the ordinary loader.
-    let mut segment =
-        load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
+    let mut segment = load_segment(
+        &segment_path,
+        Uuid::nil(),
+        None,
+        &AtomicBool::new(false),
+        false,
+    )
+    .unwrap();
     assert!(segment.append_only_mutations);
 
     // The repair every shard loader runs; deleting the leftovers it finds would

--- a/lib/segment/tests/integration/segment_builder_test.rs
+++ b/lib/segment/tests/integration/segment_builder_test.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 use common::budget::ResourcePermit;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::progress_tracker::ProgressTracker;
+use common::storage_version::VERSION_FILE;
 use fs_err as fs;
 use itertools::Itertools;
 use segment::common::operation_error::OperationError;
@@ -17,6 +18,7 @@ use segment::id_tracker::IdTrackerRead;
 use segment::index::hnsw_index::get_num_indexing_threads;
 use segment::json_path::JsonPath;
 use segment::segment::Segment;
+use segment::segment_constructor::normalize_segment_dir;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
 use segment::segment_constructor::simple_segment_constructor::build_simple_segment_with_payload_storage;
 use segment::types::{
@@ -305,6 +307,53 @@ fn test_building_new_sparse_segment() {
     assert_eq!(merged_segment.point_version(3.into()), Some(100));
 }
 
+#[test]
+fn test_build_not_ready_defers_version_file() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let temp_dir = Builder::new().prefix("segment_temp_dir").tempdir().unwrap();
+
+    let stopped = AtomicBool::new(false);
+    let segment1 = build_segment_1(dir.path());
+
+    let mut builder = SegmentBuilder::new(
+        temp_dir.path(),
+        &segment1.segment_config,
+        &HnswGlobalConfig::default(),
+    )
+    .unwrap();
+
+    let hw_counter = HardwareCounterCell::new();
+    builder.update(&[&segment1], &stopped, &hw_counter).unwrap();
+
+    let permit = ResourcePermit::dummy(get_num_indexing_threads(0) as u32);
+    let mut rng = rand::rng();
+
+    let built_segment = builder
+        .build(
+            dir.path(),
+            Uuid::new_v4(),
+            None,
+            false, // ready
+            permit,
+            &stopped,
+            &mut rng,
+            &hw_counter,
+            ProgressTracker::new_for_test(),
+        )
+        .unwrap();
+
+    let segment_path = built_segment.segment_path.clone();
+    drop(built_segment);
+
+    // Version file must not be written while not `ready`.
+    assert!(!segment_path.join(VERSION_FILE).is_file());
+
+    // A restart (or snapshot recovery) must not pick this segment up before it is marked
+    // ready; `normalize_segment_dir` discards it, same as any other half-built segment.
+    assert!(normalize_segment_dir(&segment_path).unwrap().is_none());
+    assert!(!segment_path.exists());
+}
+
 fn estimate_build_time(segment: &Segment, stop_delay_millis: Option<u64>) -> (u64, bool) {
     let mut rng = rand::rng();
     let stopped = Arc::new(AtomicBool::new(false));
@@ -362,6 +411,7 @@ fn estimate_build_time(segment: &Segment, stop_delay_millis: Option<u64>) -> (u6
         dir.path(),
         Uuid::new_v4(),
         None,
+        true,
         permit,
         &stopped,
         &mut rng,

--- a/lib/segment/tests/integration/segment_on_disk_snapshot.rs
+++ b/lib/segment/tests/integration/segment_on_disk_snapshot.rs
@@ -206,8 +206,14 @@ fn test_on_disk_segment_snapshot(#[case] format: SnapshotFormat) {
     assert!(entry.path().is_dir());
     assert_eq!(entry.file_name(), segment_id);
 
-    let restored_segment =
-        load_segment(&entry.path(), Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
+    let restored_segment = load_segment(
+        &entry.path(),
+        Uuid::nil(),
+        None,
+        &AtomicBool::new(false),
+        false,
+    )
+    .unwrap();
 
     // validate restored snapshot is the same as original segment
     assert_eq!(

--- a/lib/segment/tests/integration/segment_tests.rs
+++ b/lib/segment/tests/integration/segment_tests.rs
@@ -207,7 +207,7 @@ fn ordered_deletion_test() {
         segment.segment_path.clone()
     };
 
-    let segment = load_segment(&path, Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
+    let segment = load_segment(&path, Uuid::nil(), None, &AtomicBool::new(false), false).unwrap();
     let query_vector = [1.0, 1.0, 1.0, 1.0].into();
 
     let res = segment

--- a/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
+++ b/lib/segment/tests/integration/sparse_vector_index_search_tests.rs
@@ -650,7 +650,7 @@ fn sparse_vector_index_persistence_test() {
 
     // persistence using rebuild of inverted index
     // for appendable segment vector index has to be rebuilt
-    let segment = load_segment(&path, Uuid::nil(), None, &stopped).unwrap();
+    let segment = load_segment(&path, Uuid::nil(), None, &stopped, false).unwrap();
     let search_after_reload_result = segment
         .search(
             SPARSE_VECTOR_NAME,

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -615,6 +615,13 @@ fn finish_optimization(
             .unwrap();
     }
 
+    // Force flush propagated changes in segment
+    // Up until here all proxied changes are only durably persisted in the associated proxy
+    // segment, but we will drop this last source of persisted data a bit further down. We must
+    // therefore flush this segment to persist the changes in a new location. WAL recovery would
+    // not help us here, because all proapgated changes are already acknowledged in the WAL.
+    optimized_segment.flush(true)?;
+
     // Replace proxy segments with new optimized segment
     let point_count = optimized_segment.available_point_count();
     let optimized_segment_version = optimized_segment.version();

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -659,13 +659,15 @@ fn finish_optimization(
     // `SegmentHolder::register_post_flush_action`.
     //
     // This cap has to be tracked at the holder level because the proxy can no longer
-    // impose it. While a proxy was a member of the holder it pinned the WAL acknowledge for
-    // free: its `persistent_version` reported the wrapped source's durable point while its
-    // `version` climbed with every propagated change, so `flush_all` saw unsaved work and
-    // capped the ack there. The `swap_new` above evicted the proxies, so that contribution is
-    // gone from the holder's flush accounting even though the source files it protected are
-    // still on disk. `register_segment_drop` re-expresses the same pin independently of segment
-    // membership, snapshotting each proxy's final `persistent_version` as `ack_pin`.
+    // impose it. While a proxy was a member of the holder, `flush_all` accounted for it like any
+    // other segment: its `persistent_version` covers the wrapped source's durable point plus
+    // whatever the proxy persisted into its pending changes log, and anything buffered past that
+    // showed up as unsaved work capping the ack. The `swap_new` above evicted the proxies, so
+    // that contribution is gone from the holder's flush accounting even though the source files
+    // (and their pending changes logs) it protected are still on disk, while the optimized
+    // segment holding the same operations is not durable yet. `register_segment_drop`
+    // re-expresses the same pin independently of segment membership, snapshotting each proxy's
+    // final `persistent_version` as `ack_pin`.
     for proxy in proxies {
         let ack_pin = proxy.get().read().persistent_version();
         read_segment_holder.register_segment_drop(optimized_segment_version, ack_pin, proxy);

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -1046,6 +1046,7 @@ pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
 #[cfg(test)]
 mod tests {
     use common::counter::hardware_counter::HardwareCounterCell;
+    use common::flags::{FeatureFlags, init_feature_flags};
     use common::types::DeferredBehavior;
     use tempfile::Builder;
 
@@ -1103,6 +1104,11 @@ mod tests {
     #[test]
     fn unwrap_proxy_removes_pending_changes_log_after_flush() {
         use crate::segment_holder::FlushMode;
+
+        init_feature_flags(FeatureFlags {
+            persist_proxy_segments: true,
+            ..Default::default()
+        });
 
         let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
         let hw_counter = HardwareCounterCell::new();

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -405,6 +405,9 @@ fn build_new_segment<F: ?Sized + OptimizationStrategy>(
         segments_path,
         output_segment_uuid,
         deferred_internal_id,
+        // Don't mark segment as ready after building. This function is only used in the optimizer.
+        // We must first propagate proxied changes into the optimized segment before marking ready.
+        false,
         indexing_permit,
         stopped,
         &mut rng,
@@ -615,6 +618,7 @@ fn finish_optimization(
     // Replace proxy segments with new optimized segment
     let point_count = optimized_segment.available_point_count();
     let optimized_segment_version = optimized_segment.version();
+    let optimized_segment_path = optimized_segment.segment_path.clone();
     let mut writable_segment_holder = RwLockUpgradableReadGuard::upgrade(upgradable_segment_holder);
 
     let (_, proxies) = writable_segment_holder.swap_new(optimized_segment, proxy_ids);
@@ -657,6 +661,9 @@ fn finish_optimization(
     // as we don't want to have a situation, where new segment is not yet registered, but
     // old segment data is already dropped.
     read_segment_holder.sync_segment_manifest(None)?;
+
+    // All pending proxy changes are now applied — safe to make loadable on restart.
+    SegmentVersion::save(&optimized_segment_path)?;
 
     // Don't destroy the replaced segments' data yet. Points were copy-on-write moved out of them
     // (and out of the optimized segment's in-memory state, which the next optimization bakes into

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -138,6 +138,17 @@ pub fn unwrap_proxy(
                     log::warn!("Attempt to unwrap raw segment! Should not happen.");
                 }
                 LockedSegment::Proxy(proxy_segment) => {
+                    // The wrapped segment is put back into the segment holder, so all changes
+                    // buffered in the proxy must be propagated into it first. Failing to
+                    // propagate loses in-memory state, but is recovered on restart: the
+                    // persisted pending changes log stays behind and is replayed then, and
+                    // everything past it is replayed from the WAL.
+                    if let Err(err) = proxy_segment.write().propagate_to_wrapped() {
+                        log::error!(
+                            "Propagating proxy segment {proxy_id} changes to wrapped segment failed, ignoring: {err}",
+                        );
+                    }
+
                     let wrapped_segment = proxy_segment.read().wrapped_segment.clone();
                     segments_lock.replace(proxy_id, wrapped_segment)?;
                 }

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -844,7 +844,7 @@ pub fn execute_optimization<F: ?Sized + OptimizationStrategy>(
 
     let mut proxies = Vec::new();
     for sg in input_segments.iter() {
-        let proxy = UnsyncedProxySegment::new(sg.clone());
+        let proxy = UnsyncedProxySegment::new(sg.clone())?;
         // Wrapped segment is fresh, so it has no operations
         // Operation with number 0 will be applied
         if let Some(extra_cow_segment) = &extra_cow_segment_opt {

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -41,8 +41,8 @@ use crate::proxy_segment::{
     UnsyncedProxySegment,
 };
 use crate::quota::{self, DiskFit};
-use crate::segment_holder::SegmentId;
 use crate::segment_holder::locked::LockedSegmentHolder;
+use crate::segment_holder::{PostFlushOutcome, SegmentId};
 use crate::segment_manifest::NewSegmentToken;
 
 /// Result of optimization execution
@@ -91,6 +91,9 @@ pub trait OptimizationStrategy: Send {
 /// Proxied changes (deleted points, index and vector-name changes) are always propagated into the
 /// wrapped segments first, so they are not lost when the proxies are dropped. If that propagation
 /// fails, no proxy is unwrapped and the error is returned.
+///
+/// Each proxy's pending changes log file should be deleted after the next segments flush cycle. It
+/// is left on disk now, but it schedules a post flush action to remove it later.
 ///
 /// # Arguments
 ///
@@ -143,14 +146,38 @@ pub fn unwrap_proxy(
                     // propagate loses in-memory state, but is recovered on restart: the
                     // persisted pending changes log stays behind and is replayed then, and
                     // everything past it is replayed from the WAL.
-                    if let Err(err) = proxy_segment.write().propagate_to_wrapped() {
+                    let propagated = proxy_segment.write().propagate_to_wrapped();
+                    if let Err(err) = &propagated {
                         log::error!(
                             "Propagating proxy segment {proxy_id} changes to wrapped segment failed, ignoring: {err}",
                         );
                     }
 
-                    let wrapped_segment = proxy_segment.read().wrapped_segment.clone();
-                    segments_lock.replace(proxy_id, wrapped_segment)?;
+                    let proxy_segment_read = proxy_segment.read();
+                    let wrapped_segment = proxy_segment_read.wrapped_segment.clone();
+                    let log_path = proxy_segment_read.pending_changes_log_path().to_path_buf();
+                    drop(proxy_segment_read);
+
+                    segments_lock.replace(proxy_id, wrapped_segment.clone())?;
+
+                    // Schedule proxy log file to delete after next flush cycle
+                    if propagated.is_ok() {
+                        let ready_at = wrapped_segment.get().read().version();
+                        segments_lock.register_post_flush_action(ready_at, ready_at, move || {
+                            match fs::remove_file(&log_path) {
+                                Ok(()) => {}
+                                // File may never have existed on disk at all if never flushed before unwrap
+                                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                                Err(err) => {
+                                    return Err(OperationError::service_error(format!(
+                                        "Failed to remove pending changes log {}: {err}",
+                                        log_path.display(),
+                                    )));
+                                }
+                            }
+                            Ok(PostFlushOutcome::Done)
+                        });
+                    }
                 }
             }
         }
@@ -1066,6 +1093,50 @@ mod tests {
                 .has_point(1.into(), DeferredBehavior::WithDeferred),
             "deletion recorded on the proxy must reach the wrapped segment before it goes back \
              into the holder",
+        );
+    }
+
+    /// Unwrapping a proxy must not delete its pending changes log file right away (that would not
+    /// be crash safe), but it must not leave the file behind forever either: once the wrapped
+    /// segment durably persists past the propagated changes, a later flush must remove it, without
+    /// requiring a restart.
+    #[test]
+    fn unwrap_proxy_removes_pending_changes_log_after_flush() {
+        use crate::segment_holder::FlushMode;
+
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        let wrapped = LockedSegment::new(build_segment_1(dir.path()));
+        let mut holder = SegmentHolder::default();
+        let segment_id = holder.add_new_locked(wrapped.clone());
+
+        // Delete a point through the proxy and flush it, so the pending change is actually
+        // persisted to its log file on disk; otherwise there is nothing to clean up.
+        let mut proxy = ProxySegment::new(wrapped.clone());
+        let log_path = proxy.pending_changes_log_path().to_path_buf();
+        proxy.delete_point(100, 1.into(), &hw_counter).unwrap();
+        proxy.flush(false).unwrap();
+        assert!(log_path.is_file(), "log file must exist once flushed");
+
+        let holder = LockedSegmentHolder::new(holder);
+        holder
+            .write()
+            .replace(segment_id, LockedSegment::from(proxy))
+            .unwrap();
+
+        unwrap_proxy(&holder, &[segment_id]).unwrap();
+        assert!(
+            log_path.is_file(),
+            "unwrapping must leave the log file in place until the wrapped segment durably \
+             persists the propagated changes",
+        );
+
+        holder.read().flush_all(FlushMode::Sync, true).unwrap();
+        assert!(
+            !log_path.is_file(),
+            "the log file must be removed once the wrapped segment flushed past the propagated \
+             changes",
         );
     }
 

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -7,11 +7,11 @@ mod tests;
 use std::borrow::Cow;
 use std::cmp::max;
 
-use ahash::AHashMap;
 use common::bitvec::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use segment::common::operation_error::OperationResult;
+use segment::pending_changes::PendingChanges;
 pub use segment::pending_changes::{
     DeletedPoints, IntendedVector, ProxyDeletedPoint, ProxyIndexChange, ProxyIndexChanges,
     ProxyVectorNameChanges,
@@ -31,10 +31,10 @@ pub struct ProxySegment {
     /// Present if the wrapped segment is a plain segment
     /// Used for faster deletion checks
     deleted_mask: Option<BitVec>,
-    changed_indexes: ProxyIndexChanges,
-    changed_vector_names: ProxyVectorNameChanges,
-    /// Points which should no longer used from wrapped_segment
-    deleted_points: DeletedPoints,
+    /// Pending point deletes, payload index changes and vector name changes buffered by this
+    /// proxy, along with their persistence into the pending changes log file inside the wrapped
+    /// segment's directory.
+    pending_changes: PendingChanges,
     deleted_deferred_count: usize,
     wrapped_config: SegmentConfig,
 
@@ -69,27 +69,43 @@ impl UnsyncedProxySegment {
     /// segment-holder write lock (see the type-level docs). The mask is read exactly once, later,
     /// by [`Self::finalize`] — which is also the only way to turn this into a usable
     /// [`ProxySegment`], so the sync cannot be forgotten nor done twice.
-    pub fn new(segment: LockedSegment) -> Self {
-        if matches!(segment, LockedSegment::Proxy(_)) {
-            log::debug!("Double proxy segment creation");
-        }
-
-        let (wrapped_config, version) = {
+    ///
+    /// Opens the pending changes log for this proxy layer inside the wrapped segment's
+    /// directory. Wrapping a segment that already is a proxy uses the next layer up, writing to a
+    /// dedicated log file. If a log file for this layer already exists — left behind by a
+    /// previous proxy that propagated its changes into the segment before unwrapping — it is
+    /// adopted and appended to.
+    pub fn new(segment: LockedSegment) -> OperationResult<Self> {
+        let (wrapped_config, version, data_path) = {
             let read_segment = segment.get().read();
-            (read_segment.config().clone(), read_segment.version())
+            (
+                read_segment.config().clone(),
+                read_segment.version(),
+                read_segment.data_path(),
+            )
         };
 
-        UnsyncedProxySegment(ProxySegment {
+        // Each proxy layer writes its pending changes to a dedicated log file; wrapping another
+        // proxy means this proxy is one layer further up
+        let pending_changes_level = match &segment {
+            LockedSegment::Original(_) => 0,
+            LockedSegment::Proxy(proxy_segment) => {
+                log::debug!("Double proxy segment creation");
+                proxy_segment.read().pending_changes.level() + 1
+            }
+        };
+
+        let pending_changes = PendingChanges::open(&data_path, pending_changes_level)?;
+
+        Ok(UnsyncedProxySegment(ProxySegment {
             wrapped_segment: segment,
             // Synced only in `finalize`, once the wrapped segment is frozen.
             deleted_mask: None,
-            changed_indexes: ProxyIndexChanges::default(),
-            changed_vector_names: ProxyVectorNameChanges::default(),
-            deleted_points: AHashMap::new(),
+            pending_changes,
             deleted_deferred_count: 0,
             wrapped_config,
             version,
-        })
+        }))
     }
 
     /// Sync `deleted_mask` from the now-frozen wrapped segment and return the usable proxy.
@@ -128,7 +144,9 @@ impl ProxySegment {
     /// [`UnsyncedProxySegment`].
     #[cfg(feature = "testing")]
     pub fn new(segment: LockedSegment) -> Self {
-        UnsyncedProxySegment::new(segment).finalize()
+        UnsyncedProxySegment::new(segment)
+            .expect("failed to open proxy segment pending changes")
+            .finalize()
     }
 
     /// Read the wrapped segment's deleted bitvec into `deleted_mask`.
@@ -241,6 +259,11 @@ impl ProxySegment {
     /// This is required if making both the wrapped segment and the writable segment available in a
     /// shard holder at the same time. If the wrapped segment is thrown away, then this is not
     /// required.
+    ///
+    /// The pending changes log file is deliberately left in place: deleting it before the wrapped
+    /// segment has flushed the propagated changes would not be crash safe. It is cleaned up on
+    /// restart and when the segment directory is dropped, and a new proxy on the same segment
+    /// adopts it. Replaying it is safe because all operations are version gated.
     pub fn propagate_to_wrapped(&mut self) -> OperationResult<()> {
         // Important: we must not keep a write lock on the wrapped segment for the duration of this
         // function to prevent a deadlock. The search functions conflict with it trying to take a
@@ -255,9 +278,10 @@ impl ProxySegment {
         // Point deletions bump the segment version, can cause index changes to be ignored
         // Lock ordering is important here and must match the flush function to prevent a deadlock
         {
-            if !self.changed_indexes.is_empty() {
+            if !self.pending_changes.index_changes().is_empty() {
                 wrapped_segment.with_upgraded(|wrapped_segment| {
-                    for (field_name, change) in self.changed_indexes.iter_ordered() {
+                    for (field_name, change) in self.pending_changes.index_changes().iter_ordered()
+                    {
                         debug_assert!(
                             change.version() >= wrapped_segment.version(),
                             "proxied index change should have newer version than segment",
@@ -283,7 +307,7 @@ impl ProxySegment {
                     }
                     OperationResult::Ok(())
                 })?;
-                self.changed_indexes.clear();
+                self.pending_changes.clear_index_changes();
             }
         }
 
@@ -294,9 +318,11 @@ impl ProxySegment {
         // Alternatively we can interleave index, vector name and deletion changes and apply them
         // in exactly the same order they arrive, but that requires more complex changes.
         {
-            if !self.changed_vector_names.is_empty() {
+            if !self.pending_changes.vector_name_changes().is_empty() {
                 wrapped_segment.with_upgraded(|wrapped_segment| {
-                    for (vector_name, intent) in self.changed_vector_names.iter_ordered() {
+                    for (vector_name, intent) in
+                        self.pending_changes.vector_name_changes().iter_ordered()
+                    {
                         match intent {
                             IntendedVector::Absent { version } => {
                                 let op_num = max(*version, wrapped_segment.version());
@@ -320,16 +346,16 @@ impl ProxySegment {
                     }
                     OperationResult::Ok(())
                 })?;
-                self.changed_vector_names.clear();
+                self.pending_changes.clear_vector_name_changes();
             }
         }
 
         // Propagate deleted points
         // Lock ordering is important here and must match the flush function to prevent a deadlock
         {
-            if !self.deleted_points.is_empty() {
+            if !self.pending_changes.deleted_points().is_empty() {
                 wrapped_segment.with_upgraded(|wrapped_segment| {
-                    for (point_id, versions) in self.deleted_points.iter() {
+                    for (point_id, versions) in self.pending_changes.deleted_points().iter() {
                         // Note:
                         // Queued deletes may have an older version than what is currently in the
                         // wrapped segment. Such deletes are ignored because the point in the
@@ -344,7 +370,7 @@ impl ProxySegment {
                     }
                     OperationResult::Ok(())
                 })?;
-                self.deleted_points.clear();
+                self.pending_changes.clear_deleted_points();
                 self.deleted_deferred_count = 0;
 
                 // Note: We do not clear the deleted mask here, as it provides
@@ -357,14 +383,14 @@ impl ProxySegment {
     }
 
     pub fn get_deleted_points(&self) -> &DeletedPoints {
-        &self.deleted_points
+        self.pending_changes.deleted_points()
     }
 
     pub fn get_index_changes(&self) -> &ProxyIndexChanges {
-        &self.changed_indexes
+        self.pending_changes.index_changes()
     }
 
     pub fn get_vector_name_changes(&self) -> &ProxyVectorNameChanges {
-        &self.changed_vector_names
+        self.pending_changes.vector_name_changes()
     }
 }

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -71,10 +71,10 @@ impl UnsyncedProxySegment {
     /// [`ProxySegment`], so the sync cannot be forgotten nor done twice.
     ///
     /// Opens the pending changes log for this proxy layer inside the wrapped segment's
-    /// directory. Wrapping a segment that already is a proxy uses the next layer up, writing to a
-    /// dedicated log file. If a log file for this layer already exists — left behind by a
-    /// previous proxy that propagated its changes into the segment before unwrapping — it is
-    /// adopted and appended to.
+    /// directory, under a freshly minted, uniquely named log file. Wrapping a segment that
+    /// already is a proxy uses the next layer up, writing to its own dedicated log file. This
+    /// never reuses a log file left behind by an earlier proxy at the same level that propagated
+    /// its changes into the segment before unwrapping; that file is left untouched.
     pub fn new(segment: LockedSegment) -> OperationResult<Self> {
         let (wrapped_config, version, data_path) = {
             let read_segment = segment.get().read();
@@ -95,7 +95,7 @@ impl UnsyncedProxySegment {
             }
         };
 
-        let pending_changes = PendingChanges::open(&data_path, pending_changes_level)?;
+        let pending_changes = PendingChanges::new(&data_path, pending_changes_level)?;
 
         Ok(UnsyncedProxySegment(ProxySegment {
             wrapped_segment: segment,

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -6,6 +6,7 @@ mod tests;
 
 use std::borrow::Cow;
 use std::cmp::max;
+use std::path::Path;
 
 use common::bitvec::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -259,10 +260,8 @@ impl ProxySegment {
     /// Required before making the wrapped segment available in the shard holder. If the wrapped
     /// segment is thrown away, propagating is not needed.
     ///
-    /// The pending changes log file is deliberately left in place: deleting it before the wrapped
-    /// segment has flushed the propagated changes would not be crash safe. It is cleaned up on
-    /// restart and when the segment directory is dropped, and a new proxy on the same segment
-    /// adopts it. Replaying it is safe because all operations are version gated.
+    /// The pending changes log file is left in place here. `unwarp_proxy` is responsible for
+    /// removing it.
     pub fn propagate_to_wrapped(&mut self) -> OperationResult<()> {
         // Important: we must not keep a write lock on the wrapped segment for the duration of this
         // function to prevent a deadlock. The search functions conflict with it trying to take a
@@ -379,6 +378,10 @@ impl ProxySegment {
         }
 
         Ok(())
+    }
+
+    pub fn pending_changes_log_path(&self) -> &Path {
+        self.pending_changes.log_path()
     }
 
     pub fn get_deleted_points(&self) -> &DeletedPoints {

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -1,6 +1,5 @@
 pub mod segment_entry;
 pub mod snapshot_entry;
-mod vector_name_changes;
 
 #[cfg(test)]
 mod tests;
@@ -12,14 +11,14 @@ use ahash::AHashMap;
 use common::bitvec::BitVec;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use itertools::Itertools as _;
 use segment::common::operation_error::OperationResult;
+pub use segment::pending_changes::{
+    DeletedPoints, IntendedVector, ProxyDeletedPoint, ProxyIndexChange, ProxyIndexChanges,
+    ProxyVectorNameChanges,
+};
 use segment::types::*;
 
-pub use self::vector_name_changes::{IntendedVector, ProxyVectorNameChanges};
 use crate::locked_segment::LockedSegment;
-
-pub type DeletedPoints = AHashMap<PointIdType, ProxyDeletedPoint>;
 
 /// This object is a wrapper around read-only segment.
 ///
@@ -367,83 +366,5 @@ impl ProxySegment {
 
     pub fn get_vector_name_changes(&self) -> &ProxyVectorNameChanges {
         &self.changed_vector_names
-    }
-}
-
-/// Point persion information of points to delete from a wrapped proxy segment.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ProxyDeletedPoint {
-    /// Version the point had in the wrapped segment when the delete was scheduled.
-    /// We use it to determine if some other proxy segment should move the point again with
-    /// `move_if_exists` if it has newer point data.
-    pub local_version: SeqNumberType,
-    /// Version of the operation that caused the delete to be scheduled.
-    /// We use it for the delete operations when propagating them to the wrapped or optimized
-    /// segment.
-    pub operation_version: SeqNumberType,
-}
-
-#[derive(Debug, Default)]
-pub struct ProxyIndexChanges {
-    changes: AHashMap<PayloadKeyType, ProxyIndexChange>,
-}
-
-impl ProxyIndexChanges {
-    pub fn insert(&mut self, key: PayloadKeyType, change: ProxyIndexChange) {
-        self.changes.insert(key, change);
-    }
-
-    pub fn remove(&mut self, key: &PayloadKeyType) {
-        self.changes.remove(key);
-    }
-
-    pub fn len(&self) -> usize {
-        self.changes.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.changes.is_empty()
-    }
-
-    pub fn clear(&mut self) {
-        self.changes.clear();
-    }
-
-    /// Iterate over proxy index changes in order of version.
-    ///
-    /// Index changes must be applied in order because changes with an old version will silently be
-    /// rejected.
-    pub fn iter_ordered(&self) -> impl Iterator<Item = (&PayloadKeyType, &ProxyIndexChange)> {
-        self.changes
-            .iter()
-            .sorted_by_key(|(_, change)| change.version())
-    }
-
-    /// Iterate over proxy index changes in arbitrary order.
-    pub fn iter_unordered(&self) -> impl Iterator<Item = (&PayloadKeyType, &ProxyIndexChange)> {
-        self.changes.iter()
-    }
-
-    pub fn merge(&mut self, other: &Self) {
-        for (key, change) in &other.changes {
-            self.changes.insert(key.clone(), change.clone());
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum ProxyIndexChange {
-    Create(PayloadFieldSchema, SeqNumberType),
-    Delete(SeqNumberType),
-    DeleteIfIncompatible(SeqNumberType, PayloadFieldSchema),
-}
-
-impl ProxyIndexChange {
-    pub fn version(&self) -> SeqNumberType {
-        match self {
-            ProxyIndexChange::Create(_, version) => *version,
-            ProxyIndexChange::Delete(version) => *version,
-            ProxyIndexChange::DeleteIfIncompatible(version, _) => *version,
-        }
     }
 }

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -256,9 +256,8 @@ impl ProxySegment {
     /// - deleted payload indexes
     /// - created payload indexes
     ///
-    /// This is required if making both the wrapped segment and the writable segment available in a
-    /// shard holder at the same time. If the wrapped segment is thrown away, then this is not
-    /// required.
+    /// Required before making the wrapped segment available in the shard holder. If the wrapped
+    /// segment is thrown away, propagating is not needed.
     ///
     /// The pending changes log file is deliberately left in place: deleting it before the wrapped
     /// segment has flushed the propagated changes would not be crash safe. It is cleaned up on

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -39,12 +39,13 @@ impl ProxySegment {
         point_ids: &[PointIdType],
     ) -> (std::borrow::Cow<'a, WithVector>, Vec<PointIdType>) {
         let with_vector = self
-            .changed_vector_names
+            .pending_changes
+            .vector_name_changes()
             .redact_with_vector(with_vector, &self.wrapped_config);
         let filtered_point_ids = point_ids
             .iter()
             .copied()
-            .filter(|id| !self.deleted_points.contains_key(id))
+            .filter(|id| !self.pending_changes.deleted_points().contains_key(id))
             .collect();
         (with_vector, filtered_point_ids)
     }
@@ -64,7 +65,11 @@ impl ProxySegment {
         let mut removed_num_indexed = 0usize;
         let mut removed_num_deleted = 0usize;
         vector_data.retain(|name, info| {
-            if self.changed_vector_names.is_wrapped_data_stale(name) {
+            if self
+                .pending_changes
+                .vector_name_changes()
+                .is_wrapped_data_stale(name)
+            {
                 removed_num_vectors += info.num_vectors;
                 removed_num_indexed += info.num_indexed_vectors;
                 removed_num_deleted += info.num_deleted_vectors;
@@ -75,7 +80,7 @@ impl ProxySegment {
         });
 
         let vector_name_count = vector_data.len();
-        let deleted_points_count = self.deleted_points.len();
+        let deleted_points_count = self.pending_changes.deleted_points().len();
 
         // Best estimate: start from wrapped aggregate, subtract what we just
         // removed (stale vectors) and what the proxy deleted (per-point
@@ -139,7 +144,8 @@ impl ReadSegmentEntry for ProxySegment {
         // is deleted. This also prevents `move_if_exists` from moving an old point
         // into the write segment again.
         if self
-            .deleted_points
+            .pending_changes
+            .deleted_points()
             .get(&point_id)
             .is_some_and(|delete| wrapped_version <= delete.local_version)
         {
@@ -165,7 +171,11 @@ impl ReadSegmentEntry for ProxySegment {
         // would error on a dimensionality mismatch). Short-circuit to an
         // empty result-per-query batch — semantically the new vector has no
         // points indexed in this segment yet.
-        if self.changed_vector_names.is_wrapped_data_stale(vector_name) {
+        if self
+            .pending_changes
+            .vector_name_changes()
+            .is_wrapped_data_stale(vector_name)
+        {
             return Ok(vec![Vec::new(); vectors.len()]);
         }
 
@@ -173,16 +183,17 @@ impl ReadSegmentEntry for ProxySegment {
         // with a different schema, so the wrapped segment doesn't return
         // stale data for them. `Cow::Borrowed` in the common case.
         let with_vector = self
-            .changed_vector_names
+            .pending_changes
+            .vector_name_changes()
             .redact_with_vector(with_vector, &self.wrapped_config);
         let with_vector = with_vector.as_ref();
 
-        let filter = filter.map(|f| self.changed_vector_names.redact_filter(f));
+        let filter = filter.map(|f| self.pending_changes.vector_name_changes().redact_filter(f));
 
         // Some point might be deleted after temporary segment creation
         // We need to prevent them from being found by search request
         // That is why we need to pass additional filter for deleted points
-        let do_update_filter = !self.deleted_points.is_empty();
+        let do_update_filter = !self.pending_changes.deleted_points().is_empty();
 
         let wrapped_results = if do_update_filter {
             // If we are wrapping a segment with deleted points,
@@ -205,7 +216,7 @@ impl ReadSegmentEntry for ProxySegment {
             } else {
                 let wrapped_filter = Self::add_deleted_points_condition_to_filter(
                     filter,
-                    self.deleted_points.keys().copied(),
+                    self.pending_changes.deleted_points().keys().copied(),
                 );
 
                 self.wrapped_segment.get().read().search_batch(
@@ -247,12 +258,17 @@ impl ReadSegmentEntry for ProxySegment {
             .rescore_with_formula(formula_ctx, hw_counter)?;
 
         let result = {
-            if self.deleted_points.is_empty() {
+            if self.pending_changes.deleted_points().is_empty() {
                 wrapped_results
             } else {
                 wrapped_results
                     .into_iter()
-                    .filter(|point| !self.deleted_points.contains_key(&point.id))
+                    .filter(|point| {
+                        !self
+                            .pending_changes
+                            .deleted_points()
+                            .contains_key(&point.id)
+                    })
                     .collect()
             }
         };
@@ -286,11 +302,19 @@ impl ReadSegmentEntry for ProxySegment {
         // Treat the lookup as if the point had no value for this vector.
         // `all_vectors` enumerates names and skips `None`s, so this also
         // hides stale entries from the per-point vector dump.
-        if self.changed_vector_names.is_wrapped_data_stale(vector_name) {
+        if self
+            .pending_changes
+            .vector_name_changes()
+            .is_wrapped_data_stale(vector_name)
+        {
             return Ok(None);
         }
 
-        if self.deleted_points.contains_key(&point_id) {
+        if self
+            .pending_changes
+            .deleted_points()
+            .contains_key(&point_id)
+        {
             Ok(None)
         } else {
             self.wrapped_segment.get().read().vector_with_behavior(
@@ -341,7 +365,11 @@ impl ReadSegmentEntry for ProxySegment {
         point_id: PointIdType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Payload> {
-        if self.deleted_points.contains_key(&point_id) {
+        if self
+            .pending_changes
+            .deleted_points()
+            .contains_key(&point_id)
+        {
             Ok(Payload::default())
         } else {
             self.wrapped_segment
@@ -400,9 +428,9 @@ impl ReadSegmentEntry for ProxySegment {
         hw_counter: &HardwareCounterCell,
         deferred_behavior: DeferredBehavior,
     ) -> OperationResult<Vec<PointIdType>> {
-        let filter = filter.map(|f| self.changed_vector_names.redact_filter(f));
+        let filter = filter.map(|f| self.pending_changes.vector_name_changes().redact_filter(f));
 
-        if self.deleted_points.is_empty() {
+        if self.pending_changes.deleted_points().is_empty() {
             self.wrapped_segment.get().read().read_filtered(
                 offset,
                 limit,
@@ -414,7 +442,7 @@ impl ReadSegmentEntry for ProxySegment {
         } else {
             let wrapped_filter = Self::add_deleted_points_condition_to_filter(
                 filter,
-                self.deleted_points.keys().copied(),
+                self.pending_changes.deleted_points().keys().copied(),
             );
             self.wrapped_segment.get().read().read_filtered(
                 offset,
@@ -436,9 +464,9 @@ impl ReadSegmentEntry for ProxySegment {
         hw_counter: &HardwareCounterCell,
         deferred_behavior: DeferredBehavior,
     ) -> OperationResult<Vec<(OrderValue, PointIdType)>> {
-        let filter = filter.map(|f| self.changed_vector_names.redact_filter(f));
+        let filter = filter.map(|f| self.pending_changes.vector_name_changes().redact_filter(f));
 
-        let read_points = if self.deleted_points.is_empty() {
+        let read_points = if self.pending_changes.deleted_points().is_empty() {
             self.wrapped_segment.get().read().read_ordered_filtered(
                 limit,
                 filter.as_deref(),
@@ -450,7 +478,7 @@ impl ReadSegmentEntry for ProxySegment {
         } else {
             let wrapped_filter = Self::add_deleted_points_condition_to_filter(
                 filter,
-                self.deleted_points.keys().copied(),
+                self.pending_changes.deleted_points().keys().copied(),
             );
             self.wrapped_segment.get().read().read_ordered_filtered(
                 limit,
@@ -471,9 +499,9 @@ impl ReadSegmentEntry for ProxySegment {
         is_stopped: &AtomicBool,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<Vec<PointIdType>> {
-        let filter = filter.map(|f| self.changed_vector_names.redact_filter(f));
+        let filter = filter.map(|f| self.pending_changes.vector_name_changes().redact_filter(f));
 
-        if self.deleted_points.is_empty() {
+        if self.pending_changes.deleted_points().is_empty() {
             self.wrapped_segment.get().read().read_random_filtered(
                 limit,
                 filter.as_deref(),
@@ -483,7 +511,7 @@ impl ReadSegmentEntry for ProxySegment {
         } else {
             let wrapped_filter = Self::add_deleted_points_condition_to_filter(
                 filter,
-                self.deleted_points.keys().copied(),
+                self.pending_changes.deleted_points().keys().copied(),
             );
             self.wrapped_segment.get().read().read_random_filtered(
                 limit,
@@ -497,12 +525,12 @@ impl ReadSegmentEntry for ProxySegment {
     /// Read points in [from; to) range
     fn read_range(&self, from: Option<PointIdType>, to: Option<PointIdType>) -> Vec<PointIdType> {
         let read_points = self.wrapped_segment.get().read().read_range(from, to);
-        if self.deleted_points.is_empty() {
+        if self.pending_changes.deleted_points().is_empty() {
             read_points
         } else {
             read_points
                 .into_iter()
-                .filter(|idx| !self.deleted_points.contains_key(idx))
+                .filter(|idx| !self.pending_changes.deleted_points().contains_key(idx))
                 .collect()
         }
     }
@@ -514,7 +542,7 @@ impl ReadSegmentEntry for ProxySegment {
         is_stopped: &AtomicBool,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<BTreeSet<FacetValue>> {
-        let filter = filter.map(|f| self.changed_vector_names.redact_filter(f));
+        let filter = filter.map(|f| self.pending_changes.vector_name_changes().redact_filter(f));
         let values = self.wrapped_segment.get().read().unique_values(
             key,
             filter.as_deref(),
@@ -533,9 +561,9 @@ impl ReadSegmentEntry for ProxySegment {
         let filter = request
             .filter
             .as_ref()
-            .map(|f| self.changed_vector_names.redact_filter(f));
+            .map(|f| self.pending_changes.vector_name_changes().redact_filter(f));
 
-        let hits = if self.deleted_points.is_empty() {
+        let hits = if self.pending_changes.deleted_points().is_empty() {
             match filter {
                 // No filter, or filter unchanged — use original request as-is.
                 None | Some(std::borrow::Cow::Borrowed(_)) => self
@@ -558,7 +586,7 @@ impl ReadSegmentEntry for ProxySegment {
         } else {
             let wrapped_filter = Self::add_deleted_points_condition_to_filter(
                 filter,
-                self.deleted_points.keys().copied(),
+                self.pending_changes.deleted_points().keys().copied(),
             );
             let new_request = FacetParams {
                 filter: Some(wrapped_filter),
@@ -574,7 +602,10 @@ impl ReadSegmentEntry for ProxySegment {
     }
 
     fn has_point(&self, point_id: PointIdType, deferred_behavior: DeferredBehavior) -> bool {
-        !self.deleted_points.contains_key(&point_id)
+        !self
+            .pending_changes
+            .deleted_points()
+            .contains_key(&point_id)
             && self
                 .wrapped_segment
                 .get()
@@ -587,7 +618,7 @@ impl ReadSegmentEntry for ProxySegment {
     }
 
     fn available_point_count(&self) -> usize {
-        let deleted_points_count = self.deleted_points.len();
+        let deleted_points_count = self.pending_changes.deleted_points().len();
         let wrapped_segment_count = self.wrapped_segment.get().read().available_point_count();
         wrapped_segment_count.saturating_sub(deleted_points_count)
     }
@@ -601,7 +632,8 @@ impl ReadSegmentEntry for ProxySegment {
 
         // Amount of visible points that are deleted in this proxy.
         let deleted_visible = self
-            .deleted_points
+            .pending_changes
+            .deleted_points()
             .len()
             .saturating_sub(self.deleted_deferred_count);
 
@@ -609,7 +641,8 @@ impl ReadSegmentEntry for ProxySegment {
     }
 
     fn deleted_point_count(&self) -> usize {
-        self.wrapped_segment.get().read().deleted_point_count() + self.deleted_points.len()
+        self.wrapped_segment.get().read().deleted_point_count()
+            + self.pending_changes.deleted_points().len()
     }
 
     fn available_vectors_size_in_bytes(&self, vector_name: &VectorName) -> OperationResult<usize> {
@@ -618,7 +651,11 @@ impl ReadSegmentEntry for ProxySegment {
         // any new schema has no points indexed in this segment yet. Also
         // avoids calling into the wrapped with a name whose query may now
         // mean a different shape.
-        if self.changed_vector_names.is_wrapped_data_stale(vector_name) {
+        if self
+            .pending_changes
+            .vector_name_changes()
+            .is_wrapped_data_stale(vector_name)
+        {
             return Ok(0);
         }
 
@@ -631,7 +668,7 @@ impl ReadSegmentEntry for ProxySegment {
         let stored_points = wrapped_count;
         // because we don't know the exact size of deleted vectors, we assume that they are the same avg size as the wrapped ones
         if stored_points > 0 {
-            let deleted_points_count = self.deleted_points.len();
+            let deleted_points_count = self.pending_changes.deleted_points().len();
             let available_points = stored_points.saturating_sub(deleted_points_count);
             Ok(
                 ((wrapped_size as u128) * available_points as u128 / stored_points as u128)
@@ -647,10 +684,11 @@ impl ReadSegmentEntry for ProxySegment {
         filter: Option<&'a Filter>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<CardinalityEstimation> {
-        let filter = filter.map(|f| self.changed_vector_names.redact_filter(f));
+        let filter = filter.map(|f| self.pending_changes.vector_name_changes().redact_filter(f));
 
         let deleted_point_count = self
-            .deleted_points
+            .pending_changes
+            .deleted_points()
             .len()
             .saturating_sub(self.deleted_deferred_count);
 
@@ -716,7 +754,7 @@ impl ReadSegmentEntry for ProxySegment {
     fn get_indexed_fields(&self) -> HashMap<PayloadKeyType, PayloadFieldSchema> {
         let mut indexed_fields = self.wrapped_segment.get().read().get_indexed_fields();
 
-        for (field_name, change) in self.changed_indexes.iter_unordered() {
+        for (field_name, change) in self.pending_changes.index_changes().iter_unordered() {
             match change {
                 ProxyIndexChange::Create(schema, _) => {
                     indexed_fields.insert(field_name.to_owned(), schema.to_owned());
@@ -754,7 +792,10 @@ impl ReadSegmentEntry for ProxySegment {
     }
 
     fn point_is_deferred(&self, point_id: PointIdType) -> bool {
-        !self.deleted_points.contains_key(&point_id)
+        !self
+            .pending_changes
+            .deleted_points()
+            .contains_key(&point_id)
             && self
                 .wrapped_segment
                 .get()
@@ -765,7 +806,7 @@ impl ReadSegmentEntry for ProxySegment {
     fn deferred_point_ids(&self) -> Vec<PointIdType> {
         let mut ids = self.wrapped_segment.get().read().deferred_point_ids();
         if self.deleted_deferred_count > 0 {
-            ids.retain(|point_id| !self.deleted_points.contains_key(point_id));
+            ids.retain(|point_id| !self.pending_changes.deleted_points().contains_key(point_id));
         }
         ids
     }
@@ -947,7 +988,7 @@ impl NonAppendableSegmentEntry for ProxySegment {
                 was_deferred_point = is_deferred;
 
                 if point_offset.is_some() {
-                    let prev = self.deleted_points.insert(
+                    let prev = self.pending_changes.register_delete_point(
                         point_id,
                         ProxyDeletedPoint {
                             local_version: op_num,
@@ -975,7 +1016,7 @@ impl NonAppendableSegmentEntry for ProxySegment {
                 was_deferred_point = is_deferred;
 
                 if has_point {
-                    let prev = self.deleted_points.insert(
+                    let prev = self.pending_changes.register_delete_point(
                         point_id,
                         ProxyDeletedPoint {
                             local_version: op_num,
@@ -1012,8 +1053,8 @@ impl NonAppendableSegmentEntry for ProxySegment {
         self.version = cmp::max(self.version, op_num);
 
         // Store index change to later propagate to optimized/wrapped segment
-        self.changed_indexes
-            .insert(key.clone(), ProxyIndexChange::Delete(op_num));
+        self.pending_changes
+            .register_index_change(key.clone(), ProxyIndexChange::Delete(op_num));
 
         Ok(true)
     }
@@ -1030,7 +1071,7 @@ impl NonAppendableSegmentEntry for ProxySegment {
 
         self.version = cmp::max(self.version, op_num);
 
-        self.changed_indexes.insert(
+        self.pending_changes.register_index_change(
             key.clone(),
             ProxyIndexChange::DeleteIfIncompatible(op_num, field_schema.clone()),
         );
@@ -1069,8 +1110,8 @@ impl NonAppendableSegmentEntry for ProxySegment {
         self.version = cmp::max(self.version, op_num);
 
         // Store index change to later propagate to optimized/wrapped segment
-        self.changed_indexes
-            .insert(key, ProxyIndexChange::Create(field_schema, op_num));
+        self.pending_changes
+            .register_index_change(key, ProxyIndexChange::Create(field_schema, op_num));
 
         Ok(true)
     }
@@ -1087,10 +1128,10 @@ impl NonAppendableSegmentEntry for ProxySegment {
 
         self.version = cmp::max(self.version, op_num);
 
-        // `record_create` consults `wrapped_config` (and any earlier intent
+        // `register_vector_name_create` consults `wrapped_config` (and any earlier intent
         // recorded for this name) to compute `supersedes_wrapped`, so the
         // optimiser/propagator can clear stale wrapped storage when needed.
-        self.changed_vector_names.record_create(
+        self.pending_changes.register_vector_name_create(
             vector_name.to_owned(),
             vector_config.clone(),
             op_num,
@@ -1111,8 +1152,8 @@ impl NonAppendableSegmentEntry for ProxySegment {
 
         self.version = cmp::max(self.version, op_num);
 
-        self.changed_vector_names
-            .record_delete(vector_name.to_owned(), op_num);
+        self.pending_changes
+            .register_vector_name_delete(vector_name.to_owned(), op_num);
 
         Ok(true)
     }

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::AtomicBool;
 
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
+use common::flags::feature_flags;
 use common::types::{DeferredBehavior, TelemetryDetail};
 use segment::common::Flusher;
 use segment::common::operation_error::{OperationError, OperationResult, SegmentFailedState};
@@ -834,6 +835,10 @@ impl StorageSegmentEntry for ProxySegment {
     }
 
     fn persistent_version(&self) -> SeqNumberType {
+        if !feature_flags().persist_proxy_segments {
+            return self.wrapped_segment.get().read().persistent_version();
+        }
+
         // Everything this proxy buffers at or below the persisted pending changes version is
         // durable in the pending changes log, on top of whatever the wrapped segment persisted
         // itself. Reporting it here is what allows the WAL to be acknowledged past operations
@@ -855,7 +860,9 @@ impl StorageSegmentEntry for ProxySegment {
                 if let Some(wrapped_flusher) = wrapped_flusher {
                     wrapped_flusher()?;
                 }
-                if let Some(pending_changes_flusher) = pending_changes_flusher {
+                if let Some(pending_changes_flusher) = pending_changes_flusher
+                    && feature_flags().persist_proxy_segments
+                {
                     pending_changes_flusher()?;
                 }
                 Ok(())

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -846,18 +846,17 @@ impl StorageSegmentEntry for ProxySegment {
     }
 
     fn flusher(&self, force: bool, up_to: Option<SeqNumberType>) -> Option<Flusher> {
-        // Persist our pending changes before passing the flush along to the wrapped segment
-        let pending_changes_flusher = self.pending_changes.flusher(self.version);
         let wrapped_flusher = self.wrapped_segment.get().read().flusher(force, up_to);
+        let pending_changes_flusher = self.pending_changes.flusher(self.version);
 
-        match (pending_changes_flusher, wrapped_flusher) {
+        match (wrapped_flusher, pending_changes_flusher) {
             (None, None) => None,
-            (pending_changes_flusher, wrapped_flusher) => Some(Box::new(move || {
-                if let Some(pending_changes_flusher) = pending_changes_flusher {
-                    pending_changes_flusher()?;
-                }
+            (wrapped_flusher, pending_changes_flusher) => Some(Box::new(move || {
                 if let Some(wrapped_flusher) = wrapped_flusher {
                     wrapped_flusher()?;
+                }
+                if let Some(pending_changes_flusher) = pending_changes_flusher {
+                    pending_changes_flusher()?;
                 }
                 Ok(())
             })),

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -834,17 +834,46 @@ impl StorageSegmentEntry for ProxySegment {
     }
 
     fn persistent_version(&self) -> SeqNumberType {
-        self.wrapped_segment.get().read().persistent_version()
+        // Everything this proxy buffers at or below the persisted pending changes version is
+        // durable in the pending changes log, on top of whatever the wrapped segment persisted
+        // itself. Reporting it here is what allows the WAL to be acknowledged past operations
+        // that only live in this proxy: on a restart the log is replayed onto the segment
+        // instead of replaying the WAL.
+        cmp::max(
+            self.wrapped_segment.get().read().persistent_version(),
+            self.pending_changes.persisted_version(),
+        )
     }
 
     fn flusher(&self, force: bool, up_to: Option<SeqNumberType>) -> Option<Flusher> {
-        let wrapped_segment = self.wrapped_segment.get();
-        let wrapped_segment_guard = wrapped_segment.read();
-        wrapped_segment_guard.flusher(force, up_to)
+        // Persist our pending changes before passing the flush along to the wrapped segment
+        let pending_changes_flusher = self.pending_changes.flusher(self.version);
+        let wrapped_flusher = self.wrapped_segment.get().read().flusher(force, up_to);
+
+        match (pending_changes_flusher, wrapped_flusher) {
+            (None, None) => None,
+            (pending_changes_flusher, wrapped_flusher) => Some(Box::new(move || {
+                if let Some(pending_changes_flusher) = pending_changes_flusher {
+                    pending_changes_flusher()?;
+                }
+                if let Some(wrapped_flusher) = wrapped_flusher {
+                    wrapped_flusher()?;
+                }
+                Ok(())
+            })),
+        }
     }
 
     fn drop_data(self) -> OperationResult<()> {
-        self.wrapped_segment.drop_data()
+        let ProxySegment {
+            wrapped_segment,
+            pending_changes,
+            ..
+        } = self;
+        // Drop the pending changes first: this waits for any in-flight pending changes flusher,
+        // so it cannot append to the segment directory while it is being deleted
+        drop(pending_changes);
+        wrapped_segment.drop_data()
     }
 
     fn data_path(&self) -> PathBuf {

--- a/lib/shard/src/proxy_segment/snapshot_entry.rs
+++ b/lib/shard/src/proxy_segment/snapshot_entry.rs
@@ -1,11 +1,10 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use common::tar_ext;
 use segment::common::operation_error::OperationResult;
 use segment::data_types::manifest::{FileVersion, SegmentManifest};
 use segment::entry::StorageSegmentEntry;
 use segment::entry::snapshot_entry::SnapshotEntry;
-use segment::pending_changes::pending_changes_log_path;
 use segment::types::*;
 
 use super::ProxySegment;
@@ -38,8 +37,13 @@ impl SnapshotEntry for ProxySegment {
 
         // Add persisted pending changes log file
         manifest.segment_version = self.version();
+        let log_file_name = self
+            .pending_changes
+            .log_path()
+            .file_name()
+            .expect("pending changes log path must have a file name");
         manifest.file_versions.insert(
-            pending_changes_log_path(Path::new(""), self.pending_changes.level()),
+            PathBuf::from(log_file_name),
             FileVersion::Version(manifest.segment_version),
         );
 

--- a/lib/shard/src/proxy_segment/snapshot_entry.rs
+++ b/lib/shard/src/proxy_segment/snapshot_entry.rs
@@ -2,8 +2,10 @@ use std::path::Path;
 
 use common::tar_ext;
 use segment::common::operation_error::OperationResult;
-use segment::data_types::manifest::SegmentManifest;
+use segment::data_types::manifest::{FileVersion, SegmentManifest};
+use segment::entry::StorageSegmentEntry;
 use segment::entry::snapshot_entry::SnapshotEntry;
+use segment::pending_changes::pending_changes_log_path;
 use segment::types::*;
 
 use super::ProxySegment;
@@ -32,6 +34,15 @@ impl SnapshotEntry for ProxySegment {
     }
 
     fn get_segment_manifest(&self) -> OperationResult<SegmentManifest> {
-        self.wrapped_segment.get().read().get_segment_manifest()
+        let mut manifest = self.wrapped_segment.get().read().get_segment_manifest()?;
+
+        // Add persisted pending changes log file
+        manifest.segment_version = self.version();
+        manifest.file_versions.insert(
+            pending_changes_log_path(Path::new(""), self.pending_changes.level()),
+            FileVersion::Version(manifest.segment_version),
+        );
+
+        Ok(manifest)
     }
 }

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -95,7 +95,7 @@ fn test_proxy_deleted_mask_resync_after_race_window_write() {
 
         // Keep a handle so we can write to the wrapped segment around the proxy lifecycle.
         let wrapped_handle = original_segment.clone();
-        let proxy = UnsyncedProxySegment::new(original_segment);
+        let proxy = UnsyncedProxySegment::new(original_segment).unwrap();
         (proxy, wrapped_handle)
     };
 

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -531,6 +531,56 @@ fn test_take_snapshot() {
     }
 }
 
+/// A persisted pending changes log is part of the segment snapshot and manifest, so full,
+/// partial and streamed snapshots all carry it and recovery can replay it.
+#[test]
+fn test_take_snapshot_includes_pending_changes_log() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let original_segment = LockedSegment::new(build_segment_1(dir.path()));
+
+    let hw_cell = HardwareCounterCell::new();
+
+    let mut proxy_segment = ProxySegment::new(original_segment);
+    proxy_segment.delete_point(102, 1.into(), &hw_cell).unwrap();
+    // Persist the pending delete into the pending changes log
+    proxy_segment.flush(false).unwrap();
+
+    // The pending changes log is part of the segment manifest; it is registered unversioned, so
+    // its effective version resolves to the wrapped segment version
+    let manifest = proxy_segment.get_segment_manifest().unwrap();
+    let file_version = manifest
+        .file_version(std::path::Path::new(
+            segment::pending_changes::PENDING_CHANGES_LOG_FILE,
+        ))
+        .expect("pending changes log must be listed in the segment manifest");
+    assert_eq!(file_version, manifest.segment_version);
+
+    // The pending changes log is included in the snapshot files
+    let snapshot_file = Builder::new().suffix(".snapshot.tar").tempfile().unwrap();
+    let tar = tar_ext::BuilderExt::new_seekable_owned(File::create(snapshot_file.path()).unwrap());
+    let temp_dir = Builder::new().prefix("temp_dir").tempdir().unwrap();
+    proxy_segment
+        .take_snapshot(temp_dir.path(), &tar, SnapshotFormat::Streamable, None)
+        .unwrap();
+    tar.blocking_finish().unwrap();
+
+    let mut tar = tar::Archive::new(File::open(snapshot_file.path()).unwrap());
+    let has_pending_changes_log = tar.entries_with_seek().unwrap().any(|entry| {
+        entry
+            .unwrap()
+            .path()
+            .unwrap()
+            .ends_with(std::path::Path::new(&format!(
+                "files/{}",
+                segment::pending_changes::PENDING_CHANGES_LOG_FILE,
+            )))
+    });
+    assert!(
+        has_pending_changes_log,
+        "snapshot must carry the pending changes log",
+    );
+}
+
 #[test]
 fn test_point_vector_count() {
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
@@ -662,6 +712,188 @@ fn test_proxy_segment_flush() {
     let flushed_version_3 = proxy_segment.flush(false).unwrap();
     assert_eq!(flushed_version_3, 101);
     assert_eq!(flushed_version_3, proxy_segment.version());
+}
+
+/// Pending proxy changes are persisted on flush, survive dropping the proxy without propagation
+/// (e.g. a crash) and are replayed onto the actual segment when it is loaded again.
+#[test]
+fn test_pending_changes_recovered_on_restart() {
+    let hw_counter = HardwareCounterCell::new();
+    let tmp_dir = tempfile::Builder::new()
+        .prefix("segment_dir")
+        .tempdir()
+        .unwrap();
+
+    let locked_wrapped_segment = LockedSegment::new(build_segment_1(tmp_dir.path()));
+    let wrapped_segment_dir = locked_wrapped_segment.get().read().data_path();
+
+    let mut proxy_segment = ProxySegment::new(locked_wrapped_segment.clone());
+
+    proxy_segment
+        .delete_point(100, 2.into(), &hw_counter)
+        .unwrap();
+    proxy_segment
+        .apply_field_index(
+            101,
+            "color".parse().unwrap(),
+            PayloadFieldSchema::FieldType(PayloadSchemaType::Keyword),
+            vec![],
+        )
+        .unwrap();
+
+    // Flush persists the pending changes log; the wrapped segment itself never sees the changes
+    let flushed_version = proxy_segment.flush(false).unwrap();
+    assert_eq!(flushed_version, 101);
+
+    // "Crash": drop the proxy without propagating to the wrapped segment
+    drop(proxy_segment);
+    drop(locked_wrapped_segment);
+    assert!(segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 0).is_file());
+
+    // "Restart": load the segment from disk and recover the pending changes, as done on start-up
+    let mut segment = segment::segment_constructor::load_segment(
+        &wrapped_segment_dir,
+        uuid::Uuid::nil(),
+        None,
+        &std::sync::atomic::AtomicBool::new(false),
+    )
+    .unwrap();
+
+    // Before recovery the segment does not know about the buffered operations
+    assert!(segment.has_point(2.into(), DeferredBehavior::VisibleOnly));
+
+    let replayed = segment::pending_changes::recover_pending_changes(&mut segment).unwrap();
+    assert_eq!(replayed, 2);
+
+    assert!(!segment.has_point(2.into(), DeferredBehavior::VisibleOnly));
+    assert!(
+        segment
+            .get_indexed_fields()
+            .contains_key(&"color".parse().unwrap())
+    );
+    assert_eq!(segment.version(), 101);
+    // Recovery flushed the segment and removed the log file
+    assert_eq!(segment.persistent_version(), 101);
+    assert!(!segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 0).is_file());
+}
+
+/// Unwrapping a proxy leaves the pending changes log in place (deleting it before the wrapped
+/// segment flushed the propagated changes would not be crash safe), and a new proxy on the same
+/// segment adopts and appends to it.
+#[test]
+fn test_unproxy_leaves_pending_changes_log_for_adoption() {
+    let hw_counter = HardwareCounterCell::new();
+    let tmp_dir = tempfile::Builder::new()
+        .prefix("segment_dir")
+        .tempdir()
+        .unwrap();
+
+    let locked_wrapped_segment = LockedSegment::new(build_segment_1(tmp_dir.path()));
+    let wrapped_segment_dir = locked_wrapped_segment.get().read().data_path();
+    let log_path = segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 0);
+
+    let mut proxy_segment = ProxySegment::new(locked_wrapped_segment.clone());
+    proxy_segment
+        .delete_point(100, 2.into(), &hw_counter)
+        .unwrap();
+    proxy_segment.flush(false).unwrap();
+
+    // Unproxy: propagate pending changes into the wrapped segment, then drop the proxy
+    proxy_segment.propagate_to_wrapped().unwrap();
+    assert!(proxy_segment.get_deleted_points().is_empty());
+    drop(proxy_segment);
+
+    assert!(
+        !locked_wrapped_segment
+            .get()
+            .read()
+            .has_point(2.into(), DeferredBehavior::VisibleOnly)
+    );
+    assert!(
+        log_path.is_file(),
+        "unproxying must leave the pending changes log in place",
+    );
+
+    // A new proxy on the same segment adopts the log: its persisted version covers the old
+    // operations, and new operations are appended after them
+    let mut proxy_segment = ProxySegment::new(locked_wrapped_segment.clone());
+    assert_eq!(proxy_segment.persistent_version(), 100);
+    assert!(proxy_segment.get_deleted_points().is_empty());
+
+    proxy_segment
+        .delete_point(110, 3.into(), &hw_counter)
+        .unwrap();
+    proxy_segment.flush(false).unwrap();
+
+    let loaded = segment::pending_changes::PendingChanges::load(&wrapped_segment_dir, 0).unwrap();
+    assert_eq!(loaded.deleted_points().len(), 2);
+    assert_eq!(loaded.persisted_version(), 110);
+}
+
+/// Each proxy layer persists its pending changes into a dedicated log file; on restart all files
+/// are replayed onto the segment, inner most layer first.
+#[test]
+fn test_double_proxy_pending_changes_levels() {
+    let hw_counter = HardwareCounterCell::new();
+    let tmp_dir = tempfile::Builder::new()
+        .prefix("segment_dir")
+        .tempdir()
+        .unwrap();
+
+    let locked_wrapped_segment = LockedSegment::new(build_segment_1(tmp_dir.path()));
+    let wrapped_segment_dir = locked_wrapped_segment.get().read().data_path();
+
+    // Inner proxy (e.g. an ongoing optimization) buffers a delete of point 2
+    let mut inner_proxy = ProxySegment::new(locked_wrapped_segment.clone());
+    inner_proxy
+        .delete_point(100, 2.into(), &hw_counter)
+        .unwrap();
+
+    // Outer proxy (e.g. an ongoing snapshot) wraps the inner proxy and buffers a delete of
+    // point 3
+    let locked_inner_proxy = LockedSegment::from(inner_proxy);
+    let mut outer_proxy = ProxySegment::new(locked_inner_proxy.clone());
+    outer_proxy
+        .delete_point(101, 3.into(), &hw_counter)
+        .unwrap();
+
+    // Flushing the outer proxy persists its own pending changes and passes the flush along to
+    // the inner proxy, which persists its own as well
+    let flushed_version = outer_proxy.flush(false).unwrap();
+    assert_eq!(flushed_version, 101);
+
+    let log_files = segment::pending_changes::list_pending_changes_log_files(&wrapped_segment_dir);
+    assert_eq!(
+        log_files,
+        vec![
+            segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 0),
+            segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 1),
+        ],
+        "each proxy layer must persist into its own log file",
+    );
+
+    // "Crash": drop both proxies without propagating, then load the segment and recover
+    drop(outer_proxy);
+    drop(locked_inner_proxy);
+    drop(locked_wrapped_segment);
+
+    let mut segment = segment::segment_constructor::load_segment(
+        &wrapped_segment_dir,
+        uuid::Uuid::nil(),
+        None,
+        &std::sync::atomic::AtomicBool::new(false),
+    )
+    .unwrap();
+
+    let replayed = segment::pending_changes::recover_pending_changes(&mut segment).unwrap();
+    assert_eq!(replayed, 2);
+
+    assert!(!segment.has_point(2.into(), DeferredBehavior::VisibleOnly));
+    assert!(!segment.has_point(3.into(), DeferredBehavior::VisibleOnly));
+    assert_eq!(segment.version(), 101);
+    assert!(
+        segment::pending_changes::list_pending_changes_log_files(&wrapped_segment_dir).is_empty()
+    );
 }
 
 #[test]

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -629,24 +629,39 @@ fn test_proxy_segment_flush() {
         .unwrap();
 
     let locked_wrapped_segment = LockedSegment::new(build_segment_1(tmp_dir.path()));
+    let wrapped_segment_dir = locked_wrapped_segment.get().read().data_path();
 
     let mut proxy_segment = ProxySegment::new(locked_wrapped_segment.clone());
 
     let flushed_version_1 = proxy_segment.flush(false).unwrap();
+    assert_eq!(flushed_version_1, proxy_segment.version());
 
     proxy_segment
         .delete_point(100, 2.into(), &HardwareCounterCell::new())
         .unwrap();
 
+    // The pending delete is not persisted yet, so it caps the persistent version
+    assert_eq!(proxy_segment.persistent_version(), flushed_version_1);
+
     let flushed_version_2 = proxy_segment.flush(false).unwrap();
 
-    assert_eq!(flushed_version_2, flushed_version_1);
+    // Flushing persisted the pending delete into the pending changes log, so the proxy is fully
+    // persisted and does not hold back acknowledging the WAL
+    assert_eq!(flushed_version_2, 100);
+    assert_eq!(flushed_version_2, proxy_segment.version());
+    assert!(
+        segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 0).is_file(),
+        "flush must persist pending changes log into the wrapped segment directory",
+    );
 
-    let version_after_delete = proxy_segment.version();
-
-    // We can never fully persist proxy segment, as list of deleted points is always in-memory only.
-    // So we have to keep WAL for deleted points.
-    assert!(version_after_delete > flushed_version_2);
+    // An operation that buffers nothing (delete of an absent point) must not cap the persistent
+    // version either
+    proxy_segment
+        .delete_point(101, 12345.into(), &HardwareCounterCell::new())
+        .unwrap();
+    let flushed_version_3 = proxy_segment.flush(false).unwrap();
+    assert_eq!(flushed_version_3, 101);
+    assert_eq!(flushed_version_3, proxy_segment.version());
 }
 
 #[test]

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -762,7 +762,11 @@ fn test_pending_changes_recovered_on_restart() {
     // Before recovery the segment does not know about the buffered operations
     assert!(segment.has_point(2.into(), DeferredBehavior::VisibleOnly));
 
-    let replayed = segment::pending_changes::recover_pending_changes(&mut segment).unwrap();
+    let replayed = segment::pending_changes::recover_pending_changes(
+        &mut segment,
+        segment::pending_changes::PersistedProxyChanges::Replay,
+    )
+    .unwrap();
     assert_eq!(replayed, 2);
 
     assert!(!segment.has_point(2.into(), DeferredBehavior::VisibleOnly));
@@ -885,7 +889,11 @@ fn test_double_proxy_pending_changes_levels() {
     )
     .unwrap();
 
-    let replayed = segment::pending_changes::recover_pending_changes(&mut segment).unwrap();
+    let replayed = segment::pending_changes::recover_pending_changes(
+        &mut segment,
+        segment::pending_changes::PersistedProxyChanges::Replay,
+    )
+    .unwrap();
     assert_eq!(replayed, 2);
 
     assert!(!segment.has_point(2.into(), DeferredBehavior::VisibleOnly));

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -744,6 +744,9 @@ fn test_pending_changes_recovered_on_restart() {
     // Flush persists the pending changes log; the wrapped segment itself never sees the changes
     let flushed_version = proxy_segment.flush(false).unwrap();
     assert_eq!(flushed_version, 101);
+    // The proxy flush durably persisted the wrapped segment's own (unrelated) base state; this is
+    // the persisted version the reloaded segment starts from below
+    let wrapped_persisted_version = locked_wrapped_segment.get().read().persistent_version();
 
     // "Crash": drop the proxy without propagating to the wrapped segment
     drop(proxy_segment);
@@ -763,12 +766,12 @@ fn test_pending_changes_recovered_on_restart() {
     // Before recovery the segment does not know about the buffered operations
     assert!(segment.has_point(2.into(), DeferredBehavior::VisibleOnly));
 
-    let replayed = segment::pending_changes::recover_pending_changes(
+    let recovered = segment::pending_changes::recover_pending_changes(
         &mut segment,
         segment::pending_changes::PersistedProxyChanges::Replay,
     )
     .unwrap();
-    assert_eq!(replayed, 2);
+    assert_eq!(recovered.replayed, 2);
 
     assert!(!segment.has_point(2.into(), DeferredBehavior::VisibleOnly));
     assert!(
@@ -777,8 +780,18 @@ fn test_pending_changes_recovered_on_restart() {
             .contains_key(&"color".parse().unwrap())
     );
     assert_eq!(segment.version(), 101);
-    // Recovery flushed the segment and removed the log file
+    assert_eq!(recovered.ready_at, 101);
+    // Recovery does not flush; the log file must survive until the segment durably persists
+    // past `ready_at`, so the caller (the segment holder, via a post-flush action) can safely
+    // remove it
+    assert_eq!(segment.persistent_version(), wrapped_persisted_version);
+    assert!(segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 0).is_file());
+
+    segment.flush(true).unwrap();
     assert_eq!(segment.persistent_version(), 101);
+    for path in &recovered.log_files {
+        fs_err::remove_file(path).unwrap();
+    }
     assert!(!segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 0).is_file());
 }
 
@@ -891,16 +904,26 @@ fn test_double_proxy_pending_changes_levels() {
     )
     .unwrap();
 
-    let replayed = segment::pending_changes::recover_pending_changes(
+    let recovered = segment::pending_changes::recover_pending_changes(
         &mut segment,
         segment::pending_changes::PersistedProxyChanges::Replay,
     )
     .unwrap();
-    assert_eq!(replayed, 2);
+    assert_eq!(recovered.replayed, 2);
 
     assert!(!segment.has_point(2.into(), DeferredBehavior::VisibleOnly));
     assert!(!segment.has_point(3.into(), DeferredBehavior::VisibleOnly));
     assert_eq!(segment.version(), 101);
+    assert_eq!(recovered.ready_at, 101);
+    assert_eq!(
+        segment::pending_changes::list_pending_changes_log_files(&wrapped_segment_dir),
+        recovered.log_files,
+    );
+
+    segment.flush(true).unwrap();
+    for path in &recovered.log_files {
+        fs_err::remove_file(path).unwrap();
+    }
     assert!(
         segment::pending_changes::list_pending_changes_log_files(&wrapped_segment_dir).is_empty()
     );

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -756,6 +756,7 @@ fn test_pending_changes_recovered_on_restart() {
         uuid::Uuid::nil(),
         None,
         &std::sync::atomic::AtomicBool::new(false),
+        false,
     )
     .unwrap();
 
@@ -886,6 +887,7 @@ fn test_double_proxy_pending_changes_levels() {
         uuid::Uuid::nil(),
         None,
         &std::sync::atomic::AtomicBool::new(false),
+        false,
     )
     .unwrap();
 

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::AtomicBool;
 
 use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::flags::{FeatureFlags, init_feature_flags};
 use common::tar_ext;
 use common::types::DeferredBehavior;
 use fs_err::File;
@@ -535,6 +536,11 @@ fn test_take_snapshot() {
 /// partial and streamed snapshots all carry it and recovery can replay it.
 #[test]
 fn test_take_snapshot_includes_pending_changes_log() {
+    init_feature_flags(FeatureFlags {
+        persist_proxy_segments: true,
+        ..Default::default()
+    });
+
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let original_segment = LockedSegment::new(build_segment_1(dir.path()));
 
@@ -673,6 +679,11 @@ fn test_point_vector_count_multivec() {
 
 #[test]
 fn test_proxy_segment_flush() {
+    init_feature_flags(FeatureFlags {
+        persist_proxy_segments: true,
+        ..Default::default()
+    });
+
     let tmp_dir = tempfile::Builder::new()
         .prefix("segment_dir")
         .tempdir()
@@ -717,6 +728,11 @@ fn test_proxy_segment_flush() {
 /// (e.g. a crash) and are replayed onto the actual segment when it is loaded again.
 #[test]
 fn test_pending_changes_recovered_on_restart() {
+    init_feature_flags(FeatureFlags {
+        persist_proxy_segments: true,
+        ..Default::default()
+    });
+
     let hw_counter = HardwareCounterCell::new();
     let tmp_dir = tempfile::Builder::new()
         .prefix("segment_dir")
@@ -801,6 +817,11 @@ fn test_pending_changes_recovered_on_restart() {
 /// the old file untouched.
 #[test]
 fn test_unproxy_leaves_pending_changes_log_without_adoption() {
+    init_feature_flags(FeatureFlags {
+        persist_proxy_segments: true,
+        ..Default::default()
+    });
+
     let hw_counter = HardwareCounterCell::new();
     let tmp_dir = tempfile::Builder::new()
         .prefix("segment_dir")
@@ -871,6 +892,11 @@ fn test_unproxy_leaves_pending_changes_log_without_adoption() {
 /// are replayed onto the segment, inner most layer first.
 #[test]
 fn test_double_proxy_pending_changes_levels() {
+    init_feature_flags(FeatureFlags {
+        persist_proxy_segments: true,
+        ..Default::default()
+    });
+
     let hw_counter = HardwareCounterCell::new();
     let tmp_dir = tempfile::Builder::new()
         .prefix("segment_dir")

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -541,17 +541,20 @@ fn test_take_snapshot_includes_pending_changes_log() {
     let hw_cell = HardwareCounterCell::new();
 
     let mut proxy_segment = ProxySegment::new(original_segment);
+    let log_file_name = proxy_segment
+        .pending_changes
+        .log_path()
+        .file_name()
+        .unwrap()
+        .to_owned();
     proxy_segment.delete_point(102, 1.into(), &hw_cell).unwrap();
     // Persist the pending delete into the pending changes log
     proxy_segment.flush(false).unwrap();
-
-    // The pending changes log is part of the segment manifest; it is registered unversioned, so
-    // its effective version resolves to the wrapped segment version
+    // The pending changes log is part of the segment manifest, with an explicit version matching
+    // the proxy's own version
     let manifest = proxy_segment.get_segment_manifest().unwrap();
     let file_version = manifest
-        .file_version(std::path::Path::new(
-            segment::pending_changes::PENDING_CHANGES_LOG_FILE,
-        ))
+        .file_version(std::path::Path::new(&log_file_name))
         .expect("pending changes log must be listed in the segment manifest");
     assert_eq!(file_version, manifest.segment_version);
 
@@ -570,10 +573,7 @@ fn test_take_snapshot_includes_pending_changes_log() {
             .unwrap()
             .path()
             .unwrap()
-            .ends_with(std::path::Path::new(&format!(
-                "files/{}",
-                segment::pending_changes::PENDING_CHANGES_LOG_FILE,
-            )))
+            .ends_with(std::path::Path::new("files").join(&log_file_name))
     });
     assert!(
         has_pending_changes_log,
@@ -679,7 +679,6 @@ fn test_proxy_segment_flush() {
         .unwrap();
 
     let locked_wrapped_segment = LockedSegment::new(build_segment_1(tmp_dir.path()));
-    let wrapped_segment_dir = locked_wrapped_segment.get().read().data_path();
 
     let mut proxy_segment = ProxySegment::new(locked_wrapped_segment.clone());
 
@@ -700,7 +699,7 @@ fn test_proxy_segment_flush() {
     assert_eq!(flushed_version_2, 100);
     assert_eq!(flushed_version_2, proxy_segment.version());
     assert!(
-        segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 0).is_file(),
+        proxy_segment.pending_changes.log_path().is_file(),
         "flush must persist pending changes log into the wrapped segment directory",
     );
 
@@ -728,6 +727,7 @@ fn test_pending_changes_recovered_on_restart() {
     let wrapped_segment_dir = locked_wrapped_segment.get().read().data_path();
 
     let mut proxy_segment = ProxySegment::new(locked_wrapped_segment.clone());
+    let log_path = proxy_segment.pending_changes.log_path().to_path_buf();
 
     proxy_segment
         .delete_point(100, 2.into(), &hw_counter)
@@ -751,7 +751,7 @@ fn test_pending_changes_recovered_on_restart() {
     // "Crash": drop the proxy without propagating to the wrapped segment
     drop(proxy_segment);
     drop(locked_wrapped_segment);
-    assert!(segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 0).is_file());
+    assert!(log_path.is_file());
 
     // "Restart": load the segment from disk and recover the pending changes, as done on start-up
     let mut segment = segment::segment_constructor::load_segment(
@@ -785,21 +785,22 @@ fn test_pending_changes_recovered_on_restart() {
     // past `ready_at`, so the caller (the segment holder, via a post-flush action) can safely
     // remove it
     assert_eq!(segment.persistent_version(), wrapped_persisted_version);
-    assert!(segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 0).is_file());
+    assert!(log_path.is_file());
 
     segment.flush(true).unwrap();
     assert_eq!(segment.persistent_version(), 101);
     for path in &recovered.log_files {
         fs_err::remove_file(path).unwrap();
     }
-    assert!(!segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 0).is_file());
+    assert!(!log_path.is_file());
 }
 
 /// Unwrapping a proxy leaves the pending changes log in place (deleting it before the wrapped
-/// segment flushed the propagated changes would not be crash safe), and a new proxy on the same
-/// segment adopts and appends to it.
+/// segment flushed the propagated changes would not be crash safe). A new proxy on the same
+/// segment never adopts that file though: it always starts a fresh, uniquely named one, leaving
+/// the old file untouched.
 #[test]
-fn test_unproxy_leaves_pending_changes_log_for_adoption() {
+fn test_unproxy_leaves_pending_changes_log_without_adoption() {
     let hw_counter = HardwareCounterCell::new();
     let tmp_dir = tempfile::Builder::new()
         .prefix("segment_dir")
@@ -808,9 +809,9 @@ fn test_unproxy_leaves_pending_changes_log_for_adoption() {
 
     let locked_wrapped_segment = LockedSegment::new(build_segment_1(tmp_dir.path()));
     let wrapped_segment_dir = locked_wrapped_segment.get().read().data_path();
-    let log_path = segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 0);
 
     let mut proxy_segment = ProxySegment::new(locked_wrapped_segment.clone());
+    let log_path = proxy_segment.pending_changes.log_path().to_path_buf();
     proxy_segment
         .delete_point(100, 2.into(), &hw_counter)
         .unwrap();
@@ -832,10 +833,18 @@ fn test_unproxy_leaves_pending_changes_log_for_adoption() {
         "unproxying must leave the pending changes log in place",
     );
 
-    // A new proxy on the same segment adopts the log: its persisted version covers the old
-    // operations, and new operations are appended after them
+    // A new proxy on the same segment does not adopt the old log: it starts a fresh, uniquely
+    // named one, and reports only the wrapped segment's own persisted version — it does not know
+    // about the old proxy's now-orphaned file (those operations are still safely recovered from
+    // there on restart, see `recover_pending_changes`)
+    let wrapped_persistent_version = locked_wrapped_segment.get().read().persistent_version();
     let mut proxy_segment = ProxySegment::new(locked_wrapped_segment.clone());
-    assert_eq!(proxy_segment.persistent_version(), 100);
+    let new_log_path = proxy_segment.pending_changes.log_path().to_path_buf();
+    assert_ne!(new_log_path, log_path);
+    assert_eq!(
+        proxy_segment.persistent_version(),
+        wrapped_persistent_version
+    );
     assert!(proxy_segment.get_deleted_points().is_empty());
 
     proxy_segment
@@ -843,9 +852,19 @@ fn test_unproxy_leaves_pending_changes_log_for_adoption() {
         .unwrap();
     proxy_segment.flush(false).unwrap();
 
-    let loaded = segment::pending_changes::PendingChanges::load(&wrapped_segment_dir, 0).unwrap();
-    assert_eq!(loaded.deleted_points().len(), 2);
-    assert_eq!(loaded.persisted_version(), 110);
+    // The old file still holds only the first proxy's entry, the new file only the second's
+    let loaded_old = segment::pending_changes::PendingChanges::load(&log_path).unwrap();
+    assert_eq!(loaded_old.deleted_points().len(), 1);
+    assert_eq!(loaded_old.persisted_version(), 100);
+
+    let loaded_new = segment::pending_changes::PendingChanges::load(&new_log_path).unwrap();
+    assert_eq!(loaded_new.deleted_points().len(), 1);
+    assert_eq!(loaded_new.persisted_version(), 110);
+
+    assert_eq!(
+        segment::pending_changes::list_pending_changes_log_files(&wrapped_segment_dir).len(),
+        2,
+    );
 }
 
 /// Each proxy layer persists its pending changes into a dedicated log file; on restart all files
@@ -863,6 +882,7 @@ fn test_double_proxy_pending_changes_levels() {
 
     // Inner proxy (e.g. an ongoing optimization) buffers a delete of point 2
     let mut inner_proxy = ProxySegment::new(locked_wrapped_segment.clone());
+    let inner_log_path = inner_proxy.pending_changes.log_path().to_path_buf();
     inner_proxy
         .delete_point(100, 2.into(), &hw_counter)
         .unwrap();
@@ -871,6 +891,7 @@ fn test_double_proxy_pending_changes_levels() {
     // point 3
     let locked_inner_proxy = LockedSegment::from(inner_proxy);
     let mut outer_proxy = ProxySegment::new(locked_inner_proxy.clone());
+    let outer_log_path = outer_proxy.pending_changes.log_path().to_path_buf();
     outer_proxy
         .delete_point(101, 3.into(), &hw_counter)
         .unwrap();
@@ -883,11 +904,8 @@ fn test_double_proxy_pending_changes_levels() {
     let log_files = segment::pending_changes::list_pending_changes_log_files(&wrapped_segment_dir);
     assert_eq!(
         log_files,
-        vec![
-            segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 0),
-            segment::pending_changes::pending_changes_log_path(&wrapped_segment_dir, 1),
-        ],
-        "each proxy layer must persist into its own log file",
+        vec![inner_log_path, outer_log_path],
+        "each proxy layer must persist into its own log file, inner most first",
     );
 
     // "Crash": drop both proxies without propagating, then load the segment and recover

--- a/lib/shard/src/segment_holder/snapshot.rs
+++ b/lib/shard/src/segment_holder/snapshot.rs
@@ -63,7 +63,7 @@ impl SegmentHolder {
         let mut new_proxies = Vec::with_capacity(segment_ids.len());
         for segment_id in segment_ids {
             let segment = segments_lock.get(segment_id).unwrap();
-            let proxy = UnsyncedProxySegment::new(segment.clone());
+            let proxy = UnsyncedProxySegment::new(segment.clone())?;
 
             // Write segment is fresh, so it has no operations
             // Operation with number 0 will be applied

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -2540,3 +2540,48 @@ fn test_flush_up_to_keeps_cow_dependency_past_the_bound() {
         "the dependency is persisted, it must be retired",
     );
 }
+
+/// A proxy segment must not hold back acknowledging the WAL. Flushing persists its buffered
+/// changes into the pending changes log, so the version returned by `flush_all` — which is what
+/// gets acknowledged in the WAL — advances past operations that only live in the proxy.
+#[test]
+fn test_proxy_segment_does_not_hold_back_wal_ack() {
+    use crate::proxy_segment::ProxySegment;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let mut holder = SegmentHolder::default();
+
+    // Wrap a segment at version 6 in a proxy, as the optimizer and snapshots do
+    let wrapped_segment = LockedSegment::new(build_segment_1(dir.path()));
+    let proxy_segment = ProxySegment::new(wrapped_segment.clone());
+    let proxy_id = holder.add_new_locked(LockedSegment::from(proxy_segment));
+
+    // All segment state is persisted after a flush, the full version can be acknowledged
+    let version = holder.flush_all(FlushMode::Sync, false).unwrap();
+    assert_eq!(version, 6);
+
+    // Buffer a point delete in the proxy; it is in memory only, so it caps the acknowledgeable
+    // version until it is persisted
+    holder
+        .get(proxy_id)
+        .unwrap()
+        .get()
+        .write()
+        .delete_point(100, 2.into(), &hw_counter)
+        .unwrap();
+
+    // Flushing persists the buffered delete into the pending changes log of the wrapped
+    // segment, so the WAL can be acknowledged up to and including the delete operation even
+    // though the wrapped segment itself never saw it
+    let version = holder.flush_all(FlushMode::Sync, false).unwrap();
+    assert_eq!(
+        version, 100,
+        "flushed proxy segment must not hold back the WAL acknowledge",
+    );
+
+    // The wrapped segment on disk is still at its own version; the difference is covered by the
+    // pending changes log
+    assert_eq!(wrapped_segment.get().read().version(), 6);
+}

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
+use common::flags::{FeatureFlags, init_feature_flags};
 use rand::RngExt;
 use segment::data_types::vectors::{DEFAULT_VECTOR_NAME, VectorInternal};
 use segment::json_path::JsonPath;
@@ -2547,6 +2548,11 @@ fn test_flush_up_to_keeps_cow_dependency_past_the_bound() {
 #[test]
 fn test_proxy_segment_does_not_hold_back_wal_ack() {
     use crate::proxy_segment::ProxySegment;
+
+    init_feature_flags(FeatureFlags {
+        persist_proxy_segments: true,
+        ..Default::default()
+    });
 
     let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
     let hw_counter = HardwareCounterCell::new();

--- a/lib/shard/src/snapshots/snapshot_manifest.rs
+++ b/lib/shard/src/snapshots/snapshot_manifest.rs
@@ -5,6 +5,7 @@ use fs_err as fs;
 use fs_err::File;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::data_types::manifest::SegmentManifest;
+use segment::pending_changes::PersistedProxyChanges;
 use segment::segment::snapshot::SEGMENT_MANIFEST_FILE_NAME;
 use segment::types::SeqNumberType;
 
@@ -189,5 +190,17 @@ impl RecoveryType {
 
     pub fn is_partial(self) -> bool {
         matches!(self, Self::Partial)
+    }
+
+    /// Whether persisted pending proxy changes are replayed when the recovered segments load.
+    ///
+    /// Partial snapshots are recovered by read replicas in a read/write segregation setup. A read
+    /// replica must not mutate its segments, so it cannot replay the persisted proxy segment
+    /// changes and ignores them instead.
+    pub fn persisted_proxy_changes(self) -> PersistedProxyChanges {
+        match self {
+            Self::Full => PersistedProxyChanges::Replay,
+            Self::Partial => PersistedProxyChanges::Ignore,
+        }
     }
 }

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -1143,7 +1143,14 @@ fn flush_between_batches_of_one_operation_keeps_the_rest_replayable() {
     );
 
     drop(holder);
-    let reloaded = load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
+    let reloaded = load_segment(
+        &segment_path,
+        Uuid::nil(),
+        None,
+        &AtomicBool::new(false),
+        false,
+    )
+    .unwrap();
     let hits = reloaded
         .read_filtered(
             None,

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -927,8 +927,14 @@ fn create_field_index_pins_pending_payload_state() {
     // Simulated crash: dropped without any flush after the op.
     drop(holder);
 
-    let mut segment = load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false))
-        .expect("segment must load after simulated crash");
+    let mut segment = load_segment(
+        &segment_path,
+        Uuid::nil(),
+        None,
+        &AtomicBool::new(false),
+        false,
+    )
+    .expect("segment must load after simulated crash");
 
     // The pre-build flush persisted the pending clear together with the index.
     let reloaded = segment.payload(0.into(), &hw_counter).unwrap();

--- a/src/segment_inspector.rs
+++ b/src/segment_inspector.rs
@@ -48,7 +48,15 @@ fn main() {
             .and_then(|s| Uuid::try_parse(s.to_str()?).ok())
             .unwrap_or(Uuid::nil());
 
-        let segment = load_segment(path, segment_uuid, None, &AtomicBool::new(false)).unwrap();
+        let segment = load_segment(
+            path,
+            segment_uuid,
+            None,
+            &AtomicBool::new(false),
+            // Allow to ignore missing version file, this is a debugging tool
+            true,
+        )
+        .unwrap();
 
         eprintln!(
             "path = {:#?}, size-points = {}",


### PR DESCRIPTION
Modify proxy segments to persist all tracked changes, rather than keeping it exclusively in memory.

On restart, any such proxy segment changes are replayed on their respective segments.

Prevents us from blocking WAL ack's for a long time and growing it very large while proxy segments are present.

Some facts:
- proxies now persist their pending changes during every flush cycle
- on restart proxies are not reconstructed but their changes are replayed directly on segments, so there will be no proxies when restarted
- WAL version can ack later version now, don't stall version while proxy is in place just ack latest flushed version
- prevents growing shard WAL very large
- uses size header per entry in log file to protect against torn writes, truncated tail (torn write) is safely ignored
- regular snapshots include these files and replay on restore
- partial snapshots (for R/W segregation) include these files but don't replay on restore, because segments are supposed to be immutable
- log file is stored as `proxy_changes.0.UUID.dat` inside respective segment directory, `proxy_changes.1.UUID.dat` and up for every extra proxy around that
- proxy persists all changes: deletes, payload index changes, named vector changes
- persisted changes are removed after replay and a full flush cycle
- differentiates proxy instances with an UUID in the file name
- has all crash windows covered, random crash should never result in loss

Note: the new behavior is gated behind the `persist_proxy_segments` runtime feature flag.

Extra tests are found here: https://github.com/qdrant/qdrant/pull/10445

### Depends on
- [x] https://github.com/qdrant/qdrant/pull/10364
- [x] https://github.com/qdrant/qdrant/pull/10507
- [x] https://github.com/qdrant/qdrant/pull/10531

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
