### PR TITLE
[edge] open and reload IO don't block search pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2043,6 +2043,7 @@ dependencies = [
  "common",
  "core_affinity",
  "fs-err",
+ "futures",
  "itertools 0.15.0",
  "log",
  "ordered-float 5.5.0",

--- a/lib/common/common/src/universal_io/cached_fs/mod.rs
+++ b/lib/common/common/src/universal_io/cached_fs/mod.rs
@@ -315,9 +315,10 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
             .insert(path, ScheduledFile::Future(fut));
     }
 
-    async fn wait_all(&self) {
-        let futs = self
-            .files_prefetched
+    fn wait_all(&self) -> impl Future<Output = ()> + Send + 'static + use<Fs> {
+        let files_prefetched = Arc::clone(&self.files_prefetched);
+
+        let futs = files_prefetched
             .lock()
             .extract_if(|_path, scheduled| matches!(scheduled, ScheduledFile::Future(_)))
             .filter_map(|(path, scheduled)| match scheduled {
@@ -326,10 +327,12 @@ impl<Fs: UniversalReadFs> CachedReadFs for CachedFs<Fs> {
             })
             .collect::<FuturesUnordered<_>>();
 
-        let results = futs.collect::<Vec<_>>().await;
-        let mut lock = self.files_prefetched.lock();
-        for (path, result) in results {
-            lock.insert(path, ScheduledFile::Ready(result));
+        async move {
+            let results = futs.collect::<Vec<_>>().await;
+            let mut lock = files_prefetched.lock();
+            for (path, result) in results {
+                lock.insert(path, ScheduledFile::Ready(result));
+            }
         }
     }
 

--- a/lib/common/common/src/universal_io/traits/file_ops.rs
+++ b/lib/common/common/src/universal_io/traits/file_ops.rs
@@ -201,7 +201,10 @@ pub trait CachedReadFs: UniversalReadFs {
     fn schedule(&self, path: PathBuf, fut: BoxFuture<'static, UioResult<Self::File>>);
 
     /// Wait for all scheduled files to resolve.
-    fn wait_all(&self) -> impl Future<Output = ()>;
+    ///
+    /// The future is detached (`use<Self>`: no lifetime capture), so it can be
+    /// driven after the `&self` borrow ends.
+    fn wait_all(&self) -> impl Future<Output = ()> + Send + 'static + use<Self>;
 
     /// Return the file info from the current snapshot.
     fn cached_file_info(&self, path: &Path) -> Option<FileInfo>;

--- a/lib/edge/Cargo.toml
+++ b/lib/edge/Cargo.toml
@@ -31,6 +31,7 @@ rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
+futures.workspace = true
 
 [dev-dependencies]
 fs-err = { workspace = true, features = ["debug"] }

--- a/lib/edge/Cargo.toml
+++ b/lib/edge/Cargo.toml
@@ -31,7 +31,7 @@ rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
-futures.workspace = true
+futures = { workspace = true }
 
 [dev-dependencies]
 fs-err = { workspace = true, features = ["debug"] }

--- a/lib/edge/src/read_only/load.rs
+++ b/lib/edge/src/read_only/load.rs
@@ -1,8 +1,12 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
+use common::counter::hardware_counter::HardwareCounterCell;
 use futures::future::join_all;
+use parking_lot::RwLock;
 use rayon::ThreadPool;
 use rayon::prelude::*;
+use segment::common::operation_error::OperationResult;
 use segment::data_types::load_profile::LoadProfile;
 use segment::index::UniversalReadExt;
 use segment::segment::read_only::ReadOnlySegment;
@@ -61,6 +65,52 @@ where
                     None
                 }
             })
+            .collect()
+    })
+}
+
+/// Live-reload the given segments in two phases — stage every fetch under
+/// shared access (`live_preload`), then apply under exclusive access
+/// (`live_reload`) — so the exclusive phase never waits on IO.
+///
+/// Like [`load_segments_parallel`], the IO is driven to completion on the
+/// calling thread; `pool` only runs the staging and the CPU-bound apply.
+/// A failed preload is benign (warn): its reload still runs and surfaces
+/// anything real. Returns each segment's reload result, in input order.
+pub(crate) fn reload_segments_parallel<S>(
+    pool: &ThreadPool,
+    segments: Vec<(Uuid, Arc<RwLock<ReadOnlySegment<S>>>)>,
+    hw_counter: &HardwareCounterCell,
+) -> Vec<(Uuid, OperationResult<()>)>
+where
+    S: UniversalReadExt + 'static,
+    S::Fs: Send + Sync + Clone + 'static,
+{
+    let io_futures = pool.install(|| {
+        segments
+            .par_iter()
+            .filter_map(|(uuid, segment)| match segment.read().live_preload() {
+                Ok(future) => Some(future),
+                Err(err) => {
+                    log::warn!("live_preload of segment {uuid} failed: {err}");
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+    });
+
+    futures::executor::block_on(join_all(io_futures));
+
+    let reloads: Vec<_> = segments
+        .into_iter()
+        // The counter cell is not `Sync`, so fork one per reload outside the
+        // pool; forks drain into the shared accumulator on drop.
+        .map(|(uuid, segment)| (uuid, segment, hw_counter.fork()))
+        .collect();
+    pool.install(|| {
+        reloads
+            .into_par_iter()
+            .map(|(uuid, segment, hw)| (uuid, segment.write().live_reload(&hw)))
             .collect()
     })
 }

--- a/lib/edge/src/read_only/load.rs
+++ b/lib/edge/src/read_only/load.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use futures::future::join_all;
 use rayon::ThreadPool;
 use rayon::prelude::*;
 use segment::data_types::load_profile::LoadProfile;
@@ -7,10 +8,12 @@ use segment::index::UniversalReadExt;
 use segment::segment::read_only::ReadOnlySegment;
 use uuid::Uuid;
 
-/// Open the given segments in parallel on `pool` and return the ones that loaded, in input order.
+/// Open the given segments and return the ones that loaded, in input order.
 ///
-/// Reuses the shard's long-lived search thread pool instead of spawning a fresh OS thread per
-/// segment, bounding concurrency to the pool size.
+/// The IO never rides `pool` (the shard's search pool): every segment's
+/// fetches are staged up front and driven to completion on the calling
+/// thread, so the pool only runs the CPU-bound assembly and searches are
+/// not stalled behind parked IO threads.
 ///
 /// A `load_profile` (see [`LoadProfile`]) parks the components the shard's request won't touch
 /// cold instead of warming them per the segment configs.
@@ -29,18 +32,33 @@ where
     S: UniversalReadExt + 'static,
     S::Fs: Send + Sync + Clone + 'static,
 {
-    let segments: Vec<(Uuid, PathBuf)> = segments.into_iter().collect();
+    // Stage every open: per-segment LIST + config reads, with the bulk
+    // fetches going in flight as scheduled.
+    let staged: Vec<_> = segments
+        .into_iter()
+        .filter_map(|(uuid, segment_path)| {
+            match ReadOnlySegment::<S>::schedule_open(fs, &segment_path, uuid, None, load_profile) {
+                Ok(staged) => Some((uuid, staged)),
+                Err(err) => {
+                    log::warn!("read-only open: skipping unloadable segment {uuid}: {err}");
+                    None
+                }
+            }
+        })
+        .collect();
 
+    // Drive all segments' fetches to completion here, overlapped, off the pool.
+    futures::executor::block_on(join_all(staged.iter().map(|(_, staged)| staged.wait())));
+
+    // Assemble from the resolved handles on the pool.
     pool.install(|| {
-        segments
+        staged
             .into_par_iter()
-            .filter_map(|(uuid, segment_path)| {
-                match ReadOnlySegment::<S>::open(fs, &segment_path, uuid, None, load_profile) {
-                    Ok(segment) => Some((uuid, segment)),
-                    Err(err) => {
-                        log::warn!("read-only open: skipping unloadable segment {uuid}: {err}");
-                        None
-                    }
+            .filter_map(|(uuid, staged)| match staged.finish(fs) {
+                Ok(segment) => Some((uuid, segment)),
+                Err(err) => {
+                    log::warn!("read-only open: skipping unloadable segment {uuid}: {err}");
+                    None
                 }
             })
             .collect()

--- a/lib/edge/src/read_only/refresh.rs
+++ b/lib/edge/src/read_only/refresh.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::universal_io::IsNotFound as _;
 use parking_lot::RwLock;
-use rayon::prelude::*;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::index::UniversalReadExt;
 use segment::segment::read_only::ReadOnlySegment;
@@ -12,7 +11,7 @@ use uuid::Uuid;
 
 use crate::EdgeConfig;
 use crate::read_only::ReadOnlyEdgeShard;
-use crate::read_only::load::load_segments_parallel;
+use crate::read_only::load::{load_segments_parallel, reload_segments_parallel};
 
 /// How a single [`refresh_attempt`](ReadOnlyEdgeShard::refresh_attempt) ended.
 enum RefreshOutcome {
@@ -160,38 +159,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
         }
 
         // 4. Live-reload survivors to assimilate new appends and deletes from data.
-        // Done in 2 steps: preload -> reload, so that we can avoid locking when prefetching.
-        let io_futures = self.search_pool.install(|| {
-            survivors
-                .par_iter()
-                .filter_map(|(uuid, segment)| match segment.read().live_preload() {
-                    Ok(future) => Some(future),
-                    Err(err) => {
-                        // Error when preloading is considered benign.
-                        log::warn!("live_preload of segment {uuid} failed: {err}");
-                        None
-                    }
-                })
-                .collect::<Vec<_>>()
-        });
-
-        // Wait for all preload futures to complete
-        futures::executor::block_on(async {
-            futures::future::join_all(io_futures).await;
-        });
-
-        let reloads: Vec<_> = survivors
-            .into_iter()
-            // The counter cell is not `Sync`, so fork one per reload outside the
-            // pool; forks drain into the shared accumulator on drop.
-            .map(|(uuid, segment)| (uuid, segment, hw_counter.fork()))
-            .collect();
-        let results: Vec<_> = self.search_pool.install(|| {
-            reloads
-                .into_par_iter()
-                .map(|(uuid, segment, hw)| (uuid, segment.write().live_reload(&hw)))
-                .collect()
-        });
+        let results = reload_segments_parallel(&self.search_pool, survivors, hw_counter);
 
         let mut not_found: Vec<(Uuid, OperationError)> = Vec::new();
         let mut first_hard_error: Option<OperationError> = None;

--- a/lib/edge/src/read_only/refresh.rs
+++ b/lib/edge/src/read_only/refresh.rs
@@ -161,12 +161,23 @@ impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
 
         // 4. Live-reload survivors to assimilate new appends and deletes from data.
         // Done in 2 steps: preload -> reload, so that we can avoid locking when prefetching.
-        self.search_pool.install(|| {
-            survivors.par_iter().for_each(|(uuid, segment)| {
-                let _ = segment.read().live_preload().inspect_err(|err| {
-                    log::warn!("live_preload of segment {uuid} failed: {err}");
-                });
-            });
+        let io_futures = self.search_pool.install(|| {
+            survivors
+                .par_iter()
+                .filter_map(|(uuid, segment)| match segment.read().live_preload() {
+                    Ok(future) => Some(future),
+                    Err(err) => {
+                        // Error when preloading is considered benign.
+                        log::warn!("live_preload of segment {uuid} failed: {err}");
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+        });
+
+        // Wait for all preload futures to complete
+        futures::executor::block_on(async {
+            futures::future::join_all(io_futures).await;
         });
 
         let reloads: Vec<_> = survivors

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
@@ -91,19 +91,31 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
         deferred_internal_id: Option<PointOffsetType>,
         load_profile: Option<&LoadProfile>,
     ) -> OperationResult<Self> {
-        let cached_fs = build_cached_fs(fs, segment_path)?;
-        let (segment_config, payload_config) =
-            Self::first_preopen(&cached_fs, segment_path, load_profile)?;
-        Self::open_via(
-            cached_fs,
+        Self::schedule_open(fs, segment_path, uuid, deferred_internal_id, load_profile)?.finish(fs)
+    }
+
+    /// Stage an open without assembling the segment: take the listing snapshot
+    /// and put every fetch the open needs in flight. Callers opening many
+    /// segments overlap their IO ([`StagedSegmentOpen::wait`]) before
+    /// assembling each one ([`StagedSegmentOpen::finish`]).
+    pub fn schedule_open<'a>(
+        fs: &S::Fs,
+        segment_path: &Path,
+        uuid: Uuid,
+        deferred_internal_id: Option<PointOffsetType>,
+        load_profile: Option<&'a LoadProfile>,
+    ) -> OperationResult<StagedSegmentOpen<'a, S>> {
+        let fs = build_cached_fs(fs, segment_path)?;
+        let (config, payload_config) = Self::first_preopen(&fs, segment_path, load_profile)?;
+        Ok(StagedSegmentOpen {
             fs,
-            segment_path,
-            segment_config,
-            payload_config,
+            segment_path: segment_path.to_path_buf(),
             uuid,
             deferred_internal_id,
+            config,
+            payload_config,
             load_profile,
-        )
+        })
     }
 
     /// Schedule the prefetch of every file the segment's components will open,
@@ -325,6 +337,50 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
             segment_type,
             segment_config: config,
         })
+    }
+}
+
+/// An open staged by [`ReadOnlySegment::schedule_open`]: prefetches in flight,
+/// segment not yet assembled.
+pub struct StagedSegmentOpen<'a, S: UniversalReadExt + 'static> {
+    fs: CachedFs<S::Fs>,
+    segment_path: PathBuf,
+    uuid: Uuid,
+    deferred_internal_id: Option<PointOffsetType>,
+    config: SegmentConfig,
+    payload_config: PayloadConfig,
+    load_profile: Option<&'a LoadProfile>,
+}
+
+impl<'a, S: UniversalReadExt + 'static> StagedSegmentOpen<'a, S> {
+    /// Drive the staged fetches to completion. Detached (`use<S>`), so many
+    /// segments' waits can be collected and awaited together.
+    pub fn wait(&self) -> impl Future<Output = ()> + Send + 'static + use<S> {
+        self.fs.wait_all()
+    }
+
+    /// Assemble the segment from the staged handles. Fetches not already
+    /// resolved via [`Self::wait`] are driven to completion here.
+    pub fn finish(self, raw_fs: &S::Fs) -> OperationResult<ReadOnlySegment<S>> {
+        let Self {
+            fs,
+            segment_path,
+            uuid,
+            deferred_internal_id,
+            config,
+            payload_config,
+            load_profile,
+        } = self;
+        ReadOnlySegment::open_via(
+            fs,
+            raw_fs,
+            &segment_path,
+            config,
+            payload_config,
+            uuid,
+            deferred_internal_id,
+            load_profile,
+        )
     }
 }
 

--- a/lib/segment/src/segment/read_only/live_reload.rs
+++ b/lib/segment/src/segment/read_only/live_reload.rs
@@ -15,7 +15,9 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
     /// re-snapshot the retained caching filesystem's listing, schedule every
     /// fetch the reload will need, then drive them all to completion — so the
     /// reload only applies ready data.
-    pub fn live_preload(&self) -> OperationResult<()> {
+    pub fn live_preload(
+        &self,
+    ) -> OperationResult<impl Future<Output = ()> + Send + 'static + use<S>> {
         let Self {
             uuid: _,
             segment_path: _,
@@ -42,9 +44,11 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegment<S> {
             preloads.extend(vector_data.live_preload(fs)?);
         }
 
-        // Complete all IO before returning
-        futures::executor::block_on(async { futures::join!(fs.wait_all(), join_all(preloads)) });
-        Ok(())
+        let reopens = fs.wait_all();
+
+        Ok(async move {
+            futures::join!(reopens, join_all(preloads));
+        })
     }
 
     /// Refresh every component to the current on-disk state (id-tracker delta → all components).

--- a/lib/segment/src/segment/read_only/mod.rs
+++ b/lib/segment/src/segment/read_only/mod.rs
@@ -26,6 +26,7 @@ mod lifecycle;
 mod live_reload;
 
 pub use config_reload::SegmentConfigReloadDiff;
+pub use lifecycle::StagedSegmentOpen;
 mod read_entry;
 #[cfg(test)]
 mod tests;

--- a/lib/segment/src/segment/read_only/tests.rs
+++ b/lib/segment/src/segment/read_only/tests.rs
@@ -495,7 +495,7 @@ fn preload_then_reload(
     segment: &mut ReadOnlySegment<MmapFile>,
     hw_counter: &HardwareCounterCell,
 ) -> crate::common::operation_error::OperationResult<()> {
-    segment.live_preload()?;
+    futures::executor::block_on(segment.live_preload()?);
     segment.live_reload(hw_counter)
 }
 


### PR DESCRIPTION
This fixes https://github.com/qdrant/qdrant/pull/10353#discussion_r3880966570, for live reloading, but also for when we load new segments. 

Everything was happening inside of the search pool, which could potentially hog up the searching threads unnecessarily. Instead of adding a second threadpool, now only scheduling happens in parallel, but we await concurrently outside the search pool.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>