### PR TITLE
[combined-storage] Remove unused (Sparse)VectorStorageType::Empty

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12716,13 +12716,6 @@
             "enum": [
               "InRamMmap"
             ]
-          },
-          {
-            "description": "Placeholder storage: contains no data, all vectors reported as deleted. Used for newly created named vectors on immutable segments. No files on disk, reconstructed from config on load.",
-            "type": "string",
-            "enum": [
-              "Empty"
-            ]
           }
         ]
       },
@@ -12879,13 +12872,6 @@
             "type": "string",
             "enum": [
               "mmap"
-            ]
-          },
-          {
-            "description": "Placeholder storage: contains no data, all vectors reported as deleted. Used for newly created sparse named vectors on immutable segments.",
-            "type": "string",
-            "enum": [
-              "empty"
             ]
           }
         ]

--- a/lib/segment/src/segment_constructor/segment_constructor_base/vector_storage.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/vector_storage.rs
@@ -132,19 +132,6 @@ pub(crate) fn open_vector_storage(
             AdviceSetting::from(Advice::Normal),
             true,
         ),
-
-        // Empty placeholder storage, no files on disk
-        VectorStorageType::Empty => {
-            use crate::vector_storage::dense::empty_dense_vector_storage::new_empty_dense_vector_storage;
-            Ok(new_empty_dense_vector_storage(
-                vector_config.size,
-                vector_config.distance,
-                vector_config.datatype.unwrap_or_default(),
-                vector_config.storage_type.is_on_disk(),
-                vector_config.multivector_config,
-                0, // num_points set after id_tracker is loaded
-            ))
-        }
     }
 }
 
@@ -156,10 +143,6 @@ pub(crate) fn create_sparse_vector_storage(
         SparseVectorStorageType::Mmap => {
             let mmap_storage = MmapSparseVectorStorage::open_or_create(path)?;
             Ok(VectorStorageEnum::SparseMmap(mmap_storage))
-        }
-        SparseVectorStorageType::Empty => {
-            use crate::vector_storage::sparse::empty_sparse_vector_storage::new_empty_sparse_vector_storage;
-            Ok(new_empty_sparse_vector_storage(0))
         }
     }
 }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2019,10 +2019,6 @@ pub enum VectorStorageType {
     /// Storage in a single mmap file, not appendable
     /// Pre-fetched into RAM on load
     InRamMmap,
-    /// Placeholder storage: contains no data, all vectors reported as deleted.
-    /// Used for newly created named vectors on immutable segments.
-    /// No files on disk, reconstructed from config on load.
-    Empty,
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -2124,9 +2120,6 @@ impl VectorStorageType {
             Self::Memory => Memory::Pinned,
             Self::Mmap | Self::ChunkedMmap => Memory::Cold,
             Self::InRamChunkedMmap | Self::InRamMmap => Memory::Cached,
-            // Empty storage has no data; report the safe placement, consistent with
-            // `is_on_disk`
-            Self::Empty => Memory::Cold,
         }
     }
 
@@ -2135,17 +2128,7 @@ impl VectorStorageType {
         match self {
             Self::Memory | Self::InRamChunkedMmap | Self::InRamMmap => false,
             Self::Mmap | Self::ChunkedMmap => true,
-            // Empty storage has no actual data; report based on what the
-            // runtime EmptyDenseVectorStorage was configured with.
-            // This fallback returns true to be safe, but callers that need
-            // the real on-disk status should check the storage instance.
-            Self::Empty => true,
         }
-    }
-
-    /// Whether this is a placeholder empty storage type
-    pub fn is_empty(&self) -> bool {
-        matches!(self, Self::Empty)
     }
 }
 
@@ -2186,7 +2169,6 @@ impl VectorDataConfig {
             VectorStorageType::ChunkedMmap => true,
             VectorStorageType::InRamChunkedMmap => true,
             VectorStorageType::InRamMmap => false,
-            VectorStorageType::Empty => false,
         };
         is_index_appendable && is_storage_appendable
     }
@@ -2286,18 +2268,15 @@ pub enum SparseVectorStorageType {
     /// Storage in memory maps (gridstore storage)
     #[default]
     Mmap,
-    /// Placeholder storage: contains no data, all vectors reported as deleted.
-    /// Used for newly created sparse named vectors on immutable segments.
-    Empty,
 }
 
 impl SparseVectorStorageType {
     /// Whether this storage type is a mmap on disk
     pub fn is_on_disk(&self) -> bool {
         match self {
-            // Both options are on disk, but we keep it explicit for the case if someone adds a new
-            // storage type in the future
-            Self::Mmap | Self::Empty => true,
+            // On disk; kept explicit for the case if someone adds a new storage
+            // type in the future.
+            Self::Mmap => true,
         }
     }
 }

