### PR TITLE
Fetch payload and vectors in scroll leaves only

### DIFF
--- a/lib/shard/src/query/planned_query.rs
+++ b/lib/shard/src/query/planned_query.rs
@@ -197,16 +197,25 @@ impl PlannedQuery {
             })),
         };
 
-        // Without rescoring the leaf is the final result: let it fetch payload
-        // and vectors itself instead of retrieving them again afterwards.
+        // A scroll leaf is the final result and retrieves payload and vectors once, for the
+        // merged page, so it can fetch them itself instead of resolving the ids again afterwards.
+        // A search leaf fetches them per segment before merging, which multiplies the I/O by
+        // the segment count, so it stays bare and the root plan retrieves for the final result.
+        // See: <https://github.com/qdrant/qdrant/pull/6279>
+        let leaf_fetches = match &query {
+            None | Some(ScoringQuery::OrderBy(_)) | Some(ScoringQuery::Sample(_)) => true,
+            Some(ScoringQuery::Vector(_))
+            | Some(ScoringQuery::Fusion(_))
+            | Some(ScoringQuery::Formula(_))
+            | Some(ScoringQuery::Mmr(_)) => false,
+        };
         let requested = (with_vector, with_payload);
         let nothing = (WithVector::from(false), WithPayloadInterface::from(false));
-        let ((leaf_with_vector, leaf_with_payload), (with_vector, with_payload)) =
-            if rescore_stages.is_none() {
-                (requested, nothing)
-            } else {
-                (nothing, requested)
-            };
+        let ((leaf_with_vector, leaf_with_payload), (with_vector, with_payload)) = if leaf_fetches {
+            (requested, nothing)
+        } else {
+            (nothing, requested)
+        };
 
         // Everything must come from a single source.
         let sources = vec![leaf_source_from_scoring_query(

--- a/lib/shard/src/query/tests.rs
+++ b/lib/shard/src/query/tests.rs
@@ -184,18 +184,18 @@ fn test_try_from_no_prefetch() {
             params: Some(SearchParams::default()),
             limit: 22,
             offset: 0,
-            with_vector: Some(WithVector::Bool(true)),
-            with_payload: Some(WithPayloadInterface::Bool(true)),
+            with_vector: Some(WithVector::Bool(false)),
+            with_payload: Some(WithPayloadInterface::Bool(false)),
             score_threshold: Some(0.5),
         }]
     );
 
-    // The leaf fetches payload and vectors, so the root plan does not.
+    // A search leaf fetches per segment, so the root plan retrieves for the merged result.
     assert_eq!(
         planned_query.root_plans,
         vec![RootPlan {
-            with_payload: WithPayloadInterface::Bool(false),
-            with_vector: WithVector::Bool(false),
+            with_payload: WithPayloadInterface::Bool(true),
+            with_vector: WithVector::Bool(true),
             merge_plan: MergePlan {
                 sources: vec![Source::SearchesIdx(0)],
                 rescore_stages: None,


### PR DESCRIPTION
Fix for the `integration-tests-consensus` failure on #10333: `test_payload_io_read_is_within_limit[query]` reads 7229 B instead of < 300 B.

## Why

`root_plan_without_prefetches` pushes `with_payload`/`with_vector` into the leaf for every no-rescore query. For a **search** leaf that ends up in `Segment::search_batch`, which hydrates every segment's local top-k *before* the merge — 50 segments × limit 10 = 500 payload reads for a 10-point result. This is the read amplification #6279 removed, and the test guards it.

**Scroll** leaves are different: `internal_scroll_by_id` / `internal_scroll_by_field` / `scroll_randomly` read ids (and order values) per segment, merge, `take(limit)`, and only then call `scroll_records` once for the final page. Pushing the fetch down there costs nothing extra and keeps the redundant id resolution out.

## Change

- The leaf fetches only for scroll-type queries (`None` / `OrderBy` / `Sample`); `Vector` / `Fusion` / `Formula` / `Mmr` leaves stay bare and the root plan retrieves for the merged result, as before.
- `test_try_from_no_prefetch` goes back to expecting a bare search leaf; the new MMR and scroll planner tests are unchanged.

Getting the same win for vector search would need internal offsets carried through the merge so the final points can be fetched without re-resolving — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUWh5PqUeSefrUqUwXxU3E
