### PR TITLE
Turbo4 dotprod batch

### DIFF
--- a/lib/quantization/benches/turbo_simd.rs
+++ b/lib/quantization/benches/turbo_simd.rs
@@ -277,6 +277,28 @@ fn dotprod_scan<const PLANES: usize, const QUERY_BYTES: usize>(
                 black_box(&out);
             });
         });
+
+        // Per-backend rows, so the batch kernels can be compared on one host.
+        #[cfg(target_arch = "x86_64")]
+        {
+            if std::is_x86_feature_detected!("avx512f")
+                && std::is_x86_feature_detected!("avx512bw")
+                && std::is_x86_feature_detected!("avx512vnni")
+            {
+                group.bench_with_input(BenchmarkId::new("batch_avx512_vnni", dim), &dim, |b, _| {
+                    let mut out = vec![0.0f32; SCAN_RUN];
+                    let mut cursor = 0usize;
+                    b.iter(|| {
+                        let run = pool.run(cursor, SCAN_RUN);
+                        cursor = cursor.wrapping_add(1);
+                        unsafe {
+                            query.dotprod_batch_avx512_vnni(black_box(run), stride, &mut out)
+                        };
+                        black_box(&out);
+                    });
+                });
+            }
+        }
     }
     group.finish();
 }

--- a/lib/quantization/benches/turbo_simd.rs
+++ b/lib/quantization/benches/turbo_simd.rs
@@ -94,6 +94,14 @@ impl VectorPool {
         let idx = self.indices[cursor % self.indices.len()] as usize;
         &self.buf[idx * self.packed_bytes..(idx + 1) * self.packed_bytes]
     }
