### PR TITLE
Fix gridstore new page panic

### DIFF
--- a/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
@@ -170,6 +170,26 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         Ok(())
     }
 
+    /// Rewrites the file to contain exactly the given regions, resizing it as needed.
+    pub fn reset(
+        &mut self,
+        fs: &S::Fs,
+        iter: impl ExactSizeIterator<Item = RegionGaps>,
+    ) -> Result<()> {
+        // Flush outstanding changes so no stale dirty pages of the old mapping can be written
+        // back over the recreated content.
+        self.slice_store.flusher()()?;
+
+        let dir = self
+            .path
+            .parent()
+            .expect("gaps file has a parent directory")
+            .to_path_buf();
+        *self = Self::create(fs, &dir, iter, self.config.clone())?;
+
+        Ok(())
+    }
+
     pub fn trailing_free_blocks(&self) -> Result<u32> {
         let slice = self.read_all()?;
         Ok(slice

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
@@ -170,23 +170,17 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
         Ok(())
     }
 
-    /// Rewrites the file to contain exactly the given regions, resizing it as needed.
-    pub fn reset(
-        &mut self,
-        fs: &S::Fs,
-        iter: impl ExactSizeIterator<Item = RegionGaps>,
-    ) -> Result<()> {
-        // Flush outstanding changes so no stale dirty pages of the old mapping can be written
-        // back over the recreated content.
-        self.slice_store.flusher()()?;
+    /// Overwrite all entries in place.
+    ///
+    /// `iter` must yield exactly the current number of entries: the file is not resized, since
+    /// that would require unmapping it first (Windows refuses to resize a file with a live
+    /// mapping). A length divergence is repaired with a full file replacement instead, see
+    /// `Bitmask::into_rebuilt_gaps`.
+    pub fn overwrite(&mut self, iter: impl ExactSizeIterator<Item = RegionGaps>) -> Result<()> {
+        let data: Vec<RegionGaps> = iter.collect();
+        debug_assert_eq!(self.len()?, data.len(), "overwrite cannot resize");
 
-        let dir = self
-            .path
-            .parent()
-            .expect("gaps file has a parent directory")
-            .to_path_buf();
-        *self = Self::create(fs, &dir, iter, self.config.clone())?;
-
+        self.slice_store.write(0, &data)?;
         Ok(())
     }
 

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/gaps.rs
@@ -172,15 +172,14 @@ impl<S: UniversalWrite> BitmaskGaps<S> {
 
     /// Overwrite all entries in place.
     ///
-    /// `iter` must yield exactly the current number of entries: the file is not resized, since
+    /// `data` must hold exactly the current number of entries: the file is not resized, since
     /// that would require unmapping it first (Windows refuses to resize a file with a live
     /// mapping). A length divergence is repaired with a full file replacement instead, see
     /// `Bitmask::into_rebuilt_gaps`.
-    pub fn overwrite(&mut self, iter: impl ExactSizeIterator<Item = RegionGaps>) -> Result<()> {
-        let data: Vec<RegionGaps> = iter.collect();
+    pub fn overwrite(&mut self, data: &[RegionGaps]) -> Result<()> {
         debug_assert_eq!(self.len()?, data.len(), "overwrite cannot resize");
 
-        self.slice_store.write(0, &data)?;
+        self.slice_store.write(0, data)?;
         Ok(())
     }
 

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
@@ -263,15 +263,14 @@ impl<S: UniversalWrite> Bitmask<S> {
         let regions_start_offset = region_id_range.start as usize * self.config.region_size_blocks;
         let regions_end_offset = region_id_range.end as usize * self.config.region_size_blocks;
 
-        let all_bits = self.bitslice.read_all()?;
-
         // The persisted gaps can diverge from the bitmask after an unclean shutdown; never let a
         // proposed window reach beyond the bitmask itself. A clamped (and thereby failed) search
         // is recovered by a gaps rebuild, see `Gridstore::find_or_create_available_blocks`.
-        if regions_start_offset >= all_bits.len() {
+        let bit_len = self.bitslice.bit_len() as usize;
+        if regions_start_offset >= bit_len {
             return Ok(None);
         }
-        let regions_end_offset = regions_end_offset.min(all_bits.len());
+        let regions_end_offset = regions_end_offset.min(bit_len);
 
         let translate_to_answer = |local_index: u32| {
             let page_size_in_blocks = self.config.page_size_bytes / self.config.block_size_bytes;
@@ -285,6 +284,7 @@ impl<S: UniversalWrite> Bitmask<S> {
             (page_id as PageId, page_block_offset as BlockOffset)
         };
 
+        let all_bits = self.bitslice.read_all()?;
         let regions_bitslice = &all_bits[regions_start_offset..regions_end_offset];
 
         Ok(Self::find_available_blocks_in_slice(
@@ -468,16 +468,11 @@ impl<S: UniversalWrite> Bitmask<S> {
     /// Recompute the gap entries of every region from the bitmask.
     fn compute_gaps(&self) -> Result<Vec<RegionGaps>> {
         let region_size_blocks = self.config.region_size_blocks;
-        let num_regions = (self.bitslice.bit_len() as usize).div_euclid(region_size_blocks);
-
-        let mut gaps = Vec::with_capacity(num_regions);
-        for region_id in 0..num_regions {
-            let region_start = (region_id * region_size_blocks) as u64;
-            let region_end = region_start + region_size_blocks as u64;
-            let bitslice = &self.bitslice.read_bit_range(region_start..region_end)?;
-            gaps.push(Self::calculate_gaps(bitslice, region_size_blocks));
-        }
-        Ok(gaps)
+        let all_bits = self.bitslice.read_all()?;
+        Ok(all_bits
+            .chunks_exact(region_size_blocks)
+            .map(|region| Self::calculate_gaps(region, region_size_blocks))
+            .collect())
     }
 
     /// Rebuild all region gaps from the bitmask, in place.
@@ -501,7 +496,7 @@ impl<S: UniversalWrite> Bitmask<S> {
         }
 
         let gaps = self.compute_gaps()?;
-        self.regions_gaps.overwrite(gaps.into_iter())
+        self.regions_gaps.overwrite(&gaps)
     }
 
     /// Rebuild all region gaps from the bitmask, repairing a gaps file whose length diverged
@@ -692,22 +687,26 @@ mod tests {
         assert_eq!(MmapBitmask::length_for_page(config), 8);
     }
 
-    #[test]
-    fn test_find_available_blocks() {
-        let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
-
-        let blocks_per_page = (page_size / DEFAULT_BLOCK_SIZE_BYTES) as u32;
-
+    /// A bitmask covering a single page that holds exactly one region, in a fresh temp dir.
+    fn create_test_bitmask() -> (tempfile::TempDir, MmapBitmask) {
         let dir = tempfile::tempdir().unwrap();
 
         let config = GridstoreConfig {
-            page_size_bytes: page_size,
+            page_size_bytes: DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS,
             block_size_bytes: DEFAULT_BLOCK_SIZE_BYTES,
             region_size_blocks: DEFAULT_REGION_SIZE_BLOCKS,
             compression: Compression::LZ4,
         };
 
-        let mut bitmask: MmapBitmask = super::Bitmask::create(&MmapFs, dir.path(), config).unwrap();
+        let bitmask = super::Bitmask::create(&MmapFs, dir.path(), config).unwrap();
+        (dir, bitmask)
+    }
+
+    #[test]
+    fn test_find_available_blocks() {
+        let blocks_per_page = DEFAULT_REGION_SIZE_BLOCKS as u32;
+
+        let (_dir, mut bitmask) = create_test_bitmask();
         bitmask.cover_new_page().unwrap();
 
         assert_eq!(bitmask.bitslice.bit_len() as u32, blocks_per_page * 2);
@@ -754,20 +753,10 @@ mod tests {
 
     #[test]
     fn test_rebuild_gaps() {
-        let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
-        let blocks_per_page = (page_size / DEFAULT_BLOCK_SIZE_BYTES) as u32;
-
-        let dir = tempfile::tempdir().unwrap();
-
-        let config = GridstoreConfig {
-            page_size_bytes: page_size,
-            block_size_bytes: DEFAULT_BLOCK_SIZE_BYTES,
-            region_size_blocks: DEFAULT_REGION_SIZE_BLOCKS,
-            compression: Compression::LZ4,
-        };
+        let blocks_per_page = DEFAULT_REGION_SIZE_BLOCKS as u32;
 
         // Two pages, one region per page.
-        let mut bitmask: MmapBitmask = super::Bitmask::create(&MmapFs, dir.path(), config).unwrap();
+        let (_dir, mut bitmask) = create_test_bitmask();
         bitmask.cover_new_page().unwrap();
 
         // Occupy all of region 0 and the first block of region 1.
@@ -794,45 +783,12 @@ mod tests {
         // The search finds the free space in region 1 again.
         let (page_id, block_offset) = bitmask.find_available_blocks(1).unwrap().unwrap();
         assert_eq!((page_id, block_offset), (1, 1));
-
-        // Corrupt the gaps again, now also appending a phantom region beyond the bitmask. The
-        // in-place rebuild refuses the length divergence; the by-value rebuild replaces the
-        // file and repairs both length and content.
-        bitmask.regions_gaps.set(0, all_free).unwrap();
-        bitmask
-            .regions_gaps
-            .extend(std::iter::once(all_free))
-            .unwrap();
-        assert_eq!(bitmask.regions_gaps.len().unwrap(), 3);
-
-        assert!(bitmask.rebuild_gaps().is_err());
-
-        let bitmask = bitmask.into_rebuilt_gaps(&MmapFs).unwrap();
-        assert_eq!(bitmask.regions_gaps.len().unwrap(), 2);
-        assert_eq!(
-            bitmask.regions_gaps.read_all().unwrap().as_ref(),
-            expected.as_slice(),
-        );
-
-        let (page_id, block_offset) = bitmask.find_available_blocks(1).unwrap().unwrap();
-        assert_eq!((page_id, block_offset), (1, 1));
     }
 
     #[test]
     fn test_gaps_length_mismatch() {
-        let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
-
-        let dir = tempfile::tempdir().unwrap();
-
-        let config = GridstoreConfig {
-            page_size_bytes: page_size,
-            block_size_bytes: DEFAULT_BLOCK_SIZE_BYTES,
-            region_size_blocks: DEFAULT_REGION_SIZE_BLOCKS,
-            compression: Compression::LZ4,
-        };
-
         // One page, one region.
-        let mut bitmask: MmapBitmask = super::Bitmask::create(&MmapFs, dir.path(), config).unwrap();
+        let (_dir, mut bitmask) = create_test_bitmask();
         bitmask.mark_blocks(0, 0, 3, true).unwrap();
 
         assert_eq!(bitmask.gaps_length_mismatch().unwrap(), None);
@@ -859,6 +815,10 @@ mod tests {
             bitmask.regions_gaps.read_all().unwrap().as_ref(),
             expected.as_slice(),
         );
+
+        // The search sees the real free space again.
+        let (page_id, block_offset) = bitmask.find_available_blocks(1).unwrap().unwrap();
+        assert_eq!((page_id, block_offset), (0, 3));
     }
 
     #[test]

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
@@ -7,7 +7,9 @@ use ahash::AHashSet;
 use common::bitvec::BitSlice;
 use common::mmap::{Advice, AdviceSetting, create_and_ensure_length};
 use common::stored_bitslice::StoredBitSlice;
-use common::universal_io::{MmapFile, OpenOptions, Populate, UniversalWrite};
+use common::universal_io::{
+    MmapFile, OpenOptions, Populate, UniversalWrite, UniversalWriteFileOps,
+};
 use gaps::{BitmaskGaps, RegionGaps};
 use itertools::Itertools;
 
@@ -463,14 +465,8 @@ impl<S: UniversalWrite> Bitmask<S> {
         Ok((expected != actual).then_some((expected, actual)))
     }
 
-    /// Rebuild all region gaps from the bitmask, from scratch.
-    ///
-    /// The gaps are a persisted acceleration structure derived from the bitmask, but they are
-    /// persisted to a separate file without ordering guarantees. After an unclean shutdown the
-    /// persisted gaps can be inconsistent with the bitmask (in content or in length), making the
-    /// gap search miss free space. The bitmask is authoritative, so recomputing every region
-    /// restores consistency.
-    pub(crate) fn rebuild_gaps(&mut self, fs: &S::Fs) -> Result<()> {
+    /// Recompute the gap entries of every region from the bitmask.
+    fn compute_gaps(&self) -> Result<Vec<RegionGaps>> {
         let region_size_blocks = self.config.region_size_blocks;
         let num_regions = (self.bitslice.bit_len() as usize).div_euclid(region_size_blocks);
 
@@ -481,10 +477,65 @@ impl<S: UniversalWrite> Bitmask<S> {
             let bitslice = &self.bitslice.read_bit_range(region_start..region_end)?;
             gaps.push(Self::calculate_gaps(bitslice, region_size_blocks));
         }
+        Ok(gaps)
+    }
 
-        // Reset rather than update the entries one by one: this also repairs a persisted gaps
-        // file whose length diverged from the bitmask.
-        self.regions_gaps.reset(fs, gaps.into_iter())
+    /// Rebuild all region gaps from the bitmask, in place.
+    ///
+    /// The gaps are a persisted acceleration structure derived from the bitmask, but they are
+    /// persisted to a separate file without ordering guarantees. After an unclean shutdown the
+    /// persisted gaps can be stale, making the gap search miss free space. The bitmask is
+    /// authoritative, so recomputing every region restores consistency.
+    ///
+    /// Requires the gaps to cover exactly the regions of the bitmask: the entries are
+    /// overwritten through the existing mapping, because resizing the file would require
+    /// unmapping it first (Windows refuses to resize a file with a live mapping). A length
+    /// divergence is repaired when the storage is opened, see [`Self::into_rebuilt_gaps`].
+    pub(crate) fn rebuild_gaps(&mut self) -> Result<()> {
+        if let Some((expected, actual)) = self.gaps_length_mismatch()? {
+            return Err(BlobstoreError::service_error(format!(
+                "Cannot rebuild region gaps of bitmask at {:?} in place: the gaps cover \
+                 {actual} regions, but the bitmask has {expected}",
+                self.path,
+            )));
+        }
+
+        let gaps = self.compute_gaps()?;
+        self.regions_gaps.overwrite(gaps.into_iter())
+    }
+
+    /// Rebuild all region gaps from the bitmask, repairing a gaps file whose length diverged
+    /// from the bitmask.
+    ///
+    /// Consumes and returns `self`: the gaps file must be unmapped while it is replaced, since
+    /// Windows refuses to resize or replace a file with a live mapping.
+    pub(crate) fn into_rebuilt_gaps(self, fs: &S::Fs) -> Result<Self> {
+        let gaps = self.compute_gaps()?;
+
+        let Self {
+            config,
+            regions_gaps,
+            bitslice,
+            path,
+        } = self;
+
+        let gaps_path = regions_gaps.path();
+        // Unmap the gaps file before replacing it.
+        drop(regions_gaps);
+
+        fs.atomic_save(&gaps_path, bytemuck::cast_slice(&gaps))?;
+
+        let dir = gaps_path
+            .parent()
+            .expect("gaps file has a parent directory");
+        let regions_gaps = BitmaskGaps::open(fs, dir, config.clone())?;
+
+        Ok(Self {
+            config,
+            regions_gaps,
+            bitslice,
+            path,
+        })
     }
 
     pub fn calculate_gaps(region: &BitSlice, region_size_blocks: usize) -> RegionGaps {
@@ -726,8 +777,27 @@ mod tests {
         let expected = bitmask.regions_gaps.read_all().unwrap().into_owned();
 
         // Corrupt the persisted gaps, as an unclean shutdown can leave them: claim region 0 is
-        // all free, and append a phantom region beyond the bitmask.
+        // all free.
         let all_free = RegionGaps::all_free(DEFAULT_REGION_SIZE_BLOCKS as u16);
+        bitmask.regions_gaps.set(0, all_free).unwrap();
+
+        // With the corrupted gaps the search proposes region 0, which is actually full.
+        assert_eq!(bitmask.find_available_blocks(1).unwrap(), None);
+
+        // The in-place rebuild restores every entry from the bitmask.
+        bitmask.rebuild_gaps().unwrap();
+        assert_eq!(
+            bitmask.regions_gaps.read_all().unwrap().as_ref(),
+            expected.as_slice(),
+        );
+
+        // The search finds the free space in region 1 again.
+        let (page_id, block_offset) = bitmask.find_available_blocks(1).unwrap().unwrap();
+        assert_eq!((page_id, block_offset), (1, 1));
+
+        // Corrupt the gaps again, now also appending a phantom region beyond the bitmask. The
+        // in-place rebuild refuses the length divergence; the by-value rebuild replaces the
+        // file and repairs both length and content.
         bitmask.regions_gaps.set(0, all_free).unwrap();
         bitmask
             .regions_gaps
@@ -735,19 +805,15 @@ mod tests {
             .unwrap();
         assert_eq!(bitmask.regions_gaps.len().unwrap(), 3);
 
-        // With the corrupted gaps the search proposes region 0, which is actually full.
-        assert_eq!(bitmask.find_available_blocks(1).unwrap(), None);
+        assert!(bitmask.rebuild_gaps().is_err());
 
-        bitmask.rebuild_gaps(&MmapFs).unwrap();
-
-        // The length is repaired and every entry matches a fresh recomputation.
+        let bitmask = bitmask.into_rebuilt_gaps(&MmapFs).unwrap();
         assert_eq!(bitmask.regions_gaps.len().unwrap(), 2);
         assert_eq!(
             bitmask.regions_gaps.read_all().unwrap().as_ref(),
             expected.as_slice(),
         );
 
-        // The search finds the free space in region 1 again.
         let (page_id, block_offset) = bitmask.find_available_blocks(1).unwrap().unwrap();
         assert_eq!((page_id, block_offset), (1, 1));
     }
@@ -782,7 +848,10 @@ mod tests {
 
         assert_eq!(bitmask.gaps_length_mismatch().unwrap(), Some((1, 3)));
 
-        bitmask.rebuild_gaps(&MmapFs).unwrap();
+        // The in-place rebuild refuses a length divergence; repairing it needs the file to be
+        // replaced while unmapped.
+        assert!(bitmask.rebuild_gaps().is_err());
+        let bitmask = bitmask.into_rebuilt_gaps(&MmapFs).unwrap();
 
         // The length is repaired and the real region's entry is intact.
         assert_eq!(bitmask.gaps_length_mismatch().unwrap(), None);

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
@@ -261,6 +261,16 @@ impl<S: UniversalWrite> Bitmask<S> {
         let regions_start_offset = region_id_range.start as usize * self.config.region_size_blocks;
         let regions_end_offset = region_id_range.end as usize * self.config.region_size_blocks;
 
+        let all_bits = self.bitslice.read_all()?;
+
+        // The persisted gaps can diverge from the bitmask after an unclean shutdown; never let a
+        // proposed window reach beyond the bitmask itself. A clamped (and thereby failed) search
+        // is recovered by a gaps rebuild, see `Gridstore::find_or_create_available_blocks`.
+        if regions_start_offset >= all_bits.len() {
+            return Ok(None);
+        }
+        let regions_end_offset = regions_end_offset.min(all_bits.len());
+
         let translate_to_answer = |local_index: u32| {
             let page_size_in_blocks = self.config.page_size_bytes / self.config.block_size_bytes;
 
@@ -273,7 +283,6 @@ impl<S: UniversalWrite> Bitmask<S> {
             (page_id as PageId, page_block_offset as BlockOffset)
         };
 
-        let all_bits = self.bitslice.read_all()?;
         let regions_bitslice = &all_bits[regions_start_offset..regions_end_offset];
 
         Ok(Self::find_available_blocks_in_slice(
@@ -443,6 +452,30 @@ impl<S: UniversalWrite> Bitmask<S> {
         Ok(())
     }
 
+    /// Rebuild all region gaps from the bitmask, from scratch.
+    ///
+    /// The gaps are a persisted acceleration structure derived from the bitmask, but they are
+    /// persisted to a separate file without ordering guarantees. After an unclean shutdown the
+    /// persisted gaps can be inconsistent with the bitmask (in content or in length), making the
+    /// gap search miss free space. The bitmask is authoritative, so recomputing every region
+    /// restores consistency.
+    pub(crate) fn rebuild_gaps(&mut self, fs: &S::Fs) -> Result<()> {
+        let region_size_blocks = self.config.region_size_blocks;
+        let num_regions = (self.bitslice.bit_len() as usize).div_euclid(region_size_blocks);
+
+        let mut gaps = Vec::with_capacity(num_regions);
+        for region_id in 0..num_regions {
+            let region_start = (region_id * region_size_blocks) as u64;
+            let region_end = region_start + region_size_blocks as u64;
+            let bitslice = &self.bitslice.read_bit_range(region_start..region_end)?;
+            gaps.push(Self::calculate_gaps(bitslice, region_size_blocks));
+        }
+
+        // Reset rather than update the entries one by one: this also repairs a persisted gaps
+        // file whose length diverged from the bitmask.
+        self.regions_gaps.reset(fs, gaps.into_iter())
+    }
+
     pub fn calculate_gaps(region: &BitSlice, region_size_blocks: usize) -> RegionGaps {
         debug_assert_eq!(region.len(), region_size_blocks, "Unexpected region size");
         // Get raw memory region
@@ -581,7 +614,7 @@ mod tests {
     use proptest::prelude::*;
     use rand::{RngExt, rng};
 
-    use super::MmapBitmask;
+    use super::{MmapBitmask, RegionGaps};
     use crate::config::{
         Compression, DEFAULT_BLOCK_SIZE_BYTES, DEFAULT_REGION_SIZE_BLOCKS, GridstoreConfig,
     };
@@ -655,6 +688,57 @@ mod tests {
         // not fitting cell
         let found_large = bitmask.find_available_blocks(blocks_per_page).unwrap();
         assert_eq!(found_large, None);
+    }
+
+    #[test]
+    fn test_rebuild_gaps() {
+        let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
+        let blocks_per_page = (page_size / DEFAULT_BLOCK_SIZE_BYTES) as u32;
+
+        let dir = tempfile::tempdir().unwrap();
+
+        let config = GridstoreConfig {
+            page_size_bytes: page_size,
+            block_size_bytes: DEFAULT_BLOCK_SIZE_BYTES,
+            region_size_blocks: DEFAULT_REGION_SIZE_BLOCKS,
+            compression: Compression::LZ4,
+        };
+
+        // Two pages, one region per page.
+        let mut bitmask: MmapBitmask = super::Bitmask::create(&MmapFs, dir.path(), config).unwrap();
+        bitmask.cover_new_page().unwrap();
+
+        // Occupy all of region 0 and the first block of region 1.
+        bitmask.mark_blocks(0, 0, blocks_per_page, true).unwrap();
+        bitmask.mark_blocks(1, 0, 1, true).unwrap();
+
+        let expected = bitmask.regions_gaps.read_all().unwrap().into_owned();
+
+        // Corrupt the persisted gaps, as an unclean shutdown can leave them: claim region 0 is
+        // all free, and append a phantom region beyond the bitmask.
+        let all_free = RegionGaps::all_free(DEFAULT_REGION_SIZE_BLOCKS as u16);
+        bitmask.regions_gaps.set(0, all_free).unwrap();
+        bitmask
+            .regions_gaps
+            .extend(std::iter::once(all_free))
+            .unwrap();
+        assert_eq!(bitmask.regions_gaps.len().unwrap(), 3);
+
+        // With the corrupted gaps the search proposes region 0, which is actually full.
+        assert_eq!(bitmask.find_available_blocks(1).unwrap(), None);
+
+        bitmask.rebuild_gaps(&MmapFs).unwrap();
+
+        // The length is repaired and every entry matches a fresh recomputation.
+        assert_eq!(bitmask.regions_gaps.len().unwrap(), 2);
+        assert_eq!(
+            bitmask.regions_gaps.read_all().unwrap().as_ref(),
+            expected.as_slice(),
+        );
+
+        // The search finds the free space in region 1 again.
+        let (page_id, block_offset) = bitmask.find_available_blocks(1).unwrap().unwrap();
+        assert_eq!((page_id, block_offset), (1, 1));
     }
 
     #[test]

--- a/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/bitmask/mod.rs
@@ -452,6 +452,17 @@ impl<S: UniversalWrite> Bitmask<S> {
         Ok(())
     }
 
+    /// Check whether the region gaps cover exactly the regions of the bitmask.
+    ///
+    /// Cheap length-only comparison. Returns `Some((expected, actual))` region counts when the
+    /// persisted gaps diverged in length from the bitmask, which an unclean shutdown can cause.
+    pub(crate) fn gaps_length_mismatch(&self) -> Result<Option<(usize, usize)>> {
+        let expected =
+            (self.bitslice.bit_len() as usize).div_euclid(self.config.region_size_blocks);
+        let actual = self.regions_gaps.len()?;
+        Ok((expected != actual).then_some((expected, actual)))
+    }
+
     /// Rebuild all region gaps from the bitmask, from scratch.
     ///
     /// The gaps are a persisted acceleration structure derived from the bitmask, but they are
@@ -739,6 +750,46 @@ mod tests {
         // The search finds the free space in region 1 again.
         let (page_id, block_offset) = bitmask.find_available_blocks(1).unwrap().unwrap();
         assert_eq!((page_id, block_offset), (1, 1));
+    }
+
+    #[test]
+    fn test_gaps_length_mismatch() {
+        let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
+
+        let dir = tempfile::tempdir().unwrap();
+
+        let config = GridstoreConfig {
+            page_size_bytes: page_size,
+            block_size_bytes: DEFAULT_BLOCK_SIZE_BYTES,
+            region_size_blocks: DEFAULT_REGION_SIZE_BLOCKS,
+            compression: Compression::LZ4,
+        };
+
+        // One page, one region.
+        let mut bitmask: MmapBitmask = super::Bitmask::create(&MmapFs, dir.path(), config).unwrap();
+        bitmask.mark_blocks(0, 0, 3, true).unwrap();
+
+        assert_eq!(bitmask.gaps_length_mismatch().unwrap(), None);
+        let expected = bitmask.regions_gaps.read_all().unwrap().into_owned();
+
+        // Append multiple phantom full entries, as a lost `extend` writeback leaves them.
+        let full = RegionGaps {
+            max: 0,
+            leading: 0,
+            trailing: 0,
+        };
+        bitmask.regions_gaps.extend([full; 2].into_iter()).unwrap();
+
+        assert_eq!(bitmask.gaps_length_mismatch().unwrap(), Some((1, 3)));
+
+        bitmask.rebuild_gaps(&MmapFs).unwrap();
+
+        // The length is repaired and the real region's entry is intact.
+        assert_eq!(bitmask.gaps_length_mismatch().unwrap(), None);
+        assert_eq!(
+            bitmask.regions_gaps.read_all().unwrap().as_ref(),
+            expected.as_slice(),
+        );
     }
 
     #[test]

--- a/lib/blobstore/src/blobstore/gridstore/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/mod.rs
@@ -58,7 +58,7 @@ where
     ///
     /// An unclean shutdown can leave persisted gaps inconsistent with the bitmask. If we detect
     /// this case at runtime, allow to rebuilt the gaps from the bitmask once.
-    gaps_rebuilt: bool,
+    pub(super) gaps_rebuilt: bool,
 }
 
 impl<V, S> Gridstore<V, S>
@@ -146,7 +146,7 @@ where
     ) -> Result<Self> {
         // Writable store: open pages and tracker writable so it can append.
         let tracker = Tracker::open(&fs, &base_path, populate, true)?;
-        let bitmask = Bitmask::open(&fs, &base_path, config.clone())?;
+        let mut bitmask = Bitmask::open(&fs, &base_path, config.clone())?;
         let num_pages = bitmask.infer_num_pages();
 
         let pages = Pages::open(&fs, &base_path, true, populate)?;
@@ -158,6 +158,25 @@ where
             )));
         }
 
+        // The region gaps are persisted separately from the bitmask without ordering guarantees,
+        // so an unclean shutdown can leave them covering a different number of regions (e.g.
+        // phantom entries from a lost `extend` writeback). Such entries would make page creation
+        // panic, so repair a length divergence up front — the check is a cheap length
+        // comparison. Content-level staleness is still repaired lazily, see
+        // `find_or_create_available_blocks`.
+        let gaps_rebuilt = match bitmask.gaps_length_mismatch()? {
+            Some((expected_regions, actual_regions)) => {
+                log::warn!(
+                    "Gridstore region gaps at {base_path:?} cover {actual_regions} regions, but \
+                     the bitmask has {expected_regions}, possibly due to an unclean shutdown. \
+                     Rebuilding the gaps from the bitmask",
+                );
+                bitmask.rebuild_gaps(&fs)?;
+                true
+            }
+            None => false,
+        };
+
         Ok(Self {
             fs,
             config,
@@ -167,7 +186,7 @@ where
             base_path,
             _value_type: std::marker::PhantomData,
             is_alive_flush_lock: IsAliveLock::new(),
-            gaps_rebuilt: false,
+            gaps_rebuilt,
         })
     }
 

--- a/lib/blobstore/src/blobstore/gridstore/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/mod.rs
@@ -146,7 +146,7 @@ where
     ) -> Result<Self> {
         // Writable store: open pages and tracker writable so it can append.
         let tracker = Tracker::open(&fs, &base_path, populate, true)?;
-        let mut bitmask = Bitmask::open(&fs, &base_path, config.clone())?;
+        let bitmask = Bitmask::open(&fs, &base_path, config.clone())?;
         let num_pages = bitmask.infer_num_pages();
 
         let pages = Pages::open(&fs, &base_path, true, populate)?;
@@ -164,17 +164,17 @@ where
         // panic, so repair a length divergence up front — the check is a cheap length
         // comparison. Content-level staleness is still repaired lazily, see
         // `find_or_create_available_blocks`.
-        let gaps_rebuilt = match bitmask.gaps_length_mismatch()? {
+        let (bitmask, gaps_rebuilt) = match bitmask.gaps_length_mismatch()? {
             Some((expected_regions, actual_regions)) => {
                 log::warn!(
                     "Gridstore region gaps at {base_path:?} cover {actual_regions} regions, but \
                      the bitmask has {expected_regions}, possibly due to an unclean shutdown. \
                      Rebuilding the gaps from the bitmask",
                 );
-                bitmask.rebuild_gaps(&fs)?;
-                true
+                // Replaces the gaps file, which must happen before anything else can map it.
+                (bitmask.into_rebuilt_gaps(&fs)?, true)
             }
-            None => false,
+            None => (bitmask, false),
         };
 
         Ok(Self {
@@ -236,7 +236,7 @@ where
             "Detected inconsistent region gaps at {:?} are for Gridstore bitmask, rebuilding gaps from the bitmask",
             self.base_path,
         );
-        self.bitmask.write().rebuild_gaps(&self.fs)?;
+        self.bitmask.write().rebuild_gaps()?;
 
         let available = self
             .try_find_or_create_available_blocks(num_blocks)?

--- a/lib/blobstore/src/blobstore/gridstore/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/mod.rs
@@ -202,7 +202,7 @@ where
         }
 
         // No fitting gap was found even though enough pages should be covered by now. This signals
-        // the gaps are incosistent with the bitmask. Stale gaps can occur after an unclean
+        // the gaps are inconsistent with the bitmask. Stale gaps can occur after an unclean
         // shutdown. Rebuilt the gaps at most once from the bitmask and try again.
         if self.gaps_rebuilt {
             panic!(

--- a/lib/blobstore/src/blobstore/gridstore/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/mod.rs
@@ -57,7 +57,7 @@ where
     /// Whether the region gaps have been rebuilt from the bitmask since startup
     ///
     /// An unclean shutdown can leave persisted gaps inconsistent with the bitmask. If we detect
-    /// this case at runtime, allow to rebuilt the gaps from the bitmask once.
+    /// this case at runtime, rebuild the gaps from the bitmask, at most once.
     pub(super) gaps_rebuilt: bool,
 }
 
@@ -146,7 +146,7 @@ where
     ) -> Result<Self> {
         // Writable store: open pages and tracker writable so it can append.
         let tracker = Tracker::open(&fs, &base_path, populate, true)?;
-        let bitmask = Bitmask::open(&fs, &base_path, config.clone())?;
+        let mut bitmask = Bitmask::open(&fs, &base_path, config.clone())?;
         let num_pages = bitmask.infer_num_pages();
 
         let pages = Pages::open(&fs, &base_path, true, populate)?;
@@ -164,18 +164,15 @@ where
         // panic, so repair a length divergence up front — the check is a cheap length
         // comparison. Content-level staleness is still repaired lazily, see
         // `find_or_create_available_blocks`.
-        let (bitmask, gaps_rebuilt) = match bitmask.gaps_length_mismatch()? {
-            Some((expected_regions, actual_regions)) => {
-                log::warn!(
-                    "Gridstore region gaps at {base_path:?} cover {actual_regions} regions, but \
-                     the bitmask has {expected_regions}, possibly due to an unclean shutdown. \
-                     Rebuilding the gaps from the bitmask",
-                );
-                // Replaces the gaps file, which must happen before anything else can map it.
-                (bitmask.into_rebuilt_gaps(&fs)?, true)
-            }
-            None => (bitmask, false),
-        };
+        let mut gaps_rebuilt = false;
+        if bitmask.gaps_length_mismatch()?.is_some() {
+            log::warn!(
+                "Detected region gaps length mismatch for Gridstore bitmask at {base_path:?}, rebuilding gaps from the bitmask",
+            );
+            // Replaces the gaps file, which must happen before anything else can map it.
+            bitmask = bitmask.into_rebuilt_gaps(&fs)?;
+            gaps_rebuilt = true;
+        }
 
         Ok(Self {
             fs,
@@ -222,7 +219,7 @@ where
 
         // No fitting gap was found even though enough pages should be covered by now. This signals
         // the gaps are inconsistent with the bitmask. Stale gaps can occur after an unclean
-        // shutdown. Rebuilt the gaps at most once from the bitmask and try again.
+        // shutdown. Rebuild the gaps at most once from the bitmask and try again.
         if self.gaps_rebuilt {
             panic!(
                 "No available blocks in gridstore at {:?} after creating a new page, \
@@ -233,16 +230,14 @@ where
         self.gaps_rebuilt = true;
 
         log::warn!(
-            "Detected inconsistent region gaps at {:?} are for Gridstore bitmask, rebuilding gaps from the bitmask",
+            "Detected inconsistent region gaps for Gridstore bitmask at {:?}, rebuilding gaps from the bitmask",
             self.base_path,
         );
         self.bitmask.write().rebuild_gaps()?;
 
-        let available = self
+        Ok(self
             .try_find_or_create_available_blocks(num_blocks)?
-            .expect("New page has just been created and gaps have just been rebuilt");
-
-        Ok(available)
+            .expect("New page has just been created and gaps have just been rebuilt"))
     }
 
     /// Find a spot for `num_blocks` contiguous blocks, creating new pages as needed.

--- a/lib/blobstore/src/blobstore/gridstore/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/mod.rs
@@ -54,6 +54,11 @@ where
     pub(super) _value_type: std::marker::PhantomData<V>,
     /// Lock to prevent concurrent flushes and used for waiting for ongoing flushes to finish.
     is_alive_flush_lock: IsAliveLock,
+    /// Whether the region gaps have been rebuilt from the bitmask since startup
+    ///
+    /// An unclean shutdown can leave persisted gaps inconsistent with the bitmask. If we detect
+    /// this case at runtime, allow to rebuilt the gaps from the bitmask once.
+    gaps_rebuilt: bool,
 }
 
 impl<V, S> Gridstore<V, S>
@@ -113,6 +118,7 @@ where
             _value_type: std::marker::PhantomData,
             bitmask: Arc::new(RwLock::new(bitmask)),
             is_alive_flush_lock: IsAliveLock::new(),
+            gaps_rebuilt: false,
         };
 
         let new_page_id = storage.next_page_id();
@@ -161,6 +167,7 @@ where
             base_path,
             _value_type: std::marker::PhantomData,
             is_alive_flush_lock: IsAliveLock::new(),
+            gaps_rebuilt: false,
         })
     }
 
@@ -190,9 +197,46 @@ where
     ) -> Result<(PageId, BlockOffset)> {
         debug_assert!(num_blocks > 0, "num_blocks must be greater than 0");
 
+        if let Some(available) = self.try_find_or_create_available_blocks(num_blocks)? {
+            return Ok(available);
+        }
+
+        // No fitting gap was found even though enough pages should be covered by now. This signals
+        // the gaps are incosistent with the bitmask. Stale gaps can occur after an unclean
+        // shutdown. Rebuilt the gaps at most once from the bitmask and try again.
+        if self.gaps_rebuilt {
+            panic!(
+                "No available blocks in gridstore at {:?} after creating a new page, \
+                 even though the region gaps have already been rebuilt",
+                self.base_path,
+            );
+        }
+        self.gaps_rebuilt = true;
+
+        log::warn!(
+            "Detected inconsistent region gaps at {:?} are for Gridstore bitmask, rebuilding gaps from the bitmask",
+            self.base_path,
+        );
+        self.bitmask.write().rebuild_gaps(&self.fs)?;
+
+        let available = self
+            .try_find_or_create_available_blocks(num_blocks)?
+            .expect("New page has just been created and gaps have just been rebuilt");
+
+        Ok(available)
+    }
+
+    /// Find a spot for `num_blocks` contiguous blocks, creating new pages as needed.
+    ///
+    /// Returns `None` if no spot was found even after page creation, which only happens when the
+    /// region gaps are inconsistent with the bitmask.
+    fn try_find_or_create_available_blocks(
+        &mut self,
+        num_blocks: u32,
+    ) -> Result<Option<(PageId, BlockOffset)>> {
         let bitmask_guard = self.bitmask.read();
         if let Some((page_id, block_offset)) = bitmask_guard.find_available_blocks(num_blocks)? {
-            return Ok((page_id, block_offset));
+            return Ok(Some((page_id, block_offset)));
         }
         let trailing_free_blocks = bitmask_guard.trailing_free_blocks()?;
 
@@ -206,13 +250,7 @@ where
             self.create_new_page()?;
         }
 
-        let available = self
-            .bitmask
-            .read()
-            .find_available_blocks(num_blocks)?
-            .expect("New page has just been created");
-
-        Ok(available)
+        self.bitmask.read().find_available_blocks(num_blocks)
     }
 
     /// Write value into a new cell, considering that it can span more than one page.
@@ -373,6 +411,7 @@ where
             config: _,
             _value_type,
             is_alive_flush_lock,
+            gaps_rebuilt: _,
         } = self;
 
         is_alive_flush_lock.blocking_mark_dead();
@@ -644,6 +683,7 @@ impl<V, S: UniversalWrite + 'static> Gridstore<V, S> {
             base_path: _,
             _value_type,
             is_alive_flush_lock: _,
+            gaps_rebuilt: _,
         } = self;
         pages.read().clear_cache()?;
         bitmask.read().clear_cache()?;

--- a/lib/blobstore/src/blobstore/tests.rs
+++ b/lib/blobstore/src/blobstore/tests.rs
@@ -1,4 +1,4 @@
-use std::io::BufReader;
+use std::io::{BufReader, Write as _};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
@@ -1991,6 +1991,21 @@ fn read_only_reader_over_write_enforced_backend() {
     assert_eq!(stored, Some(payload));
 }
 
+/// Assert that every value reads back byte-for-byte from the storage.
+fn assert_stored_bytes(storage: &Blobstore<Payload>, values: &[Vec<u8>]) {
+    let hw_counter = HardwareCounterCell::new();
+    for (offset, expected) in values.iter().enumerate() {
+        let stored = storage
+            .get_value_bytes::<Random>(offset as u32, &hw_counter)
+            .unwrap();
+        assert_eq!(
+            stored.as_deref(),
+            Some(expected.as_slice()),
+            "value {offset}"
+        );
+    }
+}
+
 /// Reproduces the state behind the `New page has just been created` panic seen on startup WAL
 /// replay after an unclean shutdown (power loss / kernel crash), and checks that it is recovered
 /// by rebuilding the gaps from the bitmask.
@@ -2014,10 +2029,6 @@ fn read_only_reader_over_write_enforced_backend() {
 /// See: <github.com/qdrant/qdrant/pull/10364>
 #[test]
 fn test_put_value_rebuilds_stale_gaps() {
-    use std::io::Write as _;
-
-    use common::universal_io::Populate;
-
     // 1 MiB pages: exactly one region (8192 blocks * 128 B) per page.
     let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
     let (dir, mut storage) = empty_storage_sized(page_size, Compression::None);
@@ -2060,9 +2071,6 @@ fn test_put_value_rebuilds_stale_gaps() {
     let mut storage: Blobstore<Payload> =
         Blobstore::open(MmapFs, dir.path().to_path_buf(), Populate::No).unwrap();
 
-    let hw_cell = HardwareCounterCell::new();
-    let hw_counter = hw_cell.ref_payload_io_write_counter();
-
     // Region 1 still has 8191 genuinely free blocks. This put used to panic with "New page has
     // just been created"; now it detects the inconsistency, rebuilds the gaps, and allocates.
     storage
@@ -2075,17 +2083,7 @@ fn test_put_value_rebuilds_stale_gaps() {
     let pointer = storage.get_pointer(2).unwrap();
     assert_eq!((pointer.page_id, pointer.block_offset), (1, 1));
 
-    let hw_read = HardwareCounterCell::new();
-    for (offset, expected) in values.iter().enumerate().take(3) {
-        let stored = storage
-            .get_value_bytes::<Random>(offset as u32, &hw_read)
-            .unwrap();
-        assert_eq!(
-            stored.as_deref(),
-            Some(expected.as_slice()),
-            "value {offset}"
-        );
-    }
+    assert_stored_bytes(&storage, &values[..3]);
 
     storage.flusher()().unwrap();
     drop(storage);
@@ -2099,8 +2097,6 @@ fn test_put_value_rebuilds_stale_gaps() {
     let mut storage: Blobstore<Payload> =
         Blobstore::open(MmapFs, dir.path().to_path_buf(), Populate::No).unwrap();
 
-    let hw_cell = HardwareCounterCell::new();
-    let hw_counter = hw_cell.ref_payload_io_write_counter();
     storage
         .put_value_bytes(3, values[3].clone(), hw_counter)
         .unwrap();
@@ -2108,17 +2104,7 @@ fn test_put_value_rebuilds_stale_gaps() {
     let pointer = storage.get_pointer(3).unwrap();
     assert_eq!((pointer.page_id, pointer.block_offset), (1, 3));
 
-    let hw_read = HardwareCounterCell::new();
-    for (offset, expected) in values.iter().enumerate() {
-        let stored = storage
-            .get_value_bytes::<Random>(offset as u32, &hw_read)
-            .unwrap();
-        assert_eq!(
-            stored.as_deref(),
-            Some(expected.as_slice()),
-            "value {offset}"
-        );
-    }
+    assert_stored_bytes(&storage, &values);
 }
 
 /// Reproduces a gaps-file length divergence that the lazy gaps rebuild cannot recover from.
@@ -2139,10 +2125,6 @@ fn test_put_value_rebuilds_stale_gaps() {
 /// See: <github.com/qdrant/qdrant/pull/10364>
 #[test]
 fn test_open_repairs_gaps_length_mismatch() {
-    use std::io::Write as _;
-
-    use common::universal_io::Populate;
-
     // 1 MiB pages: exactly one region (8192 blocks * 128 B) per page.
     let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
     let (dir, mut storage) = empty_storage_sized(page_size, Compression::None);
@@ -2178,8 +2160,6 @@ fn test_open_repairs_gaps_length_mismatch() {
 
     // Page 0 is full, so this put creates a new page. Without the repair at open, this panicked
     // in `cover_new_page` on the "Bitmask length mismatch" assertion.
-    let hw_cell = HardwareCounterCell::new();
-    let hw_counter = hw_cell.ref_payload_io_write_counter();
     storage
         .put_value_bytes(1, values[1].clone(), hw_counter)
         .unwrap();
@@ -2188,17 +2168,7 @@ fn test_open_repairs_gaps_length_mismatch() {
     let pointer = storage.get_pointer(1).unwrap();
     assert_eq!((pointer.page_id, pointer.block_offset), (1, 0));
 
-    let hw_read = HardwareCounterCell::new();
-    for (offset, expected) in values.iter().enumerate() {
-        let stored = storage
-            .get_value_bytes::<Random>(offset as u32, &hw_read)
-            .unwrap();
-        assert_eq!(
-            stored.as_deref(),
-            Some(expected.as_slice()),
-            "value {offset}"
-        );
-    }
+    assert_stored_bytes(&storage, &values);
 
     storage.flusher()().unwrap();
     drop(storage);

--- a/lib/blobstore/src/blobstore/tests.rs
+++ b/lib/blobstore/src/blobstore/tests.rs
@@ -2148,7 +2148,9 @@ fn test_open_repairs_gaps_length_mismatch() {
 
     // Fill page 0 (= region 0) completely.
     let values = [vec![0xAB; page_size], vec![0xCD; DEFAULT_BLOCK_SIZE_BYTES]];
-    storage.put_value_bytes(0, values[0].clone(), hw_counter).unwrap();
+    storage
+        .put_value_bytes(0, values[0].clone(), hw_counter)
+        .unwrap();
 
     storage.flusher()().unwrap();
     drop(storage);
@@ -2167,11 +2169,16 @@ fn test_open_repairs_gaps_length_mismatch() {
     let mut storage: Blobstore<Payload> =
         Blobstore::open(MmapFs, dir.path().to_path_buf(), Populate::No).unwrap();
 
+    // The repair immediately consumes the once-per-instance rebuild allowance.
+    assert!(storage.as_gridstore().gaps_rebuilt);
+
     // Page 0 is full, so this put creates a new page. Without the repair at open, this panicked
     // in `cover_new_page` on the "Bitmask length mismatch" assertion.
     let hw_cell = HardwareCounterCell::new();
     let hw_counter = hw_cell.ref_payload_io_write_counter();
-    storage.put_value_bytes(1, values[1].clone(), hw_counter).unwrap();
+    storage
+        .put_value_bytes(1, values[1].clone(), hw_counter)
+        .unwrap();
 
     assert_eq!(storage.as_gridstore().pages.read().num_pages(), 2);
     let pointer = storage.get_pointer(1).unwrap();
@@ -2182,7 +2189,11 @@ fn test_open_repairs_gaps_length_mismatch() {
         let stored = storage
             .get_value_bytes::<Random>(offset as u32, &hw_read)
             .unwrap();
-        assert_eq!(stored.as_deref(), Some(expected.as_slice()), "value {offset}");
+        assert_eq!(
+            stored.as_deref(),
+            Some(expected.as_slice()),
+            "value {offset}"
+        );
     }
 
     storage.flusher()().unwrap();

--- a/lib/blobstore/src/blobstore/tests.rs
+++ b/lib/blobstore/src/blobstore/tests.rs
@@ -1990,3 +1990,131 @@ fn read_only_reader_over_write_enforced_backend() {
     let stored = reader.get_value::<Random>(0, &hw_counter).unwrap();
     assert_eq!(stored, Some(payload));
 }
+
+/// Reproduces the state behind the `New page has just been created` panic seen on startup WAL
+/// replay after an unclean shutdown (power loss / kernel crash), and checks that it is recovered
+/// by rebuilding the gaps from the bitmask.
+///
+/// The region gaps (`gaps.dat`) are a persisted acceleration structure derived from the bitmask
+/// (`bitmask.dat`). They live in two separately mmapped files with no write-ordering barrier
+/// between them, so after a hard crash the OS may have written back one file's dirty pages but
+/// not the other's. On reopen the gaps can then claim free space where the bitmask has the
+/// blocks marked as used.
+///
+/// In that state:
+/// - `find_available_blocks` only scans the first window `find_fitting_gap` proposes; a stale
+///   all-free gap entry points it at a fully used region, so it comes up empty even though other
+///   space is genuinely free further along.
+/// - `trailing_free_blocks` (gaps-derived, accurate here) reports enough trailing space, so
+///   `find_or_create_available_blocks` computes `missing_blocks == 0` and creates no page.
+///
+/// This used to hit `.expect("New page has just been created")`; now the inconsistency must be
+/// detected, the gaps rebuilt, and the value allocated in the genuinely free space.
+#[test]
+fn test_put_value_rebuilds_stale_gaps() {
+    use std::io::Write as _;
+
+    use common::universal_io::Populate;
+
+    // 1 MiB pages: exactly one region (8192 blocks * 128 B) per page.
+    let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
+    let (dir, mut storage) = empty_storage_sized(page_size, Compression::None);
+
+    let hw_cell = HardwareCounterCell::new();
+    let hw_counter = hw_cell.ref_payload_io_write_counter();
+
+    // Fill page 0 (= region 0) completely, then start page 1 (= region 1).
+    let values = [
+        vec![0xAB; page_size],
+        vec![0xCD; DEFAULT_BLOCK_SIZE_BYTES],
+        vec![0xEF; DEFAULT_BLOCK_SIZE_BYTES * 2],
+        vec![0x42; DEFAULT_BLOCK_SIZE_BYTES],
+    ];
+    storage
+        .put_value_bytes(0, values[0].clone(), hw_counter)
+        .unwrap();
+    storage
+        .put_value_bytes(1, values[1].clone(), hw_counter)
+        .unwrap();
+
+    storage.flusher()().unwrap();
+    drop(storage);
+
+    // Simulate the crash-torn state: the bitmask.dat writeback reached the disk, the
+    // corresponding gaps.dat page did not. Region 0's persisted gap entry still shows the region
+    // as all-free (`RegionGaps { max, leading, trailing }`, all u16 = region size), while the
+    // bitmask correctly has it fully used. Region 1's entry stays accurate, so the trailing free
+    // blocks count still matches the bitmask.
+    let all_free = (DEFAULT_REGION_SIZE_BLOCKS as u16).to_le_bytes();
+    let stale_entry: Vec<u8> = [all_free; 3].concat();
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .open(dir.path().join("gaps.dat"))
+        .unwrap();
+    file.write_all(&stale_entry).unwrap();
+    file.sync_all().unwrap();
+    drop(file);
+
+    let mut storage: Blobstore<Payload> =
+        Blobstore::open(MmapFs, dir.path().to_path_buf(), Populate::No).unwrap();
+
+    let hw_cell = HardwareCounterCell::new();
+    let hw_counter = hw_cell.ref_payload_io_write_counter();
+
+    // Region 1 still has 8191 genuinely free blocks. This put used to panic with "New page has
+    // just been created"; now it detects the inconsistency, rebuilds the gaps, and allocates.
+    storage
+        .put_value_bytes(2, values[2].clone(), hw_counter)
+        .unwrap();
+
+    // The value lands in the free space of the existing pages, right after the second value; no
+    // new page is created.
+    assert_eq!(storage.as_gridstore().pages.read().num_pages(), 2);
+    let pointer = storage.get_pointer(2).unwrap();
+    assert_eq!((pointer.page_id, pointer.block_offset), (1, 1));
+
+    let hw_read = HardwareCounterCell::new();
+    for (offset, expected) in values.iter().enumerate().take(3) {
+        let stored = storage
+            .get_value_bytes::<Random>(offset as u32, &hw_read)
+            .unwrap();
+        assert_eq!(
+            stored.as_deref(),
+            Some(expected.as_slice()),
+            "value {offset}"
+        );
+    }
+
+    storage.flusher()().unwrap();
+    drop(storage);
+
+    // The rebuilt gaps are persisted: region 0 is full again on disk (all gaps zero).
+    let gaps_bytes = fs::read(dir.path().join("gaps.dat")).unwrap();
+    assert_eq!(gaps_bytes.len(), 2 * 6, "one 6-byte entry per region");
+    assert_eq!(gaps_bytes[..6], [0; 6], "region 0 must be full");
+
+    // The storage keeps working normally across a clean reopen.
+    let mut storage: Blobstore<Payload> =
+        Blobstore::open(MmapFs, dir.path().to_path_buf(), Populate::No).unwrap();
+
+    let hw_cell = HardwareCounterCell::new();
+    let hw_counter = hw_cell.ref_payload_io_write_counter();
+    storage
+        .put_value_bytes(3, values[3].clone(), hw_counter)
+        .unwrap();
+
+    let pointer = storage.get_pointer(3).unwrap();
+    assert_eq!((pointer.page_id, pointer.block_offset), (1, 3));
+
+    let hw_read = HardwareCounterCell::new();
+    for (offset, expected) in values.iter().enumerate() {
+        let stored = storage
+            .get_value_bytes::<Random>(offset as u32, &hw_read)
+            .unwrap();
+        assert_eq!(
+            stored.as_deref(),
+            Some(expected.as_slice()),
+            "value {offset}"
+        );
+    }
+}

--- a/lib/blobstore/src/blobstore/tests.rs
+++ b/lib/blobstore/src/blobstore/tests.rs
@@ -2010,6 +2010,8 @@ fn read_only_reader_over_write_enforced_backend() {
 ///
 /// This used to hit `.expect("New page has just been created")`; now the inconsistency must be
 /// detected, the gaps rebuilt, and the value allocated in the genuinely free space.
+///
+/// See: <github.com/qdrant/qdrant/pull/10364>
 #[test]
 fn test_put_value_rebuilds_stale_gaps() {
     use std::io::Write as _;
@@ -2133,6 +2135,8 @@ fn test_put_value_rebuilds_stale_gaps() {
 ///
 /// Opening the storage must repair the length divergence up front (a cheap length comparison)
 /// by rebuilding the gaps from the bitmask.
+///
+/// See: <github.com/qdrant/qdrant/pull/10364>
 #[test]
 fn test_open_repairs_gaps_length_mismatch() {
     use std::io::Write as _;

--- a/lib/blobstore/src/blobstore/tests.rs
+++ b/lib/blobstore/src/blobstore/tests.rs
@@ -2118,3 +2118,77 @@ fn test_put_value_rebuilds_stale_gaps() {
         );
     }
 }
+
+/// Reproduces a gaps-file length divergence that the lazy gaps rebuild cannot recover from.
+///
+/// `BitmaskGaps::extend` grows the file (with zeroes) and then writes the new all-free entries
+/// through the mmap. After an unclean shutdown the growth can have reached the disk while the
+/// entry contents did not, leaving phantom all-zero entries beyond the bitmask — each claiming a
+/// completely full region.
+///
+/// Phantom full entries are invisible to the gap search but force `trailing_free_blocks` to
+/// report zero, so the next allocation always tries to create a new page. `cover_new_page` then
+/// panics on its "Bitmask length mismatch" assertion — before the lazy rebuild in
+/// `find_or_create_available_blocks` can detect anything.
+///
+/// Opening the storage must repair the length divergence up front (a cheap length comparison)
+/// by rebuilding the gaps from the bitmask.
+#[test]
+fn test_open_repairs_gaps_length_mismatch() {
+    use std::io::Write as _;
+
+    use common::universal_io::Populate;
+
+    // 1 MiB pages: exactly one region (8192 blocks * 128 B) per page.
+    let page_size = DEFAULT_BLOCK_SIZE_BYTES * DEFAULT_REGION_SIZE_BLOCKS;
+    let (dir, mut storage) = empty_storage_sized(page_size, Compression::None);
+
+    let hw_cell = HardwareCounterCell::new();
+    let hw_counter = hw_cell.ref_payload_io_write_counter();
+
+    // Fill page 0 (= region 0) completely.
+    let values = [vec![0xAB; page_size], vec![0xCD; DEFAULT_BLOCK_SIZE_BYTES]];
+    storage.put_value_bytes(0, values[0].clone(), hw_counter).unwrap();
+
+    storage.flusher()().unwrap();
+    drop(storage);
+
+    // Simulate the crash-torn state: append two phantom all-zero entries (6 bytes each) to the
+    // gaps file, as a lost `extend` writeback leaves them.
+    let mut file = fs::OpenOptions::new()
+        .append(true)
+        .open(dir.path().join("gaps.dat"))
+        .unwrap();
+    file.write_all(&[0; 2 * 6]).unwrap();
+    file.sync_all().unwrap();
+    drop(file);
+
+    // Opening must detect the length mismatch and rebuild the gaps from the bitmask.
+    let mut storage: Blobstore<Payload> =
+        Blobstore::open(MmapFs, dir.path().to_path_buf(), Populate::No).unwrap();
+
+    // Page 0 is full, so this put creates a new page. Without the repair at open, this panicked
+    // in `cover_new_page` on the "Bitmask length mismatch" assertion.
+    let hw_cell = HardwareCounterCell::new();
+    let hw_counter = hw_cell.ref_payload_io_write_counter();
+    storage.put_value_bytes(1, values[1].clone(), hw_counter).unwrap();
+
+    assert_eq!(storage.as_gridstore().pages.read().num_pages(), 2);
+    let pointer = storage.get_pointer(1).unwrap();
+    assert_eq!((pointer.page_id, pointer.block_offset), (1, 0));
+
+    let hw_read = HardwareCounterCell::new();
+    for (offset, expected) in values.iter().enumerate() {
+        let stored = storage
+            .get_value_bytes::<Random>(offset as u32, &hw_read)
+            .unwrap();
+        assert_eq!(stored.as_deref(), Some(expected.as_slice()), "value {offset}");
+    }
+
+    storage.flusher()().unwrap();
+    drop(storage);
+
+    // The repaired gaps are persisted with the right length: one entry per region.
+    let gaps_bytes = fs::read(dir.path().join("gaps.dat")).unwrap();
+    assert_eq!(gaps_bytes.len(), 2 * 6, "one 6-byte entry per region");
+}


### PR DESCRIPTION
An unsafe shutdown may corrupt the Gridstore `gaps.dat` file. Because this file is memory mapped, the kernel may flush it for us at an unexpected time. The result is a gaps file that does not match with the used blocks bitmask, causing a panic.

Specifically, the gaps file tells us there is space somewhere. But scanning over the 'used' bit flags finds us nothing. That panics. The gaps file functions as (stale) cache, and the bit flags are the source of truth.

We already had an unhappy branch in place that detected this scenario ('New page has just been created'). It resulted in a panic as it was deemed impossible to reach.

This unhappy branch now rebuilds the inconsistent file for us at runtime to reconcile/recover it. Gridstore remains functioning normally. We allow rebuilding only once, because we don't expect inconsistencies without an unsafe shutdown.

On startup it does a second test to evaluate the length of the file. It's cheap to check. If it isn't what we expect, we rebuilt on startup.

Includes an artificial test showing this situation. It fails before the fix, and now it's happy.

This does fix existing storages already broken in this way.

May be related to <https://github.com/qdrant/qdrant/issues/9857>

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
