### PR TITLE
[UIO] make `UniversalRead::live_preload` async

### DIFF
--- a/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
@@ -160,7 +160,7 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
 
         create_and_ensure_length(&self.path, new_length_in_bytes)?;
 
-        self.slice_store.reopen()?;
+        self.slice_store.live_reload()?;
 
         debug_assert_eq!(self.len()? - prev_len, data.len());
 

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
@@ -210,7 +210,7 @@ impl<S: UniversalWrite> Bitmask<S> {
         let new_length = (previous_bit_len / u8::BITS as usize) + extra_length;
         create_and_ensure_length(&self.path, new_length)?;
 
-        self.bitslice.reopen()?;
+        self.bitslice.live_reload()?;
 
         let current_bit_len = self.bitslice.bit_len() as usize;
 

--- a/lib/blobstore/src/blobstore/logstore/page.rs
+++ b/lib/blobstore/src/blobstore/logstore/page.rs
@@ -496,21 +496,21 @@ impl<S: UniversalRead> AppendOnlyPage<S> {
 
     fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> Result<()> {
         self.file
-            .schedule_reopen(|path| fs.cached_file_info(path))?;
+            .live_preload(|path| fs.cached_file_info(path))?;
         Ok(())
     }
 
-    /// Reopen the page file handle and reload its length, making newly appended value data
+    /// Reload the page file handle and reload its length, making newly appended value data
     /// visible to reads and the reported storage size.
     ///
-    /// The reopen is a no-op for backends that read the file directly, those see newly appended
+    /// The reload is a no-op for backends that read the file directly, those see newly appended
     /// data without it.
     fn live_reload(&mut self) -> Result<()> {
         debug_assert!(
             self.pending.is_empty(),
             "live reload must only be used on read-only instances",
         );
-        self.file.reopen()?;
+        self.file.live_reload()?;
         self.persisted_len = self.file.len::<u8>()?;
         Ok(())
     }
@@ -590,7 +590,7 @@ impl<S: UniversalAppend> AppendOnlyPage<S> {
             // landed before; adopt them as persisted. Any other length means the file was
             // modified outside this writer.
             Err(UniversalIoError::AppendOffsetConflict { .. }) => {
-                self.file.reopen()?;
+                self.file.live_reload()?;
                 let len = self.file.len::<u8>()?;
                 if len != end {
                     return Err(BlobstoreError::service_error(format!(

--- a/lib/blobstore/src/blobstore/logstore/page.rs
+++ b/lib/blobstore/src/blobstore/logstore/page.rs
@@ -495,8 +495,8 @@ impl<S: UniversalRead> AppendOnlyPage<S> {
     }
 
     fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> Result<()> {
-        self.file
-            .live_preload(|path| fs.cached_file_info(path))?;
+        #[expect(unused_must_use)] // todo(uio): remove after propagating future
+        self.file.live_preload(|path| fs.cached_file_info(path))?;
         Ok(())
     }
 

--- a/lib/blobstore/src/tracker/append_only.rs
+++ b/lib/blobstore/src/tracker/append_only.rs
@@ -246,7 +246,7 @@ impl<S: UniversalRead> AppendOnlyTracker<S> {
             "live reload must only be used on read-only instances",
         );
 
-        self.file.reopen()?;
+        self.file.live_reload()?;
         let len = self.file.len::<u8>()?;
         let new_count = count_from_len(len)?;
 
@@ -275,7 +275,7 @@ impl<S: UniversalRead> AppendOnlyTracker<S> {
 
     pub(crate) fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> Result<()> {
         self.file
-            .schedule_reopen(|path| fs.cached_file_info(path))?;
+            .live_preload(|path| fs.cached_file_info(path))?;
         Ok(())
     }
 }
@@ -411,7 +411,7 @@ impl<S: UniversalAppend> AppendOnlyTracker<S> {
             // landed before; adopt them as persisted. Any other length means the file was
             // modified outside this writer.
             Err(UniversalIoError::AppendOffsetConflict { .. }) => {
-                self.file.reopen()?;
+                self.file.live_reload()?;
                 let len = self.file.len::<u8>()?;
                 if len != end {
                     return Err(BlobstoreError::service_error(format!(

--- a/lib/blobstore/src/tracker/append_only.rs
+++ b/lib/blobstore/src/tracker/append_only.rs
@@ -274,8 +274,8 @@ impl<S: UniversalRead> AppendOnlyTracker<S> {
     }
 
     pub(crate) fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> Result<()> {
-        self.file
-            .live_preload(|path| fs.cached_file_info(path))?;
+        #[expect(unused_must_use)] // todo(uio): remove after propagating future
+        self.file.live_preload(|path| fs.cached_file_info(path))?;
         Ok(())
     }
 }

--- a/lib/blobstore/src/tracker/mod.rs
+++ b/lib/blobstore/src/tracker/mod.rs
@@ -568,7 +568,7 @@ where
             self.storage.flusher()()?;
             let new_size = end_offset.next_power_of_two();
             create_and_ensure_length(&self.path, new_size)?;
-            self.storage.reopen()?;
+            self.storage.live_reload()?;
         }
 
         let pointer = OptionalPointer::from(pointer);

--- a/lib/common/common/src/stored_bitslice.rs
+++ b/lib/common/common/src/stored_bitslice.rs
@@ -79,8 +79,8 @@ impl<S: UniversalRead> StoredBitSlice<S> {
         })
     }
 
-    pub fn reopen(&mut self) -> UioResult<()> {
-        self.storage.reopen()?;
+    pub fn live_reload(&mut self) -> UioResult<()> {
+        self.storage.live_reload()?;
         self.element_len = self.storage.len()?;
         Ok(())
     }

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -279,7 +279,7 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
         let scheduled = futures::executor::block_on(async move {
             match futures::poll!(fut.as_mut()) {
                 Poll::Ready(file) => ScheduledFile::Ready(file),
-                Poll::Pending => ScheduledFile::Future(Box::pin(fut)),
+                Poll::Pending => ScheduledFile::Future(fut),
             }
         });
         files_prefetched.insert(path.to_path_buf(), scheduled);

--- a/lib/common/common/src/universal_io/conformance.rs
+++ b/lib/common/common/src/universal_io/conformance.rs
@@ -108,7 +108,7 @@ where
         .unwrap();
     assert_eq!(reader.len::<u8>().unwrap(), eof);
     file.append(eof, b"tail".as_slice()).unwrap();
-    reader.reopen().unwrap();
+    reader.live_reload().unwrap();
     assert_eq!(reader.len::<u8>().unwrap(), eof + 4);
     assert_eq!(
         reader
@@ -145,7 +145,7 @@ where
 
     // Recovery per the contract: reopen the stale handle, re-check the
     // length to learn the true end of file, and append there.
-    first.reopen().unwrap();
+    first.live_reload().unwrap();
     let eof = first.len::<u8>().unwrap();
     assert_eq!(eof, 6);
     first.append(eof, b"ccc".as_slice()).unwrap();

--- a/lib/common/common/src/universal_io/disk_cache/mod.rs
+++ b/lib/common/common/src/universal_io/disk_cache/mod.rs
@@ -154,7 +154,7 @@ impl UniversalRead for CachedSlice {
         Self: 'a,
         U: UserData;
 
-    fn reopen(&mut self) -> UioResult<()> {
+    fn live_reload(&mut self) -> UioResult<()> {
         // TODO: revise if this is the best way to reopen
         *self = CachedSlice::open(&self.controller, &self.path)
             .map_err(|err| UniversalIoError::extract_not_found(err, &self.path))?;

--- a/lib/common/common/src/universal_io/io_uring/mod.rs
+++ b/lib/common/common/src/universal_io/io_uring/mod.rs
@@ -190,7 +190,7 @@ impl UniversalRead for IoUringFile {
         Self: 'a,
         U: UserData;
 
-    fn reopen(&mut self) -> UioResult<()> {
+    fn live_reload(&mut self) -> UioResult<()> {
         Ok(())
     }
 

--- a/lib/common/common/src/universal_io/mmap/mod.rs
+++ b/lib/common/common/src/universal_io/mmap/mod.rs
@@ -190,7 +190,7 @@ impl UniversalRead for MmapFile {
         Self: 'a,
         U: UserData;
 
-    fn reopen(&mut self) -> UioResult<()> {
+    fn live_reload(&mut self) -> UioResult<()> {
         let old_len = self.len as u64;
         let new_len = fs_err::File::open(self.path())
             .map_err(|err| UniversalIoError::extract_not_found(err, self.path()))?
@@ -393,7 +393,7 @@ impl MmapFile {
     /// Grow the mapping to `new_len` without consulting the filesystem: the
     /// caller already knows the file's new length (an append it just made,
     /// or a `set_len` it just issued), so the `open`+`fstat`+`close` of a
-    /// full [`reopen`](UniversalRead::reopen) is skipped. Unlike a reopen,
+    /// full [`live_reload`](UniversalRead::live_reload) is skipped. Unlike a reopen,
     /// the non-Linux re-mmap never re-populates: growth is mapping
     /// maintenance, and re-faulting the whole file would make each append
     /// O(file size) for handles opened with [`Populate::Blocking`].

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
@@ -5,6 +5,7 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
+use futures::future::{BoxFuture, Shared};
 use parking_lot::Mutex;
 
 use super::DiskCacheRemote;
@@ -107,11 +108,14 @@ pub(crate) enum ScheduledReopen<R: UniversalRead + 'static> {
     /// `target_len` and lets the new blocks fault in on demand.
     Resize { target_len: u64 },
     /// Populated (`Blocking` / `PreferBackground`): the appended tail is
-    /// already in flight on a clone of the remote; apply resizes, drains it
-    /// and writes it. Holds exactly one read, whose user data is the block
-    /// range it covers, as in [`State::PartialPrefill`].
+    /// already in flight on a fresh remote handle; apply resizes, drains it
+    /// and writes it. `future` drives the fetch (clones of it may be polled
+    /// externally); `data` receives the fetched bytes and the handle once
+    /// `future` completes.
     Tail {
-        pipeline: OwnedPipeline<R, Range<u32>>,
+        future: Shared<BoxFuture<'static, ()>>,
+        data: futures::channel::oneshot::Receiver<UioResult<(R, Vec<u8>)>>,
+        blocks_range: Range<u32>,
         target_len: u64,
     },
 }
@@ -125,7 +129,9 @@ impl<R: UniversalRead + 'static> ScheduledReopen<R> {
             ScheduledReopen::Resize { target_len }
             | ScheduledReopen::Tail {
                 target_len,
-                pipeline: _,
+                data: _,
+                future: _,
+                blocks_range: _,
             } => Some(*target_len),
         }
     }

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
@@ -19,7 +19,7 @@ mod reopen;
 /// A lazily-populated local mirror of an append-only remote file.
 ///
 /// The remote's existing bytes are assumed to be immutable for the lifetime
-/// of the file: it may grow externally (picked up by [`reopen`]), but never
+/// of the file: it may grow externally (picked up by [`live_reload`]), but never
 /// shrink or change in place. This type implements [`UniversalRead`] only —
 /// appends are deliberately not supported through the cache (append
 /// directly to the backing storage instead), and random-offset writes stay
@@ -55,9 +55,9 @@ where
     /// Fast-path gate: `true` when `state` is [`State::Ready`].
     pub(super) is_ready: AtomicBool,
     /// Entity tag of the remote object, as last known: seeded from the open
-    /// extras, refreshed by [`schedule_reopen`] and [`set_etag`](Self::set_etag).
+    /// extras, refreshed by [`live_preload`] and [`set_etag`](Self::set_etag).
     ///
-    /// [`schedule_reopen`]: UniversalRead::schedule_reopen
+    /// [`live_preload`]: UniversalRead::live_preload
     etag: Mutex<Option<String>>,
 }
 
@@ -71,13 +71,13 @@ pub(crate) enum State<R: UniversalRead + 'static> {
     Ready {
         remote: R,
         local: LocalState,
-        /// What the next [`reopen`] must do. Staged by [`schedule_reopen`],
-        /// consumed (reset to [`ScheduledReopen::No`]) by [`reopen`]. Only
+        /// What the next [`live_reload`] must do. Staged by [`live_preload`],
+        /// consumed (reset to [`ScheduledReopen::No`]) by [`live_reload`]. Only
         /// touched under `&mut self`, and `ReadyRef` borrows just
         /// `remote`/`local`, so staging never disturbs the served state.
         ///
-        /// [`reopen`]: UniversalRead::reopen
-        /// [`schedule_reopen`]: UniversalRead::schedule_reopen
+        /// [`live_reload`]: UniversalRead::live_reload
+        /// [`live_preload`]: UniversalRead::live_preload
         scheduled_reopen: Option<ScheduledReopen<R>>,
     },
     /// Eager open-time prefill: an in-flight whole-object read scheduled at open;
@@ -91,8 +91,8 @@ pub(crate) enum State<R: UniversalRead + 'static> {
     },
 }
 
-/// The obligation of the next [`reopen`](UniversalRead::reopen), staged ahead
-/// of time by [`schedule_reopen`](UniversalRead::schedule_reopen).
+/// The obligation of the next [`live_reload`](UniversalRead::live_reload), staged ahead
+/// of time by [`live_preload`](UniversalRead::live_preload).
 ///
 /// Staging deliberately leaves the mirror alone: its length keeps matching its
 /// persisted content until the apply, so readers observe nothing in between

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -5,6 +5,8 @@ use std::borrow::Cow;
 use std::ops::Range;
 use std::path::Path;
 
+use futures::FutureExt as _;
+
 use super::DiskCache;
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Random, Sequential};
@@ -67,8 +69,21 @@ where
     fn live_preload<F: FnOnce(&Path) -> Option<FileInfo>>(
         &self,
         get_file_info: F,
-    ) -> UioResult<()> {
-        self.live_preload_impl(get_file_info)
+    ) -> UioResult<impl Future<Output = ()> + Send + 'static> {
+        let mut future = self.live_preload_impl(get_file_info)?;
+
+        // Poll once so that actual async work begins right away
+        let future = futures::executor::block_on(
+            #[expect(clippy::async_yields_async)] // so it can be polled externally
+            async move {
+                match futures::poll!(&mut future) {
+                    std::task::Poll::Ready(()) => async {}.left_future(),
+                    std::task::Poll::Pending => future.right_future(),
+                }
+            },
+        );
+
+        Ok(future)
     }
 
     fn read_bytes<P: AccessPattern>(

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/read.rs
@@ -60,15 +60,15 @@ where
         R: 'a,
         U: UserData;
 
-    fn reopen(&mut self) -> UioResult<()> {
+    fn live_reload(&mut self) -> UioResult<()> {
         self.reopen_impl()
     }
 
-    fn schedule_reopen<F: FnOnce(&Path) -> Option<FileInfo>>(
+    fn live_preload<F: FnOnce(&Path) -> Option<FileInfo>>(
         &self,
         get_file_info: F,
     ) -> UioResult<()> {
-        self.schedule_reopen_impl(get_file_info)
+        self.live_preload_impl(get_file_info)
     }
 
     fn read_bytes<P: AccessPattern>(

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -8,12 +8,15 @@
 use std::io::{self, ErrorKind};
 use std::path::Path;
 
+use futures::FutureExt;
+use futures::future::{BoxFuture, Shared};
+
 use super::{DiskCache, ScheduledReopen, State};
 use crate::generic_consts::Sequential;
 use crate::universal_io::cached_fs::FileInfo;
 use crate::universal_io::simple_disk_cache::pipeline::REMOTE_READ_ALIGNMENT;
 use crate::universal_io::simple_disk_cache::{DiskCacheRemote, block_aligned_fetch};
-use crate::universal_io::{OwnedPipeline, Populate, UioResult, UniversalIoError, UniversalRead};
+use crate::universal_io::{Populate, UioResult, UniversalIoError, UniversalRead};
 
 impl<R> DiskCache<R>
 where
@@ -26,7 +29,7 @@ where
         }
 
         // If not previously done, schedule and wait blockingly
-        self.live_preload_with_len(None)?;
+        futures::executor::block_on(self.live_preload_with_len(None)?);
         self.resolve_pending_reload()?;
 
         Ok(())
@@ -61,27 +64,28 @@ where
                 local.resize(&self.local_path, target_len)?;
             }
             ScheduledReopen::Tail {
-                mut pipeline,
+                future,
+                mut data,
+                blocks_range,
                 target_len,
             } => {
-                let fetched = pipeline.wait()?;
+                futures::executor::block_on(future);
+                let (new_remote, fetched) = data
+                    .try_recv()
+                    .expect("sender is never dropped before sending")
+                    .expect("data should be available, and no other consumer exists")?;
 
-                // resize only after pipeline.wait() returns Ok
+                // resize only after the fetch succeeded
                 local.resize(&self.local_path, target_len)?;
 
-                match fetched {
-                    Some((blocks_range, bytes)) if !bytes.is_empty() => {
-                        // SAFETY: `bytes` covers `blocks_range` exactly
-                        // (clamped to EOF)
-                        unsafe { local.write_mmap_bytes(&bytes, blocks_range) }
-                    }
-                    // Nothing landed: the resize still makes the length visible,
-                    // and the new blocks fault in on demand.
-                    Some(_) | None => {}
+                if !fetched.is_empty() {
+                    // SAFETY: `fetched` covers `blocks_range` exactly
+                    // (clamped to EOF)
+                    unsafe { local.write_mmap_bytes(&fetched, blocks_range) }
                 }
 
-                // replace remote with the one from the owned pipeline
-                *remote = pipeline.into_inner();
+                // replace remote with the one that fetched the tail
+                *remote = new_remote;
             }
         }
 
@@ -91,16 +95,15 @@ where
     pub(super) fn live_preload_impl<F: FnOnce(&Path) -> Option<FileInfo>>(
         &self,
         get_file_info: F,
-    ) -> UioResult<()> {
+    ) -> UioResult<Shared<BoxFuture<'static, ()>>> {
         let Some(file_info) = get_file_info(&self.remote_path) else {
             return Err(UniversalIoError::NotFound {
                 path: self.remote_path.clone(),
             });
         };
-
-        self.live_preload_with_len(Some(file_info.size))?;
+        let fut = self.live_preload_with_len(Some(file_info.size))?;
         self.set_etag(file_info.etag);
-        Ok(())
+        Ok(fut)
     }
 
     /// Body of [`UniversalRead::live_preload`].
@@ -111,7 +114,10 @@ where
     /// apply.
     ///
     /// [`UniversalRead::live_preload`]: crate::universal_io::UniversalRead::live_preload
-    pub(super) fn live_preload_with_len(&self, known_len: Option<u64>) -> UioResult<()> {
+    pub(super) fn live_preload_with_len(
+        &self,
+        known_len: Option<u64>,
+    ) -> UioResult<Shared<BoxFuture<'static, ()>>> {
         // Wait for scheduled prefill, if any.
         //
         // warn: this will do a length request if uninit, but when using a
@@ -130,7 +136,7 @@ where
 
         let local_len = local.mmap().len::<u8>()?;
 
-        // If we don't have a known length, reopen the remote to tell the new length.
+        // If we don't have a known length, reload the remote to tell the new length.
         let remote_len = match known_len {
             Some(known_len) => known_len,
             None => {
@@ -149,16 +155,27 @@ where
             )));
         }
 
-        // Check if staged length has grown
-        if scheduled_reopen
-            .as_ref()
-            .is_some_and(|r| r.target_len() == Some(remote_len))
+        // Already staged at this length: reuse the staged fetch's signal so
+        // the caller still observes its completion.
+        if let Some(scheduled) = scheduled_reopen.as_ref()
+            && scheduled.target_len() == Some(remote_len)
         {
-            return Ok(());
+            let future = match scheduled {
+                ScheduledReopen::Tail {
+                    future,
+                    data: _,
+                    blocks_range: _,
+                    target_len: _,
+                } => future.clone(),
+                ScheduledReopen::Unchanged | ScheduledReopen::Resize { target_len: _ } => {
+                    async {}.boxed().shared()
+                }
+            };
+            return Ok(future);
         }
 
-        let new_scheduled_reopen = if remote_len == local_len {
-            ScheduledReopen::Unchanged
+        if remote_len == local_len {
+            *scheduled_reopen = Some(ScheduledReopen::Unchanged);
         } else {
             match self.open_options.populate {
                 Populate::Blocking | Populate::PreferBackground => {
@@ -169,28 +186,42 @@ where
 
                     // Fresh remote handle
                     let new_remote = self.open_remote()?;
-                    let mut pipeline = OwnedPipeline::new(new_remote)?;
-                    // FIXME: check can_schedule in a loop?
-                    pipeline.schedule::<Sequential>(
-                        blocks_range,
-                        byte_range,
-                        REMOTE_READ_ALIGNMENT,
-                    )?;
+                    let (tx, rx) = futures::channel::oneshot::channel();
+                    let future = {
+                        async move {
+                            let fetch = || async {
+                                Ok(new_remote
+                                    .read_bytes_async(byte_range, Sequential, REMOTE_READ_ALIGNMENT)
+                                    .await?
+                                    .try_cast_bytemuck::<u8>()?
+                                    .into_owned())
+                            };
+                            let result = fetch().await.map(|fetched| (new_remote, fetched));
 
-                    ScheduledReopen::Tail {
-                        pipeline,
+                            tx.send(result).ok();
+                        }
+                        .boxed()
+                        .shared()
+                    };
+
+                    *scheduled_reopen = Some(ScheduledReopen::Tail {
                         target_len: remote_len,
-                    }
+                        future: future.clone(),
+                        data: rx,
+                        blocks_range,
+                    });
+
+                    return Ok(future);
                 }
                 // No prefetch for lazy population
-                Populate::Auto | Populate::No | Populate::Partial(_) => ScheduledReopen::Resize {
-                    target_len: remote_len,
-                },
+                Populate::Auto | Populate::No | Populate::Partial(_) => {
+                    *scheduled_reopen = Some(ScheduledReopen::Resize {
+                        target_len: remote_len,
+                    });
+                }
             }
         };
 
-        *scheduled_reopen = Some(new_scheduled_reopen);
-
-        Ok(())
+        Ok(async {}.boxed().shared())
     }
 }

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -1,9 +1,9 @@
-//! [`Reopen`] the local mirror after the (append-only) remote has grown,
+//! [`live_reload`] the local mirror after the (append-only) remote has grown,
 //! either in one blocking step or split into a schedule and an apply phase
-//! ([`schedule_reopen`]).
+//! ([`live_preload`]).
 //!
-//! [`reopen`]: crate::universal_io::UniversalRead::reopen
-//! [`schedule_reopen`]: crate::universal_io::UniversalRead::schedule_reopen
+//! [`live_reload`]: crate::universal_io::UniversalRead::live_reload
+//! [`live_preload`]: crate::universal_io::UniversalRead::live_preload
 
 use std::io::{self, ErrorKind};
 use std::path::Path;
@@ -19,23 +19,23 @@ impl<R> DiskCache<R>
 where
     R: DiskCacheRemote,
 {
-    /// Body of [`UniversalRead::reopen`](crate::universal_io::UniversalRead::reopen).
+    /// Body of [`UniversalRead::live_reload`](crate::universal_io::UniversalRead::live_reload).
     pub(super) fn reopen_impl(&mut self) -> UioResult<()> {
-        if self.resolve_pending_reopen()? {
+        if self.resolve_pending_reload()? {
             return Ok(());
         }
 
         // If not previously done, schedule and wait blockingly
-        self.schedule_reopen_with_len(None)?;
-        self.resolve_pending_reopen()?;
+        self.live_preload_with_len(None)?;
+        self.resolve_pending_reload()?;
 
         Ok(())
     }
 
-    // Apply whatever `schedule_reopen` staged, if anything.
+    // Apply whatever `live_preload` staged, if anything.
     //
     // Returns `true` if a pending reopen was resolved, `false` otherwise.
-    fn resolve_pending_reopen(&mut self) -> UioResult<bool> {
+    fn resolve_pending_reload(&mut self) -> UioResult<bool> {
         let State::Ready {
             remote,
             local,
@@ -56,7 +56,7 @@ where
             ScheduledReopen::Unchanged => {}
             ScheduledReopen::Resize { target_len } => {
                 // reopen remote, so we can read up to the new length.
-                remote.reopen()?;
+                remote.live_reload()?;
 
                 local.resize(&self.local_path, target_len)?;
             }
@@ -88,7 +88,7 @@ where
         Ok(true)
     }
 
-    pub(super) fn schedule_reopen_impl<F: FnOnce(&Path) -> Option<FileInfo>>(
+    pub(super) fn live_preload_impl<F: FnOnce(&Path) -> Option<FileInfo>>(
         &self,
         get_file_info: F,
     ) -> UioResult<()> {
@@ -98,20 +98,20 @@ where
             });
         };
 
-        self.schedule_reopen_with_len(Some(file_info.size))?;
+        self.live_preload_with_len(Some(file_info.size))?;
         self.set_etag(file_info.etag);
         Ok(())
     }
 
-    /// Body of [`UniversalRead::schedule_reopen`].
+    /// Body of [`UniversalRead::live_preload`].
     ///
     /// Records what the next [`reopen_impl`](Self::reopen_impl) must do and,
     /// for populated files, puts the tail fetch in flight — without waiting on
     /// it and without touching the mirror, so readers see no change until the
     /// apply.
     ///
-    /// [`UniversalRead::schedule_reopen`]: crate::universal_io::UniversalRead::schedule_reopen
-    pub(super) fn schedule_reopen_with_len(&self, known_len: Option<u64>) -> UioResult<()> {
+    /// [`UniversalRead::live_preload`]: crate::universal_io::UniversalRead::live_preload
+    pub(super) fn live_preload_with_len(&self, known_len: Option<u64>) -> UioResult<()> {
         // Wait for scheduled prefill, if any.
         //
         // warn: this will do a length request if uninit, but when using a
@@ -134,7 +134,7 @@ where
         let remote_len = match known_len {
             Some(known_len) => known_len,
             None => {
-                remote.reopen()?;
+                remote.live_reload()?;
                 remote.len::<u8>()?
             }
         };

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -460,9 +460,7 @@ mod tests_mod {
         let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
 
         let new_data = scn.grow_remote(BLOCK_SIZE);
-        cache
-            .live_preload(scn.snapshot_file_info::<R>())
-            .unwrap();
+        let _ = cache.live_preload(scn.snapshot_file_info::<R>());
 
         // Nothing changed yet: same length, and the appended region is still
         // out of bounds.
@@ -501,9 +499,7 @@ mod tests_mod {
         let mut cache = scn.open::<R>(PREFILL);
         assert!(!cache.is_ready());
 
-        cache
-            .live_preload(scn.snapshot_file_info::<R>())
-            .unwrap();
+        let _ = cache.live_preload(scn.snapshot_file_info::<R>());
 
         assert!(cache.is_ready());
         assert_eq!(cache.len::<u8>().unwrap(), scn.data.len() as u64);
@@ -533,9 +529,7 @@ mod tests_mod {
             )
         };
 
-        cache
-            .live_preload(scn.snapshot_file_info::<R>())
-            .unwrap();
+        let _ = cache.live_preload(scn.snapshot_file_info::<R>());
         cache.live_reload().unwrap();
 
         let local = cache.state().unwrap().local;
@@ -553,13 +547,9 @@ mod tests_mod {
         let _ = cache.read::<_, u8>(ReadRange::one(0), Sequential).unwrap();
 
         scn.grow_remote(BLOCK_SIZE);
-        cache
-            .live_preload(scn.snapshot_file_info::<R>())
-            .unwrap();
+        let _ = cache.live_preload(scn.snapshot_file_info::<R>());
         let new_data = scn.grow_remote(BLOCK_SIZE);
-        cache
-            .live_preload(scn.snapshot_file_info::<R>())
-            .unwrap();
+        let _ = cache.live_preload(scn.snapshot_file_info::<R>());
 
         cache.live_reload().unwrap();
 
@@ -579,8 +569,9 @@ mod tests_mod {
 
         let new_data = scn.grow_remote(BLOCK_SIZE);
         let get_file_info = scn.snapshot_file_info::<R>();
-        cache.live_preload(&get_file_info).unwrap();
-        cache.live_preload(&get_file_info).unwrap();
+
+        let _ = cache.live_preload(&get_file_info);
+        let _ = cache.live_preload(&get_file_info);
 
         cache.live_reload().unwrap();
 
@@ -595,9 +586,10 @@ mod tests_mod {
     #[test]
     fn reopen_schedule_missing_from_snapshot_errors() {
         let scn = Scenario::new(BLOCK_SIZE);
-        let cache = scn.open::<R>(PREFILL);
+        let mut cache = scn.open::<R>(PREFILL);
 
-        let err = cache.live_preload(|_| None).unwrap_err();
+        let _ = cache.live_preload(|_| None);
+        let err = cache.live_reload().unwrap_err();
         assert_matches!(err, UniversalIoError::NotFound { .. });
     }
 

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -135,7 +135,7 @@ impl Scenario {
         &self.data[range.start as usize..range.end as usize]
     }
 
-    /// A `get_file_info` for `schedule_reopen`, backed by a `CachedFs`
+    /// A `get_file_info` for `live_preload`, backed by a `CachedFs`
     /// listing snapshot taken now — the schedule-phase view of the remote.
     /// Take a fresh one after growing the remote, as a refresh pass would.
     fn snapshot_file_info<R>(&self) -> impl Fn(&Path) -> Option<FileInfo>
@@ -366,7 +366,7 @@ mod tests_mod {
             )
         };
 
-        cache.reopen().unwrap();
+        cache.live_reload().unwrap();
 
         let local = if PREFILL {
             // in case of Populate::PreferBackground, we need to await for
@@ -408,7 +408,7 @@ mod tests_mod {
             crate::universal_io::UniversalIoError::OutOfBounds { .. },
         );
 
-        cache.reopen().unwrap();
+        cache.live_reload().unwrap();
 
         let bytes = cache
             .read::<_, u8>(ReadRange::new(original_len, BLOCK_SIZE as u64), Sequential)
@@ -434,7 +434,7 @@ mod tests_mod {
         // Grow remote past the old tail block boundary.
         let new_data = scn.grow_remote(BLOCK_SIZE);
 
-        cache.reopen().unwrap();
+        cache.live_reload().unwrap();
 
         // Read covers both the originally-partial range [BLOCK_SIZE..old_len)
         // and the newly-grown tail [old_len..BLOCK_SIZE*2). Without the
@@ -461,7 +461,7 @@ mod tests_mod {
 
         let new_data = scn.grow_remote(BLOCK_SIZE);
         cache
-            .schedule_reopen(scn.snapshot_file_info::<R>())
+            .live_preload(scn.snapshot_file_info::<R>())
             .unwrap();
 
         // Nothing changed yet: same length, and the appended region is still
@@ -472,7 +472,7 @@ mod tests_mod {
             .unwrap_err();
         assert_matches!(err, UniversalIoError::OutOfBounds { .. });
 
-        cache.reopen().unwrap();
+        cache.live_reload().unwrap();
 
         assert_eq!(cache.len::<u8>().unwrap(), new_data.len() as u64);
         // A populated cache staged the tail fetch, so the appended block is
@@ -502,7 +502,7 @@ mod tests_mod {
         assert!(!cache.is_ready());
 
         cache
-            .schedule_reopen(scn.snapshot_file_info::<R>())
+            .live_preload(scn.snapshot_file_info::<R>())
             .unwrap();
 
         assert!(cache.is_ready());
@@ -510,7 +510,7 @@ mod tests_mod {
 
         // A later reopen (nothing staged — the length didn't grow) must
         // leave the mirror alone.
-        cache.reopen().unwrap();
+        cache.live_reload().unwrap();
         assert_eq!(cache.len::<u8>().unwrap(), scn.data.len() as u64);
 
         let bytes = cache.read_whole::<u8>().unwrap();
@@ -534,9 +534,9 @@ mod tests_mod {
         };
 
         cache
-            .schedule_reopen(scn.snapshot_file_info::<R>())
+            .live_preload(scn.snapshot_file_info::<R>())
             .unwrap();
-        cache.reopen().unwrap();
+        cache.live_reload().unwrap();
 
         let local = cache.state().unwrap().local;
         assert_eq!(local.mmap().len::<u8>().unwrap(), len_before);
@@ -554,14 +554,14 @@ mod tests_mod {
 
         scn.grow_remote(BLOCK_SIZE);
         cache
-            .schedule_reopen(scn.snapshot_file_info::<R>())
+            .live_preload(scn.snapshot_file_info::<R>())
             .unwrap();
         let new_data = scn.grow_remote(BLOCK_SIZE);
         cache
-            .schedule_reopen(scn.snapshot_file_info::<R>())
+            .live_preload(scn.snapshot_file_info::<R>())
             .unwrap();
 
-        cache.reopen().unwrap();
+        cache.live_reload().unwrap();
 
         assert_eq!(cache.len::<u8>().unwrap(), new_data.len() as u64);
         let bytes = cache.read_whole::<u8>().unwrap();
@@ -579,10 +579,10 @@ mod tests_mod {
 
         let new_data = scn.grow_remote(BLOCK_SIZE);
         let get_file_info = scn.snapshot_file_info::<R>();
-        cache.schedule_reopen(&get_file_info).unwrap();
-        cache.schedule_reopen(&get_file_info).unwrap();
+        cache.live_preload(&get_file_info).unwrap();
+        cache.live_preload(&get_file_info).unwrap();
 
-        cache.reopen().unwrap();
+        cache.live_reload().unwrap();
 
         assert_eq!(cache.len::<u8>().unwrap(), new_data.len() as u64);
         let bytes = cache.read_whole::<u8>().unwrap();
@@ -597,7 +597,7 @@ mod tests_mod {
         let scn = Scenario::new(BLOCK_SIZE);
         let cache = scn.open::<R>(PREFILL);
 
-        let err = cache.schedule_reopen(|_| None).unwrap_err();
+        let err = cache.live_preload(|_| None).unwrap_err();
         assert_matches!(err, UniversalIoError::NotFound { .. });
     }
 
@@ -1003,8 +1003,8 @@ mod tests_async {
             Self: 'a,
             U: UserData;
 
-        fn reopen(&mut self) -> UioResult<()> {
-            self.inner.reopen()
+        fn live_reload(&mut self) -> UioResult<()> {
+            self.inner.live_reload()
         }
 
         fn read_bytes<P: AccessPattern>(

--- a/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/tests.rs
@@ -586,10 +586,10 @@ mod tests_mod {
     #[test]
     fn reopen_schedule_missing_from_snapshot_errors() {
         let scn = Scenario::new(BLOCK_SIZE);
-        let mut cache = scn.open::<R>(PREFILL);
+        let cache = scn.open::<R>(PREFILL);
 
-        let _ = cache.live_preload(|_| None);
-        let err = cache.live_reload().unwrap_err();
+        // `map(drop)` discards the staged future, which is not `Debug`.
+        let err = cache.live_preload(|_| None).map(drop).unwrap_err();
         assert_matches!(err, UniversalIoError::NotFound { .. });
     }
 

--- a/lib/common/common/src/universal_io/traits/append.rs
+++ b/lib/common/common/src/universal_io/traits/append.rs
@@ -26,7 +26,7 @@ use crate::universal_io::{ByteOffset, UioResult};
 ///   rejected with [`AppendOffsetConflict`] and nothing is written — so a
 ///   duplicate of an append that already landed conflicts instead of
 ///   appending twice. To recover from a conflict, re-check the length
-///   ([`len`], after [`reopen`] on a stale handle) to learn where the file
+///   ([`len`], after [`live_reload`] on a stale handle) to learn where the file
 ///   actually ends before appending anew.
 /// - Single logical writer: exactly one handle appends to a given file at a
 ///   time. With concurrent appenders, object-store backends reject
@@ -34,10 +34,10 @@ use crate::universal_io::{ByteOffset, UioResult};
 ///   non-atomically, so an out-of-contract concurrent grow can land data
 ///   past the validated offset (never overwriting existing bytes).
 /// - After `Ok`, this handle's [`len`]/reads observe the appended bytes.
-///   Other handles (including clones) must [`reopen`] first. For mmap-backed
+///   Other handles (including clones) must [`live_reload`] first. For mmap-backed
 ///   handles this is a hard requirement rather than staleness: an append may
 ///   move the shared mapping, so any later read through a clone that has not
-///   [`reopen`]ed is undefined behavior (see [`MmapFile`]).
+///   [`live_reload`]ed is undefined behavior (see [`MmapFile`]).
 /// - Durability: local backends require running [`UniversalFlush::flusher`];
 ///   object-store backends are durable when `append` returns `Ok` (their
 ///   flusher is a no-op).
@@ -63,7 +63,7 @@ use crate::universal_io::{ByteOffset, UioResult};
 /// [`UniversalWrite`]: super::UniversalWrite
 /// [`UniversalWrite::write`]: super::UniversalWrite::write
 /// [`len`]: UniversalRead::len
-/// [`reopen`]: UniversalRead::reopen
+/// [`live_reload`]: UniversalRead::live_reload
 pub trait UniversalAppend:
     UniversalRead<Fs: UniversalWriteFileOps<AppendFile = Self>> + UniversalFlush
 {

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -58,9 +58,9 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     /// underlying file larger, so reopening can account for this growth.
     ///
     /// This may be a no-op in some implementations.
-    fn reopen(&mut self) -> UioResult<()>;
+    fn live_reload(&mut self) -> UioResult<()>;
 
-    /// Stage the work that the next [`reopen`](Self::reopen) must do, reading
+    /// Stage the work that the next [`live_reload`](Self::reopen) must do, reading
     /// the file's current length via `get_file_info` — typically backed by a
     /// [`CachedReadFs`] listing snapshot. The implementation resolves its own
     /// path, so there is nothing to mispair.
@@ -77,7 +77,7 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     ///
     /// [`CachedReadFs`]: crate::universal_io::CachedReadFs
     /// [`DiskCache`]: crate::universal_io::DiskCache
-    fn schedule_reopen<F: FnOnce(&Path) -> Option<FileInfo>>(
+    fn live_preload<F: FnOnce(&Path) -> Option<FileInfo>>(
         &self,
         get_file_info: F,
     ) -> UioResult<()> {

--- a/lib/common/common/src/universal_io/traits/read.rs
+++ b/lib/common/common/src/universal_io/traits/read.rs
@@ -3,6 +3,8 @@ use std::fmt::Debug;
 use std::ops::Range;
 use std::path::Path;
 
+use futures::FutureExt as _;
+
 use super::{Item, ReadPipeline, UniversalReadFs, UserData};
 use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::{AccessPattern, Sequential};
@@ -72,6 +74,8 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     /// readers of an already-live mirror — no length change, no cache
     /// invalidation.
     ///
+    /// The returned future signals when the preload is complete.
+    ///
     /// Defaults to a no-op: local backends' `reopen` is a stat plus a remap,
     /// so there is nothing worth pre-staging. Only [`DiskCache`] overrides it.
     ///
@@ -80,9 +84,10 @@ pub trait UniversalRead: Sized + Debug + Send + Sync {
     fn live_preload<F: FnOnce(&Path) -> Option<FileInfo>>(
         &self,
         get_file_info: F,
-    ) -> UioResult<()> {
+    ) -> UioResult<impl Future<Output = ()> + Send + 'static> {
         let _ = get_file_info;
-        Ok(())
+
+        Ok(async {}.boxed())
     }
 
     /// Prefer [`read_batch`] if you need high performance.

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -122,16 +122,16 @@ where
         U: UserData;
 
     #[inline]
-    fn reopen(&mut self) -> UioResult<()> {
-        self.0.reopen()
+    fn live_reload(&mut self) -> UioResult<()> {
+        self.0.live_reload()
     }
 
     #[inline]
-    fn schedule_reopen<F: FnOnce(&Path) -> Option<FileInfo>>(
+    fn live_preload<F: FnOnce(&Path) -> Option<FileInfo>>(
         &self,
         get_file_info: F,
     ) -> UioResult<()> {
-        self.0.schedule_reopen(get_file_info)
+        self.0.live_preload(get_file_info)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/read_only.rs
+++ b/lib/common/common/src/universal_io/wrappers/read_only.rs
@@ -130,7 +130,7 @@ where
     fn live_preload<F: FnOnce(&Path) -> Option<FileInfo>>(
         &self,
         get_file_info: F,
-    ) -> UioResult<()> {
+    ) -> UioResult<impl Future<Output = ()> + Send + 'static> {
         self.0.live_preload(get_file_info)
     }
 

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -68,15 +68,15 @@ where
         fs.open(path, options, extra).map(Self::new)
     }
 
-    pub fn reopen(&mut self) -> UioResult<()> {
-        self.inner.reopen()
+    pub fn live_reload(&mut self) -> UioResult<()> {
+        self.inner.live_reload()
     }
 
-    pub fn schedule_reopen<F: FnOnce(&Path) -> Option<FileInfo>>(
+    pub fn live_preload<F: FnOnce(&Path) -> Option<FileInfo>>(
         &mut self,
         get_file_info: F,
     ) -> UioResult<()> {
-        self.inner.schedule_reopen(get_file_info)
+        self.inner.live_preload(get_file_info)
     }
 
     #[inline]

--- a/lib/common/common/src/universal_io/wrappers/typed.rs
+++ b/lib/common/common/src/universal_io/wrappers/typed.rs
@@ -75,7 +75,7 @@ where
     pub fn live_preload<F: FnOnce(&Path) -> Option<FileInfo>>(
         &mut self,
         get_file_info: F,
-    ) -> UioResult<()> {
+    ) -> UioResult<impl Future<Output = ()>> {
         self.inner.live_preload(get_file_info)
     }
 

--- a/lib/common/io_bridge/src/cached/mod.rs
+++ b/lib/common/io_bridge/src/cached/mod.rs
@@ -121,14 +121,14 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
             );
         }
 
-        self.cache.schedule_reopen(|_| {
+        self.cache.live_preload(|_| {
             Some(FileInfo {
                 size: new_len,
                 last_modified: None,
                 etag: None,
             })
         })?;
-        self.cache.reopen()
+        self.cache.live_reload()
     }
 
     /// Replace the whole remote object with `[0, offset) + data`, built on
@@ -191,15 +191,15 @@ where
         Self: 'a,
         U: UserData;
 
-    fn reopen(&mut self) -> UioResult<()> {
-        self.cache.reopen()
+    fn live_reload(&mut self) -> UioResult<()> {
+        self.cache.live_reload()
     }
 
-    fn schedule_reopen<F: FnOnce(&Path) -> Option<FileInfo>>(
+    fn live_preload<F: FnOnce(&Path) -> Option<FileInfo>>(
         &self,
         get_file_info: F,
     ) -> UioResult<()> {
-        self.cache.schedule_reopen(get_file_info)
+        self.cache.live_preload(get_file_info)
     }
 
     fn read_bytes<P: AccessPattern>(

--- a/lib/common/io_bridge/src/cached/mod.rs
+++ b/lib/common/io_bridge/src/cached/mod.rs
@@ -121,13 +121,13 @@ impl<A: AsyncAppend + Clone> CachedBlobFile<A> {
             );
         }
 
-        self.cache.live_preload(|_| {
+        let _ = self.cache.live_preload(|_| {
             Some(FileInfo {
                 size: new_len,
                 last_modified: None,
                 etag: None,
             })
-        })?;
+        });
         self.cache.live_reload()
     }
 
@@ -198,7 +198,7 @@ where
     fn live_preload<F: FnOnce(&Path) -> Option<FileInfo>>(
         &self,
         get_file_info: F,
-    ) -> UioResult<()> {
+    ) -> UioResult<impl Future<Output = ()> + Send + 'static> {
         self.cache.live_preload(get_file_info)
     }
 

--- a/lib/common/io_bridge/src/file.rs
+++ b/lib/common/io_bridge/src/file.rs
@@ -98,7 +98,7 @@ impl<A: AsyncRead + Clone> UniversalRead for BlobFile<A> {
         Self: 'a,
         U: UserData;
 
-    fn reopen(&mut self) -> UioResult<()> {
+    fn live_reload(&mut self) -> UioResult<()> {
         Ok(())
     }
 

--- a/lib/segment/src/common/flags/dynamic_stored_flags.rs
+++ b/lib/segment/src/common/flags/dynamic_stored_flags.rs
@@ -203,7 +203,7 @@ where
 
             // Don't read the whole file on resize
             let populate = Populate::No;
-            // TODO(uio): consider using UniversalRead::reopen
+            // TODO(uio): consider using UniversalRead::live_reload
             let flags = Self::open_storage(fs, new_len, &self.directory, populate)?;
 
             // Swap operation. It is important this section is not interrupted by errors.

--- a/lib/segment/src/id_tracker/mutable_id_tracker/read_only/live_reload.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/read_only/live_reload.rs
@@ -70,7 +70,7 @@ impl<S: UniversalRead> ReadOnlyAppendableIdTracker<S> {
         ] {
             match file {
                 Some(file) => {
-                    file.schedule_reopen(|p| fs.cached_file_info(p))
+                    file.live_preload(|p| fs.cached_file_info(p))
                         .ok_not_found()?;
                 }
                 None => {
@@ -83,7 +83,7 @@ impl<S: UniversalRead> ReadOnlyAppendableIdTracker<S> {
 
     /// Consume mapping and version changes appended to storage since the last reload.
     ///
-    /// File handles are refreshed via [`UniversalRead::reopen`] so data appended by the writer
+    /// File handles are refreshed via [`UniversalRead::live_reload`] so data appended by the writer
     /// becomes visible; not-yet-opened files are opened lazily through `fs` (a caching wrapper's
     /// prefetch pool serves these opens when staged). Both result lists are sorted ascending.
     ///
@@ -168,7 +168,7 @@ impl<S: UniversalRead> ReadOnlyAppendableIdTracker<S> {
                 // Refresh the handle to observe data appended by the writer. A lazily-opened handle whose
                 // object does not exist yet (e.g. S3) reports `NotFound` here or from `len`; treat that as
                 // an empty file.
-                file.reopen().ok_not_found()?;
+                file.live_reload().ok_not_found()?;
             }
             None => {
                 self.mappings_file = Self::try_open(fs, &mappings_path(&self.segment_path))?;
@@ -226,7 +226,7 @@ impl<S: UniversalRead> ReadOnlyAppendableIdTracker<S> {
                 // Refresh the handle to observe data appended by the writer. A lazily-opened handle whose
                 // object does not exist yet (e.g. S3) reports `NotFound` here or from `len`; treat that as
                 // an empty file (no committed versions).
-                versions_file.reopen().ok_not_found()?;
+                versions_file.live_reload().ok_not_found()?;
             }
             None => {
                 self.versions_file = Self::try_open(fs, &versions_path(&self.segment_path))?;

--- a/lib/segment/src/id_tracker/mutable_id_tracker/read_only/mod.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/read_only/mod.rs
@@ -23,7 +23,7 @@ use crate::types::{PointIdType, SeqNumberType};
 ///
 /// Backed by [`UniversalRead`] file handles so it works over any storage backend (mmap, io_uring,
 /// object storage, ...). The handles are retained between reloads and refreshed via
-/// [`UniversalRead::reopen`] to pick up data appended by the writer.
+/// [`UniversalRead::live_reload`] to pick up data appended by the writer.
 ///
 /// The mappings and versions files may be absent: the writer only creates them once it flushes the
 /// first point (an empty file is never written), exactly as


### PR DESCRIPTION
Renames:
- `UniversalRead::reopen`->`UniversalRead::live_reload`
- `UniversalRead::schedule_reopen`->`UniversalRead::live_preload`


Then makes an overhaul of `live_preload`, so that it returns a future that signals completion of such preload.

For DiskCache, the returned future is actually a `futures::future::Shared`, which means it can be driven internally (when calling `live_preload`, then `live_reload`); or externally, by joining multiple `live_preload` futures.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>