### PR TITLE
[updater] Batch upsert quantized vectors

### DIFF
--- a/lib/quantization/src/encoded_storage.rs
+++ b/lib/quantization/src/encoded_storage.rs
@@ -32,6 +32,21 @@ pub trait EncodedStorageWrite {
         hw_counter: &HardwareCounterCell,
     ) -> std::io::Result<()>;
 
+    /// Persist `vectors` on consecutive ids starting at `start_id`. A storage
+    /// whose backend can batch writes overrides this; the default loops over
+    /// [`upsert_vector`](Self::upsert_vector).
+    fn upsert_many<'a>(
+        &mut self,
+        start_id: PointOffsetType,
+        vectors: impl IntoIterator<Item = &'a [u8]>,
+        hw_counter: &HardwareCounterCell,
+    ) -> std::io::Result<()> {
+        for (offset, vector) in vectors.into_iter().enumerate() {
+            self.upsert_vector(start_id + offset as PointOffsetType, vector, hw_counter)?;
+        }
+        Ok(())
+    }
+
     fn vectors_count(&self) -> usize;
 
     fn flusher(&self) -> MmapFlusher;

--- a/lib/quantization/src/encoded_storage.rs
+++ b/lib/quantization/src/encoded_storage.rs
@@ -35,12 +35,16 @@ pub trait EncodedStorageWrite {
     /// Persist `vectors` on consecutive ids starting at `start_id`. A storage
     /// whose backend can batch writes overrides this; the default loops over
     /// [`upsert_vector`](Self::upsert_vector).
-    fn upsert_many<'a>(
+    fn upsert_many<'a, I>(
         &mut self,
         start_id: PointOffsetType,
-        vectors: impl IntoIterator<Item = &'a [u8]>,
+        vectors: I,
         hw_counter: &HardwareCounterCell,
-    ) -> std::io::Result<()> {
+    ) -> std::io::Result<()>
+    where
+        I: IntoIterator<Item = &'a [u8]>,
+        I::IntoIter: ExactSizeIterator,
+    {
         for (offset, vector) in vectors.into_iter().enumerate() {
             self.upsert_vector(start_id + offset as PointOffsetType, vector, hw_counter)?;
         }

--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -671,26 +671,32 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorageWrite>
         }
     }
 
