### PR TITLE
fix(segment): don't retire live postings on a redundant map-index removal

### DIFF
--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/lifecycle.rs
@@ -153,17 +153,35 @@ where
     }
 
     /// Removes `idx` from values-to-points-container.
-    /// It is implemented by shrinking the range of values-to-points by one and moving the removed element
-    /// out of the range.
-    /// Previously last element is swapped with the removed one and then the range is shrank by one.
     ///
+    /// The posting itself stays in `value_to_points_container`; it is marked in
+    /// `deleted_value_to_points_container` so the read-side iterator skips it, and
+    /// the value's live-posting counter is shrunk by one.
+    ///
+    /// The shrink must happen **only when this call actually retired a live
+    /// posting**. `count` is not a hint: `get_mut_point_ids_slice` refuses a value
+    /// once it reaches zero, and reaching zero here drops the value's key from
+    /// `value_to_points` outright, which makes every *remaining* live posting of
+    /// that value unreachable through `get_iterator`. Shrinking on a call that
+    /// removed nothing therefore retires a slot that is still in use, and enough
+    /// of them silently delete a whole value from the index while the payload,
+    /// `point_to_values` and the posting container all still hold it.
+    ///
+    /// Two ways a call can remove nothing, both of which used to fall through to
+    /// the shrink (their `debug_assert!`s are compiled out in release builds, so
+    /// the corruption was silent in production):
+    ///
+    /// - `idx` holds no posting for `value` at all — the binary search misses.
+    /// - `idx`'s posting was already marked deleted by an earlier call, e.g. a
+    ///   point whose `point_to_values` entry lists the same value twice, so
+    ///   [`Self::remove_point`] visits it twice in one pass.
     ///
     /// Example:
     ///     Before:
     ///
     /// value_to_points -> {
-    ///     "a": 0..5,
-    ///     "b": 5..10
+    ///     "a": range 0..5, count 5
+    ///     "b": range 5..10, count 5
     /// }
     /// value_to_points_container -> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     ///
@@ -174,12 +192,13 @@ where
     /// After:
     ///
     /// value_to_points -> {
-    ///    "a": 0..4,
-    ///    "b": 5..10
+    ///    "a": range 0..5, count 4
+    ///    "b": range 5..10, count 5
     /// }
     ///
