### PR TITLE
[UIO] `UniversalReadFs::open_async`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,7 @@ dependencies = [
  "strum",
  "tempfile",
  "thiserror 2.0.20",
+ "tokio",
  "zerocopy",
 ]
 
@@ -1369,6 +1370,7 @@ dependencies = [
  "fs-err",
  "fs4 1.1.0",
  "fs_extra",
+ "futures",
  "humantime",
  "io-uring 0.7.14",
  "itertools 0.15.0",
@@ -7210,6 +7212,7 @@ dependencies = [
  "sha2 0.11.0",
  "sparse",
  "tempfile",
+ "tokio",
  "validator",
  "zerocopy",
 ]

--- a/lib/blobstore/Cargo.toml
+++ b/lib/blobstore/Cargo.toml
@@ -37,6 +37,7 @@ dataset = { path = "../common/dataset" }
 fs-err = { workspace = true, features = ["debug"] }
 rstest = { workspace = true }
 proptest = { workspace = true }
+tokio = { workspace = true }
 bustle = "0.5.1"
 common = { path = "../common/common", features = ["testing"] }
 env_logger = { workspace = true }

--- a/lib/common/common/Cargo.toml
+++ b/lib/common/common/Cargo.toml
@@ -26,6 +26,7 @@ chrono = { workspace = true }
 fs-err = { workspace = true }
 fs4 = { workspace = true }
 fs_extra = { workspace = true }
+futures.workspace = true
 humantime = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }

--- a/lib/common/common/src/generic_consts.rs
+++ b/lib/common/common/src/generic_consts.rs
@@ -1,4 +1,4 @@
-pub trait AccessPattern: Copy + Default {
+pub trait AccessPattern: Copy + Default + Send {
     const IS_SEQUENTIAL: bool;
 }
 

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -3,6 +3,7 @@ use std::fmt::{Debug, Formatter};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::Poll;
 
 use parking_lot::Mutex;
 
@@ -89,6 +90,7 @@ where
 
 enum ScheduledFile<S: 'static> {
     Future(Pin<Box<dyn Future<Output = UioResult<S>> + Send + 'static>>),
+    Ready(UioResult<S>),
     Unchanged,
 }
 
@@ -96,6 +98,7 @@ impl<S> Debug for ScheduledFile<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ScheduledFile::Future(_) => write!(f, "Future"),
+            ScheduledFile::Ready(_) => write!(f, "Ready"),
             ScheduledFile::Unchanged => write!(f, "Unchanged"),
         }
     }
@@ -256,8 +259,17 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
         // Clone the fs handle so that the future can own it.
         let fs = self.fs.clone();
         let path_owned = path.to_path_buf();
-        let file = async move { fs.open_async(path_owned, open_options, open_extra).await };
-        files_prefetched.insert(path.to_path_buf(), ScheduledFile::Future(Box::pin(file)));
+        let mut fut =
+            Box::pin(async move { fs.open_async(path_owned, open_options, open_extra).await });
+
+        // Poll once, so that real async work begins right away
+        let scheduled = futures::executor::block_on(async move {
+            match futures::poll!(fut.as_mut()) {
+                Poll::Ready(file) => ScheduledFile::Ready(file),
+                Poll::Pending => ScheduledFile::Future(Box::pin(fut)),
+            }
+        });
+        files_prefetched.insert(path.to_path_buf(), scheduled);
 
         Ok(())
     }