+
+    /// The `run_idx`-th run of `len` consecutive vectors, in storage order.
+    #[inline]
+    fn run(&self, run_idx: usize, len: usize) -> &[u8] {
+        let run_bytes = len * self.packed_bytes;
+        let start = (run_idx % (self.indices.len() / len)) * run_bytes;
+        &self.buf[start..start + run_bytes]
+    }
 }
 
 fn make_query(dim: usize) -> Vec<f32> {
@@ -219,6 +227,78 @@ fn bench_dotprod_cold(c: &mut Criterion) {
     dotprod_cold::<4, 2>(c, "query2bit_dotprod_cold", DIMS_2BIT);
     dotprod_cold::<8, 1>(c, "query1bit_dotprod_cold", DIMS_1BIT);
     dotprod_cold::<8, 2>(c, "query1bit_wide_dotprod_cold", DIMS_1BIT);
+}
+
+/// Vectors per `dotprod_batch` call in the scan benchmark — the scoring
+/// chunk of an exhaustive search.
+const SCAN_RUN: usize = 512;
+
+/// Sequential-scan benchmark at the width packing `PLANES` codes per byte:
+/// a hot query against a contiguous pool ≫ cache, scored in runs of
+/// [`SCAN_RUN`] consecutive vectors — the shape of an exhaustive search over
+/// a segment, streaming from DRAM.  Vectors sit at the TurboQuant stride
+/// (packed codes plus an `f32` of extras).  `per_vector` calls `dotprod` on
+/// every vector of the run; `batch` hands the whole run to `dotprod_batch`.
+fn dotprod_scan<const PLANES: usize, const QUERY_BYTES: usize>(
+    c: &mut Criterion,
+    group: &str,
+    default_dims: &[usize],
+) {
+    let mut group = c.benchmark_group(group);
+    for dim in dims(default_dims) {
+        let q = make_query(dim);
+        let query = QuerySimd::<PLANES, QUERY_BYTES>::new(&q);
+        let packed_bytes = dim / PLANES;
+        let stride = packed_bytes + size_of::<f32>();
+        let pool = VectorPool::with_packed_bytes(stride, 7);
+
+        group.throughput(Throughput::Elements((SCAN_RUN * dim) as u64));
+
+        group.bench_with_input(BenchmarkId::new("per_vector", dim), &dim, |b, _| {
+            let mut out = vec![0.0f32; SCAN_RUN];
+            let mut cursor = 0usize;
+            b.iter(|| {
+                let run = pool.run(cursor, SCAN_RUN);
+                cursor = cursor.wrapping_add(1);
+                for (v, out) in out.iter_mut().enumerate() {
+                    *out = query.dotprod(&run[v * stride..][..packed_bytes]);
+                }
+                black_box(&out);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("batch", dim), &dim, |b, _| {
+            let mut out = vec![0.0f32; SCAN_RUN];
+            let mut cursor = 0usize;
+            b.iter(|| {
+                let run = pool.run(cursor, SCAN_RUN);
+                cursor = cursor.wrapping_add(1);
+                query.dotprod_batch(black_box(run), stride, &mut out);
+                black_box(&out);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Scan dims: powers of two plus each width's odd-block-count dim with a
+/// maximal tail (see `DIMS_{4,2,1}BIT`).
+fn bench_dotprod_scan(c: &mut Criterion) {
+    dotprod_scan::<2, 2>(
+        c,
+        "query4bit_dotprod_scan",
+        &[64, 128, 256, 512, 1024, 1534, 1536],
+    );
+    dotprod_scan::<4, 2>(
+        c,
+        "query2bit_dotprod_scan",
+        &[64, 128, 256, 512, 1024, 1532, 1536],
+    );
+    dotprod_scan::<8, 1>(
+        c,
+        "query1bit_dotprod_scan",
+        &[64, 128, 256, 512, 1024, 1528, 1536],
+    );
 }
 
 /// Benchmarks [`score_4bit_internal`] (both vectors already PQ-encoded, both
@@ -593,6 +673,7 @@ fn bench_score_2bit_cold(c: &mut Criterion) {
 criterion_group!(
     benches,
     bench_dotprod_cold,
+    bench_dotprod_scan,
     bench_score_cold,
     bench_score_2bit_cold,
     bench_score_1bit_cold,

--- a/lib/quantization/benches/turbo_simd.rs
+++ b/lib/quantization/benches/turbo_simd.rs
@@ -281,6 +281,19 @@ fn dotprod_scan<const PLANES: usize, const QUERY_BYTES: usize>(
         // Per-backend rows, so the batch kernels can be compared on one host.
         #[cfg(target_arch = "x86_64")]
         {
+            if std::is_x86_feature_detected!("avx2") {
+                group.bench_with_input(BenchmarkId::new("batch_avx2", dim), &dim, |b, _| {
+                    let mut out = vec![0.0f32; SCAN_RUN];
+                    let mut cursor = 0usize;
+                    b.iter(|| {
+                        let run = pool.run(cursor, SCAN_RUN);
+                        cursor = cursor.wrapping_add(1);
+                        unsafe { query.dotprod_batch_avx2(black_box(run), stride, &mut out) };
+                        black_box(&out);
+                    });
+                });
+            }
+
             if std::is_x86_feature_detected!("avx512f")
                 && std::is_x86_feature_detected!("avx512bw")
                 && std::is_x86_feature_detected!("avx512vnni")

--- a/lib/quantization/benches/turbo_simd.rs
+++ b/lib/quantization/benches/turbo_simd.rs
@@ -312,6 +312,33 @@ fn dotprod_scan<const PLANES: usize, const QUERY_BYTES: usize>(
                 });
             }
         }
+
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            group.bench_with_input(BenchmarkId::new("batch_neon", dim), &dim, |b, _| {
+                let mut out = vec![0.0f32; SCAN_RUN];
+                let mut cursor = 0usize;
+                b.iter(|| {
+                    let run = pool.run(cursor, SCAN_RUN);
+                    cursor = cursor.wrapping_add(1);
+                    unsafe { query.dotprod_batch_neon(black_box(run), stride, &mut out) };
+                    black_box(&out);
+                });
+            });
+
+            if std::arch::is_aarch64_feature_detected!("dotprod") {
+                group.bench_with_input(BenchmarkId::new("batch_neon_sdot", dim), &dim, |b, _| {
+                    let mut out = vec![0.0f32; SCAN_RUN];
+                    let mut cursor = 0usize;
+                    b.iter(|| {
+                        let run = pool.run(cursor, SCAN_RUN);
+                        cursor = cursor.wrapping_add(1);
+                        unsafe { query.dotprod_batch_neon_sdot(black_box(run), stride, &mut out) };
+                        black_box(&out);
+                    });
+                });
+            }
+        }
     }
     group.finish();
 }

--- a/lib/quantization/src/turboquant/simd/query/arm.rs
+++ b/lib/quantization/src/turboquant/simd/query/arm.rs
@@ -7,7 +7,7 @@
 
 use core::arch::aarch64::*;
 
-use super::{Code, PLANE_BLOCK, QueryPlanes, QuerySimd, encoding};
+use super::{Code, PLANE_BLOCK, QueryPlanes, QuerySimd, encoding, tail_block};
 
 /// Packed data bytes per NEON block: one 128-bit register of codes.
 const BLOCK_128: usize = 16;
@@ -223,8 +223,7 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
             if tail > 0 {
                 let offset = full_blocks * BLOCK_128;
                 let query = QueryBlock128::load(&self.planes, offset);
-                let mut block = [0u8; BLOCK_128];
-                std::ptr::copy_nonoverlapping(data.add(offset), block.as_mut_ptr(), tail);
+                let block = tail_block::<BLOCK_128>(data.add(offset), tail);
                 acc.accumulate_mull(vld1q_u8(block.as_ptr()), query);
             }
 
@@ -276,8 +275,7 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
             if tail > 0 {
                 let offset = full_blocks * BLOCK_128;
                 let query = QueryBlock128::load(&self.planes, offset);
-                let mut block = [0u8; BLOCK_128];
-                std::ptr::copy_nonoverlapping(data.add(offset), block.as_mut_ptr(), tail);
+                let block = tail_block::<BLOCK_128>(data.add(offset), tail);
                 acc.accumulate_sdot(vld1q_u8(block.as_ptr()), query);
             }
 

--- a/lib/quantization/src/turboquant/simd/query/arm.rs
+++ b/lib/quantization/src/turboquant/simd/query/arm.rs
@@ -199,35 +199,77 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
             self.vector_bytes,
         );
 
-        unsafe { Self::reduce_neon(self.accumulate_neon(vector.as_ptr())) }
+        unsafe {
+            let [acc] = self.accumulate_neon::<1>(vector.as_ptr(), 0);
+            Self::reduce_neon(acc)
+        }
+    }
+
+    /// Batch counterpart of [`Self::dotprod_raw_neon`] with the float
+    /// reconstruction applied — see `dotprod_batch` for the layout contract
+    /// (asserted there).  Same grouping policy as
+    /// [`Self::dotprod_batch_neon_sdot`].
+    ///
+    /// # Safety
+    /// `data` must hold `out.len()` vectors at `stride`.
+    #[target_feature(enable = "neon")]
+    pub unsafe fn dotprod_batch_neon(&self, data: &[u8], stride: usize, out: &mut [f32]) {
+        unsafe {
+            let mut v = 0;
+            if self.vector_bytes <= INTERLEAVE_MAX_BYTES {
+                let (groups, _) = out.as_chunks_mut::<GROUP_128>();
+                for group in groups {
+                    let accs =
+                        self.accumulate_neon::<GROUP_128>(data.as_ptr().add(v * stride), stride);
+                    for (out, acc) in group.iter_mut().zip(accs) {
+                        *out = self.postprocess(Self::reduce_neon(acc));
+                    }
+                    v += GROUP_128;
+                }
+            }
+            for out in &mut out[v..] {
+                let [acc] = self.accumulate_neon::<1>(data.as_ptr().add(v * stride), stride);
+                *out = self.postprocess(Self::reduce_neon(acc));
+                v += 1;
+            }
+        }
     }
 
     /// [`Self::accumulate_neon_sdot`] for CPUs without `dotprod`.
     ///
     /// # Safety
-    /// `data` must be readable for `self.vector_bytes` bytes.
+    /// `data` must be readable for `(N - 1) * stride + self.vector_bytes`
+    /// bytes.
     #[inline]
     #[target_feature(enable = "neon")]
-    unsafe fn accumulate_neon(&self, data: *const u8) -> Acc128<QUERY_BYTES> {
+    unsafe fn accumulate_neon<const N: usize>(
+        &self,
+        data: *const u8,
+        stride: usize,
+    ) -> [Acc128<QUERY_BYTES>; N] {
         unsafe {
-            let mut acc = Acc128::zero();
+            let mut accs = [Acc128::zero(); N];
 
             let full_blocks = self.vector_bytes / BLOCK_128;
             for block in 0..full_blocks {
                 let offset = block * BLOCK_128;
                 let query = QueryBlock128::load(&self.planes, offset);
-                acc.accumulate_mull(vld1q_u8(data.add(offset)), query);
+                for (v, acc) in accs.iter_mut().enumerate() {
+                    acc.accumulate_mull(vld1q_u8(data.add(v * stride + offset)), query);
+                }
             }
 
             let tail = self.vector_bytes % BLOCK_128;
             if tail > 0 {
                 let offset = full_blocks * BLOCK_128;
                 let query = QueryBlock128::load(&self.planes, offset);
-                let block = tail_block::<BLOCK_128>(data.add(offset), tail);
-                acc.accumulate_mull(vld1q_u8(block.as_ptr()), query);
+                for (v, acc) in accs.iter_mut().enumerate() {
+                    let block = tail_block::<BLOCK_128>(data.add(v * stride + offset), tail);
+                    acc.accumulate_mull(vld1q_u8(block.as_ptr()), query);
+                }
             }
 
-            acc
+            accs
         }
     }
 
@@ -250,36 +292,85 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
             self.vector_bytes,
         );
 
-        unsafe { Self::reduce_neon(self.accumulate_neon_sdot(vector.as_ptr())) }
+        unsafe {
+            let [acc] = self.accumulate_neon_sdot::<1>(vector.as_ptr(), 0);
+            Self::reduce_neon(acc)
+        }
     }
 
-    /// Block loop of the SDOT kernels over the vector at `data`.
+    /// Batch counterpart of [`Self::dotprod_raw_neon_sdot`] with the float
+    /// reconstruction applied — see `dotprod_batch` for the layout contract
+    /// (asserted there).
+    ///
+    /// Vectors up to [`INTERLEAVE_MAX_BYTES`] are scored in groups of
+    /// [`GROUP_128`]: the group shares each query block load, and its
+    /// independent accumulators keep the multi-cycle `SDOT` latency off the
+    /// critical path.  Longer vectors keep the one-vector-at-a-time walk so
+    /// the hardware prefetcher sees a single sequential stream.
+    ///
+    /// # Safety
+    /// CPU must support `dotprod`; `data` must hold `out.len()` vectors at
+    /// `stride`.
+    #[target_feature(enable = "neon,dotprod")]
+    pub unsafe fn dotprod_batch_neon_sdot(&self, data: &[u8], stride: usize, out: &mut [f32]) {
+        unsafe {
+            let mut v = 0;
+            if self.vector_bytes <= INTERLEAVE_MAX_BYTES {
+                let (groups, _) = out.as_chunks_mut::<GROUP_128>();
+                for group in groups {
+                    let accs = self
+                        .accumulate_neon_sdot::<GROUP_128>(data.as_ptr().add(v * stride), stride);
+                    for (out, acc) in group.iter_mut().zip(accs) {
+                        *out = self.postprocess(Self::reduce_neon(acc));
+                    }
+                    v += GROUP_128;
+                }
+            }
+            for out in &mut out[v..] {
+                let [acc] = self.accumulate_neon_sdot::<1>(data.as_ptr().add(v * stride), stride);
+                *out = self.postprocess(Self::reduce_neon(acc));
+                v += 1;
+            }
+        }
+    }
+
+    /// Block loop of the SDOT kernels over `N` vectors stored `stride` bytes
+    /// apart starting at `data`.  Every query block is loaded once and folded
+    /// into all `N` accumulator sets.
     ///
     /// # Safety
     /// CPU must support `dotprod`; `data` must be readable for
-    /// `self.vector_bytes` bytes.
+    /// `(N - 1) * stride + self.vector_bytes` bytes.
     #[inline]
     #[target_feature(enable = "neon,dotprod")]
-    unsafe fn accumulate_neon_sdot(&self, data: *const u8) -> Acc128<QUERY_BYTES> {
+    unsafe fn accumulate_neon_sdot<const N: usize>(
+        &self,
+        data: *const u8,
+        stride: usize,
+    ) -> [Acc128<QUERY_BYTES>; N] {
         unsafe {
-            let mut acc = Acc128::zero();
+            let mut accs = [Acc128::zero(); N];
 
             let full_blocks = self.vector_bytes / BLOCK_128;
             for block in 0..full_blocks {
                 let offset = block * BLOCK_128;
                 let query = QueryBlock128::load(&self.planes, offset);
-                acc.accumulate_sdot(vld1q_u8(data.add(offset)), query);
+                for (v, acc) in accs.iter_mut().enumerate() {
+                    acc.accumulate_sdot(vld1q_u8(data.add(v * stride + offset)), query);
+                }
             }
 
             let tail = self.vector_bytes % BLOCK_128;
             if tail > 0 {
                 let offset = full_blocks * BLOCK_128;
                 let query = QueryBlock128::load(&self.planes, offset);
-                let block = tail_block::<BLOCK_128>(data.add(offset), tail);
-                acc.accumulate_sdot(vld1q_u8(block.as_ptr()), query);
+                for (v, acc) in accs.iter_mut().enumerate() {
+                    let block = tail_block::<BLOCK_128>(data.add(v * stride + offset), tail);
+                    acc.accumulate_sdot(vld1q_u8(block.as_ptr()), query);
+                }
             }
 
-            acc
+            accs
         }
     }
 
@@ -292,11 +383,22 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
     }
 }
 
+/// Vectors per interleaved group of the NEON batch kernels: 4 × 4
+/// accumulators plus the query block and codebook fit the 32 vector
+/// registers.
+const GROUP_128: usize = 4;
+
+/// Longest encoded vector (bytes) the NEON batch kernels score in
+/// interleaved groups: four cache lines per vector — the value measured for
+/// the AVX-512 kernel; not yet tuned on ARM hardware.
+const INTERLEAVE_MAX_BYTES: usize = 256;
+
 #[cfg(test)]
 mod tests {
     use rand::SeedableRng as _;
     use rand::prelude::StdRng;
 
+    use super::super::super::shared::random_bytes;
     use super::super::QuerySimd;
     use super::super::shared::{parity_dims, random_inputs};
 
@@ -356,5 +458,46 @@ mod tests {
         saturation_safety_64k::<4, 2>();
         saturation_safety_64k::<8, 1>();
         saturation_safety_64k::<8, 2>();
+    }
+
+    /// The batch kernels must reproduce the scalar reference for every
+    /// parity dim (interleaved groups and the per-vector remainder) at a
+    /// stride equal to and larger than the vector.
+    fn batch_kernels_match_scalar<const PLANES: usize, const QUERY_BYTES: usize>() {
+        let has_dotprod = std::arch::is_aarch64_feature_detected!("dotprod");
+        let mut rng = StdRng::seed_from_u64(7);
+        for dim in parity_dims::<PLANES>() {
+            let (query, _) = random_inputs::<PLANES, QUERY_BYTES>(&mut rng, dim);
+            let vector_bytes = dim / PLANES;
+            for stride in [vector_bytes, vector_bytes + 4] {
+                let count = 11;
+                let data = random_bytes(&mut rng, count * stride);
+                let expected: Vec<f32> = (0..count)
+                    .map(|v| {
+                        query.postprocess(query.dotprod_raw(&data[v * stride..][..vector_bytes]))
+                    })
+                    .collect();
+                let tag =
+                    format!("PLANES={PLANES} QUERY_BYTES={QUERY_BYTES} dim={dim} stride={stride}");
+
+                let mut actual = vec![0.0; count];
+                unsafe { query.dotprod_batch_neon(&data, stride, &mut actual) };
+                assert_eq!(expected, actual, "{tag}: neon batch");
+
+                if has_dotprod {
+                    let mut actual = vec![0.0; count];
+                    unsafe { query.dotprod_batch_neon_sdot(&data, stride, &mut actual) };
+                    assert_eq!(expected, actual, "{tag}: sdot batch");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_batch_kernels_match_scalar() {
+        batch_kernels_match_scalar::<2, 2>();
+        batch_kernels_match_scalar::<4, 2>();
+        batch_kernels_match_scalar::<8, 1>();
+        batch_kernels_match_scalar::<8, 2>();
     }
 }

--- a/lib/quantization/src/turboquant/simd/query/mod.rs
+++ b/lib/quantization/src/turboquant/simd/query/mod.rs
@@ -262,7 +262,11 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
             data.len(),
         );
 
-        self.dotprod_batch_per_vector(data, stride, out);
+        match self.backend {
+            #[cfg(target_arch = "x86_64")]
+            SimdBackend::Avx512Vnni => unsafe { self.dotprod_batch_avx512_vnni(data, stride, out) },
+            _ => self.dotprod_batch_per_vector(data, stride, out),
+        }
     }
 
     /// [`Self::dotprod_batch`] as a plain loop over [`Self::dotprod`], for

--- a/lib/quantization/src/turboquant/simd/query/mod.rs
+++ b/lib/quantization/src/turboquant/simd/query/mod.rs
@@ -240,6 +240,40 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
         self.postprocess(self.dotprod_raw_best(vector))
     }
 
+    /// Batch counterpart of [`Self::dotprod`] for vectors stored `stride`
+    /// bytes apart in one contiguous `data` slice: `out[v]` ← score of the
+    /// vector at `data[v * stride..]`.  Scoring a contiguous run in one call
+    /// lets the kernels amortize their per-call setup and share the query
+    /// loads across vectors.
+    ///
+    /// # Panics
+    /// Panics if `stride` is shorter than an encoded vector or `data` is too
+    /// short for `out.len()` vectors.
+    pub fn dotprod_batch(&self, data: &[u8], stride: usize, out: &mut [f32]) {
+        let Some(last) = out.len().checked_sub(1) else {
+            return;
+        };
+        assert!(
+            stride >= self.vector_bytes && data.len() >= last * stride + self.vector_bytes,
+            "QuerySimd<{PLANES}, {QUERY_BYTES}>::dotprod_batch: {} vectors of {} bytes at stride \
+             {stride} don't fit into {} data bytes",
+            out.len(),
+            self.vector_bytes,
+            data.len(),
+        );
+
+        self.dotprod_batch_per_vector(data, stride, out);
+    }
+
+    /// [`Self::dotprod_batch`] as a plain loop over [`Self::dotprod`], for
+    /// backends without a batch kernel.
+    fn dotprod_batch_per_vector(&self, data: &[u8], stride: usize, out: &mut [f32]) {
+        for (v, out) in out.iter_mut().enumerate() {
+            let vector = &data[v * stride..][..self.vector_bytes];
+            *out = self.postprocess(self.dotprod_raw_best(vector));
+        }
+    }
+
     /// Float reconstruction of a raw integer dot product.
     #[inline]
     fn postprocess(&self, dot_raw: i64) -> f32 {
@@ -353,8 +387,11 @@ mod tests {
     use rand::SeedableRng as _;
     use rand::prelude::StdRng;
 
-    use super::super::shared::{encode_to_nearest_centroid, pack_codes, sample_normal_vec};
+    use super::super::shared::{
+        encode_to_nearest_centroid, pack_codes, random_bytes, sample_normal_vec,
+    };
     use super::QuerySimd;
+    use super::shared::{parity_dims, random_inputs};
     use crate::turboquant::TQBits;
 
     /// The width packing `PLANES` codes per byte.
@@ -484,5 +521,40 @@ mod tests {
         simd_noise_below_pq_noise::<4, 2>();
         simd_noise_below_pq_noise::<8, 1>();
         simd_noise_below_pq_noise::<8, 2>();
+    }
+
+    /// `dotprod_batch` must reproduce per-vector `dotprod` bit-exactly on
+    /// the host's backend: every parity dim, a stride equal to and larger
+    /// than the encoded vector, and counts leaving every group remainder.
+    fn dotprod_batch_matches_dotprod<const PLANES: usize, const QUERY_BYTES: usize>() {
+        let mut rng = StdRng::seed_from_u64(11);
+        for dim in parity_dims::<PLANES>() {
+            let (query, _) = random_inputs::<PLANES, QUERY_BYTES>(&mut rng, dim);
+            let vector_bytes = dim / PLANES;
+            for stride in [vector_bytes, vector_bytes + 4] {
+                for count in [1, 3, 4, 11] {
+                    let data = random_bytes(&mut rng, count * stride);
+                    let expected: Vec<f32> = (0..count)
+                        .map(|v| query.dotprod(&data[v * stride..][..vector_bytes]))
+                        .collect();
+                    let mut actual = vec![0.0; count];
+                    query.dotprod_batch(&data, stride, &mut actual);
+                    assert_eq!(
+                        expected, actual,
+                        "PLANES={PLANES} QUERY_BYTES={QUERY_BYTES} dim={dim} stride={stride} \
+                         count={count}"
+                    );
+                }
+            }
+            query.dotprod_batch(&[], vector_bytes, &mut []);
+        }
+    }
+
+    #[test]
+    fn test_dotprod_batch_matches_dotprod() {
+        dotprod_batch_matches_dotprod::<2, 2>();
+        dotprod_batch_matches_dotprod::<4, 2>();
+        dotprod_batch_matches_dotprod::<8, 1>();
+        dotprod_batch_matches_dotprod::<8, 2>();
     }
 }

--- a/lib/quantization/src/turboquant/simd/query/mod.rs
+++ b/lib/quantization/src/turboquant/simd/query/mod.rs
@@ -265,6 +265,8 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
         match self.backend {
             #[cfg(target_arch = "x86_64")]
             SimdBackend::Avx512Vnni => unsafe { self.dotprod_batch_avx512_vnni(data, stride, out) },
+            #[cfg(target_arch = "x86_64")]
+            SimdBackend::Avx2 => unsafe { self.dotprod_batch_avx2(data, stride, out) },
             _ => self.dotprod_batch_per_vector(data, stride, out),
         }
     }

--- a/lib/quantization/src/turboquant/simd/query/mod.rs
+++ b/lib/quantization/src/turboquant/simd/query/mod.rs
@@ -305,6 +305,10 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
             SimdBackend::Avx512Vnni => unsafe { self.dotprod_batch_avx512_vnni(data, stride, out) },
             #[cfg(target_arch = "x86_64")]
             SimdBackend::Avx2 => unsafe { self.dotprod_batch_avx2(data, stride, out) },
+            #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+            SimdBackend::NeonSdot => unsafe { self.dotprod_batch_neon_sdot(data, stride, out) },
+            #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+            SimdBackend::Neon => unsafe { self.dotprod_batch_neon(data, stride, out) },
             _ => self.dotprod_batch_per_vector(data, stride, out),
         }
     }

--- a/lib/quantization/src/turboquant/simd/query/mod.rs
+++ b/lib/quantization/src/turboquant/simd/query/mod.rs
@@ -95,6 +95,44 @@ const fn encoding(planes: usize) -> Encoding {
 /// 64 bytes).  Every query plane is padded to a multiple of it.
 const PLANE_BLOCK: usize = 64;
 
+/// The last `len` (`< N`) packed bytes of a vector at `data`, zero-padded to
+/// a full block so a kernel can run its regular block step on them: the
+/// padding lanes meet the planes' zero padding and contribute nothing.
+///
+/// The copy proceeds in power-of-two pieces of constant size rather than one
+/// `len`-byte copy, which the compiler would turn into a `memcpy` call (plus
+/// a `memset` for the rest) — a call that also forces the accumulators out
+/// of their registers around it.  `len` is the same for every vector of a
+/// query, so the piece branches predict perfectly.
+///
+/// # Safety
+/// `data` must be readable for `len` bytes.
+#[inline]
+#[cfg(any(
+    target_arch = "x86_64",
+    all(target_arch = "aarch64", target_feature = "neon")
+))]
+unsafe fn tail_block<const N: usize>(data: *const u8, len: usize) -> [u8; N] {
+    debug_assert!(N.is_power_of_two() && len < N);
+    let mut block = [0; N];
+    let mut copied = 0;
+    let mut piece = N / 2;
+    while piece > 0 {
+        if len & piece != 0 {
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    data.add(copied),
+                    block.as_mut_ptr().add(copied),
+                    piece,
+                );
+            }
+            copied += piece;
+        }
+        piece /= 2;
+    }
+    block
+}
+
 /// Query bytes regrouped by code position — the layout the SIMD kernels
 /// consume.
 ///