-    /// Encode and persist `vector` at `id`, sized and encoded from this instance's already-fitted
-    /// metadata. A true inherent method (not the [`EncodedVectors`] trait's `upsert_vector`) so
-    /// it only needs [`EncodedStorageWrite`] — a storage that can only append, never read, e.g.
-    /// an update-only segment's overlay, can still call this.
-    pub fn upsert_vector(
+    /// Encode and persist `vectors` on consecutive ids from `start_id`, handing the storage the
+    /// whole run as one batch. Inherent rather than on the [`EncodedVectors`] trait, so a
+    /// write-only [`EncodedStorageWrite`] storage can call it.
+    pub fn append_many<'a>(
         &mut self,
-        id: PointOffsetType,
-        vector: &[f32],
+        start_id: PointOffsetType,
+        vectors: impl IntoIterator<Item = &'a [f32]>,
         hw_counter: &HardwareCounterCell,
     ) -> std::io::Result<()> {
-        let encoded_vector =
-            Self::encode_vector(vector, &self.metadata.vector_stats, self.metadata.encoding);
-        self.encoded_vectors.upsert_vector(
-            id,
-            bytemuck::cast_slice(encoded_vector.encoded_vector.as_slice()),
+        // Encoded whole rather than streamed: the storage borrows the encoded rows.
+        let encoded: Vec<_> = vectors
+            .into_iter()
+            .map(|vector| {
+                Self::encode_vector(vector, &self.metadata.vector_stats, self.metadata.encoding)
+            })
+            .collect();
+        self.encoded_vectors.upsert_many(
+            start_id,
+            encoded
+                .iter()
+                .map(|vector| bytemuck::cast_slice(vector.encoded_vector.as_slice())),
             hw_counter,
         )
     }
 
-    /// See [`Self::upsert_vector`]: an inherent counterpart of the [`EncodedVectors`] trait's
+    /// See [`Self::append_many`]: an inherent counterpart of the [`EncodedVectors`] trait's
     /// `flusher`, so a write-only [`EncodedStorageWrite`] storage can call it too.
     pub fn flusher(&self) -> MmapFlusher {
         self.encoded_vectors.flusher()

--- a/lib/quantization/src/encoded_vectors_tq.rs
+++ b/lib/quantization/src/encoded_vectors_tq.rs
@@ -342,26 +342,27 @@ impl<TStorage: EncodedStorageWrite> EncodedVectorsTQ<TStorage> {
         &self.metadata
     }
 
-    /// Encode and persist `vector` at `id`, using this instance's already-fitted quantizer. A
-    /// true inherent method (not the [`EncodedVectors`] trait's `upsert_vector`) so it only needs
-    /// [`EncodedStorageWrite`] — a storage that can only append, never read, e.g. an
-    /// update-only segment's overlay, can still call this.
-    pub fn upsert_vector(
+    /// Encode and persist `vectors` on consecutive ids from `start_id`, handing the storage the
+    /// whole run as one batch. Inherent rather than on the [`EncodedVectors`] trait, so a
+    /// write-only [`EncodedStorageWrite`] storage can call it.
+    pub fn append_many<'a>(
         &mut self,
-        id: PointOffsetType,
-        vector: &[f32],
+        start_id: PointOffsetType,
+        vectors: impl IntoIterator<Item = &'a [f32]>,
         hw_counter: &HardwareCounterCell,
     ) -> std::io::Result<()> {
-        let encoded_vector =
-            Self::encode_vector(vector, &self.quantizer, &mut self.encoding_buffer);
-        self.encoded_vectors.upsert_vector(
-            id,
-            bytemuck::cast_slice(encoded_vector.as_slice()),
-            hw_counter,
-        )
+        // Encoded whole rather than streamed: the storage borrows the encoded rows.
+        let quantizer = &self.quantizer;
+        let encoding_buffer = &mut self.encoding_buffer;
+        let encoded: Vec<_> = vectors
+            .into_iter()
+            .map(|vector| Self::encode_vector(vector, quantizer, encoding_buffer))
+            .collect();
+        self.encoded_vectors
+            .upsert_many(start_id, encoded.iter().map(Vec::as_slice), hw_counter)
     }
 
-    /// See [`Self::upsert_vector`]: an inherent counterpart of the [`EncodedVectors`] trait's
+    /// See [`Self::append_many`]: an inherent counterpart of the [`EncodedVectors`] trait's
     /// `flusher`, so a write-only [`EncodedStorageWrite`] storage can call it too.
     pub fn flusher(&self) -> MmapFlusher {
         self.encoded_vectors.flusher()

--- a/lib/segment/src/segment/update_only/appendable/mod.rs
+++ b/lib/segment/src/segment/update_only/appendable/mod.rs
@@ -1,7 +1,6 @@
 //! The write phase for the appendable segment: the one segment of a shard a
 //! batch appends its points to.
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -10,22 +9,15 @@ use common::types::PointOffsetType;
 use common::universal_io::UniversalAppend;
 
 use super::AppendableIdTrackerState;
-use crate::common::operation_error::{OperationError, OperationResult};
+use crate::common::operation_error::OperationResult;
 use crate::data_types::fully_qualified_point::FullyQualifiedPoint;
-use crate::data_types::primitive::PrimitiveVectorElement;
-use crate::data_types::vectors::{
-    VectorElementType, VectorElementTypeByte, VectorElementTypeHalf, VectorRef,
-};
 use crate::id_tracker::mutable_id_tracker::update_only::{
     MappingOperation, UpdateOnlyAppendableIdTracker,
 };
 use crate::index::struct_payload_index::update_only::UpdateOnlyStructPayloadIndex;
 use crate::payload_storage::update_only::UpdateOnlyPayloadStorage;
 use crate::segment_constructor::get_vector_storage_path;
-use crate::types::{
-    Distance, PointIdType, QuantizationConfig, SegmentConfig, SeqNumberType, VectorNameBuf,
-    VectorStorageDatatype,
-};
+use crate::types::{PointIdType, SegmentConfig, SeqNumberType, VectorNameBuf};
 use crate::vector_storage::quantized::update_only::UpdateOnlyQuantizedVectors;
 use crate::vector_storage::update_only::{UpdateOnlyVectorStorage, VectorToStore};
 
@@ -73,15 +65,10 @@ impl<S: UniversalAppend + 'static> StoreComponents<S> {
             let storage = UpdateOnlyVectorStorage::open(fs.clone(), &path, vector_config)?;
             vector_storages.push((vector_name.clone(), storage));
 
-            // Turbo4-datatype vectors already store a compressed representation as their raw
-            // format; a `QuantizationConfig` overlay on top of that is not a combination the
-            // non-update-only path supports either, so it is out of scope here too.
-            let is_turbo4_datatype = vector_config.datatype == Some(VectorStorageDatatype::Turbo4);
-            if vector_config.multivector_config.is_none() && !is_turbo4_datatype {
-                let quantized = UpdateOnlyQuantizedVectors::open(fs.clone(), &path)?;
-                if let Some(quantized) = quantized {
-                    quantized_vectors.insert(vector_name.clone(), quantized);
-                }
+            if let Some(quantized) =
+                UpdateOnlyQuantizedVectors::open(fs.clone(), &path, vector_config)?
+            {
+                quantized_vectors.insert(vector_name.clone(), quantized);
             }
         }
         for vector_name in config.sparse_vector_data.keys() {
@@ -96,53 +83,6 @@ impl<S: UniversalAppend + 'static> StoreComponents<S> {
             vector_storages,
             quantized_vectors,
         })
-    }
-}
-
-/// Reconstruct the `f32` form of a vector stored as raw, storage-native bytes — carried over
-/// from a point's previous slot rather than freshly decoded — so it can be pushed through a
-/// quantized overlay the same way a freshly decoded vector is. Mirrors
-/// `QuantizedVectors::create_impl`'s use of `PrimitiveVectorElement::quantization_preprocess`
-/// for the same purpose on the non-update-only path.
-fn decode_raw_dense_vector(
-    datatype: VectorStorageDatatype,
-    quantization_config: &QuantizationConfig,
-    distance: Distance,
-    bytes: &[u8],
-) -> Vec<VectorElementType> {
-    match datatype {
-        VectorStorageDatatype::Float32 => {
-            let vector: &[VectorElementType] = bytemuck::cast_slice(bytes);
-            VectorElementType::quantization_preprocess(
-                quantization_config,
-                distance,
-                Cow::Borrowed(vector),
-            )
-            .into_owned()
-        }
-        VectorStorageDatatype::Uint8 => {
-            let vector: &[VectorElementTypeByte] = bytemuck::cast_slice(bytes);
-            VectorElementTypeByte::quantization_preprocess(
-                quantization_config,
-                distance,
-                Cow::Borrowed(vector),
-            )
-            .into_owned()
-        }
-        VectorStorageDatatype::Float16 => {
-            let vector: &[VectorElementTypeHalf] = bytemuck::cast_slice(bytes);
-            VectorElementTypeHalf::quantization_preprocess(
-                quantization_config,
-                distance,
-                Cow::Borrowed(vector),
-            )
-            .into_owned()
-        }
-        VectorStorageDatatype::Turbo4 => {
-            unreachable!(
-                "a Turbo4-datatype vector never has a quantized overlay open, see StoreComponents::open"
-            )
-        }
     }
 }
 
