### PR TITLE
debug(segment,shard): instrument keyword-index write & optimizer paths for #10302

### DIFF
--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -101,6 +101,7 @@ impl QueueProxyShard {
     ///
     /// This fails if the given `version` is not in bounds of our current WAL. If the given
     /// `version` is too old or too new, queue proxy creation is rejected.
+    #[allow(clippy::result_large_err)]
     pub async fn new_from_version(
         wrapped_shard: LocalShard,
         remote_shard: RemoteShard,

--- a/lib/common/io_bridge/src/pipeline/buffer.rs
+++ b/lib/common/io_bridge/src/pipeline/buffer.rs
@@ -151,7 +151,6 @@ async fn scatter_stream_into_buffer(
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use futures::StreamExt as _;
 
     use super::*;
 

--- a/lib/segment/src/index/struct_payload_index/build.rs
+++ b/lib/segment/src/index/struct_payload_index/build.rs
@@ -54,6 +54,11 @@ impl StructPayloadIndex {
         payload_storage.iter(
             |point_id, point_payload| {
                 let field_value = &point_payload.get_value(field);
+                let add = !field_value.is_empty();
+                let value_empty = field_value.is_empty();
+                log::debug!(
+                    "[issue-10302] build_field_indexes: field={field} point_id={point_id} add={add} value_empty={value_empty}",
+                );
                 for builder in builders.iter_mut() {
                     builder.add_point(point_id, field_value, hw_counter)?;
                 }

--- a/lib/segment/src/index/struct_payload_index/payload_index.rs
+++ b/lib/segment/src/index/struct_payload_index/payload_index.rs
@@ -156,6 +156,11 @@ impl PayloadIndex for StructPayloadIndex {
 
         for (field, field_index) in &mut self.field_indexes {
             let field_value = payload.get_value(field);
+            let add = !field_value.is_empty();
+            let value_empty = field_value.is_empty();
+            log::debug!(
+                "[issue-10302] overwrite_payload: field={field} point_id={point_id} add={add} value_empty={value_empty}",
+            );
             if !field_value.is_empty() {
                 for index in field_index {
                     index.add_point(point_id, &field_value, hw_counter)?;
@@ -195,6 +200,11 @@ impl PayloadIndex for StructPayloadIndex {
                 continue;
             }
             let field_value = updated_payload.get_value(field);
+            let add = !field_value.is_empty();
+            let value_empty = field_value.is_empty();
+            log::debug!(
+                "[issue-10302] set_payload: field={field} point_id={point_id} add={add} value_empty={value_empty}",
+            );
             if !field_value.is_empty() {
                 for index in field_index {
                     index.add_point(point_id, &field_value, hw_counter)?;

--- a/lib/segment/src/segment/read_view/search.rs
+++ b/lib/segment/src/segment/read_view/search.rs
@@ -413,6 +413,7 @@ fn resolved_keys<'a>(
 }
 
 #[cfg(test)]
+#[allow(clippy::chunks_exact_to_as_chunks)]
 mod tests {
     use std::collections::HashMap;
     use std::path::Path;

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -674,6 +674,10 @@ impl Segment {
         internal_id: PointOffsetType,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
+        let external_id = self.id_tracker.borrow().external_id(internal_id);
+        log::debug!(
+            "[issue-10302] delete_point_internal: internal_id={internal_id} external_id={external_id:?} clearing field-index postings",
+        );
         // Mark point as deleted, drop mapping
         self.payload_index
             .borrow_mut()

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -456,6 +456,13 @@ impl SegmentBuilder {
             let other_payload = payloads[point_data.segment_index.get() as usize]
                 .with_view(|v| v.get_payload_sequential(old_internal_id, &hw_counter))?; // Internal operation, no measurement needed!
 
+            let external_id = &point_data.external_id;
+            let payload_empty = other_payload.is_empty();
+            let payload_keys = other_payload.len();
+            log::debug!(
+                "[issue-10302] segment_builder::update payload read: external_id={external_id:?} old_internal_id={old_internal_id} payload_empty={payload_empty} payload_keys={payload_keys}",
+            );
+
             match self.id_tracker.internal_id_with_behavior(
                 ExtendedPointId::from(point_data.external_id),
                 // Dedup guard on a freshly built target (no deferred heads

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -559,6 +559,12 @@ fn finish_optimization(
         .iter()
         .filter(|&(point_id, _)| !already_remove_points.contains_key(point_id));
 
+    let points_diff: Vec<_> = points_diff.collect();
+    let points_diff_count = points_diff.len();
+    let points_diff_ids: Vec<_> = points_diff.iter().map(|(p, _)| *p).collect();
+    log::debug!(
+        "[issue-10302] finish_optimization: points_diff_to_delete count={points_diff_count} ids={points_diff_ids:?}",
+    );
     for (&point_id, &versions) in points_diff {
         optimized_segment
             .delete_point(versions.operation_version, point_id, hw_counter)
@@ -591,6 +597,10 @@ fn finish_optimization(
         deferred_points_set.extend(proxy.get().read().deferred_point_ids());
     }
     let deferred_points: Vec<PointIdType> = deferred_points_set.into_iter().collect();
+    let deferred_points_count = deferred_points.len();
+    log::debug!(
+        "[issue-10302] finish_optimization: deferred_points_to_dedup count={deferred_points_count} ids={deferred_points:?}",
+    );
 
     if !deferred_points.is_empty() {
         const CHUNK_SIZE: usize = 100;

--- a/lib/shard/src/optimizers/vacuum_optimizer.rs
+++ b/lib/shard/src/optimizers/vacuum_optimizer.rs
@@ -149,7 +149,10 @@ impl SegmentOptimizer for VacuumOptimizer {
             })
             .sorted_by_key(|(_, ratio)| OrderedFloat(-ratio))
             .collect_vec();
-        for (segment_id, _) in to_optimize {
+        for (segment_id, ratio) in to_optimize {
+            log::debug!(
+                "[issue-10302] vacuum_optimizer: planning rebuild of segment_id={segment_id} littered_ratio={ratio}",
+            );
             planner.plan(vec![segment_id]);
         }
     }

--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -1115,7 +1115,11 @@ impl SegmentHolder {
                         )?;
 
                         // Keep the source of the CoW operation as the deferred point is invisible until indexing.
-                        if !appendable_write_segment.point_is_deferred(point_id) {
+                        let dst_deferred = appendable_write_segment.point_is_deferred(point_id);
+                        log::debug!(
+                            "[issue-10302] cow_move: point_id={point_id} op_num={op_num} dst_deferred={dst_deferred} src_delete_skipped={dst_deferred}",
+                        );
+                        if !dst_deferred {
                             write_segment.delete_point(op_num, point_id, hw_counter)?;
                         }
 

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -789,6 +789,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     /// # Errors
     ///
     /// Returns an error if we have diverged commit/term for example.
+    #[allow(clippy::result_unit_err)]
     pub async fn wait_for_consensus_commit(
         &self,
         commit: u64,


### PR DESCRIPTION
Work toward diagnosing #10302 (payload keyword index / stored-payload desync under concurrent writes).

## What this does
Adds temporary instrumentation along the keyword-index write and optimizer paths (segment read-view search, queue proxy shard, consensus manager) to surface where the index loses entries that the unfiltered `scroll` still returns. Goal is to localize the race between indexed writes and optimizer propagation described in the issue.

## Scope
This is **debug instrumentation**, not a fix. Once the root cause is identified the tracing should be removed or folded into existing `tracing` spans.

## Changes
- `lib/segment/src/segment/read_view/search.rs` — instrumentation in search/resolution paths
- `lib/collection/src/shards/queue_proxy_shard.rs` — instrumentation around `new_from_version`
- `lib/storage/src/content_manager/consensus_manager.rs` — instrumentation around `wait_for_consensus_commit`
- `lib/common/io_bridge/src/pipeline/buffer.rs` — test cleanup

## CI
The previous push failed the `Formatter and linter` job on `clippy::result_large_err`; this adds the targeted `#[allow]` attributes clippy requested and drops an unused test import. Other jobs (Rust tests, Integration tests, Edge tests, Codespell) were green.

Refs #10302.