--- a/lib/quantization/src/turboquant/simd/query/x64.rs
+++ b/lib/quantization/src/turboquant/simd/query/x64.rs
@@ -430,7 +430,31 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
             self.vector_bytes,
         );
 
-        unsafe { Self::reduce_avx2(self.accumulate_avx2(vector.as_ptr())) }
+        unsafe { self.reduce_avx2(self.accumulate_avx2(vector.as_ptr())) }
+    }
+
+    /// Batch counterpart of [`Self::dotprod_raw_avx2`] with the float
+    /// reconstruction applied — see `dotprod_batch` for the layout contract
+    /// (asserted there).
+    ///
+    /// Unlike the VNNI kernel this one scores vectors one at a time: its
+    /// loop-carried chain is a single `vpaddd` per accumulator (the
+    /// `maddubs → madd` products hang off the loads), so the accumulator
+    /// pairs already keep the pipeline full, and interleaving vectors only
+    /// adds register pressure on the 16 YMM registers — measured 10–15 %
+    /// slower with groups of two or four on Zen 4 at the 4-bit width.
+    ///
+    /// # Safety
+    /// CPU must support `avx2`; `data` must hold `out.len()` vectors at
+    /// `stride`.
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn dotprod_batch_avx2(&self, data: &[u8], stride: usize, out: &mut [f32]) {
+        unsafe {
+            for (v, out) in out.iter_mut().enumerate() {
+                let acc = self.accumulate_avx2(data.as_ptr().add(v * stride));
+                *out = self.postprocess(self.reduce_avx2(acc));
+            }
+        }
     }
 
     /// Block loop of the AVX2 kernels over the vector at `data`.