@@ -220,21 +160,6 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
         let inserted = self.id_tracker.insert_operations(&operations)?;
         let (_, start_slot) = *inserted.first().expect("one slot per insert");
 
-        // Distance/datatype per named vector, needed to decode a `VectorToStore::Raw` blob back
-        // to `f32` for its quantized overlay. Captured before `store_components()` borrows
-        // `self` mutably — `self.config` and `self.store` cannot both be borrowed through it.
-        let vector_metadata: HashMap<VectorNameBuf, (Distance, VectorStorageDatatype)> = self
-            .config
-            .vector_data
-            .iter()
-            .map(|(name, cfg)| {
-                (
-                    name.clone(),
-                    (cfg.distance, cfg.datatype.unwrap_or_default()),
-                )
-            })
-            .collect();
-
         let store = self.store_components()?;
 
         // Each named vector, from whichever half of the point holds it: the
@@ -242,56 +167,27 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
         // point's previous slot, and a name in neither still takes its slot —
         // the storage records it as a vector the point does not have.
         for (vector_name, storage) in &mut store.vector_storages {
-            let vectors = points.iter().map(|point| {
-                if let Some(vector) = point.updated_vectors.get(vector_name) {
-                    VectorToStore::Decoded(vector)
-                } else if let Some((_, bytes)) = point
-                    .stored_vectors
-                    .iter()
-                    .find(|(name, _)| name == vector_name)
-                {
-                    VectorToStore::Raw(bytes)
-                } else {
-                    VectorToStore::Missing
-                }
-            });
-            storage.append_many(start_slot, vectors, hw_counter)?;
-
-            // The quantized overlay, if this vector has one, must keep its row count in exact
-            // lockstep with the raw storage above: every point takes a row here too — a
-            // decoded/carried-over vector encoded for real, a missing one as an all-zero
-            // placeholder — so row `k` always means the same point in both. Skipping a row for
-            // a `Raw`/`Missing` point here would silently misalign every later lookup, scoring
-            // one point's vector against another's quantized copy.
-            if let Some(quantized) = store.quantized_vectors.get_mut(vector_name) {
-                let quantization_config = quantized.quantization_config().clone();
-                let &(distance, datatype) = vector_metadata.get(vector_name).expect(
-                    "a quantized overlay only exists for a name present in config.vector_data",
-                );
-                for (offset, point) in points.iter().enumerate() {
-                    let id = start_slot + offset as PointOffsetType;
+            let vectors: Vec<VectorToStore> = points
+                .iter()
+                .map(|point| {
                     if let Some(vector) = point.updated_vectors.get(vector_name) {
-                        let VectorRef::Dense(dense) = vector else {
-                            return Err(OperationError::WrongMulti);
-                        };
-                        quantized.upsert_vector(id, VectorRef::Dense(dense), hw_counter)?;
+                        VectorToStore::Decoded(vector)
                     } else if let Some((_, bytes)) = point
                         .stored_vectors
                         .iter()
                         .find(|(name, _)| name == vector_name)
                     {
-                        let decoded = decode_raw_dense_vector(
-                            datatype,
-                            &quantization_config,
-                            distance,
-                            bytes,
-                        );
-                        quantized.upsert_vector(id, VectorRef::Dense(&decoded), hw_counter)?;
+                        VectorToStore::Raw(bytes)
                     } else {
-                        let placeholder = vec![0.0 as VectorElementType; quantized.dim()];
-                        quantized.upsert_vector(id, VectorRef::Dense(&placeholder), hw_counter)?;
+                        VectorToStore::Missing
                     }
-                }
+                })
+                .collect();
+            storage.append_many(start_slot, vectors.iter().copied(), hw_counter)?;
+
+            // The quantized storage takes the same run, row-for-row with the raw storage.
+            if let Some(quantized) = store.quantized_vectors.get_mut(vector_name) {
+                quantized.append_many(start_slot, vectors.iter().copied(), hw_counter)?;
             }
         }
 

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/update_only.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/update_only.rs
@@ -61,12 +61,16 @@ impl<S: UniversalAppend + 'static> EncodedStorageWrite for UpdateOnlyQuantizedCh
         self.upsert_many(id, std::iter::once(vector), hw_counter)
     }
 
