### PR TITLE
fix(fs): treat POSIX_FADV_NOREUSE error as non-fatal in OneshotFile (fix #10307)

### DIFF
--- a/lib/common/common/src/fs/fadvise.rs
+++ b/lib/common/common/src/fs/fadvise.rs
@@ -48,7 +48,9 @@ impl OneshotFile {
         #[cfg(posix_fadvise_supported)]
         {
             fadvise(&file, PosixFadviseAdvice::POSIX_FADV_SEQUENTIAL)?;
-            fadvise(&file, PosixFadviseAdvice::POSIX_FADV_NOREUSE)?;
+            // POSIX_FADV_NOREUSE is purely advisory; on certain filesystems (e.g. Android F2FS),
+            // a len=0 request returns ENOENT. Ignore advisory error to not fail valid file loads.
+            let _ = fadvise(&file, PosixFadviseAdvice::POSIX_FADV_NOREUSE);
         }
         Ok(Self { file: Some(file) })
     }


### PR DESCRIPTION
Fixes #10307

### Problem
When a shard is stored on an F2FS filesystem (e.g. on Android environments), OneshotFile::open() failed during posix_fadvise(fd, 0, 0, POSIX_FADV_NOREUSE) returning ENOENT because a zero-length request attempts to remove a previously registered NOREUSE range on F2FS.

### Solution
POSIX_FADV_NOREUSE is purely an advisory hint for cache eviction. In OneshotFile::open(), treat the result as non-fatal (like OneshotFile::drop() does for POSIX_FADV_DONTNEED), preventing valid shard file loading from aborting.