-    /// value_to_points_container -> [0, 1, 2, 4, (3), 5, 6, 7, 8, 9]
-    fn remove_idx_from_value_list(
+    /// value_to_points_container -> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    /// deleted_value_to_points_container -> [_, _, _, 1, _, _, _, _, _, _]
+    pub(super) fn remove_idx_from_value_list(
         value_to_points: &mut HashMap<<N as MapIndexKey>::Owned, ContainerSegment>,
         value_to_points_container: &mut [PointOffsetType],
         deleted_value_to_points_container: &mut BitVec,
@@ -189,21 +208,28 @@ where
         let Some((values, offset)) =
             Self::get_mut_point_ids_slice(value_to_points, value_to_points_container, value)
         else {
-            debug_assert!(false, "value {value} not found in value_to_points");
+            // The value is already fully retired, nothing to shrink.
             return;
         };
 
         // Finds the index of `idx` in values-to-points map which we want to remove
         // We mark it as removed in deleted flags
-        if let Ok(local_pos) = values.binary_search(&idx) {
-            let pos = offset + local_pos;
+        let Ok(local_pos) = values.binary_search(&idx) else {
+            // `idx` never had a posting for this value.
+            return;
+        };
 
-            if deleted_value_to_points_container.len() < pos + 1 {
-                deleted_value_to_points_container.resize(pos + 1, false);
-            }
+        let pos = offset + local_pos;
 
-            let did_exist = !deleted_value_to_points_container.replace(pos, true);
-            debug_assert!(did_exist, "value {value} was already deleted");
+        if deleted_value_to_points_container.len() < pos + 1 {
+            deleted_value_to_points_container.resize(pos + 1, false);
+        }
+
+        let did_exist = !deleted_value_to_points_container.replace(pos, true);
+        if !did_exist {
+            // Already retired by an earlier call; shrinking again would retire a
+            // slot that is still live.
+            return;
         }
 
         if Self::shrink_value_range(value_to_points, value) {

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/mod.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/mod.rs
@@ -13,6 +13,8 @@ use crate::index::field_index::immutable_point_to_values::ImmutablePointToValues
 mod lifecycle;
 mod live_reload;
 mod read_ops;
+#[cfg(test)]
+mod tests;
 
 pub struct ImmutableMapIndex<N, S = MmapFile>
 where

--- a/lib/segment/src/index/field_index/map_index/immutable_map_index/tests.rs
+++ b/lib/segment/src/index/field_index/map_index/immutable_map_index/tests.rs
@@ -1,0 +1,120 @@
+use bitvec::vec::BitVec;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::types::PointOffsetType;
+use common::universal_io::MmapFile;
+use serde_json::Value;
+use tempfile::Builder;
+
+use super::ImmutableMapIndex;
+use crate::index::field_index::FieldIndexBuilderTrait as _;
+use crate::index::field_index::map_index::MapIndex;
+use crate::index::field_index::map_index::read_ops::MapIndexRead as _;
+use crate::types::Memory;
+
+/// Build an immutable keyword map index where every point in `points` carries
+/// `value`, then hand back the concrete `ImmutableMapIndex` so the counter
+/// bookkeeping can be exercised directly.
+fn immutable_index_with(
+    points: &[PointOffsetType],
+    value: &str,
+) -> (tempfile::TempDir, ImmutableMapIndex<str, MmapFile>) {
+    let dir = Builder::new().prefix("immutable_map").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let deleted = BitVec::repeat(false, 1024);
+
+    let mut builder = MapIndex::<str>::builder_immutable(dir.path(), false, &deleted, false);
+    builder.init().unwrap();
+    for &point in points {
+        let json = Value::String(value.to_owned());
+        builder.add_point(point, &[&json], &hw_counter).unwrap();
+    }
+    builder.finalize().unwrap();
+
+    let index = MapIndex::<str>::new_immutable(dir.path(), Memory::Pinned, &deleted)
+        .unwrap()
+        .unwrap();
+    match index {
+        MapIndex::Immutable(index) => (dir, index),
+        MapIndex::Mutable(_) | MapIndex::OnDisk(_) => panic!("expected an immutable map index"),
+    }
+}
+
+fn postings(index: &ImmutableMapIndex<str, MmapFile>, value: &str) -> Vec<PointOffsetType> {
+    let hw_counter = HardwareCounterCell::new();
+    let mut ids: Vec<_> = index.get_iterator(value, &hw_counter).collect();
+    ids.sort_unstable();
+    ids
+}
+
+/// A removal that retires nothing must not shrink the value's live-posting
+/// counter.
+///
+/// `ContainerSegment::count` is not a hint: `get_mut_point_ids_slice` refuses a
+/// value once it hits zero, and reaching zero drops the value's key from
+/// `value_to_points` altogether. So an over-removal that still decrements
+/// retires a slot belonging to some *other*, still-live point, and enough of
+/// them delete a whole value from the index — while the payload storage,
+/// `point_to_values` and the posting container all still hold it.
+///
+/// That is the shape of the reported corruption: an unfiltered `scroll` returns
+/// the points, a `MatchValue` on the indexed field returns none of them, and
+/// rebuilding the index restores consistency.
+/// See <https://github.com/qdrant/qdrant/issues/10302>.
+#[test]
+fn redundant_removal_does_not_retire_live_postings() {
+    let (_dir, mut index) = immutable_index_with(&[0, 1, 2], "src");
+
+    assert_eq!(postings(&index, "src"), vec![0, 1, 2]);
+
+    // One genuine removal: point 0 goes, 1 and 2 stay.
+    index.remove_point(0).unwrap();
+    assert_eq!(postings(&index, "src"), vec![1, 2]);
+
+    // Two removals that retire nothing: point 0's posting is already marked
+    // deleted, and point 7 never had one. Neither may consume a live slot.
+    for _ in 0..2 {
+        ImmutableMapIndex::<str, MmapFile>::remove_idx_from_value_list(
+            &mut index.value_to_points,
+            &mut index.value_to_points_container,
+            &mut index.deleted_value_to_points_container,
+            "src",
+            0,
+        );
+        ImmutableMapIndex::<str, MmapFile>::remove_idx_from_value_list(
+            &mut index.value_to_points,
+            &mut index.value_to_points_container,
+            &mut index.deleted_value_to_points_container,
+            "src",
+            7,
+        );
+    }
+
+    assert_eq!(
+        postings(&index, "src"),
+        vec![1, 2],
+        "redundant removals retired live postings: the value became unreachable \
+         through the index while its points still hold it",
+    );
+    let hw_counter = HardwareCounterCell::new();
+    assert_eq!(
+        index.get_count_for_value("src", &hw_counter),
+        Some(2),
+        "live-posting counter drifted below the number of live postings",
+    );
+}
+
+/// `live_reload` replays a deleted-point set into an already-loaded index
+/// (`live_reload.rs`), so the same point id can be presented more than once.
+/// Replaying it must be idempotent rather than eroding unrelated postings.
+#[test]
+fn repeated_remove_point_is_idempotent() {
+    let (_dir, mut index) = immutable_index_with(&[0, 1, 2, 3], "src");
+
+    for _ in 0..3 {
+        index.remove_point(1).unwrap();
+    }
+
+    assert_eq!(postings(&index, "src"), vec![0, 2, 3]);
+    let hw_counter = HardwareCounterCell::new();
+    assert_eq!(index.get_count_for_value("src", &hw_counter), Some(3));
+}


### PR DESCRIPTION
Relates to #10302. `ImmutableMapIndex::remove_idx_from_value_list` shrinks a value's live-posting counter unconditionally, including on calls that retire nothing. Two such calls were anticipated by the code itself and guarded only by `debug_assert!`, so in release builds they were silent: `idx` holds no posting for the value because the binary search misses, or `idx`'s posting was already marked deleted by an earlier call, which happens when a point's `point_to_values` entry lists the same value twice and `remove_point` visits it twice in one pass.

That counter is not a hint. `get_mut_point_ids_slice` refuses a value once it reaches zero, and reaching zero drops the value's key from `value_to_points` outright, so every remaining live posting for that value becomes unreachable through `get_iterator`. A shrink on a call that removed nothing therefore retires a slot belonging to a still-live point, and enough of them delete a whole value from the index while the payload storage, `point_to_values` and the posting container all still hold it. This shrinks only when the call actually retired a live posting. `redundant_removal_does_not_retire_live_postings` covers it and fails without the change, reporting the value as unreachable while points 1 and 2 still hold it.