-    fn upsert_many<'a>(
+    fn upsert_many<'a, I>(
         &mut self,
         start_id: PointOffsetType,
-        vectors: impl IntoIterator<Item = &'a [u8]>,
+        vectors: I,
         hw_counter: &HardwareCounterCell,
-    ) -> std::io::Result<()> {
+    ) -> std::io::Result<()>
+    where
+        I: IntoIterator<Item = &'a [u8]>,
+        I::IntoIter: ExactSizeIterator,
+    {
         // Update-only never rewrites a slot in place (every upsert clones to a fresh one), so
         // `id` is always the current end of the storage — a genuine append, matching what
         // `UpdateOnlyChunkedVectors::append_many` requires of `start_key`.

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/update_only.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/update_only.rs
@@ -58,11 +58,20 @@ impl<S: UniversalAppend + 'static> EncodedStorageWrite for UpdateOnlyQuantizedCh
         vector: &[u8],
         hw_counter: &HardwareCounterCell,
     ) -> std::io::Result<()> {
+        self.upsert_many(id, std::iter::once(vector), hw_counter)
+    }
+
+    fn upsert_many<'a>(
+        &mut self,
+        start_id: PointOffsetType,
+        vectors: impl IntoIterator<Item = &'a [u8]>,
+        hw_counter: &HardwareCounterCell,
+    ) -> std::io::Result<()> {
         // Update-only never rewrites a slot in place (every upsert clones to a fresh one), so
         // `id` is always the current end of the storage — a genuine append, matching what
         // `UpdateOnlyChunkedVectors::append_many` requires of `start_key`.
         self.vectors
-            .append_many(id as VectorOffsetType, std::iter::once(vector), hw_counter)
+            .append_many(start_id as VectorOffsetType, vectors, hw_counter)
             .map_err(std::io::Error::other)
     }
 