--- a/lib/segment/src/vector_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/read_only/lifecycle.rs
@@ -26,7 +26,7 @@ fn storage_type_params(storage_type: VectorStorageType) -> Option<(AdviceSetting
         VectorStorageType::InRamMmap => (AdviceSetting::from(Advice::Normal), true, false),
         VectorStorageType::ChunkedMmap => (AdviceSetting::Global, false, true),
         VectorStorageType::InRamChunkedMmap => (AdviceSetting::from(Advice::Normal), true, true),
-        VectorStorageType::Memory | VectorStorageType::Empty => return None,
+        VectorStorageType::Memory => return None,
     };
 
     let populate = match populate {

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -148,21 +148,20 @@ mod tests {
             .collect()
     }
 
-    /// `Memory` and `Empty` storage types are a no-op: nothing to open read-only.
+    /// The `Memory` storage type is a no-op: nothing to open read-only.
     #[test]
-    fn open_memory_and_empty_are_noop() {
+    fn open_memory_is_noop() {
         let dir = Builder::new().prefix("disp_noop").tempdir().unwrap();
-        for storage_type in [VectorStorageType::Memory, VectorStorageType::Empty] {
-            let opened = VectorStorageReadEnum::<MmapFile>::open(
-                &MmapFs,
-                &dense_config(storage_type, None),
-                dir.path(),
-                dir.path(),
-                None,
-            )
-            .unwrap();
-            assert!(opened.is_none(), "{storage_type:?} should be a no-op");
-        }
+        let storage_type = VectorStorageType::Memory;
+        let opened = VectorStorageReadEnum::<MmapFile>::open(
+            &MmapFs,
+            &dense_config(storage_type, None),
+            dir.path(),
+            dir.path(),
+            None,
+        )
+        .unwrap();
+        assert!(opened.is_none(), "{storage_type:?} should be a no-op");
     }
 
     /// `ChunkedMmap` single-dense routes to the chunked read-only storage.
@@ -683,8 +682,7 @@ mod tests {
                 }
                 VectorStorageType::InRamMmap
                 | VectorStorageType::InRamChunkedMmap
-                | VectorStorageType::Memory
-                | VectorStorageType::Empty => {
+                | VectorStorageType::Memory => {
                     unreachable!("unexpected storage type {storage_type:?}")
                 }
             }
@@ -706,8 +704,7 @@ mod tests {
                 }
                 VectorStorageType::Memory
                 | VectorStorageType::InRamChunkedMmap
-                | VectorStorageType::InRamMmap
-                | VectorStorageType::Empty => false,
+                | VectorStorageType::InRamMmap => false,
             };
             assert!(
                 routed,

--- a/lib/segment/src/vector_storage/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/update_only/mod.rs
@@ -79,15 +79,13 @@ impl<S: UniversalAppend + 'static> UpdateOnlyVectorStorage<S> {
     /// if it is not there yet.
     ///
     /// Fails for a storage type an update-only segment cannot have: the mmap
-    /// ones are immutable, built whole rather than appended to, and the empty
-    /// placeholder has no files at all.
+    /// ones are immutable, built whole rather than appended to.
     pub fn open(fs: S::Fs, path: &Path, config: &VectorDataConfig) -> OperationResult<Self> {
         match config.storage_type {
             VectorStorageType::ChunkedMmap | VectorStorageType::InRamChunkedMmap => {}
             storage_type @ (VectorStorageType::Mmap
             | VectorStorageType::InRamMmap
-            | VectorStorageType::Memory
-            | VectorStorageType::Empty) => {
+            | VectorStorageType::Memory) => {
                 return Err(OperationError::service_error(format!(
                     "Cannot open a {storage_type:?} vector storage for appending: it is not an \
                      appendable storage type",

--- a/lib/shard/src/optimizers/config_mismatch_optimizer.rs
+++ b/lib/shard/src/optimizers/config_mismatch_optimizer.rs
@@ -100,8 +100,7 @@ impl ConfigMismatchOptimizer {
                         }
                     }
 
-                    if !vector_data.storage_type.is_empty()
-                        && let Some(required_memory) = self.requested_vectors_memory(vector_name)
+                    if let Some(required_memory) = self.requested_vectors_memory(vector_name)
                         && required_memory.is_on_disk() != vector_data.storage_type.is_on_disk()
                     {
                         return true;


### PR DESCRIPTION
These were added for named-vector CRUD (acfb650), never used. The actual placeholder storages `EmptyDenseVectorStorage` and `EmptySparseVectorStorage` stay.
