### PR TITLE
fix: reject mismatched dense dims in recommend average

### DIFF
--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -274,6 +274,7 @@ mod test {
     use sparse::common::sparse_vector::SparseVector;
 
     use super::{avg_vector_for_recommendation, avg_vectors};
+    use crate::common::operation_error::OperationError;
     use crate::data_types::vectors::{VectorInternal, VectorRef};
     use crate::vector_storage::query::{Query, RecoBestScoreQuery, RecoQuery};
 
@@ -461,6 +462,12 @@ mod test {
             positives.iter().map(VectorRef::from),
             negatives.iter().map(VectorRef::from).peekable(),
         );
-        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(OperationError::WrongVectorDimension {
+                expected_dim: 2,
+                received_dim: 3,
+            })
+        ));
     }
 }

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -163,23 +163,12 @@ fn avg_vectors<'a>(
     let mut avg_dense = DenseVector::default();
     let mut avg_sparse = SparseVector::default();
     let mut avg_multi: Option<TypedMultiDenseVector<VectorElementType>> = None;
-    let mut dense_dimension = None;
     let mut dense_count = 0;
     let mut sparse_count = 0;
     let mut multi_count = 0;
     for vector in vectors {
         match vector {
             VectorRef::Dense(vector) => {
-                if let Some(expected_dim) = dense_dimension {
-                    if expected_dim != vector.len() {
-                        return Err(OperationError::WrongVectorDimension {
-                            expected_dim,
-                            received_dim: vector.len(),
-                        });
-                    }
-                } else {
-                    dense_dimension = Some(vector.len());
-                }
                 dense_count += 1;
                 for i in 0..vector.len() {
                     if i >= avg_dense.len() {
@@ -422,12 +411,6 @@ mod test {
         );
 
         let vectors: Vec<VectorInternal> = vec![
-            VectorInternal::from(vec![1.0, 2.0, 3.0]),
-            VectorInternal::from(vec![1.0, 2.0, 3.0, 4.0]),
-        ];
-        assert!(avg_vectors(vectors.iter().map(VectorRef::from)).is_err());
-
-        let vectors: Vec<VectorInternal> = vec![
             SparseVector::new(vec![0, 1, 2], vec![0.0, 0.1, 0.2])
                 .unwrap()
                 .into(),
@@ -471,18 +454,13 @@ mod test {
         )
         .unwrap();
         assert_eq!(vector, vec![1.0, 0.0].into());
-    }
 
-    #[test]
-    fn test_avg_vector_for_recommendation_rejects_dense_dimension_mismatch() {
-        let positive = vec![VectorInternal::from(vec![1.0, 2.0, 3.0])];
-        let negative = vec![VectorInternal::from(vec![1.0, 2.0, 3.0, 4.0])];
-
+        // Negative average with a different dimension is rejected, not truncated by zip.
+        let negatives: Vec<VectorInternal> = vec![vec![0.0, 1.0, 2.0].into()];
         let result = avg_vector_for_recommendation(
-            positive.iter().map(VectorRef::from),
-            negative.iter().map(VectorRef::from).peekable(),
+            positives.iter().map(VectorRef::from),
+            negatives.iter().map(VectorRef::from).peekable(),
         );
-
         assert!(result.is_err());
     }
 }

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -163,12 +163,23 @@ fn avg_vectors<'a>(
     let mut avg_dense = DenseVector::default();
     let mut avg_sparse = SparseVector::default();
     let mut avg_multi: Option<TypedMultiDenseVector<VectorElementType>> = None;
+    let mut dense_dimension = None;
     let mut dense_count = 0;
     let mut sparse_count = 0;
     let mut multi_count = 0;
     for vector in vectors {
         match vector {
             VectorRef::Dense(vector) => {
+                if let Some(expected_dim) = dense_dimension {
+                    if expected_dim != vector.len() {
+                        return Err(OperationError::WrongVectorDimension {
+                            expected_dim,
+                            received_dim: vector.len(),
+                        });
+                    }
+                } else {
+                    dense_dimension = Some(vector.len());
+                }
                 dense_count += 1;
                 for i in 0..vector.len() {
                     if i >= avg_dense.len() {
@@ -234,6 +245,12 @@ fn merge_positive_and_negative_avg(
 ) -> OperationResult<VectorInternal> {
     match (positive, negative) {
         (VectorInternal::Dense(positive), VectorInternal::Dense(negative)) => {
+            if positive.len() != negative.len() {
+                return Err(OperationError::WrongVectorDimension {
+                    expected_dim: positive.len(),
+                    received_dim: negative.len(),
+                });
+            }
             let vector: DenseVector = positive
                 .iter()
                 .zip(negative.iter())
@@ -405,6 +422,12 @@ mod test {
         );
 
         let vectors: Vec<VectorInternal> = vec![
+            VectorInternal::from(vec![1.0, 2.0, 3.0]),
+            VectorInternal::from(vec![1.0, 2.0, 3.0, 4.0]),
+        ];
+        assert!(avg_vectors(vectors.iter().map(VectorRef::from)).is_err());
+
+        let vectors: Vec<VectorInternal> = vec![
             SparseVector::new(vec![0, 1, 2], vec![0.0, 0.1, 0.2])
                 .unwrap()
                 .into(),
@@ -448,5 +471,18 @@ mod test {
         )
         .unwrap();
         assert_eq!(vector, vec![1.0, 0.0].into());
+    }
+
+    #[test]
+    fn test_avg_vector_for_recommendation_rejects_dense_dimension_mismatch() {
+        let positive = vec![VectorInternal::from(vec![1.0, 2.0, 3.0])];
+        let negative = vec![VectorInternal::from(vec![1.0, 2.0, 3.0, 4.0])];
+
+        let result = avg_vector_for_recommendation(
+            positive.iter().map(VectorRef::from),
+            negative.iter().map(VectorRef::from).peekable(),
+        );
+
+        assert!(result.is_err());
     }
 }

--- a/lib/shard/src/query/conversions.rs
+++ b/lib/shard/src/query/conversions.rs
@@ -427,12 +427,12 @@ impl From<QueryEnum> for grpc::QueryEnum {
             },
             QueryEnum::RecommendBestScore(named) => grpc::QueryEnum {
                 query: Some(grpc::query_enum::Query::RecommendBestScore(
-                    named.query.into(),
+                    grpc::RecoQuery::from(named.query),
                 )),
             },
             QueryEnum::RecommendSumScores(named) => grpc::QueryEnum {
                 query: Some(grpc::query_enum::Query::RecommendSumScores(
-                    named.query.into(),
+                    grpc::RecoQuery::from(named.query),
                 )),
             },
             QueryEnum::Discover(named) => grpc::QueryEnum {


### PR DESCRIPTION
## Summary
- reject dense positive/negative recommendation examples with mismatched dimensions during `average_vector` averaging
- prevent zip-based truncation from silently changing recommendation scores
- no API / proto / QueryEnum changes

## Review follow-up
- [AI] Updated the regression assertion to match `OperationError::WrongVectorDimension { expected_dim: 2, received_dim: 3 }` instead of only checking `is_err()`.

## Validation
- [AI] `cargo test -p segment --lib vector_storage::query::reco_query` — 13 passed
- [AI] `cargo test --workspace` — passed
- [AI] `cargo clippy --workspace --all-features` — passed
- [AI] `rustfmt --check lib/segment/src/vector_storage/query/reco_query.rs` — passed
- [AI] `git diff --check` — passed
- `cargo test --workspace --all-features` was attempted locally but could not complete because the Windows host lacks `VK_LAYER_KHRONOS_validation`; the affected recommendation test passed.
- `cargo fmt --all -- --check` reported an unrelated pre-existing import-order difference in `lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/on_disk_postings.rs`; no unrelated file was changed.

## AI contribution
- [AI] `d21b2d23c`: `test: assert recommendation dimension errors`
- Initial prompt for this follow-up: Fix the review comment on PR #10374 by asserting the specific recommendation dimension error and expected/received dimensions.

Fixes #10369