### PR TITLE
Add max_update_by_filter_limit strict mode option

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7604,7 +7604,7 @@
             "nullable": true
           },
           "max_update_by_filter_limit": {
-            "description": "Max number of points an update operation that selects its targets by filter (e.g. delete by filter, set payload by filter, delete vectors by filter) may affect. The match count is estimated from payload indexes when the request is received, before the operation is dispatched to any shard; requests exceeding the limit are rejected.",
+            "description": "Max number of points, per shard, that an update operation selecting its targets by filter (e.g. delete by filter, set payload by filter, delete vectors by filter) may affect. Every shard counts the points its own filter scan matched and rejects the request when that count exceeds the limit, before applying anything. Split larger updates with a `slice` filter condition.",
             "type": "integer",
             "format": "uint",
             "minimum": 0,
@@ -10027,7 +10027,7 @@
             "nullable": true
           },
           "max_update_by_filter_limit": {
-            "description": "Max number of points an update operation that selects its targets by filter (e.g. delete by filter, set payload by filter, delete vectors by filter) may affect. The match count is estimated from payload indexes when the request is received, before the operation is dispatched to any shard; requests exceeding the limit are rejected.",
+            "description": "Max number of points, per shard, that an update operation selecting its targets by filter (e.g. delete by filter, set payload by filter, delete vectors by filter) may affect. Every shard counts the points its own filter scan matched and rejects the request when that count exceeds the limit, before applying anything. Split larger updates with a `slice` filter condition.",
             "type": "integer",
             "format": "uint",
             "minimum": 1,

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7603,6 +7603,13 @@
             "minimum": 0,
             "nullable": true
           },
