### PR TITLE
[combined-storage] Derive inline-storage warnings from the optimizer's vector config

### DIFF
--- a/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/config_mismatch_optimizer.rs
@@ -20,7 +20,7 @@ mod tests {
     use segment::types::{
         CompressionRatio, HnswConfig, HnswGlobalConfig, Indexes, ProductQuantization,
         ProductQuantizationConfig, QuantizationConfig, ScalarQuantizationConfig, ScalarType,
-        SegmentConfig, VectorNameBuf, VectorStorageType,
+        SegmentConfig, VectorNameBuf,
     };
     use shard::operations::optimization::OptimizerThresholds;
     use shard::optimizers::config::{
@@ -35,64 +35,61 @@ mod tests {
     use crate::collection_manager::holders::segment_holder::SegmentHolder;
     use crate::collection_manager::optimizers::indexing_optimizer::IndexingOptimizer;
 
-    fn dense_map_from_segment(
+    fn dense_config(
         segment_config: &SegmentConfig,
-        overrides: &HashMap<VectorNameBuf, DenseVectorOptimizerConfig>,
-    ) -> HashMap<VectorNameBuf, DenseVectorOptimizerConfig> {
-        segment_config
-            .vector_data
-            .keys()
-            .map(|name| {
-                let cfg = overrides
-                    .get(name)
-                    .cloned()
-                    .unwrap_or(DenseVectorOptimizerConfig {
-                        memory: None,
-                        on_disk: None,
-                        hnsw_config: HnswConfig::default(),
-                        quantization_config: None,
-                    });
-                (name.clone(), cfg)
-            })
-            .collect()
+        name: &str,
+        on_disk: Option<bool>,
+        hnsw_config: HnswConfig,
+        quantization_config: Option<QuantizationConfig>,
+    ) -> DenseVectorOptimizerConfig {
+        let vector_data = &segment_config.vector_data[name];
+        DenseVectorOptimizerConfig {
+            size: vector_data.size,
+            distance: vector_data.distance,
+            on_disk,
+            memory: None,
+            hnsw_config,
+            quantization_config,
+            multivector_config: vector_data.multivector_config,
+            datatype: vector_data.datatype,
+        }
     }
 
     fn segment_optimizer_config(
         segment_config: &SegmentConfig,
         dense_overrides: &HashMap<VectorNameBuf, DenseVectorOptimizerConfig>,
     ) -> SegmentOptimizerConfig {
-        let dense_vector = dense_map_from_segment(segment_config, dense_overrides);
-        let mut base_vector_data = segment_config.vector_data.clone();
-        for (name, cfg) in &dense_vector {
-            if let Some(vector_data) = base_vector_data.get_mut(name)
-                && let Some(on_disk) = cfg.on_disk
-            {
-                vector_data.storage_type = if on_disk {
-                    VectorStorageType::Mmap
-                } else {
-                    VectorStorageType::Memory
+        let dense_vectors = segment_config
+            .vector_data
+            .keys()
+            .map(|name| {
+                let cfg = dense_overrides.get(name).cloned().unwrap_or_else(|| {
+                    dense_config(segment_config, name, None, HnswConfig::default(), None)
+                });
+                (name.clone(), cfg)
+            })
+            .collect();
+
+        let sparse_vectors = segment_config
+            .sparse_vector_data
+            .iter()
+            .map(|(name, sparse_data)| {
+                let cfg = SparseVectorOptimizerConfig {
+                    memory: None,
+                    on_disk: None,
+                    full_scan_threshold: sparse_data.index.full_scan_threshold,
+                    index_datatype: sparse_data.index.datatype,
+                    storage_type: sparse_data.storage_type,
+                    modifier: sparse_data.modifier,
                 };
-            }
-        }
+                (name.clone(), cfg)
+            })
+            .collect();
 
         SegmentOptimizerConfig {
             payload_storage_type: segment_config.payload_storage_type,
-            plain_dense_vector_config: base_vector_data,
-            plain_sparse_vector_config: segment_config.sparse_vector_data.clone(),
-            dense_vector,
-            sparse_vector: segment_config
-                .sparse_vector_data
-                .keys()
-                .map(|name| {
-                    (
-                        name.clone(),
-                        SparseVectorOptimizerConfig {
-                            memory: None,
-                            on_disk: None,
-                        },
-                    )
-                })
-                .collect(),
+            dense_vectors,
+            sparse_vectors,
             live_vector_names: None,
         }
     }
@@ -147,12 +144,13 @@ mod tests {
         let mut dense_overrides = HashMap::new();
         dense_overrides.insert(
             VectorNameBuf::from(DEFAULT_VECTOR_NAME),
-            DenseVectorOptimizerConfig {
-                memory: None,
-                on_disk: None,
+            dense_config(
+                &base_segment_config,
+                DEFAULT_VECTOR_NAME,
+                None,
                 hnsw_config,
-                quantization_config: None,
-            },
+                None,
+            ),
         );
         let optimizer_config = segment_optimizer_config(&base_segment_config, &dense_overrides);
 
@@ -195,12 +193,13 @@ mod tests {
 
         dense_overrides.insert(
             VectorNameBuf::from(DEFAULT_VECTOR_NAME),
-            DenseVectorOptimizerConfig {
-                memory: None,
-                on_disk: None,
-                hnsw_config: changed_hnsw_config,
-                quantization_config: None,
-            },
+            dense_config(
+                &base_segment_config,
+                DEFAULT_VECTOR_NAME,
+                None,
+                changed_hnsw_config,
+                None,
+            ),
         );
         let changed_optimizer_config =
             segment_optimizer_config(&base_segment_config, &dense_overrides);
@@ -303,21 +302,23 @@ mod tests {
         let mut dense_overrides = HashMap::new();
         dense_overrides.insert(
             VectorNameBuf::from(VECTOR1_NAME),
-            DenseVectorOptimizerConfig {
-                memory: None,
-                on_disk: Some(true),
-                hnsw_config: hnsw_config_vector1,
-                quantization_config: None,
-            },
+            dense_config(
+                &base_segment_config,
+                VECTOR1_NAME,
+                Some(true),
+                hnsw_config_vector1,
+                None,
+            ),
         );
         dense_overrides.insert(
             VectorNameBuf::from(VECTOR2_NAME),
-            DenseVectorOptimizerConfig {
-                memory: None,
-                on_disk: None,
-                hnsw_config: hnsw_config_vector2,
-                quantization_config: None,
-            },
+            dense_config(
+                &base_segment_config,
+                VECTOR2_NAME,
+                None,
+                hnsw_config_vector2,
+                None,
+            ),
         );
         let optimizer_config = segment_optimizer_config(&base_segment_config, &dense_overrides);
 
@@ -359,12 +360,13 @@ mod tests {
 
         dense_overrides.insert(
             VectorNameBuf::from(VECTOR2_NAME),
-            DenseVectorOptimizerConfig {
-                memory: None,
-                on_disk: None,
-                hnsw_config: hnsw_config_vector2_changed,
-                quantization_config: None,
-            },
+            dense_config(
+                &base_segment_config,
+                VECTOR2_NAME,
+                None,
+                hnsw_config_vector2_changed,
+                None,
+            ),
         );
         let changed_optimizer_config =
             segment_optimizer_config(&base_segment_config, &dense_overrides);
@@ -473,21 +475,23 @@ mod tests {
         let mut dense_overrides = HashMap::new();
         dense_overrides.insert(
             VectorNameBuf::from(VECTOR1_NAME),
-            DenseVectorOptimizerConfig {
-                memory: None,
-                on_disk: None,
-                hnsw_config: HnswConfig::default(),
-                quantization_config: Some(quantization_config_vector1.clone()),
-            },
+            dense_config(
+                &base_segment_config,
+                VECTOR1_NAME,
+                None,
+                HnswConfig::default(),
+                Some(quantization_config_vector1.clone()),
+            ),
         );
         dense_overrides.insert(
             VectorNameBuf::from(VECTOR2_NAME),
-            DenseVectorOptimizerConfig {
-                memory: None,
-                on_disk: None,
-                hnsw_config: HnswConfig::default(),
-                quantization_config: Some(quantization_config_collection.clone()),
-            },
+            dense_config(
+                &base_segment_config,
+                VECTOR2_NAME,
+                None,
+                HnswConfig::default(),
+                Some(quantization_config_collection.clone()),
+            ),
         );
         let optimizer_config = segment_optimizer_config(&base_segment_config, &dense_overrides);
 
@@ -533,12 +537,13 @@ mod tests {
         });
         dense_overrides.insert(
             VectorNameBuf::from(VECTOR2_NAME),
-            DenseVectorOptimizerConfig {
-                memory: None,
-                on_disk: None,
-                hnsw_config: HnswConfig::default(),
-                quantization_config: Some(quantization_config_vector2.clone()),
-            },
+            dense_config(
+                &base_segment_config,
+                VECTOR2_NAME,
+                None,
+                HnswConfig::default(),
+                Some(quantization_config_vector2.clone()),
+            ),
         );
         let changed_optimizer_config =
             segment_optimizer_config(&base_segment_config, &dense_overrides);

--- a/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
+++ b/lib/collection/src/collection_manager/optimizers/merge_optimizer.rs
@@ -54,24 +54,26 @@ mod tests {
     fn test_segment_config(dim: usize) -> SegmentOptimizerConfig {
         let temp_dir = Builder::new().prefix("segment_cfg_dir").tempdir().unwrap();
         let segment = build_simple_segment(temp_dir.path(), dim, Distance::Dot).unwrap();
-        let mut dense_vector = HashMap::new();
-        for vector_name in segment.segment_config.vector_data.keys() {
-            dense_vector.insert(
+        let mut dense_vectors = HashMap::new();
+        for (vector_name, vector_data) in &segment.segment_config.vector_data {
+            dense_vectors.insert(
                 vector_name.clone(),
                 DenseVectorOptimizerConfig {
+                    size: vector_data.size,
+                    distance: vector_data.distance,
                     memory: None,
                     on_disk: None,
                     hnsw_config: HnswConfig::default(),
                     quantization_config: None,
+                    multivector_config: vector_data.multivector_config,
+                    datatype: vector_data.datatype,
                 },
             );
         }
         SegmentOptimizerConfig {
             payload_storage_type: segment.segment_config.payload_storage_type,
-            plain_dense_vector_config: segment.segment_config.vector_data.clone(),
-            plain_sparse_vector_config: segment.segment_config.sparse_vector_data.clone(),
-            dense_vector,
-            sparse_vector: Default::default(),
+            dense_vectors,
+            sparse_vectors: Default::default(),
             live_vector_names: None,
         }
     }

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -31,7 +31,7 @@ use crate::operations::types::{
     SparseVectorsConfig, VectorParams, VectorParamsDiff, VectorsConfig, VectorsConfigDiff,
 };
 use crate::operations::validation;
-use crate::optimizers_builder::OptimizersConfig;
+use crate::optimizers_builder::{OptimizersConfig, build_segment_optimizer_config};
 
 pub const COLLECTION_CONFIG_FILE: &str = "config.json";
 
@@ -400,36 +400,16 @@ impl CollectionConfigInternal {
 
     /// Get warnings related to this configuration
     pub fn get_warnings(&self) -> Vec<CollectionWarning> {
-        let mut warnings = Vec::new();
-
-        for (vector_name, vector_config) in self.params.vectors.params_iter() {
-            let vector_hnsw = self
-                .hnsw_config
-                .update_opt(vector_config.hnsw_config.as_ref());
-
-            let vector_quantization =
-                vector_config.quantization_config.is_some() || self.quantization_config.is_some();
-
-            if vector_hnsw.inline_storage.unwrap_or_default() {
-                if vector_config.multivector_config.is_some() {
-                    warnings.push(CollectionWarning {
-                        message: format!(
-                            "The `hnsw_config.inline_storage` option for vector '{vector_name}' \
-                             is not compatible with multivectors. This option will be ignored."
-                        ),
-                    });
-                } else if !vector_quantization {
-                    warnings.push(CollectionWarning {
-                        message: format!(
-                            "The `hnsw_config.inline_storage` option for vector '{vector_name}' \
-                             requires quantization to be enabled. This option will be ignored."
-                        ),
-                    });
-                }
-            }
-        }
-
-        warnings
+        build_segment_optimizer_config(&self.params, &self.hnsw_config, &self.quantization_config)
+            .dense_vectors
+            .iter()
+            .filter_map(|(vector_name, vector_config)| {
+                let message = vector_config.indexed().check_inline_vectors().err()?;
+                Some(CollectionWarning {
+                    message: format!("Vector '{vector_name}': {message}"),
+                })
+            })
+            .collect()
     }
 
     pub fn to_base_segment_config(&self) -> SegmentConfig {

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 use shard::files::SEGMENTS_PATH;
 use shard::operations::optimization::OptimizerThresholds;
 use shard::optimizers::config::{
-    DEFAULT_DELETED_THRESHOLD, DEFAULT_VACUUM_MIN_VECTOR_NUMBER, DenseVectorOptimizerInput,
-    LiveVectorNamesProvider, SegmentOptimizerConfig, SparseVectorOptimizerInput,
+    DEFAULT_DELETED_THRESHOLD, DEFAULT_VACUUM_MIN_VECTOR_NUMBER, DenseVectorOptimizerConfig,
+    LiveVectorNamesProvider, SegmentOptimizerConfig, SparseVectorOptimizerConfig,
     TEMP_SEGMENTS_PATH, get_deferred_points_threshold_bytes, get_indexing_threshold_kb,
     get_max_segment_size_kb, get_number_segments,
 };
@@ -209,7 +209,7 @@ pub fn build_segment_optimizer_config(
 
             (
                 name.into(),
-                DenseVectorOptimizerInput {
+                DenseVectorOptimizerConfig {
                     size: size.get() as usize,
                     distance: *distance,
                     on_disk: *on_disk,
@@ -237,7 +237,7 @@ pub fn build_segment_optimizer_config(
 
                     (
                         name.clone(),
-                        SparseVectorOptimizerInput {
+                        SparseVectorOptimizerConfig {
                             on_disk: index.and_then(|index| index.on_disk),
                             memory: index.and_then(|index| index.memory),
                             full_scan_threshold: index.and_then(|index| index.full_scan_threshold),
@@ -253,11 +253,12 @@ pub fn build_segment_optimizer_config(
         })
         .unwrap_or_default();
 
-    SegmentOptimizerConfig::new(
-        collection_params.payload_storage_type(),
+    SegmentOptimizerConfig {
+        payload_storage_type: collection_params.payload_storage_type(),
         dense_vectors,
         sparse_vectors,
-    )
+        live_vector_names: None,
+    }
 }
 
 /// Build a [`LiveVectorNamesProvider`] that reads the collection's current vector names.

--- a/lib/edge/src/config/shard.rs
+++ b/lib/edge/src/config/shard.rs
@@ -11,6 +11,7 @@ use segment::types::{
 };
 use serde::{Deserialize, Serialize};
 use shard::operations::optimization::OptimizerThresholds;
+use shard::optimizers::config::DenseVectorOptimizerConfig;
 use wal::WalOptions;
 
 use super::optimizers::EdgeOptimizersConfig;
@@ -222,29 +223,7 @@ impl EdgeConfig {
     /// Segment config for creating appendable segments only.
     /// Does not contain any HNSW configuration (plain index only).
     pub fn plain_segment_config(&self) -> SegmentConfig {
-        let payload_storage_type = PayloadStorageType::from_on_disk_payload(self.on_disk_payload());
-        let vector_data = self
-            .vectors
-            .iter()
-            .map(|(name, p)| {
-                (
-                    name.clone(),
-                    p.to_plain_vector_data_config(self.quantization_config.as_ref()),
-                )
-            })
-            .collect();
-
-        let sparse_vector_data = self
-            .sparse_vectors
-            .iter()
-            .map(|(name, p)| (name.clone(), p.to_plain_sparse_vector_data_config()))
-            .collect();
-
-        SegmentConfig {
-            vector_data,
-            sparse_vector_data,
-            payload_storage_type,
-        }
+        self.segment_optimizer_config().plain_segment_config()
     }
 
     /// All vector names (dense and sparse) currently present in this config.
@@ -264,41 +243,34 @@ impl EdgeConfig {
     pub fn segment_optimizer_config(&self) -> shard::optimizers::config::SegmentOptimizerConfig {
         use shard::optimizers::config::SegmentOptimizerConfig;
 
-        let SegmentConfig {
-            vector_data: plain_dense_vector_config,
-            sparse_vector_data: plain_sparse_vector_config,
-            payload_storage_type,
-        } = self.plain_segment_config();
-
-        let hnsw_config = self.hnsw_config();
-        let dense_vector = self
+        let dense_vectors = self
             .vectors
             .iter()
-            .map(|(name, p)| {
-                (
-                    name.clone(),
-                    p.to_dense_vector_optimizer_config(
-                        &hnsw_config,
-                        self.quantization_config.as_ref(),
-                    ),
-                )
-            })
+            .map(|(name, p)| (name.clone(), self.dense_vector_optimizer_config(p)))
             .collect();
 
-        let sparse_vector = self
+        let sparse_vectors = self
             .sparse_vectors
             .iter()
             .map(|(name, p)| (name.clone(), p.to_sparse_vector_optimizer_config()))
             .collect();
 
         SegmentOptimizerConfig {
-            payload_storage_type,
-            plain_dense_vector_config,
-            plain_sparse_vector_config,
-            dense_vector,
-            sparse_vector,
+            payload_storage_type: PayloadStorageType::from_on_disk_payload(self.on_disk_payload()),
+            dense_vectors,
+            sparse_vectors,
             live_vector_names: None,
         }
+    }
+
+    fn dense_vector_optimizer_config(
+        &self,
+        params: &EdgeVectorParams,
+    ) -> DenseVectorOptimizerConfig {
+        params.to_dense_vector_optimizer_config(
+            &self.hnsw_config(),
+            self.quantization_config.as_ref(),
+        )
     }
 
     /// Return vector data config for a named vector (for read-only use, e.g. query).
@@ -309,7 +281,7 @@ impl EdgeConfig {
     ) -> Option<segment::types::VectorDataConfig> {
         self.vectors
             .get(name)
-            .map(|p| p.to_plain_vector_data_config(self.quantization_config.as_ref()))
+            .map(|p| self.dense_vector_optimizer_config(p).plain())
     }
 
     /// Distance of a named vector, mirroring `CollectionParams::get_distance`:

--- a/lib/edge/src/config/vectors.rs
+++ b/lib/edge/src/config/vectors.rs
@@ -5,13 +5,13 @@
 //! global `EdgeShardConfig::quantization_config` for that vector.
 
 use segment::data_types::modifier::Modifier;
-use segment::index::sparse_index::sparse_index_config::{SparseIndexConfig, SparseIndexType};
+use segment::index::sparse_index::sparse_index_config::SparseIndexConfig;
 use segment::types::{
     Distance, HnswConfig, Indexes, MultiVectorConfig, QuantizationConfig, SparseVectorDataConfig,
-    SparseVectorStorageType, VectorDataConfig, VectorStorageDatatype, VectorStorageType,
+    SparseVectorStorageType, VectorDataConfig, VectorStorageDatatype,
 };
 use serde::{Deserialize, Serialize};
-use shard::optimizers::config::DenseVectorOptimizerConfig;
+use shard::optimizers::config::{DenseVectorOptimizerConfig, SparseVectorOptimizerConfig};
 
 /// User-facing dense vector parameters.
 ///
@@ -43,11 +43,11 @@ impl EdgeVectorParams {
         crate::builders::EdgeVectorParamsBuilder::new(size, distance)
     }
 
-    /// Build `VectorDataConfig` for segment/optimizer use, using global quantization.
-    pub fn to_plain_vector_data_config(
+    pub fn to_dense_vector_optimizer_config(
         &self,
-        global_quantization: Option<&QuantizationConfig>,
-    ) -> VectorDataConfig {
+        global_hnsw_config: &HnswConfig,
+        global_quantization_config: Option<&QuantizationConfig>,
+    ) -> DenseVectorOptimizerConfig {
         let EdgeVectorParams {
             size,
             distance,
@@ -55,44 +55,19 @@ impl EdgeVectorParams {
             multivector_config,
             datatype,
             quantization_config,
-            hnsw_config: _, // edge does not use per-vector HNSW config
-        } = self;
-
-        let resolved_quantization_config = quantization_config.as_ref().or(global_quantization);
-        let quantization_config =
-            QuantizationConfig::for_appendable_segment(resolved_quantization_config);
-        VectorDataConfig {
-            size: *size,
-            distance: *distance,
-            storage_type: VectorStorageType::from_on_disk(on_disk.unwrap_or_default()),
-            index: Indexes::Plain {},
-            quantization_config,
-            multivector_config: *multivector_config,
-            datatype: *datatype,
-        }
-    }
-
-    pub fn to_dense_vector_optimizer_config(
-        &self,
-        global_hnsw_config: &HnswConfig,
-        global_quantization_config: Option<&QuantizationConfig>,
-    ) -> DenseVectorOptimizerConfig {
-        let EdgeVectorParams {
-            size: _,
-            distance: _,
-            on_disk,
-            multivector_config: _,
-            datatype: _,
-            quantization_config,
             hnsw_config,
         } = self;
         DenseVectorOptimizerConfig {
+            size: *size,
+            distance: *distance,
             on_disk: *on_disk,
             memory: None,
             hnsw_config: hnsw_config.unwrap_or(*global_hnsw_config),
             quantization_config: quantization_config
                 .clone()
                 .or_else(|| global_quantization_config.cloned()),
+            multivector_config: *multivector_config,
+            datatype: *datatype,
         }
     }
 
@@ -144,37 +119,20 @@ impl EdgeSparseVectorParams {
         crate::builders::EdgeSparseVectorParamsBuilder::new()
     }
 
-    pub fn to_plain_sparse_vector_data_config(&self) -> SparseVectorDataConfig {
+    pub fn to_sparse_vector_optimizer_config(&self) -> SparseVectorOptimizerConfig {
         let EdgeSparseVectorParams {
             full_scan_threshold,
-            on_disk: _,
+            on_disk,
             modifier,
             datatype,
         } = self;
-        SparseVectorDataConfig {
-            index: SparseIndexConfig {
-                full_scan_threshold: *full_scan_threshold,
-                index_type: SparseIndexType::default(),
-                datatype: *datatype,
-                memory: None,
-            },
-            storage_type: SparseVectorStorageType::Mmap,
-            modifier: *modifier,
-        }
-    }
-
-    pub fn to_sparse_vector_optimizer_config(
-        &self,
-    ) -> shard::optimizers::config::SparseVectorOptimizerConfig {
-        let EdgeSparseVectorParams {
-            full_scan_threshold: _,
-            on_disk,
-            modifier: _,
-            datatype: _,
-        } = self;
-        shard::optimizers::config::SparseVectorOptimizerConfig {
+        SparseVectorOptimizerConfig {
             on_disk: *on_disk,
             memory: None,
+            full_scan_threshold: *full_scan_threshold,
+            index_datatype: *datatype,
+            storage_type: SparseVectorStorageType::Mmap,
+            modifier: *modifier,
         }
     }
 

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2243,6 +2243,39 @@ impl VectorDataConfig {
         }
         Ok(())
     }
+
+    /// Effective check: whether inline-storage should be used.
+    pub fn inline_vectors_in_graph(&self) -> bool {
+        self.check_inline_vectors() == Ok(true)
+    }
+
+    /// Whether inline-storage is configured AND should be used.
+    ///
+    /// - `Ok(true)`    - configured,     should be used.
+    /// - `Ok(false)`   - not configured, should not be used.
+    /// - `Err(reason)` - configured, but won't be used because of `reason`.
+    pub fn check_inline_vectors(&self) -> Result<bool, &'static str> {
+        let hnsw_config = match &self.index {
+            Indexes::Hnsw(hnsw_config) => hnsw_config,
+            Indexes::Plain {} => return Ok(false),
+        };
+        if !hnsw_config.inline_storage.unwrap_or_default() {
+            return Ok(false);
+        }
+        if self.multivector_config.is_some() {
+            return Err(
+                "The `hnsw_config.inline_storage` option is not compatible with multivectors. \
+                 This option will be ignored.",
+            );
+        }
+        if self.quantization_config.is_none() {
+            return Err(
+                "The `hnsw_config.inline_storage` option requires quantization to be enabled. \
+                 This option will be ignored.",
+            );
+        }
+        Ok(true)
+    }
 }
 
 #[derive(

--- a/lib/shard/src/optimizers/config.rs
+++ b/lib/shard/src/optimizers/config.rs
@@ -18,13 +18,16 @@ pub const DEFAULT_INDEXING_THRESHOLD_KB: usize = 10_000;
 pub const DEFAULT_DELETED_THRESHOLD: f64 = 0.2;
 pub const DEFAULT_VACUUM_MIN_VECTOR_NUMBER: usize = 1000;
 
-/// Extra configuration for dense vectors, applied on top of the plain config during optimization.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DenseVectorOptimizerConfig {
+    pub size: usize,
+    pub distance: Distance,
     pub on_disk: Option<bool>,
     pub memory: Option<Memory>,
     pub hnsw_config: HnswConfig,
     pub quantization_config: Option<QuantizationConfig>,
+    pub multivector_config: Option<MultiVectorConfig>,
+    pub datatype: Option<VectorStorageDatatype>,
 }
 
 impl DenseVectorOptimizerConfig {
@@ -33,13 +36,49 @@ impl DenseVectorOptimizerConfig {
     pub fn memory_placement(&self) -> Option<Memory> {
         Memory::resolve(self.memory, self.on_disk.map(Memory::from_on_disk))
     }
+
+    /// Config for a plain (appendable, unindexed) segment.
+    pub fn plain(&self) -> VectorDataConfig {
+        self.vector_data_config(
+            Indexes::Plain {},
+            QuantizationConfig::for_appendable_segment(self.quantization_config.as_ref()),
+        )
+    }
+
+    /// Config for an indexed segment.
+    pub fn indexed(&self) -> VectorDataConfig {
+        self.vector_data_config(
+            Indexes::Hnsw(self.hnsw_config),
+            self.quantization_config.clone(),
+        )
+    }
+
+    fn vector_data_config(
+        &self,
+        index: Indexes,
+        quantization_config: Option<QuantizationConfig>,
+    ) -> VectorDataConfig {
+        let memory = self.memory_placement().unwrap_or(Memory::Cached);
+        VectorDataConfig {
+            size: self.size,
+            distance: self.distance,
+            index,
+            storage_type: VectorStorageType::appendable_from_memory(memory),
+            quantization_config,
+            multivector_config: self.multivector_config,
+            datatype: self.datatype,
+        }
+    }
 }
 
-/// Extra configuration for sparse vectors, applied on top of the plain config during optimization.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SparseVectorOptimizerConfig {
     pub on_disk: Option<bool>,
     pub memory: Option<Memory>,
+    pub full_scan_threshold: Option<usize>,
+    pub index_datatype: Option<VectorStorageDatatype>,
+    pub storage_type: SparseVectorStorageType,
+    pub modifier: Option<Modifier>,
 }
 
 impl SparseVectorOptimizerConfig {
@@ -47,6 +86,29 @@ impl SparseVectorOptimizerConfig {
     /// against the deprecated `on_disk` flag. `None` if neither is configured.
     pub fn memory_placement(&self) -> Option<Memory> {
         Memory::resolve(self.memory, self.on_disk.map(Memory::from_on_disk_heap))
+    }
+
+    /// Config for a plain (appendable) segment.
+    pub fn plain(&self) -> SparseVectorDataConfig {
+        self.with_index_type(SparseIndexType::MutableRam)
+    }
+
+    pub fn with_index_type(&self, index_type: SparseIndexType) -> SparseVectorDataConfig {
+        SparseVectorDataConfig {
+            index: SparseIndexConfig {
+                full_scan_threshold: self.full_scan_threshold,
+                index_type,
+                datatype: self.index_datatype,
+                // Persist only the explicitly requested `memory` parameter: the structural
+                // decision is carried by `index_type`, and only the cold/cached distinction
+                // (reachable solely through the explicit parameter) needs the extra field.
+                // Legacy-only configurations thus keep a byte-identical index config,
+                // which older Qdrant versions can load without any unknown fields.
+                memory: self.memory,
+            },
+            storage_type: self.storage_type,
+            modifier: self.modifier,
+        }
     }
 }
 
@@ -82,16 +144,8 @@ impl fmt::Debug for LiveVectorNamesProvider {
 #[derive(Debug, Clone)]
 pub struct SegmentOptimizerConfig {
     pub payload_storage_type: PayloadStorageType,
-    /// Configuration of dense vectors, as it should be for a plain segment (without any optimization).
-    pub plain_dense_vector_config: HashMap<VectorNameBuf, VectorDataConfig>,
-    /// Configuration of sparse vectors, as it should be for a plain segment (without any optimization).
-    pub plain_sparse_vector_config: HashMap<VectorNameBuf, SparseVectorDataConfig>,
-    /// Extra configuration for dense vectors, which _might_ be applied during optimization,
-    /// depending on the segment state.
-    pub dense_vector: HashMap<VectorNameBuf, DenseVectorOptimizerConfig>,
-    /// Extra configuration for sparse vectors, which _might_ be applied during optimization,
-    /// depending on the segment state.
-    pub sparse_vector: HashMap<VectorNameBuf, SparseVectorOptimizerConfig>,
+    pub dense_vectors: HashMap<VectorNameBuf, DenseVectorOptimizerConfig>,
+    pub sparse_vectors: HashMap<VectorNameBuf, SparseVectorOptimizerConfig>,
     /// Live read of the collection's vector names, when wired in via
     /// [`SegmentOptimizerConfig::with_live_vector_names`]. `None` if no live source is available.
     pub live_vector_names: Option<LiveVectorNamesProvider>,
@@ -100,92 +154,17 @@ pub struct SegmentOptimizerConfig {
 impl SegmentOptimizerConfig {
     pub fn plain_segment_config(&self) -> SegmentConfig {
         SegmentConfig {
-            vector_data: self.plain_dense_vector_config.clone(),
-            sparse_vector_data: self.plain_sparse_vector_config.clone(),
+            vector_data: self
+                .dense_vectors
+                .iter()
+                .map(|(name, config)| (name.clone(), config.plain()))
+                .collect(),
+            sparse_vector_data: self
+                .sparse_vectors
+                .iter()
+                .map(|(name, config)| (name.clone(), config.plain()))
+                .collect(),
             payload_storage_type: self.payload_storage_type,
-        }
-    }
-
-    pub fn new(
-        payload_storage_type: PayloadStorageType,
-        dense_vectors: HashMap<VectorNameBuf, DenseVectorOptimizerInput>,
-        sparse_vectors: HashMap<VectorNameBuf, SparseVectorOptimizerInput>,
-    ) -> SegmentOptimizerConfig {
-        let (mut plain_dense_vector_config, mut dense_vector) = (HashMap::new(), HashMap::new());
-        for (name, input) in dense_vectors {
-            let DenseVectorOptimizerInput {
-                size,
-                distance,
-                on_disk,
-                memory,
-                hnsw_config,
-                quantization_config,
-                multivector_config,
-                datatype,
-            } = input;
-            let plain_memory = Memory::resolve(
-                memory,
-                Some(Memory::from_on_disk(on_disk.unwrap_or_default())),
-            )
-            .unwrap_or(Memory::Cached);
-            plain_dense_vector_config.insert(
-                name.clone(),
-                VectorDataConfig {
-                    size,
-                    distance,
-                    index: Indexes::Plain {},
-                    storage_type: VectorStorageType::appendable_from_memory(plain_memory),
-                    quantization_config: QuantizationConfig::for_appendable_segment(
-                        quantization_config.as_ref(),
-                    ),
-                    multivector_config,
-                    datatype,
-                },
-            );
-            dense_vector.insert(
-                name,
-                DenseVectorOptimizerConfig {
-                    on_disk,
-                    memory,
-                    hnsw_config,
-                    quantization_config,
-                },
-            );
-        }
-
-        let (mut plain_sparse_vector_config, mut sparse_vector) = (HashMap::new(), HashMap::new());
-        for (name, input) in sparse_vectors {
-            let SparseVectorOptimizerInput {
-                on_disk,
-                memory,
-                full_scan_threshold,
-                index_datatype,
-                storage_type,
-                modifier,
-            } = input;
-            plain_sparse_vector_config.insert(
-                name.clone(),
-                SparseVectorDataConfig {
-                    index: SparseIndexConfig {
-                        full_scan_threshold,
-                        index_type: SparseIndexType::MutableRam,
-                        datatype: index_datatype,
-                        memory,
-                    },
-                    storage_type,
-                    modifier,
-                },
-            );
-            sparse_vector.insert(name, SparseVectorOptimizerConfig { on_disk, memory });
-        }
-
-        SegmentOptimizerConfig {
-            payload_storage_type,
-            plain_dense_vector_config,
-            plain_sparse_vector_config,
-            dense_vector,
-            sparse_vector,
-            live_vector_names: None,
         }
     }
 
@@ -202,30 +181,6 @@ impl SegmentOptimizerConfig {
             .as_ref()
             .map(LiveVectorNamesProvider::get)
     }
-}
-
-/// Per-dense-vector input for the optimizer builder.
-#[derive(Debug, Clone)]
-pub struct DenseVectorOptimizerInput {
-    pub size: usize,
-    pub distance: Distance,
-    pub on_disk: Option<bool>,
-    pub memory: Option<Memory>,
-    pub hnsw_config: HnswConfig,
-    pub quantization_config: Option<QuantizationConfig>,
-    pub multivector_config: Option<MultiVectorConfig>,
-    pub datatype: Option<VectorStorageDatatype>,
-}
-
-/// Per-sparse-vector input for the optimizer builder.
-#[derive(Debug, Clone)]
-pub struct SparseVectorOptimizerInput {
-    pub on_disk: Option<bool>,
-    pub memory: Option<Memory>,
-    pub full_scan_threshold: Option<usize>,
-    pub index_datatype: Option<VectorStorageDatatype>,
-    pub storage_type: SparseVectorStorageType,
-    pub modifier: Option<Modifier>,
 }
 
 /// Target segment count for the merge optimizer.

--- a/lib/shard/src/optimizers/config_mismatch_optimizer.rs
+++ b/lib/shard/src/optimizers/config_mismatch_optimizer.rs
@@ -51,7 +51,7 @@ impl ConfigMismatchOptimizer {
     /// Memory placement the current configuration requests for original vectors, if configured
     fn requested_vectors_memory(&self, vector_name: &VectorName) -> Option<Memory> {
         self.segment_optimizer_config
-            .dense_vector
+            .dense_vectors
             .get(vector_name)
             .and_then(|cfg| cfg.memory_placement())
     }
@@ -60,7 +60,7 @@ impl ConfigMismatchOptimizer {
     /// if configured
     fn requested_sparse_index_memory(&self, vector_name: &VectorName) -> Option<Memory> {
         self.segment_optimizer_config
-            .sparse_vector
+            .sparse_vectors
             .get(vector_name)
             .and_then(|cfg| cfg.memory_placement())
     }
@@ -90,7 +90,7 @@ impl ConfigMismatchOptimizer {
                             // Select segment if we have an HNSW mismatch that requires rebuild
                             let target_hnsw = self
                                 .segment_optimizer_config
-                                .dense_vector
+                                .dense_vectors
                                 .get(vector_name)
                                 .map(|cfg| cfg.hnsw_config)
                                 .unwrap_or(self.global_hnsw_config);
@@ -110,7 +110,7 @@ impl ConfigMismatchOptimizer {
                     // Check quantization mismatch
                     let target_quantization = self
                         .segment_optimizer_config
-                        .dense_vector
+                        .dense_vectors
                         .get(vector_name)
                         .and_then(|cfg| cfg.quantization_config.as_ref());
 

--- a/lib/shard/src/optimizers/indexing_optimizer.rs
+++ b/lib/shard/src/optimizers/indexing_optimizer.rs
@@ -63,7 +63,7 @@ impl IndexingOptimizer {
 
         let has_deferred_points = segment.has_deferred_points();
 
-        for (vector_name, vector_cfg) in &self.segment_optimizer_config.dense_vector {
+        for (vector_name, vector_cfg) in &self.segment_optimizer_config.dense_vectors {
             if let Some(vector_data) = segment_data_config.vector_data.get(vector_name) {
                 let is_indexed = vector_data.index.is_indexed();
                 let is_on_disk = vector_data.storage_type.is_on_disk();
@@ -87,7 +87,7 @@ impl IndexingOptimizer {
             }
         }
 
-        for sparse_vector_name in self.segment_optimizer_config.sparse_vector.keys() {
+        for sparse_vector_name in self.segment_optimizer_config.sparse_vectors.keys() {
             if let Some(sparse_vector_data) = segment_data_config
                 .sparse_vector_data
                 .get(sparse_vector_name)

--- a/lib/shard/src/optimizers/segment_optimizer.rs
+++ b/lib/shard/src/optimizers/segment_optimizer.rs
@@ -16,7 +16,7 @@ use segment::index::sparse_index::sparse_index_config::SparseIndexType;
 use segment::segment::Segment;
 use segment::segment_constructor::build_segment;
 use segment::segment_constructor::segment_builder::SegmentBuilder;
-use segment::types::{HnswGlobalConfig, Indexes, Memory, VectorNameBuf, VectorStorageType};
+use segment::types::{HnswGlobalConfig, Memory, VectorNameBuf, VectorStorageType};
 use uuid::Uuid;
 
 use super::config::SegmentOptimizerConfig;
@@ -32,7 +32,7 @@ const BYTES_IN_KB: usize = 1024;
 /// Resolves per-vector HNSW max_indexing_threads (0 = auto) and returns the actual thread count.
 pub fn max_num_indexing_threads(segment_optimizer_config: &SegmentOptimizerConfig) -> usize {
     let segment_resolution = segment_optimizer_config
-        .dense_vector
+        .dense_vectors
         .values()
         .map(|cfg| get_num_indexing_threads(cfg.hnsw_config.max_indexing_threads))
         .max();
@@ -219,26 +219,26 @@ pub trait SegmentOptimizer: Sync {
         let threshold_is_on_disk = maximal_vector_store_size_bytes
             >= thresholds.memmap_threshold_kb.saturating_mul(BYTES_IN_KB);
 
-        let mut vector_data = segment_optimizer_config.plain_dense_vector_config.clone();
-        let mut sparse_vector_data = segment_optimizer_config.plain_sparse_vector_config.clone();
-
         // If indexing, change to HNSW index and quantization
         // We must always create an HNSW index if we have deferred points to be able to promote them
-        if threshold_is_indexed || any_has_deferred {
-            if !threshold_is_indexed {
-                log::info!(
-                    "Segment has deferred points, but doesn't exceed indexing threshold. It will be optimized with HNSW index and quantization."
-                );
-            }
-            vector_data.iter_mut().for_each(|(vector_name, config)| {
-                if let Some(vector_cfg) = segment_optimizer_config.dense_vector.get(vector_name) {
-                    // Assign HNSW index
-                    config.index = Indexes::Hnsw(vector_cfg.hnsw_config);
-                    // Assign quantization config
-                    config.quantization_config = vector_cfg.quantization_config.clone();
-                }
-            });
+        let indexed = threshold_is_indexed || any_has_deferred;
+        if indexed && !threshold_is_indexed {
+            log::info!(
+                "Segment has deferred points, but doesn't exceed indexing threshold. It will be optimized with HNSW index and quantization."
+            );
         }
+        let mut vector_data: HashMap<_, _> = segment_optimizer_config
+            .dense_vectors
+            .iter()
+            .map(|(vector_name, config)| {
+                let config = if indexed {
+                    config.indexed()
+                } else {
+                    config.plain()
+                };
+                (vector_name.clone(), config)
+            })
+            .collect();
 
         // We want to use single-file mmap in the following cases:
         // - It is explicitly configured by `mmap_threshold` -> threshold_is_on_disk=true
@@ -248,7 +248,7 @@ pub trait SegmentOptimizer: Sync {
             vector_data.iter_mut().for_each(|(vector_name, config)| {
                 // Requested memory placement: explicit `memory`, or the deprecated `on_disk`
                 let config_memory = segment_optimizer_config
-                    .dense_vector
+                    .dense_vectors
                     .get(vector_name)
                     .and_then(|cfg| {
                         Memory::resolve_or_warn(
@@ -291,20 +291,16 @@ pub trait SegmentOptimizer: Sync {
             });
         }
 
-        sparse_vector_data
-            .iter_mut()
-            .for_each(|(vector_name, config)| {
+        let sparse_vector_data = segment_optimizer_config
+            .sparse_vectors
+            .iter()
+            .map(|(vector_name, cfg)| {
                 // Requested memory placement: explicit `memory`, or the deprecated `on_disk`
-                let config_memory = segment_optimizer_config
-                    .sparse_vector
-                    .get(vector_name)
-                    .and_then(|cfg| {
-                        Memory::resolve_or_warn(
-                            cfg.memory,
-                            cfg.on_disk.map(Memory::from_on_disk_heap),
-                            &format_args!("sparse vector `{vector_name}`"),
-                        )
-                    });
+                let config_memory = Memory::resolve_or_warn(
+                    cfg.memory,
+                    cfg.on_disk.map(Memory::from_on_disk_heap),
+                    &format_args!("sparse vector `{vector_name}`"),
+                );
 
                 let requested_memory = config_memory
                     .unwrap_or_else(|| Memory::from_on_disk_heap(threshold_is_on_disk));
@@ -323,17 +319,9 @@ pub trait SegmentOptimizer: Sync {
                     SparseIndexType::MutableRam
                 };
 
-                config.index.index_type = index_type;
-                // Persist only the explicitly requested `memory` parameter: the structural
-                // decision is carried by `index_type`, and only the cold/cached distinction
-                // (reachable solely through the explicit parameter) needs the extra field.
-                // Legacy-only configurations thus keep a byte-identical index config,
-                // which older Qdrant versions can load without any unknown fields.
-                config.index.memory = segment_optimizer_config
-                    .sparse_vector
-                    .get(vector_name)
-                    .and_then(|cfg| cfg.memory);
-            });
+                (vector_name.clone(), cfg.with_index_type(index_type))
+            })
+            .collect();
 
         let optimized_config = segment::types::SegmentConfig {
             vector_data,


### PR DESCRIPTION
In multiple parts of the code we reassemble the effective segment/hnsw configuration from a disjoint set of scraps. (and hope that the logic doesn't diverge) In the upcoming "combined storage" change set, we will have yet another place that does the same.

This PR refactors it to have a single source of truth.

- Part 1: Untangle SegmentOptimizerConfig. It's a pure refactoring change.

- Part 2: adds `fn check_inline_vectors`. It will be the only place that decides whether inline vectors should be used.
  - Almost pure refactoring change. The only minor difference is the message wording:
    ```diff
    -The `hnsw_config.inline_storage` option for vector 'text' requires quantization to be enabled. This option will be ignored
    +Vector 'text': The `hnsw_config.inline_storage` option requires quantization to be enabled. This option will be ignored.
    ```

As part 1 touches a lot of places, here is an illustration:

## Part 1: Before

```rust
// The actual full configuration. Only ever seen by `new()`.
pub struct DenseVectorOptimizerInput { /* 8 fields */ }
pub struct SparseVectorOptimizerInput { /* 6 fields */ }

// "Extra configuration", contains half of the fields.
pub struct DenseVectorOptimizerConfig { /* 4 fields */ }
pub struct SparseVectorOptimizerConfig { /* 2 fields */ }

pub struct SegmentOptimizerConfig {
    // Extra configuration (half of the fields).
    pub dense_vector: HashMap<VectorNameBuf, DenseVectorOptimizerConfig>,
    pub sparse_vector: HashMap<VectorNameBuf, SparseVectorOptimizerConfig>,

    // Another half of the fields (plus some overlap), adapted for plain segments.
    pub plain_dense_vector_config: HashMap<VectorNameBuf, VectorDataConfig>,
    pub plain_sparse_vector_config: HashMap<VectorNameBuf, SparseVectorDataConfig>,

    /* … rest of the fields … */
}

impl SegmentOptimizerConfig {
    fn new(dense_vectors, sparse_vectors) -> Self {
        Self {
            // Split each 8-field input into two halves.
            dense_vector: dense_vectors.map(…),
            plain_dense_vector_config: dense_vectors.map(…),

            sparse_vector: sparse_vectors.map(…),
            plain_sparse_vector_config: sparse_vectors.map(…),

            …
        }
    }
}

fn SegmentOptimizer::optimized_segment_builder(…) {
    // …

    // Patch plain config to get indexed config.
    let vector_data = segment_optimizer_config.plain_dense_vector_config.clone();
    if indexed {
        for (vector_name, config) in &mut vector_data {
            if let Some(vector_cfg) = segment_optimizer_config.dense_vector.get(vector_name) {
                config.index = Indexes::Hnsw(vector_cfg.hnsw_config);
                config.quantization_config = vector_cfg.quantization_config.clone();
            }
        }
    }

    // …
}
```


## Part 1: After

```rust
// No DenseVectorOptimizerInput/SparseVectorOptimizerInput.

// Full configuration. Source of the truth.
pub struct DenseVectorOptimizerConfig { /* 8 fields */ }
pub struct SparseVectorOptimizerConfig { /* 6 fields */ }

impl DenseVectorOptimizerConfig {
    fn plain() -> VectorDataConfig;
    fn indexed() -> VectorDataConfig;
}
impl SparseVectorOptimizerConfig { /* similar */ }

pub struct SegmentOptimizerConfig {
    // The full configuration.
    pub dense_vectors: HashMap<VectorNameBuf, DenseVectorOptimizerConfig>,
    pub sparse_vectors: HashMap<VectorNameBuf, SparseVectorOptimizerConfig>,

    /* … rest of the fields … */
}

impl SegmentOptimizerConfig {
    // no `fn new()` needed
}

fn SegmentOptimizer::optimized_segment_builder(…) {
    // …

    let vector_data = segment_optimizer_config.dense_vectors
        .map(|config| if indexed { config.indexed() } else { config.plain() });

    // …
}
```
