### PR TITLE
fix(strict-mode): enforce max_query_limit on scroll requests when limit is omitted

### DIFF
--- a/lib/collection/src/operations/verification/local_shard.rs
+++ b/lib/collection/src/operations/verification/local_shard.rs
@@ -5,7 +5,10 @@ use crate::operations::types::PointRequestInternal;
 
 impl StrictModeVerification for ScrollRequestInternal {
     fn query_limit(&self) -> Option<usize> {
-        Some(self.limit.unwrap_or_else(ScrollRequestInternal::default_limit))
+        Some(
+            self.limit
+                .unwrap_or_else(ScrollRequestInternal::default_limit),
+        )
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {

--- a/lib/collection/src/operations/verification/local_shard.rs
+++ b/lib/collection/src/operations/verification/local_shard.rs
@@ -5,7 +5,7 @@ use crate::operations::types::PointRequestInternal;
 
 impl StrictModeVerification for ScrollRequestInternal {
     fn query_limit(&self) -> Option<usize> {
-        self.limit
+        Some(self.limit.unwrap_or_else(ScrollRequestInternal::default_limit))
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -422,6 +422,7 @@ mod test {
         let collection = fixture().await;
 
         test_query_limit(&collection).await;
+        test_scroll_query_limit(&collection).await;
         test_search_params(&collection).await;
         test_filter_read(&collection).await;
         test_filter_write(&collection).await;
@@ -433,6 +434,43 @@ mod test {
     async fn test_query_limit(collection: &Collection) {
         assert_strict_mode_error(discover_fixture(Some(10), None, None), collection).await;
         assert_strict_mode_success(discover_fixture(Some(4), None, None), collection).await;
+    }
+
+    async fn test_scroll_query_limit(collection: &Collection) {
+        use shard::scroll::ScrollRequestInternal;
+
+        // Default limit (10) exceeds max_query_limit (4), so omitted limit should error
+        let request_omitted_limit = ScrollRequestInternal {
+            offset: None,
+            limit: None,
+            filter: None,
+            with_payload: None,
+            with_vector: Default::default(),
+            order_by: None,
+        };
+        assert_strict_mode_error(request_omitted_limit, collection).await;
+
+        // Explicit limit (10) exceeds max_query_limit (4)
+        let request_explicit_exceeding_limit = ScrollRequestInternal {
+            offset: None,
+            limit: Some(10),
+            filter: None,
+            with_payload: None,
+            with_vector: Default::default(),
+            order_by: None,
+        };
+        assert_strict_mode_error(request_explicit_exceeding_limit, collection).await;
+
+        // Explicit limit (4) matches max_query_limit (4)
+        let request_valid_limit = ScrollRequestInternal {
+            offset: None,
+            limit: Some(4),
+            filter: None,
+            with_payload: None,
+            with_vector: Default::default(),
+            order_by: None,
+        };
+        assert_strict_mode_success(request_valid_limit, collection).await;
     }
 
     async fn test_filter_read(collection: &Collection) {


### PR DESCRIPTION
### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---

### What does this PR do?

Fixes #10373.

When `strict_mode_config.max_query_limit` is configured (e.g. `max_query_limit: 5`), executing a `scroll` request with an omitted `limit` would bypass the limit check and return the built-in default of 10 points.

#### Root Cause:
`ScrollRequestInternal`'s `StrictModeVerification` implementation was returning `self.limit` (`Option<usize>`). When `limit` was omitted (`None`), `check_limit_opt` bypassed validation because `None` was treated as no limit specified, and the default (10) was only applied downstream during execution.

#### Solution:
Updated `ScrollRequestInternal::query_limit()` in `lib/collection/src/operations/verification/local_shard.rs` to materialize the default limit before strict-mode validation via:
```rust
Some(self.limit.unwrap_or_else(ScrollRequestInternal::default_limit))
```
This aligns `scroll` with the `query` / `search` endpoint families where default limits are checked against `max_query_limit`.

#### Tests Added:
- Added `test_scroll_query_limit` in `lib/collection/src/operations/verification/mod.rs` asserting that:
  - Omitted `limit` (defaulting to 10) is rejected when `max_query_limit` is 4.
  - Explicit `limit` exceeding `max_query_limit` is rejected.
  - Valid `limit` within `max_query_limit` succeeds.
