### PR TITLE
storage: reject standalone replica snapshot recovery

### DIFF
--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -108,6 +108,8 @@ async fn _do_recover_from_snapshot(
     let pass = new_unchecked_verification_pass();
 
     let toc = dispatcher.toc(&auth, &pass);
+    let priority = priority.unwrap_or_default();
+    validate_snapshot_priority(priority, toc.is_distributed())?;
 
     // Measure this scope for metrics/telemetry.
     // (This must be a named variable so it doesn't get dropped prematurely!)
@@ -269,8 +271,6 @@ async fn _do_recover_from_snapshot(
             Some(_) | None => {} // Shard is not on this node, skip
         }
     }
-
-    let priority = priority.unwrap_or_default();
 
     // Recover shards from the snapshot
     for (shard_id, shard_info) in &state.shards {
@@ -438,4 +438,41 @@ async fn _do_recover_from_snapshot(
     tokio_fs::remove_dir_all(&tmp_collection_dir).await?;
 
     Ok(true)
+}
+
+/// Reject priorities that cannot be honored by the current deployment topology.
+fn validate_snapshot_priority(
+    priority: SnapshotPriority,
+    is_distributed: bool,
+) -> Result<(), StorageError> {
+    if !is_distributed && matches!(priority, SnapshotPriority::Replica) {
+        return Err(StorageError::bad_request(
+            "Snapshot recovery with `replica` priority is not supported in standalone mode",
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replica_priority_requires_distributed_mode() {
+        let error = validate_snapshot_priority(SnapshotPriority::Replica, false).unwrap_err();
+
+        assert!(matches!(
+            error,
+            StorageError::BadRequest { description }
+                if description == "Snapshot recovery with `replica` priority is not supported in standalone mode"
+        ));
+        assert!(validate_snapshot_priority(SnapshotPriority::Replica, true).is_ok());
+    }
+
+    #[test]
+    fn other_priorities_remain_supported_in_standalone_mode() {
+        assert!(validate_snapshot_priority(SnapshotPriority::NoSync, false).is_ok());
+        assert!(validate_snapshot_priority(SnapshotPriority::Snapshot, false).is_ok());
+    }
 }

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -109,7 +109,23 @@ async fn _do_recover_from_snapshot(
 
     let toc = dispatcher.toc(&auth, &pass);
     let priority = priority.unwrap_or_default();
-    validate_snapshot_priority(priority, toc.is_distributed())?;
+    let this_peer_id = toc.this_peer_id;
+
+    if let Ok(collection) = toc.get_collection(&collection_pass).await {
+        let state = collection.state().await;
+        let all_local_shards_have_other_active_replicas = state.shards.values().all(|shard_info| {
+            !shard_info.replicas.contains_key(&this_peer_id)
+                || shard_info.replicas.iter().any(|(&peer_id, &state)| {
+                    peer_id != this_peer_id
+                        && matches!(
+                            state,
+                            ReplicaState::Active | ReplicaState::ReshardingScaleDown
+                        )
+                })
+        });
+
+        validate_snapshot_priority(priority, all_local_shards_have_other_active_replicas)?;
+    }
 
     // Measure this scope for metrics/telemetry.
     // (This must be a named variable so it doesn't get dropped prematurely!)
@@ -117,8 +133,6 @@ async fn _do_recover_from_snapshot(
         .snapshot_telemetry_collector(collection_pass.name())
         .running_snapshot_recovery
         .measure_scope();
-
-    let this_peer_id = toc.this_peer_id;
 
     let is_distributed = toc.is_distributed();
 
@@ -443,11 +457,11 @@ async fn _do_recover_from_snapshot(
 /// Reject priorities that cannot be honored by the current deployment topology.
 fn validate_snapshot_priority(
     priority: SnapshotPriority,
-    is_distributed: bool,
+    has_other_active_replicas: bool,
 ) -> Result<(), StorageError> {
-    if !is_distributed && matches!(priority, SnapshotPriority::Replica) {
+    if !has_other_active_replicas && matches!(priority, SnapshotPriority::Replica) {
         return Err(StorageError::bad_request(
-            "Snapshot recovery with `replica` priority is not supported in standalone mode",
+            "Snapshot recovery with `replica` priority requires another active replica",
         ));
     }
 
@@ -459,13 +473,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn replica_priority_requires_distributed_mode() {
+    fn replica_priority_requires_another_active_replica() {
         let error = validate_snapshot_priority(SnapshotPriority::Replica, false).unwrap_err();
 
         assert!(matches!(
             error,
             StorageError::BadRequest { description }
-                if description == "Snapshot recovery with `replica` priority is not supported in standalone mode"
+                if description == "Snapshot recovery with `replica` priority requires another active replica"
         ));
         assert!(validate_snapshot_priority(SnapshotPriority::Replica, true).is_ok());
     }

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -112,19 +112,7 @@ async fn _do_recover_from_snapshot(
     let this_peer_id = toc.this_peer_id;
 
     if let Ok(collection) = toc.get_collection(&collection_pass).await {
-        let state = collection.state().await;
-        let all_local_shards_have_other_active_replicas = state.shards.values().all(|shard_info| {
-            !shard_info.replicas.contains_key(&this_peer_id)
-                || shard_info.replicas.iter().any(|(&peer_id, &state)| {
-                    peer_id != this_peer_id
-                        && matches!(
-                            state,
-                            ReplicaState::Active | ReplicaState::ReshardingScaleDown
-                        )
-                })
-        });
-
-        validate_snapshot_priority(priority, all_local_shards_have_other_active_replicas)?;
+        validate_snapshot_priority_for_collection(priority, &collection, this_peer_id).await?;
     }
 
     // Measure this scope for metrics/telemetry.
@@ -228,6 +216,10 @@ async fn _do_recover_from_snapshot(
             toc.get_collection(&collection_pass).await?
         }
     };
+
+    // The collection may have been created after the initial lookup. Revalidate its topology
+    // before changing any shard state.
+    validate_snapshot_priority_for_collection(priority, &collection, this_peer_id).await?;
 
     let state = collection.state().await;
 
@@ -455,6 +447,26 @@ async fn _do_recover_from_snapshot(
 }
 
 /// Reject priorities that cannot be honored by the current deployment topology.
+async fn validate_snapshot_priority_for_collection(
+    priority: SnapshotPriority,
+    collection: &Collection,
+    this_peer_id: PeerId,
+) -> Result<(), StorageError> {
+    let state = collection.state().await;
+    let all_local_shards_have_other_active_replicas = state.shards.values().all(|shard_info| {
+        !shard_info.replicas.contains_key(&this_peer_id)
+            || shard_info.replicas.iter().any(|(&peer_id, &state)| {
+                peer_id != this_peer_id
+                    && matches!(
+                        state,
+                        ReplicaState::Active | ReplicaState::ReshardingScaleDown
+                    )
+            })
+    });
+
+    validate_snapshot_priority(priority, all_local_shards_have_other_active_replicas)
+}
+
 fn validate_snapshot_priority(
     priority: SnapshotPriority,
     has_other_active_replicas: bool,


### PR DESCRIPTION
## Summary

Snapshot recovery with `priority: "replica"` cannot be honored when the current collection has no other active replica to use as the source of truth. Without validation, the fallback can restore and activate the snapshot after destroying the current shard data.

Reject this combination before downloading or mutating an already-resolved collection when no other active replica is available, including degraded clusters where a failure leaves only one active replica. The topology is now revalidated after the final collection lookup as well, closing the race where a collection is created between the initial lookup and recovery mutation.

Fixes #10368

## Implementation

- Reuse a collection-level topology validation helper for the initial pre-download check.
- Revalidate the resolved collection immediately before checking compatibility or changing shard state.
- Keep distributed recovery with another active or resharding-scale-down replica and all other priority behaviors unchanged.

This does not change the public API shape. Unsupported `replica` recovery now returns the existing bad-request error before destructive shard-state changes.

## Tests

- `rustfmt --edition 2024 --check lib/storage/src/content_manager/snapshots/recover.rs` (passed)
- `cargo test -p storage content_manager::snapshots::recover::tests --lib` (2 passed)
- `cargo test -p storage --lib` (104 passed)
- `cargo clippy -p storage --lib --no-deps -- -D warnings` (passed)
- `git diff --check` (passed)

`cargo fmt --all -- --check` was not used as the final formatter check because the recovered source archive contains pre-existing formatting differences in unrelated files; the required single-file formatter check passed. End-to-end cluster recovery tests were not run because this change is covered by the topology validation path and the repository's existing storage unit-test target.