@@ -466,14 +490,23 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
         }
     }
 
-    /// Raw dot product from one vector's accumulators.
+    /// Raw dot product from one vector's accumulators: the fused reduction
+    /// whenever the vector is short enough for its lane bound, otherwise
+    /// one reduction per query byte.
     ///
     /// # Safety
     /// CPU must support `avx2`.
     #[inline]
     #[target_feature(enable = "avx2")]
-    unsafe fn reduce_avx2(acc: Acc256<QUERY_BYTES>) -> i64 {
-        unsafe { Self::combine_bytes(acc.fold().map(|total| i64::from(hsum_i32_avx2(total)))) }
+    unsafe fn reduce_avx2(&self, acc: Acc256<QUERY_BYTES>) -> i64 {
+        unsafe {
+            let totals = acc.fold();
+            if self.vector_bytes <= Self::FUSED_REDUCTION_MAX_BYTES {
+                reduce_fused_256::<PLANES, QUERY_BYTES>(totals)
+            } else {
+                Self::combine_bytes(totals.map(|total| i64::from(hsum_i32_avx2(total))))
+            }
+        }
     }
 
     /// AVX-512 VNNI (Ice Lake Xeon+, Zen 4+) over the query planes: one ZMM
@@ -833,11 +866,10 @@ mod tests {
         }
     }
 
-    /// The AVX-512 batch kernel must reproduce the scalar reference for
-    /// every parity dim (interleaved groups and the per-vector remainder,
-    /// both reduction paths) at a stride equal to and larger than the
-    /// vector.
-    fn batch_avx512_vnni_matches_scalar<const PLANES: usize, const QUERY_BYTES: usize>() {
+    /// The batch kernels must reproduce the scalar reference for every
+    /// parity dim (interleaved groups and the per-vector remainder, both
+    /// reduction paths) at a stride equal to and larger than the vector.
+    fn batch_kernels_match_scalar<const PLANES: usize, const QUERY_BYTES: usize>() {
         let mut rng = StdRng::seed_from_u64(7);
         for dim in parity_dims::<PLANES>().chain(fused_bound_dims::<PLANES, QUERY_BYTES>()) {
             let (query, _) = random_inputs::<PLANES, QUERY_BYTES>(&mut rng, dim);
@@ -850,25 +882,30 @@ mod tests {
                         query.postprocess(query.dotprod_raw(&data[v * stride..][..vector_bytes]))
                     })
                     .collect();
-                let mut actual = vec![0.0; count];
-                unsafe { query.dotprod_batch_avx512_vnni(&data, stride, &mut actual) };
-                assert_eq!(
-                    expected, actual,
-                    "PLANES={PLANES} QUERY_BYTES={QUERY_BYTES} dim={dim} stride={stride}"
-                );
+                let tag =
+                    format!("PLANES={PLANES} QUERY_BYTES={QUERY_BYTES} dim={dim} stride={stride}");
+                unsafe {
+                    if std::is_x86_feature_detected!("avx2") {
+                        let mut actual = vec![0.0; count];
+                        query.dotprod_batch_avx2(&data, stride, &mut actual);
+                        assert_eq!(expected, actual, "{tag}: avx2 batch");
+                    }
+                    if has_avx512_vnni() {
+                        let mut actual = vec![0.0; count];
+                        query.dotprod_batch_avx512_vnni(&data, stride, &mut actual);
+                        assert_eq!(expected, actual, "{tag}: avx512_vnni batch");
+                    }
+                }
             }
         }
     }
 
     #[test]
