### PR TITLE
Fix TurboQuantizer::quantized_size double-padding for Bits1_5

### DIFF
--- a/lib/quantization/src/turboquant/encoding.rs
+++ b/lib/quantization/src/turboquant/encoding.rs
@@ -171,7 +171,10 @@ impl TurboQuantizer {
 
     /// Size in bytes of a vector quantized by this quantizer.
     pub fn quantized_size(&self) -> usize {
-        Self::quantized_size_for(self.padded_dim, self.bits, self.distance, self.mode)
+        // `self.padded_dim` is already padded; `quantized_size_for` pads its
+        // input again, which is not idempotent for `Bits1_5` (x1.5 twice).
+        let vector_data_size = self.padded_dim * self.bits.bit_size() as usize / u8::BITS as usize;
+        vector_data_size + TqVectorExtras::size_for(self.bits, self.distance, self.mode)
     }
 
     /// Total size in bytes of a quantized vector, including both the packed

--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -728,7 +728,7 @@ mod tests {
     #[test]
     fn quantize_output_byte_length() {
         let dims = [64, 128, 300, 384, 512, 768, 1024, 1536];
-        let bit_widths = [TQBits::Bits1, TQBits::Bits2, TQBits::Bits4];
+        let bit_widths = [TQBits::Bits1, TQBits::Bits1_5, TQBits::Bits2, TQBits::Bits4];
 
         for &bits in &bit_widths {
             for &dim in &dims {


### PR DESCRIPTION
A tricky bug, there is a possibility to apply padding function twice. For 1.5bit TQ it's a problem, because it multiplies dim 1.5x twice.

Note. It's a safety PR, it does not affect released version because the bug scenario works on TQDT, where we have 4bit quantization only.

Found in tests while reworking SIMD kernels for TQ.