### PR TITLE
Flush segments only at update operation boundaries

### DIFF
--- a/lib/collection/src/update_workers/flush_workers.rs
+++ b/lib/collection/src/update_workers/flush_workers.rs
@@ -19,9 +19,26 @@ use crate::wal_delta::LockedWal;
 impl UpdateWorkers {
     /// Returns confirmed version after flush of all segments
     ///
+    /// Runs at an operation boundary: the updates lock is held while flushers are captured and
+    /// the persisted waterline is read, so this pass can never observe a half-applied operation.
+    ///
+    /// A single update operation writes to segments in several separately locked phases. E.g.
+    /// `upsert_points_impl` first updates the points that already exist, then takes a fresh write
+    /// lock on the smallest appendable segment to insert the new ones. `flush_all` read-locks
+    /// every segment, which prevents interleaving *within* a phase, but without this guard a pass
+    /// could still start *between* two phases of the same operation. It would then capture a
+    /// segment at `version = op_num` with only part of that operation applied, and stamp
+    /// `persisted_version = op_num` once the flush completes. The segment looks clean from then on
+    /// (`version == persisted_version`), so the rest of the operation is never written, while the
+    /// waterline reports it as fully saved and the WAL is acknowledged past it, dropping the only
+    /// recoverable copy. See #10402.
+    ///
     /// # Errors
     /// Returns an error on flush failure
     fn flush_segments(segments: LockedSegmentHolder) -> OperationResult<SeqNumberType> {
+        // Taken before the holder read lock, matching `CollectionUpdater::update`, so waiting for
+        // it never blocks a writer that is waiting for the holder lock.
+        let _updates_guard = segments.acquire_updates_lock();
         let read_segments = segments.read();
         let flushed_version = read_segments.flush_all(FlushMode::Background, false)?;
         Ok(match read_segments.failed_operation.iter().cloned().min() {
@@ -140,5 +157,52 @@ impl UpdateWorkers {
                 log::error!("Flush worker failed: {error}",);
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::thread;
+    use std::time::Duration;
+
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::collection_manager::fixtures::build_test_holder;
+
+    /// A flush pass must not start in the middle of an update operation.
+    ///
+    /// Operations write to segments in several separately locked phases; a flush that lands
+    /// between two of them captures a segment with the operation half applied and then marks it
+    /// as fully persisted, so the remainder is never written (#10402). Holding the updates lock
+    /// for the duration of an operation is what keeps flushes on operation boundaries.
+    #[test]
+    fn flush_segments_waits_for_operation_boundary() {
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let holder = build_test_holder(dir.path());
+
+        let updates_guard = holder.acquire_updates_lock();
+
+        let flushed = Arc::new(AtomicBool::new(false));
+        let handle = thread::spawn({
+            let holder = holder.clone();
+            let flushed = flushed.clone();
+            move || {
+                UpdateWorkers::flush_segments(holder).unwrap();
+                flushed.store(true, Ordering::SeqCst);
+            }
+        });
+
+        thread::sleep(Duration::from_millis(100));
+        assert!(
+            !flushed.load(Ordering::SeqCst),
+            "flush must block while an update operation holds the updates lock",
+        );
+
+        drop(updates_guard);
+        handle.join().unwrap();
+        assert!(flushed.load(Ordering::SeqCst));
     }
 }


### PR DESCRIPTION
Fixes the missing-points class behind #10402: a flush pass that starts between the phases of a single update operation marks a segment clean while part of that operation is still only in memory.

- `upsert_points_impl` writes in two separately locked phases: existing points first, then the new points into the smallest appendable segment. `flush_all` read-locks every segment so nothing interleaves within a phase, but a pass could start between them.
- Captured that way, the segment sits at `version = op_num` with the operation half applied. The flush stamps `persisted_version = op_num`, so `version == persisted_version` and every later pass skips it, the waterline reports all-saved, and the WAL is acknowledged past the op. The second-phase points are then only in memory with nothing left to replay.
- Fix: hold the updates lock across flusher capture and the waterline read. Taken before the holder read lock, matching `CollectionUpdater::update`, so waiting for it never blocks a writer waiting on the holder lock. Held only for the capture, not for background flush IO.
- The failure is normally invisible because any later write to that segment bumps its version and the next flush writes the whole state. It bites when the segment stays untouched until a restart, which is why it presents as flaky. `SetFlushInterval` inflates the rate by creating more passes.

Evidence, seed `2961593037309707336`, single shard, optimizer off, on tmpfs. Before, at op 1929 (upsert of 5 points, 3 of them new):

```
ROUTE update={5:[NumId(123)], 2:[NumId(150)]}                    phase 1
FLUSH_CAPTURE a760937f version=Some(1929) persisted=Some(1922)   pass captures mid-operation
NEW_POINT op=1929 id=028f6484 seg=a760937f seg_version=1929      phase 2, version does not move
NEW_POINT op=1929 id=NumId(56)  seg=a760937f seg_version=1929
NEW_POINT op=1929 id=a94a0f6e   seg=a760937f seg_version=1929
FLUSH_SKIP a760937f version=1929                                 from here on, forever
ACK ack=1929
```

At the restart the replay window opens at 1939 and none of the three ids exist in any segment on disk, which is exactly the reported failure (`missing: [NumId(56), Uuid(028f6484-...), Uuid(a94a0f6e-...)]`).

Test plan
- [x] Repro seed, 6/6 pass with the fix, and zero occurrences of the capture-then-insert interleave in the logs (baseline: 3-4 per run, failing 3/6 to 4/4 depending on logging overhead)
- [x] New unit test `flush_segments_waits_for_operation_boundary`, verified to fail without the guard
- [x] Soak with the optimizer on, 3 shards, 4000 ops, restarts, 382 optimized points, no deadlock
- [x] `cargo fmt` (stable + nightly), `cargo clippy -p collection --lib --all-targets` clean
- [ ] CI

Notes
- #10405 does not fix this and should not close #10402. The torn segment is marked clean, so its final flush skips it. With that patch applied, passing runs still show the same tear at op 1929, the ack at 1929, and no re-flush of the segment until op 1963: the window where a crash loses those points is unchanged, the restart just lands outside it.
- Not touched: the snapshot `flush_all` under proxying and the load-time flush. Neither races a live operation the way the worker does, but if you want the invariant enforced in one place rather than at the one call site that needs it, say so and I will move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)