-    fn test_batch_avx512_vnni_matches_scalar() {
-        if !has_avx512_vnni() {
-            return;
-        }
-        batch_avx512_vnni_matches_scalar::<2, 2>();
-        batch_avx512_vnni_matches_scalar::<4, 2>();
-        batch_avx512_vnni_matches_scalar::<8, 1>();
-        batch_avx512_vnni_matches_scalar::<8, 2>();
+    fn test_batch_kernels_match_scalar() {
+        batch_kernels_match_scalar::<2, 2>();
+        batch_kernels_match_scalar::<4, 2>();
+        batch_kernels_match_scalar::<8, 1>();
+        batch_kernels_match_scalar::<8, 2>();
     }
 
     /// The fused reduction at its exact lane bound under the heaviest load
@@ -881,20 +918,25 @@ mod tests {
         for sign in [1.0_f32, -1.0] {
             let query = QuerySimd::<PLANES, QUERY_BYTES>::new(&vec![sign; bytes * PLANES]);
             let scalar = query.dotprod_raw(&vector);
-            let vnni512 = unsafe { query.dotprod_raw_avx512_vnni(&vector) };
-            assert_eq!(
-                scalar, vnni512,
-                "PLANES={PLANES} QUERY_BYTES={QUERY_BYTES} sign={sign}: avx512_vnni fused \
-                 reduction overflowed"
-            );
+            let tag = format!("PLANES={PLANES} QUERY_BYTES={QUERY_BYTES} sign={sign}");
+            unsafe {
+                if std::is_x86_feature_detected!("avx2") {
+                    let avx2 = query.dotprod_raw_avx2(&vector);
+                    assert_eq!(scalar, avx2, "{tag}: avx2 fused reduction overflowed");
+                }
+                if has_avx512_vnni() {
+                    let vnni512 = query.dotprod_raw_avx512_vnni(&vector);
+                    assert_eq!(
+                        scalar, vnni512,
+                        "{tag}: avx512_vnni fused reduction overflowed"
+                    );
+                }
+            }
         }
     }
 
     #[test]
     fn test_fused_reduction_bound_worst_case() {
-        if !has_avx512_vnni() {
-            return;
-        }
         fused_reduction_bound_worst_case::<2, 2>();
         fused_reduction_bound_worst_case::<4, 2>();
         fused_reduction_bound_worst_case::<8, 2>();

--- a/lib/quantization/src/turboquant/simd/query/x64.rs
+++ b/lib/quantization/src/turboquant/simd/query/x64.rs
@@ -495,26 +495,76 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
             self.vector_bytes,
         );
 
-        unsafe { Self::reduce_avx512(self.accumulate_avx512(vector.as_ptr())) }
+        unsafe {
+            let [acc] = self.accumulate_avx512::<1>(vector.as_ptr(), 0);
+            self.reduce_avx512(acc)
+        }
     }
 
-    /// Block loop of the AVX-512 kernels over the vector at `data`.
+    /// Batch counterpart of [`Self::dotprod_raw_avx512_vnni`] with the float
+    /// reconstruction applied — see `dotprod_batch` for the layout contract
+    /// (asserted there).
+    ///
+    /// Vectors up to [`INTERLEAVE_MAX_BYTES`] are scored in groups of
+    /// [`GROUP_512`]: the group shares each query block load and its tail
+    /// mask, and its independent accumulators keep `VPDPBUSD` saturated
+    /// while the per-vector reductions overlap with the next group's loads.
+    /// Longer vectors keep the one-vector-at-a-time walk: the group reads
+    /// [`GROUP_512`] interleaved byte streams, which hardware prefetchers
+    /// stream far worse than a single sequential one once each vector spans
+    /// more than a couple of cache lines.
     ///
     /// # Safety
     /// CPU must support `avx512f`, `avx512bw`, and `avx512vnni`; `data` must
-    /// be readable for `self.vector_bytes` bytes.
+    /// hold `out.len()` vectors at `stride`.
+    #[target_feature(enable = "avx512f,avx512bw,avx512vnni")]
+    pub unsafe fn dotprod_batch_avx512_vnni(&self, data: &[u8], stride: usize, out: &mut [f32]) {
+        unsafe {
+            let mut v = 0;
+            if self.vector_bytes <= INTERLEAVE_MAX_BYTES {
+                let (groups, _) = out.as_chunks_mut::<GROUP_512>();
+                for group in groups {
+                    let accs =
+                        self.accumulate_avx512::<GROUP_512>(data.as_ptr().add(v * stride), stride);
+                    for (out, acc) in group.iter_mut().zip(accs) {
+                        *out = self.postprocess(self.reduce_avx512(acc));
+                    }
+                    v += GROUP_512;
+                }
+            }
+            for out in &mut out[v..] {
+                let [acc] = self.accumulate_avx512::<1>(data.as_ptr().add(v * stride), stride);
+                *out = self.postprocess(self.reduce_avx512(acc));
+                v += 1;
+            }
+        }
+    }
+
+    /// Block loop of the AVX-512 kernels over `N` vectors stored `stride`
+    /// bytes apart starting at `data`.  Every query block is loaded once and
+    /// folded into all `N` accumulator sets.
+    ///
+    /// # Safety
+    /// CPU must support `avx512f`, `avx512bw`, and `avx512vnni`; `data` must
+    /// be readable for `(N - 1) * stride + self.vector_bytes` bytes.
     #[inline]
     #[target_feature(enable = "avx512f,avx512bw,avx512vnni")]
-    unsafe fn accumulate_avx512(&self, data: *const u8) -> Acc512<QUERY_BYTES> {
+    unsafe fn accumulate_avx512<const N: usize>(
+        &self,
+        data: *const u8,
+        stride: usize,
+    ) -> [Acc512<QUERY_BYTES>; N] {
         unsafe {
-            let mut acc = Acc512::zero();
+            let mut accs = [Acc512::zero(); N];
 
             let full_blocks = self.vector_bytes / BLOCK_512;
             for block in 0..full_blocks {
                 let offset = block * BLOCK_512;
                 let query = QueryBlock512::load(&self.planes, offset);
-                let codes = _mm512_loadu_si512(data.add(offset).cast::<__m512i>());
-                acc.accumulate(codes, query);
+                for (v, acc) in accs.iter_mut().enumerate() {
+                    let codes = _mm512_loadu_si512(data.add(v * stride + offset).cast::<__m512i>());
+                    acc.accumulate(codes, query);
+                }
             }
 
             let tail = self.vector_bytes % BLOCK_512;
@@ -522,27 +572,133 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
                 let offset = full_blocks * BLOCK_512;
                 let query = QueryBlock512::load(&self.planes, offset);
                 let mask: __mmask64 = (1 << tail) - 1;
-                let codes = _mm512_maskz_loadu_epi8(mask, data.add(offset).cast::<i8>());
-                acc.accumulate(codes, query);
+                for (v, acc) in accs.iter_mut().enumerate() {
+                    let codes =
+                        _mm512_maskz_loadu_epi8(mask, data.add(v * stride + offset).cast::<i8>());
+                    acc.accumulate(codes, query);
+                }
             }
 
-            acc
+            accs
         }
     }
 
