### PR TITLE
Fail snapshot unproxying when proxy propagation fails

### DIFF
--- a/lib/shard/src/segment_holder/snapshot.rs
+++ b/lib/shard/src/segment_holder/snapshot.rs
@@ -149,13 +149,14 @@ impl SegmentHolder {
             }
         };
 
-        // propagate changes to wrapped segment with segment holder read lock
-        {
-            if let Err(err) = proxy_segment.write().propagate_to_wrapped() {
-                log::error!(
-                    "Propagating proxy segment {segment_id} changes to wrapped segment failed, ignoring: {err}",
-                );
-            }
+        // Propagate changes to wrapped segment with segment holder read lock. On failure keep the
+        // proxy installed rather than unwrapping into a segment that never got the changes;
+        // `unproxy_all_segments` retries the propagation for every proxy left behind.
+        if let Err(err) = proxy_segment.write().propagate_to_wrapped() {
+            log::error!(
+                "Propagating proxy segment {segment_id} changes to wrapped segment failed: {err}",
+            );
+            return Err(segments_lock);
         }
 
         let mut write_segments = RwLockUpgradableReadGuard::upgrade(segments_lock);
@@ -181,16 +182,21 @@ impl SegmentHolder {
         // so it is important, that we don't block reads while doing this.
 
         // propagate changes to wrapped segment with segment holder read lock
-        proxies
-            .iter()
-            .filter_map(|(segment_id, proxy_segment)| match proxy_segment {
-                LockedSegment::Proxy(proxy_segment) => Some((segment_id, proxy_segment)),
-                LockedSegment::Original(_) => None,
-            }).for_each(|(proxy_id, proxy_segment)| {
-            if let Err(err) = proxy_segment.write().propagate_to_wrapped() {
-                log::error!("Propagating proxy segment {proxy_id} changes to wrapped segment failed, ignoring: {err}");
-            }
+        let proxies_to_propagate = proxies.iter().filter_map(|(id, segment)| match segment {
+            LockedSegment::Proxy(proxy_segment) => Some((id, proxy_segment)),
+            LockedSegment::Original(_) => None,
         });
+        for (proxy_id, proxy_segment) in proxies_to_propagate {
+            // Unwrapping a proxy whose changes did not reach the wrapped segment loses them for
+            // good, so bail out before touching the holder. Every proxy stays installed and keeps
+            // serving its changes, and the temp segment they write into is left in place.
+            if let Err(err) = proxy_segment.write().propagate_to_wrapped() {
+                log::error!(
+                    "Propagating proxy segment {proxy_id} changes to wrapped segment failed: {err}",
+                );
+                return Err(err);
+            }
+        }
 
         // Swap out each proxy with wrapped segment once changes are propagated
         let mut write_segments = RwLockUpgradableReadGuard::upgrade(segments_lock);


### PR DESCRIPTION
Same fix as `unwrap_proxy` in the optimizer, applied to the two snapshot paths that still log `propagate_to_wrapped` failures and unwrap anyway, losing the deletes and index changes that never reached the wrapped segment.

- `try_unproxy_segment` hands the lock back and leaves the proxy installed, exactly the failure mode its doc comment already describes: the caller keeps it in `proxies` and `unproxy_all_segments` retries the propagation moments later
- retrying is safe because `propagate_to_wrapped` clears each change set only after that stage succeeds, and the individual index and delete operations are version guarded
- `unproxy_all_segments` returns before touching the holder rather than skipping one proxy and continuing, so the temp segment the surviving proxies write into stays in place: `remove_segment_if_not_needed` only checks whether it is empty and appendable, not whether a proxy still references it
- a proxy left behind is not picked up by optimizers again (`iter_original` filters proxies out), reads stay correct through it, and a restart rebuilds the wrapped segment from disk plus WAL replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpoaAtGbAQAEuxEi8ScHc5