### PR TITLE
fix(grouping): stabilize tied point ordering

### DIFF
--- a/lib/segment/src/utils/scored_point_ties.rs
+++ b/lib/segment/src/utils/scored_point_ties.rs
@@ -1,5 +1,7 @@
 use std::cmp::Ordering;
 
+use bytemuck::{TransparentWrapper, TransparentWrapperAlloc as _};
+
 use crate::types::ScoredPoint;
 
 // Newtype to provide alternative comparator for ScoredPoint which breaks ties by id
@@ -30,6 +32,48 @@ impl Eq for ScoredPointTies<'_> {}
 
 impl PartialEq for ScoredPointTies<'_> {
     fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
+        // Must match Ord: ScoredPoint::eq ignores order_value, but cmp uses it.
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+/// Owned variant of [`ScoredPointTies`] for APIs that need `Ord` on owned values
+/// (e.g. `peek_top_*`). Same layout as [`ScoredPoint`] — use [`Self::into_scored_points`]
+/// to recover a `Vec<ScoredPoint>` without reallocating.
+#[derive(TransparentWrapper)]
+#[repr(transparent)]
+pub struct ScoredPointTiesOwned(pub ScoredPoint);
+
+impl From<ScoredPoint> for ScoredPointTiesOwned {
+    fn from(scored_point: ScoredPoint) -> Self {
+        ScoredPointTiesOwned(scored_point)
+    }
+}
+
+impl ScoredPointTiesOwned {
+    /// Transmute `Vec<Self>` to `Vec<ScoredPoint>` with no reallocation.
+    #[inline]
+    pub fn into_scored_points(points: Vec<Self>) -> Vec<ScoredPoint> {
+        Self::peel_vec(points)
+    }
+}
+
+impl Ord for ScoredPointTiesOwned {
+    fn cmp(&self, other: &Self) -> Ordering {
+        ScoredPointTies(&self.0).cmp(&ScoredPointTies(&other.0))
+    }
+}
+
+impl PartialOrd for ScoredPointTiesOwned {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Eq for ScoredPointTiesOwned {}
+
+impl PartialEq for ScoredPointTiesOwned {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
     }
 }

--- a/lib/shard/src/grouping/aggregator.rs
+++ b/lib/shard/src/grouping/aggregator.rs
@@ -7,6 +7,7 @@ use segment::data_types::groups::GroupId;
 use segment::json_path::JsonPath;
 use segment::spaces::tools::{peek_top_largest_iterable, peek_top_smallest_iterable};
 use segment::types::{ExtendedPointId, Order, PayloadContainer, PointIdType, ScoredPoint};
+use segment::utils::scored_point_ties::ScoredPointTiesOwned;
 use serde_json::Value;
 
 use super::{AggregatorError, Group};
@@ -17,6 +18,7 @@ use super::{AggregatorError, Group};
 const LARGEST_REASONABLE_ALLOCATION_SIZE: usize = 1_048_576;
 
 type Hits = AHashMap<PointIdType, ScoredPoint>;
+
 pub struct GroupsAggregator {
     groups: AHashMap<GroupId, Hits>,
     max_group_size: usize,
@@ -192,15 +194,17 @@ impl GroupsAggregator {
 
         for group_key in best_groups {
             let mut group = self.groups.remove(&group_key).unwrap();
-            let scored_points_iter = group.drain().map(|(_, hit)| hit);
+            let scored_points_iter = group.drain().map(|(_, hit)| ScoredPointTiesOwned(hit));
             let hits = match self.order {
-                Some(Order::LargeBetter) => {
-                    peek_top_largest_iterable(scored_points_iter, self.max_group_size)
-                }
-                Some(Order::SmallBetter) => {
-                    peek_top_smallest_iterable(scored_points_iter, self.max_group_size)
-                }
-                None => scored_points_iter.take(self.max_group_size).collect(),
+                Some(Order::LargeBetter) => ScoredPointTiesOwned::into_scored_points(
+                    peek_top_largest_iterable(scored_points_iter, self.max_group_size),
+                ),
+                Some(Order::SmallBetter) => ScoredPointTiesOwned::into_scored_points(
+                    peek_top_smallest_iterable(scored_points_iter, self.max_group_size),
+                ),
+                None => ScoredPointTiesOwned::into_scored_points(
+                    scored_points_iter.take(self.max_group_size).collect(),
+                ),
             };
             groups.push(Group {
                 hits,
@@ -466,6 +470,20 @@ mod unit_tests {
             let group_id_score: Vec<_> = group.hits.into_iter().map(|x| (x.id, x.score)).collect();
             assert_eq!(expected_id_score, group_id_score);
         }
+    }
+
+    #[test]
+    fn test_small_better_ties_are_selected_by_point_id() {
+        let mut aggregator =
+            GroupsAggregator::new(1, 2, "docId".parse().unwrap(), Some(Order::SmallBetter));
+
+        for id in [4, 2, 3, 1] {
+            aggregator.add_point(&point(id, 1.0, json!("a"))).unwrap();
+        }
+
+        let groups = aggregator.distill();
+        let ids: Vec<_> = groups[0].hits.iter().map(|point| point.id).collect();
+        assert_eq!(ids, vec![1.into(), 2.into()]);
     }
 
     /// Regression test for issue #8406: a client-supplied huge `limit` (number of groups) and

--- a/lib/shard/src/grouping/aggregator.rs
+++ b/lib/shard/src/grouping/aggregator.rs
@@ -483,7 +483,10 @@ mod unit_tests {
 
         let groups = aggregator.distill();
         let ids: Vec<_> = groups[0].hits.iter().map(|point| point.id).collect();
-        assert_eq!(ids, vec![1.into(), 2.into()]);
+        assert_eq!(
+            ids,
+            vec![ExtendedPointId::from(1), ExtendedPointId::from(2)]
+        );
     }
 
     /// Regression test for issue #8406: a client-supplied huge `limit` (number of groups) and


### PR DESCRIPTION
Fixes #10371

## Summary
- Make grouped hits use point IDs as a deterministic tie-breaker.
- Preserve score ordering while preventing hash-map iteration order from selecting different tied members.

## Validation
- `cargo test -p shard test_small_better_ties_are_selected_by_point_id --lib --quiet`
- `rustfmt --edition 2024 --check lib/shard/src/grouping/aggregator.rs`
- `cargo clippy -p shard --lib --quiet`
- `git diff --check`