@@ -371,6 +383,7 @@ impl<Fs: UniversalReadFs> UniversalReadFs for CachedFs<Fs> {
         if let Some(file) = self.files_prefetched.lock().remove(path) {
             return match file {
                 ScheduledFile::Future(future) => futures::executor::block_on(future),
+                ScheduledFile::Ready(result) => result,
                 ScheduledFile::Unchanged => Err(UniversalIoError::UnchangedOpen {
                     path: path.to_owned(),
                     since: self.file_info(path).and_then(|info| info.last_modified),
@@ -418,6 +431,7 @@ impl<Fs: UniversalReadFs> UniversalReadFs for CachedFs<Fs> {
         if let Some(file) = scheduled_file {
             return match file {
                 ScheduledFile::Future(future) => future.await,
+                ScheduledFile::Ready(result) => result,
                 ScheduledFile::Unchanged => Err(UniversalIoError::UnchangedOpen {
                     since: self.file_info(&path).and_then(|info| info.last_modified),
                     path,

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -71,7 +72,11 @@ impl FileInfo {
 /// Prefetched handles are take-once: [`UniversalReadFs::open`] removes the
 /// handle from the pool and returns it owned. The pool is shared across
 /// clones.
-pub struct CachedFs<Fs: UniversalReadFs> {
+pub struct CachedFs<Fs>
+where
+    Fs: UniversalReadFs,
+    Fs::File: 'static,
+{
     fs: Fs,
     prefix_path: PathBuf,
     /// `None` until [`CachedFs::cache_file_info`] takes the listing
@@ -79,7 +84,21 @@ pub struct CachedFs<Fs: UniversalReadFs> {
     files_info: Option<HashMap<PathBuf, FileInfo>>,
     /// Previous listing snapshot.
     previous_files_info: Option<HashMap<PathBuf, FileInfo>>,
-    files_prefetched: Arc<Mutex<HashMap<PathBuf, Option<Fs::File>>>>,
+    files_prefetched: Arc<Mutex<HashMap<PathBuf, ScheduledFile<Fs::File>>>>,
+}
+
+enum ScheduledFile<S: 'static> {
+    Future(Pin<Box<dyn Future<Output = UioResult<S>> + Send + 'static>>),
+    Unchanged,
+}
+
+impl<S> Debug for ScheduledFile<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ScheduledFile::Future(_) => write!(f, "Future"),
+            ScheduledFile::Unchanged => write!(f, "Unchanged"),
+        }
+    }
 }
 
 /// Manual impl: `derive(Clone)` would add a spurious `Fs::File: Clone`
@@ -234,8 +253,11 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
             open_extra = open_extra.with_known_len(info.size);
         }
 
-        let file = self.fs.open(path, open_options, open_extra)?;
-        files_prefetched.insert(path.to_path_buf(), Some(file));
+        // Clone the fs handle so that the future can own it.
+        let fs = self.fs.clone();
+        let path_owned = path.to_path_buf();
+        let file = async move { fs.open_async(path_owned, open_options, open_extra).await };
+        files_prefetched.insert(path.to_path_buf(), ScheduledFile::Future(Box::pin(file)));
 
         Ok(())
     }
@@ -259,7 +281,7 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
                 .zip(self.file_info(path))
                 .is_some_and(|(previous, current)| previous.full_eq(current))
             {
-                files_prefetched.insert(path.to_path_buf(), None);
+                files_prefetched.insert(path.to_path_buf(), ScheduledFile::Unchanged);
                 return Ok(());
             }
         }
@@ -348,8 +370,8 @@ impl<Fs: UniversalReadFs> UniversalReadFs for CachedFs<Fs> {
 
         if let Some(file) = self.files_prefetched.lock().remove(path) {
             return match file {
-                Some(file) => Ok(file),
-                None => Err(UniversalIoError::UnchangedOpen {
+                ScheduledFile::Future(future) => futures::executor::block_on(future),
+                ScheduledFile::Unchanged => Err(UniversalIoError::UnchangedOpen {
                     path: path.to_owned(),
                     since: self.file_info(path).and_then(|info| info.last_modified),
                 }),
@@ -376,5 +398,50 @@ impl<Fs: UniversalReadFs> UniversalReadFs for CachedFs<Fs> {
             None => extra,
         };
         self.fs.open(path, options, extra)
+    }
+
+    async fn open_async(
+        &self,
+        path: PathBuf,
+        options: OpenOptions,
+        extra: Self::OpenExtra,
+    ) -> UioResult<Self::File> {
+        if options.writeable {
+            return Err(UniversalIoError::Uninitialized {
+                description:
+                    "CachedReadFs only supports read-only files, writeable option is not allowed"
+                        .to_string(),
+            });
+        }
+
+        let scheduled_file = self.files_prefetched.lock().remove(&path);
+        if let Some(file) = scheduled_file {
+            return match file {
+                ScheduledFile::Future(future) => future.await,
+                ScheduledFile::Unchanged => Err(UniversalIoError::UnchangedOpen {
+                    since: self.file_info(&path).and_then(|info| info.last_modified),
+                    path,
+                }),
+            };
+        }
+
+        // With a snapshot, unlisted paths fail locally — probing for
+        // optional files never reaches the inner filesystem.
+        if let Some(files_info) = &self.files_info
+            && !files_info.contains_key(&path)
+        {
+            return Err(UniversalIoError::NotFound { path });
+        }
+
+        // The path was never scheduled for prefetch. If a snapshot was taken it
+        // still carries the file's size, so thread it into the open as a known
+        // length — this lets the backend skip a remote `len`/HEAD round-trip
+        // (e.g. `DiskCacheFs` opens straight into `State::Ready`). Without a
+        // snapshot this is a plain cache-bypass open.
+        let extra = match self.file_info(&path) {
+            Some(info) => extra.with_known_len(info.size),
+            None => extra,
+        };
+        self.fs.open_async(path, options, extra).await
     }
 }

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -1,5 +1,5 @@
 use std::ops::Range;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use fs_err as fs;
@@ -132,6 +132,16 @@ impl UniversalReadFs for BlockCacheFs {
 
         CachedSlice::open(&self.controller, path.as_ref())
             .map_err(|err| UniversalIoError::extract_not_found(err, path.as_ref()))
+    }
+
+    fn open_async(
+        &self,
+        path: PathBuf,
+        options: OpenOptions,
+        extra: (),
+    ) -> impl Future<Output = UioResult<CachedSlice>> + '_ {
+        // FIXME: implement proper async
+        std::future::ready(self.open(&path, options, extra))
     }
 }
 

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -169,6 +169,16 @@ impl UniversalReadFs for IoUringFs {
             direct_io,
         })
     }
+
+    fn open_async(
+        &self,
+        path: std::path::PathBuf,
+        options: OpenOptions,
+        extra: Self::OpenExtra,
+    ) -> impl Future<Output = UioResult<Self::File>> + '_ {
+        // IoUringFile does not handle `populate` parameter
+        std::future::ready(self.open(&path, options, extra))
+    }
 }
 
 impl UniversalRead for IoUringFile {

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -80,6 +80,15 @@ impl UniversalReadFs for MmapFs {
     ) -> UioResult<MmapFile> {
         MmapFile::open_inner(path, options)
     }
+
+    fn open_async(
+        &self,
+        path: PathBuf,
+        options: OpenOptions,
+        extra: (),
+    ) -> impl Future<Output = UioResult<MmapFile>> + '_ {
+        std::future::ready(self.open(&path, options, extra))
+    }
 }
 
 /// A memory-mapped local file handle.

--- a/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/fs.rs
@@ -8,8 +8,8 @@ use super::file::{DiskCache, State};
 use super::pipeline::REMOTE_READ_ALIGNMENT;
 use super::{DiskCacheRemote, block_aligned_fetch};
 use crate::generic_consts::Sequential;
-use crate::universal_io::simple_disk_cache::REMOTE_OPEN_OPTIONS;
 use crate::universal_io::simple_disk_cache::local_state::LocalState;
+use crate::universal_io::simple_disk_cache::{REMOTE_OPEN_OPTIONS, to_block_range};
 use crate::universal_io::{
     ListedFile, OpenExtra, OpenOptions, OwnedPipeline, Populate, UioResult, UniversalIoError,
     UniversalRead, UniversalReadFileOps, UniversalReadFs,
@@ -119,7 +119,7 @@ impl<R: UniversalRead> DiskCacheFs<R> {
 
 impl<R> UniversalReadFileOps for DiskCacheFs<R>
 where
-    R: UniversalRead,
+    R: UniversalRead + 'static,
 {
     type ContextConfig = DiskCacheFsContext<<R::Fs as UniversalReadFileOps>::ContextConfig>;
 
@@ -271,5 +271,72 @@ where
         }
 
         Ok(cache)
+    }
+
+    async fn open_async(
+        &self,
+        path: PathBuf,
+        options: OpenOptions,
+        extra: Self::OpenExtra,
+    ) -> UioResult<Self::File> {
+        let populate = if crate::low_memory::low_memory_mode().skip_populate() {
+            Populate::No
+        } else {
+            options.populate
+        };
+
+        let local_path = unique_local_path(self.config.local_path_for(path.as_ref())?);
+
+        let remote_extra = extra.remote_extra.clone().with_prevent_caching(true);
+
+        let state = match populate {
+            Populate::Auto | Populate::No | Populate::Blocking => {
+                return self.open(path, options, extra);
+            }
+            Populate::PreferBackground => {
+                let remote = self.open_remote(&path, remote_extra.clone())?;
+                let len = match extra.known_len {
+                    Some(len) => len,
+                    None => remote.len::<u8>()?,
+                };
+                let byte_range = 0..len;
+
+                let content = remote
+                    .read_bytes_async(byte_range.clone(), Sequential, REMOTE_READ_ALIGNMENT)
+                    .await?;
+
+                let local = LocalState::new(&local_path, len, options)?;
+                unsafe { local.write_mmap_bytes(&content, to_block_range(byte_range)) };
+                State::ready(remote, local)
+            }
+            Populate::Partial(read_range) => {
+                let remote = self.open_remote(&path, remote_extra.clone())?;
+                let file_len = match extra.known_len {
+                    Some(len) => len,
+                    None => remote.len::<u8>()?,
+                };
+                let byte_range = read_range.into_byte_range::<u8>();
+                let (block_range, fetch_range) =
+                    block_aligned_fetch(byte_range, file_len).expect("range should not be empty");
+
+                let content = remote
+                    .read_bytes_async(fetch_range.clone(), Sequential, REMOTE_READ_ALIGNMENT)
+                    .await?;
+
+                let local = LocalState::new(&local_path, file_len, options)?;
+                unsafe { local.write_mmap_bytes(&content, block_range) };
+                State::ready(remote, local)
+            }
+        };
+
+        Ok(DiskCache::new(
+            self.remote_fs.clone(),
+            remote_extra,
+            path,
+            local_path,
+            options,
+            state,
+            extra.known_etag,
+        ))
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -980,6 +980,18 @@ mod tests_async {
                 async_reads: AtomicUsize::new(0),
             })
         }
+
+        async fn open_async(
+            &self,
+            path: PathBuf,
+            options: OpenOptions,
+            extra: Self::OpenExtra,
+        ) -> UioResult<Self::File> {
+            Ok(AsyncOnlyRemote {
+                inner: self.0.open_async(path, options, extra).await?,
+                async_reads: AtomicUsize::new(0),
+            })
+        }
     }
 
     impl UniversalRead for AsyncOnlyRemote {

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -1,5 +1,5 @@
 use std::fmt::Debug;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::universal_io::cached_fs::FileInfo;
 use crate::universal_io::traits::append::UniversalAppend;
@@ -21,10 +21,11 @@ use crate::universal_io::{ListedFile, OpenOptions, UioResult};
 /// [`UniversalWriteFileOps`] subtrait.
 ///
 /// Handles are cheap to clone and shareable across threads, e.g. to move
-/// them into background flushers.
+/// them into background flushers. They own their resources (`'static`), so
+/// futures built from a cloned handle can be parked or spawned.
 ///
 /// [`UniversalWrite`]: super::UniversalWrite
-pub trait UniversalReadFileOps: Clone + Debug + Send + Sync + Sized {
+pub trait UniversalReadFileOps: Clone + Debug + Send + Sync + Sized + 'static {
     /// Implementation-specific construction config. Backends are free to
     /// require explicit construction; callers that want to opt into the
     /// `<Fs::ContextConfig>::default()` pattern must constrain
@@ -134,7 +135,7 @@ pub trait UniversalReadFs: UniversalReadFileOps {
     /// here. Generic callers pass `Default::default()` and chain
     /// [`OpenExtra`] setters (e.g. [`OpenExtra::with_prevent_caching`]) for
     /// behaviors that have universal meaning across backends.
-    type OpenExtra: OpenExtra;
+    type OpenExtra: OpenExtra + Send;
 
     /// Open a file for reading.
     ///
@@ -146,6 +147,16 @@ pub trait UniversalReadFs: UniversalReadFileOps {
         options: OpenOptions,
         extra: Self::OpenExtra,
     ) -> UioResult<Self::File>;
+
+    /// Open a file, and populate it asynchronously.
+    ///
+    /// Must not depend on ambient async context; capture any runtime by value.
+    fn open_async(
+        &self,
+        path: PathBuf,
+        options: OpenOptions,
+        extra: Self::OpenExtra,
+    ) -> impl Future<Output = UioResult<Self::File>> + Send + '_;
 }
 
 /// Capability extension over [`UniversalReadFs`]: a filesystem that snapshots

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -115,7 +115,7 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
         range: Range<u64>,
         access_pattern: P,
         align: usize,
-    ) -> impl Future<Output = UioResult<ACow<'_>>>;
+    ) -> impl Future<Output = UioResult<ACow<'_>>> + Send;
 
     /// Read the entire file in one logical access.
     ///

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -68,6 +68,16 @@ impl<F: UniversalReadFs> UniversalReadFs for ReadOnlyFs<F> {
         debug_assert!(!options.writeable);
         Ok(ReadOnly(self.0.open(path, options, extra)?))
     }
+
+    async fn open_async(
+        &self,
+        path: std::path::PathBuf,
+        options: OpenOptions,
+        extra: Self::OpenExtra,
+    ) -> UioResult<Self::File> {
+        debug_assert!(!options.writeable);
+        Ok(ReadOnly(self.0.open_async(path, options, extra).await?))
+    }
 }
 
 /// Construction context for [`ReadOnlyFs`], forwarding to the inner Fs's

--- a/lib/common/io_bridge/src/cached/fs.rs
+++ b/lib/common/io_bridge/src/cached/fs.rs
@@ -1,6 +1,6 @@
 //! Filesystem handle producing [`CachedBlobFile`]s.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use common::universal_io::{
@@ -105,6 +105,25 @@ where
         let cache = self.cache_fs.open(path.as_ref(), cache_options, extra)?;
 
         let remote = self.blob_fs.open(path.as_ref(), options, ())?;
+
+        Ok(CachedBlobFile::new(cache, remote, options.writeable))
+    }
+
+    async fn open_async(
+        &self,
+        path: PathBuf,
+        options: OpenOptions,
+        extra: Self::OpenExtra,
+    ) -> UioResult<Self::File> {
+        let mut cache_options = options;
+        cache_options.writeable = false;
+
+        let cache = self
+            .cache_fs
+            .open_async(path.clone(), cache_options, extra)
+            .await?;
+
+        let remote = self.blob_fs.open_async(path, options, ()).await?;
 
         Ok(CachedBlobFile::new(cache, remote, options.writeable))
     }

