### PR TITLE
[UIO] Segment `live_preload` waits for all IO before returning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6656,6 +6656,7 @@ dependencies = [
  "fnv",
  "fs-err",
  "fs_extra",
+ "futures",
  "geo",
  "geohash",
  "gpu",

--- a/lib/blobstore/src/blobstore/gridstore/reader.rs
+++ b/lib/blobstore/src/blobstore/gridstore/reader.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 
 use common::counter::counter_cell::CounterCell;
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -219,10 +220,13 @@ impl<V: Blob, S: UniversalRead> GridstoreReader<V, S> {
         self.view().get_storage_size_bytes()
     }
 
-    pub(crate) fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> Result<()> {
+    pub(crate) fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> Result<Vec<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>> {
         self.tracker.live_preload(fs);
         self.pages.live_preload(fs, self.populate)?;
-        Ok(())
+        Ok(Vec::new())
     }
 
     /// This method reloads the Gridstore data from "disk", so that

--- a/lib/blobstore/src/blobstore/logstore/page.rs
+++ b/lib/blobstore/src/blobstore/logstore/page.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 
 use ahash::{HashMap, HashSet};
 use common::generic_consts::AccessPattern;
@@ -270,16 +271,18 @@ impl<S: UniversalRead> AppendOnlyPages<S> {
         &self,
         fs: &Fs,
         populate: Populate,
-    ) -> Result<()> {
+    ) -> Result<Vec<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>> {
         let page_list: HashMap<_, _> = fs
             .list_files(&self.dir.join(PAGE_FILE_NAME_PREFIX))?
             .into_iter()
             .map(|listed| (listed.path, listed.size))
             .collect();
 
+        let mut futs = Vec::new();
+
         // Reload pages
         for page in &self.pages {
-            page.live_preload(fs)?;
+            futs.push(page.live_preload(fs)?);
         }
 
         // Load new pages
@@ -294,7 +297,7 @@ impl<S: UniversalRead> AppendOnlyPages<S> {
                 None,
             );
         }
-        Ok(())
+        Ok(futs)
     }
 }
 
@@ -494,10 +497,13 @@ impl<S: UniversalRead> AppendOnlyPage<S> {
             })
     }
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> Result<()> {
-        #[expect(unused_must_use)] // todo(uio): remove after propagating future
-        self.file.live_preload(|path| fs.cached_file_info(path))?;
-        Ok(())
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> Result<Pin<Box<dyn Future<Output = ()> + Send + 'static>>> {
+        Ok(Box::pin(
+            self.file.live_preload(|path| fs.cached_file_info(path))?,
+        ))
     }
 
     /// Reload the page file handle and reload its length, making newly appended value data

--- a/lib/blobstore/src/blobstore/logstore/reader.rs
+++ b/lib/blobstore/src/blobstore/logstore/reader.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 
 use common::counter::counter_cell::CounterCell;
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -195,12 +196,13 @@ impl<V: Blob, S: UniversalRead> LogstoreReader<V, S> {
         self.view().get_storage_size_bytes()
     }
 
-    pub(crate) fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> Result<()> {
-        self.tracker.live_preload(fs)?;
-
-        self.pages.live_preload(fs, self.populate)?;
-
-        Ok(())
+    pub(crate) fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> Result<Vec<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>> {
+        let mut futs = vec![self.tracker.live_preload(fs)?];
+        futs.extend(self.pages.live_preload(fs, self.populate)?);
+        Ok(futs)
     }
 
     /// This method reloads the storage from "disk", so that it makes newly appended data

--- a/lib/blobstore/src/blobstore/reader.rs
+++ b/lib/blobstore/src/blobstore/reader.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::pin::Pin;
 
 use common::counter::counter_cell::CounterCell;
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -217,7 +218,10 @@ impl<V: Blob, S: UniversalRead> BlobstoreReader<V, S> {
         }
     }
 