-    /// Raw dot product from one vector's accumulators.
+    /// Raw dot product from one vector's accumulators: the fused reduction
+    /// whenever the vector is short enough for its lane bound, otherwise
+    /// one reduction per query byte.
     ///
     /// # Safety
-    /// CPU must support `avx512f`.
+    /// CPU must support `avx512f` and `avx512bw`.
     #[inline]
-    #[target_feature(enable = "avx512f")]
-    unsafe fn reduce_avx512(acc: Acc512<QUERY_BYTES>) -> i64 {
+    #[target_feature(enable = "avx512f,avx512bw")]
+    unsafe fn reduce_avx512(&self, acc: Acc512<QUERY_BYTES>) -> i64 {
         unsafe {
-            Self::combine_bytes(
-                acc.fold()
-                    .map(|total| i64::from(_mm512_reduce_add_epi32(total))),
-            )
+            let totals = acc.fold();
+            if self.vector_bytes <= Self::FUSED_REDUCTION_MAX_BYTES {
+                reduce_fused_512::<PLANES, QUERY_BYTES>(totals)
+            } else {
+                Self::combine_bytes(totals.map(|total| i64::from(_mm512_reduce_add_epi32(total))))
+            }
         }
+    }
+
+    /// Longest encoded vector (bytes) the fused reduction accepts — see
+    /// [`fused_reduction_max_bytes`].
+    const FUSED_REDUCTION_MAX_BYTES: usize = fused_reduction_max_bytes::<PLANES, QUERY_BYTES>();
+}
+
+/// Vectors per interleaved group of the AVX-512 batch kernel: 4 × 4
+/// accumulators plus the query block, codebook and mask fit the 32 ZMM
+/// registers without spilling.
+const GROUP_512: usize = 4;
+
+/// Longest encoded vector (bytes) the AVX-512 batch kernel scores in
+/// interleaved groups: four cache lines per vector.  Measured streaming
+/// from DRAM on Zen 4 at the 4-bit width: grouping is 10 % faster than the
+/// per-vector walk at dim 512 and twice as slow at dim 1024.
+const INTERLEAVE_MAX_BYTES: usize = 4 * BLOCK_512;
+
+/// Longest encoded vector (bytes) [`reduce_fused_256`] accepts at a width.
+///
+/// Per packed byte, its `PLANES` codes add at most `PLANES · c_max · K/2`
+/// to the folded lane of each query byte holding it, so `(1 + K)` times
+/// that to the fused lane (`low + K · high`).  The reduction folds to four
+/// i32 lanes before widening, each holding a quarter of the bytes:
+/// `bytes / 4 · per_byte ≤ i32::MAX`.  A one-byte query has no `K · high`
+/// term and cannot overflow the fold within any real dim.
+const fn fused_reduction_max_bytes<const PLANES: usize, const QUERY_BYTES: usize>() -> usize {
+    if QUERY_BYTES == 1 {
+        return usize::MAX;
+    }
+    let encoding = encoding(PLANES);
+    let mut c_max = 0;
+    let mut k = 0;
+    while k < (1 << (8 / PLANES)) {
+        if encoding.codebook[k] as usize > c_max {
+            c_max = encoding.codebook[k] as usize;
+        }
+        k += 1;
+    }
+    let radix = encoding.query_high_coef as usize;
+    let per_byte = PLANES * c_max * (radix / 2) * (1 + radix);
+    4 * (i32::MAX as usize) / per_byte
+}
+
+/// `Σ_b K^b · Σ totals[b]` with the horizontal reductions fused into one:
+/// the high lanes are shifted by `log2(K)` and added to the low lanes up
+/// front, leaving a single tree reduction that widens to i64 before its
+/// last two adds.
+///
+/// # Safety
+/// CPU must support `avx2`; the totals must come from a vector within the
+/// width's [`fused_reduction_max_bytes`].
+#[inline]
+#[target_feature(enable = "avx2")]
+unsafe fn reduce_fused_256<const PLANES: usize, const QUERY_BYTES: usize>(
+    totals: [__m256i; QUERY_BYTES],
+) -> i64 {
+    let mut combined = totals[0];
+    if QUERY_BYTES == 2 {
+        // The radix is a power of two (128 or 256); the shift is an immediate.
+        let high = totals[1];
+        let scaled = match const { encoding(PLANES).query_high_coef } {
+            128 => _mm256_slli_epi32(high, 7),
+            _ => _mm256_slli_epi32(high, 8),
+        };
+        combined = _mm256_add_epi32(combined, scaled);
+    }
+    let fold_128 = _mm_add_epi32(
+        _mm256_castsi256_si128(combined),
+        _mm256_extracti128_si256(combined, 1),
+    );
+    let wide = _mm256_cvtepi32_epi64(fold_128);
+    let pair = _mm_add_epi64(
+        _mm256_castsi256_si128(wide),
+        _mm256_extracti128_si256(wide, 1),
+    );
+    let total = _mm_add_epi64(pair, _mm_unpackhi_epi64(pair, pair));
+    _mm_cvtsi128_si64(total)
+}
+
+/// [`reduce_fused_256`] for ZMM accumulators: folds each to 256 bits first,
+/// which halves the lanes and doubles their values — the per-byte bound
+/// behind [`fused_reduction_max_bytes`] is unchanged.
+///
+/// # Safety
+/// CPU must support `avx512f`; the totals must come from a vector within
+/// the width's [`fused_reduction_max_bytes`].
+#[inline]
+#[target_feature(enable = "avx512f")]
+unsafe fn reduce_fused_512<const PLANES: usize, const QUERY_BYTES: usize>(
+    totals: [__m512i; QUERY_BYTES],
+) -> i64 {
+    unsafe {
+        reduce_fused_256::<PLANES, QUERY_BYTES>(totals.map(|total| {
+            _mm256_add_epi32(
+                _mm512_castsi512_si256(total),
+                _mm512_extracti64x4_epi64(total, 1),
+            )
+        }))
     }
 }
 