--- a/lib/common/io_bridge/src/fs.rs
+++ b/lib/common/io_bridge/src/fs.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
 use common::universal_io::{
@@ -112,5 +112,15 @@ impl<A: AsyncRead + Clone> UniversalReadFs for BlobFs<A> {
             BlobFile::new(self.inner.clone(), self.runtime.clone(), path.as_ref())
                 .with_writeable(options.writeable),
         )
+    }
+
+    async fn open_async(
+        &self,
+        path: PathBuf,
+        options: OpenOptions,
+        extra: (),
+    ) -> UioResult<BlobFile<A>> {
+        // BlobFile does not populate on open.
+        self.open(path, options, extra)
     }
 }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -91,6 +91,7 @@ sha2 = { workspace = true }
 siphasher = "1.0.3"
 smallvec = { workspace = true }
 strum = { workspace = true }
+tokio = { workspace = true }
 byteorder = { workspace = true }
 stumpalo = { workspace = true }
 zerocopy = { workspace = true }

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
@@ -235,6 +235,7 @@ mod tests {
     #[case(true, false)]
     #[case(true, true)]
     #[case(false, false)]
+    #[case(false, true)]
     fn live_reload_matches_fresh_open(
         #[case] materialize_before_reload: bool,
         #[case] preload: bool,

--- a/lib/sparse/Cargo.toml
+++ b/lib/sparse/Cargo.toml
@@ -43,6 +43,7 @@ indicatif = { workspace = true }
 sha2 = { workspace = true }
 sparse = { path = ".", features = ["testing"] }
 tempfile = { workspace = true }
+tokio = { workspace = true }
 zerocopy = { workspace = true }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]


### PR DESCRIPTION
Adds and implements a new `open_async` function on `UniversalReadFs` and its implementors.

Notably, `DiskCache` can now return a future which returns a populated file when awaited.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>