### PR TITLE
Update-only writer: leave optimizing targets alone and create fresh appendable segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,6 +2057,7 @@ dependencies = [
  "tempfile",
  "uuid",
  "wal",
+ "walkdir",
 ]
 
 [[package]]

--- a/lib/edge/Cargo.toml
+++ b/lib/edge/Cargo.toml
@@ -31,7 +31,9 @@ rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 uuid = { workspace = true }
+walkdir = { workspace = true }
 
 [dev-dependencies]
 fs-err = { workspace = true, features = ["debug"] }

--- a/lib/edge/src/read_only/enumerate.rs
+++ b/lib/edge/src/read_only/enumerate.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use common::universal_io::{UniversalReadFs, read_json_via};
 use segment::common::operation_error::OperationResult;
 use shard::files::{SEGMENTS_PATH, segment_manifest_path};
-use shard::segment_manifest::SegmentsManifest;
+use shard::segment_manifest::{SegmentManifestState, SegmentsManifest};
 use uuid::Uuid;
 
 use crate::edge_shard::scan_segment_dirs;
@@ -24,7 +24,14 @@ use crate::edge_shard::scan_segment_dirs;
 ///
 /// [`ReadOnlySegment::open`]: segment::segment::read_only::ReadOnlySegment::open
 pub trait SegmentEnumerator: Send + Sync {
-    fn list_segments(&self) -> OperationResult<HashMap<Uuid, PathBuf>>;
+    fn list_segments(&self) -> OperationResult<HashMap<Uuid, ListedSegment>>;
+}
+
+/// An enumerated segment; `writable` gates write-target choice, readers ignore it.
+#[derive(Clone, Debug)]
+pub struct ListedSegment {
+    pub path: PathBuf,
+    pub writable: bool,
 }
 
 /// [`SegmentEnumerator`] that reads the leader's segment manifest (`segments_manifest.json`, sitting
