### PR TITLE
Turbo4 batched scan

### DIFF
--- a/lib/quantization/src/encoded_storage.rs
+++ b/lib/quantization/src/encoded_storage.rs
@@ -71,6 +71,26 @@ pub trait EncodedStorage: EncodedStorageWrite {
         callback: impl FnMut(usize, Cow<'_, [u8]>),
     );
 
+    /// Invoke `callback(first, count, bytes)` over `offsets` split into runs
+    /// the storage serves from one contiguous slice: `bytes` holds the
+    /// concatenated vectors of `offsets[first..first + count]`.  Runs cover
+    /// `offsets` in order, so a sequential scan over consecutive offsets
+    /// resolves storage internals (chunk lookups, reads) once per run rather
+    /// than once per vector.
+    ///
+    /// The default serves every vector as its own run; storages with
+    /// contiguous regions should override it to coalesce consecutive offsets
+    /// (see [`for_each_consecutive_run`]).
+    fn for_each_run(
+        &self,
+        offsets: &[PointOffsetType],
+        mut callback: impl FnMut(usize, usize, Cow<'_, [u8]>),
+    ) {
+        for (index, &offset) in offsets.iter().enumerate() {
+            callback(index, 1, self.get_vector_data(offset));
+        }
+    }
+
     fn files(&self) -> Vec<PathBuf>;
 
     fn immutable_files(&self) -> Vec<PathBuf>;
@@ -83,6 +103,29 @@ pub fn default_for_each_batch<E: EncodedStorage + ?Sized>(
 ) {
     for (index, &offset) in offsets.iter().enumerate() {
         callback(index, this.get_vector_data(offset));
+    }
+}
+
+/// Run detection shared by [`EncodedStorage::for_each_run`] implementations:
+/// splits `offsets` into maximal runs of consecutive ids and invokes
+/// `emit(first, start, len)` per run, where `first` indexes into `offsets`.
+///
+/// Runs are not capped: a storage serves whatever region a run covers, even
+/// one straddling its internal chunk boundary.
+pub fn for_each_consecutive_run(
+    offsets: &[PointOffsetType],
+    mut emit: impl FnMut(usize, PointOffsetType, usize),
+) {
+    let mut first = 0;
+    while first < offsets.len() {
+        let start = offsets[first];
+        let mut len = 1;
+        while first + len < offsets.len() && offsets[first + len] == start + len as PointOffsetType
+        {
+            len += 1;
+        }
+        emit(first, start, len);
+        first += len;
     }
 }
 
@@ -249,6 +292,18 @@ impl EncodedStorage for TestEncodedStorage {
         default_for_each_batch(self, offsets, callback);
     }
 
+    fn for_each_run(
+        &self,
+        offsets: &[PointOffsetType],
+        mut callback: impl FnMut(usize, usize, Cow<'_, [u8]>),
+    ) {
+        for_each_consecutive_run(offsets, |first, start, len| {
+            let begin = start as usize * self.quantized_vector_size.get();
+            let end = begin + len * self.quantized_vector_size.get();
+            callback(first, len, Cow::Borrowed(&self.data[begin..end]));
+        });
+    }
+
     fn files(&self) -> Vec<PathBuf> {
         if let Some(ref path) = self.path {
             vec![path.clone()]
@@ -349,5 +404,52 @@ mod tests {
         let storage = storage_with_stride(260, 0);
         // With no stored vectors there is nothing to check, so any size is accepted.
         validate_storage_vector_size(&storage, 999).unwrap();
+    }
+
+    /// Runs must cover `offsets` in order, split only at non-consecutive ids.
+    #[test]
+    fn consecutive_runs_split_at_gaps() {
+        let collect = |offsets: &[u32]| {
+            let mut runs = Vec::new();
+            for_each_consecutive_run(offsets, |first, start, len| {
+                runs.push((first, start, len));
+            });
+            runs
+        };
+
+        // Split at gaps only, however long the consecutive stretch.
+        assert_eq!(
+            collect(&[0, 1, 2, 5, 6, 9]),
+            vec![(0, 0, 3), (3, 5, 2), (5, 9, 1)],
+        );
+        assert_eq!(collect(&[0, 1, 2, 3, 4, 5, 6, 7]), vec![(0, 0, 8)]);
+        // Descending and scattered ids degrade to singleton runs.
+        assert_eq!(collect(&[4, 3, 2]), vec![(0, 4, 1), (1, 3, 1), (2, 2, 1)]);
+        assert_eq!(collect(&[]), vec![]);
+    }
+
+    /// The test storage's runs must hand out exactly the bytes of the
+    /// vectors they cover.
+    #[test]
+    fn test_storage_runs_match_vectors() {
+        let stride = 3;
+        let mut builder = TestEncodedStorageBuilder::new(None, stride);
+        for i in 0..10u8 {
+            builder.push_vector_data(&[i, i, i]).unwrap();
+        }
+        let storage = builder.build().unwrap();
+
+        let mut runs = Vec::new();
+        storage.for_each_run(&[2, 3, 4, 8, 9, 1], |first, len, bytes| {
+            runs.push((first, len, bytes.into_owned()));
+        });
+        assert_eq!(
+            runs,
+            vec![
+                (0, 3, vec![2, 2, 2, 3, 3, 3, 4, 4, 4]),
+                (3, 2, vec![8, 8, 8, 9, 9, 9]),
+                (5, 1, vec![1, 1, 1]),
+            ],
+        );
     }
 }

--- a/lib/quantization/src/encoded_vectors.rs
+++ b/lib/quantization/src/encoded_vectors.rs
@@ -69,6 +69,26 @@ pub trait EncodedVectors: Sized {
         hw_counter: &HardwareCounterCell,
     ) -> f32;
 
+    /// Score a batch: `scores[i]` ← score of `query` against point
+    /// `offsets[i]`.
+    ///
+    /// The default is the per-vector loop the scorers have always run.
+    /// Implementations can batch harder — resolve contiguous storage runs
+    /// once and score each run with a single kernel call instead of paying
+    /// the per-point machinery for every vector.
+    fn score_points(
+        &self,
+        query: &Self::EncodedQuery,
+        offsets: &[PointOffsetType],
+        scores: &mut [f32],
+        hw_counter: &HardwareCounterCell,
+    ) {
+        debug_assert_eq!(offsets.len(), scores.len());
+        self.for_each_batch(offsets, |i, vector| {
+            scores[i] = self.score(query, &vector, hw_counter);
+        });
+    }
+
     fn score_internal(
         &self,
         i: PointOffsetType,

--- a/lib/quantization/src/encoded_vectors_tq.rs
+++ b/lib/quantization/src/encoded_vectors_tq.rs
@@ -461,6 +461,47 @@ impl<TStorage: EncodedStorage> EncodedVectors for EncodedVectorsTQ<TStorage> {
         self.score_bytes(True, query, &encoded_vector, hw_counter)
     }
 
+    fn score_points(
+        &self,
+        query: &EncodedQueryTQ,
+        offsets: &[PointOffsetType],
+        scores: &mut [f32],
+        hw_counter: &HardwareCounterCell,
+    ) {
+        debug_assert_eq!(offsets.len(), scores.len());
+
+        if !TStorage::is_in_ram_or_mmap() {
+            // Backends with async reads (io_uring, remote caches) pipeline
+            // per-vector reads in `for_each_batch`; run-granular reads would
+            // serialize them.
+            self.for_each_batch(offsets, |i, vector| {
+                scores[i] = self.score_bytes(True, query, &vector, hw_counter);
+            });
+            return;
+        }
+
+        hw_counter
+            .cpu_counter()
+            .incr_delta(offsets.len() * self.quantized_vector_size());
+
+        let stride = self.quantized_vector_size();
+        self.encoded_vectors
+            .for_each_run(offsets, |first, count, bytes| {
+                self.quantizer.score_precomputed_batch(
+                    query,
+                    &bytes,
+                    stride,
+                    &mut scores[first..first + count],
+                );
+            });
+
+        if self.metadata.vector_parameters.invert {
+            for score in scores {
+                *score = -*score;
+            }
+        }
+    }
+
     /// Score two points inside endoded data by their indexes
     fn score_internal(
         &self,

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -567,13 +567,84 @@ impl TurboQuantizer {
     /// [`Self::precompute_query`]. Returns an approximate `<query, v>` for Dot
     /// and `cos(θ)` for Cosine.
     pub fn score_precomputed(&self, query: &EncodedQueryTQ, vec: &[u8]) -> f32 {
+        if matches!(self.distance, DistanceType::L1) {
+            return self.score_precomputed_l1(query, vec);
+        }
         let (data_bytes, vector_extras) = self.split_vector(vec);
-        let raw_dot = match &query.data {
-            EncodedQueryTQData::Bits1(q) => q.dotprod(data_bytes),
-            EncodedQueryTQData::Bits1Wide(q) => q.dotprod(data_bytes),
-            EncodedQueryTQData::Bits2(q) => q.dotprod(data_bytes),
-            EncodedQueryTQData::Bits4(q) => q.dotprod(data_bytes),
-        };
+        let raw_dot = Self::raw_dotprod(query, data_bytes);
+        self.score_from_raw_dot(query, raw_dot, &vector_extras)
+    }
+
+    /// Batch counterpart of [`Self::score_precomputed`] for a contiguous run
+    /// of encoded vectors stored `stride` bytes apart — the storage's record
+    /// size, packed codes followed by the extras: scores the vector at
+    /// `data[v * stride..]` into `scores[v]`.  The width's kernel scores the
+    /// whole run in one call (see
+    /// [`crate::turboquant::simd::QuerySimd::dotprod_batch`]), then the
+    /// extras are applied per vector.
+    ///
+    /// # Panics
+    /// Panics if `data` holds fewer than `scores.len()` records of `stride`
+    /// bytes, or `stride` is too short for a record.
+    pub fn score_precomputed_batch(
+        &self,
+        query: &EncodedQueryTQ,
+        data: &[u8],
+        stride: usize,
+        scores: &mut [f32],
+    ) {
+        assert!(
+            data.len() >= scores.len() * stride,
+            "score_precomputed_batch: {} vectors of {stride} bytes don't fit into {} data bytes",
+            scores.len(),
+            data.len(),
+        );
+
+        if matches!(self.distance, DistanceType::L1) {
+            // Dequantizes per vector — nothing to batch.
+            for (v, score) in scores.iter_mut().enumerate() {
+                *score = self.score_precomputed_l1(query, &data[v * stride..(v + 1) * stride]);
+            }
+            return;
+        }
+
+        let extras_len = TqVectorExtras::size_for(self.bits, self.distance, self.mode);
+        let codes_len = stride.checked_sub(extras_len).unwrap_or_else(|| {
+            panic!("score_precomputed_batch: stride {stride} < extras {extras_len}")
+        });
+        match &query.data {
+            EncodedQueryTQData::Bits1(q) => q.dotprod_batch(data, stride, scores),
+            EncodedQueryTQData::Bits1Wide(q) => q.dotprod_batch(data, stride, scores),
+            EncodedQueryTQData::Bits2(q) => q.dotprod_batch(data, stride, scores),
+            EncodedQueryTQData::Bits4(q) => q.dotprod_batch(data, stride, scores),
+        }
+
+        for (v, score) in scores.iter_mut().enumerate() {
+            let extras =
+                TqVectorExtras::from_bytes(&data[v * stride + codes_len..(v + 1) * stride]);
+            *score = self.score_from_raw_dot(query, *score, &extras);
+        }
+    }
+
+    /// `Σ query · centroid` over the packed codes, from the bit-width's SIMD
+    /// kernel.
+    fn raw_dotprod(query: &EncodedQueryTQ, codes: &[u8]) -> f32 {
+        match &query.data {
+            EncodedQueryTQData::Bits1(q) => q.dotprod(codes),
+            EncodedQueryTQData::Bits1Wide(q) => q.dotprod(codes),
+            EncodedQueryTQData::Bits2(q) => q.dotprod(codes),
+            EncodedQueryTQData::Bits4(q) => q.dotprod(codes),
+        }
+    }
+
+    /// Turn the raw codebook dot product of one vector into its score for
+    /// every distance but L1, using the extras stored alongside its codes.
+    fn score_from_raw_dot(
+        &self,
+        query: &EncodedQueryTQ,
+        raw_dot: f32,
+        vector_extras: &TqVectorExtras<'_>,
+    ) -> f32 {
         // TQ+: SIMD raw_dot ≈ ⟨Q · D', X+⟩; add `qm = ⟨Q, M⟩` to recover
         // ⟨Q, rescaled_v⟩, which is the quantity the existing arms expect.
         let dot = raw_dot + query.ec_correction;
@@ -593,19 +664,23 @@ impl TurboQuantizer {
                 let query_l2 = query.l2_norm.unwrap_or(1.0);
                 query_l2 * query_l2 + l2 * l2 - 2.0 * dot * scaling_factor
             }
-            DistanceType::L1 => {
-                let mut deq_v: Vec<f64> = self.dequantize(vec);
-                self.apply_inverse_rotation(deq_v.as_mut_slice());
-                query
-                    .query
-                    .as_ref()
-                    .unwrap()
-                    .iter()
-                    .zip(deq_v.iter())
-                    .map(|(&q, &v)| (f64::from(q) - v).abs() as f32)
-                    .sum()
-            }
+            DistanceType::L1 => unreachable!("L1 is scored by `score_precomputed_l1`"),
         }
+    }
+
+    /// L1 distance: dequantize the vector and compare it with the original
+    /// query coordinate by coordinate.
+    fn score_precomputed_l1(&self, query: &EncodedQueryTQ, vec: &[u8]) -> f32 {
+        let mut deq_v: Vec<f64> = self.dequantize(vec);
+        self.apply_inverse_rotation(deq_v.as_mut_slice());
+        query
+            .query
+            .as_ref()
+            .unwrap()
+            .iter()
+            .zip(deq_v.iter())
+            .map(|(&q, &v)| (f64::from(q) - v).abs() as f32)
+            .sum()
     }
 }
 
@@ -1493,6 +1568,88 @@ mod tests {
                 gap > ref_mag,
                 "score spread too small for {bits:?}/{distance:?}: self={self_score}, anti={anti_score}",
             );
+        }
+    }
+
+    /// `score_precomputed_batch` must reproduce per-vector `score_precomputed`
+    /// bit-exactly for every bit width, distance, and mode, across run sizes
+    /// that hit every kernel path (single vector, partial group, full runs).
+    #[rstest::rstest]
+    #[case(TQBits::Bits1)]
+    #[case(TQBits::Bits1_5)]
+    #[case(TQBits::Bits2)]
+    #[case(TQBits::Bits4)]
+    fn score_precomputed_batch_matches_single(#[case] bits: TQBits) {
+        // 200 dims: the 4-bit kernels see a partial trailing block.
+        let dim = 200;
+        let count = 100;
+
+        for &distance in &[
+            DistanceType::Dot,
+            DistanceType::Cosine,
+            DistanceType::L2,
+            DistanceType::L1,
+        ] {
+            for &mode in &[TQMode::Normal, TQMode::Plus] {
+                let mut rng = StdRng::seed_from_u64(0xBA7C4);
+                let padded_dim = TurboQuantizer::padded_dim(dim, bits);
+                let error_correction = match mode {
+                    TQMode::Normal => None,
+                    TQMode::Plus => Some(ErrorCorrection::new(
+                        (0..padded_dim)
+                            .map(|_| rng.random_range(-0.1..0.1))
+                            .collect(),
+                        (0..padded_dim)
+                            .map(|_| rng.random_range(0.9..1.1))
+                            .collect(),
+                    )),
+                };
+                let tq = TurboQuantizer::new(
+                    dim,
+                    bits,
+                    mode,
+                    distance,
+                    TQRotation::Padded,
+                    error_correction,
+                );
+
+                let mut buf = vec![0.0f64; tq.padded_dim];
+                let mut data = Vec::new();
+                for _ in 0..count {
+                    let v = match distance {
+                        DistanceType::Cosine => normalize_vector(&random_vector(dim, &mut rng)),
+                        DistanceType::Dot | DistanceType::L1 | DistanceType::L2 => {
+                            random_vector(dim, &mut rng)
+                        }
+                    };
+                    data.extend_from_slice(&tq.quantize(&v, &mut buf));
+                }
+
+                // Every record `quantize` produced has the same length.
+                let stride = data.len() / count;
+                let query = tq.precompute_query(&random_vector(dim, &mut rng));
+
+                let single: Vec<f32> = (0..count)
+                    .map(|v| tq.score_precomputed(&query, &data[v * stride..(v + 1) * stride]))
+                    .collect();
+
+                for run_len in [1, 7, count] {
+                    let mut batched = vec![0.0f32; count];
+                    for (run_idx, scores) in batched.chunks_mut(run_len).enumerate() {
+                        let start = run_idx * run_len * stride;
+                        tq.score_precomputed_batch(
+                            &query,
+                            &data[start..start + scores.len() * stride],
+                            stride,
+                            scores,
+                        );
+                    }
+                    assert_eq!(
+                        single, batched,
+                        "batch mismatch for {bits:?}/{distance:?}/{mode:?} at run_len {run_len}",
+                    );
+                }
+            }
         }
     }
 }

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -95,6 +95,11 @@ impl ErrorCorrection {
     }
 }
 
+/// Vectors per sub-run of [`TurboQuantizer::score_precomputed_batch`]: 64
+/// vectors of up to 512 bytes stay in L1 between the kernel pass and the
+/// extras pass.
+const SCORE_SUB_RUN: usize = 64;
+
 impl TurboQuantizer {
     /// Heap memory owned by the quantizer: the rotation tables and, in TQ+
     /// mode, the per-coordinate error-correction vectors. Resident in RAM
@@ -612,17 +617,24 @@ impl TurboQuantizer {
         let codes_len = stride.checked_sub(extras_len).unwrap_or_else(|| {
             panic!("score_precomputed_batch: stride {stride} < extras {extras_len}")
         });
-        match &query.data {
-            EncodedQueryTQData::Bits1(q) => q.dotprod_batch(data, stride, scores),
-            EncodedQueryTQData::Bits1Wide(q) => q.dotprod_batch(data, stride, scores),
-            EncodedQueryTQData::Bits2(q) => q.dotprod_batch(data, stride, scores),
-            EncodedQueryTQData::Bits4(q) => q.dotprod_batch(data, stride, scores),
-        }
 
-        for (v, score) in scores.iter_mut().enumerate() {
-            let extras =
-                TqVectorExtras::from_bytes(&data[v * stride + codes_len..(v + 1) * stride]);
-            *score = self.score_from_raw_dot(query, *score, &extras);
+        // Two passes per sub-run — the kernel over the codes, then the extras
+        // — sized so the sub-run's bytes are still in L1 for the second pass;
+        // one pair of passes over a long run would refetch the extras from L2.
+        for (sub_run, scores) in scores.chunks_mut(SCORE_SUB_RUN).enumerate() {
+            let data = &data[sub_run * SCORE_SUB_RUN * stride..];
+            match &query.data {
+                EncodedQueryTQData::Bits1(q) => q.dotprod_batch(data, stride, scores),
+                EncodedQueryTQData::Bits1Wide(q) => q.dotprod_batch(data, stride, scores),
+                EncodedQueryTQData::Bits2(q) => q.dotprod_batch(data, stride, scores),
+                EncodedQueryTQData::Bits4(q) => q.dotprod_batch(data, stride, scores),
+            }
+
+            for (v, score) in scores.iter_mut().enumerate() {
+                let extras =
+                    TqVectorExtras::from_bytes(&data[v * stride + codes_len..(v + 1) * stride]);
+                *score = self.score_from_raw_dot(query, *score, &extras);
+            }
         }
     }
 

--- a/lib/quantization/tests/integration/test_tq.rs
+++ b/lib/quantization/tests/integration/test_tq.rs
@@ -1132,4 +1132,68 @@ mod tests {
             }
         }
     }
+
+    /// The batched `score_points` (contiguous-run path) must reproduce
+    /// per-point `score_point` bit-exactly — including the hoisted score
+    /// inversion (L2) — for sequential, scattered, and descending id orders.
+    #[rstest::rstest]
+    #[case::dot(DistanceType::Dot, false)]
+    #[case::l2(DistanceType::L2, true)]
+    fn test_tq_score_points_matches_score_point(
+        #[case] distance_type: DistanceType,
+        #[case] invert: bool,
+    ) {
+        let dim = 128;
+        for &bits in BITS {
+            for &mode in &[TQMode::Normal, TQMode::Plus] {
+                let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                let vector_data: Vec<Vec<f32>> = (0..VECTORS_COUNT)
+                    .map(|_| (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect())
+                    .collect();
+                let query: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
+
+                let vector_parameters = VectorParameters {
+                    dim,
+                    deprecated_count: None,
+                    distance_type,
+                    invert,
+                };
+                let quantized_vector_size =
+                    encoded_vectors_tq::get_quantized_vector_size(&vector_parameters, bits, mode);
+                let encoded = EncodedVectorsTQ::encode(
+                    vector_data.iter(),
+                    TestEncodedStorageBuilder::new(None, quantized_vector_size),
+                    &vector_parameters,
+                    VECTORS_COUNT,
+                    bits,
+                    mode,
+                    TQRotation::Padded,
+                    false,
+                    1,
+                    None,
+                    &AtomicBool::new(false),
+                )
+                .unwrap();
+                let encoded_query = encoded.encode_query(&query);
+                let counter = HardwareCounterCell::new();
+
+                let sequential: Vec<u32> = (0..VECTORS_COUNT as u32).collect();
+                let scattered: Vec<u32> = (0..VECTORS_COUNT as u32).step_by(3).collect();
+                let descending: Vec<u32> = (0..VECTORS_COUNT as u32).rev().collect();
+
+                for ids in [&sequential, &scattered, &descending] {
+                    let expected: Vec<f32> = ids
+                        .iter()
+                        .map(|&id| encoded.score_point(&encoded_query, id, &counter))
+                        .collect();
+                    let mut batched = vec![0.0f32; ids.len()];
+                    encoded.score_points(&encoded_query, ids, &mut batched, &counter);
+                    assert_eq!(
+                        expected, batched,
+                        "score_points mismatch for bits={bits:?}, mode={mode:?}, distance={distance_type:?}",
+                    );
+                }
+            }
+        }
+    }
 }

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -137,6 +137,10 @@ name = "turbo_vector_search"
 harness = false
 
 [[bench]]
+name = "turbo_full_scan"
+harness = false
+
+[[bench]]
 name = "read_vectors"
 harness = false
 

--- a/lib/segment/benches/turbo_full_scan.rs
+++ b/lib/segment/benches/turbo_full_scan.rs
@@ -1,0 +1,179 @@
+//! Exhaustive (plain-index) search over 4-bit TurboQuant storages.
+//!
+//! Runs the exact driver a non-indexed search uses —
+//! `BatchFilteredSearcher::peek_top_visible` over every live point — so the
+//! fixed per-point cost of the scan (id harvesting, batching, scoring
+//! dispatch, top-k maintenance) shows up next to the kernel cost.  Two
+//! storages over the same normalized random dataset:
+//!
+//! - `datatype`: Turbo4 as the vector datatype (appendable chunked storage, in
+//!   RAM);
+//! - `quantized`: Turbo4 as quantization over a RAM dense storage.
+//!
+//! Throughput is reported per scored point.
+
+#![allow(deprecated)]
+
+use std::hint::black_box;
+
+use common::bitvec::BitVec;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::distr::StandardUniform;
+use rand::rngs::SmallRng;
+use rand::{Rng, RngExt, SeedableRng};
+use segment::data_types::vectors::{DenseVector, QueryVector};
+use segment::index::hnsw_index::point_scorer::BatchFilteredSearcher;
+use segment::types::{
+    Distance, QuantizationConfig, TurboQuantBitSize, TurboQuantQuantizationConfig,
+    TurboQuantization,
+};
+use segment::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
+use segment::vector_storage::quantized::quantized_vectors::{
+    QuantizedVectors, QuantizedVectorsStorageType,
+};
+use segment::vector_storage::turbo::open_appendable_turbo_vector_storage;
+use segment::vector_storage::{DEFAULT_STOPPED, VectorStorage, VectorStorageEnum};
+use tempfile::TempDir;
+
+const DIMS: &[usize] = &[64, 128, 256, 512, 1024];
+const DISTANCE: Distance = Distance::Dot;
+const VECTORS: usize = 200_000;
+const TOP: usize = 10;
+
+fn random_unit_vector(rng: &mut impl Rng, dim: usize) -> DenseVector {
+    let vector: DenseVector = rng.sample_iter(StandardUniform).take(dim).collect();
+    let norm = vector.iter().map(|x| x * x).sum::<f32>().sqrt();
+    vector.into_iter().map(|x| x / norm).collect()
+}
+
+struct Dataset {
+    dense: VectorStorageEnum,
+    quantized: QuantizedVectors,
+    turbo: VectorStorageEnum,
+    query: QueryVector,
+    point_deleted: BitVec,
+    _dirs: [TempDir; 2],
+}
+
+fn build_dataset(dim: usize) -> Dataset {
+    let mut rng = SmallRng::seed_from_u64(dim as u64);
+    let hw_counter = HardwareCounterCell::new();
+
+    let turbo_dir = TempDir::new().expect("turbo tempdir created");
+    let mut turbo = VectorStorageEnum::DenseTurboAppendableMemmap(Box::new(
+        open_appendable_turbo_vector_storage(turbo_dir.path(), dim, DISTANCE, true)
+            .expect("turbo storage created"),
+    ));
+    let mut dense = new_volatile_dense_vector_storage(dim, DISTANCE);
+    for i in 0..VECTORS as PointOffsetType {
+        let vector = random_unit_vector(&mut rng, dim);
+        dense
+            .insert_vector(i, vector.as_slice().into(), &hw_counter)
+            .expect("dense vector inserted");
+        turbo
+            .insert_vector(i, vector.as_slice().into(), &hw_counter)
+            .expect("turbo vector inserted");
+    }
+
+    let quantized_dir = TempDir::new().expect("quantization tempdir created");
+    let config = QuantizationConfig::Turbo(TurboQuantization {
+        turbo: TurboQuantQuantizationConfig {
+            always_ram: None,
+            memory: None,
+            bits: Some(TurboQuantBitSize::Bits4),
+        },
+    });
+    let quantized = QuantizedVectors::create(
+        &dense,
+        &config,
+        QuantizedVectorsStorageType::Immutable,
+        quantized_dir.path(),
+        4,
+        &DEFAULT_STOPPED,
+    )
+    .expect("quantized vectors created");
+
+    Dataset {
+        dense,
+        quantized,
+        turbo,
+        query: QueryVector::from(random_unit_vector(&mut rng, dim)),
+        point_deleted: BitVec::repeat(false, VECTORS),
+        _dirs: [turbo_dir, quantized_dir],
+    }
+}
+
+/// One exhaustive search: build the searcher (query preprocessing) and scan
+/// every point through the visible-scan driver.
+fn full_scan(dataset: &Dataset, quantized: bool) {
+    let queries = [&dataset.query];
+    let empty = BitVec::new();
+    let searcher = if quantized {
+        BatchFilteredSearcher::new(
+            &queries,
+            &dataset.dense,
+            Some(&dataset.quantized),
+            None,
+            TOP,
+            &dataset.point_deleted,
+            HardwareCounterCell::new(),
+        )
+    } else {
+        BatchFilteredSearcher::new(
+            &queries,
+            &dataset.turbo,
+            None::<&QuantizedVectors>,
+            None,
+            TOP,
+            &dataset.point_deleted,
+            HardwareCounterCell::new(),
+        )
+    }
+    .expect("searcher created");
+    let results = searcher
+        .peek_top_visible(None, &empty, &empty, &DEFAULT_STOPPED)
+        .expect("scan completed");
+    black_box(results);
+}
+
+/// Dims to run: `TURBO_SCAN_DIMS=64,128` overrides [`DIMS`], so a single
+/// dataset can be rebuilt and measured while iterating on the scan path.
+fn dims() -> Vec<usize> {
+    match std::env::var("TURBO_SCAN_DIMS") {
+        Ok(dims) => dims
+            .split(',')
+            .map(|dim| {
+                dim.trim()
+                    .parse()
+                    .expect("TURBO_SCAN_DIMS: dims are integers")
+            })
+            .collect(),
+        Err(_) => DIMS.to_vec(),
+    }
+}
+
+fn benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("turbo4_full_scan");
+    group.sample_size(20);
+    for dim in dims() {
+        let dataset = build_dataset(dim);
+        group.throughput(Throughput::Elements(VECTORS as u64));
+        group.bench_with_input(BenchmarkId::new("datatype", dim), &dim, |b, _| {
+            b.iter(|| full_scan(&dataset, false));
+        });
+        group.bench_with_input(BenchmarkId::new("quantized", dim), &dim, |b, _| {
+            b.iter(|| full_scan(&dataset, true));
+        });
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = benchmark,
+}
+
+criterion_main!(benches);

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_only.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_only.rs
@@ -142,6 +142,17 @@ impl<S: UniversalRead> quantization::EncodedStorage for QuantizedChunkedStorageR
             .expect("vectors read");
     }
 
