### PR TITLE
fix: accumulate NEON f16 metrics in f32 to prevent overflow

### DIFF
--- a/lib/segment/src/spaces/metric_f16/cpp/neon.c
+++ b/lib/segment/src/spaces/metric_f16/cpp/neon.c
@@ -7,30 +7,52 @@
 float32_t dotProduct_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB, uint32_t blockSize)
 {
     float32_t dotProduct = 0.0f;
-    float16x8_t sum1 = vdupq_n_f16(0.0f);
-    float16x8_t sum2 = vdupq_n_f16(0.0f);
-    float16x8_t sum3 = vdupq_n_f16(0.0f);
-    float16x8_t sum4 = vdupq_n_f16(0.0f);
+    // Accumulate in f32, not f16: an f16 lane sum saturates to +inf once it
+    // exceeds 65504, while the scalar and AVX paths accumulate in f32
+    // (see PR #9811). Keeping the four float16x8_t accumulators here makes
+    // NEON disagree with those paths and can serialize a valid score as null.
+    float32x4_t sum1_lo = vdupq_n_f32(0.0f);
+    float32x4_t sum1_hi = vdupq_n_f32(0.0f);
+    float32x4_t sum2_lo = vdupq_n_f32(0.0f);
+    float32x4_t sum2_hi = vdupq_n_f32(0.0f);
+    float32x4_t sum3_lo = vdupq_n_f32(0.0f);
+    float32x4_t sum3_hi = vdupq_n_f32(0.0f);
+    float32x4_t sum4_lo = vdupq_n_f32(0.0f);
+    float32x4_t sum4_hi = vdupq_n_f32(0.0f);
 
     for(uint32_t i=0; i < blockSize - (blockSize % 32); i+=32)
     {
-        sum1 = vfmaq_f16(sum1, vld1q_f16(pSrcA), vld1q_f16(pSrcB));
-        sum2 = vfmaq_f16(sum2, vld1q_f16(pSrcA+8), vld1q_f16(pSrcB+8));
-        sum3 = vfmaq_f16(sum3, vld1q_f16(pSrcA+16), vld1q_f16(pSrcB+16));
-        sum4 = vfmaq_f16(sum4, vld1q_f16(pSrcA+24), vld1q_f16(pSrcB+24));
+        float16x8_t a1 = vld1q_f16(pSrcA);
+        float16x8_t b1 = vld1q_f16(pSrcB);
+        sum1_lo = vfmaq_f32(sum1_lo, vcvt_f32_f16(vget_low_f16(a1)),  vcvt_f32_f16(vget_low_f16(b1)));
+        sum1_hi = vfmaq_f32(sum1_hi, vcvt_f32_f16(vget_high_f16(a1)), vcvt_f32_f16(vget_high_f16(b1)));
+
+        float16x8_t a2 = vld1q_f16(pSrcA+8);
+        float16x8_t b2 = vld1q_f16(pSrcB+8);
+        sum2_lo = vfmaq_f32(sum2_lo, vcvt_f32_f16(vget_low_f16(a2)),  vcvt_f32_f16(vget_low_f16(b2)));
+        sum2_hi = vfmaq_f32(sum2_hi, vcvt_f32_f16(vget_high_f16(a2)), vcvt_f32_f16(vget_high_f16(b2)));
+
+        float16x8_t a3 = vld1q_f16(pSrcA+16);
+        float16x8_t b3 = vld1q_f16(pSrcB+16);
+        sum3_lo = vfmaq_f32(sum3_lo, vcvt_f32_f16(vget_low_f16(a3)),  vcvt_f32_f16(vget_low_f16(b3)));
+        sum3_hi = vfmaq_f32(sum3_hi, vcvt_f32_f16(vget_high_f16(a3)), vcvt_f32_f16(vget_high_f16(b3)));
+
+        float16x8_t a4 = vld1q_f16(pSrcA+24);
+        float16x8_t b4 = vld1q_f16(pSrcB+24);
+        sum4_lo = vfmaq_f32(sum4_lo, vcvt_f32_f16(vget_low_f16(a4)),  vcvt_f32_f16(vget_low_f16(b4)));
+        sum4_hi = vfmaq_f32(sum4_hi, vcvt_f32_f16(vget_high_f16(a4)), vcvt_f32_f16(vget_high_f16(b4)));
 
         pSrcA += 32;
         pSrcB += 32;
     }
 
-    float32x4_t sum = vcvt_f32_f16(vget_high_f16(sum1));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_low_f16(sum1)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_high_f16(sum2)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_low_f16(sum2)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_high_f16(sum3)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_low_f16(sum3)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_high_f16(sum4)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_low_f16(sum4)));
+    float32x4_t sum = vaddq_f32(sum1_lo, sum1_hi);
+    sum = vaddq_f32(sum, sum2_lo);
+    sum = vaddq_f32(sum, sum2_hi);
+    sum = vaddq_f32(sum, sum3_lo);
+    sum = vaddq_f32(sum, sum3_hi);
+    sum = vaddq_f32(sum, sum4_lo);
+    sum = vaddq_f32(sum, sum4_hi);
 
     dotProduct = vaddvq_f32(sum);
     for (uint32_t i=0; i < (blockSize % 32); i++) {
@@ -45,41 +67,60 @@ float32_t dotProduct_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB, ui
 float32_t euclideanDist_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB, uint32_t blockSize)
 {
     float32_t euclideanDistance = 0.0f;
-    float16x8_t sum1 = vdupq_n_f16(0.0f);
-    float16x8_t sub1 = vdupq_n_f16(0.0f);
-    float16x8_t sum2 = vdupq_n_f16(0.0f);
-    float16x8_t sub2 = vdupq_n_f16(0.0f);
-    float16x8_t sum3 = vdupq_n_f16(0.0f);
-    float16x8_t sub3 = vdupq_n_f16(0.0f);
-    float16x8_t sum4 = vdupq_n_f16(0.0f);
-    float16x8_t sub4 = vdupq_n_f16(0.0f);
+    // Accumulate in f32 (see dotProduct_half_4x4): a single lane with
+    // a=256.0, b=0.0 contributes 65536 to the sum, which overflows the f16
+    // maximum 65504 and saturates the lane sum to +inf, so the final score
+    // is serialized as JSON null once the 32-element kernel loop executes.
+    float32x4_t sum1_lo = vdupq_n_f32(0.0f);
+    float32x4_t sum1_hi = vdupq_n_f32(0.0f);
+    float32x4_t sum2_lo = vdupq_n_f32(0.0f);
+    float32x4_t sum2_hi = vdupq_n_f32(0.0f);
+    float32x4_t sum3_lo = vdupq_n_f32(0.0f);
+    float32x4_t sum3_hi = vdupq_n_f32(0.0f);
+    float32x4_t sum4_lo = vdupq_n_f32(0.0f);
+    float32x4_t sum4_hi = vdupq_n_f32(0.0f);
 
     for(uint32_t i=0; i < blockSize - (blockSize % 32); i+=32)
     {
-        sub1 = vsubq_f16(vld1q_f16(pSrcA), vld1q_f16(pSrcB));
-        sum1 = vfmaq_f16(sum1, sub1, sub1);
+        float16x8_t a1 = vld1q_f16(pSrcA);
+        float16x8_t b1 = vld1q_f16(pSrcB);
+        float32x4_t sub1_lo = vsubq_f32(vcvt_f32_f16(vget_low_f16(a1)),  vcvt_f32_f16(vget_low_f16(b1)));
+        float32x4_t sub1_hi = vsubq_f32(vcvt_f32_f16(vget_high_f16(a1)), vcvt_f32_f16(vget_high_f16(b1)));
+        sum1_lo = vfmaq_f32(sum1_lo, sub1_lo, sub1_lo);
+        sum1_hi = vfmaq_f32(sum1_hi, sub1_hi, sub1_hi);
 
-        sub2 = vsubq_f16(vld1q_f16(pSrcA+8), vld1q_f16(pSrcB+8));
-        sum2 = vfmaq_f16(sum2, sub2, sub2);
+        float16x8_t a2 = vld1q_f16(pSrcA+8);
+        float16x8_t b2 = vld1q_f16(pSrcB+8);
+        float32x4_t sub2_lo = vsubq_f32(vcvt_f32_f16(vget_low_f16(a2)),  vcvt_f32_f16(vget_low_f16(b2)));
+        float32x4_t sub2_hi = vsubq_f32(vcvt_f32_f16(vget_high_f16(a2)), vcvt_f32_f16(vget_high_f16(b2)));
+        sum2_lo = vfmaq_f32(sum2_lo, sub2_lo, sub2_lo);
+        sum2_hi = vfmaq_f32(sum2_hi, sub2_hi, sub2_hi);
 
-        sub3 = vsubq_f16(vld1q_f16(pSrcA+16), vld1q_f16(pSrcB+16));
-        sum3 = vfmaq_f16(sum3, sub3, sub3);
+        float16x8_t a3 = vld1q_f16(pSrcA+16);
+        float16x8_t b3 = vld1q_f16(pSrcB+16);
+        float32x4_t sub3_lo = vsubq_f32(vcvt_f32_f16(vget_low_f16(a3)),  vcvt_f32_f16(vget_low_f16(b3)));
+        float32x4_t sub3_hi = vsubq_f32(vcvt_f32_f16(vget_high_f16(a3)), vcvt_f32_f16(vget_high_f16(b3)));
+        sum3_lo = vfmaq_f32(sum3_lo, sub3_lo, sub3_lo);
+        sum3_hi = vfmaq_f32(sum3_hi, sub3_hi, sub3_hi);
 
-        sub4 = vsubq_f16(vld1q_f16(pSrcA+24), vld1q_f16(pSrcB+24));
-        sum4 = vfmaq_f16(sum4, sub4, sub4);
+        float16x8_t a4 = vld1q_f16(pSrcA+24);
+        float16x8_t b4 = vld1q_f16(pSrcB+24);
+        float32x4_t sub4_lo = vsubq_f32(vcvt_f32_f16(vget_low_f16(a4)),  vcvt_f32_f16(vget_low_f16(b4)));
+        float32x4_t sub4_hi = vsubq_f32(vcvt_f32_f16(vget_high_f16(a4)), vcvt_f32_f16(vget_high_f16(b4)));
+        sum4_lo = vfmaq_f32(sum4_lo, sub4_lo, sub4_lo);
+        sum4_hi = vfmaq_f32(sum4_hi, sub4_hi, sub4_hi);
 
         pSrcA += 32;
         pSrcB += 32;
     }
 
-    float32x4_t sum = vcvt_f32_f16(vget_high_f16(sum1));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_low_f16(sum1)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_high_f16(sum2)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_low_f16(sum2)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_high_f16(sum3)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_low_f16(sum3)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_high_f16(sum4)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_low_f16(sum4)));
+    float32x4_t sum = vaddq_f32(sum1_lo, sum1_hi);
+    sum = vaddq_f32(sum, sum2_lo);
+    sum = vaddq_f32(sum, sum2_hi);
+    sum = vaddq_f32(sum, sum3_lo);
+    sum = vaddq_f32(sum, sum3_hi);
+    sum = vaddq_f32(sum, sum4_lo);
+    sum = vaddq_f32(sum, sum4_hi);
 
     euclideanDistance = vaddvq_f32(sum);
     float16_t tmp = 0.0f;