-    pub fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> Result<()> {
+    pub fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> Result<Vec<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>> {
         match self {
             Self::Gridstore(reader) => reader.live_preload(fs),
             Self::Logstore(reader) => reader.live_preload(fs),

--- a/lib/blobstore/src/blobstore/tests.rs
+++ b/lib/blobstore/src/blobstore/tests.rs
@@ -1904,8 +1904,11 @@ fn test_batch_read_honors_pending_unset_of_flushed_value() {
 /// Merely opening after a preopen proves nothing: `CachedFs` falls back to a regular open for
 /// paths that were never scheduled. Instead, delete the backend-read files after the preopen —
 /// the open can then only succeed if it is served from the prefetch pool.
+#[tokio::test]
 #[rstest]
-fn test_preopen_schedules_files_for_open(#[values(Mode::Mutable, Mode::AppendOnly)] mode: Mode) {
+async fn test_preopen_schedules_files_for_open(
+    #[values(Mode::Mutable, Mode::AppendOnly)] mode: Mode,
+) {
     use common::universal_io::{
         CachedFs, CachedReadFs, Populate, ReadOnly, UniversalRead, UniversalReadFileOps,
     };
@@ -1932,7 +1935,7 @@ fn test_preopen_schedules_files_for_open(#[values(Mode::Mutable, Mode::AppendOnl
         Populate::No,
     )
     .unwrap();
-    cached_fs.wait_all();
+    cached_fs.wait_all().await;
 
     // Delete everything `open` reads through the backend. The append-only tracker is read
     // directly from disk, not through the backend, so it must stay.

--- a/lib/blobstore/src/tracker/append_only.rs
+++ b/lib/blobstore/src/tracker/append_only.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 
 use common::generic_consts::{AccessPattern, Random};
 use common::mmap::{Advice, AdviceSetting};
@@ -273,10 +274,13 @@ impl<S: UniversalRead> AppendOnlyTracker<S> {
         self.persisted_count = count;
     }
 
-    pub(crate) fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> Result<()> {
-        #[expect(unused_must_use)] // todo(uio): remove after propagating future
-        self.file.live_preload(|path| fs.cached_file_info(path))?;
-        Ok(())
+    pub(crate) fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> Result<Pin<Box<dyn Future<Output = ()> + Send + 'static>>> {
+        Ok(Box::pin(
+            self.file.live_preload(|path| fs.cached_file_info(path))?,
+        ))
     }
 }
 

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -315,9 +315,10 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
             .insert(path, ScheduledFile::Future(fut));
     }
 
-    fn wait_all(&self) {
-        let mut lock = self.files_prefetched.lock();
-        let futs = lock
+    async fn wait_all(&self) {
+        let futs = self
+            .files_prefetched
+            .lock()
             .extract_if(|_path, scheduled| matches!(scheduled, ScheduledFile::Future(_)))
             .filter_map(|(path, scheduled)| match scheduled {
                 ScheduledFile::Future(fut) => Some(async move { (path, fut.await) }),
@@ -325,7 +326,8 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
             })
             .collect::<FuturesUnordered<_>>();
 
-        let results = futures::executor::block_on(futs.collect::<Vec<_>>());
+        let results = futs.collect::<Vec<_>>().await;
+        let mut lock = self.files_prefetched.lock();
         for (path, result) in results {
             lock.insert(path, ScheduledFile::Ready(result));
         }

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -201,7 +201,7 @@ pub trait CachedReadFs: UniversalReadFs {
     fn schedule(&self, path: PathBuf, fut: BoxFuture<'static, UioResult<Self::File>>);
 
     /// Wait for all scheduled files to resolve.
-    fn wait_all(&self);
+    fn wait_all(&self) -> impl Future<Output = ()>;
 
     /// Return the file info from the current snapshot.
     fn cached_file_info(&self, path: &Path) -> Option<FileInfo>;

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -47,6 +47,7 @@ pprof = { workspace = true }
 [dependencies]
 io_bridge_object_store = { path = "../common/io_bridge_object_store" }
 blink-alloc = { workspace = true }
+futures = { workspace = true }
 bytemuck = { workspace = true }
 data-encoding = { workspace = true }
 fs-err = { workspace = true }

--- a/lib/segment/src/common/flags/read_only_flags.rs
+++ b/lib/segment/src/common/flags/read_only_flags.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 use roaring::RoaringBitmap;
 
 use super::mode::FlagsMode;
@@ -76,12 +77,12 @@ impl<S: UniversalRead> LiveReload for ReadOnlyFlags<S> {
     fn live_preload<Fs: CachedReadFs<File = Self::File>>(
         &self,
         cached_fs: &Fs,
-    ) -> OperationResult<()> {
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         match self {
             ReadOnlyFlags::Dynamic(dynamic) => dynamic.live_preload(cached_fs),
             ReadOnlyFlags::Compact(compact) => compact.live_preload(cached_fs),
         };
-        Ok(())
+        Ok(Vec::new())
     }
 
     fn live_reload<Fs: UniversalReadFs<File = Self::File>>(

--- a/lib/segment/src/common/live_reload.rs
+++ b/lib/segment/src/common/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use crate::common::operation_error::OperationResult;
 
@@ -33,11 +34,13 @@ pub(crate) trait LiveReload {
 
     /// Stage everything the next [`Self::live_reload`] needs: schedule
     /// reopens on kept handles, (re)schedule prefetches for swapped and new
-    /// files. Shared access; must not wait on any fetch.
+    /// files. Shared access; must not wait on any fetch. Returns the futures
+    /// driving the staged fetches — the caller polls them, concurrently
+    /// across components.
     fn live_preload<Fs: CachedReadFs<File = Self::File>>(
         &self,
         cached_fs: &Fs,
-    ) -> OperationResult<()>;
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>>;
 
     fn live_reload<Fs: UniversalReadFs<File = Self::File>>(
         &mut self,

--- a/lib/segment/src/id_tracker/disk_id_tracker/read_only/live_reload.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/read_only/live_reload.rs
@@ -4,6 +4,7 @@ use common::bitvec::BitVec;
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, OkUnchanged, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyDiskIdTracker;
 use crate::common::operation_error::OperationResult;
@@ -12,14 +13,17 @@ use crate::id_tracker::mutable_id_tracker::read_only::LiveReloadResult;
 
 impl<S: UniversalRead> ReadOnlyDiskIdTracker<S> {
     /// Stage the fresh deleted-bitslice handle [`live_reload`](Self::live_reload) swaps in.
-    pub fn live_preload(&self, fs: &impl CachedReadFs<File = S>) -> OperationResult<()> {
+    pub fn live_preload(
+        &self,
+        fs: &impl CachedReadFs<File = S>,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         // The reload reads the whole bitslice
         fs.reschedule_open(
             &deleted_path(&self.path),
             Some(Self::deleted_open_options()),
             None,
         );
-        Ok(())
+        Ok(Vec::new())
     }
 
     /// Re-read the on-disk deleted bitslice and report points deleted since the

--- a/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::disk_id_tracker::ReadOnlyDiskIdTracker;
@@ -58,7 +59,10 @@ impl<S: UniversalRead> ReadOnlyIdTrackerEnum<S> {
     }
 
     /// Stage everything the next [`Self::live_reload`] needs. Shared access.
-    pub fn live_preload(&self, fs: &impl CachedReadFs<File = S>) -> OperationResult<()> {
+    pub fn live_preload(
+        &self,
+        fs: &impl CachedReadFs<File = S>,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         match self {
             Self::Appendable(id_tracker) => id_tracker.live_preload(fs),
             Self::Immutable(id_tracker) => id_tracker.live_preload(fs),

--- a/lib/segment/src/id_tracker/immutable_id_tracker/read_only/live_reload.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/read_only/live_reload.rs
@@ -1,6 +1,7 @@
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, OkUnchanged, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyImmutableIdTracker;
 use crate::common::operation_error::OperationResult;
@@ -9,9 +10,12 @@ use crate::id_tracker::mutable_id_tracker::read_only::LiveReloadResult;
 
 impl<S: UniversalRead> ReadOnlyImmutableIdTracker<S> {
     /// Stage the fresh deleted-bitslice handle [`live_reload`](Self::live_reload) swaps in.
-    pub fn live_preload(&self, fs: &impl CachedReadFs<File = S>) -> OperationResult<()> {
+    pub fn live_preload(
+        &self,
+        fs: &impl CachedReadFs<File = S>,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         fs.reschedule_open(&deleted_path(&self.path), Some(Self::open_options()), None);
-        Ok(())
+        Ok(Vec::new())
     }
 
     /// Re-read the on-disk `deleted` bitslice and apply points deleted since the last reload.

--- a/lib/segment/src/id_tracker/mutable_id_tracker/read_only/live_reload.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/read_only/live_reload.rs
@@ -3,6 +3,8 @@ use std::io::Cursor;
 use common::generic_consts::Sequential;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, OkNotFound, ReadRange, UniversalRead, UniversalReadFs};
+use futures::FutureExt;
+use futures::future::BoxFuture;
 
 use super::ReadOnlyAppendableIdTracker;
 use crate::common::operation_error::OperationResult;
@@ -62,23 +64,30 @@ impl<S: UniversalRead> ReadOnlyAppendableIdTracker<S> {
     /// Stage what the next [`live_reload`](Self::live_reload) does per file: a
     /// reopen for held handles, a prefetch for files it opens lazily. Absence
     /// is tolerated the same way the reload tolerates it.
-    pub fn live_preload(&self, fs: &impl CachedReadFs<File = S>) -> OperationResult<()> {
+    pub fn live_preload(
+        &self,
+        fs: &impl CachedReadFs<File = S>,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         let options = Self::open_options();
+        let mut futs: Vec<BoxFuture<'static, ()>> = Vec::new();
         for (file, path) in [
             (&self.versions_file, versions_path(&self.segment_path)),
             (&self.mappings_file, mappings_path(&self.segment_path)),
         ] {
             match file {
                 Some(file) => {
-                    file.live_preload(|p| fs.cached_file_info(p))
-                        .ok_not_found()?;
+                    futs.extend(
+                        file.live_preload(|p| fs.cached_file_info(p))
+                            .ok_not_found()?
+                            .map(FutureExt::boxed),
+                    );
                 }
                 None => {
                     fs.schedule_open(&path, Some(options), None);
                 }
             };
         }
-        Ok(())
+        Ok(futs)
     }
 
     /// Consume mapping and version changes appended to storage since the last reload.

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyBoolIndex;
 use crate::common::operation_error::OperationResult;
@@ -11,10 +12,13 @@ use crate::index::field_index::LiveReload;
 impl<S: UniversalReadExt> LiveReload for ReadOnlyBoolIndex<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, cached_fs: &Fs) -> OperationResult<()> {
-        self.storage.trues_flags.live_preload(cached_fs)?;
-        self.storage.falses_flags.live_preload(cached_fs)?;
-        Ok(())
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        cached_fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        let mut futs = self.storage.trues_flags.live_preload(cached_fs)?;
+        futs.extend(self.storage.falses_flags.live_preload(cached_fs)?);
+        Ok(futs)
     }
 
     fn live_reload<Fs: UniversalReadFs<File = S>>(

--- a/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/read_only_bool_index/mod.rs
@@ -485,7 +485,7 @@ mod tests {
             )
             .unwrap()
         );
-        cached_fs.wait_all();
+        futures::executor::block_on(cached_fs.wait_all());
 
         // Everything `open` reads must now come from the prefetch pool.
         fs_err::remove_dir_all(dir.path().join(TRUES_DIRNAME)).unwrap();

--- a/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/read_only/mod.rs
@@ -8,6 +8,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalReadFs};
+use futures::future::BoxFuture;
 
 pub(crate) use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
@@ -276,7 +277,10 @@ impl<S: UniversalReadExt> ReadOnlyFieldIndex<S> {
 impl<S: UniversalReadExt> LiveReload for ReadOnlyFieldIndex<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         match self {
             ReadOnlyFieldIndex::IntIndex(index) => index.live_preload(fs),
             ReadOnlyFieldIndex::DatetimeIndex(index) => index.live_preload(fs),

--- a/lib/segment/src/index/field_index/full_text_index/immutable_text_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/immutable_text_index/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ImmutableFullTextIndex;
 use crate::common::operation_error::OperationResult;
@@ -10,8 +11,11 @@ use crate::index::field_index::LiveReload;
 impl<S: UniversalRead> LiveReload for ImmutableFullTextIndex<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, _fs: &Fs) -> OperationResult<()> {
-        Ok(())
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        _fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        Ok(Vec::new())
     }
 
     fn live_reload<Fs: UniversalReadFs<File = S>>(

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/live_reload.rs
@@ -3,6 +3,7 @@ use common::generic_consts::Sequential;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyAppendableFullTextIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -15,7 +16,10 @@ use crate::index::field_index::full_text_index::inverted_index::{
 impl<S: UniversalRead> LiveReload for ReadOnlyAppendableFullTextIndex<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         Ok(self.storage.live_preload(fs)?)
     }
 

--- a/lib/segment/src/index/field_index/full_text_index/on_disk_text_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/on_disk_text_index/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::OnDiskFullTextIndex;
 use crate::common::operation_error::OperationResult;
@@ -10,8 +11,11 @@ use crate::index::field_index::LiveReload;
 impl<S: UniversalRead> LiveReload for OnDiskFullTextIndex<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, _fs: &Fs) -> OperationResult<()> {
-        Ok(())
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        _fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        Ok(Vec::new())
     }
 
     fn live_reload<Fs: UniversalReadFs<File = S>>(

--- a/lib/segment/src/index/field_index/full_text_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyFullTextIndex;
 use crate::common::operation_error::OperationResult;
@@ -10,7 +11,10 @@ use crate::index::field_index::LiveReload;
 impl<S: UniversalRead> LiveReload for ReadOnlyFullTextIndex<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         match self {
             Self::Appendable(index) => index.live_preload(fs),
             Self::Immutable(index) => index.live_preload(fs),

--- a/lib/segment/src/index/field_index/geo_index/immutable_geo_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/immutable_geo_index/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ImmutableGeoIndex;
 use crate::common::operation_error::OperationResult;
@@ -10,8 +11,11 @@ use crate::index::field_index::LiveReload;
 impl<S: UniversalRead> LiveReload for ImmutableGeoIndex<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, _fs: &Fs) -> OperationResult<()> {
-        Ok(())
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        _fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        Ok(Vec::new())
     }
 
     fn live_reload<Fs: UniversalReadFs<File = S>>(

--- a/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/mutable_geo_index/read_only/live_reload.rs
@@ -3,6 +3,7 @@ use common::generic_consts::Sequential;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyAppendableGeoIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -12,7 +13,10 @@ use crate::types::{GeoPoint, RawGeoPoint};
 impl<S: UniversalRead> LiveReload for ReadOnlyAppendableGeoIndex<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         Ok(self.storage.live_preload(fs)?)
     }
 

--- a/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/on_disk_geo_index/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::OnDiskGeoIndex;
 use crate::common::operation_error::OperationResult;
@@ -10,8 +11,11 @@ use crate::index::field_index::LiveReload;
 impl<S: UniversalRead> LiveReload for OnDiskGeoIndex<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, _fs: &Fs) -> OperationResult<()> {
-        Ok(())
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        _fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        Ok(Vec::new())
     }
 
     fn live_reload<Fs: UniversalReadFs<File = S>>(

--- a/lib/segment/src/index/field_index/geo_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/geo_index/read_only/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyGeoIndex;
 use crate::common::operation_error::OperationResult;
@@ -10,7 +11,10 @@ use crate::index::field_index::LiveReload;
 impl<S: UniversalRead> LiveReload for ReadOnlyGeoIndex<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         match self {
             Self::Appendable(index) => index.live_preload(fs),
             Self::Immutable(index) => index.live_preload(fs),

--- a/lib/segment/src/index/field_index/geo_index/tests.rs
+++ b/lib/segment/src/index/field_index/geo_index/tests.rs
@@ -1345,7 +1345,7 @@ fn test_block_index_preopen() {
         OnDiskGeoIndex::<Storage>::preopen(&cached_fs, temp_dir.path(), Populate::PreferBackground)
             .unwrap()
     );
-    cached_fs.wait_all();
+    futures::executor::block_on(cached_fs.wait_all());
 
     // The sidecar reads of `open` must now come from the prefetch pool.
     fs_err::remove_file(&counts_sidecar).unwrap();

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/live_reload.rs
@@ -4,6 +4,7 @@ use common::persisted_hashmap::Key;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ImmutableMapIndex;
 use crate::common::operation_error::OperationResult;
@@ -18,8 +19,11 @@ where
 {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, _fs: &Fs) -> OperationResult<()> {
-        Ok(())
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        _fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        Ok(Vec::new())
     }
 
     fn live_reload<Fs: UniversalReadFs<File = S>>(

--- a/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/mutable_map_index/read_only/live_reload.rs
@@ -5,6 +5,7 @@ use common::generic_consts::Sequential;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
@@ -17,7 +18,10 @@ where
 {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         Ok(self.storage.live_preload(fs)?)
     }
 

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/live_reload.rs
@@ -3,6 +3,7 @@ use common::persisted_hashmap::Key;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
@@ -16,8 +17,11 @@ where
 {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, _fs: &Fs) -> OperationResult<()> {
-        Ok(())
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        _fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        Ok(Vec::new())
     }
 
     fn live_reload<Fs: UniversalReadFs<File = S>>(

--- a/lib/segment/src/index/field_index/map_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/map_index/read_only/live_reload.rs
@@ -4,6 +4,7 @@ use common::persisted_hashmap::Key;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::super::MapIndexKey;
 use super::ReadOnlyMapIndex;
@@ -16,7 +17,10 @@ where
 {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         match self {
             Self::Appendable(index) => index.live_preload(fs),
             Self::Immutable(index) => index.live_preload(fs),

--- a/lib/segment/src/index/field_index/null_index/read_only_null_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/null_index/read_only_null_index/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyNullIndex;
 use crate::common::operation_error::OperationResult;
@@ -10,10 +11,13 @@ use crate::index::field_index::LiveReload;
 impl<S: UniversalRead> LiveReload for ReadOnlyNullIndex<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, cached_fs: &Fs) -> OperationResult<()> {
-        self.storage.has_values_flags.live_preload(cached_fs)?;
-        self.storage.is_null_flags.live_preload(cached_fs)?;
-        Ok(())
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        cached_fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        let mut futs = self.storage.has_values_flags.live_preload(cached_fs)?;
+        futs.extend(self.storage.is_null_flags.live_preload(cached_fs)?);
+        Ok(futs)
     }
 
     fn live_reload<Fs: UniversalReadFs<File = S>>(

--- a/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/immutable_numeric_index/live_reload.rs
@@ -3,6 +3,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ImmutableNumericIndex;
 use crate::common::operation_error::OperationResult;
@@ -18,8 +19,11 @@ where
 {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, _fs: &Fs) -> OperationResult<()> {
-        Ok(())
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        _fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        Ok(Vec::new())
     }
 
     fn live_reload<Fs: UniversalReadFs<File = S>>(

--- a/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/mutable_numeric_index/read_only/live_reload.rs
@@ -5,6 +5,7 @@ use common::generic_consts::Sequential;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyAppendableNumericIndex;
 use crate::common::operation_error::OperationResult;
@@ -19,7 +20,10 @@ where
 {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         Ok(self.storage.live_preload(fs)?)
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/on_disk_numeric_index/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
@@ -15,8 +16,11 @@ impl<T: Encodable + Numericable + Default + StoredValue + 'static, S: UniversalR
 {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, _fs: &Fs) -> OperationResult<()> {
-        Ok(())
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        _fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        Ok(Vec::new())
     }
 
     fn live_reload<Fs: UniversalReadFs<File = S>>(

--- a/lib/segment/src/index/field_index/numeric_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/read_only/live_reload.rs
@@ -3,6 +3,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::{Encodable, ReadOnlyNumericIndex};
 use crate::common::operation_error::OperationResult;
@@ -20,7 +21,10 @@ where
 {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         self.inner.live_preload(fs)
     }
 

--- a/lib/segment/src/index/field_index/numeric_index/storage/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/numeric_index/storage/read_only/live_reload.rs
@@ -3,6 +3,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyNumericIndexInner;
 use crate::common::operation_error::OperationResult;
@@ -18,7 +19,10 @@ where
 {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         match self {
             Self::Appendable(index) => index.live_preload(fs),
             Self::Immutable(index) => index.live_preload(fs),

--- a/lib/segment/src/index/field_index/numeric_index/tests.rs
+++ b/lib/segment/src/index/field_index/numeric_index/tests.rs
@@ -1178,7 +1178,7 @@ fn test_block_index_preopen() {
         )
         .unwrap()
     );
-    cached_fs.wait_all();
+    futures::executor::block_on(cached_fs.wait_all());
 
     // The sidecar read of `open` must now come from the prefetch pool.
     fs_err::remove_file(&block_index_path).unwrap();

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -800,7 +800,7 @@ mod tests {
         let mut cached_fs = CachedFs::new(MmapFs, dir.path()).unwrap();
         cached_fs.cache_file_info().unwrap();
         HnswGraph::<MmapFile>::preopen_universal(&cached_fs, dir.path(), residency).unwrap();
-        cached_fs.wait_all();
+        futures::executor::block_on(cached_fs.wait_all());
 
         // Everything `load_universal` reads must now come from the prefetch pool.
         for entry in fs_err::read_dir(dir.path()).unwrap() {

--- a/lib/segment/src/index/read_only/live_reload.rs
+++ b/lib/segment/src/index/read_only/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::VectorIndexReadEnum;
 use crate::common::live_reload::LiveReload;
@@ -11,11 +12,14 @@ use crate::index::UniversalReadExt;
 impl<S: UniversalReadExt> LiveReload for VectorIndexReadEnum<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, _fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        _fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         // Nothing to stage: the persisted variants are immutable after build,
         // and the mutable-RAM sparse index ingests through the already-reloaded
         // vector storage.
-        Ok(())
+        Ok(Vec::new())
     }
 
     /// No-op for the persisted variants: read-only vector indexes are immutable —

--- a/lib/segment/src/index/struct_payload_index/read_only/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/read_only/mod.rs
@@ -8,6 +8,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
@@ -74,12 +75,16 @@ impl<S: UniversalReadExt> ReadOnlyStructPayloadIndex<S> {
 impl<S: UniversalReadExt> LiveReload for ReadOnlyStructPayloadIndex<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        let mut futs = Vec::new();
         for field_index in self.field_indexes.values().flatten() {
-            field_index.live_preload(fs)?;
+            futs.extend(field_index.live_preload(fs)?);
         }
 
-        Ok(())
+        Ok(futs)
     }
 
     fn live_reload<Fs: UniversalReadFs<File = S>>(

--- a/lib/segment/src/payload_storage/read_only/live_reload.rs
+++ b/lib/segment/src/payload_storage/read_only/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyPayloadStorage;
 use crate::common::live_reload::LiveReload;
@@ -13,9 +14,8 @@ impl<S: UniversalRead> LiveReload for ReadOnlyPayloadStorage<S> {
     fn live_preload<Fs: common::universal_io::CachedReadFs<File = Self::File>>(
         &self,
         cached_fs: &Fs,
-    ) -> OperationResult<()> {
-        self.storage.live_preload(cached_fs)?;
-        Ok(())
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        Ok(self.storage.live_preload(cached_fs)?)
     }
 
     fn live_reload<Fs: UniversalReadFs<File = S>>(

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -206,7 +206,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         deferred_internal_id: Option<PointOffsetType>,
         load_profile: Option<&LoadProfile>,
     ) -> OperationResult<Self> {
-        fs.wait_all();
+        futures::executor::block_on(fs.wait_all());
 
         if SegmentVersion::load_universal(&fs, segment_path)?.is_none() {
             // `FileNotFound`, not a service error: the version file is written last, so

--- a/lib/segment/src/segment/read_only/live_reload.rs
+++ b/lib/segment/src/segment/read_only/live_reload.rs
@@ -35,19 +35,15 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         reload_fs.cache_file_info()?;
         let fs = &*reload_fs;
 
-        let mut futs = id_tracker.borrow().live_preload(fs)?;
-        futs.extend(payload_storage.borrow().live_preload(fs)?);
-        futs.extend(payload_index.borrow().live_preload(fs)?);
+        let mut preloads = id_tracker.borrow().live_preload(fs)?;
+        preloads.extend(payload_storage.borrow().live_preload(fs)?);
+        preloads.extend(payload_index.borrow().live_preload(fs)?);
         for vector_data in vector_data.values() {
-            futs.extend(vector_data.live_preload(fs)?);
+            preloads.extend(vector_data.live_preload(fs)?);
         }
 
-        // Pin the staged files before the writer can churn them: reload then
-        // consumes ready handles and never races the filesystem.
-        fs.wait_all();
-        // perf: the tail fetches only start draining once wait_all is done;
-        // both pools could be driven together.
-        futures::executor::block_on(join_all(futs));
+        // Complete all IO before returning
+        futures::executor::block_on(async { futures::join!(fs.wait_all(), join_all(preloads)) });
         Ok(())
     }
 

--- a/lib/segment/src/segment/read_only/live_reload.rs
+++ b/lib/segment/src/segment/read_only/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalReadFs};
+use futures::future::{BoxFuture, join_all};
 
 use super::{ReadOnlySegment, ReadOnlyVectorData};
 use crate::common::live_reload::LiveReload;
@@ -11,8 +12,9 @@ use crate::index::UniversalReadExt;
 
 impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     /// Stage every component's next [`Self::live_reload`] under shared access:
-    /// re-snapshot the retained caching filesystem's listing, then schedule
-    /// every fetch the reload will need. Fetches go in flight as scheduled.
+    /// re-snapshot the retained caching filesystem's listing, schedule every
+    /// fetch the reload will need, then drive them all to completion — so the
+    /// reload only applies ready data.
     pub fn live_preload(&self) -> OperationResult<()> {
         let Self {
             uuid: _,
@@ -33,16 +35,19 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         reload_fs.cache_file_info()?;
         let fs = &*reload_fs;
 
-        id_tracker.borrow().live_preload(fs)?;
-        payload_storage.borrow().live_preload(fs)?;
-        payload_index.borrow().live_preload(fs)?;
+        let mut futs = id_tracker.borrow().live_preload(fs)?;
+        futs.extend(payload_storage.borrow().live_preload(fs)?);
+        futs.extend(payload_index.borrow().live_preload(fs)?);
         for vector_data in vector_data.values() {
-            vector_data.live_preload(fs)?;
+            futs.extend(vector_data.live_preload(fs)?);
         }
 
         // Pin the staged files before the writer can churn them: reload then
         // consumes ready handles and never races the filesystem.
         fs.wait_all();
+        // perf: the tail fetches only start draining once wait_all is done;
+        // both pools could be driven together.
+        futures::executor::block_on(join_all(futs));
         Ok(())
     }
 
@@ -112,19 +117,22 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
 
 impl<S: UniversalReadExt + 'static> ReadOnlyVectorData<S> {
     /// Stage this vector's next [`Self::live_reload`]. Shared access only.
-    fn live_preload(&self, fs: &impl CachedReadFs<File = S>) -> OperationResult<()> {
+    fn live_preload(
+        &self,
+        fs: &impl CachedReadFs<File = S>,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         let Self {
             vector_index,
             vector_storage,
             quantized_vectors,
         } = self;
 
-        vector_storage.borrow().live_preload(fs)?;
-        vector_index.borrow().live_preload(fs)?;
+        let mut futs = vector_storage.borrow().live_preload(fs)?;
+        futs.extend(vector_index.borrow().live_preload(fs)?);
         if let Some(quantized_vectors) = quantized_vectors.borrow().as_ref() {
-            quantized_vectors.live_preload(fs)?;
+            futs.extend(quantized_vectors.live_preload(fs)?);
         }
-        Ok(())
+        Ok(futs)
     }
 
     /// Refresh this vector's storage, index and quantized vectors to the current

--- a/lib/segment/src/vector_storage/chunked_vectors/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read_only/live_reload.rs
@@ -4,6 +4,7 @@ use common::types::PointOffsetType;
 use common::universal_io::{
     CachedReadFs, OkUnchanged, TypedStorage, UniversalRead, UniversalReadFs,
 };
+use futures::future::BoxFuture;
 
 use super::super::chunks::{chunk_name, chunk_open_options, list_chunk_files, read_chunks_from};
 use super::super::config::{read_status_len, status_file};
@@ -14,7 +15,10 @@ use crate::common::operation_error::OperationResult;
 impl<T: bytemuck::Pod + Send, S: UniversalRead> LiveReload for ReadOnlyChunkedVectors<T, S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         // Status is the change signal, let reload skip reloading if this didn't change.
         fs.reschedule_open(&status_file(&self.directory), None, None);
 
@@ -43,7 +47,7 @@ impl<T: bytemuck::Pod + Send, S: UniversalRead> LiveReload for ReadOnlyChunkedVe
                 None,
             );
         }
-        Ok(())
+        Ok(Vec::new())
     }
 
     /// Refresh the chunks that can have gained vectors since the last load; a

--- a/lib/segment/src/vector_storage/chunked_vectors/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read_only/mod.rs
@@ -122,7 +122,7 @@ mod tests {
         let mut cached_fs = CachedFs::new(MmapFs, dir.path()).unwrap();
         cached_fs.cache_file_info().unwrap();
         LiveReload::live_preload(&reader, &cached_fs).unwrap();
-        cached_fs.wait_all();
+        futures::executor::block_on(cached_fs.wait_all());
 
         for file in fs_err::read_dir(dir.path()).unwrap() {
             fs_err::remove_file(file.unwrap().path()).unwrap();

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/live_reload.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyImmutableDenseVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -13,9 +14,12 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> LiveReload
 {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, _fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        _fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         // Reload only applies deletes directly from arguments. No file to check.
-        Ok(())
+        Ok(Vec::new())
     }
 
     /// Vector data is immutable, so only the in-memory deletion flags are patched

--- a/lib/segment/src/vector_storage/dense/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyChunkedDenseVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -13,10 +14,13 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> LiveReload
 {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
-        self.vectors.live_preload(fs)?;
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        let futs = self.vectors.live_preload(fs)?;
         self.deleted.live_preload(fs)?;
-        Ok(())
+        Ok(futs)
     }
 
     /// Reload the chunked vectors, apply `deleted_points`, and fold in the

--- a/lib/segment/src/vector_storage/dense/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/mod.rs
@@ -189,7 +189,7 @@ mod tests {
             let mut cached_fs = CachedFs::new(MmapFs, dir.path()).unwrap();
             cached_fs.cache_file_info().unwrap();
             reader.live_preload(&cached_fs).unwrap();
-            cached_fs.wait_all();
+            futures::executor::block_on(cached_fs.wait_all());
 
             fs_err::remove_dir_all(dir.path()).unwrap();
 

--- a/lib/segment/src/vector_storage/multi_dense/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/multi_dense/read_only/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -13,11 +14,14 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> LiveReload
 {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
-        self.vectors.live_preload(fs)?;
-        self.offsets.live_preload(fs)?;
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        let mut futs = self.vectors.live_preload(fs)?;
+        futs.extend(self.offsets.live_preload(fs)?);
         self.deleted.live_preload(fs)?;
-        Ok(())
+        Ok(futs)
     }
 
     /// Reload the vectors and offsets, apply `deleted_points`, and fold in the

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/live_reload.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use crate::common::operation_error::OperationResult;
 use crate::index::field_index::LiveReload;
@@ -10,7 +11,10 @@ use crate::vector_storage::quantized::quantized_chunked_mmap_storage::QuantizedC
 impl<S: UniversalRead> LiveReload for QuantizedChunkedStorageRead<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         self.data.live_preload(fs)
     }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/live_reload.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_multivector_storage/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::MultivectorOffsetsStorageChunkedRead;
 use crate::common::operation_error::OperationResult;
@@ -10,7 +11,10 @@ use crate::index::field_index::LiveReload;
 impl<S: UniversalRead> LiveReload for MultivectorOffsetsStorageChunkedRead<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         self.data.live_preload(fs)
     }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::{ReadOnlyQuantizedVectorStorage, ReadOnlyQuantizedVectors};
 use crate::common::live_reload::LiveReload;
@@ -10,7 +11,10 @@ use crate::common::operation_error::OperationResult;
 impl<S: UniversalRead> LiveReload for ReadOnlyQuantizedVectors<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         self.storage_impl.live_preload(fs)
     }
 
@@ -30,7 +34,11 @@ impl<S: UniversalRead> LiveReload for ReadOnlyQuantizedVectors<S> {
 impl<S: UniversalRead> LiveReload for ReadOnlyQuantizedVectorStorage<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        let mut futs = Vec::new();
         match self {
             // Ram/Mmap layouts are immutable: nothing to stage.
             ReadOnlyQuantizedVectorStorage::ScalarRam(_)
@@ -49,18 +57,22 @@ impl<S: UniversalRead> LiveReload for ReadOnlyQuantizedVectorStorage<S> {
             | ReadOnlyQuantizedVectorStorage::BinaryMmapMulti(_)
             | ReadOnlyQuantizedVectorStorage::TQRamMulti(_)
             | ReadOnlyQuantizedVectorStorage::TQMmapMulti(_) => {}
-            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => q.storage().live_preload(fs)?,
-            ReadOnlyQuantizedVectorStorage::TQChunked(q) => q.storage().live_preload(fs)?,
+            ReadOnlyQuantizedVectorStorage::BinaryChunked(q) => {
+                futs.extend(q.storage().live_preload(fs)?);
+            }
+            ReadOnlyQuantizedVectorStorage::TQChunked(q) => {
+                futs.extend(q.storage().live_preload(fs)?);
+            }
             ReadOnlyQuantizedVectorStorage::BinaryChunkedMulti(q) => {
-                q.storage().storage().live_preload(fs)?;
-                q.offsets_storage().live_preload(fs)?;
+                futs.extend(q.storage().storage().live_preload(fs)?);
+                futs.extend(q.offsets_storage().live_preload(fs)?);
             }
             ReadOnlyQuantizedVectorStorage::TQChunkedMulti(q) => {
-                q.storage().storage().live_preload(fs)?;
-                q.offsets_storage().live_preload(fs)?;
+                futs.extend(q.storage().storage().live_preload(fs)?);
+                futs.extend(q.offsets_storage().live_preload(fs)?);
             }
         }
-        Ok(())
+        Ok(futs)
     }
 
     /// Pick up quantized vectors a writer appended. Only the chunked (appendable)

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/read_only/tests.rs
@@ -357,7 +357,7 @@ fn preopen_and_unlink(
     let mut cached_fs = CachedFs::new(MmapFs, dir).unwrap();
     cached_fs.cache_file_info().unwrap();
     ReadOnlyQuantizedVectors::<MmapFile>::preopen(&cached_fs, dir, &vector_config, None).unwrap();
-    cached_fs.wait_all();
+    futures::executor::block_on(cached_fs.wait_all());
 
     for entry in fs_err::read_dir(dir).unwrap() {
         let path = entry.unwrap().path();
@@ -603,7 +603,7 @@ fn reload_chunked_preserves_scores(preload: bool) {
         let mut cached_fs = CachedFs::new(MmapFs, quant_dir.path()).unwrap();
         cached_fs.cache_file_info().unwrap();
         ro.live_preload(&cached_fs).unwrap();
-        cached_fs.wait_all();
+        futures::executor::block_on(cached_fs.wait_all());
 
         fs_err::remove_dir_all(quant_dir.path()).unwrap();
 

--- a/lib/segment/src/vector_storage/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/read_only/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::VectorStorageReadEnum;
 use crate::common::live_reload::LiveReload;
@@ -10,7 +11,10 @@ use crate::common::operation_error::OperationResult;
 impl<S: UniversalRead> LiveReload for VectorStorageReadEnum<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         match self {
             VectorStorageReadEnum::Dense(s) => s.live_preload(fs),
             VectorStorageReadEnum::DenseByte(s) => s.live_preload(fs),

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -353,7 +353,7 @@ mod tests {
         let config = dense_config(VectorStorageType::ChunkedMmap, None);
         let cached_fs = snapshot_cached_fs(dir.path());
         VectorStorageReadEnum::<MmapFile>::preopen(&cached_fs, &config, dir.path(), None).unwrap();
-        cached_fs.wait_all();
+        futures::executor::block_on(cached_fs.wait_all());
 
         // Everything `open` reads must now come from the prefetch pool.
         for dir_name in [
@@ -402,7 +402,7 @@ mod tests {
         let config = dense_config(VectorStorageType::Mmap, None);
         let cached_fs = snapshot_cached_fs(dir.path());
         VectorStorageReadEnum::<MmapFile>::preopen(&cached_fs, &config, dir.path(), None).unwrap();
-        cached_fs.wait_all();
+        futures::executor::block_on(cached_fs.wait_all());
 
         // Everything `open` reads must now come from the prefetch pool.
         for file_name in [
@@ -466,7 +466,7 @@ mod tests {
         );
         let cached_fs = snapshot_cached_fs(dir.path());
         VectorStorageReadEnum::<MmapFile>::preopen(&cached_fs, &config, dir.path(), None).unwrap();
-        cached_fs.wait_all();
+        futures::executor::block_on(cached_fs.wait_all());
 
         // Everything `open` reads must now come from the prefetch pool.
         for dir_name in [

--- a/lib/segment/src/vector_storage/sparse/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlySparseVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -10,10 +11,13 @@ use crate::common::operation_error::OperationResult;
 impl<S: UniversalRead> LiveReload for ReadOnlySparseVectorStorage<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
-        self.storage.live_preload(fs)?;
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        let futs = self.storage.live_preload(fs)?;
         self.deleted.live_preload(fs)?;
-        Ok(())
+        Ok(futs)
     }
 
     /// Reload the Blobstore, apply `deleted_points`, fold in the persisted

--- a/lib/segment/src/vector_storage/sparse/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/sparse/read_only/mod.rs
@@ -145,7 +145,7 @@ mod tests {
         cached_fs.cache_file_info().unwrap();
         ReadOnlySparseVectorStorage::<MmapFile>::preopen(&cached_fs, dir.path(), Populate::No)
             .unwrap();
-        cached_fs.wait_all();
+        futures::executor::block_on(cached_fs.wait_all());
 
         // Everything `open` reads must now come from the prefetch pool.
         for dir_name in [STORAGE_DIRNAME, DELETED_DIRNAME] {
@@ -235,7 +235,7 @@ mod tests {
             let mut cached_fs = CachedFs::new(MmapFs, dir.path()).unwrap();
             cached_fs.cache_file_info().unwrap();
             reader.live_preload(&cached_fs).unwrap();
-            cached_fs.wait_all();
+            futures::executor::block_on(cached_fs.wait_all());
 
             fs_err::remove_dir_all(dir.path()).unwrap();
 

--- a/lib/segment/src/vector_storage/turbo/multi_turbo/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/turbo/multi_turbo/read_only/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyChunkedMultiTurboVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -10,11 +11,14 @@ use crate::common::operation_error::OperationResult;
 impl<S: UniversalRead> LiveReload for ReadOnlyChunkedMultiTurboVectorStorage<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
-        self.storage.live_preload(fs)?;
-        self.offsets.live_preload(fs)?;
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        let mut futs = self.storage.live_preload(fs)?;
+        futs.extend(self.offsets.live_preload(fs)?);
         self.deleted.live_preload(fs)?;
-        Ok(())
+        Ok(futs)
     }
 
     /// Reload the vectors and offsets, apply `deleted_points`, and fold in the

--- a/lib/segment/src/vector_storage/turbo/read_only/immutable/live_reload.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/immutable/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyImmutableTurboVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -10,9 +11,12 @@ use crate::common::operation_error::OperationResult;
 impl<S: UniversalRead> LiveReload for ReadOnlyImmutableTurboVectorStorage<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, _fs: &Fs) -> OperationResult<()> {
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        _fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
         // No new data to fetch, deletions are applied directly from arguments
-        Ok(())
+        Ok(Vec::new())
     }
 
     /// Vector data is immutable, so only the in-memory deletion flags are patched

--- a/lib/segment/src/vector_storage/turbo/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/live_reload.rs
@@ -2,6 +2,7 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use futures::future::BoxFuture;
 
 use super::ReadOnlyChunkedTurboVectorStorage;
 use crate::common::live_reload::LiveReload;
@@ -10,10 +11,13 @@ use crate::common::operation_error::OperationResult;
 impl<S: UniversalRead> LiveReload for ReadOnlyChunkedTurboVectorStorage<S> {
     type File = S;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(&self, fs: &Fs) -> OperationResult<()> {
-        self.storage.live_preload(fs)?;
+    fn live_preload<Fs: CachedReadFs<File = S>>(
+        &self,
+        fs: &Fs,
+    ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
+        let futs = self.storage.live_preload(fs)?;
         self.deleted.live_preload(fs)?;
-        Ok(())
+        Ok(futs)
     }
 
     /// Reload the chunked vectors, apply `deleted_points`, and fold in the

--- a/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
+++ b/lib/sparse/src/index/inverted_index/inverted_index_compressed_mmap.rs
@@ -686,8 +686,8 @@ mod tests {
     /// make the prefetch pool the *only* possible source, the index directory
     /// is emptied between the two calls: the already-open handles parked in
     /// the pool stay readable, while any fallback open hits `NotFound`.
-    #[test]
-    fn preopen_then_open_ro_through_cached_fs() {
+    #[tokio::test]
+    async fn preopen_then_open_ro_through_cached_fs() {
         use common::universal_io::{CachedFs, CachedReadFs};
 
         let hw_counter = HardwareCounterCell::new();
@@ -724,7 +724,7 @@ mod tests {
         let mut cached_fs = CachedFs::new(MmapFs, dir.path()).unwrap();
         cached_fs.cache_file_info().unwrap();
         preopen(&cached_fs, dir.path(), Populate::No).unwrap();
-        cached_fs.wait_all();
+        cached_fs.wait_all().await;
 
         // Everything `open_ro` reads must now come from the prefetch pool.
         for entry in fs_err::read_dir(dir.path()).unwrap() {


### PR DESCRIPTION
This PR integrates the new async `live_preload` functionality, so that we have a Future for each preloaded file.

It then joins them concurrently with the scheduled files in `CachedFs`.

The result is that segments only return from `live_preload` calls once all IO has completed. This makes locking for `live_reload` shorter, since it only applies the already-local data.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>