### PR TITLE
fix(strict-mode): enforce max query limit for default scrolls

### DIFF
--- a/lib/collection/src/operations/verification/local_shard.rs
+++ b/lib/collection/src/operations/verification/local_shard.rs
@@ -5,7 +5,7 @@ use crate::operations::types::PointRequestInternal;
 
 impl StrictModeVerification for ScrollRequestInternal {
     fn query_limit(&self) -> Option<usize> {
-        self.limit
+        self.limit.or(Some(ScrollRequestInternal::default_limit()))
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -398,6 +398,7 @@ mod test {
         Condition, FieldCondition, Filter, Match, PayloadFieldSchema, PayloadSchemaType,
         SearchParams, StrictModeConfig, ValueVariants,
     };
+    use shard::scroll::ScrollRequestInternal;
     use tempfile::Builder;
 
     use super::StrictModeVerification;
@@ -433,6 +434,16 @@ mod test {
     async fn test_query_limit(collection: &Collection) {
         assert_strict_mode_error(discover_fixture(Some(10), None, None), collection).await;
         assert_strict_mode_success(discover_fixture(Some(4), None, None), collection).await;
+
+        assert_strict_mode_error(ScrollRequestInternal::default(), collection).await;
+        assert_strict_mode_success(
+            ScrollRequestInternal {
+                limit: Some(4),
+                ..Default::default()
+            },
+            collection,
+        )
+        .await;
     }
 
     async fn test_filter_read(collection: &Collection) {


### PR DESCRIPTION
Fixes #10373

## Summary
- Validate the default scroll page size against strict mode `max_query_limit`.
- Keep explicit scroll limits unchanged and add regression coverage for default and explicit limits.

## Validation
- `cargo test -p collection test_strict_mode_verification_trait --lib --quiet`
- `cargo fmt -p collection -- --check`
- `cargo clippy -p collection --lib --quiet`
- `git diff --check`