@@ -96,34 +137,60 @@ float32_t euclideanDist_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB,
 float32_t manhattanDist_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB, uint32_t blockSize)
 {
     float32_t manhattanDistance = 0.0f;
-    float16x8_t sum1 = vdupq_n_f16(0.0f);
-    float16x8_t sum2 = vdupq_n_f16(0.0f);
-    float16x8_t sum3 = vdupq_n_f16(0.0f);
-    float16x8_t sum4 = vdupq_n_f16(0.0f);
+    // Accumulate in f32 (see dotProduct_half_4x4): f16 lane sums of |a-b|
+    // saturate to +inf past 65504, disagreeing with the f32-accumulating
+    // scalar and AVX paths.
+    float32x4_t sum1_lo = vdupq_n_f32(0.0f);
+    float32x4_t sum1_hi = vdupq_n_f32(0.0f);
+    float32x4_t sum2_lo = vdupq_n_f32(0.0f);
+    float32x4_t sum2_hi = vdupq_n_f32(0.0f);
+    float32x4_t sum3_lo = vdupq_n_f32(0.0f);
+    float32x4_t sum3_hi = vdupq_n_f32(0.0f);
+    float32x4_t sum4_lo = vdupq_n_f32(0.0f);
+    float32x4_t sum4_hi = vdupq_n_f32(0.0f);
     uint32_t i = 0;
 
     for(i=0; i < blockSize - (blockSize % 32); i+=32)
     {
-        sum1 = vaddq_f16(sum1, vabdq_f16(vld1q_f16(pSrcA), vld1q_f16(pSrcB)));
+        float16x8_t a1 = vld1q_f16(pSrcA);
+        float16x8_t b1 = vld1q_f16(pSrcB);
+        float32x4_t sub1_lo = vsubq_f32(vcvt_f32_f16(vget_low_f16(a1)),  vcvt_f32_f16(vget_low_f16(b1)));
+        float32x4_t sub1_hi = vsubq_f32(vcvt_f32_f16(vget_high_f16(a1)), vcvt_f32_f16(vget_high_f16(b1)));
+        sum1_lo = vaddq_f32(sum1_lo, vabsq_f32(sub1_lo));
+        sum1_hi = vaddq_f32(sum1_hi, vabsq_f32(sub1_hi));
 
-        sum2 = vaddq_f16(sum2, vabdq_f16(vld1q_f16(pSrcA+8), vld1q_f16(pSrcB+8)));
+        float16x8_t a2 = vld1q_f16(pSrcA+8);
+        float16x8_t b2 = vld1q_f16(pSrcB+8);
+        float32x4_t sub2_lo = vsubq_f32(vcvt_f32_f16(vget_low_f16(a2)),  vcvt_f32_f16(vget_low_f16(b2)));
+        float32x4_t sub2_hi = vsubq_f32(vcvt_f32_f16(vget_high_f16(a2)), vcvt_f32_f16(vget_high_f16(b2)));
+        sum2_lo = vaddq_f32(sum2_lo, vabsq_f32(sub2_lo));
+        sum2_hi = vaddq_f32(sum2_hi, vabsq_f32(sub2_hi));
 
-        sum3 = vaddq_f16(sum3, vabdq_f16(vld1q_f16(pSrcA+16), vld1q_f16(pSrcB+16)));
+        float16x8_t a3 = vld1q_f16(pSrcA+16);
+        float16x8_t b3 = vld1q_f16(pSrcB+16);
+        float32x4_t sub3_lo = vsubq_f32(vcvt_f32_f16(vget_low_f16(a3)),  vcvt_f32_f16(vget_low_f16(b3)));
+        float32x4_t sub3_hi = vsubq_f32(vcvt_f32_f16(vget_high_f16(a3)), vcvt_f32_f16(vget_high_f16(b3)));
+        sum3_lo = vaddq_f32(sum3_lo, vabsq_f32(sub3_lo));
+        sum3_hi = vaddq_f32(sum3_hi, vabsq_f32(sub3_hi));
 
-        sum4 = vaddq_f16(sum4, vabdq_f16(vld1q_f16(pSrcA+24), vld1q_f16(pSrcB+24)));
+        float16x8_t a4 = vld1q_f16(pSrcA+24);
+        float16x8_t b4 = vld1q_f16(pSrcB+24);
+        float32x4_t sub4_lo = vsubq_f32(vcvt_f32_f16(vget_low_f16(a4)),  vcvt_f32_f16(vget_low_f16(b4)));
+        float32x4_t sub4_hi = vsubq_f32(vcvt_f32_f16(vget_high_f16(a4)), vcvt_f32_f16(vget_high_f16(b4)));
+        sum4_lo = vaddq_f32(sum4_lo, vabsq_f32(sub4_lo));
+        sum4_hi = vaddq_f32(sum4_hi, vabsq_f32(sub4_hi));
 
         pSrcA += 32;
         pSrcB += 32;
     }
 
-    float32x4_t sum = vcvt_f32_f16(vget_high_f16(sum1));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_low_f16(sum1)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_high_f16(sum2)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_low_f16(sum2)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_high_f16(sum3)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_low_f16(sum3)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_high_f16(sum4)));
-    sum = vaddq_f32(sum, vcvt_f32_f16(vget_low_f16(sum4)));
+    float32x4_t sum = vaddq_f32(sum1_lo, sum1_hi);
+    sum = vaddq_f32(sum, sum2_lo);
+    sum = vaddq_f32(sum, sum2_hi);
+    sum = vaddq_f32(sum, sum3_lo);
+    sum = vaddq_f32(sum, sum3_hi);
+    sum = vaddq_f32(sum, sum4_lo);
+    sum = vaddq_f32(sum, sum4_hi);
 
     manhattanDistance = vaddvq_f32(sum);
     for (i=0; i < (blockSize % 32); i++) {

--- a/lib/segment/src/spaces/metric_f16/cpp/neon.c
+++ b/lib/segment/src/spaces/metric_f16/cpp/neon.c
@@ -56,7 +56,10 @@ float32_t dotProduct_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB, ui
 
     dotProduct = vaddvq_f32(sum);
     for (uint32_t i=0; i < (blockSize % 32); i++) {
-        dotProduct += (float32_t)((*pSrcA)*(*pSrcB));
+        // Multiply in f32: two f16 operands each up to 256.0 give 65536,
+        // which overflows the f16 maximum 65504 (saturates to +inf) while
+        // the f32-accumulating scalar and AVX paths stay finite.
+        dotProduct += (float32_t)(*pSrcA) * (float32_t)(*pSrcB);
         pSrcA += 1;
         pSrcB += 1;
     }
@@ -123,10 +126,13 @@ float32_t euclideanDist_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB,
     sum = vaddq_f32(sum, sum4_hi);
 
     euclideanDistance = vaddvq_f32(sum);
-    float16_t tmp = 0.0f;
     for (uint32_t i=0; i < (blockSize % 32); i++) {
-        tmp = (*pSrcA - *pSrcB);
-        euclideanDistance += (float32_t)(tmp * tmp);
+        // Compute the difference in f32: the f16 difference of two up-to-65504
+        // operands (e.g. 65504.0 - (-65504.0) = 131008) or the f16 square of a
+        // 256.0 difference (262144) would overflow the f16 maximum 65504 and
+        // saturate to +inf, disagreeing with the scalar path.
+        float32_t diff = (float32_t)(*pSrcA) - (float32_t)(*pSrcB);
+        euclideanDistance += diff * diff;
         pSrcA += 1;
         pSrcB += 1;
     }
@@ -194,7 +200,11 @@ float32_t manhattanDist_half_4x4(const float16_t* pSrcA, const float16_t* pSrcB,
 
     manhattanDistance = vaddvq_f32(sum);
     for (i=0; i < (blockSize % 32); i++) {
-        manhattanDistance += (float32_t)(vabsh_f16(*pSrcA - *pSrcB));
+        // Compute the difference in f32: the f16 difference of two up-to-65504
+        // operands would overflow the f16 maximum 65504 and saturate to +inf,
+        // disagreeing with the scalar path.
+        float32_t diff = (float32_t)(*pSrcA) - (float32_t)(*pSrcB);
+        manhattanDistance += (diff < 0.0f) ? -diff : diff;
         pSrcA += 1;
         pSrcB += 1;
     }

--- a/lib/segment/src/spaces/metric_f16/neon/dot.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/dot.rs
@@ -74,6 +74,19 @@ mod tests {
             let dot_simd = unsafe { neon_dot_similarity_half(&v1, &v2) };
             let dot = dot_similarity_half(&v1, &v2);
             assert!((dot_simd - dot).abs() / dot.abs() < 0.0005);
+            // Regression test: https://github.com/qdrant/qdrant/issues/10350
+            // Dot 256.0*256.0 = 65536 overflows f16. The NEON kernel must accumulate in f32 to stay
+            // consistent with the scalar path; an f16 accumulator would saturate
+            // to +inf and serialise the score as JSON null.
+            let v1_ovf_f32: Vec<f32> = vec![256.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+            let v2_ovf_f32: Vec<f32> = vec![256.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+            let v1_ovf: Vec<f16> = v1_ovf_f32.iter().map(|x| f16::from_f32(*x)).collect();
+            let v2_ovf: Vec<f16> = v2_ovf_f32.iter().map(|x| f16::from_f32(*x)).collect();
+            let dot_simd_ovf = unsafe { neon_dot_similarity_half(&v1_ovf, &v2_ovf) };
+            let dot_ovf = dot_similarity_half(&v1_ovf, &v2_ovf);
+            assert!(dot_simd_ovf.is_finite(), "NEON dot.rs must not overflow f16 accumulation");
+            assert!((dot_simd_ovf - dot_ovf).abs() / dot_ovf.abs() < 0.0005);
+
         } else {
             println!("neon test skipped");
         }

--- a/lib/segment/src/spaces/metric_f16/neon/dot.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/dot.rs
@@ -87,6 +87,25 @@ mod tests {
             assert!(dot_simd_ovf.is_finite(), "NEON dot.rs must not overflow f16 accumulation");
             assert!((dot_simd_ovf - dot_ovf).abs() / dot_ovf.abs() < 0.0005);
 
+            // Regression: 33-element vector exercises the scalar remainder path
+            // (32 elements in the SIMD loop + 1 in the tail). The f16 product
+            // 65504.0 * 65504.0 = 4294836224 overflows f16 (max 65504) and would
+            // saturate to +inf under f16 remainder arithmetic; the scalar path
+            // returns a finite value.
+            let mut v1_rem_f32: Vec<f32> = vec![0.0; 32];
+            v1_rem_f32.push(65504.0);
+            let mut v2_rem_f32: Vec<f32> = vec![0.0; 32];
+            v2_rem_f32.push(65504.0);
+            let v1_rem: Vec<f16> = v1_rem_f32.iter().map(|x| f16::from_f32(*x)).collect();
+            let v2_rem: Vec<f16> = v2_rem_f32.iter().map(|x| f16::from_f32(*x)).collect();
+            let dot_simd_rem = unsafe { neon_dot_similarity_half(&v1_rem, &v2_rem) };
+            let dot_rem = dot_similarity_half(&v1_rem, &v2_rem);
+            assert!(
+                dot_simd_rem.is_finite(),
+                "NEON dot.rs remainder path must not overflow f16"
+            );
+            assert!((dot_simd_rem - dot_rem).abs() / dot_rem.abs() < 0.0005);
+
         } else {
             println!("neon test skipped");
         }

--- a/lib/segment/src/spaces/metric_f16/neon/euclid.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/euclid.rs
@@ -87,6 +87,25 @@ mod tests {
             assert!(euclid_simd_ovf.is_finite(), "NEON euclid.rs must not overflow f16 accumulation");
             assert!((euclid_simd_ovf - euclid_ovf).abs() / euclid_ovf.abs() < 0.0005);
 
+            // Regression: 33-element vector exercises the scalar remainder path
+            // (32 elements in the SIMD loop + 1 in the tail). The f16 difference
+            // 65504.0 - (-65504.0) = 131008 overflows f16 (max 65504) and would
+            // saturate to +inf under f16 remainder arithmetic; the scalar path
+            // returns a finite value.
+            let mut v1_rem_f32: Vec<f32> = vec![0.0; 32];
+            v1_rem_f32.push(65504.0);
+            let mut v2_rem_f32: Vec<f32> = vec![0.0; 32];
+            v2_rem_f32.push(-65504.0);
+            let v1_rem: Vec<f16> = v1_rem_f32.iter().map(|x| f16::from_f32(*x)).collect();
+            let v2_rem: Vec<f16> = v2_rem_f32.iter().map(|x| f16::from_f32(*x)).collect();
+            let euclid_simd_rem = unsafe { neon_euclid_similarity_half(&v1_rem, &v2_rem) };
+            let euclid_rem = euclid_similarity_half(&v1_rem, &v2_rem);
+            assert!(
+                euclid_simd_rem.is_finite(),
+                "NEON euclid.rs remainder path must not overflow f16"
+            );
+            assert!((euclid_simd_rem - euclid_rem).abs() / euclid_rem.abs() < 0.0005);
+
         } else {
             println!("neon test skipped");
         }

--- a/lib/segment/src/spaces/metric_f16/neon/euclid.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/euclid.rs
@@ -74,6 +74,19 @@ mod tests {
             let euclid_simd = unsafe { neon_euclid_similarity_half(&v1, &v2) };
             let euclid = euclid_similarity_half(&v1, &v2);
             assert!((euclid_simd - euclid).abs() / euclid.abs() < 0.0005);
+            // Regression test: https://github.com/qdrant/qdrant/issues/10350
+            // Euclid 256.0^2 = 65536 overflows f16 (max 65504). The NEON kernel must accumulate in f32 to stay
+            // consistent with the scalar path; an f16 accumulator would saturate
+            // to +inf and serialise the score as JSON null.
+            let v1_ovf_f32: Vec<f32> = vec![256.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+            let v2_ovf_f32: Vec<f32> = vec![0.0; 32];
+            let v1_ovf: Vec<f16> = v1_ovf_f32.iter().map(|x| f16::from_f32(*x)).collect();
+            let v2_ovf: Vec<f16> = v2_ovf_f32.iter().map(|x| f16::from_f32(*x)).collect();
+            let euclid_simd_ovf = unsafe { neon_euclid_similarity_half(&v1_ovf, &v2_ovf) };
+            let euclid_ovf = euclid_similarity_half(&v1_ovf, &v2_ovf);
+            assert!(euclid_simd_ovf.is_finite(), "NEON euclid.rs must not overflow f16 accumulation");
+            assert!((euclid_simd_ovf - euclid_ovf).abs() / euclid_ovf.abs() < 0.0005);
+
         } else {
             println!("neon test skipped");
         }

--- a/lib/segment/src/spaces/metric_f16/neon/manhattan.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/manhattan.rs
@@ -87,6 +87,25 @@ mod tests {
             assert!(manhattan_simd_ovf.is_finite(), "NEON manhattan.rs must not overflow f16 accumulation");
             assert!((manhattan_simd_ovf - manhattan_ovf).abs() / manhattan_ovf.abs() < 0.0005);
 
+            // Regression: 33-element vector exercises the scalar remainder path
+            // (32 elements in the SIMD loop + 1 in the tail). The f16 difference
+            // 65504.0 - (-65504.0) = 131008 overflows f16 (max 65504) and would
+            // saturate to +inf under f16 remainder arithmetic; the scalar path
+            // returns a finite value.
+            let mut v1_rem_f32: Vec<f32> = vec![0.0; 32];
+            v1_rem_f32.push(65504.0);
+            let mut v2_rem_f32: Vec<f32> = vec![0.0; 32];
+            v2_rem_f32.push(-65504.0);
+            let v1_rem: Vec<f16> = v1_rem_f32.iter().map(|x| f16::from_f32(*x)).collect();
+            let v2_rem: Vec<f16> = v2_rem_f32.iter().map(|x| f16::from_f32(*x)).collect();
+            let manhattan_simd_rem = unsafe { neon_manhattan_similarity_half(&v1_rem, &v2_rem) };
+            let manhattan_rem = manhattan_similarity_half(&v1_rem, &v2_rem);
+            assert!(
+                manhattan_simd_rem.is_finite(),
+                "NEON manhattan.rs remainder path must not overflow f16"
+            );
+            assert!((manhattan_simd_rem - manhattan_rem).abs() / manhattan_rem.abs() < 0.0005);
+
         } else {
             println!("neon test skipped");
         }

--- a/lib/segment/src/spaces/metric_f16/neon/manhattan.rs
+++ b/lib/segment/src/spaces/metric_f16/neon/manhattan.rs
@@ -74,6 +74,19 @@ mod tests {
             let manhattan_simd = unsafe { neon_manhattan_similarity_half(&v1, &v2) };
             let manhattan = manhattan_similarity_half(&v1, &v2);
             assert!((manhattan_simd - manhattan).abs() / manhattan.abs() < 0.0005);
+            // Regression test: https://github.com/qdrant/qdrant/issues/10350
+            // Manhattan: a lane accumulates 4 iterations x 20000 = 80000, overflows f16 (max 65504). The NEON kernel must accumulate in f32 to stay
+            // consistent with the scalar path; an f16 accumulator would saturate
+            // to +inf and serialise the score as JSON null.
+            let v1_ovf_f32: Vec<f32> = vec![20000.0; 128];
+            let v2_ovf_f32: Vec<f32> = vec![0.0; 128];
+            let v1_ovf: Vec<f16> = v1_ovf_f32.iter().map(|x| f16::from_f32(*x)).collect();
+            let v2_ovf: Vec<f16> = v2_ovf_f32.iter().map(|x| f16::from_f32(*x)).collect();
+            let manhattan_simd_ovf = unsafe { neon_manhattan_similarity_half(&v1_ovf, &v2_ovf) };
+            let manhattan_ovf = manhattan_similarity_half(&v1_ovf, &v2_ovf);
+            assert!(manhattan_simd_ovf.is_finite(), "NEON manhattan.rs must not overflow f16 accumulation");
+            assert!((manhattan_simd_ovf - manhattan_ovf).abs() / manhattan_ovf.abs() < 0.0005);
+
         } else {
             println!("neon test skipped");
         }


### PR DESCRIPTION
### Summary

The NEON kernels in `lib/segment/src/spaces/metric_f16/cpp/neon.c` — `dotProduct_half_4x4`, `euclideanDist_half_4x4` and `manhattanDist_half_4x4` — accumulate in IEEE binary16 (`float16x8_t` lane sums). A single lane sum can exceed the f16 maximum of 65504 and saturate to `+inf`:

- **Euclid** / **Dot**: a component of `256.0` produces a lane contribution of `256.0^2 = 65536 > 65504`, so `dim >= 32` (the kernel's 32-element stride) returns `+inf`, and the score is serialised as JSON `null` — the official Python client then fails to deserialise it.
- **Manhattan**: a lane accumulates `|a-b|` across iterations; e.g. 4 iterations × 20000 = 80000 overflows as well.

The scalar (`simple_*.rs`) and AVX paths already accumulate in `f32` (PR #9811, "Align scalar f16 metrics precision with SIMD thresholds"). This change makes the NEON kernels accumulate in `f32` (8 `float32x4_t` accumulators per kernel, converting each `float16x8_t` chunk via `vcvt_f32_f16`) so all three paths return identical scores.

### Reproduction (from the issue)

Qdrant on aarch64, `datatype: "float16"`, `distance: "Euclid"`, `exact: true`. A single point with first component `256.0` and the rest zero, queried with the zero vector:

| dim | before | after |
|---|---|---|
| 8–31 | 256.0 | 256.0 |
| ≥32 | `null` (JSON) | 256.0 |

### Regression tests

Added overflow-scenario assertions to the existing `test_spaces_neon` tests in `neon/euclid.rs`, `neon/dot.rs` and `neon/manhattan.rs`: the NEON result must be finite and match the scalar `f32`-accumulating path.

Fixes #10350