+          "max_update_by_filter_limit": {
+            "description": "Max number of points an update operation that selects its targets by filter (e.g. delete by filter, set payload by filter, delete vectors by filter) may affect. The match count is estimated from payload indexes when the request is received, before the operation is dispatched to any shard; requests exceeding the limit are rejected.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
           "max_resident_memory_percent": {
             "description": "Deprecated: use the node-wide quota config instead. Reject memory-consuming update operations when resident memory exceeds this percentage of total RAM (1-100)",
             "deprecated": true,
@@ -10017,6 +10024,13 @@
             "type": "integer",
             "format": "uint",
             "minimum": 0,
+            "nullable": true
+          },
+          "max_update_by_filter_limit": {
+            "description": "Max number of points an update operation that selects its targets by filter (e.g. delete by filter, set payload by filter, delete vectors by filter) may affect. The match count is estimated from payload indexes when the request is received, before the operation is dispatched to any shard; requests exceeding the limit are rejected.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1,
             "nullable": true
           },
           "max_resident_memory_percent": {

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7604,7 +7604,7 @@
             "nullable": true
           },
           "max_update_by_filter_limit": {
-            "description": "Max number of points, per shard, that an update operation selecting its targets by filter (e.g. delete by filter, set payload by filter, delete vectors by filter) may affect. Every shard counts the points its own filter scan matched and rejects the request when that count exceeds the limit, before applying anything. Split larger updates with a `slice` filter condition.",
+            "description": "Max number of points, per shard, that an update operation selecting its targets by filter (e.g. delete by filter, set payload by filter, delete vectors by filter) may affect. Every shard counts the points its own filter scan matched and rejects the request when that count exceeds the limit, without applying it there. Shards and replicas are gated independently, so a rejected request may still have been applied by those that matched fewer points. Split larger updates with a `slice` filter condition.",
             "type": "integer",
             "format": "uint",
             "minimum": 0,
@@ -10027,7 +10027,7 @@
             "nullable": true
           },
           "max_update_by_filter_limit": {
-            "description": "Max number of points, per shard, that an update operation selecting its targets by filter (e.g. delete by filter, set payload by filter, delete vectors by filter) may affect. Every shard counts the points its own filter scan matched and rejects the request when that count exceeds the limit, before applying anything. Split larger updates with a `slice` filter condition.",
+            "description": "Max number of points, per shard, that an update operation selecting its targets by filter (e.g. delete by filter, set payload by filter, delete vectors by filter) may affect. Every shard counts the points its own filter scan matched and rejects the request when that count exceeds the limit, without applying it there. Shards and replicas are gated independently, so a rejected request may still have been applied by those that matched fewer points. Split larger updates with a `slice` filter condition.",
             "type": "integer",
             "format": "uint",
             "minimum": 1,

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -190,6 +190,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("StrictModeConfig.max_query_limit", "range(min = 1)"),
             ("StrictModeConfig.max_timeout", "range(min = 1)"),
             ("StrictModeConfig.max_points_count", "range(min = 1)"),
+            ("StrictModeConfig.max_update_by_filter_limit", "range(min = 1)"),
             ("StrictModeConfig.read_rate_limit", "range(min = 1)"),
             ("StrictModeConfig.write_rate_limit", "range(min = 1)"),
             ("StrictModeConfig.max_resident_memory_percent", "range(min = 1, max = 100)"),

--- a/lib/api/src/grpc/conversions.rs
+++ b/lib/api/src/grpc/conversions.rs
@@ -2551,6 +2551,7 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfig {
             multivector_config,
             sparse_config,
             max_payload_index_count,
+            max_update_by_filter_limit,
             max_resident_memory_percent,
         } = value;
         Self {
@@ -2576,6 +2577,7 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfig {
                 .map(segment::types::StrictModeMultivectorConfig::from),
             sparse_config: sparse_config.map(segment::types::StrictModeSparseConfig::from),
             max_payload_index_count: max_payload_index_count.map(|i| i as usize),
+            max_update_by_filter_limit: max_update_by_filter_limit.map(|i| i as usize),
             max_resident_memory_percent: max_resident_memory_percent.map(|i| i as u8),
         }
     }
@@ -2680,6 +2682,7 @@ impl From<segment::types::StrictModeConfigOutput> for StrictModeConfig {
             multivector_config,
             sparse_config,
             max_payload_index_count,
+            max_update_by_filter_limit,
             max_resident_memory_percent,
         } = value;
         Self {
@@ -2703,6 +2706,7 @@ impl From<segment::types::StrictModeConfigOutput> for StrictModeConfig {
             sparse_config: sparse_config.map(StrictModeSparseConfig::from),
             max_points_count: max_points_count.map(|i| i as u64),
             max_payload_index_count: max_payload_index_count.map(|i| i as u64),
+            max_update_by_filter_limit: max_update_by_filter_limit.map(|i| i as u64),
             max_resident_memory_percent: max_resident_memory_percent.map(u32::from),
         }
     }
@@ -2731,6 +2735,7 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfigOutput {
             multivector_config,
             sparse_config,
             max_payload_index_count,
+            max_update_by_filter_limit,
             max_resident_memory_percent,
         } = value;
         Self {
@@ -2756,6 +2761,7 @@ impl From<StrictModeConfig> for segment::types::StrictModeConfigOutput {
                 .map(segment::types::StrictModeMultivectorConfigOutput::from),
             sparse_config: sparse_config.map(segment::types::StrictModeSparseConfigOutput::from),
             max_payload_index_count: max_payload_index_count.map(|i| i as usize),
+            max_update_by_filter_limit: max_update_by_filter_limit.map(|i| i as usize),
             max_resident_memory_percent: max_resident_memory_percent.map(|i| i as u8),
         }
     }

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -494,6 +494,8 @@ message StrictModeConfig {
   optional uint64 max_points_count = 18;
   // Max number of payload indexes in a collection
   optional uint64 max_payload_index_count = 19;
+  // Max number of points an update operation that selects its targets by filter may affect, estimated from payload indexes when the request is received
+  optional uint64 max_update_by_filter_limit = 23;
   // Deprecated: memory is node-wide, use the global quota config instead. Removal planned for 1.21.
   // Reject memory-consuming update operations when process resident memory exceeds this percentage of total RAM (cgroup-aware, 1-100).
   // Delete-style operations are still allowed so memory can be freed.

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -494,7 +494,7 @@ message StrictModeConfig {
   optional uint64 max_points_count = 18;
   // Max number of payload indexes in a collection
   optional uint64 max_payload_index_count = 19;
-  // Max number of points an update operation that selects its targets by filter may affect, estimated from payload indexes when the request is received
+  // Max number of points per shard an update operation that selects its targets by filter may affect, counted by each shard when it resolves the filter
   optional uint64 max_update_by_filter_limit = 23;
   // Deprecated: memory is node-wide, use the global quota config instead. Removal planned for 1.21.
   // Reject memory-consuming update operations when process resident memory exceeds this percentage of total RAM (cgroup-aware, 1-100).

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1121,6 +1121,10 @@ pub struct StrictModeConfig {
     /// Max number of payload indexes in a collection
     #[prost(uint64, optional, tag = "19")]
     pub max_payload_index_count: ::core::option::Option<u64>,
+    /// Max number of points an update operation that selects its targets by filter may affect, estimated from payload indexes when the request is received
+    #[prost(uint64, optional, tag = "23")]
+    #[validate(range(min = 1))]
+    pub max_update_by_filter_limit: ::core::option::Option<u64>,
     /// Deprecated: memory is node-wide, use the global quota config instead. Removal planned for 1.21.
     /// Reject memory-consuming update operations when process resident memory exceeds this percentage of total RAM (cgroup-aware, 1-100).
     /// Delete-style operations are still allowed so memory can be freed.

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1121,7 +1121,7 @@ pub struct StrictModeConfig {
     /// Max number of payload indexes in a collection
     #[prost(uint64, optional, tag = "19")]
     pub max_payload_index_count: ::core::option::Option<u64>,
-    /// Max number of points an update operation that selects its targets by filter may affect, estimated from payload indexes when the request is received
+    /// Max number of points per shard an update operation that selects its targets by filter may affect, counted by each shard when it resolves the filter
     #[prost(uint64, optional, tag = "23")]
     #[validate(range(min = 1))]
     pub max_update_by_filter_limit: ::core::option::Option<u64>,

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -367,6 +367,7 @@ impl DiffConfig<StrictModeConfig> for StrictModeConfig {
             sparse_config,
             max_payload_index_count,
             search_max_batchsize,
+            max_update_by_filter_limit,
             max_resident_memory_percent,
         } = diff;
 
@@ -401,6 +402,8 @@ impl DiffConfig<StrictModeConfig> for StrictModeConfig {
                 .or(self.sparse_config.as_ref())
                 .cloned(),
             max_payload_index_count: max_payload_index_count.or(self.max_payload_index_count),
+            max_update_by_filter_limit: max_update_by_filter_limit
+                .or(self.max_update_by_filter_limit),
             max_resident_memory_percent: max_resident_memory_percent
                 .or(self.max_resident_memory_percent),
         }

--- a/lib/collection/src/operations/types.rs
+++ b/lib/collection/src/operations/types.rs
@@ -1107,6 +1107,35 @@ impl CollectionError {
         matches!(self, Self::PreConditionFailed { .. })
     }
 
+    /// Whether a strict mode rule refused this request, including through the
+    /// wrappers that carry another peer's or another shard's error.
+    ///
+    /// A refusal says the request was not allowed, not that the replica which
+    /// answered is unhealthy, so the replica set reads this to keep a refusing
+    /// replica active. A refusal from another peer only arrives as itself when
+    /// its status carried [`STRICT_MODE_METADATA_KEY`].
+    pub fn is_strict_mode(&self) -> bool {
+        match self {
+            Self::StrictMode { .. } => true,
+            Self::ForwardProxyError { error, .. } => error.is_strict_mode(),
+            Self::InconsistentShardFailure { first_err, .. } => first_err.is_strict_mode(),
+            Self::BadInput { .. } => false,
+            Self::NotFound { .. } => false,
+            Self::PointNotFound { .. } => false,
+            Self::ServiceError { .. } => false,
+            Self::BadRequest { .. } => false,
+            Self::Timeout { .. } => false,
+            Self::Cancelled { .. } => false,
+            Self::OutOfMemory { .. } => false,
+            Self::PreConditionFailed { .. } => false,
+            Self::ObjectStoreError { .. } => false,
+            Self::InferenceError { .. } => false,
+            Self::RateLimitExceeded { .. } => false,
+            Self::ShardUnavailable { .. } => false,
+            Self::InsufficientStorage { .. } => false,
+        }
+    }
+
     pub fn is_missing_point(&self) -> bool {
         #[expect(clippy::wildcard_enum_match_arm, reason = "error handling")]
         match self {
@@ -1273,9 +1302,25 @@ impl From<InvalidUri> for CollectionError {
 /// of the set. Set on the way out, read on the way back in.
 pub const INSUFFICIENT_STORAGE_METADATA_KEY: &str = "qdrant-insufficient-storage";
 
+/// Marks an `InvalidArgument` status as a strict mode refusal rather than a
+/// malformed request.
+///
+/// Both are the caller's problem, but only one of them says something about the
+/// replica that answered: a replica set must not read a strict mode refusal as
+/// a replica that failed to apply an operation. Set on the way out, read on the
+/// way back in.
+pub const STRICT_MODE_METADATA_KEY: &str = "qdrant-strict-mode";
+
 impl From<tonic::Status> for CollectionError {
     fn from(err: tonic::Status) -> Self {
         match err.code() {
+            tonic::Code::InvalidArgument
+                if err.metadata().contains_key(STRICT_MODE_METADATA_KEY) =>
+            {
+                Self::StrictMode {
+                    description: err.message().to_string(),
+                }
+            }
             tonic::Code::InvalidArgument => Self::bad_input(format!("InvalidArgument: {err}")),
             tonic::Code::AlreadyExists => Self::bad_input(format!("AlreadyExists: {err}")),
             tonic::Code::NotFound => Self::not_found(err.to_string()),

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -10,13 +10,24 @@ mod update;
 
 use std::fmt::Display;
 
+use api::rest::ShardKeySelector;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use segment::json_path::JsonPath;
 use segment::types::{Filter, SearchParams, StrictModeConfig};
 pub use shard::operation_rate_cost;
 
-use super::types::{CollectionError, CollectionResult};
+use super::shard_selector_internal::ShardSelectorInternal;
+use super::types::{CollectionError, CollectionResult, CountRequestInternal};
 use crate::collection::Collection;
+
+/// The filter an update operation selects its target points with, when that
+/// target set is the result of scanning the collection rather than a point
+/// list the client sent.
+pub struct UpdateByFilter<'a> {
+    pub filter: &'a Filter,
+    pub shard_key: Option<&'a ShardKeySelector>,
+}
 
 // Creates a new `VerificationPass` without actually verifying anything.
 // This is useful in situations where we don't need to check for strict mode, but still
@@ -70,6 +81,14 @@ pub trait StrictModeVerification {
     /// if the filter is used for filtered-UPDATES like delete by payload.
     /// For read only filters implement `request_indexed_filter_read`!
     fn indexed_filter_write(&self) -> Option<&Filter>;
+
+    /// Implement this for update operations that select their targets by
+    /// scanning the collection with a filter (delete by filter, set payload by
+    /// filter, ...). Gates the `max_update_by_filter_limit` check; operations
+    /// that only trim a client-supplied point list must return `None`.
+    fn update_by_filter(&self) -> Option<UpdateByFilter<'_>> {
+        None
+    }
 
     fn request_exact(&self) -> Option<bool>;
 
@@ -160,6 +179,61 @@ pub trait StrictModeVerification {
         Ok(())
     }
 
+    /// Rejects update-by-filter operations whose filter is estimated to match
+    /// more points than `max_update_by_filter_limit`.
+    ///
+    /// The match count is estimated from payload indexes across the selected
+    /// shards (the same estimate as an inexact count request), so it is
+    /// evaluated once per request before the operation is dispatched to any
+    /// shard. Like the other strict mode checks it is a request-time guard,
+    /// not a transactional invariant: concurrent writes can move the real
+    /// match count after the check.
+    #[allow(async_fn_in_trait)]
+    async fn check_update_by_filter_limit(
+        &self,
+        collection: &Collection,
+        strict_mode_config: &StrictModeConfig,
+    ) -> CollectionResult<()> {
+        let Some(limit) = strict_mode_config.max_update_by_filter_limit else {
+            return Ok(());
+        };
+        let Some(UpdateByFilter { filter, shard_key }) = self.update_by_filter() else {
+            return Ok(());
+        };
+
+        let shard_selection = shard_key
+            .cloned()
+            .map_or(ShardSelectorInternal::All, ShardSelectorInternal::from);
+        let request = CountRequestInternal {
+            filter: Some(filter.clone()),
+            exact: false,
+        };
+        let estimated = collection
+            .count(
+                request,
+                None,
+                None,
+                &shard_selection,
+                None,
+                HwMeasurementAcc::disposable(),
+            )
+            .await?
+            .count;
+
+        if estimated > limit {
+            return Err(CollectionError::strict_mode(
+                format!(
+                    "Update by filter matches an estimated {estimated} points, \
+                     exceeding the configured limit of {limit}",
+                ),
+                "Narrow your filter so it matches at most `max_update_by_filter_limit` \
+                 points, or raise `max_update_by_filter_limit` in the strict mode config.",
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Does the verification of all configured parameters. Only implement this function if you know what
     /// you are doing. In most cases implementing `check_custom` is sufficient.
     #[allow(async_fn_in_trait)]
@@ -171,6 +245,8 @@ pub trait StrictModeVerification {
         self.check_custom(collection, strict_mode_config).await?;
         self.check_request_query_limit(strict_mode_config)?;
         self.check_request_filter(collection, strict_mode_config)?;
+        self.check_update_by_filter_limit(collection, strict_mode_config)
+            .await?;
         self.check_request_exact(strict_mode_config)?;
         self.check_search_params(collection, strict_mode_config)
             .await?;
@@ -394,16 +470,22 @@ mod test {
     use api::rest::{PointInsertOperations, PointStruct, PointsList, SearchRequestInternal};
     use common::budget::ResourceBudget;
     use common::counter::hardware_accumulator::HwMeasurementAcc;
+    use segment::payload_json;
     use segment::types::{
         Condition, FieldCondition, Filter, Match, PayloadFieldSchema, PayloadSchemaType,
         SearchParams, StrictModeConfig, ValueVariants,
     };
-    use tempfile::Builder;
+    use tempfile::{Builder, TempDir};
 
     use super::StrictModeVerification;
     use crate::collection::{Collection, RequestShardTransfer};
     use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
-    use crate::operations::point_ops::{FilterSelector, PointsSelector};
+    use crate::operations::CollectionUpdateOperations;
+    use crate::operations::payload_ops::SetPayload;
+    use crate::operations::point_ops::{
+        FilterSelector, PointInsertOperationsInternal, PointOperations, PointStructPersisted,
+        PointsSelector, VectorStructPersisted, WriteOrdering,
+    };
     use crate::operations::shared_storage_config::SharedStorageConfig;
     use crate::operations::types::{
         CollectionError, CountRequestInternal, DiscoverRequestInternal, SearchRequest,
@@ -412,6 +494,7 @@ mod test {
     use crate::optimizers_builder::OptimizersConfig;
     use crate::shards::channel_service::ChannelService;
     use crate::shards::collection_shard_distribution::CollectionShardDistribution;
+    use crate::shards::replica_set::replica_set_state::ReplicaState;
     use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
 
     const UNINDEXED_KEY: &str = "key";
@@ -429,6 +512,70 @@ mod test {
         test_request_exact(&collection).await;
         test_search_batch_limit(&collection).await;
         test_upsert_batch_limit(&collection).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_update_by_filter_limit() {
+        let strict_mode_config = StrictModeConfig {
+            enabled: Some(true),
+            max_update_by_filter_limit: Some(2),
+            ..Default::default()
+        };
+        let collection = fixture_collection(&strict_mode_config).await;
+        // Shard 0 is the only shard; activate its local replica for writes.
+        collection
+            .set_shard_replica_state(0, 0, ReplicaState::Active, None)
+            .await
+            .expect("failed to activate replica");
+
+        let points = (1..=3)
+            .map(|id| PointStructPersisted {
+                id: id.into(),
+                vector: VectorStructPersisted::Named(Default::default()),
+                payload: Some(payload_json! {"num": 123}),
+            })
+            .collect();
+        collection
+            .update_from_client_simple(
+                CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+                    PointInsertOperationsInternal::PointsList(points),
+                )),
+                true,
+                None,
+                WriteOrdering::default(),
+                HwMeasurementAcc::new(),
+            )
+            .await
+            .expect("failed to upsert points");
+
+        // Three indexed matches exceed the limit of two.
+        let over_limit = PointsSelector::FilterSelector(FilterSelector {
+            filter: filter_fixture(INDEXED_KEY),
+            shard_key: None,
+        });
+        assert_strict_mode_error(over_limit, &collection).await;
+
+        // Same filter, but an explicit id list takes precedence on apply, so
+        // this is not a filter scan and must not be capped.
+        let with_ids = SetPayload {
+            payload: payload_json! {"a": 1},
+            points: Some(vec![1.into()]),
+            filter: Some(filter_fixture(INDEXED_KEY)),
+            shard_key: None,
+            key: None,
+        };
+        assert_strict_mode_success(with_ids, &collection).await;
+
+        // A filter with no matches stays under the limit.
+        let no_match = Filter::new_must(Condition::Field(FieldCondition::new_match(
+            INDEXED_KEY.try_into().unwrap(),
+            Match::new_value(ValueVariants::Integer(0)),
+        )));
+        let under_limit = PointsSelector::FilterSelector(FilterSelector {
+            filter: no_match,
+            shard_key: None,
+        });
+        assert_strict_mode_success(under_limit, &collection).await;
     }
 
     async fn test_query_limit(collection: &Collection) {
@@ -711,7 +858,22 @@ mod test {
         }
     }
 
-    async fn fixture() -> Collection {
+    /// A collection plus the temp dirs backing it, so on-disk writes (point
+    /// upserts, replica state changes) keep working for the test's lifetime.
+    struct CollectionFixture {
+        collection: Collection,
+        _dirs: (TempDir, TempDir),
+    }
+
+    impl std::ops::Deref for CollectionFixture {
+        type Target = Collection;
+
+        fn deref(&self) -> &Collection {
+            &self.collection
+        }
+    }
+
+    async fn fixture() -> CollectionFixture {
         let strict_mode_config = StrictModeConfig {
             enabled: Some(true),
             max_timeout: Some(3),
@@ -729,7 +891,7 @@ mod test {
         fixture_collection(&strict_mode_config).await
     }
 
-    async fn fixture_collection(strict_mode_config: &StrictModeConfig) -> Collection {
+    async fn fixture_collection(strict_mode_config: &StrictModeConfig) -> CollectionFixture {
         let wal_config = WalConfig::default();
         let collection_params = CollectionParams::empty();
 
@@ -782,7 +944,10 @@ mod test {
             .await
             .expect("failed to create payload index");
 
-        collection
+        CollectionFixture {
+            collection,
+            _dirs: (collection_dir, snapshots_path),
+        }
     }
 
     pub fn dummy_on_replica_failure() -> ChangePeerFromState {

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -10,24 +10,13 @@ mod update;
 
 use std::fmt::Display;
 
-use api::rest::ShardKeySelector;
-use common::counter::hardware_accumulator::HwMeasurementAcc;
 use itertools::Itertools;
 use segment::json_path::JsonPath;
 use segment::types::{Filter, SearchParams, StrictModeConfig};
 pub use shard::operation_rate_cost;
 
-use super::shard_selector_internal::ShardSelectorInternal;
-use super::types::{CollectionError, CollectionResult, CountRequestInternal};
+use super::types::{CollectionError, CollectionResult};
 use crate::collection::Collection;
-
-/// The filter an update operation selects its target points with, when that
-/// target set is the result of scanning the collection rather than a point
-/// list the client sent.
-pub struct UpdateByFilter<'a> {
-    pub filter: &'a Filter,
-    pub shard_key: Option<&'a ShardKeySelector>,
-}
 
 // Creates a new `VerificationPass` without actually verifying anything.
 // This is useful in situations where we don't need to check for strict mode, but still
@@ -81,14 +70,6 @@ pub trait StrictModeVerification {
     /// if the filter is used for filtered-UPDATES like delete by payload.
     /// For read only filters implement `request_indexed_filter_read`!
     fn indexed_filter_write(&self) -> Option<&Filter>;
-
-    /// Implement this for update operations that select their targets by
-    /// scanning the collection with a filter (delete by filter, set payload by
-    /// filter, ...). Gates the `max_update_by_filter_limit` check; operations
-    /// that only trim a client-supplied point list must return `None`.
-    fn update_by_filter(&self) -> Option<UpdateByFilter<'_>> {
-        None
-    }
 
     fn request_exact(&self) -> Option<bool>;
 
@@ -179,61 +160,6 @@ pub trait StrictModeVerification {
         Ok(())
     }
 
-    /// Rejects update-by-filter operations whose filter is estimated to match
-    /// more points than `max_update_by_filter_limit`.
-    ///
-    /// The match count is estimated from payload indexes across the selected
-    /// shards (the same estimate as an inexact count request), so it is
-    /// evaluated once per request before the operation is dispatched to any
-    /// shard. Like the other strict mode checks it is a request-time guard,
-    /// not a transactional invariant: concurrent writes can move the real
-    /// match count after the check.
-    #[allow(async_fn_in_trait)]
-    async fn check_update_by_filter_limit(
-        &self,
-        collection: &Collection,
-        strict_mode_config: &StrictModeConfig,
-    ) -> CollectionResult<()> {
-        let Some(limit) = strict_mode_config.max_update_by_filter_limit else {
-            return Ok(());
-        };
-        let Some(UpdateByFilter { filter, shard_key }) = self.update_by_filter() else {
-            return Ok(());
-        };
-
-        let shard_selection = shard_key
-            .cloned()
-            .map_or(ShardSelectorInternal::All, ShardSelectorInternal::from);
-        let request = CountRequestInternal {
-            filter: Some(filter.clone()),
-            exact: false,
-        };
-        let estimated = collection
-            .count(
-                request,
-                None,
-                None,
-                &shard_selection,
-                None,
-                HwMeasurementAcc::disposable(),
-            )
-            .await?
-            .count;
-
-        if estimated > limit {
-            return Err(CollectionError::strict_mode(
-                format!(
-                    "Update by filter matches an estimated {estimated} points, \
-                     exceeding the configured limit of {limit}",
-                ),
-                "Narrow your filter so it matches at most `max_update_by_filter_limit` \
-                 points, or raise `max_update_by_filter_limit` in the strict mode config.",
-            ));
-        }
-
-        Ok(())
-    }
-
     /// Does the verification of all configured parameters. Only implement this function if you know what
     /// you are doing. In most cases implementing `check_custom` is sufficient.
     #[allow(async_fn_in_trait)]
@@ -245,8 +171,6 @@ pub trait StrictModeVerification {
         self.check_custom(collection, strict_mode_config).await?;
         self.check_request_query_limit(strict_mode_config)?;
         self.check_request_filter(collection, strict_mode_config)?;
-        self.check_update_by_filter_limit(collection, strict_mode_config)
-            .await?;
         self.check_request_exact(strict_mode_config)?;
         self.check_search_params(collection, strict_mode_config)
             .await?;
@@ -470,22 +394,16 @@ mod test {
     use api::rest::{PointInsertOperations, PointStruct, PointsList, SearchRequestInternal};
     use common::budget::ResourceBudget;
     use common::counter::hardware_accumulator::HwMeasurementAcc;
-    use segment::payload_json;
     use segment::types::{
         Condition, FieldCondition, Filter, Match, PayloadFieldSchema, PayloadSchemaType,
         SearchParams, StrictModeConfig, ValueVariants,
     };
-    use tempfile::{Builder, TempDir};
+    use tempfile::Builder;
 
     use super::StrictModeVerification;
     use crate::collection::{Collection, RequestShardTransfer};
     use crate::config::{CollectionConfigInternal, CollectionParams, WalConfig};
-    use crate::operations::CollectionUpdateOperations;
-    use crate::operations::payload_ops::SetPayload;
-    use crate::operations::point_ops::{
-        FilterSelector, PointInsertOperationsInternal, PointOperations, PointStructPersisted,
-        PointsSelector, VectorStructPersisted, WriteOrdering,
-    };
+    use crate::operations::point_ops::{FilterSelector, PointsSelector};
     use crate::operations::shared_storage_config::SharedStorageConfig;
     use crate::operations::types::{
         CollectionError, CountRequestInternal, DiscoverRequestInternal, SearchRequest,
@@ -494,7 +412,6 @@ mod test {
     use crate::optimizers_builder::OptimizersConfig;
     use crate::shards::channel_service::ChannelService;
     use crate::shards::collection_shard_distribution::CollectionShardDistribution;
-    use crate::shards::replica_set::replica_set_state::ReplicaState;
     use crate::shards::replica_set::{AbortShardTransfer, ChangePeerFromState};
 
     const UNINDEXED_KEY: &str = "key";
@@ -512,70 +429,6 @@ mod test {
         test_request_exact(&collection).await;
         test_search_batch_limit(&collection).await;
         test_upsert_batch_limit(&collection).await;
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_update_by_filter_limit() {
-        let strict_mode_config = StrictModeConfig {
-            enabled: Some(true),
-            max_update_by_filter_limit: Some(2),
-            ..Default::default()
-        };
-        let collection = fixture_collection(&strict_mode_config).await;
-        // Shard 0 is the only shard; activate its local replica for writes.
-        collection
-            .set_shard_replica_state(0, 0, ReplicaState::Active, None)
-            .await
-            .expect("failed to activate replica");
-
-        let points = (1..=3)
-            .map(|id| PointStructPersisted {
-                id: id.into(),
-                vector: VectorStructPersisted::Named(Default::default()),
-                payload: Some(payload_json! {"num": 123}),
-            })
-            .collect();
-        collection
-            .update_from_client_simple(
-                CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
-                    PointInsertOperationsInternal::PointsList(points),
-                )),
-                true,
-                None,
-                WriteOrdering::default(),
-                HwMeasurementAcc::new(),
-            )
-            .await
-            .expect("failed to upsert points");
-
-        // Three indexed matches exceed the limit of two.
-        let over_limit = PointsSelector::FilterSelector(FilterSelector {
-            filter: filter_fixture(INDEXED_KEY),
-            shard_key: None,
-        });
-        assert_strict_mode_error(over_limit, &collection).await;
-
-        // Same filter, but an explicit id list takes precedence on apply, so
-        // this is not a filter scan and must not be capped.
-        let with_ids = SetPayload {
-            payload: payload_json! {"a": 1},
-            points: Some(vec![1.into()]),
-            filter: Some(filter_fixture(INDEXED_KEY)),
-            shard_key: None,
-            key: None,
-        };
-        assert_strict_mode_success(with_ids, &collection).await;
-
-        // A filter with no matches stays under the limit.
-        let no_match = Filter::new_must(Condition::Field(FieldCondition::new_match(
-            INDEXED_KEY.try_into().unwrap(),
-            Match::new_value(ValueVariants::Integer(0)),
-        )));
-        let under_limit = PointsSelector::FilterSelector(FilterSelector {
-            filter: no_match,
-            shard_key: None,
-        });
-        assert_strict_mode_success(under_limit, &collection).await;
     }
 
     async fn test_query_limit(collection: &Collection) {
@@ -858,22 +711,7 @@ mod test {
         }
     }
 
-    /// A collection plus the temp dirs backing it, so on-disk writes (point
-    /// upserts, replica state changes) keep working for the test's lifetime.
-    struct CollectionFixture {
-        collection: Collection,
-        _dirs: (TempDir, TempDir),
-    }
-
-    impl std::ops::Deref for CollectionFixture {
-        type Target = Collection;
-
-        fn deref(&self) -> &Collection {
-            &self.collection
-        }
-    }
-
-    async fn fixture() -> CollectionFixture {
+    async fn fixture() -> Collection {
         let strict_mode_config = StrictModeConfig {
             enabled: Some(true),
             max_timeout: Some(3),
@@ -891,7 +729,7 @@ mod test {
         fixture_collection(&strict_mode_config).await
     }
 
-    async fn fixture_collection(strict_mode_config: &StrictModeConfig) -> CollectionFixture {
+    async fn fixture_collection(strict_mode_config: &StrictModeConfig) -> Collection {
         let wal_config = WalConfig::default();
         let collection_params = CollectionParams::empty();
 
@@ -944,10 +782,7 @@ mod test {
             .await
             .expect("failed to create payload index");
 
-        CollectionFixture {
-            collection,
-            _dirs: (collection_dir, snapshots_path),
-        }
+        collection
     }
 
     pub fn dummy_on_replica_failure() -> ChangePeerFromState {

--- a/lib/collection/src/operations/verification/update.rs
+++ b/lib/collection/src/operations/verification/update.rs
@@ -9,7 +9,7 @@ use segment::types::{
     VectorNameBuf,
 };
 
-use super::{StrictModeVerification, check_limit_opt};
+use super::{StrictModeVerification, UpdateByFilter, check_limit_opt};
 use crate::collection::Collection;
 use crate::common::collection_size_stats::CollectionSizeAtomicStats;
 use crate::operations::payload_ops::{DeletePayload, SetPayload};
@@ -51,6 +51,16 @@ impl StrictModeVerification for PointsSelector {
         }
     }
 
+    fn update_by_filter(&self) -> Option<UpdateByFilter<'_>> {
+        match self {
+            PointsSelector::FilterSelector(selector) => Some(UpdateByFilter {
+                filter: &selector.filter,
+                shard_key: selector.shard_key.as_ref(),
+            }),
+            PointsSelector::PointIdsSelector(_) => None,
+        }
+    }
+
     fn query_limit(&self) -> Option<usize> {
         None
     }
@@ -69,6 +79,17 @@ impl StrictModeVerification for PointsSelector {
 }
 
 impl StrictModeVerification for DeleteVectors {
+    fn update_by_filter(&self) -> Option<UpdateByFilter<'_>> {
+        // An explicit id list takes precedence over the filter on apply.
+        if self.points.is_some() {
+            return None;
+        }
+        Some(UpdateByFilter {
+            filter: self.filter.as_ref()?,
+            shard_key: self.shard_key.as_ref(),
+        })
+    }
+
     fn query_limit(&self) -> Option<usize> {
         None
     }
@@ -113,6 +134,17 @@ impl StrictModeVerification for SetPayload {
         self.filter.as_ref()
     }
 
+    fn update_by_filter(&self) -> Option<UpdateByFilter<'_>> {
+        // An explicit id list takes precedence over the filter on apply.
+        if self.points.is_some() {
+            return None;
+        }
+        Some(UpdateByFilter {
+            filter: self.filter.as_ref()?,
+            shard_key: self.shard_key.as_ref(),
+        })
+    }
+
     fn query_limit(&self) -> Option<usize> {
         None
     }
@@ -133,6 +165,17 @@ impl StrictModeVerification for SetPayload {
 impl StrictModeVerification for DeletePayload {
     fn indexed_filter_write(&self) -> Option<&Filter> {
         self.filter.as_ref()
+    }
+
+    fn update_by_filter(&self) -> Option<UpdateByFilter<'_>> {
+        // An explicit id list takes precedence over the filter on apply.
+        if self.points.is_some() {
+            return None;
+        }
+        Some(UpdateByFilter {
+            filter: self.filter.as_ref()?,
+            shard_key: self.shard_key.as_ref(),
+        })
     }
 
     fn query_limit(&self) -> Option<usize> {

--- a/lib/collection/src/operations/verification/update.rs
+++ b/lib/collection/src/operations/verification/update.rs
@@ -9,7 +9,7 @@ use segment::types::{
     VectorNameBuf,
 };
 
-use super::{StrictModeVerification, UpdateByFilter, check_limit_opt};
+use super::{StrictModeVerification, check_limit_opt};
 use crate::collection::Collection;
 use crate::common::collection_size_stats::CollectionSizeAtomicStats;
 use crate::operations::payload_ops::{DeletePayload, SetPayload};
@@ -51,16 +51,6 @@ impl StrictModeVerification for PointsSelector {
         }
     }
 
-    fn update_by_filter(&self) -> Option<UpdateByFilter<'_>> {
-        match self {
-            PointsSelector::FilterSelector(selector) => Some(UpdateByFilter {
-                filter: &selector.filter,
-                shard_key: selector.shard_key.as_ref(),
-            }),
-            PointsSelector::PointIdsSelector(_) => None,
-        }
-    }
-
     fn query_limit(&self) -> Option<usize> {
         None
     }
@@ -79,17 +69,6 @@ impl StrictModeVerification for PointsSelector {
 }
 
 impl StrictModeVerification for DeleteVectors {
-    fn update_by_filter(&self) -> Option<UpdateByFilter<'_>> {
-        // An explicit id list takes precedence over the filter on apply.
-        if self.points.is_some() {
-            return None;
-        }
-        Some(UpdateByFilter {
-            filter: self.filter.as_ref()?,
-            shard_key: self.shard_key.as_ref(),
-        })
-    }
-
     fn query_limit(&self) -> Option<usize> {
         None
     }
@@ -134,17 +113,6 @@ impl StrictModeVerification for SetPayload {
         self.filter.as_ref()
     }
 
-    fn update_by_filter(&self) -> Option<UpdateByFilter<'_>> {
-        // An explicit id list takes precedence over the filter on apply.
-        if self.points.is_some() {
-            return None;
-        }
-        Some(UpdateByFilter {
-            filter: self.filter.as_ref()?,
-            shard_key: self.shard_key.as_ref(),
-        })
-    }
-
     fn query_limit(&self) -> Option<usize> {
         None
     }
@@ -165,17 +133,6 @@ impl StrictModeVerification for SetPayload {
 impl StrictModeVerification for DeletePayload {
     fn indexed_filter_write(&self) -> Option<&Filter> {
         self.filter.as_ref()
-    }
-
-    fn update_by_filter(&self) -> Option<UpdateByFilter<'_>> {
-        // An explicit id list takes precedence over the filter on apply.
-        if self.points.is_some() {
-            return None;
-        }
-        Some(UpdateByFilter {
-            filter: self.filter.as_ref()?,
-            shard_key: self.shard_key.as_ref(),
-        })
     }
 
     fn query_limit(&self) -> Option<usize> {

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -6,7 +6,7 @@ pub(super) mod query;
 pub(super) mod resolve_submit;
 pub(super) mod scroll;
 pub(super) mod search;
-pub(super) mod shard_ops;
+pub(crate) mod shard_ops;
 
 mod snapshot;
 mod telemetry;

--- a/lib/collection/src/shards/local_shard/resolve_submit.rs
+++ b/lib/collection/src/shards/local_shard/resolve_submit.rs
@@ -26,12 +26,25 @@
 //! and one tag can cover only one record — untagged or tag-sharing records
 //! break WAL-delta recovery. Splitting oversized resolutions is a follow-up.
 //!
-//! `max_update_by_filter_limit` (strict mode) is enforced here, on the exact
-//! point set the scan resolved to. Each shard gates its own share of the
-//! request: the check runs after the filter is resolved and before the WAL
-//! append, so a rejected operation leaves no trace on this shard. Only filter
-//! scans are gated, and only clients issue those: internal operations resolve
-//! no filters, so they need no exemption.
+//! `max_update_by_filter_limit` (strict mode) is enforced here, on the point
+//! set the scan resolved to. The limit is also the scan's budget: the resolver
+//! reads one point past it per segment and stops, so refusing an oversized
+//! update costs what the limit allows rather than what the filter matches.
+//!
+//! The verdict is local to this shard, and it is not atomic for the request
+//! that carried the operation. The check runs before the WAL append, so a
+//! rejection leaves no trace *here*, but every shard gates the point set it
+//! resolved on its own, so another shard of the collection may have applied its
+//! share before this one refused (the client sees `InconsistentShardFailure`).
+//! Replicas of one shard can disagree the same way when their point sets have
+//! drifted apart; that divergence is the accepted cost of a per-shard limit,
+//! and a refusal is never a reason to deactivate a replica (see
+//! `handle_failed_replicas`), which would trade it for a full resync.
+//!
+//! Only the replica taking the client write gates: `submit_update`'s
+//! `enforce_strict_mode` is off for a replica that is catching up, which is
+//! also how the operations that reach one arrive unresolved (a forward proxy
+//! relays the original operation to a transfer target).
 
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use shard::resolve::{ResolvedOperation, resolve_operation};
@@ -79,6 +92,7 @@ impl LocalShard {
         &self,
         operation: OperationWithClockTag,
         wait: WaitUntil,
+        enforce_strict_mode: bool,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<SubmitOutcome> {
         let OperationWithClockTag {
@@ -88,7 +102,11 @@ impl LocalShard {
 
         self.check_wal_disk_space().await?;
 
-        let update_by_filter_limit = self.max_update_by_filter_limit().await;
+        let update_by_filter_limit = if enforce_strict_mode {
+            self.max_update_by_filter_limit().await
+        } else {
+            None
+        };
 
         // 1. Fence: block new submits; in-flight ones (holding `read`) have
         // already appended and enqueued by the time `write` is granted.
@@ -117,17 +135,23 @@ impl LocalShard {
             scanned_points,
         } = tokio::task::spawn_blocking(move || {
             let segments = segments.read();
-            resolve_operation(&segments, operation, &hw_acc.get_counter_cell())
+            resolve_operation(
+                &segments,
+                operation,
+                update_by_filter_limit,
+                &hw_acc.get_counter_cell(),
+            )
         })
         .await??;
 
-        // Gate on the exact number of points the scan selected in this shard,
-        // before anything is written.
+        // Gate on the points the scan selected in this shard, before anything
+        // is written. Over the limit the resolved operation is truncated, so
+        // this rejection is the only sound thing to do with it.
         if let Some(limit) = update_by_filter_limit
             && let Some(matched) = scanned_points
             && matched > limit
         {
-            return Err(update_by_filter_limit_error(matched, limit));
+            return Err(update_by_filter_limit_error(limit));
         }
 
         // Guard against `is_filter_resolving` and `resolve_operation` drifting
@@ -160,27 +184,26 @@ impl LocalShard {
     }
 }
 
-/// Reject an update whose filter selected more points than strict mode allows,
-/// pointing at the `slice` condition as the way to split it up.
-fn update_by_filter_limit_error(matched: usize, limit: usize) -> CollectionError {
-    // `matched / limit` slices only make the *average* slice fit, and slices
-    // are hash-based rather than balanced, so suggest twice that as a starting
-    // point. Another shard may have matched more points than this one, so the
-    // suggestion can still fall short; the message says so.
-    let slices = (2 * matched).div_ceil(limit.max(1));
+/// Reject an update whose filter scan selected more points than strict mode
+/// allows, pointing at the `slice` condition as the way to split it up.
+fn update_by_filter_limit_error(limit: usize) -> CollectionError {
+    // The scan stops one point past the limit, so how far over it the filter
+    // really goes is unknown here. Start at the smallest split that can change
+    // anything and let the user double from there, which is also what an
+    // unbalanced slice or a bigger share on another shard asks for.
+    let slices = 2;
 
     CollectionError::strict_mode(
-        format!(
-            "Update by filter matches {matched} points in one shard, \
-             exceeding the per-shard limit of {limit}",
-        ),
+        format!("Update by filter matches more points in one shard than the limit of {limit}"),
         format!(
             "Split the update into disjoint slices and send one request per slice: add \
-             `{{\"slice\": {{\"total\": {slices}, \"index\": 0}}}}` to your filter and repeat \
-             it for every index in `0..{slices}`. Together the slices cover all matching points. \
-             Slices are hash-based and not exactly balanced, so raise `total` further if a slice \
-             is still rejected. Alternatively, raise `max_update_by_filter_limit` in the strict \
-             mode config.",
+             `{{\"slice\": {{\"total\": {slices}, \"index\": 0}}}}` to the `must` clause of \
+             your filter and repeat it for every index in `0..{slices}`. Together the slices \
+             cover all matching points. Raise `total` and repeat while a slice is still \
+             rejected: each doubling halves what one slice matches. Alternatively, raise \
+             `max_update_by_filter_limit` in the strict mode config. Each shard and each replica \
+             applies this limit to the points it resolved on its own, so parts of this request \
+             may have been applied already.",
         ),
     )
 }

--- a/lib/collection/src/shards/local_shard/resolve_submit.rs
+++ b/lib/collection/src/shards/local_shard/resolve_submit.rs
@@ -25,9 +25,16 @@
 //! the filter matched: it reuses the incoming operation's single clock tag,
 //! and one tag can cover only one record — untagged or tag-sharing records
 //! break WAL-delta recovery. Splitting oversized resolutions is a follow-up.
+//!
+//! `max_update_by_filter_limit` (strict mode) is enforced here, on the exact
+//! point set the scan resolved to. Each shard gates its own share of the
+//! request: the check runs after the filter is resolved and before the WAL
+//! append, so a rejected operation leaves no trace on this shard. Only filter
+//! scans are gated, and only clients issue those: internal operations resolve
+//! no filters, so they need no exemption.
 
 use common::counter::hardware_accumulator::HwMeasurementAcc;
-use shard::resolve::resolve_operation;
+use shard::resolve::{ResolvedOperation, resolve_operation};
 use tokio::sync::oneshot;
 
 use crate::operations::OperationWithClockTag;
@@ -81,6 +88,8 @@ impl LocalShard {
 
         self.check_wal_disk_space().await?;
 
+        let update_by_filter_limit = self.max_update_by_filter_limit().await;
+
         // 1. Fence: block new submits; in-flight ones (holding `read`) have
         // already appended and enqueued by the time `write` is granted.
         let _fence = self.update_lock.write().await;
@@ -103,11 +112,23 @@ impl LocalShard {
         // operation to its id-based form.
         let segments = self.segments.clone();
         let hw_acc = hw_measurement_acc.clone();
-        let resolved = tokio::task::spawn_blocking(move || {
+        let ResolvedOperation {
+            operation: resolved,
+            scanned_points,
+        } = tokio::task::spawn_blocking(move || {
             let segments = segments.read();
             resolve_operation(&segments, operation, &hw_acc.get_counter_cell())
         })
         .await??;
+
+        // Gate on the exact number of points the scan selected in this shard,
+        // before anything is written.
+        if let Some(limit) = update_by_filter_limit
+            && let Some(matched) = scanned_points
+            && matched > limit
+        {
+            return Err(update_by_filter_limit_error(matched, limit));
+        }
 
         // Guard against `is_filter_resolving` and `resolve_operation` drifting
         // apart: a resolved operation must never classify as filter-resolving,
@@ -126,4 +147,40 @@ impl LocalShard {
         )
         .await
     }
+
+    /// Configured `max_update_by_filter_limit`, if strict mode is enabled.
+    async fn max_update_by_filter_limit(&self) -> Option<usize> {
+        self.collection_config
+            .read()
+            .await
+            .strict_mode_config
+            .as_ref()
+            .filter(|config| config.enabled == Some(true))
+            .and_then(|config| config.max_update_by_filter_limit)
+    }
+}
+
+/// Reject an update whose filter selected more points than strict mode allows,
+/// pointing at the `slice` condition as the way to split it up.
+fn update_by_filter_limit_error(matched: usize, limit: usize) -> CollectionError {
+    // `matched / limit` slices only make the *average* slice fit, and slices
+    // are hash-based rather than balanced, so suggest twice that as a starting
+    // point. Another shard may have matched more points than this one, so the
+    // suggestion can still fall short; the message says so.
+    let slices = (2 * matched).div_ceil(limit.max(1));
+
+    CollectionError::strict_mode(
+        format!(
+            "Update by filter matches {matched} points in one shard, \
+             exceeding the per-shard limit of {limit}",
+        ),
+        format!(
+            "Split the update into disjoint slices and send one request per slice: add \
+             `{{\"slice\": {{\"total\": {slices}, \"index\": 0}}}}` to your filter and repeat \
+             it for every index in `0..{slices}`. Together the slices cover all matching points. \
+             Slices are hash-based and not exactly balanced, so raise `total` further if a slice \
+             is still rejected. Alternatively, raise `max_update_by_filter_limit` in the strict \
+             mode config.",
+        ),
+    )
 }

--- a/lib/collection/src/shards/local_shard/resolve_submit.rs
+++ b/lib/collection/src/shards/local_shard/resolve_submit.rs
@@ -37,9 +37,11 @@
 //! resolved on its own, so another shard of the collection may have applied its
 //! share before this one refused (the client sees `InconsistentShardFailure`).
 //! Replicas of one shard can disagree the same way when their point sets have
-//! drifted apart; that divergence is the accepted cost of a per-shard limit,
-//! and a refusal is never a reason to deactivate a replica (see
-//! `handle_failed_replicas`), which would trade it for a full resync.
+//! drifted apart; that divergence is the accepted cost of a per-shard limit.
+//! A refusal is never a reason to deactivate a replica (see
+//! `handle_failed_replicas`), which would trade it for a full resync, but the
+//! replica set still returns the refusal to the client so a partial apply is
+//! never reported as success.
 //!
 //! Only the replica taking the client write gates: `submit_update`'s
 //! `enforce_strict_mode` is off for a replica that is catching up, which is

--- a/lib/collection/src/shards/local_shard/shard_ops.rs
+++ b/lib/collection/src/shards/local_shard/shard_ops.rs
@@ -58,10 +58,18 @@ impl LocalShard {
     /// [`SubmitOutcome::Submitted`] carries an owned `oneshot::Receiver` that
     /// can be awaited via [`await_update_result`] after dropping any outer
     /// read guards on the replica set.
+    ///
+    /// `enforce_strict_mode` gates the shard-local strict mode rules, which
+    /// only apply to a replica serving client writes. The caller decides from
+    /// the replica state, exactly as it does for the write rate limiter: a
+    /// replica that is catching up (transfer target, listener, resharding)
+    /// holds a different point set than the one the client's request was
+    /// gated against, and must not second-guess it.
     pub async fn submit_update(
         &self,
         operation: OperationWithClockTag,
         wait: WaitUntil,
+        enforce_strict_mode: bool,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<SubmitOutcome> {
         // Filter/condition-resolving operations must never reach the WAL as-is:
@@ -70,7 +78,12 @@ impl LocalShard {
         // the same filter to the same point set.
         if shard::resolve::is_filter_resolving(&operation.operation) {
             return self
-                .submit_update_filter_resolving(operation, wait, hw_measurement_acc)
+                .submit_update_filter_resolving(
+                    operation,
+                    wait,
+                    enforce_strict_mode,
+                    hw_measurement_acc,
+                )
                 .await;
         }
 
@@ -245,8 +258,12 @@ impl ShardOperation for LocalShard {
         // The filter-resolving fallback inside `submit_update` adds more awaits (fence, drain,
         // resolution scan), but nothing is appended or dispatched until its single WAL write, so
         // cancelling before that point leaves no partial state and the property still holds.
+        // Shard-local strict mode belongs to the replica that takes the client
+        // write, and the replica set decides that (see `submit_update`). A
+        // proxy wrapping this shard forwards writes on behalf of that replica,
+        // so this path enforces.
         let outcome = self
-            .submit_update(operation, wait, hw_measurement_acc)
+            .submit_update(operation, wait, true, hw_measurement_acc)
             .await?;
         await_update_result(outcome, timeout).await
     }

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -115,6 +115,12 @@ impl ShardReplicaSet {
                 .await?;
         }
 
+        // Shard-local strict mode rules apply to the replica that takes the
+        // client write, on the same states as the rate limiter above. A replica
+        // still catching up resolves a filter against a point set the client's
+        // request was never gated against.
+        let enforce_strict_mode = state.is_write_rate_limitable();
+
         // For a plain `Shard::Local`, submit the operation while the read
         // guard is held (brief), then drop the guard before awaiting
         // completion. Holding the guard across a deferred-points wait would
@@ -123,7 +129,12 @@ impl ShardReplicaSet {
         let result = match shard {
             Shard::Local(local_shard) => {
                 let outcome = local_shard
-                    .submit_update(operation, effective_wait, hw_measurement)
+                    .submit_update(
+                        operation,
+                        effective_wait,
+                        enforce_strict_mode,
+                        hw_measurement,
+                    )
                     .await?;
                 drop(local);
                 await_update_result(outcome, effective_timeout).await?
@@ -426,7 +437,12 @@ impl ShardReplicaSet {
             match local.deref() {
                 Some(Shard::Local(local_shard)) if local_is_updatable => {
                     let outcome = local_shard
-                        .submit_update(operation, local_wait, hw_measurement_acc)
+                        .submit_update(
+                            operation,
+                            local_wait,
+                            self.peer_is_write_rate_limitable(this_peer_id),
+                            hw_measurement_acc,
+                        )
                         .await?;
                     drop(local);
 
@@ -560,15 +576,17 @@ impl ShardReplicaSet {
                 // If there are enough successes, deactivate failed replicas
                 // Failed replicas will automatically recover from another replica ensuring consistency
 
-                let failures_to_handle: Vec<_> = if !has_full_completed_updates {
+                let failures_to_handle: Vec<_> = failures
+                    .into_iter()
+                    // A strict mode refusal says the request was not allowed,
+                    // not that the replica failed to apply it. Dropping it here
+                    // rather than only in `handle_failed_replicas` also keeps it
+                    // out of the deactivation wait below, which would otherwise
+                    // wait out its timeout on a replica nothing is deactivating.
+                    .filter(|(_, err)| !err.is_strict_mode())
                     // We can only deactivate transient errors
-                    failures
-                        .into_iter()
-                        .filter(|(_, err)| err.is_transient())
-                        .collect()
-                } else {
-                    failures
-                };
+                    .filter(|(_, err)| has_full_completed_updates || err.is_transient())
+                    .collect();
 
                 let wait_for_deactivation = self.handle_failed_replicas(
                     &failures_to_handle,
@@ -738,6 +756,15 @@ impl ShardReplicaSet {
                 | ReplicaState::Resharding
                 | ReplicaState::ReshardingScaleDown
                 | ReplicaState::ActiveRead => (),
+            }
+
+            // A strict mode rejection is a policy verdict on the request, not a
+            // health signal: the replica refused the operation before writing
+            // anything and is otherwise fine. Deactivating it would trade a
+            // rejected update for a full shard resync, and abort any transfer
+            // the replica takes part in.
+            if err.is_strict_mode() {
+                continue;
             }
 
             // Handle a special case where transfer receiver is not in the expected replica state yet.
@@ -993,6 +1020,48 @@ mod tests {
 
         assert_eq!(rs.highest_replica_peer_id(), Some(5));
         assert_eq!(rs.highest_alive_replica_peer_id(), Some(4));
+    }
+
+    /// A strict mode rejection is a verdict on the request, not a replica
+    /// health signal, so it must never cost the replica its `Active` state.
+    #[tokio::test]
+    async fn test_strict_mode_failure_does_not_deactivate_replica() {
+        let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+        let rs = new_shard_replica_set(&collection_dir).await;
+
+        for peer_id in [1, 2, 3] {
+            rs.set_replica_state(peer_id, ReplicaState::Active)
+                .await
+                .unwrap();
+        }
+
+        let strict_mode = vec![(
+            2,
+            CollectionError::strict_mode("matches 100 points", "use a slice"),
+        )];
+        let forwarded_strict_mode = vec![(
+            2,
+            CollectionError::forward_proxy_error(
+                3,
+                CollectionError::strict_mode("matches 100 points", "use a slice"),
+            ),
+        )];
+        let other_failure = vec![(3, CollectionError::service_error("something broke"))];
+
+        let state = rs.replica_state.read();
+        assert!(!rs.handle_failed_replicas(&strict_mode, &state, false));
+        assert!(!rs.handle_failed_replicas(&forwarded_strict_mode, &state, false));
+        rs.handle_failed_replicas(&other_failure, &state, false);
+        drop(state);
+
+        assert!(
+            !rs.is_locally_disabled(2),
+            "a strict mode rejection must leave the replica active",
+        );
+        assert!(
+            rs.is_locally_disabled(3),
+            "any other failure still deactivates the replica",
+        );
     }
 
     const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -576,14 +576,10 @@ impl ShardReplicaSet {
                 // If there are enough successes, deactivate failed replicas
                 // Failed replicas will automatically recover from another replica ensuring consistency
 
-                let failures_to_handle: Vec<_> = failures
+                let (strict_mode_refusals, other_failures) = split_strict_mode_failures(failures);
+
+                let failures_to_handle: Vec<_> = other_failures
                     .into_iter()
-                    // A strict mode refusal says the request was not allowed,
-                    // not that the replica failed to apply it. Dropping it here
-                    // rather than only in `handle_failed_replicas` also keeps it
-                    // out of the deactivation wait below, which would otherwise
-                    // wait out its timeout on a replica nothing is deactivating.
-                    .filter(|(_, err)| !err.is_strict_mode())
                     // We can only deactivate transient errors
                     .filter(|(_, err)| has_full_completed_updates || err.is_transient())
                     .collect();
@@ -634,6 +630,10 @@ impl ShardReplicaSet {
                             self.shard_id,
                         )));
                     }
+                }
+
+                if let Some((_peer_id, err)) = strict_mode_refusals.into_iter().next() {
+                    return Err(err);
                 }
             } else {
                 // If there aren't enough successes, report error to user
@@ -814,7 +814,26 @@ impl ShardReplicaSet {
 
         wait_for_deactivation
     }
+}
 
+/// Split replica-set update failures into strict-mode refusals and the rest.
+///
+/// A refusal is a policy verdict on the request, not a replica health signal:
+/// keep the refusing replica Active, but still surface the error to the client
+/// so a partial apply (other replicas already succeeded) is never reported as
+/// success.
+fn split_strict_mode_failures(
+    failures: Vec<(PeerId, CollectionError)>,
+) -> (
+    Vec<(PeerId, CollectionError)>,
+    Vec<(PeerId, CollectionError)>,
+) {
+    failures
+        .into_iter()
+        .partition(|(_, err)| err.is_strict_mode())
+}
+
+impl ShardReplicaSet {
     /// Forward update to the leader replica
     ///
     /// # Cancel safety
@@ -1062,6 +1081,35 @@ mod tests {
             rs.is_locally_disabled(3),
             "any other failure still deactivates the replica",
         );
+    }
+
+    /// Refusals must be split out of the deactivation set *and* kept for the
+    /// caller: otherwise enough successes would turn a remote Active refusal
+    /// into a silent 200 while that replica stays Active without the update.
+    #[test]
+    fn test_split_strict_mode_failures_keeps_refusals_for_the_client() {
+        let failures = vec![
+            (
+                1,
+                CollectionError::strict_mode("matches 100 points", "use a slice"),
+            ),
+            (
+                2,
+                CollectionError::forward_proxy_error(
+                    9,
+                    CollectionError::strict_mode("matches 100 points", "use a slice"),
+                ),
+            ),
+            (3, CollectionError::service_error("something broke")),
+            (4, CollectionError::bad_input("malformed")),
+        ];
+
+        let (refusals, other) = split_strict_mode_failures(failures);
+
+        assert_eq!(refusals.len(), 2);
+        assert!(refusals.iter().all(|(_, err)| err.is_strict_mode()));
+        assert_eq!(other.len(), 2);
+        assert!(other.iter().all(|(_, err)| !err.is_strict_mode()));
     }
 
     const TEST_OPTIMIZERS_CONFIG: OptimizersConfig = OptimizersConfig {

--- a/lib/collection/src/shards/replica_set/update.rs
+++ b/lib/collection/src/shards/replica_set/update.rs
@@ -822,12 +822,11 @@ impl ShardReplicaSet {
 /// keep the refusing replica Active, but still surface the error to the client
 /// so a partial apply (other replicas already succeeded) is never reported as
 /// success.
+type ReplicaUpdateFailure = (PeerId, CollectionError);
+
 fn split_strict_mode_failures(
-    failures: Vec<(PeerId, CollectionError)>,
-) -> (
-    Vec<(PeerId, CollectionError)>,
-    Vec<(PeerId, CollectionError)>,
-) {
+    failures: Vec<ReplicaUpdateFailure>,
+) -> (Vec<ReplicaUpdateFailure>, Vec<ReplicaUpdateFailure>) {
     failures
         .into_iter()
         .partition(|(_, err)| err.is_strict_mode())

--- a/lib/collection/src/tests/mod.rs
+++ b/lib/collection/src/tests/mod.rs
@@ -14,6 +14,7 @@ mod shard_query;
 mod shard_telemetry;
 mod snapshot_test;
 mod sparse_vectors_validation_tests;
+mod update_by_filter_limit;
 mod wal_recovery_test;
 
 use std::assert_matches;

--- a/lib/collection/src/tests/update_by_filter_limit.rs
+++ b/lib/collection/src/tests/update_by_filter_limit.rs
@@ -1,5 +1,6 @@
 //! Strict mode `max_update_by_filter_limit`: every shard gates the update it
-//! resolved from a filter scan on its own point count, before writing anything.
+//! resolved from a filter scan on its own point count, before writing anything,
+//! reading no more than the limit allows to decide.
 
 use std::sync::Arc;
 
@@ -175,21 +176,44 @@ async fn delete_by_filter_over_the_limit_is_rejected() {
     let message = err.to_string();
 
     assert!(
-        message.contains(&format!("matches {POINT_COUNT} points")),
-        "error must report the exact match count: {message}",
+        message.contains(&format!(
+            "more points in one shard than the limit of {LIMIT}"
+        )),
+        "error must report the limit it exceeded: {message}",
     );
     assert!(
-        message.contains(&format!("per-shard limit of {LIMIT}")),
-        "error must report the limit: {message}",
-    );
-    // The nudge: 6 points at a limit of 2, with headroom for unbalanced slices.
-    assert!(
-        message.contains(r#"{"slice": {"total": 6, "index": 0}}"#),
+        message.contains(r#"{"slice": {"total": 2, "index": 0}}"#),
         "error must point at the slice condition: {message}",
     );
 
     // Rejected before the WAL append, so nothing was deleted.
     assert_eq!(count(shard, red_filter()).await, POINT_COUNT as usize);
+
+    fixture.stop().await;
+}
+
+/// A replica that is catching up (transfer target, listener, resharding) holds
+/// a different point set than the one the client's request was gated against,
+/// so it applies what it is given instead of gating again.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_replica_that_does_not_enforce_is_not_gated() {
+    let fixture = shard_fixture(Some(LIMIT)).await;
+    let shard = &fixture.shard;
+
+    let outcome = shard
+        .submit_update(
+            delete_by_filter(red_filter()).into(),
+            WaitUntil::Visible,
+            false,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("an exempt replica must apply the update");
+    crate::shards::local_shard::shard_ops::await_update_result(outcome, None)
+        .await
+        .expect("update must complete");
+
+    assert_eq!(count(shard, red_filter()).await, 0);
 
     fixture.stop().await;
 }

--- a/lib/collection/src/tests/update_by_filter_limit.rs
+++ b/lib/collection/src/tests/update_by_filter_limit.rs
@@ -1,0 +1,332 @@
+//! Strict mode `max_update_by_filter_limit`: every shard gates the update it
+//! resolved from a filter scan on its own point count, before writing anything.
+
+use std::sync::Arc;
+
+use common::budget::ResourceBudget;
+use common::counter::hardware_accumulator::HwMeasurementAcc;
+use common::save_on_disk::SaveOnDisk;
+use common::types::DeferredBehavior;
+use segment::data_types::vectors::VectorStructInternal;
+use segment::payload_json;
+use segment::types::{
+    Condition, FieldCondition, Filter, Match, PointIdType, Slice, SliceCondition, StrictModeConfig,
+    ValueVariants,
+};
+use shard::operations::CollectionUpdateOperations;
+use shard::operations::payload_ops::{PayloadOps, SetPayloadOp};
+use shard::operations::point_ops::{
+    PointInsertOperationsInternal, PointOperations, PointStructPersisted,
+};
+use tempfile::{Builder, TempDir};
+use tokio::runtime::Handle;
+use tokio::sync::RwLock;
+
+use crate::common::adaptive_handle::AdaptiveSearchHandle;
+use crate::operations::types::CountRequestInternal;
+use crate::shards::local_shard::LocalShard;
+use crate::shards::shard_trait::{ShardOperation, WaitUntil};
+use crate::tests::fixtures::create_collection_config;
+
+/// Points 1..=POINT_COUNT all carry `color: "red"`, so the filter below scans
+/// them all.
+const POINT_COUNT: u64 = 6;
+const LIMIT: usize = 2;
+
+struct ShardFixture {
+    shard: LocalShard,
+    _collection_dir: TempDir,
+    _payload_schema_dir: TempDir,
+}
+
+impl ShardFixture {
+    async fn stop(self) {
+        self.shard.stop_gracefully().await;
+    }
+}
+
+fn red_filter() -> Filter {
+    Filter::new_must(Condition::Field(FieldCondition::new_match(
+        "color".try_into().unwrap(),
+        Match::new_value(ValueVariants::String("red".into())),
+    )))
+}
+
+fn point_ids() -> Vec<PointIdType> {
+    (1..=POINT_COUNT).map(PointIdType::from).collect()
+}
+
+/// Build a shard holding [`POINT_COUNT`] red points, with strict mode enabled
+/// and the given update-by-filter limit.
+async fn shard_fixture(max_update_by_filter_limit: Option<usize>) -> ShardFixture {
+    let collection_dir = Builder::new().prefix("update_by_filter").tempdir().unwrap();
+    let payload_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+    let payload_index_schema = Arc::new(
+        SaveOnDisk::load_or_init_default(payload_schema_dir.path().join("payload-schema.json"))
+            .unwrap(),
+    );
+
+    let mut config = create_collection_config();
+    config.strict_mode_config = Some(StrictModeConfig {
+        enabled: Some(true),
+        max_update_by_filter_limit,
+        ..Default::default()
+    });
+
+    let shard = LocalShard::build(
+        0,
+        "test_update_by_filter_limit".to_string(),
+        collection_dir.path(),
+        Arc::new(RwLock::new(config.clone())),
+        Arc::new(Default::default()),
+        payload_index_schema,
+        Handle::current(),
+        AdaptiveSearchHandle::current_for_tests(),
+        ResourceBudget::default(),
+        config.optimizer_config.clone(),
+    )
+    .await
+    .unwrap();
+
+    let points = (1..=POINT_COUNT)
+        .map(|id| PointStructPersisted {
+            id: id.into(),
+            vector: VectorStructInternal::from(vec![1.0, 0.0, 0.5, 0.25]).into(),
+            payload: Some(payload_json! {"color": "red"}),
+        })
+        .collect();
+    let upsert = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::PointsList(points),
+    ));
+    shard
+        .update(
+            upsert.into(),
+            WaitUntil::Visible,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("failed to upsert points");
+
+    ShardFixture {
+        shard,
+        _collection_dir: collection_dir,
+        _payload_schema_dir: payload_schema_dir,
+    }
+}
+
+/// Points currently matching `filter`.
+async fn count(shard: &LocalShard, filter: Filter) -> usize {
+    shard
+        .count(
+            Arc::new(CountRequestInternal {
+                filter: Some(filter),
+                exact: true,
+            }),
+            &AdaptiveSearchHandle::current_for_tests(),
+            None,
+            HwMeasurementAcc::new(),
+            DeferredBehavior::VisibleOnly,
+        )
+        .await
+        .expect("count failed")
+        .count
+}
+
+fn delete_by_filter(filter: Filter) -> CollectionUpdateOperations {
+    CollectionUpdateOperations::PointOperation(PointOperations::DeletePointsByFilter(filter))
+}
+
+fn set_payload_by_filter(
+    filter: Option<Filter>,
+    points: Option<Vec<PointIdType>>,
+) -> CollectionUpdateOperations {
+    CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(SetPayloadOp {
+        payload: payload_json! {"visited": true},
+        points,
+        filter,
+        key: None,
+    }))
+}
+
+async fn update(
+    shard: &LocalShard,
+    operation: CollectionUpdateOperations,
+) -> crate::operations::types::CollectionResult<()> {
+    shard
+        .update(
+            operation.into(),
+            WaitUntil::Visible,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .map(|_| ())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_by_filter_over_the_limit_is_rejected() {
+    let fixture = shard_fixture(Some(LIMIT)).await;
+    let shard = &fixture.shard;
+
+    let err = update(shard, delete_by_filter(red_filter()))
+        .await
+        .expect_err("scan over the limit must be rejected");
+    let message = err.to_string();
+
+    assert!(
+        message.contains(&format!("matches {POINT_COUNT} points")),
+        "error must report the exact match count: {message}",
+    );
+    assert!(
+        message.contains(&format!("per-shard limit of {LIMIT}")),
+        "error must report the limit: {message}",
+    );
+    // The nudge: 6 points at a limit of 2, with headroom for unbalanced slices.
+    assert!(
+        message.contains(r#"{"slice": {"total": 6, "index": 0}}"#),
+        "error must point at the slice condition: {message}",
+    );
+
+    // Rejected before the WAL append, so nothing was deleted.
+    assert_eq!(count(shard, red_filter()).await, POINT_COUNT as usize);
+
+    fixture.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn scan_matching_exactly_the_limit_is_allowed() {
+    let fixture = shard_fixture(Some(LIMIT)).await;
+    let shard = &fixture.shard;
+
+    // Narrow the scan to exactly `LIMIT` points with a `has_id` condition.
+    let ids = point_ids().into_iter().take(LIMIT).collect::<Vec<_>>();
+    let filter = red_filter().merge(&Filter::new_must(Condition::HasId(
+        ids.iter().copied().collect::<ahash::AHashSet<_>>().into(),
+    )));
+
+    update(shard, delete_by_filter(filter))
+        .await
+        .expect("a scan matching exactly the limit must be allowed");
+
+    assert_eq!(
+        count(shard, red_filter()).await,
+        POINT_COUNT as usize - LIMIT,
+    );
+
+    fixture.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn slice_condition_splits_a_rejected_update() {
+    let fixture = shard_fixture(Some(LIMIT)).await;
+    let shard = &fixture.shard;
+
+    // The nudge in the error message: split the scan into `total` disjoint
+    // slices. Slices are uniform over the id space but not exactly balanced,
+    // so pick the smallest `total` that actually brings every slice under the
+    // limit for these ids (deterministic: the slice hash is a stable API).
+    let total = (1..=16u32)
+        .find(|&total| {
+            let total = total.try_into().unwrap();
+            (0..u32::from(total)).all(|index| {
+                let slice = Slice { total, index };
+                point_ids().iter().filter(|id| slice.check(**id)).count() <= LIMIT
+            })
+        })
+        .expect("some slicing must fit under the limit");
+    assert!(
+        total >= 3,
+        "6 points at a limit of 2 need at least 3 slices"
+    );
+
+    for index in 0..total {
+        let filter = red_filter().merge(&Filter::new_must(Condition::Slice(SliceCondition {
+            slice: Slice {
+                total: total.try_into().unwrap(),
+                index,
+            },
+        })));
+        update(shard, delete_by_filter(filter))
+            .await
+            .expect("each slice stays under the limit");
+    }
+
+    // The slices together covered every matching point.
+    assert_eq!(count(shard, red_filter()).await, 0);
+
+    fixture.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_payload_is_gated_only_when_it_scans() {
+    let fixture = shard_fixture(Some(LIMIT)).await;
+    let shard = &fixture.shard;
+
+    update(shard, set_payload_by_filter(Some(red_filter()), None))
+        .await
+        .expect_err("set payload by filter over the limit must be rejected");
+
+    // An explicit id list takes precedence over the filter on apply, so the
+    // operation never scans and is not gated, however long the list is.
+    update(
+        shard,
+        set_payload_by_filter(Some(red_filter()), Some(point_ids())),
+    )
+    .await
+    .expect("set payload with an explicit id list must be allowed");
+
+    fixture.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn limit_does_not_apply_to_id_lists() {
+    let fixture = shard_fixture(Some(LIMIT)).await;
+    let shard = &fixture.shard;
+
+    // An id-based delete is not a scan, whatever its size.
+    let delete_by_ids = CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints {
+        ids: point_ids(),
+    });
+    update(shard, delete_by_ids)
+        .await
+        .expect("id-based deletes must not be gated");
+    assert_eq!(count(shard, red_filter()).await, 0);
+
+    fixture.stop().await;
+}
+
+/// A disposable measurement marks an operation as unmetered (it is also
+/// swapped in for client updates routed to a resharding replica). It must not
+/// switch the limit off.
+#[tokio::test(flavor = "multi_thread")]
+async fn unmetered_updates_are_still_gated() {
+    let fixture = shard_fixture(Some(LIMIT)).await;
+    let shard = &fixture.shard;
+
+    shard
+        .update(
+            delete_by_filter(red_filter()).into(),
+            WaitUntil::Visible,
+            None,
+            HwMeasurementAcc::disposable(),
+        )
+        .await
+        .expect_err("a disposable measurement must not bypass the limit");
+    assert_eq!(count(shard, red_filter()).await, POINT_COUNT as usize);
+
+    fixture.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn no_limit_allows_any_scan() {
+    let fixture = shard_fixture(None).await;
+    let shard = &fixture.shard;
+
+    update(shard, delete_by_filter(red_filter()))
+        .await
+        .expect("without a limit any scan is allowed");
+    assert_eq!(count(shard, red_filter()).await, 0);
+
+    fixture.stop().await;
+}

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1417,7 +1417,9 @@ pub struct StrictModeConfig {
     /// targets by filter (e.g. delete by filter, set payload by filter, delete
     /// vectors by filter) may affect. Every shard counts the points its own
     /// filter scan matched and rejects the request when that count exceeds the
-    /// limit, before applying anything. Split larger updates with a `slice`
+    /// limit, without applying it there. Shards and replicas are gated
+    /// independently, so a rejected request may still have been applied by
+    /// those that matched fewer points. Split larger updates with a `slice`
     /// filter condition.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 1))]
@@ -1596,7 +1598,9 @@ pub struct StrictModeConfigOutput {
     /// targets by filter (e.g. delete by filter, set payload by filter, delete
     /// vectors by filter) may affect. Every shard counts the points its own
     /// filter scan matched and rejects the request when that count exceeds the
-    /// limit, before applying anything. Split larger updates with a `slice`
+    /// limit, without applying it there. Shards and replicas are gated
+    /// independently, so a rejected request may still have been applied by
+    /// those that matched fewer points. Split larger updates with a `slice`
     /// filter condition.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[anonymize(false)]

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1413,6 +1413,15 @@ pub struct StrictModeConfig {
     #[validate(range(min = 0))]
     pub max_payload_index_count: Option<usize>,
 
+    /// Max number of points an update operation that selects its targets by
+    /// filter (e.g. delete by filter, set payload by filter, delete vectors by
+    /// filter) may affect. The match count is estimated from payload indexes
+    /// when the request is received, before the operation is dispatched to
+    /// any shard; requests exceeding the limit are rejected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[validate(range(min = 1))]
+    pub max_update_by_filter_limit: Option<usize>,
+
     /// Deprecated: use the node-wide quota config (`PUT /quotas`) instead, which
     /// caps the same resource for every collection. Scheduled for removal in
     /// 1.21.
@@ -1458,6 +1467,7 @@ impl Hash for StrictModeConfig {
             multivector_config,
             sparse_config,
             max_payload_index_count,
+            max_update_by_filter_limit,
             max_resident_memory_percent,
         } = self;
         enabled.hash(state);
@@ -1479,6 +1489,7 @@ impl Hash for StrictModeConfig {
         multivector_config.hash(state);
         sparse_config.hash(state);
         max_payload_index_count.hash(state);
+        max_update_by_filter_limit.hash(state);
         max_resident_memory_percent.hash(state);
     }
 }
@@ -1580,6 +1591,15 @@ pub struct StrictModeConfigOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_payload_index_count: Option<usize>,
 
+    /// Max number of points an update operation that selects its targets by
+    /// filter (e.g. delete by filter, set payload by filter, delete vectors by
+    /// filter) may affect. The match count is estimated from payload indexes
+    /// when the request is received, before the operation is dispatched to
+    /// any shard; requests exceeding the limit are rejected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[anonymize(false)]
+    pub max_update_by_filter_limit: Option<usize>,
+
     /// Deprecated: use the node-wide quota config instead. Reject memory-consuming update operations when resident memory exceeds this percentage of total RAM (1-100)
     #[deprecated(
         since = "1.19.0",
@@ -1613,6 +1633,7 @@ impl From<StrictModeConfig> for StrictModeConfigOutput {
             multivector_config,
             sparse_config,
             max_payload_index_count,
+            max_update_by_filter_limit,
             max_resident_memory_percent,
         } = config;
 
@@ -1637,6 +1658,7 @@ impl From<StrictModeConfig> for StrictModeConfigOutput {
             multivector_config: multivector_config.map(StrictModeMultivectorConfigOutput::from),
             sparse_config: sparse_config.map(StrictModeSparseConfigOutput::from),
             max_payload_index_count,
+            max_update_by_filter_limit,
             max_resident_memory_percent,
         }
     }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -1413,11 +1413,12 @@ pub struct StrictModeConfig {
     #[validate(range(min = 0))]
     pub max_payload_index_count: Option<usize>,
 
-    /// Max number of points an update operation that selects its targets by
-    /// filter (e.g. delete by filter, set payload by filter, delete vectors by
-    /// filter) may affect. The match count is estimated from payload indexes
-    /// when the request is received, before the operation is dispatched to
-    /// any shard; requests exceeding the limit are rejected.
+    /// Max number of points, per shard, that an update operation selecting its
+    /// targets by filter (e.g. delete by filter, set payload by filter, delete
+    /// vectors by filter) may affect. Every shard counts the points its own
+    /// filter scan matched and rejects the request when that count exceeds the
+    /// limit, before applying anything. Split larger updates with a `slice`
+    /// filter condition.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[validate(range(min = 1))]
     pub max_update_by_filter_limit: Option<usize>,
@@ -1591,11 +1592,12 @@ pub struct StrictModeConfigOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_payload_index_count: Option<usize>,
 
-    /// Max number of points an update operation that selects its targets by
-    /// filter (e.g. delete by filter, set payload by filter, delete vectors by
-    /// filter) may affect. The match count is estimated from payload indexes
-    /// when the request is received, before the operation is dispatched to
-    /// any shard; requests exceeding the limit are rejected.
+    /// Max number of points, per shard, that an update operation selecting its
+    /// targets by filter (e.g. delete by filter, set payload by filter, delete
+    /// vectors by filter) may affect. Every shard counts the points its own
+    /// filter scan matched and rejects the request when that count exceeds the
+    /// limit, before applying anything. Split larger updates with a `slice`
+    /// filter condition.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[anonymize(false)]
     pub max_update_by_filter_limit: Option<usize>,

--- a/lib/shard/src/resolve.rs
+++ b/lib/shard/src/resolve.rs
@@ -13,6 +13,10 @@
 //! `segments`, and no new operation may be appended between resolution and
 //! the append of the rewritten operation. Callers provide this via the shard
 //! update fence.
+//!
+//! Resolution also reports how many points a filter *scan* selected, so the
+//! caller can gate oversized updates on the exact point count this shard is
+//! about to touch (`max_update_by_filter_limit` in strict mode).
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use segment::common::operation_error::OperationResult;
@@ -73,6 +77,22 @@ pub fn is_filter_resolving(operation: &CollectionUpdateOperations) -> bool {
     }
 }
 
+/// Outcome of [`resolve_operation`].
+#[derive(Debug)]
+pub struct ResolvedOperation {
+    /// The operation, rewritten to its id-based form.
+    pub operation: CollectionUpdateOperations,
+
+    /// How many points a filter scan selected, for operations that pick their
+    /// targets by scanning this shard (delete by filter, payload by filter,
+    /// clear payload by filter, delete vectors by filter).
+    ///
+    /// `None` when the target set came from the client instead: an explicit id
+    /// list, a conditional upsert or an `update_filter`, which only trim a
+    /// point list the client already sent.
+    pub scanned_points: Option<usize>,
+}
+
 /// Rewrite a filter/condition-resolving operation into its id-based
 /// equivalent by resolving the filter against current segment state.
 ///
@@ -85,12 +105,15 @@ pub fn resolve_operation(
     segments: &SegmentHolder,
     operation: CollectionUpdateOperations,
     hw_counter: &HardwareCounterCell,
-) -> OperationResult<CollectionUpdateOperations> {
+) -> OperationResult<ResolvedOperation> {
+    let mut scanned_points = None;
+
     let resolved = match operation {
         CollectionUpdateOperations::PointOperation(op) => {
             CollectionUpdateOperations::PointOperation(match op {
                 PointOperations::DeletePointsByFilter(filter) => {
                     let ids = matched_ids(segments, &filter, hw_counter)?;
+                    scanned_points = Some(ids.len());
                     PointOperations::DeletePoints { ids }
                 }
                 PointOperations::UpsertPointsConditional(op) => {
@@ -107,6 +130,7 @@ pub fn resolve_operation(
             CollectionUpdateOperations::VectorOperation(match op {
                 VectorOperations::DeleteVectorsByFilter(filter, vector_names) => {
                     let ids = matched_ids(segments, &filter, hw_counter)?;
+                    scanned_points = Some(ids.len());
                     VectorOperations::DeleteVectors(ids.into(), vector_names)
                 }
                 VectorOperations::UpdateVectors(update) => {
@@ -132,19 +156,28 @@ pub fn resolve_operation(
         }
         CollectionUpdateOperations::PayloadOperation(op) => {
             CollectionUpdateOperations::PayloadOperation(match op {
-                PayloadOps::SetPayload(sp) => {
-                    PayloadOps::SetPayload(resolve_set_payload(segments, sp, hw_counter)?)
-                }
-                PayloadOps::OverwritePayload(sp) => {
-                    PayloadOps::OverwritePayload(resolve_set_payload(segments, sp, hw_counter)?)
-                }
+                PayloadOps::SetPayload(sp) => PayloadOps::SetPayload(resolve_set_payload(
+                    segments,
+                    sp,
+                    &mut scanned_points,
+                    hw_counter,
+                )?),
+                PayloadOps::OverwritePayload(sp) => PayloadOps::OverwritePayload(
+                    resolve_set_payload(segments, sp, &mut scanned_points, hw_counter)?,
+                ),
                 PayloadOps::DeletePayload(dp) => {
                     let DeletePayloadOp {
                         keys,
                         points,
                         filter,
                     } = dp;
-                    let points = resolve_points_or_filter(segments, points, filter, hw_counter)?;
+                    let points = resolve_points_or_filter(
+                        segments,
+                        points,
+                        filter,
+                        &mut scanned_points,
+                        hw_counter,
+                    )?;
                     PayloadOps::DeletePayload(DeletePayloadOp {
                         keys,
                         points,
@@ -153,6 +186,7 @@ pub fn resolve_operation(
                 }
                 PayloadOps::ClearPayloadByFilter(filter) => {
                     let points = matched_ids(segments, &filter, hw_counter)?;
+                    scanned_points = Some(points.len());
                     PayloadOps::ClearPayload { points }
                 }
                 op @ PayloadOps::ClearPayload { .. } => op,
@@ -164,7 +198,10 @@ pub fn resolve_operation(
         op @ CollectionUpdateOperations::StagingOperation(_) => op,
     };
 
-    Ok(resolved)
+    Ok(ResolvedOperation {
+        operation: resolved,
+        scanned_points,
+    })
 }
 
 /// Resolve the point set matched by `filter`, deduplicated and in a
@@ -189,10 +226,15 @@ fn resolve_points_or_filter(
     segments: &SegmentHolder,
     points: Option<Vec<PointIdType>>,
     filter: Option<segment::types::Filter>,
+    scanned_points: &mut Option<usize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<Option<Vec<PointIdType>>> {
     match (points, filter) {
-        (None, Some(filter)) => Ok(Some(matched_ids(segments, &filter, hw_counter)?)),
+        (None, Some(filter)) => {
+            let ids = matched_ids(segments, &filter, hw_counter)?;
+            *scanned_points = Some(ids.len());
+            Ok(Some(ids))
+        }
         (points, _) => Ok(points),
     }
 }
@@ -218,6 +260,7 @@ fn resolve_conditional_upsert(
 fn resolve_set_payload(
     segments: &SegmentHolder,
     operation: SetPayloadOp,
+    scanned_points: &mut Option<usize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<SetPayloadOp> {
     let SetPayloadOp {
@@ -226,7 +269,7 @@ fn resolve_set_payload(
         filter,
         key,
     } = operation;
-    let points = resolve_points_or_filter(segments, points, filter, hw_counter)?;
+    let points = resolve_points_or_filter(segments, points, filter, scanned_points, hw_counter)?;
     Ok(SetPayloadOp {
         payload,
         points,
@@ -285,7 +328,10 @@ mod tests {
 
         let filter = color_filter("blue");
 
-        let resolved = resolve_operation(
+        let ResolvedOperation {
+            operation: resolved,
+            scanned_points,
+        } = resolve_operation(
             &holder,
             CollectionUpdateOperations::PointOperation(PointOperations::DeletePointsByFilter(
                 filter.clone(),
@@ -299,6 +345,9 @@ mod tests {
         else {
             panic!("expected DeletePoints, got {resolved:?}");
         };
+
+        // A filter scan reports its exact match count for the strict mode gate.
+        assert_eq!(scanned_points, Some(ids.len()));
 
         // Deterministic: sorted, no duplicates (points 4 and 5 exist in both segments).
         assert!(!ids.is_empty());
@@ -340,7 +389,10 @@ mod tests {
             }),
         );
 
-        let resolved = resolve_operation(&holder, operation, &hw_counter).unwrap();
+        let ResolvedOperation {
+            operation: resolved,
+            scanned_points,
+        } = resolve_operation(&holder, operation, &hw_counter).unwrap();
 
         let CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(points_op)) =
             resolved
@@ -348,6 +400,10 @@ mod tests {
             panic!("expected plain UpsertPoints");
         };
         assert_eq!(points_op.point_ids(), vec![100.into()]);
+
+        // A conditional upsert only trims the client's own point list, so it
+        // is not a scan and must not be gated by the update-by-filter limit.
+        assert_eq!(scanned_points, None);
     }
 
     #[test]
@@ -364,7 +420,10 @@ mod tests {
                 key: None,
             }));
 
-        let resolved = resolve_operation(&holder, operation, &hw_counter).unwrap();
+        let ResolvedOperation {
+            operation: resolved,
+            scanned_points,
+        } = resolve_operation(&holder, operation, &hw_counter).unwrap();
 
         let CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(sp)) = resolved
         else {
@@ -373,6 +432,7 @@ mod tests {
         assert!(sp.filter.is_none());
         let points = sp.points.expect("points must be resolved");
         assert!(!points.is_empty());
+        assert_eq!(scanned_points, Some(points.len()));
 
         let mut expected = points_by_filter(&holder, &color_filter("red"), &hw_counter).unwrap();
         expected.sort_unstable();
@@ -392,7 +452,8 @@ mod tests {
         assert!(!is_filter_resolving(&operation));
 
         let resolved = resolve_operation(&holder, operation.clone(), &hw_counter).unwrap();
-        assert_eq!(resolved, operation);
+        assert_eq!(resolved.operation, operation);
+        assert_eq!(resolved.scanned_points, None);
     }
 
     #[test]

--- a/lib/shard/src/resolve.rs
+++ b/lib/shard/src/resolve.rs
@@ -15,8 +15,11 @@
 //! update fence.
 //!
 //! Resolution also reports how many points a filter *scan* selected, so the
-//! caller can gate oversized updates on the exact point count this shard is
-//! about to touch (`max_update_by_filter_limit` in strict mode).
+//! caller can gate oversized updates on the point count this shard is about to
+//! touch (`max_update_by_filter_limit` in strict mode). Callers that pass that
+//! limit get a scan whose cost is bounded by it: the resolver stops reading
+//! once it knows the match set is bigger, and the operation it returns is then
+//! truncated and must be rejected rather than applied.
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use segment::common::operation_error::OperationResult;
@@ -28,7 +31,8 @@ use crate::operations::vector_ops::{UpdateVectorsOp, VectorOperations};
 use crate::operations::{CollectionUpdateOperations, FieldIndexOperations, VectorNameOperations};
 use crate::segment_holder::SegmentHolder;
 use crate::update::{
-    points_by_filter, retain_conditional_upsert_points, select_excluded_by_filter_ids,
+    FilteredPoints, points_by_filter_limited, retain_conditional_upsert_points,
+    select_excluded_by_filter_ids,
 };
 
 /// Does this operation decide its target point set by reading current segment
@@ -90,6 +94,10 @@ pub struct ResolvedOperation {
     /// `None` when the target set came from the client instead: an explicit id
     /// list, a conditional upsert or an `update_filter`, which only trim a
     /// point list the client already sent.
+    ///
+    /// A count above the `limit` passed to [`resolve_operation`] is only a
+    /// lower bound, and [`ResolvedOperation::operation`] holds a truncated
+    /// point set: over the limit the caller must reject the operation.
     pub scanned_points: Option<usize>,
 }
 
@@ -100,10 +108,16 @@ pub struct ResolvedOperation {
 /// unchanged. The rewritten form only uses pre-existing operation variants,
 /// so the WAL format is unaffected.
 ///
+/// `limit` caps what a filter scan is allowed to select. It buys a bounded
+/// scan, not a different result: under the limit the resolved operation is
+/// exactly the one an unbounded scan produces, and above it the scan stops
+/// early and reports a count over the limit for the caller to reject.
+///
 /// See the module docs for the ordering contract callers must uphold.
 pub fn resolve_operation(
     segments: &SegmentHolder,
     operation: CollectionUpdateOperations,
+    limit: Option<usize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<ResolvedOperation> {
     let mut scanned_points = None;
@@ -112,7 +126,7 @@ pub fn resolve_operation(
         CollectionUpdateOperations::PointOperation(op) => {
             CollectionUpdateOperations::PointOperation(match op {
                 PointOperations::DeletePointsByFilter(filter) => {
-                    let ids = matched_ids(segments, &filter, hw_counter)?;
+                    let ids = matched_ids(segments, &filter, limit, hw_counter)?;
                     scanned_points = Some(ids.len());
                     PointOperations::DeletePoints { ids }
                 }
@@ -129,7 +143,7 @@ pub fn resolve_operation(
         CollectionUpdateOperations::VectorOperation(op) => {
             CollectionUpdateOperations::VectorOperation(match op {
                 VectorOperations::DeleteVectorsByFilter(filter, vector_names) => {
-                    let ids = matched_ids(segments, &filter, hw_counter)?;
+                    let ids = matched_ids(segments, &filter, limit, hw_counter)?;
                     scanned_points = Some(ids.len());
                     VectorOperations::DeleteVectors(ids.into(), vector_names)
                 }
@@ -159,11 +173,12 @@ pub fn resolve_operation(
                 PayloadOps::SetPayload(sp) => PayloadOps::SetPayload(resolve_set_payload(
                     segments,
                     sp,
+                    limit,
                     &mut scanned_points,
                     hw_counter,
                 )?),
                 PayloadOps::OverwritePayload(sp) => PayloadOps::OverwritePayload(
-                    resolve_set_payload(segments, sp, &mut scanned_points, hw_counter)?,
+                    resolve_set_payload(segments, sp, limit, &mut scanned_points, hw_counter)?,
                 ),
                 PayloadOps::DeletePayload(dp) => {
                     let DeletePayloadOp {
@@ -175,6 +190,7 @@ pub fn resolve_operation(
                         segments,
                         points,
                         filter,
+                        limit,
                         &mut scanned_points,
                         hw_counter,
                     )?;
@@ -185,7 +201,7 @@ pub fn resolve_operation(
                     })
                 }
                 PayloadOps::ClearPayloadByFilter(filter) => {
-                    let points = matched_ids(segments, &filter, hw_counter)?;
+                    let points = matched_ids(segments, &filter, limit, hw_counter)?;
                     scanned_points = Some(points.len());
                     PayloadOps::ClearPayload { points }
                 }
@@ -206,17 +222,43 @@ pub fn resolve_operation(
 
 /// Resolve the point set matched by `filter`, deduplicated and in a
 /// deterministic order.
+///
+/// With a `limit`, the read stops one point past it in every segment. That is
+/// enough to tell an over-the-limit scan from an exact match set: a result
+/// above the limit is a lower bound the caller rejects on, and a result at or
+/// below it is the complete set, unread points included.
 fn matched_ids(
     segments: &SegmentHolder,
     filter: &segment::types::Filter,
+    limit: Option<usize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<Vec<PointIdType>> {
-    // `points_by_filter` flattens per-segment matches, so a point with copies
-    // in several segments can appear more than once.
-    let mut ids = points_by_filter(segments, filter, hw_counter)?;
+    let budget = limit.map(|limit| limit + 1);
+    let FilteredPoints { points, truncated } =
+        points_by_filter_limited(segments, filter, budget, hw_counter)?;
+    let ids = sorted_unique(points);
+
+    // Cross-segment duplicates and the deferred-points correction both shrink
+    // the read, so a truncated one can land back under the limit. The count is
+    // then neither complete nor decisive, and only the full scan can say which
+    // side of the limit the filter falls on. It takes a single segment holding
+    // more matches than the limit, so it is the rare case, not the scan we set
+    // out to avoid.
+    if truncated && limit.is_some_and(|limit| ids.len() <= limit) {
+        let FilteredPoints { points, .. } =
+            points_by_filter_limited(segments, filter, None, hw_counter)?;
+        return Ok(sorted_unique(points));
+    }
+
+    Ok(ids)
+}
+
+/// `points_by_filter_limited` flattens per-segment matches, so a point with
+/// copies in several segments can appear more than once.
+fn sorted_unique(mut ids: Vec<PointIdType>) -> Vec<PointIdType> {
     ids.sort_unstable();
     ids.dedup();
-    Ok(ids)
+    ids
 }
 
 /// Resolve the `(points, filter)` pair of a payload operation. An explicit id
@@ -226,12 +268,13 @@ fn resolve_points_or_filter(
     segments: &SegmentHolder,
     points: Option<Vec<PointIdType>>,
     filter: Option<segment::types::Filter>,
+    limit: Option<usize>,
     scanned_points: &mut Option<usize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<Option<Vec<PointIdType>>> {
     match (points, filter) {
         (None, Some(filter)) => {
-            let ids = matched_ids(segments, &filter, hw_counter)?;
+            let ids = matched_ids(segments, &filter, limit, hw_counter)?;
             *scanned_points = Some(ids.len());
             Ok(Some(ids))
         }
@@ -260,6 +303,7 @@ fn resolve_conditional_upsert(
 fn resolve_set_payload(
     segments: &SegmentHolder,
     operation: SetPayloadOp,
+    limit: Option<usize>,
     scanned_points: &mut Option<usize>,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<SetPayloadOp> {
@@ -269,7 +313,8 @@ fn resolve_set_payload(
         filter,
         key,
     } = operation;
-    let points = resolve_points_or_filter(segments, points, filter, scanned_points, hw_counter)?;
+    let points =
+        resolve_points_or_filter(segments, points, filter, limit, scanned_points, hw_counter)?;
     Ok(SetPayloadOp {
         payload,
         points,
@@ -292,7 +337,18 @@ mod tests {
     use crate::operations::point_ops::{
         PointInsertOperationsInternal, PointStructPersisted, UpdateMode, VectorStructPersisted,
     };
-    use crate::update::{delete_points_by_filter, points_by_filter, process_point_operation};
+    use crate::update::{delete_points_by_filter, process_point_operation};
+
+    /// Every point matching `filter`, read without a budget.
+    fn all_points_by_filter(
+        holder: &SegmentHolder,
+        filter: &Filter,
+        hw_counter: &HardwareCounterCell,
+    ) -> Vec<PointIdType> {
+        points_by_filter_limited(holder, filter, None, hw_counter)
+            .unwrap()
+            .points
+    }
 
     fn color_filter(color: &str) -> Filter {
         Filter::new_must(Condition::Field(FieldCondition::new_match(
@@ -336,6 +392,7 @@ mod tests {
             CollectionUpdateOperations::PointOperation(PointOperations::DeletePointsByFilter(
                 filter.clone(),
             )),
+            None,
             &hw_counter,
         )
         .unwrap();
@@ -353,7 +410,7 @@ mod tests {
         assert!(!ids.is_empty());
         assert!(ids.windows(2).all(|pair| pair[0] < pair[1]));
 
-        let mut expected = points_by_filter(&holder, &filter, &hw_counter).unwrap();
+        let mut expected = all_points_by_filter(&holder, &filter, &hw_counter);
         expected.sort_unstable();
         expected.dedup();
         assert_eq!(*ids, expected);
@@ -365,10 +422,62 @@ mod tests {
         process_point_operation(&holder, 100, op, None, &hw_counter).unwrap();
         delete_points_by_filter(&twin_holder, 100, &filter, &hw_counter).unwrap();
 
-        let remaining = points_by_filter(&holder, &filter, &hw_counter).unwrap();
-        let twin_remaining = points_by_filter(&twin_holder, &filter, &hw_counter).unwrap();
+        let remaining = all_points_by_filter(&holder, &filter, &hw_counter);
+        let twin_remaining = all_points_by_filter(&twin_holder, &filter, &hw_counter);
         assert!(remaining.is_empty(), "resolved delete left {remaining:?}");
         assert!(twin_remaining.is_empty());
+    }
+
+    /// The `limit` only buys a bounded scan: whatever it is, resolution either
+    /// returns the complete match set or a count the caller can reject on.
+    #[test]
+    fn resolve_with_a_limit_is_complete_or_decisive() {
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::new();
+        let holder = build_holder(dir.path());
+        let filter = color_filter("blue");
+
+        let mut full = all_points_by_filter(&holder, &filter, &hw_counter);
+        full.sort_unstable();
+        full.dedup();
+        // Points 4 and 5 live in both segments, so the per-segment budget and
+        // the deduplicated result disagree, which is what the fallback is for.
+        assert!(full.len() >= 2, "fixture must match several points");
+
+        for limit in 0..=full.len() + 1 {
+            let ResolvedOperation {
+                operation: resolved,
+                scanned_points,
+            } = resolve_operation(
+                &holder,
+                CollectionUpdateOperations::PointOperation(PointOperations::DeletePointsByFilter(
+                    filter.clone(),
+                )),
+                Some(limit),
+                &hw_counter,
+            )
+            .unwrap();
+
+            let CollectionUpdateOperations::PointOperation(PointOperations::DeletePoints { ids }) =
+                &resolved
+            else {
+                panic!("expected DeletePoints, got {resolved:?}");
+            };
+            assert_eq!(scanned_points, Some(ids.len()));
+
+            if full.len() > limit {
+                assert!(
+                    ids.len() > limit,
+                    "limit {limit}: a scan over the limit must report over it, got {}",
+                    ids.len(),
+                );
+            } else {
+                assert_eq!(
+                    *ids, full,
+                    "limit {limit}: a scan within the limit must be the complete set",
+                );
+            }
+        }
     }
 
     #[test]
@@ -392,7 +501,7 @@ mod tests {
         let ResolvedOperation {
             operation: resolved,
             scanned_points,
-        } = resolve_operation(&holder, operation, &hw_counter).unwrap();
+        } = resolve_operation(&holder, operation, None, &hw_counter).unwrap();
 
         let CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(points_op)) =
             resolved
@@ -423,7 +532,7 @@ mod tests {
         let ResolvedOperation {
             operation: resolved,
             scanned_points,
-        } = resolve_operation(&holder, operation, &hw_counter).unwrap();
+        } = resolve_operation(&holder, operation, None, &hw_counter).unwrap();
 
         let CollectionUpdateOperations::PayloadOperation(PayloadOps::SetPayload(sp)) = resolved
         else {
@@ -434,7 +543,7 @@ mod tests {
         assert!(!points.is_empty());
         assert_eq!(scanned_points, Some(points.len()));
 
-        let mut expected = points_by_filter(&holder, &color_filter("red"), &hw_counter).unwrap();
+        let mut expected = all_points_by_filter(&holder, &color_filter("red"), &hw_counter);
         expected.sort_unstable();
         expected.dedup();
         assert_eq!(points, expected);
@@ -451,7 +560,7 @@ mod tests {
         });
         assert!(!is_filter_resolving(&operation));
 
-        let resolved = resolve_operation(&holder, operation.clone(), &hw_counter).unwrap();
+        let resolved = resolve_operation(&holder, operation.clone(), None, &hw_counter).unwrap();
         assert_eq!(resolved.operation, operation);
         assert_eq!(resolved.scanned_points, None);
     }

--- a/lib/shard/src/update/helpers.rs
+++ b/lib/shard/src/update/helpers.rs
@@ -77,22 +77,48 @@ pub(crate) fn points_by_filter(
     filter: &Filter,
     hw_counter: &HardwareCounterCell,
 ) -> OperationResult<Vec<PointIdType>> {
+    Ok(points_by_filter_limited(segments, filter, None, hw_counter)?.points)
+}
+
+/// Points matching a filter, with a budget on how many are read per segment.
+pub(crate) struct FilteredPoints {
+    /// Matching points, as flattened per-segment reads: a point with copies in
+    /// several segments can appear more than once.
+    pub points: Vec<PointIdType>,
+
+    /// Whether some segment filled its budget, in which case `points` is only
+    /// a subset of what the filter matches.
+    pub truncated: bool,
+}
+
+/// [`points_by_filter`], reading at most `per_segment_limit` points from each
+/// segment. Callers that only need to know whether the match set is bigger
+/// than some bound can cap the read at that bound instead of paying for the
+/// whole scan.
+pub(crate) fn points_by_filter_limited(
+    segments: &SegmentHolder,
+    filter: &Filter,
+    per_segment_limit: Option<usize>,
+    hw_counter: &HardwareCounterCell,
+) -> OperationResult<FilteredPoints> {
     // we don’t want to cancel this filtered read
     let is_stopped = AtomicBool::new(false);
     let mut has_deferred = false;
+    let mut truncated = false;
     let per_segment_points: AHashMap<SegmentId, Vec<PointIdType>> = segments
         .iter()
         .map(|(segment_id, segment)| {
             let segment = segment.get().read();
             let point_ids = segment.read_filtered(
                 None,
-                None,
+                per_segment_limit,
                 Some(filter),
                 &is_stopped,
                 hw_counter,
                 // Read operation used for updates, so we must handle all points
                 DeferredBehavior::WithDeferred,
             )?;
+            truncated |= per_segment_limit.is_some_and(|limit| point_ids.len() >= limit);
             has_deferred |= segment.has_deferred_points();
             Ok((segment_id, point_ids))
         })
@@ -112,7 +138,10 @@ pub(crate) fn points_by_filter(
         }
     }
 
-    Ok(affected_points)
+    Ok(FilteredPoints {
+        points: affected_points,
+        truncated,
+    })
 }
 
 pub(super) fn check_unprocessed_points(

--- a/lib/shard/src/update/mod.rs
+++ b/lib/shard/src/update/mod.rs
@@ -15,7 +15,9 @@ use segment::common::operation_error::{OperationError, OperationResult};
 use segment::types::{Payload, SeqNumberType};
 
 pub use self::field_index::{create_field_index, delete_field_index};
-pub(crate) use self::helpers::{points_by_filter, select_excluded_by_filter_ids};
+pub(crate) use self::helpers::{
+    FilteredPoints, points_by_filter_limited, select_excluded_by_filter_ids,
+};
 pub use self::payload::{
     clear_payload, clear_payload_by_filter, delete_payload, delete_payload_by_filter,
     overwrite_payload, overwrite_payload_by_filter, set_payload, set_payload_by_filter,

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -161,6 +161,7 @@ pub fn strict_mode_from_api(value: grpc::StrictModeConfig) -> StrictModeConfig {
         multivector_config,
         sparse_config,
         max_payload_index_count,
+        max_update_by_filter_limit,
         max_resident_memory_percent,
     } = value;
     StrictModeConfig {
@@ -184,6 +185,7 @@ pub fn strict_mode_from_api(value: grpc::StrictModeConfig) -> StrictModeConfig {
         multivector_config: multivector_config.map(StrictModeMultivectorConfig::from),
         sparse_config: sparse_config.map(StrictModeSparseConfig::from),
         max_payload_index_count: max_payload_index_count.map(|i| i as usize),
+        max_update_by_filter_limit: max_update_by_filter_limit.map(|i| i as usize),
         max_resident_memory_percent: max_resident_memory_percent.map(|i| i as u8),
     }
 }

--- a/lib/storage/src/content_manager/conversions.rs
+++ b/lib/storage/src/content_manager/conversions.rs
@@ -13,7 +13,8 @@ use collection::operations::config_diff::{
 };
 use collection::operations::conversions::sharding_method_from_proto;
 use collection::operations::types::{
-    INSUFFICIENT_STORAGE_METADATA_KEY, SparseVectorsConfig, VectorsConfigDiff,
+    INSUFFICIENT_STORAGE_METADATA_KEY, STRICT_MODE_METADATA_KEY, SparseVectorsConfig,
+    VectorsConfigDiff,
 };
 use segment::types::{StrictModeConfig, StrictModeMultivectorConfig, StrictModeSparseConfig};
 use tonic::Status;
@@ -64,6 +65,13 @@ impl From<StorageError> for Status {
                 // back into an error.
                 metadata_headers.insert(INSUFFICIENT_STORAGE_METADATA_KEY, "1".to_string());
                 tonic::Code::ResourceExhausted
+            }
+            StorageError::StrictMode { .. } => {
+                // Shares `InvalidArgument` with every other bad request, so it
+                // carries a marker: a replica that refuses a request on a strict
+                // mode rule is not a failed replica.
+                metadata_headers.insert(STRICT_MODE_METADATA_KEY, "1".to_string());
+                tonic::Code::InvalidArgument
             }
         };
         let mut status = Status::new(error_code, error.to_string());
@@ -398,7 +406,32 @@ impl From<ConsensusThreadStatus> for grpc::ConsensusThreadStatus {
 
 #[cfg(test)]
 mod tests {
+    use collection::operations::types::CollectionError;
+
     use super::*;
+
+    /// A strict mode refusal has to survive the trip to another peer as itself:
+    /// the replica set reads it to tell "the request was not allowed" from "the
+    /// replica failed", and `InvalidArgument` alone cannot say which.
+    #[test]
+    fn strict_mode_refusal_survives_the_wire() {
+        let error = StorageError::StrictMode {
+            description: "Update by filter matches more points than the limit".to_string(),
+        };
+
+        let status = Status::from(error);
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+
+        let round_tripped = CollectionError::from(status);
+        assert!(
+            round_tripped.is_strict_mode(),
+            "expected a strict mode error, got {round_tripped:?}",
+        );
+
+        // A plain bad request still comes back as one, marker or no marker.
+        let plain = CollectionError::from(Status::from(StorageError::bad_request("nope")));
+        assert!(!plain.is_strict_mode(), "got {plain:?}");
+    }
 
     fn create_request(
         vector_memory: Option<grpc::Memory>,

--- a/lib/storage/src/content_manager/errors.rs
+++ b/lib/storage/src/content_manager/errors.rs
@@ -52,6 +52,11 @@ pub enum StorageError {
     /// A node has reached its resource quota and cannot take on more data.
     #[error("Insufficient storage: {description}")]
     InsufficientStorage { description: String },
+    /// A request was refused by a strict mode rule. Answers like a bad request,
+    /// but stays a variant of its own so a peer can tell the two apart when it
+    /// converts a status back into an error.
+    #[error("Bad request: {description}")]
+    StrictMode { description: String },
 }
 
 impl StorageError {
@@ -176,7 +181,9 @@ impl StorageError {
                 description: overriding_description,
                 backtrace: None,
             },
-            CollectionError::StrictMode { description } => StorageError::BadRequest { description },
+            CollectionError::StrictMode { .. } => StorageError::StrictMode {
+                description: overriding_description,
+            },
             CollectionError::InferenceError { description } => {
                 StorageError::InferenceError { description }
             }
@@ -253,7 +260,7 @@ impl From<CollectionError> for StorageError {
                 description: err.to_string(),
                 backtrace: None,
             },
-            CollectionError::StrictMode { description } => StorageError::BadRequest { description },
+            CollectionError::StrictMode { description } => StorageError::StrictMode { description },
             CollectionError::InferenceError { description } => {
                 StorageError::InferenceError { description }
             }

--- a/src/actix/helpers.rs
+++ b/src/actix/helpers.rs
@@ -236,6 +236,7 @@ impl HttpError {
             StorageError::ShardUnavailable { .. } => {}
             StorageError::EmptyPartialSnapshot { .. } => {}
             StorageError::InsufficientStorage { .. } => {}
+            StorageError::StrictMode { .. } => {}
         }
         headers
     }
@@ -260,6 +261,7 @@ impl ResponseError for HttpError {
             StorageError::ShardUnavailable { .. } => http::StatusCode::SERVICE_UNAVAILABLE,
             StorageError::EmptyPartialSnapshot { .. } => http::StatusCode::NOT_MODIFIED,
             StorageError::InsufficientStorage { .. } => http::StatusCode::INSUFFICIENT_STORAGE,
+            StorageError::StrictMode { .. } => http::StatusCode::BAD_REQUEST,
         }
     }
 }

--- a/tests/consensus_tests/fixtures.py
+++ b/tests/consensus_tests/fixtures.py
@@ -82,6 +82,31 @@ def update_points_payload(
     return r_batch.json()
 
 
+def delete_points_by_filter(
+        peer_url,
+        filter,
+        collection_name="test_collection",
+        wait="true",
+):
+    return requests.post(
+        f"{peer_url}/collections/{collection_name}/points/delete?wait={wait}",
+        json={"filter": filter},
+    )
+
+
+def set_payload_by_filter(
+        peer_url,
+        payload,
+        filter,
+        collection_name="test_collection",
+        wait="true",
+):
+    return requests.post(
+        f"{peer_url}/collections/{collection_name}/points/payload?wait={wait}",
+        json={"payload": payload, "filter": filter},
+    )
+
+
 def upsert_random_points(
     peer_url,
     num,

--- a/tests/consensus_tests/test_strict_mode.py
+++ b/tests/consensus_tests/test_strict_mode.py
@@ -1,7 +1,7 @@
 import logging
 import pathlib
 
-from .fixtures import create_collection, upsert_random_points, upsert_points, random_dense_vector, set_strict_mode
+from .fixtures import create_collection, create_field_index, upsert_random_points, upsert_points, random_dense_vector, set_strict_mode, delete_points_by_filter, set_payload_by_filter
 from .utils import *
 
 logging.basicConfig(level=logging.DEBUG)
@@ -245,3 +245,133 @@ def test_write_rate_limiting_across_node(tmp_path: pathlib.Path):
             return
 
     raise AssertionError("rate limiter was never triggered")
+
+
+def test_max_update_by_filter_limit(tmp_path: pathlib.Path):
+    # Two shards: the limit applies to the estimated match count across all
+    # shards of the request, not per shard.
+    n_peers = 1
+    n_shard = 2
+    n_replica = 1
+    peer_urls, peer_dirs, bootstrap_url = start_cluster(tmp_path, n_peers)
+
+    create_collection(
+        peer_urls[0],
+        collection=COLLECTION_NAME,
+        shard_number=n_shard,
+        replication_factor=n_replica,
+    )
+
+    wait_collection_exists_and_active_on_all_peers(
+        collection_name=COLLECTION_NAME, peer_api_uris=peer_urls
+    )
+
+    # The match count is estimated from payload indexes, so index the keys
+    # the filters below use.
+    create_field_index(peer_urls[0], COLLECTION_NAME, "city", "keyword")
+    create_field_index(peer_urls[0], COLLECTION_NAME, "tier", "keyword")
+
+    # All 20 points share the same city; the first 10 share a tier.
+    berlin_points = [
+        {
+            "id": i,
+            "vector": random_dense_vector(),
+            "payload": {"city": "Berlin", "tier": "a" if i < 10 else "b"},
+        }
+        for i in range(20)
+    ]
+    upsert_points(peer_urls[0], berlin_points, collection_name=COLLECTION_NAME).raise_for_status()
+
+    berlin_filter = {
+        "must": [{"key": "city", "match": {"value": "Berlin"}}],
+    }
+    tier_a_filter = {
+        "must": [{"key": "tier", "match": {"value": "a"}}],
+    }
+
+    # Enable the limit: at most 10 points per update-by-filter operation.
+    set_strict_mode(
+        peer_urls[0],
+        COLLECTION_NAME,
+        {
+            "enabled": True,
+            "max_update_by_filter_limit": 10,
+        },
+    )
+    wait_for_strict_mode_enabled(peer_urls[0], COLLECTION_NAME)
+
+    # A delete by filter matching all 20 points exceeds the limit.
+    res = delete_points_by_filter(peer_urls[0], berlin_filter, collection_name=COLLECTION_NAME)
+    assert res.status_code == 400
+    assert "exceeding the configured limit of 10" in res.json()["status"]["error"]
+
+    # A set-payload by filter matching all 20 points is also rejected.
+    res = set_payload_by_filter(
+        peer_urls[0],
+        {"visited": True},
+        berlin_filter,
+        collection_name=COLLECTION_NAME,
+    )
+    assert res.status_code == 400
+    assert "exceeding the configured limit of 10" in res.json()["status"]["error"]
+
+    # Matching exactly the limit is allowed.
+    res = set_payload_by_filter(
+        peer_urls[0],
+        {"visited": True},
+        tier_a_filter,
+        collection_name=COLLECTION_NAME,
+    )
+    assert_http_ok(res)
+
+    # Conditional upserts and filtered vector updates also read segment state
+    # before they are written, but they only trim the point list the client
+    # sent: their size is a batch size, not a filter match count, so the limit
+    # must not apply to them.
+    # Upsert with `update_filter`, 20 points > limit 10.
+    res = requests.put(
+        f"{peer_urls[0]}/collections/{COLLECTION_NAME}/points?wait=true",
+        json={"points": berlin_points, "update_filter": berlin_filter},
+    )
+    assert_http_ok(res)
+
+    # `update_mode` takes the same path without carrying a filter at all.
+    res = requests.put(
+        f"{peer_urls[0]}/collections/{COLLECTION_NAME}/points?wait=true",
+        json={"points": berlin_points, "update_mode": "update_only"},
+    )
+    assert_http_ok(res)
+
+    # Vector update with `update_filter`, 20 points > limit 10.
+    res = requests.put(
+        f"{peer_urls[0]}/collections/{COLLECTION_NAME}/points/vectors?wait=true",
+        json={
+            "points": [
+                {"id": i, "vector": {"": random_dense_vector()}} for i in range(20)
+            ],
+            "update_filter": berlin_filter,
+        },
+    )
+    assert_http_ok(res)
+
+    # An explicit delete by ids is not filter-resolving, so it is allowed
+    # regardless of the limit.
+    r = requests.post(
+        f"{peer_urls[0]}/collections/{COLLECTION_NAME}/points/delete?wait=true",
+        json={"points": list(range(20))},
+    )
+    assert_http_ok(r)
+
+    # With strict mode disabled, the same delete by filter that was rejected
+    # above (20 points > limit 10) is now allowed, proving the limit is tied to
+    # the enabled flag. Re-upsert the points first, since the id-based delete
+    # above removed them.
+    upsert_points(peer_urls[0], berlin_points, collection_name=COLLECTION_NAME).raise_for_status()
+
+    set_strict_mode(peer_urls[0], COLLECTION_NAME, {"enabled": False})
+    wait_for_strict_mode_disabled(peer_urls[0], COLLECTION_NAME)
+
+    res = delete_points_by_filter(
+        peer_urls[0], berlin_filter, collection_name=COLLECTION_NAME
+    )
+    assert_http_ok(res)

--- a/tests/consensus_tests/test_strict_mode.py
+++ b/tests/consensus_tests/test_strict_mode.py
@@ -1,7 +1,7 @@
 import logging
 import pathlib
 
-from .fixtures import create_collection, create_field_index, upsert_random_points, upsert_points, random_dense_vector, set_strict_mode, delete_points_by_filter, set_payload_by_filter
+from .fixtures import create_collection, upsert_random_points, upsert_points, random_dense_vector, set_strict_mode, delete_points_by_filter, set_payload_by_filter
 from .utils import *
 
 logging.basicConfig(level=logging.DEBUG)
@@ -248,130 +248,105 @@ def test_write_rate_limiting_across_node(tmp_path: pathlib.Path):
 
 
 def test_max_update_by_filter_limit(tmp_path: pathlib.Path):
-    # Two shards: the limit applies to the estimated match count across all
-    # shards of the request, not per shard.
-    n_peers = 1
-    n_shard = 2
-    n_replica = 1
-    peer_urls, peer_dirs, bootstrap_url = start_cluster(tmp_path, n_peers)
+    """`max_update_by_filter_limit` is enforced by every shard on the point set
+    its own filter scan resolved to, before anything is written."""
+    peer_urls, peer_dirs, bootstrap_url = start_cluster(tmp_path, N_PEERS)
 
+    # Two shards: each one gates its own share of the request, so the limit is
+    # a per-shard bound rather than a bound on the whole request.
     create_collection(
         peer_urls[0],
         collection=COLLECTION_NAME,
-        shard_number=n_shard,
-        replication_factor=n_replica,
+        shard_number=2,
+        replication_factor=N_REPLICAS,
     )
-
     wait_collection_exists_and_active_on_all_peers(
         collection_name=COLLECTION_NAME, peer_api_uris=peer_urls
     )
 
-    # The match count is estimated from payload indexes, so index the keys
-    # the filters below use.
-    create_field_index(peer_urls[0], COLLECTION_NAME, "city", "keyword")
-    create_field_index(peer_urls[0], COLLECTION_NAME, "tier", "keyword")
-
-    # All 20 points share the same city; the first 10 share a tier.
-    berlin_points = [
-        {
-            "id": i,
-            "vector": random_dense_vector(),
-            "payload": {"city": "Berlin", "tier": "a" if i < 10 else "b"},
-        }
-        for i in range(20)
+    point_count = 60
+    limit = 10
+    points = [
+        {"id": i, "vector": random_dense_vector(), "payload": {"city": "Berlin"}}
+        for i in range(point_count)
     ]
-    upsert_points(peer_urls[0], berlin_points, collection_name=COLLECTION_NAME).raise_for_status()
+    berlin_filter = {"must": [{"key": "city", "match": {"value": "Berlin"}}]}
 
-    berlin_filter = {
-        "must": [{"key": "city", "match": {"value": "Berlin"}}],
-    }
-    tier_a_filter = {
-        "must": [{"key": "tier", "match": {"value": "a"}}],
-    }
+    def upsert_all():
+        upsert_points(peer_urls[0], points, collection_name=COLLECTION_NAME).raise_for_status()
 
-    # Enable the limit: at most 10 points per update-by-filter operation.
+    def count_all():
+        res = requests.post(
+            f"{peer_urls[0]}/collections/{COLLECTION_NAME}/points/count",
+            json={"exact": True},
+        )
+        assert_http_ok(res)
+        return res.json()["result"]["count"]
+
+    upsert_all()
+
     set_strict_mode(
         peer_urls[0],
         COLLECTION_NAME,
-        {
-            "enabled": True,
-            "max_update_by_filter_limit": 10,
-        },
+        {"enabled": True, "max_update_by_filter_limit": limit},
     )
-    wait_for_strict_mode_enabled(peer_urls[0], COLLECTION_NAME)
+    # The gate runs on whichever peer holds the shard, so every peer must have
+    # the new config before the update is sent.
+    for peer_url in peer_urls:
+        wait_for_strict_mode_enabled(peer_url, COLLECTION_NAME)
 
-    # A delete by filter matching all 20 points exceeds the limit.
+    # Each shard resolves ~30 of the 60 points, over its limit of 10.
     res = delete_points_by_filter(peer_urls[0], berlin_filter, collection_name=COLLECTION_NAME)
     assert res.status_code == 400
-    assert "exceeding the configured limit of 10" in res.json()["status"]["error"]
+    error = res.json()["status"]["error"]
+    assert "points in one shard" in error, error
+    assert f"exceeding the per-shard limit of {limit}" in error, error
+    # The error nudges the user towards splitting the scan with `slice`.
+    assert '"slice"' in error, error
 
-    # A set-payload by filter matching all 20 points is also rejected.
+    # The rejection happens before the WAL append on every shard, so nothing
+    # was deleted anywhere.
+    assert count_all() == point_count
+
+    # A set-payload by filter scans the same way and is rejected too.
     res = set_payload_by_filter(
-        peer_urls[0],
-        {"visited": True},
-        berlin_filter,
-        collection_name=COLLECTION_NAME,
+        peer_urls[0], {"visited": True}, berlin_filter, collection_name=COLLECTION_NAME
     )
     assert res.status_code == 400
-    assert "exceeding the configured limit of 10" in res.json()["status"]["error"]
+    assert f"exceeding the per-shard limit of {limit}" in res.json()["status"]["error"]
 
-    # Matching exactly the limit is allowed.
-    res = set_payload_by_filter(
-        peer_urls[0],
-        {"visited": True},
-        tier_a_filter,
-        collection_name=COLLECTION_NAME,
-    )
-    assert_http_ok(res)
+    # Following the nudge: 16 disjoint slices bring every shard's share of each
+    # request well under the limit, and together they cover all the points.
+    slices = 16
+    for index in range(slices):
+        sliced = {"must": berlin_filter["must"] + [{"slice": {"total": slices, "index": index}}]}
+        res = delete_points_by_filter(peer_urls[0], sliced, collection_name=COLLECTION_NAME)
+        assert_http_ok(res)
+    assert count_all() == 0
 
-    # Conditional upserts and filtered vector updates also read segment state
-    # before they are written, but they only trim the point list the client
-    # sent: their size is a batch size, not a filter match count, so the limit
-    # must not apply to them.
-    # Upsert with `update_filter`, 20 points > limit 10.
-    res = requests.put(
-        f"{peer_urls[0]}/collections/{COLLECTION_NAME}/points?wait=true",
-        json={"points": berlin_points, "update_filter": berlin_filter},
-    )
-    assert_http_ok(res)
-
-    # `update_mode` takes the same path without carrying a filter at all.
-    res = requests.put(
-        f"{peer_urls[0]}/collections/{COLLECTION_NAME}/points?wait=true",
-        json={"points": berlin_points, "update_mode": "update_only"},
-    )
-    assert_http_ok(res)
-
-    # Vector update with `update_filter`, 20 points > limit 10.
-    res = requests.put(
-        f"{peer_urls[0]}/collections/{COLLECTION_NAME}/points/vectors?wait=true",
-        json={
-            "points": [
-                {"id": i, "vector": {"": random_dense_vector()}} for i in range(20)
-            ],
-            "update_filter": berlin_filter,
-        },
-    )
-    assert_http_ok(res)
-
-    # An explicit delete by ids is not filter-resolving, so it is allowed
-    # regardless of the limit.
-    r = requests.post(
+    # An explicit id list is not a filter scan, so it is never gated.
+    upsert_all()
+    res = requests.post(
         f"{peer_urls[0]}/collections/{COLLECTION_NAME}/points/delete?wait=true",
-        json={"points": list(range(20))},
-    )
-    assert_http_ok(r)
-
-    # With strict mode disabled, the same delete by filter that was rejected
-    # above (20 points > limit 10) is now allowed, proving the limit is tied to
-    # the enabled flag. Re-upsert the points first, since the id-based delete
-    # above removed them.
-    upsert_points(peer_urls[0], berlin_points, collection_name=COLLECTION_NAME).raise_for_status()
-
-    set_strict_mode(peer_urls[0], COLLECTION_NAME, {"enabled": False})
-    wait_for_strict_mode_disabled(peer_urls[0], COLLECTION_NAME)
-
-    res = delete_points_by_filter(
-        peer_urls[0], berlin_filter, collection_name=COLLECTION_NAME
+        json={"points": list(range(point_count))},
     )
     assert_http_ok(res)
+    assert count_all() == 0
+
+    # `update_filter` only trims the point list the client sent, so its size is
+    # a batch size rather than a scan and the limit must not apply.
+    res = requests.put(
+        f"{peer_urls[0]}/collections/{COLLECTION_NAME}/points?wait=true",
+        json={"points": points, "update_filter": berlin_filter},
+    )
+    assert_http_ok(res)
+
+    # With strict mode disabled the unsliced delete goes through again.
+    upsert_all()
+    set_strict_mode(peer_urls[0], COLLECTION_NAME, {"enabled": False})
+    for peer_url in peer_urls:
+        wait_for_strict_mode_disabled(peer_url, COLLECTION_NAME)
+
+    res = delete_points_by_filter(peer_urls[0], berlin_filter, collection_name=COLLECTION_NAME)
+    assert_http_ok(res)
+    assert count_all() == 0

--- a/tests/consensus_tests/test_strict_mode.py
+++ b/tests/consensus_tests/test_strict_mode.py
@@ -299,8 +299,7 @@ def test_max_update_by_filter_limit(tmp_path: pathlib.Path):
     res = delete_points_by_filter(peer_urls[0], berlin_filter, collection_name=COLLECTION_NAME)
     assert res.status_code == 400
     error = res.json()["status"]["error"]
-    assert "points in one shard" in error, error
-    assert f"exceeding the per-shard limit of {limit}" in error, error
+    assert f"more points in one shard than the limit of {limit}" in error, error
     # The error nudges the user towards splitting the scan with `slice`.
     assert '"slice"' in error, error
 
@@ -313,7 +312,10 @@ def test_max_update_by_filter_limit(tmp_path: pathlib.Path):
         peer_urls[0], {"visited": True}, berlin_filter, collection_name=COLLECTION_NAME
     )
     assert res.status_code == 400
-    assert f"exceeding the per-shard limit of {limit}" in res.json()["status"]["error"]
+    assert (
+        f"more points in one shard than the limit of {limit}"
+        in res.json()["status"]["error"]
+    )
 
     # Following the nudge: 16 disjoint slices bring every shard's share of each
     # request well under the limit, and together they cover all the points.


### PR DESCRIPTION
New strict mode option `max_update_by_filter_limit` (off by default) caps how many points one shard will update from a filter scan: delete by filter, set / overwrite / clear payload by filter, delete vectors by filter.

- Enforced by each shard on the exact point set its own scan resolved to, in the submit fence that already rewrites filter operations to their id-based form (`resolve_submit.rs`). No cardinality estimate, no payload index requirement, no extra read fan-out.
- The check runs before the WAL append, so a refused operation leaves no trace on that shard.
- The limit doubles as the scan budget: the resolver reads one point past it per segment and stops, so refusing an oversized update costs what the limit allows, not what the filter matches.
- It is a per-shard bound, not a per-request one. A request may touch up to the limit on each shard, and when only some shards are over the limit the others have already applied by the time the client gets the error. The error text and the config docs both say so.
- Id-based updates, conditional upserts and `update_filter` are not gated: they only trim a point list the client already sent, so their size is a batch size, not a scan.
- A refusal never deactivates a replica (that would trade a rejected update for a full resync and abort any transfer it takes part in), but it is still returned to the client, so a partial apply is never reported as success. Remote refusals keep their identity across gRPC through a `qdrant-strict-mode` metadata key instead of collapsing into `BadInput`.
- The error points at the `slice` filter condition as the way out: add `{"slice": {"total": 2, "index": 0}}` to the `must` clause, one request per index, and double `total` while a slice is still refused.

Tests: 8 local-shard tests (refusal, the boundary at exactly the limit, nothing written on refusal, id lists and explicit-point payload updates ungated, a non-enforcing replica ungated, unmetered updates still gated, no-limit path, and a slice round trip that deletes everything the refused request would have), 2 replica-set tests (a refusal keeps the replica `Active`, and still reaches the client), and a 2-shard consensus test (60 points at a limit of 10 refused on both shards with the count unchanged, then 16 slices drain the collection).

Supersedes #10332, which checked once at the API layer from payload index estimates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