@@ -60,12 +67,19 @@ impl<F: UniversalReadFs> ManifestSegmentEnumerator<F> {
 }
 
 impl<F: UniversalReadFs + Send + Sync> SegmentEnumerator for ManifestSegmentEnumerator<F> {
-    fn list_segments(&self) -> OperationResult<HashMap<Uuid, PathBuf>> {
+    fn list_segments(&self) -> OperationResult<HashMap<Uuid, ListedSegment>> {
         let manifest: SegmentsManifest = read_json_via(&self.fs, &self.manifest_path)?;
         Ok(manifest
             .iter()
             .filter(|(_, state)| state.is_usable())
-            .map(|(uuid, _)| (*uuid, self.segments_path.join(uuid.to_string())))
+            .map(|(uuid, state)| {
+                let writable = !matches!(state, SegmentManifestState::Optimizing { .. });
+                let listed = ListedSegment {
+                    path: self.segments_path.join(uuid.to_string()),
+                    writable,
+                };
+                (*uuid, listed)
+            })
             .collect())
     }
 }
@@ -86,7 +100,18 @@ impl LocalSegmentEnumerator {
 }
 
 impl SegmentEnumerator for LocalSegmentEnumerator {
-    fn list_segments(&self) -> OperationResult<HashMap<Uuid, PathBuf>> {
-        scan_segment_dirs(&self.segments_path)
+    fn list_segments(&self) -> OperationResult<HashMap<Uuid, ListedSegment>> {
+        Ok(scan_segment_dirs(&self.segments_path)?
+            .into_iter()
+            .map(|(uuid, path)| {
+                (
+                    uuid,
+                    ListedSegment {
+                        path,
+                        writable: true,
+                    },
+                )
+            })
+            .collect())
     }
 }

--- a/lib/edge/src/read_only/enumerate.rs
+++ b/lib/edge/src/read_only/enumerate.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use common::universal_io::{UniversalReadFs, read_json_via};
 use segment::common::operation_error::OperationResult;
 use shard::files::{SEGMENTS_PATH, segment_manifest_path};
-use shard::segment_manifest::{SegmentManifestState, SegmentsManifest};
+use shard::segment_manifest::SegmentsManifest;
 use uuid::Uuid;
 
 use crate::edge_shard::scan_segment_dirs;
@@ -73,10 +73,9 @@ impl<F: UniversalReadFs + Send + Sync> SegmentEnumerator for ManifestSegmentEnum
             .iter()
             .filter(|(_, state)| state.is_usable())
             .map(|(uuid, state)| {
-                let writable = !matches!(state, SegmentManifestState::Optimizing { .. });
                 let listed = ListedSegment {
                     path: self.segments_path.join(uuid.to_string()),
-                    writable,
+                    writable: state.is_writable(),
                 };
                 (*uuid, listed)
             })

--- a/lib/edge/src/read_only/holder.rs
+++ b/lib/edge/src/read_only/holder.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
 use segment::index::UniversalReadExt;
 use segment::segment::read_only::ReadOnlySegment;
 use uuid::Uuid;
+
+use crate::read_only::enumerate::ListedSegment;
 
 /// In-memory inventory of read-only segments, keyed by the leader-assigned segment UUID.
 ///
@@ -63,7 +64,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlySegmentHolder<S> {
     /// Drop every segment whose UUID is no longer present on disk (e.g. removed by the leader's
     /// optimization). This only releases the follower's handle/mmap — it never touches the leader's
     /// files.
-    pub(crate) fn remove_missing(&mut self, on_disk: &HashMap<Uuid, PathBuf>) {
+    pub(crate) fn remove_missing(&mut self, on_disk: &HashMap<Uuid, ListedSegment>) {
         self.by_uuid.retain(|uuid, _| on_disk.contains_key(uuid));
     }
 

--- a/lib/edge/src/read_only/mod.rs
+++ b/lib/edge/src/read_only/mod.rs
@@ -30,7 +30,7 @@ use segment::index::UniversalReadExt;
 
 use crate::EdgeConfig;
 pub use crate::read_only::enumerate::{
-    LocalSegmentEnumerator, ManifestSegmentEnumerator, SegmentEnumerator,
+    ListedSegment, LocalSegmentEnumerator, ManifestSegmentEnumerator, SegmentEnumerator,
 };
 use crate::read_only::holder::ReadOnlySegmentHolder;
 

--- a/lib/edge/src/read_only/refresh.rs
+++ b/lib/edge/src/read_only/refresh.rs
@@ -100,7 +100,7 @@ impl<S: UniversalReadExt + 'static> ReadOnlyEdgeShard<S> {
             on_disk
                 .iter()
                 .filter(|(uuid, _)| !holder.contains(uuid))
-                .map(|(uuid, segment_path)| (*uuid, segment_path.clone()))
+                .map(|(uuid, listing)| (*uuid, listing.path.clone()))
                 .collect()
         };
         let loaded = load_segments_parallel::<S>(

--- a/lib/edge/src/read_only/tests.rs
+++ b/lib/edge/src/read_only/tests.rs
@@ -21,7 +21,8 @@ use uuid::Uuid;
 use crate::config::vectors::EdgeVectorParams;
 use crate::edge_shard::scan_segment_dirs;
 use crate::read_only::{
-    LocalSegmentEnumerator, ManifestSegmentEnumerator, ReadOnlyEdgeShard, SegmentEnumerator,
+    ListedSegment, LocalSegmentEnumerator, ManifestSegmentEnumerator, ReadOnlyEdgeShard,
+    SegmentEnumerator,
 };
 use crate::read_view::EdgeShardRead;
 use crate::{CountRequest, EdgeConfig, EdgeShard, RetrieveRequestBuilder, ScrollRequestBuilder};
@@ -421,10 +422,21 @@ struct ExcludingEnumerator {
 }
 
 impl SegmentEnumerator for ExcludingEnumerator {
-    fn list_segments(&self) -> OperationResult<HashMap<Uuid, PathBuf>> {
+    fn list_segments(&self) -> OperationResult<HashMap<Uuid, ListedSegment>> {
         let mut segments = scan_segment_dirs(&self.segments_path)?;
         segments.remove(&self.exclude);
-        Ok(segments)
+        Ok(segments
+            .into_iter()
+            .map(|(uuid, path)| {
+                (
+                    uuid,
+                    ListedSegment {
+                        path,
+                        writable: true,
+                    },
+                )
+            })
+            .collect())
     }
 }
 

--- a/lib/edge/src/update_only/holder.rs
+++ b/lib/edge/src/update_only/holder.rs
@@ -25,8 +25,9 @@ impl<S: UniversalRead + 'static> Default for LookupSegmentHolder<S> {
 }
 
 impl<S: UniversalRead + 'static> LookupSegmentHolder<S> {
-    pub(crate) fn insert(&mut self, uuid: Uuid, segment: LookupSegment<S>) {
-        if segment.appendable {
+    /// A non-`writable` segment (claimed by a rebuild) never becomes the target.
+    pub(crate) fn insert(&mut self, uuid: Uuid, segment: LookupSegment<S>, writable: bool) {
+        if segment.appendable && writable {
             self.write_target = Some(uuid);
         }
         self.by_uuid.insert(uuid, Arc::new(RwLock::new(segment)));
@@ -34,10 +35,6 @@ impl<S: UniversalRead + 'static> LookupSegmentHolder<S> {
 
     pub(crate) fn len(&self) -> usize {
         self.by_uuid.len()
-    }
-
-    pub(crate) fn is_empty(&self) -> bool {
-        self.by_uuid.is_empty()
     }
 
     /// Every segment, paired with its UUID. Order is unspecified.

--- a/lib/edge/src/update_only/lifecycle.rs
+++ b/lib/edge/src/update_only/lifecycle.rs
@@ -1,16 +1,24 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::mmap::AdviceSetting;
 use common::universal_io::{
-    MmapFile, MmapFs, UniversalAppend, UniversalReadFs, UniversalReadFsAsync,
+    MmapFile, MmapFs, OpenOptions, Populate, UniversalAppend, UniversalFlush as _, UniversalReadFs,
+    UniversalReadFsAsync, UniversalWriteFileOps,
 };
 use parking_lot::RwLock;
 use rayon::prelude::*;
-use segment::common::operation_error::OperationResult;
+use segment::common::operation_error::{OperationError, OperationResult};
+use segment::entry::{NonAppendableSegmentEntry as _, StorageSegmentEntry as _};
+use segment::json_path::JsonPath;
 use segment::segment::update_only::{LookupSegment, UpdateOnlySegmentEnum};
+use segment::segment_constructor::build_segment;
+use segment::types::{PayloadFieldSchema, SegmentConfig};
+use shard::files::SEGMENTS_PATH;
 use uuid::Uuid;
 
-use crate::read_only::{LocalSegmentEnumerator, SegmentEnumerator};
+use crate::read_only::{ListedSegment, LocalSegmentEnumerator, SegmentEnumerator};
 use crate::read_view::build_segment_pool;
 use crate::update_only::UpdateOnlyEdgeShard;
 use crate::update_only::holder::LookupSegmentHolder;
@@ -53,39 +61,33 @@ impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S> {
             None,
         )?;
 
-        let segments: Vec<(Uuid, PathBuf)> = enumerator.list_segments()?.into_iter().collect();
-        let opened: Vec<(Uuid, LookupSegment<S>, UpdateOnlySegmentEnum<S>)> =
+        let segments: Vec<(Uuid, ListedSegment)> =
+            enumerator.list_segments()?.into_iter().collect();
+        let opened: Vec<(Uuid, LookupSegment<S>, UpdateOnlySegmentEnum<S>, bool)> =
             pool.install(|| {
                 segments
                     .into_par_iter()
-                    .map(|(uuid, segment_path)| {
+                    .map(|(uuid, listing)| {
                         // No deferred threshold yet: it belongs to the coordination
                         // with an external rebuilder, which does not exist in this
                         // iteration.
-                        let segment = LookupSegment::<S>::open(&fs, &segment_path, None)?;
+                        let segment = LookupSegment::<S>::open(&fs, &listing.path, None)?;
                         let writer = UpdateOnlySegmentEnum::open(
                             &fs,
-                            &segment_path,
+                            &listing.path,
                             &segment.segment_config,
                             segment.writer_state(),
                         )?;
-                        Ok((uuid, segment, writer))
+                        Ok((uuid, segment, writer, listing.writable))
                     })
                     .collect::<OperationResult<Vec<_>>>()
             })?;
 
         let mut holder = LookupSegmentHolder::default();
         let mut writers = HashMap::new();
-        for (uuid, segment, writer) in opened {
-            holder.insert(uuid, segment);
+        for (uuid, segment, writer, writable) in opened {
+            holder.insert(uuid, segment, writable);
             writers.insert(uuid, writer);
-        }
-
-        if holder.is_empty() {
-            // Creating the first appendable segment needs the append-only
-            // components the writer cannot build yet, so an empty directory is
-            // not something this iteration can bootstrap.
-            todo!("creating the initial appendable segment needs the append-only components");
         }
 
         Ok(Self {
@@ -96,4 +98,111 @@ impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S> {
             pool,
         })
     }
+}
+
+impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S>
+where
+    S::Fs: UniversalReadFs<File = S> + UniversalReadFsAsync,
+{
+    /// [`create_appendable`](Self::create_appendable) with `source`'s config.
+    pub fn create_appendable_from(
+        self,
+        source: Uuid,
+        indexed_fields: &HashMap<JsonPath, PayloadFieldSchema>,
+    ) -> OperationResult<(Self, Uuid)> {
+        let config = self
+            .segments
+            .read()
+            .get(source)?
+            .read()
+            .segment_config
+            .clone();
+        self.create_appendable(&config, indexed_fields)
+    }
+
+    /// Build an empty appendable and adopt it as the write target; the
+    /// manifest entry stays the caller's job. Also bootstraps a segmentless
+    /// shard (an empty manifest opens with no write target).
+    pub fn create_appendable(
+        mut self,
+        config: &SegmentConfig,
+        indexed_fields: &HashMap<JsonPath, PayloadFieldSchema>,
+    ) -> OperationResult<(Self, Uuid)> {
+        // Built locally: the append-only components have no create path over a backend.
+        let scratch = tempfile::tempdir()
+            .map_err(|err| OperationError::service_error(format!("create scratch dir: {err}")))?;
+        let (mut segment, _token) = build_segment(scratch.path(), config, None, true)?;
+        let hw_counter = HardwareCounterCell::disposable();
+        for (key, schema) in indexed_fields {
+            segment.create_field_index(0, key, Some(schema), &hw_counter)?;
+        }
+        segment.flush(true)?;
+        let local = segment.data_path();
+        let uuid: Uuid = local
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.parse().ok())
+            .ok_or_else(|| {
+                OperationError::service_error(format!(
+                    "built segment path carries no uuid: {}",
+                    local.display(),
+                ))
+            })?;
+        drop(segment);
+
+        let remote = self.path.join(SEGMENTS_PATH).join(uuid.to_string());
+        copy_dir_via(&self.fs, &local, &remote)?;
+
+        let lookup = LookupSegment::<S>::open(&self.fs, &remote, None)?;
+        let writer = UpdateOnlySegmentEnum::open(
+            &self.fs,
+            &remote,
+            &lookup.segment_config,
+            lookup.writer_state(),
+        )?;
+        self.segments.write().insert(uuid, lookup, true);
+        self.writers.insert(uuid, writer);
+        Ok((self, uuid))
+    }
+}
+
+fn copy_dir_via<F: UniversalWriteFileOps>(
+    fs: &F,
+    local: &Path,
+    remote: &Path,
+) -> OperationResult<()> {
+    let mut created = std::collections::HashSet::new();
+    for entry in walkdir::WalkDir::new(local) {
+        let entry = entry.map_err(|err| {
+            OperationError::service_error(format!("walk {}: {err}", local.display()))
+        })?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        let rel = path.strip_prefix(local).map_err(|err| {
+            OperationError::service_error(format!("relativize {}: {err}", path.display()))
+        })?;
+        let bytes = fs_err::read(path).map_err(|err| {
+            OperationError::service_error(format!("read {}: {err}", path.display()))
+        })?;
+        let target = remote.join(rel);
+        if let Some(parent) = target.parent()
+            && created.insert(parent.to_path_buf())
+        {
+            fs.create_dir(parent)?;
+        }
+        // Length 0: a pre-sized file would conflict with the offset-0 append.
+        fs.create(&target, 0)?;
+        let options = OpenOptions {
+            writeable: true,
+            need_sequential: true,
+            populate: Populate::No,
+            advice: AdviceSetting::Global,
+        };
+        let mut file = fs.open_append(&target, options.for_append())?;
+        file.append(0, bytes.as_slice())?;
+        file.flusher()()?;
+    }
+    Ok(())
 }

--- a/lib/edge/src/update_only/lifecycle.rs
+++ b/lib/edge/src/update_only/lifecycle.rs
@@ -68,17 +68,18 @@ impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S> {
                 segments
                     .into_par_iter()
                     .map(|(uuid, listing)| {
+                        let ListedSegment { path, writable } = listing;
                         // No deferred threshold yet: it belongs to the coordination
                         // with an external rebuilder, which does not exist in this
                         // iteration.
-                        let segment = LookupSegment::<S>::open(&fs, &listing.path, None)?;
+                        let segment = LookupSegment::<S>::open(&fs, &path, None)?;
                         let writer = UpdateOnlySegmentEnum::open(
                             &fs,
-                            &listing.path,
+                            &path,
                             &segment.segment_config,
                             segment.writer_state(),
                         )?;
-                        Ok((uuid, segment, writer, listing.writable))
+                        Ok((uuid, segment, writer, writable))
                     })
                     .collect::<OperationResult<Vec<_>>>()
             })?;
@@ -105,10 +106,12 @@ where
     S::Fs: UniversalReadFs<File = S> + UniversalReadFsAsync,
 {
     /// [`create_appendable`](Self::create_appendable) with `source`'s config.
-    pub fn create_appendable_from(
+    #[cfg(test)]
+    pub(crate) fn create_appendable_from(
         self,
         source: Uuid,
         indexed_fields: &HashMap<JsonPath, PayloadFieldSchema>,
+        temp_path: &Path,
     ) -> OperationResult<(Self, Uuid)> {
         let config = self
             .segments
@@ -117,37 +120,36 @@ where
             .read()
             .segment_config
             .clone();
-        self.create_appendable(&config, indexed_fields)
+        self.create_appendable(&config, indexed_fields, temp_path)
     }
 
     /// Build an empty appendable and adopt it as the write target; the
     /// manifest entry stays the caller's job. Also bootstraps a segmentless
     /// shard (an empty manifest opens with no write target).
+    ///
+    /// `temp_path` is a local directory the segment is built in before it is
+    /// copied to the backend (conventionally `<shard>/temp_segments`); it is
+    /// created if missing and left empty afterwards.
     pub fn create_appendable(
         mut self,
         config: &SegmentConfig,
         indexed_fields: &HashMap<JsonPath, PayloadFieldSchema>,
+        temp_path: &Path,
     ) -> OperationResult<(Self, Uuid)> {
         // Built locally: the append-only components have no create path over a backend.
-        let scratch = tempfile::tempdir()
+        fs_err::create_dir_all(temp_path)?;
+        let scratch = tempfile::Builder::new()
+            .prefix("appendable-")
+            .tempdir_in(temp_path)
             .map_err(|err| OperationError::service_error(format!("create scratch dir: {err}")))?;
-        let (mut segment, _token) = build_segment(scratch.path(), config, None, true)?;
+        let (mut segment, token) = build_segment(scratch.path(), config, None, true)?;
+        let uuid = token.id();
         let hw_counter = HardwareCounterCell::disposable();
         for (key, schema) in indexed_fields {
             segment.create_field_index(0, key, Some(schema), &hw_counter)?;
         }
         segment.flush(true)?;
         let local = segment.data_path();
-        let uuid: Uuid = local
-            .file_name()
-            .and_then(|name| name.to_str())
-            .and_then(|name| name.parse().ok())
-            .ok_or_else(|| {
-                OperationError::service_error(format!(
-                    "built segment path carries no uuid: {}",
-                    local.display(),
-                ))
-            })?;
         drop(segment);
 
         let remote = self.path.join(SEGMENTS_PATH).join(uuid.to_string());

--- a/lib/edge/src/update_only/mod.rs
+++ b/lib/edge/src/update_only/mod.rs
@@ -91,6 +91,11 @@ impl<S: UniversalAppend + 'static> UpdateOnlyEdgeShard<S> {
         self.segments.read().len()
     }
 
+    /// The append target; `None` when every appendable is claimed by a rebuild.
+    pub fn write_target(&self) -> Option<Uuid> {
+        self.segments.read().write_target_uuid()
+    }
+
     /// Every segment's config, cloned out, with the write target marked.
     /// Order is unspecified. The write target's config is the schema a write
     /// must conform to: the named vectors a point carries, and their shapes.

--- a/lib/edge/src/update_only/tests.rs
+++ b/lib/edge/src/update_only/tests.rs
@@ -14,7 +14,8 @@ use shard::operations::point_ops::PointOperations::DeletePoints;
 use tempfile::TempDir;
 
 use crate::read_only::tests::{
-    delete as leader_delete, exact_count, open_follower, scrolled_ids, test_config, upsert,
+    delete as leader_delete, exact_count, init_serverless_feature_flags, open_follower, point,
+    scrolled_ids, test_config, upsert,
 };
 use crate::update_only::{PointApplyKind, UpdateOnlyEdgeShard};
 use crate::{EdgeConfig, EdgeOptimizersConfig, EdgeShard};
@@ -560,4 +561,104 @@ mod store {
             Some(payload_json! { "kind": "updated" })
         );
     }
+}
+
+/// A claimed target opens non-writable; a created appendable takes the writes.
+#[test]
+fn optimizing_target_gets_a_created_appendable() {
+    use std::collections::HashMap;
+
+    use common::universal_io::MmapFs;
+    use shard::files::segment_manifest_path;
+    use shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
+    use shard::operations::point_ops::PointOperations::UpsertPoints;
+    use shard::segment_manifest::{SegmentManifestState, SegmentsManifest};
+    use uuid::Uuid;
+
+    use crate::read_only::ManifestSegmentEnumerator;
+
+    init_serverless_feature_flags();
+    let dir = leader_with_ten_points("edge-update-roll");
+
+    let manifest_path = segment_manifest_path(dir.path());
+    let mut manifest: SegmentsManifest =
+        serde_json::from_slice(&fs_err::read(&manifest_path).unwrap()).unwrap();
+    let old: Uuid = *manifest.iter().next().unwrap().0;
+    manifest.set(
+        old,
+        SegmentManifestState::Optimizing {
+            holder: "idx".to_string(),
+            lease_until: u64::MAX,
+        },
+    );
+    fs_err::write(&manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+
+    let writer = UpdateOnlyEdgeShard::<MmapFile>::open(
+        MmapFs,
+        dir.path(),
+        ManifestSegmentEnumerator::new(MmapFs, dir.path()),
+    )
+    .unwrap();
+    assert_eq!(
+        writer.write_target(),
+        None,
+        "a claimed target must not take appends",
+    );
+
+    let (writer, fresh) = writer.create_appendable_from(old, &HashMap::new()).unwrap();
+    assert_ne!(fresh, old);
+    assert_eq!(writer.write_target(), Some(fresh));
+
+    let batch = [(
+        100,
+        PointOperation(UpsertPoints(PointsList(vec![point(42)]))),
+    )];
+    let (_writer, outcome) = writer.apply_batch(batch).unwrap();
+    assert_eq!(outcome.stored, 1);
+
+    let follower = open_follower(dir.path());
+    assert_eq!(exact_count(&follower), 11);
+    assert!(scrolled_ids(&follower).contains(&ExtendedPointId::NumId(42)));
+}
+
+/// A segmentless shard (empty manifest) opens with no target; `create_appendable`
+/// bootstraps the first one.
+#[test]
+fn empty_manifest_shard_bootstraps_an_appendable() {
+    use std::collections::HashMap;
+
+    use common::universal_io::MmapFs;
+    use shard::files::segment_manifest_path;
+    use shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
+    use shard::operations::point_ops::PointOperations::UpsertPoints;
+
+    use crate::read_only::ManifestSegmentEnumerator;
+    use crate::read_only::tests::{init_serverless_feature_flags, point, test_config};
+
+    init_serverless_feature_flags();
+    let dir = tempfile::Builder::new()
+        .prefix("edge-update-bootstrap")
+        .tempdir()
+        .unwrap();
+    fs_err::write(segment_manifest_path(dir.path()), "{}").unwrap();
+
+    let writer = UpdateOnlyEdgeShard::<MmapFile>::open(
+        MmapFs,
+        dir.path(),
+        ManifestSegmentEnumerator::new(MmapFs, dir.path()),
+    )
+    .unwrap();
+    assert_eq!(writer.segments_count(), 0);
+    assert_eq!(writer.write_target(), None);
+
+    let config = test_config().plain_segment_config();
+    let (writer, fresh) = writer.create_appendable(&config, &HashMap::new()).unwrap();
+    assert_eq!(writer.write_target(), Some(fresh));
+
+    let batch = [(7, PointOperation(UpsertPoints(PointsList(vec![point(1)]))))];
+    let (_writer, outcome) = writer.apply_batch(batch).unwrap();
+    assert_eq!(outcome.stored, 1);
+
+    let follower = open_follower(dir.path());
+    assert_eq!(exact_count(&follower), 1);
 }

--- a/lib/edge/src/update_only/tests.rs
+++ b/lib/edge/src/update_only/tests.rs
@@ -572,6 +572,7 @@ fn optimizing_target_gets_a_created_appendable() {
     use shard::files::segment_manifest_path;
     use shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
     use shard::operations::point_ops::PointOperations::UpsertPoints;
+    use shard::optimizers::config::TEMP_SEGMENTS_PATH;
     use shard::segment_manifest::{SegmentManifestState, SegmentsManifest};
     use uuid::Uuid;
 
@@ -605,7 +606,10 @@ fn optimizing_target_gets_a_created_appendable() {
         "a claimed target must not take appends",
     );
 
-    let (writer, fresh) = writer.create_appendable_from(old, &HashMap::new()).unwrap();
+    let temp_path = dir.path().join(TEMP_SEGMENTS_PATH);
+    let (writer, fresh) = writer
+        .create_appendable_from(old, &HashMap::new(), &temp_path)
+        .unwrap();
     assert_ne!(fresh, old);
     assert_eq!(writer.write_target(), Some(fresh));
 
@@ -631,6 +635,7 @@ fn empty_manifest_shard_bootstraps_an_appendable() {
     use shard::files::segment_manifest_path;
     use shard::operations::point_ops::PointInsertOperationsInternal::PointsList;
     use shard::operations::point_ops::PointOperations::UpsertPoints;
+    use shard::optimizers::config::TEMP_SEGMENTS_PATH;
 
     use crate::read_only::ManifestSegmentEnumerator;
     use crate::read_only::tests::{init_serverless_feature_flags, point, test_config};
@@ -652,8 +657,15 @@ fn empty_manifest_shard_bootstraps_an_appendable() {
     assert_eq!(writer.write_target(), None);
 
     let config = test_config().plain_segment_config();
-    let (writer, fresh) = writer.create_appendable(&config, &HashMap::new()).unwrap();
+    let temp_path = dir.path().join(TEMP_SEGMENTS_PATH);
+    let (writer, fresh) = writer
+        .create_appendable(&config, &HashMap::new(), &temp_path)
+        .unwrap();
     assert_eq!(writer.write_target(), Some(fresh));
+    assert!(
+        fs_err::read_dir(&temp_path).unwrap().next().is_none(),
+        "scratch segment must not outlive the copy",
+    );
 
     let batch = [(7, PointOperation(UpsertPoints(PointsList(vec![point(1)]))))];
     let (_writer, outcome) = writer.apply_batch(batch).unwrap();

--- a/lib/shard/src/segment_manifest.rs
+++ b/lib/shard/src/segment_manifest.rs
@@ -58,6 +58,21 @@ impl SegmentManifestState {
         }
     }
 
+    /// Whether a writer may take the segment as its append target. Only
+    /// [`Active`](Self::Active) qualifies: an [`Optimizing`](Self::Optimizing) segment is
+    /// readable, but appends into it are lost at the swap.
+    pub fn is_writable(&self) -> bool {
+        match self {
+            SegmentManifestState::Active => true,
+            SegmentManifestState::UnderConstruction
+            | SegmentManifestState::Optimizing {
+                holder: _,
+                lease_until: _,
+            }
+            | SegmentManifestState::Retiring => false,
+        }
+    }
+
     /// Whether the state is a mark owned by an out-of-process optimizer — a rebuild claim
     /// ([`Optimizing`](Self::Optimizing)) or a pending removal ([`Retiring`](Self::Retiring)) —
     /// rather than something derivable from the segment holder. A holder rebuild must not erase


### PR DESCRIPTION
Serverless found this live: the updater's write target is the single appendable segment, and while the out-of-process indexer rebuilds it (`optimizing` in the segment manifest), the update-only writer keeps appending into it in place — the swap then publishes the rebuild and the in-flight appends are gone (2 850 of 22 500 points in the reproduction, with the WAL already consumed). The serverless side now carries an abort safeguard plus a workaround that mints a segment externally and reopens the writer until it happens to pick it (qdrant/qdrant-serverless#117) — this PR adds the two pieces of engine coordination that make the workaround unnecessary. It is the coordination the code already anticipates ("it belongs to the coordination with an external rebuilder").

- **`SegmentEnumerator` reports writability**: `list_segments()` now returns `ListedSegment { path, writable }`. `ManifestSegmentEnumerator` maps `optimizing` claims to `writable: false` — such segments stay open for lookups and tombstones (they are still live for reads until the swap), but the holder never takes them as the write target. `LocalSegmentEnumerator` and readers are unaffected.
- **`UpdateOnlyEdgeShard::write_target()`** exposes the current target; with every appendable claimed it is `None` instead of an arbitrary pick.
- **`UpdateOnlyEdgeShard::create_appendable_from(source, indexed_fields)`** builds one empty appendable segment with `source`'s config (locally, with the ordinary constructor — the append-only components still have no create path over a backend), copies its files through the backend (`create` + `append` + flush per file), opens it and adopts it as the write target. Payload indexes are seeded by the caller the way `EdgeShard` seeds its fresh appendable. Making the segment visible to readers (the manifest entry) stays the caller's job, matching how the serverless layer owns manifest CAS.

The empty-directory bootstrap `todo!` in `open` is untouched — creating the *first* segment of a shard is a separate concern.

Test: a manifest-claimed target opens with no write target; `create_appendable_from` yields a fresh target; an applied upsert lands in it; a follower over the directory serves the union. Existing edge suites green, fmt/clippy clean.

Downstream (qdrant-serverless): the updater replaces its mint + reopen loop with `write_target().is_none()` → `create_appendable_from` → manifest CAS-add, and the indexer's write-reconcile abort stays as the safety net.