@@ -569,6 +725,7 @@ mod tests {
     use rand::SeedableRng as _;
     use rand::prelude::StdRng;
 
+    use super::super::super::shared::random_bytes;
     use super::super::QuerySimd;
     use super::super::shared::{parity_dims, random_inputs};
 
@@ -651,5 +808,95 @@ mod tests {
         saturation_safety_64k::<4, 2>();
         saturation_safety_64k::<8, 1>();
         saturation_safety_64k::<8, 2>();
+    }
+
+    /// The derivation behind the fused-reduction bound, checked against
+    /// the hand-derived 4-bit value: `2 · 255 · 64 · 129 = 4 210 560` per
+    /// byte, `4 · i32::MAX / 4 210 560 = 2040`.
+    #[test]
+    fn test_fused_reduction_bound() {
+        assert_eq!(QuerySimd::<2, 2>::FUSED_REDUCTION_MAX_BYTES, 2040);
+        assert_eq!(QuerySimd::<4, 2>::FUSED_REDUCTION_MAX_BYTES, 1020);
+        assert_eq!(QuerySimd::<8, 2>::FUSED_REDUCTION_MAX_BYTES, 255);
+        assert_eq!(QuerySimd::<8, 1>::FUSED_REDUCTION_MAX_BYTES, usize::MAX);
+    }
+
+    /// Vector lengths (bytes) at and just past a width's fused-reduction
+    /// bound, so both reduction paths are exercised; none for a one-byte
+    /// query, which always fuses.
+    fn fused_bound_dims<const PLANES: usize, const QUERY_BYTES: usize>() -> Vec<usize> {
+        let bound = QuerySimd::<PLANES, QUERY_BYTES>::FUSED_REDUCTION_MAX_BYTES;
+        if bound == usize::MAX {
+            Vec::new()
+        } else {
+            vec![bound * PLANES, (bound + 1) * PLANES]
+        }
+    }
+
+    /// The AVX-512 batch kernel must reproduce the scalar reference for
+    /// every parity dim (interleaved groups and the per-vector remainder,
+    /// both reduction paths) at a stride equal to and larger than the
+    /// vector.
+    fn batch_avx512_vnni_matches_scalar<const PLANES: usize, const QUERY_BYTES: usize>() {
+        let mut rng = StdRng::seed_from_u64(7);
+        for dim in parity_dims::<PLANES>().chain(fused_bound_dims::<PLANES, QUERY_BYTES>()) {
+            let (query, _) = random_inputs::<PLANES, QUERY_BYTES>(&mut rng, dim);
+            let vector_bytes = dim / PLANES;
+            for stride in [vector_bytes, vector_bytes + 4] {
+                let count = 11;
+                let data = random_bytes(&mut rng, count * stride);
+                let expected: Vec<f32> = (0..count)
+                    .map(|v| {
+                        query.postprocess(query.dotprod_raw(&data[v * stride..][..vector_bytes]))
+                    })
+                    .collect();
+                let mut actual = vec![0.0; count];
+                unsafe { query.dotprod_batch_avx512_vnni(&data, stride, &mut actual) };
+                assert_eq!(
+                    expected, actual,
+                    "PLANES={PLANES} QUERY_BYTES={QUERY_BYTES} dim={dim} stride={stride}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_batch_avx512_vnni_matches_scalar() {
+        if !has_avx512_vnni() {
+            return;
+        }
+        batch_avx512_vnni_matches_scalar::<2, 2>();
+        batch_avx512_vnni_matches_scalar::<4, 2>();
+        batch_avx512_vnni_matches_scalar::<8, 1>();
+        batch_avx512_vnni_matches_scalar::<8, 2>();
+    }
+
+    /// The fused reduction at its exact lane bound under the heaviest load
+    /// it can see — every query dim at the extreme `q_signed` (both signs),
+    /// every code at the max-magnitude codebook slot — must still match the
+    /// i64 scalar reference.
+    fn fused_reduction_bound_worst_case<const PLANES: usize, const QUERY_BYTES: usize>() {
+        let bytes = QuerySimd::<PLANES, QUERY_BYTES>::FUSED_REDUCTION_MAX_BYTES;
+        let vector = vec![0xFF_u8; bytes];
+        for sign in [1.0_f32, -1.0] {
+            let query = QuerySimd::<PLANES, QUERY_BYTES>::new(&vec![sign; bytes * PLANES]);
+            let scalar = query.dotprod_raw(&vector);
+            let vnni512 = unsafe { query.dotprod_raw_avx512_vnni(&vector) };
+            assert_eq!(
+                scalar, vnni512,
+                "PLANES={PLANES} QUERY_BYTES={QUERY_BYTES} sign={sign}: avx512_vnni fused \
+                 reduction overflowed"
+            );
+        }
+    }
+
+    #[test]
+    fn test_fused_reduction_bound_worst_case() {
+        if !has_avx512_vnni() {
+            return;
+        }
+        fused_reduction_bound_worst_case::<2, 2>();
+        fused_reduction_bound_worst_case::<4, 2>();
+        fused_reduction_bound_worst_case::<8, 2>();
     }
 }

--- a/lib/quantization/src/turboquant/simd/query/x64.rs
+++ b/lib/quantization/src/turboquant/simd/query/x64.rs
@@ -8,7 +8,7 @@
 
 use core::arch::x86_64::*;
 
-use super::{Code, PLANE_BLOCK, QueryPlanes, QuerySimd, encoding};
+use super::{Code, PLANE_BLOCK, QueryPlanes, QuerySimd, encoding, tail_block};
 
 /// Packed data bytes per SSE block: one XMM of codes.
 const BLOCK_128: usize = 16;
@@ -402,8 +402,7 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
             if tail > 0 {
                 let offset = full_blocks * BLOCK_128;
                 let query = QueryBlock128::load(&self.planes, offset);
-                let mut block = [0u8; BLOCK_128];
-                std::ptr::copy_nonoverlapping(data.add(offset), block.as_mut_ptr(), tail);
+                let block = tail_block::<BLOCK_128>(data.add(offset), tail);
                 let codes = _mm_loadu_si128(block.as_ptr().cast::<__m128i>());
                 acc.accumulate(codes, query);
             }
@@ -480,8 +479,7 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
             if tail > 0 {
                 let offset = full_blocks * BLOCK_256;
                 let query = QueryBlock256::load(&self.planes, offset);
-                let mut block = [0u8; BLOCK_256];
-                std::ptr::copy_nonoverlapping(data.add(offset), block.as_mut_ptr(), tail);
+                let block = tail_block::<BLOCK_256>(data.add(offset), tail);
                 let codes = _mm256_loadu_si256(block.as_ptr().cast::<__m256i>());
                 acc.accumulate(codes, query);
             }


### PR DESCRIPTION
Part 2/3 of the stack, on top of turbo4-query-simd. Kernel-only change, no callers yet — they land in the next PR in the stack.

Another implementation of
https://github.com/qdrant/qdrant/pull/10291
https://github.com/qdrant/qdrant/pull/10292

Based of https://github.com/qdrant/qdrant/pull/10391

A full scan scores millions of vectors against one query, and calling dotprod per vector leaves speed on the table: every vector pays its own horizontal reduction and never fills the multiply-accumulate pipelines. This PR adds QuerySimd::dotprod_batch(data, stride, scores), which scores a whole contiguous run in one call.