--- a/lib/segment/src/vector_storage/quantized/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/update_only/mod.rs
@@ -18,7 +18,7 @@
 //! `reopen_for_write` (added alongside `load`, which additionally validates a stored vector by
 //! reading it back — a read this write-only storage cannot serve, and a guarantee a resuming
 //! writer doesn't need: every vector it writes is sized from the same metadata `load` and
-//! `reopen_for_write` both read). Both `reopen_for_write` and `upsert_vector`/`flusher` only
+//! `reopen_for_write` both read). Both `reopen_for_write` and `upsert_many`/`flusher` only
 //! require [`EncodedStorageWrite`] — the write-only half of [`EncodedStorage`], split out so a
 //! storage that can never serve a read doesn't have to fake one. The only new storage-layer code
 //! is [`UpdateOnlyQuantizedChunkedStorage`], an [`EncodedStorageWrite`] backed by
@@ -35,6 +35,7 @@
 #[cfg(test)]
 mod tests;
 
+use std::borrow::Cow;
 use std::path::Path;
 
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -44,12 +45,14 @@ use quantization::encoded_vectors_binary::EncodedVectorsBin;
 use quantization::encoded_vectors_tq::EncodedVectorsTQ;
 
 use crate::common::operation_error::{OperationError, OperationResult};
-use crate::data_types::vectors::VectorRef;
-use crate::types::QuantizationConfig;
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
+use crate::types::{Distance, QuantizationConfig, VectorDataConfig, VectorStorageDatatype};
 use crate::vector_storage::quantized::quantized_chunked_mmap_storage::UpdateOnlyQuantizedChunkedStorage;
 use crate::vector_storage::quantized::quantized_vectors::{
     QuantizedVectors, QuantizedVectorsConfig,
 };
+use crate::vector_storage::update_only::VectorToStore;
 
 enum UpdateOnlyQuantizedVectorStorage<S: UniversalAppend + 'static> {
     Binary(Box<EncodedVectorsBin<u128, UpdateOnlyQuantizedChunkedStorage<S>>>),
@@ -64,6 +67,9 @@ enum UpdateOnlyQuantizedVectorStorage<S: UniversalAppend + 'static> {
 pub struct UpdateOnlyQuantizedVectors<S: UniversalAppend + 'static> {
     storage: UpdateOnlyQuantizedVectorStorage<S>,
     config: QuantizedVectorsConfig,
+    /// Raw-storage properties, needed to decode a [`VectorToStore::Raw`].
+    distance: Distance,
+    datatype: VectorStorageDatatype,
 }
 
 impl<S: UniversalAppend + 'static> UpdateOnlyQuantizedVectors<S> {
@@ -74,13 +80,24 @@ impl<S: UniversalAppend + 'static> UpdateOnlyQuantizedVectors<S> {
     /// absence. Returns `None` when nothing was persisted, e.g. quantization was never configured
     /// for this vector, or the configured method didn't support incremental appends (Scalar,
     /// Product — see [`QuantizationConfig::supports_appendable`]) at creation time.