+    fn for_each_run(
+        &self,
+        offsets: &[PointOffsetType],
+        mut callback: impl FnMut(usize, usize, Cow<'_, [u8]>),
+    ) {
+        quantization::encoded_storage::for_each_consecutive_run(offsets, |first, start, len| {
+            let bytes = self.get_many::<Random>(start, len).expect("vectors read");
+            callback(first, len, bytes);
+        });
+    }
+
     fn files(&self) -> Vec<PathBuf> {
         self.data.files()
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_write.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/read_write.rs
@@ -146,6 +146,17 @@ impl<S: UniversalWrite + Send + 'static> quantization::EncodedStorage
             .expect("vectors read");
     }
 
+    fn for_each_run(
+        &self,
+        offsets: &[PointOffsetType],
+        mut callback: impl FnMut(usize, usize, Cow<'_, [u8]>),
+    ) {
+        quantization::encoded_storage::for_each_consecutive_run(offsets, |first, start, len| {
+            let bytes = self.get_many::<Random>(start, len).expect("vectors read");
+            callback(first, len, bytes);
+        });
+    }
+
     fn files(&self) -> Vec<PathBuf> {
         self.data.files()
     }

--- a/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_query_scorer.rs
@@ -85,11 +85,8 @@ where
             .vector_io_read()
             .incr_delta(ids.len() * self.quantized_data.quantized_vector_size());
 
-        self.quantized_data.for_each_batch(ids, |idx, vector| {
-            scores[idx] = self
-                .quantized_data
-                .score(&self.query, &vector, &self.hardware_counter);
-        });
+        self.quantized_data
+            .score_points(&self.query, ids, scores, &self.hardware_counter);
     }
 
     fn score_stored(&self, idx: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_ram_storage.rs
@@ -172,6 +172,20 @@ impl quantization::EncodedStorage for QuantizedRamStorage {
         }
     }
 
+    fn for_each_run(
+        &self,
+        offsets: &[PointOffsetType],
+        mut callback: impl FnMut(usize, usize, Cow<'_, [u8]>),
+    ) {
+        quantization::encoded_storage::for_each_consecutive_run(offsets, |first, start, len| {
+            let bytes = self
+                .vectors
+                .get_many(start as VectorOffsetType, len)
+                .expect("vectors read");
+            callback(first, len, bytes);
+        });
+    }
+
     fn files(&self) -> Vec<PathBuf> {
         vec![self.path.clone()]
     }
@@ -278,5 +292,50 @@ mod tests {
         assert_eq!(storage.vectors_count(), 2);
         assert_eq!(storage.get_vector_data(0).as_ref(), [1, 2]);
         assert_eq!(storage.get_vector_data(1).as_ref(), [3, 4]);
+    }
+
+    /// `for_each_run` must serve every offset exactly once, in order, with
+    /// bytes identical to per-point `get_vector_data` — including a run that
+    /// straddles the internal chunk boundary.
+    #[test]
+    fn runs_match_per_point_reads_across_chunk_boundary() {
+        use quantization::EncodedStorage;
+
+        use crate::vector_storage::common::CHUNK_SIZE;
+
+        const VECTOR_SIZE: usize = 68;
+        // Enough vectors to cross the first chunk boundary.
+        let count = CHUNK_SIZE / VECTOR_SIZE + 100;
+
+        let mut vectors = VolatileChunkedVectors::<u8>::new(VECTOR_SIZE);
+        for i in 0..count {
+            let vector: Vec<u8> = (0..VECTOR_SIZE).map(|b| (i * 31 + b) as u8).collect();
+            vectors.push(&vector).unwrap();
+        }
+        let storage = QuantizedRamStorage {
+            vectors,
+            path: PathBuf::new(),
+        };
+
+        let ascending: Vec<PointOffsetType> = (0..count as PointOffsetType).collect();
+        let scattered: Vec<PointOffsetType> = (0..count as PointOffsetType).step_by(7).collect();
+
+        for ids in [&ascending, &scattered] {
+            let mut visited = 0;
+            storage.for_each_run(ids, |first, run_len, bytes| {
+                assert_eq!(first, visited, "runs must cover `ids` in order");
+                assert_eq!(bytes.len(), run_len * VECTOR_SIZE);
+                for (i, vector) in bytes.as_chunks::<VECTOR_SIZE>().0.iter().enumerate() {
+                    assert_eq!(
+                        vector.as_slice(),
+                        storage.get_vector_data(ids[first + i]).as_ref(),
+                        "run bytes diverge at offset {}",
+                        ids[first + i],
+                    );
+                }
+                visited += run_len;
+            });
+            assert_eq!(visited, ids.len());
+        }
     }
 }

--- a/lib/segment/src/vector_storage/quantized/quantized_storage.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_storage.rs
@@ -313,6 +313,24 @@ impl<S: UniversalRead> quantization::EncodedStorage for QuantizedStorage<S> {
             .expect("vectors exist and are read correctly");
     }
 
+    fn for_each_run(
+        &self,
+        offsets: &[PointOffsetType],
+        mut callback: impl FnMut(usize, usize, Cow<'_, [u8]>),
+    ) {
+        let size = self.quantized_vector_size.get() as u64;
+        quantization::encoded_storage::for_each_consecutive_run(offsets, |first, start, len| {
+            let range = ReadRange::new(size * u64::from(start), size * len as u64);
+            let bytes = if len > 1 {
+                self.storage.read(range, Sequential)
+            } else {
+                self.storage.read(range, Random)
+            };
+            let bytes = bytes.expect("vectors read from quantized storage failed");
+            callback(first, len, bytes);
+        });
+    }
+
     fn files(&self) -> Vec<PathBuf> {
         vec![self.path.clone()]
     }

--- a/lib/segment/src/vector_storage/query_scorer/turbo_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/turbo_query_scorer.rs
@@ -58,11 +58,7 @@ impl<TStorage: TurboScoring> QueryScorer for TurboQueryScorer<'_, TStorage> {
         self.hardware_counter.vector_io_read().incr_delta(ids.len());
         self.hardware_counter.cpu_counter().incr_delta(ids.len());
 
-        self.storage
-            .for_each_in_dense_tq_batch(ids, |idx, bytes| {
-                scores[idx] = self.storage.score_query_bytes(&self.query, bytes);
-            })
-            .expect("read TQ vectors");
+        self.storage.score_query_batch(&self.query, ids, scores);
     }
 
     fn score_internal(&self, point_a: PointOffsetType, point_b: PointOffsetType) -> ScoreType {

--- a/lib/segment/src/vector_storage/tests/test_appendable_turbo_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_turbo_vector_storage.rs
@@ -1324,7 +1324,12 @@ fn score_stored_batch_matches_score_stored() {
     use crate::vector_storage::query_scorer::turbo_query_scorer::TurboQueryScorer;
 
     const DIM: usize = 128;
-    const COUNT: usize = 100;
+    // Enough vectors to cross a (test-sized) chunk boundary of the chunked
+    // backend, so batch scoring of a sequential scan has to split its
+    // contiguous runs there.
+    const COUNT: usize = 8192;
+    const _: () =
+        assert!(COUNT * (DIM / 2 + size_of::<f32>()) > crate::vector_storage::common::CHUNK_SIZE);
 
     let distance = Distance::Dot;
     let seed = SEEDS[0];
@@ -1336,6 +1341,9 @@ fn score_stored_batch_matches_score_stored() {
         .chain(0..(COUNT / 2) as PointOffsetType)
         .collect();
     ids.shuffle(&mut rng);
+    // An ascending full scan on top of the shuffled ids: maximal-length
+    // sequential runs, including one straddling the chunk boundary.
+    let ascending: Vec<PointOffsetType> = (0..COUNT as PointOffsetType).collect();
 
     // Backends under test: appendable chunked, single-file mmap, and (on
     // Linux) single-file uring.
@@ -1393,12 +1401,15 @@ fn score_stored_batch_matches_score_stored() {
     }
 
     check_backend("chunked", &chunked, &inputs, &ids);
+    check_backend("chunked/scan", &chunked, &inputs, &ascending);
     check_backend("mmap", &mmap, &inputs, &ids);
+    check_backend("mmap/scan", &mmap, &inputs, &ascending);
 
     #[cfg(target_os = "linux")]
     {
         let uring = open_turbo_single_uring(single_dir.path(), DIM, distance, false).unwrap();
         check_backend("uring", &uring, &inputs, &ids);
+        check_backend("uring/scan", &uring, &inputs, &ascending);
     }
 }
 

--- a/lib/segment/src/vector_storage/turbo/appendable_turbo_vector_storage.rs
+++ b/lib/segment/src/vector_storage/turbo/appendable_turbo_vector_storage.rs
@@ -314,6 +314,22 @@ impl TurboScoring for AppendableMmapTurboVectorStorage {
         Self::score_query_bytes(self, query, bytes)
     }
 
+    fn score_query_batch(
+        &self,
+        query: &EncodedQueryTQ,
+        ids: &[PointOffsetType],
+        scores: &mut [ScoreType],
+    ) {
+        shared::score_query_batch(
+            &self.storage,
+            &self.quantizer,
+            self.distance,
+            query,
+            ids,
+            scores,
+        )
+    }
+
     fn score_internal_encoded(
         &self,
         point_a: PointOffsetType,

--- a/lib/segment/src/vector_storage/turbo/read_only/immutable/read_ops.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/immutable/read_ops.rs
@@ -143,6 +143,22 @@ impl<S: UniversalRead> TurboScoring for ReadOnlyImmutableTurboVectorStorage<S> {
         shared::score_query_bytes(&self.quantizer, self.distance, query, bytes)
     }
 
+    fn score_query_batch(
+        &self,
+        query: &EncodedQueryTQ,
+        ids: &[PointOffsetType],
+        scores: &mut [ScoreType],
+    ) {
+        shared::score_query_batch(
+            &self.storage,
+            &self.quantizer,
+            self.distance,
+            query,
+            ids,
+            scores,
+        )
+    }
+
     fn score_internal_encoded(
         &self,
         point_a: PointOffsetType,

--- a/lib/segment/src/vector_storage/turbo/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/read_ops.rs
@@ -143,6 +143,22 @@ impl<S: UniversalRead> TurboScoring for ReadOnlyChunkedTurboVectorStorage<S> {
         shared::score_query_bytes(&self.quantizer, self.distance, query, bytes)
     }
 
+    fn score_query_batch(
+        &self,
+        query: &EncodedQueryTQ,
+        ids: &[PointOffsetType],
+        scores: &mut [ScoreType],
+    ) {
+        shared::score_query_batch(
+            &self.storage,
+            &self.quantizer,
+            self.distance,
+            query,
+            ids,
+            scores,
+        )
+    }
+
     fn score_internal_encoded(
         &self,
         point_a: PointOffsetType,

--- a/lib/segment/src/vector_storage/turbo/shared.rs
+++ b/lib/segment/src/vector_storage/turbo/shared.rs
@@ -9,7 +9,8 @@
 
 use std::borrow::Cow;
 
-use common::types::ScoreType;
+use common::types::{PointOffsetType, ScoreType};
+use quantization::encoded_storage::EncodedStorage;
 use quantization::turboquant::quantization::TurboQuantizer;
 use quantization::turboquant::{EncodedQueryTQ, TQBits, TQMode, TQRotation};
 
@@ -100,6 +101,44 @@ pub(super) fn score_query_bytes(
         -score
     } else {
         score
+    }
+}
+
+/// Batch counterpart of [`score_query_bytes`] over an [`EncodedStorage`]:
+/// `scores[i]` ← score of `query` against `ids[i]`.  Coalesces consecutive ids
+/// into contiguous storage runs and scores each run with one batched quantizer
+/// call, so a sequential scan pays the storage resolution and kernel setup per
+/// run rather than per vector.
+pub(super) fn score_query_batch<TStorage: EncodedStorage>(
+    storage: &TStorage,
+    quantizer: &TurboQuantizer,
+    distance: Distance,
+    query: &EncodedQueryTQ,
+    ids: &[PointOffsetType],
+    scores: &mut [ScoreType],
+) {
+    debug_assert_eq!(ids.len(), scores.len());
+
+    if !TStorage::is_in_ram_or_mmap() {
+        // Backends with async reads (io_uring, remote caches) pipeline
+        // per-vector reads in `for_each_batch`; run-granular reads would
+        // serialize them.
+        storage.for_each_batch(ids, |idx, bytes| {
+            scores[idx] = score_query_bytes(quantizer, distance, query, &bytes);
+        });
+        return;
+    }
+
+    // The record size every Turbo datatype storage is created with.
+    let stride = quantizer.quantized_size();
+    storage.for_each_run(ids, |first, count, bytes| {
+        quantizer.score_precomputed_batch(query, &bytes, stride, &mut scores[first..first + count]);
+    });
+
+    if invert_score(distance) {
+        for score in scores {
+            *score = -*score;
+        }
     }
 }
 

--- a/lib/segment/src/vector_storage/turbo/turbo_vector_storage.rs
+++ b/lib/segment/src/vector_storage/turbo/turbo_vector_storage.rs
@@ -399,6 +399,22 @@ impl<S: UniversalRead> TurboScoring for TurboVectorStorageImpl<S> {
         Self::score_query_bytes(self, query, bytes)
     }
 
+    fn score_query_batch(
+        &self,
+        query: &EncodedQueryTQ,
+        ids: &[PointOffsetType],
+        scores: &mut [ScoreType],
+    ) {
+        shared::score_query_batch(
+            &self.storage,
+            &self.quantizer,
+            self.distance,
+            query,
+            ids,
+            scores,
+        )
+    }
+
     fn score_internal_encoded(
         &self,
         point_a: PointOffsetType,

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -555,6 +555,17 @@ pub trait TurboScoring: DenseTQVectorStorageRead {
 
     fn score_query_bytes(&self, query: &EncodedQueryTQ, bytes: &[u8]) -> ScoreType;
 
+    /// Batch counterpart of [`Self::score_query_bytes`]: `scores[i]` ← score
+    /// of `query` against point `ids[i]`.  Storages backed by contiguous
+    /// encoded bytes score whole runs of consecutive ids with one batched
+    /// quantizer call (see `turbo::shared::score_query_batch`).
+    fn score_query_batch(
+        &self,
+        query: &EncodedQueryTQ,
+        ids: &[PointOffsetType],
+        scores: &mut [ScoreType],
+    );
+
     fn score_internal_encoded(
         &self,
         point_a: PointOffsetType,


### PR DESCRIPTION
This PR implements the TQ speeding up for 1/2/4bit TQ for all SIMD kernels (AVX512/AVX2/SSE/NEON).

Also it introduces batched TQ scoring.

Since this PR is huge, all changes are split into small commits to make review easier.