### PR TITLE
Apply `ChangeAliases` operation atomically

### DIFF
--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -55,6 +55,16 @@ impl AliasMapping {
         self.0.remove(alias);
     }
 
+    /// Drop every alias pointing at `collection_name`.
+    /// Returns `false` if there were none.
+    pub fn remove_collection(&mut self, collection_name: &str) -> bool {
+        let len = self.0.len();
+
+        self.0.retain(|_, target| target != collection_name);
+
+        self.0.len() != len
+    }
+
     /// Rename `old_alias` as `new_alias`, keeping collection it points at.
     /// Returns `false` if `old_alias` does not exist.
     pub fn rename(&mut self, old_alias: &str, new_alias: Alias) -> bool {
@@ -103,22 +113,18 @@ impl AliasPersistence {
     }
 
     pub fn get(&self, alias: &str) -> Option<String> {
-        self.alias_mapping.0.get(alias).cloned()
+        self.alias_mapping.get(alias).cloned()
     }
 
     pub fn insert(&mut self, alias: String, collection_name: String) -> Result<(), StorageError> {
-        self.alias_mapping.0.insert(alias, collection_name);
+        self.alias_mapping.insert(alias, collection_name);
         self.alias_mapping.save(&self.data_path)?;
         Ok(())
     }
 
     /// Removes all aliases for a given collection.
     pub fn remove_collection(&mut self, collection_name: &str) -> Result<(), StorageError> {
-        let prev_len = self.alias_mapping.0.len();
-
-        self.alias_mapping.0.retain(|_, v| v != collection_name);
-
-        if prev_len != self.alias_mapping.0.len() {
+        if self.alias_mapping.remove_collection(collection_name) {
             self.alias_mapping.save(&self.data_path)?;
         }
 
@@ -142,6 +148,6 @@ impl AliasPersistence {
     }
 
     pub fn check_alias_exists(&self, alias: &str) -> bool {
-        self.alias_mapping.0.contains_key(alias)
+        self.alias_mapping.get(alias).is_some()
     }
 }

--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -112,16 +112,6 @@ impl AliasPersistence {
         Ok(())
     }
 
-    pub fn remove(&mut self, alias: &str) -> Result<Option<String>, StorageError> {
-        let output = self.alias_mapping.0.remove(alias);
-
-        if output.is_some() {
-            self.alias_mapping.save(&self.data_path)?;
-        }
-
-        Ok(output)
-    }
-
     /// Removes all aliases for a given collection.
     pub fn remove_collection(&mut self, collection_name: &str) -> Result<(), StorageError> {
         let prev_len = self.alias_mapping.0.len();
@@ -133,25 +123,6 @@ impl AliasPersistence {
         }
 
         Ok(())
-    }
-
-    pub fn rename_alias(
-        &mut self,
-        old_alias_name: &str,
-        new_alias_name: String,
-    ) -> Result<(), StorageError> {
-        match self.get(old_alias_name) {
-            None => Err(StorageError::not_found(format!(
-                "Alias {old_alias_name} does not exists!"
-            ))),
-            Some(collection_name) => {
-                self.alias_mapping.0.remove(old_alias_name);
-                self.alias_mapping.0.insert(new_alias_name, collection_name);
-                // 'remove' & 'insert' saved atomically
-                self.alias_mapping.save(&self.data_path)?;
-                Ok(())
-            }
-        }
     }
 
     pub fn collection_aliases(&self, collection_name: &str) -> Vec<String> {

--- a/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
@@ -9,6 +9,7 @@ use collection::shards::shard::PeerId;
 use super::*;
 use crate::content_manager::collection_meta_ops::*;
 use crate::content_manager::consensus_state_machine::{Action, CollectionConfigDiff, NodeContext};
+use crate::content_manager::toc::apply_alias_actions;
 
 type Actions = Vec<Action>;
 
@@ -266,55 +267,14 @@ impl ClusterState {
         // Validate all `actions` before emitting anything, and emit a single `UpdateAliases`,
         // which the applier writes in one go. So either all `actions` apply, or none of them do.
         //
-        // `ToC::update_aliases` does the same, against a copy of the mapping it saves once.
+        // `ToC::update_aliases` runs the same actions against a copy of the mapping it saves
+        // once, and owns the function both call.
 
         let mut aliases = self.aliases.clone();
 
-        for action in actions {
-            match action {
-                AliasOperations::CreateAlias(action) => {
-                    let CreateAlias {
-                        collection_name,
-                        alias_name,
-                    } = &action.create_alias;
-
-                    // `collection_name` must name a collection, not an alias
-                    if !self.has_collection(collection_name) {
-                        return Err(StorageError::not_found(format!(
-                            "Collection `{collection_name}` does not exist"
-                        )));
-                    }
-
-                    if self.has_collection(alias_name) {
-                        return Err(StorageError::already_exists(format!(
-                            "Collection `{alias_name}` already exists"
-                        )));
-                    }
-
-                    aliases.insert(alias_name.clone(), collection_name.clone());
-                }
-
-                AliasOperations::DeleteAlias(action) => {
-                    let DeleteAlias { alias_name } = &action.delete_alias;
-
-                    // Deleting an alias that does not exist is a no-op, not an error
-                    aliases.remove(alias_name);
-                }
-
-                AliasOperations::RenameAlias(action) => {
-                    let RenameAlias {
-                        old_alias_name,
-                        new_alias_name,
-                    } = &action.rename_alias;
-
-                    if !aliases.rename(old_alias_name, new_alias_name.clone()) {
-                        return Err(StorageError::not_found(format!(
-                            "Alias {old_alias_name} does not exist"
-                        )));
-                    }
-                }
-            }
-        }
+        apply_alias_actions(&mut aliases, actions, |collection| {
+            self.has_collection(collection)
+        })?;
 
         let set: BTreeMap<_, _> = aliases
             .iter()

--- a/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
@@ -263,24 +263,10 @@ impl ClusterState {
     pub fn plan_change_aliases(&self, op: &ChangeAliasesOperation) -> StorageResult<Actions> {
         let ChangeAliasesOperation { actions } = op;
 
-        // TODO:
+        // Validate all `actions` before emitting anything, and emit a single `UpdateAliases`,
+        // which the applier writes in one go. So either all `actions` apply, or none of them do.
         //
-        // This is intentionally different from `TableOfContent::update_aliases`.
-        //
-        // `ToC::update_aliases` validates and applies `actions` one by one,
-        // and `AliasPersistence` writes the mapping on every insert, remove and rename.
-        // So if an `AliasOperation` in the middle of the list is rejected, every action
-        // before it is applied and persisted, and every action after it never runs.
-        //
-        // `plan_change_aliases` validates all `actions` first, and emits a single
-        // `UpdateAliases` action, which the applier has to write in one go.
-        // So either all `actions` apply, or none of them do.
-        //
-        // E.g., take a list of two actions:
-        // the first creates alias `new`, the second renames alias `missing`, which does not exist.
-        //
-        // `ToC::update_aliases` would create alias `new`, then return an error.
-        // `plan_change_aliases` would return an error *before* creating alias `new`.
+        // `ToC::update_aliases` does the same, against a copy of the mapping it saves once.
 
         let mut aliases = self.aliases.clone();
 

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -333,8 +333,18 @@ impl TableOfContent {
                             alias_name,
                         },
                 }) => {
-                    collection_lock.validate_collection_exists(&collection_name)?;
-                    collection_lock.validate_collection_not_exists(&alias_name)?;
+                    // `collection_name` must name a collection, not an alias
+                    if !collection_lock.collection_exists(&collection_name) {
+                        return Err(StorageError::not_found(format!(
+                            "Collection `{collection_name}` does not exist"
+                        )));
+                    }
+
+                    if collection_lock.collection_exists(&alias_name) {
+                        return Err(StorageError::already_exists(format!(
+                            "Collection `{alias_name}` already exists"
+                        )));
+                    }
 
                     aliases.insert(alias_name, collection_name);
                 }
@@ -352,7 +362,7 @@ impl TableOfContent {
                 }) => {
                     if !aliases.rename(&old_alias_name, new_alias_name) {
                         return Err(StorageError::not_found(format!(
-                            "Alias {old_alias_name} does not exists!"
+                            "Alias {old_alias_name} does not exist"
                         )));
                     }
                 }

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -14,6 +14,7 @@ use common::fs::safe_delete_in_tmp;
 
 use super::{COLLECTION_DELETE_SPIN_INTERVAL, COLLECTION_DELETE_WAIT_TIMEOUT, TableOfContent};
 use crate::common::utils::try_unwrap_with_timeout_async;
+use crate::content_manager::alias_mapping::AliasMapping;
 use crate::content_manager::collection_meta_ops::*;
 use crate::content_manager::collections_ops::Checker as _;
 use crate::content_manager::consensus_ops::ConsensusOperations;
@@ -324,50 +325,9 @@ impl TableOfContent {
         // so nothing is persisted until every action is validated.
         let mut aliases = alias_lock.state().clone();
 
-        for action in operation.actions {
-            match action {
-                AliasOperations::CreateAlias(CreateAliasOperation {
-                    create_alias:
-                        CreateAlias {
-                            collection_name,
-                            alias_name,
-                        },
-                }) => {
-                    // `collection_name` must name a collection, not an alias
-                    if !collection_lock.collection_exists(&collection_name) {
-                        return Err(StorageError::not_found(format!(
-                            "Collection `{collection_name}` does not exist"
-                        )));
-                    }
-
-                    if collection_lock.collection_exists(&alias_name) {
-                        return Err(StorageError::already_exists(format!(
-                            "Collection `{alias_name}` already exists"
-                        )));
-                    }
-
-                    aliases.insert(alias_name, collection_name);
-                }
-                AliasOperations::DeleteAlias(DeleteAliasOperation {
-                    delete_alias: DeleteAlias { alias_name },
-                }) => {
-                    aliases.remove(&alias_name);
-                }
-                AliasOperations::RenameAlias(RenameAliasOperation {
-                    rename_alias:
-                        RenameAlias {
-                            old_alias_name,
-                            new_alias_name,
-                        },
-                }) => {
-                    if !aliases.rename(&old_alias_name, new_alias_name) {
-                        return Err(StorageError::not_found(format!(
-                            "Alias {old_alias_name} does not exist"
-                        )));
-                    }
-                }
-            };
-        }
+        apply_alias_actions(&mut aliases, &operation.actions, |collection_name| {
+            collection_lock.collection_exists(collection_name)
+        })?;
 
         alias_lock.apply_state(aliases)?;
 
@@ -827,4 +787,68 @@ impl TableOfContent {
 
         Ok(())
     }
+}
+
+/// Apply `actions` to `aliases`, validating each one against `collection_exists`.
+///
+/// Returns on the first invalid action, leaving `aliases` partially updated. `update_aliases`
+/// works on a copy it only saves on success, so a rejected operation changes nothing.
+///
+/// `ClusterState::plan_change_aliases` calls this as well, so that both accept and reject the
+/// same operations. Inline it back here once the state machine drives consensus and this is the
+/// only caller.
+pub(crate) fn apply_alias_actions(
+    aliases: &mut AliasMapping,
+    actions: &[AliasOperations],
+    collection_exists: impl Fn(&str) -> bool,
+) -> Result<(), StorageError> {
+    for action in actions {
+        match action {
+            AliasOperations::CreateAlias(CreateAliasOperation {
+                create_alias:
+                    CreateAlias {
+                        collection_name,
+                        alias_name,
+                    },
+            }) => {
+                // `collection_name` must name a collection, not an alias
+                if !collection_exists(collection_name) {
+                    return Err(StorageError::not_found(format!(
+                        "Collection `{collection_name}` does not exist"
+                    )));
+                }
+
+                if collection_exists(alias_name) {
+                    return Err(StorageError::already_exists(format!(
+                        "Collection `{alias_name}` already exists"
+                    )));
+                }
+
+                aliases.insert(alias_name.clone(), collection_name.clone());
+            }
+
+            AliasOperations::DeleteAlias(DeleteAliasOperation {
+                delete_alias: DeleteAlias { alias_name },
+            }) => {
+                // Deleting an alias that does not exist is a no-op, not an error
+                aliases.remove(alias_name);
+            }
+
+            AliasOperations::RenameAlias(RenameAliasOperation {
+                rename_alias:
+                    RenameAlias {
+                        old_alias_name,
+                        new_alias_name,
+                    },
+            }) => {
+                if !aliases.rename(old_alias_name, new_alias_name.clone()) {
+                    return Err(StorageError::not_found(format!(
+                        "Alias {old_alias_name} does not exist"
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -317,6 +317,13 @@ impl TableOfContent {
         // Prevent search on partially switched collections
         let collection_lock = self.collections.write().await;
         let mut alias_lock = self.alias_persistence.write().await;
+
+        // Validate and apply `actions` to a copy of the mapping, and save it once at the end.
+        //
+        // Rejecting an action in the middle of the list must not keep the actions before it,
+        // so nothing is persisted until every action is validated.
+        let mut aliases = alias_lock.state().clone();
+
         for action in operation.actions {
             match action {
                 AliasOperations::CreateAlias(CreateAliasOperation {
@@ -329,12 +336,12 @@ impl TableOfContent {
                     collection_lock.validate_collection_exists(&collection_name)?;
                     collection_lock.validate_collection_not_exists(&alias_name)?;
 
-                    alias_lock.insert(alias_name, collection_name)?;
+                    aliases.insert(alias_name, collection_name);
                 }
                 AliasOperations::DeleteAlias(DeleteAliasOperation {
                     delete_alias: DeleteAlias { alias_name },
                 }) => {
-                    alias_lock.remove(&alias_name)?;
+                    aliases.remove(&alias_name);
                 }
                 AliasOperations::RenameAlias(RenameAliasOperation {
                     rename_alias:
@@ -343,10 +350,17 @@ impl TableOfContent {
                             new_alias_name,
                         },
                 }) => {
-                    alias_lock.rename_alias(&old_alias_name, new_alias_name)?;
+                    if !aliases.rename(&old_alias_name, new_alias_name) {
+                        return Err(StorageError::not_found(format!(
+                            "Alias {old_alias_name} does not exists!"
+                        )));
+                    }
                 }
             };
         }
+
+        alias_lock.apply_state(aliases)?;
+
         Ok(true)
     }
 

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -42,6 +42,7 @@ use segment::data_types::collection_defaults::CollectionConfigDefaults;
 use tokio::runtime::{Handle, Runtime};
 use tokio::sync::{Mutex, RwLock, Semaphore};
 
+pub(crate) use self::collection_meta_ops::apply_alias_actions;
 use self::dispatcher::TocDispatcher;
 use crate::ConsensusOperations;
 use crate::content_manager::alias_mapping::AliasPersistence;

--- a/lib/storage/tests/integration/alias_tests.rs
+++ b/lib/storage/tests/integration/alias_tests.rs
@@ -13,21 +13,128 @@ use common::budget::ResourceBudget;
 use common::load_concurrency::LoadConcurrencyConfig;
 use common::mmap;
 use segment::types::Distance;
+use storage::content_manager::alias_mapping::AliasPersistence;
 use storage::content_manager::collection_meta_ops::{
-    ChangeAliasesOperation, CollectionMetaOperations, CreateAlias, CreateCollection,
-    CreateCollectionOperation, DeleteAlias, RenameAlias,
+    AliasOperations, ChangeAliasesOperation, CollectionMetaOperations, CreateAlias,
+    CreateCollection, CreateCollectionOperation, DeleteAlias, RenameAlias,
 };
 use storage::content_manager::consensus::operation_sender::OperationSender;
-use storage::content_manager::toc::TableOfContent;
+use storage::content_manager::errors::StorageError;
+use storage::content_manager::toc::{ALIASES_PATH, TableOfContent};
 use storage::dispatcher::Dispatcher;
 use storage::rbac::{Access, AccessRequirements, Auth};
 use storage::types::{PerformanceConfig, StorageConfig};
-use tempfile::Builder;
+use tempfile::{Builder, TempDir};
+use tokio::runtime::Handle;
 
 const FULL_ACCESS: Auth = Auth::new_internal(Access::full("For test"));
 
 #[test]
 fn test_alias_operation() {
+    let (_storage_dir, handle, dispatcher) = new_dispatcher();
+
+    create_collection(&handle, &dispatcher, "test");
+
+    change_aliases(
+        &handle,
+        &dispatcher,
+        vec![
+            CreateAlias {
+                collection_name: "test".to_string(),
+                alias_name: "test_alias".to_string(),
+            }
+            .into(),
+        ],
+    )
+    .unwrap();
+
+    change_aliases(
+        &handle,
+        &dispatcher,
+        vec![
+            CreateAlias {
+                collection_name: "test".to_string(),
+                alias_name: "test_alias2".to_string(),
+            }
+            .into(),
+            DeleteAlias {
+                alias_name: "test_alias".to_string(),
+            }
+            .into(),
+            RenameAlias {
+                old_alias_name: "test_alias2".to_string(),
+                new_alias_name: "test_alias3".to_string(),
+            }
+            .into(),
+        ],
+    )
+    .unwrap();
+
+    // Nothing to verify here.
+    let pass = new_unchecked_verification_pass();
+
+    let _ = handle
+        .block_on(
+            dispatcher.toc(&FULL_ACCESS, &pass).get_collection(
+                &FULL_ACCESS
+                    .check_collection_access("test_alias3", AccessRequirements::new(), "test")
+                    .unwrap(),
+            ),
+        )
+        .unwrap();
+}
+
+#[test]
+fn change_aliases_reject_mid_list() {
+    let (storage_dir, handle, dispatcher) = new_dispatcher();
+
+    create_collection(&handle, &dispatcher, "test");
+
+    change_aliases(
+        &handle,
+        &dispatcher,
+        vec![
+            CreateAlias {
+                collection_name: "test".to_string(),
+                alias_name: "test_alias".to_string(),
+            }
+            .into(),
+        ],
+    )
+    .unwrap();
+
+    // Second action renames an alias that does not exist, so the operation is rejected
+    let error = change_aliases(
+        &handle,
+        &dispatcher,
+        vec![
+            CreateAlias {
+                collection_name: "test".to_string(),
+                alias_name: "new_alias".to_string(),
+            }
+            .into(),
+            RenameAlias {
+                old_alias_name: "missing_alias".to_string(),
+                new_alias_name: "renamed_alias".to_string(),
+            }
+            .into(),
+        ],
+    )
+    .unwrap_err();
+
+    assert!(
+        matches!(error, StorageError::NotFound { .. }),
+        "renaming a missing alias should be rejected as not found, got {error:?}"
+    );
+
+    // Rejected operation must not save the alias its first action creates
+    let aliases = AliasPersistence::open(&storage_dir.path().join(ALIASES_PATH)).unwrap();
+
+    assert_eq!(aliases.get("test_alias").as_deref(), Some("test"));
+    assert_eq!(aliases.get("new_alias"), None);
+}
+
+fn new_dispatcher() -> (TempDir, Handle, Dispatcher) {
     let storage_dir = Builder::new().prefix("storage").tempdir().unwrap();
 
     let config = StorageConfig {
@@ -94,14 +201,17 @@ fn test_alias_operation() {
         .unwrap(),
     );
     let handle = toc.general_runtime_handle().clone();
-    let dispatcher = Dispatcher::new(toc);
 
+    (storage_dir, handle, Dispatcher::new(toc))
+}
+
+fn create_collection(handle: &Handle, dispatcher: &Dispatcher, collection_name: &str) {
     handle
         .block_on(
             dispatcher.submit_collection_meta_op(
                 CollectionMetaOperations::CreateCollection(
                     CreateCollectionOperation::new(
-                        "test".to_string(),
+                        collection_name.to_string(),
                         CreateCollection {
                             vectors: VectorParamsBuilder::new(10, Distance::Cosine)
                                 .build()
@@ -129,56 +239,16 @@ fn test_alias_operation() {
             ),
         )
         .unwrap();
+}
 
-    handle
-        .block_on(dispatcher.submit_collection_meta_op(
-            CollectionMetaOperations::ChangeAliases(ChangeAliasesOperation {
-                actions: vec![CreateAlias {
-                        collection_name: "test".to_string(),
-                        alias_name: "test_alias".to_string(),
-                    }
-                    .into()],
-            }),
-            FULL_ACCESS,
-            None,
-        ))
-        .unwrap();
-
-    handle
-        .block_on(dispatcher.submit_collection_meta_op(
-            CollectionMetaOperations::ChangeAliases(ChangeAliasesOperation {
-                actions: vec![
-                        CreateAlias {
-                            collection_name: "test".to_string(),
-                            alias_name: "test_alias2".to_string(),
-                        }
-                        .into(),
-                        DeleteAlias {
-                            alias_name: "test_alias".to_string(),
-                        }
-                        .into(),
-                        RenameAlias {
-                            old_alias_name: "test_alias2".to_string(),
-                            new_alias_name: "test_alias3".to_string(),
-                        }
-                        .into(),
-                    ],
-            }),
-            FULL_ACCESS,
-            None,
-        ))
-        .unwrap();
-
-    // Nothing to verify here.
-    let pass = new_unchecked_verification_pass();
-
-    let _ = handle
-        .block_on(
-            dispatcher.toc(&FULL_ACCESS, &pass).get_collection(
-                &FULL_ACCESS
-                    .check_collection_access("test_alias3", AccessRequirements::new(), "test")
-                    .unwrap(),
-            ),
-        )
-        .unwrap();
+fn change_aliases(
+    handle: &Handle,
+    dispatcher: &Dispatcher,
+    actions: Vec<AliasOperations>,
+) -> Result<bool, StorageError> {
+    handle.block_on(dispatcher.submit_collection_meta_op(
+        CollectionMetaOperations::ChangeAliases(ChangeAliasesOperation { actions }),
+        FULL_ACCESS,
+        None,
+    ))
 }


### PR DESCRIPTION
`ChangeAliases` contains multiple `Create`/`Rename`/`Delete` actions and applies these actions one-by-one.

E.g., it renames one alias, then creates another alias, then removes third alias, etc. `AliasMapping` is saved after each action.

Each action can fail to apply if collection/alias does not exist.

So, if operation contains an invalid action, then it might be *partially* applied. It will apply some actions, then check preconditions for invalid action, return an error and ignore remaining actions.

This PR validates all actions *before* applying them, so `ChangeAliases` should either apply fully or not at all.

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