-    pub fn open(fs: S::Fs, path: &Path) -> OperationResult<Option<Self>> {
+    pub fn open(
+        fs: S::Fs,
+        path: &Path,
+        vector_config: &VectorDataConfig,
+    ) -> OperationResult<Option<Self>> {
+        let datatype = vector_config.datatype.unwrap_or_default();
+        // Multivector and Turbo4-datatype vectors never get an overlay, so they return
+        // `None` outright.
+        if vector_config.multivector_config.is_some() || datatype == VectorStorageDatatype::Turbo4 {
+            return Ok(None);
+        }
+
         let config_path = QuantizedVectors::get_config_path(path);
         if !fs.exists(&config_path)? {
             return Ok(None);
         }
         let config: QuantizedVectorsConfig = read_json_via(&fs, &config_path)?;
-        Self::open_existing(fs, config, path).map(Some)
+        Self::open_existing(fs, config, path, vector_config.distance, datatype).map(Some)
     }
 
     /// Reopen a previously-persisted overlay to resume appending: reads the fitted metadata
@@ -94,6 +111,8 @@ impl<S: UniversalAppend + 'static> UpdateOnlyQuantizedVectors<S> {
         fs: S::Fs,
         config: QuantizedVectorsConfig,
         path: &Path,
+        distance: Distance,
+        datatype: VectorStorageDatatype,
     ) -> OperationResult<Self> {
         let meta_path = QuantizedVectors::get_meta_path(path);
         let data_path = QuantizedVectors::get_data_path(path, config.storage_type);
@@ -129,42 +148,90 @@ impl<S: UniversalAppend + 'static> UpdateOnlyQuantizedVectors<S> {
             }
         };
 
-        Ok(Self { storage, config })
+        Ok(Self {
+            storage,
+            config,
+            distance,
+            datatype,
+        })
     }
 
-    /// The quantization method actually persisted for this overlay — the source of truth for a
-    /// caller deciding how to reconstruct an `f32` vector from storage-native bytes carried over
-    /// from a point's previous slot, since a reopened overlay's config is read from disk, not
-    /// necessarily identical to whatever live config the caller has to hand.
-    pub fn quantization_config(&self) -> &QuantizationConfig {
-        &self.config.quantization_config
+    /// Encode and persist one row per point of a batch, starting at `start_slot` — the current
+    /// end of the overlay, since slots are never rewritten in place.
+    ///
+    /// Every point takes a row (a missing vector as an all-zero placeholder), keeping row `k` in
+    /// lockstep with slot `k` of the raw storage this overlay shadows.
+    pub fn append_many<'a>(
+        &mut self,
+        start_slot: PointOffsetType,
+        vectors: impl IntoIterator<Item = VectorToStore<'a>>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        // Decoded whole rather than streamed: an owned row must outlive the storage call.
+        let placeholder = vec![0.0 as VectorElementType; self.dim()];
+        let mut run: Vec<Cow<[VectorElementType]>> = Vec::new();
+        for vector in vectors {
+            run.push(match vector {
+                VectorToStore::Decoded(vector) => Cow::Borrowed(vector.try_into()?),
+                VectorToStore::Raw(bytes) => self.decode_raw(bytes)?,
+                VectorToStore::Missing => Cow::Borrowed(placeholder.as_slice()),
+            });
+        }
+
+        let rows = run.iter().map(Cow::as_ref);
+        match &mut self.storage {
+            UpdateOnlyQuantizedVectorStorage::Binary(q) => {
+                Ok(q.append_many(start_slot, rows, hw_counter)?)
+            }
+            UpdateOnlyQuantizedVectorStorage::Turbo(q) => {
+                Ok(q.append_many(start_slot, rows, hw_counter)?)
+            }
+        }
     }
 
