### PR TITLE
Fix edge amalgamation path rewriting on ast-grep 0.45

### DIFF
--- a/lib/edge/publish/ast-grep-rules.yaml
+++ b/lib/edge/publish/ast-grep-rules.yaml
@@ -45,13 +45,14 @@ fix: crate::$MOD
 ---
 id: inner-deps-global
 language: rust
+# Matched by node text rather than a `::$MOD` pattern: ast-grep 0.45 no longer parses a leading
+# `::` fragment as a pattern, so that form silently stopped matching anything.
 rule:
-  pattern: ::$MOD
   kind: scoped_identifier
+  regex: ^::(%DEPS%)$
   has:
-    kind: identifier
-    regex: ^(%DEPS%)$
-    stopBy: end
+    field: name
+    pattern: $MOD
 fix: crate::$MOD
 
 # Remove `Anonymize` derives.


### PR DESCRIPTION
The edge job started failing on every branch because `uv tool install ast-grep-cli` picks up the latest release, and 0.45 changed how a leading `::` parses.

- `pattern: ::$MOD` is now an ERROR node in 0.45, so `inner-deps-global` silently matched nothing and every `::common::` / `::wal::` path survived into the generated crate: 7 unresolved-import errors in `just rs-check`, one per non-test occurrence in the amalgamated packages
- matching on node text (`kind: scoped_identifier` + `regex: ^::(%DEPS%)$`) works on 0.39, 0.44 and 0.45, with `$MOD` bound through the `name` field for the fix
- verified by regenerating the amalgamation both ways: fixed rule on 0.45.3 is byte identical to the old rule on 0.44.0, same change counts per package
- the tool is still unpinned, so a future release can break another rule the same silent way; pinning `ast-grep-cli` is worth a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)