### PR TITLE
Fix blocking consensus thread, allow cancellation in HNSW healing

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph_layers_healer.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_healer.rs
@@ -6,7 +6,7 @@ use parking_lot::RwLock;
 use rayon::ThreadPool;
 use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
 
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationResult, check_process_stopped};
 use crate::index::hnsw_index::HnswM;
 use crate::index::hnsw_index::graph_layers::GraphLayers;
 use crate::index::hnsw_index::graph_layers_builder::{GraphLayersBuilder, LockedLayersContainer};
@@ -211,11 +211,14 @@ impl<'a> GraphLayersHealer<'a> {
         pool: &ThreadPool,
         vector_storage: &VectorStorageEnum,
         quantized_vectors: Option<&QuantizedVectors>,
+        stopped: &std::sync::atomic::AtomicBool,
     ) -> OperationResult<()> {
         pool.install(|| {
             std::mem::take(&mut self.to_heal)
                 .into_par_iter()
                 .try_for_each(|(offset, level)| {
+                    check_process_stopped(stopped)?;
+
                     // Internal operation. No measurements needed.
                     let internal_hardware_counter = HardwareCounterCell::disposable();
                     let query = vector_storage

--- a/lib/segment/src/index/hnsw_index/hnsw/build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/build.rs
@@ -278,6 +278,8 @@ impl HNSWIndex {
             None
         };
 
+        check_process_stopped(stopped)?;
+
         if build_main_graph {
             let progress_main_graph = progress_main_graph.unwrap();
             let progress_migrate = progress_migrate.unwrap();
@@ -300,7 +302,14 @@ impl HNSWIndex {
                 );
                 let old_vector_storage = old_index.index.vector_storage.borrow();
                 let old_quantized_vectors = old_index.index.quantized_vectors.borrow();
-                healer.heal(&pool, &old_vector_storage, old_quantized_vectors.as_ref())?;
+
+                healer.heal(
+                    &pool,
+                    &old_vector_storage,
+                    old_quantized_vectors.as_ref(),
+                    stopped,
+                )?;
+                check_process_stopped(stopped)?;
                 healer.save_into_builder(&graph_layers_builder);
 
                 for vector_id in ids_iter {


### PR DESCRIPTION
Dropping a replica through consensus does a few things. It first aborts any ongoing optimizations, and then it waits for them to complete. After that, a replica is removed and deleted from disk.

Waiting for completion is done in the consensus thread. If it takes a long time, the consensus thread is blocked for a long time. It cascades into other issues such as missing points due to lagging consensus.

The test implemented [here](https://github.com/qdrant/qdrant/tree/bfc7f966c4b15ef760c20e6b6fb158b0b1fd95ee/tools/stall-repro) shows that HNSW healing can take a long time to cancel. That is because it did not have cancellation points implemented.

This PR implements cancellation in HNSW healing, so that cancellation remains quick and the consensus thread is not blocked.

Test results before the fix (time in seconds):
```
trial  healed  slow wait  applied
    0   12722      21.37    21.47
    1    2928       4.80     4.95
    2    2721       4.46     4.52
    3    2709       4.51     4.57
    4    3476       7.41     7.47
```

Test results after the fix, more than 100x quicker to cancel:
```
trial  healed  slow wait  applied
    0   12630          -     0.13
    1    2804          -     0.16
    2    2288          -     0.16
    3    2506          -     0.14
    4   14157          -     0.17
```

I was not able to validate whether these cancellation points have any negative effect on healing performance.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