-    /// The dimensionality of the (dense, unrotated) vector this overlay quantizes — the length
-    /// a caller must give [`Self::upsert_vector`], including for a placeholder vector standing
-    /// in for a point with no vector under this name.
-    pub fn dim(&self) -> usize {
+    /// The dimensionality of the (dense, unrotated) vector this overlay quantizes.
+    fn dim(&self) -> usize {
         self.config.vector_parameters.dim
     }
 
-    /// Encode and persist `vector` for `id`. `id` must be the current end of the overlay: like
-    /// every other update-only storage, this never rewrites a slot in place.
-    pub fn upsert_vector(
-        &mut self,
-        id: PointOffsetType,
-        vector: VectorRef,
-        hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
-        let VectorRef::Dense(vector) = vector else {
-            return Err(OperationError::WrongMulti);
-        };
-        match &mut self.storage {
-            UpdateOnlyQuantizedVectorStorage::Binary(q) => {
-                Ok(q.upsert_vector(id, vector, hw_counter)?)
-            }
-            UpdateOnlyQuantizedVectorStorage::Turbo(q) => {
-                Ok(q.upsert_vector(id, vector, hw_counter)?)
+    /// Reconstruct the `f32` form of a raw, storage-native vector, preprocessing it per the
+    /// persisted config — the source of truth over whatever live config the caller has.
+    fn decode_raw<'a>(&self, bytes: &'a [u8]) -> OperationResult<Cow<'a, [VectorElementType]>> {
+        match self.datatype {
+            VectorStorageDatatype::Float32 => self.decode_raw_as::<VectorElementType>(bytes),
+            VectorStorageDatatype::Uint8 => self.decode_raw_as::<VectorElementTypeByte>(bytes),
+            VectorStorageDatatype::Float16 => self.decode_raw_as::<VectorElementTypeHalf>(bytes),
+            VectorStorageDatatype::Turbo4 => {
+                unreachable!("`Self::open` opens no overlay for a Turbo4-datatype vector")
             }
         }
+    }
+
+    /// Mirrors `QuantizedVectors::create_impl` on the non-update-only path.
+    fn decode_raw_as<'a, T: PrimitiveVectorElement>(
+        &self,
+        bytes: &'a [u8],
+    ) -> OperationResult<Cow<'a, [VectorElementType]>> {
+        let expected_size = self.dim() * size_of::<T>();
+        if bytes.len() != expected_size {
+            // `MalformedVectorBlob`, not a service error: a blob that reached
+            // the WAL is skipped on replay rather than crash-looping recovery.
+            return Err(OperationError::malformed_vector_blob(format!(
+                "Malformed dense vector blob of {} bytes, expected {expected_size}",
+                bytes.len(),
+            )));
+        }
+
+        // A misaligned blob decodes through a copy.
+        let vector: Cow<'a, [T]> = match bytemuck::try_cast_slice(bytes) {
+            Ok(slice) => Cow::Borrowed(slice),
+            Err(_) => Cow::Owned(bytemuck::allocation::pod_collect_to_vec(bytes)),
+        };
+
+        Ok(T::quantization_preprocess(
+            &self.config.quantization_config,
+            self.distance,
+            vector,
+        ))
     }
 }

--- a/lib/segment/src/vector_storage/quantized/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/quantized/update_only/tests.rs
@@ -29,8 +29,9 @@ use tempfile::TempDir;
 use super::{UpdateOnlyQuantizedVectorStorage, UpdateOnlyQuantizedVectors};
 use crate::data_types::vectors::VectorRef;
 use crate::types::{
-    BinaryQuantization, BinaryQuantizationConfig, Distance, QuantizationConfig, TurboQuantBitSize,
-    TurboQuantQuantizationConfig, TurboQuantization,
+    BinaryQuantization, BinaryQuantizationConfig, Distance, Indexes, QuantizationConfig,
+    TurboQuantBitSize, TurboQuantQuantizationConfig, TurboQuantization, VectorDataConfig,
+    VectorStorageDatatype, VectorStorageType,
 };
 use crate::vector_storage::quantized::quantized_chunked_mmap_storage::{
     QuantizedChunkedStorage, UpdateOnlyQuantizedChunkedStorageBuilder,
@@ -39,6 +40,7 @@ use crate::vector_storage::quantized::quantized_ram_storage::QuantizedRamStorage
 use crate::vector_storage::quantized::quantized_vectors::{
     QuantizedVectors, QuantizedVectorsConfig, QuantizedVectorsStorageType,
 };
+use crate::vector_storage::update_only::VectorToStore;
 
 const DIM: usize = 8;
 
@@ -61,6 +63,19 @@ fn turbo_config() -> QuantizationConfig {
             bits: Some(TurboQuantBitSize::Bits4),
         },
     })
