### PR TITLE
[live-reload] hotfix: infallible to_owned in DiskCache

### DIFF
--- a/lib/common/common/src/ext/aligned_vec.rs
+++ b/lib/common/common/src/ext/aligned_vec.rs
@@ -21,6 +21,14 @@ impl<'a> ACow<'a> {
             ),
         })
     }
+
+    /// Convert into owned AVec. If it was a slice, it will have the provided align.
+    pub fn into_owned(self, align_if_borrowed: usize) -> AVec<u8, RuntimeAlign> {
+        match self {
+            ACow::Borrowed(slice) => AVec::from_slice(align_if_borrowed, slice),
+            ACow::Owned(vec) => vec,
+        }
+    }
 }
 
 impl Deref for ACow<'_> {

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/mod.rs
@@ -5,6 +5,7 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 
+use aligned_vec::{AVec, RuntimeAlign};
 use futures::future::{BoxFuture, Shared};
 use parking_lot::Mutex;
 
@@ -114,7 +115,7 @@ pub(crate) enum ScheduledReopen<R: UniversalRead + 'static> {
     /// `future` completes.
     Tail {
         future: Shared<BoxFuture<'static, ()>>,
-        data: futures::channel::oneshot::Receiver<UioResult<(R, Vec<u8>)>>,
+        data: futures::channel::oneshot::Receiver<UioResult<(R, AVec<u8, RuntimeAlign>)>>,
         blocks_range: Range<u32>,
         target_len: u64,
     },

--- a/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
+++ b/lib/common/common/src/universal_io/simple_disk_cache/file/reopen.rs
@@ -193,8 +193,7 @@ where
                                 Ok(new_remote
                                     .read_bytes_async(byte_range, Sequential, REMOTE_READ_ALIGNMENT)
                                     .await?
-                                    .try_cast_bytemuck::<u8>()?
-                                    .into_owned())
+                                    .into_owned(1))
                             };
                             let result = fetch().await.map(|fetched| (new_remote, fetched));
 


### PR DESCRIPTION
I recently added a fallible cast when live-reloading DiskCache file. This PR fixes it by not using fallible version.

In linux, this was destined to regularly fail because of `REMOTE_READ_ALIGNMENT` being 4kb.