+}
+
+/// The raw-storage config of the dense vector every overlay in these tests shadows.
+fn dense_vector_config() -> VectorDataConfig {
+    VectorDataConfig {
+        size: DIM,
+        distance: Distance::Dot,
+        storage_type: VectorStorageType::ChunkedMmap,
+        index: Indexes::Plain {},
+        quantization_config: None,
+        multivector_config: None,
+        datatype: None,
+    }
 }
 
 fn some_vectors(n: usize) -> Vec<Vec<f32>> {
@@ -163,6 +178,8 @@ fn create_empty_overlay(
     UpdateOnlyQuantizedVectors {
         storage,
         config: overlay_config,
+        distance: Distance::Dot,
+        datatype: VectorStorageDatatype::Float32,
     }
 }
 
@@ -174,24 +191,26 @@ fn create_empty_overlay(
 fn write_all(config: &QuantizationConfig, path: &std::path::Path, vectors: &[Vec<f32>]) {
     let hw_counter = HardwareCounterCell::new();
 
+    fn as_batch(vectors: &[Vec<f32>]) -> impl Iterator<Item = VectorToStore<'_>> {
+        vectors
+            .iter()
+            .map(|vector| VectorToStore::Decoded(VectorRef::from(vector.as_slice())))
+    }
+
     let split = vectors.len() / 2;
     let mut writer = create_empty_overlay(config, path);
-    for (id, vector) in vectors[..split].iter().enumerate() {
-        writer
-            .upsert_vector(id as u32, VectorRef::from(vector.as_slice()), &hw_counter)
-            .unwrap();
-    }
+    writer
+        .append_many(0, as_batch(&vectors[..split]), &hw_counter)
+        .unwrap();
     drop(writer);
 
-    let mut writer = UpdateOnlyQuantizedVectors::<MmapFile>::open(MmapFs, path)
-        .unwrap()
-        .expect("overlay was already created by the first writer");
-    for (offset, vector) in vectors[split..].iter().enumerate() {
-        let id = (split + offset) as u32;
-        writer
-            .upsert_vector(id, VectorRef::from(vector.as_slice()), &hw_counter)
-            .unwrap();
-    }
+    let mut writer =
+        UpdateOnlyQuantizedVectors::<MmapFile>::open(MmapFs, path, &dense_vector_config())
+            .unwrap()
+            .expect("overlay was already created by the first writer");
+    writer
+        .append_many(split as u32, as_batch(&vectors[split..]), &hw_counter)
+        .unwrap();
     drop(writer);
 }
 
@@ -351,7 +370,9 @@ fn turbo_bytes_match_the_standard_batch_encode_path() {
 #[test]
 fn open_returns_none_when_nothing_persisted() {
     let dir = TempDir::with_prefix("update_only_quantized_no_config").unwrap();
-    let overlay = UpdateOnlyQuantizedVectors::<MmapFile>::open(MmapFs, dir.path()).unwrap();
+    let overlay =
+        UpdateOnlyQuantizedVectors::<MmapFile>::open(MmapFs, dir.path(), &dense_vector_config())
+            .unwrap();
     assert!(overlay.is_none());
 }
 
@@ -368,10 +389,16 @@ fn reopening_a_nonempty_overlay_works() {
     let mut writer = create_empty_overlay(&config, dir.path());
     let vector = some_vectors(1).remove(0);
     writer
-        .upsert_vector(0, VectorRef::from(vector.as_slice()), &hw_counter)
+        .append_many(
+            0,
+            [VectorToStore::Decoded(VectorRef::from(vector.as_slice()))],
+            &hw_counter,
+        )
         .unwrap();
     drop(writer);
 
-    let reopened = UpdateOnlyQuantizedVectors::<MmapFile>::open(MmapFs, dir.path()).unwrap();
+    let reopened =
+        UpdateOnlyQuantizedVectors::<MmapFile>::open(MmapFs, dir.path(), &dense_vector_config())
+            .unwrap();
     assert!(reopened.is_some());
 }

--- a/lib/segment/src/vector_storage/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/update_only/mod.rs
@@ -35,6 +35,7 @@ use crate::vector_storage::turbo::update_only::UpdateOnlyTurboVectorStorage;
 /// storage-native bytes that never need decoding.
 ///
 /// [1]: crate::data_types::fully_qualified_point::FullyQualifiedPoint
+#[derive(Clone, Copy)]
 pub enum VectorToStore<'a> {
     /// Decoded by the batch.
     Decoded(VectorRef<'a>),


### PR DESCRIPTION
Adds `EncodedVectorsWrite::upsert_many` method, so that `UpdateOnlyQuantizedVectors` can use it to append all vectors in the batch at once, instead of one by one.

This refactor also moves some config settings inside `UpdateOnlyQuantizedVectors` and simplifies the `store_points` flow.

Almost fully written by AI™️ 
