### PR TITLE
Validate `UpdateCollection` operation *before* applying

### DIFF
--- a/lib/collection/src/collection/mod.rs
+++ b/lib/collection/src/collection/mod.rs
@@ -366,6 +366,11 @@ impl Collection {
         self.collection_config.read().await.uuid
     }
 
+    /// Copy of the config, for a caller that has to reason about it without holding the lock
+    pub async fn config(&self) -> CollectionConfigInternal {
+        self.collection_config.read().await.clone()
+    }
+
     pub async fn get_sharding_method_and_keys(&self) -> (ShardingMethod, Vec<ShardKey>) {
         let shards_holder = self.shards_holder.read().await;
 

--- a/lib/storage/src/content_manager/consensus_state_machine/action.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/action.rs
@@ -15,6 +15,7 @@ use segment::types::{
 };
 use shard::operations::vector_name_ops::VectorNameConfig;
 
+use crate::content_manager::collection_meta_ops::UpdateCollection;
 #[cfg(feature = "staging")]
 use crate::content_manager::collection_meta_ops::{TestSlowDown, TestTransientError};
 use crate::content_manager::errors::StorageResult;
@@ -185,4 +186,54 @@ impl CollectionConfigDiff {
 
         Ok(())
     }
+}
+
+/// Diffs `update` carries, in the order `TableOfContent::update_collection` applies them, each
+/// applied to `config`.
+///
+/// Only `Vectors` and `SparseVectors` can be rejected, both for naming a vector the collection
+/// does not have. `config` holds a partial result when that happens, so the caller has to work
+/// on a copy.
+pub fn apply_collection_config_diffs(
+    config: &mut CollectionConfigInternal,
+    update: &UpdateCollection,
+) -> StorageResult<Vec<CollectionConfigDiff>> {
+    let UpdateCollection {
+        vectors,
+        optimizers_config,
+        params,
+        hnsw_config,
+        quantization_config,
+        sparse_vectors,
+        strict_mode_config,
+        metadata,
+    } = update;
+
+    let diffs = [
+        optimizers_config
+            .clone()
+            .map(CollectionConfigDiff::Optimizers),
+        params.clone().map(CollectionConfigDiff::Params),
+        (*hnsw_config).map(CollectionConfigDiff::Hnsw),
+        vectors.clone().map(CollectionConfigDiff::Vectors),
+        quantization_config
+            .clone()
+            .map(CollectionConfigDiff::Quantization),
+        sparse_vectors
+            .clone()
+            .map(CollectionConfigDiff::SparseVectors),
+        strict_mode_config
+            .clone()
+            .map(CollectionConfigDiff::StrictMode),
+        metadata.clone().map(CollectionConfigDiff::Metadata),
+    ];
+
+    let mut applied = Vec::new();
+
+    for diff in diffs.into_iter().flatten() {
+        diff.apply(config)?;
+        applied.push(diff);
+    }
+
+    Ok(applied)
 }

--- a/lib/storage/src/content_manager/consensus_state_machine/mod.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/mod.rs
@@ -41,7 +41,7 @@ use collection::shards::transfer::ShardTransferMethod;
 use segment::data_types::collection_defaults::CollectionConfigDefaults;
 use segment::types::HnswConfig;
 
-pub use self::action::{Action, CollectionConfigDiff};
+pub use self::action::{Action, CollectionConfigDiff, apply_collection_config_diffs};
 pub use self::state::ClusterState;
 use super::errors::StorageResult;
 use crate::content_manager::collection_meta_ops::*;

--- a/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
@@ -129,27 +129,11 @@ impl ClusterState {
 
         let collection = self.resolve_collection(collection_name)?;
 
-        // TODO:
-        //
-        // This is intentionally different from `TableOfContent::update_collection`.
-        //
-        // `ToC::update_collection` validates and applies the diffs one by one,
-        // and saves the config after every one of them.
-        // So if a diff in the middle of the operation is rejected, every diff
-        // before it is applied and persisted, and every diff after it never runs.
-        //
-        // `plan_update_collection` validates all diffs first, and emits one
-        // `UpdateCollectionConfig` action per diff, which the applier runs in order.
-        // So either all diffs apply, or none of them do.
-        //
-        // E.g., take an operation carrying two diffs:
-        // an `hnsw_config` one, and a `vectors` one naming a vector that does not exist.
-        //
-        // `ToC::update_collection` would save the new HNSW config, then return an error.
-        // `plan_update_collection` would return an error *before* emitting any action.
-
         // Validate operation by updating a copy of the config,
         // so that `plan` and `apply_action` are always in sync.
+        //
+        // `ToC::update_collection` checks the operation with the same call, against a copy of
+        // the config it applies nothing to on rejection.
         let mut config = self
             .collection(&collection)
             .expect("collection exists")

--- a/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/state/plan.rs
@@ -8,7 +8,9 @@ use collection::shards::shard::PeerId;
 
 use super::*;
 use crate::content_manager::collection_meta_ops::*;
-use crate::content_manager::consensus_state_machine::{Action, CollectionConfigDiff, NodeContext};
+use crate::content_manager::consensus_state_machine::{
+    Action, NodeContext, apply_collection_config_diffs,
+};
 use crate::content_manager::toc::apply_alias_actions;
 
 type Actions = Vec<Action>;
@@ -154,9 +156,7 @@ impl ClusterState {
             .config
             .clone();
 
-        // One action per field diff, in the order `ToC::update_collection` applies them.
-        //
-        // `CollectionConfigDiff` merges a diff the same way `Collection::update_*` methods do.
+        // One action per diff `apply_collection_config_diffs` applies.
         //
         // Every diff kind is idempotent, except `Metadata` on a collection that has none.
         //
@@ -171,46 +171,13 @@ impl ClusterState {
         //
         // `replay_may_diverge` in `tests/replay.rs` exempts it.
 
-        let UpdateCollection {
-            vectors,
-            optimizers_config,
-            params,
-            hnsw_config,
-            quantization_config,
-            sparse_vectors,
-            strict_mode_config,
-            metadata,
-        } = update_collection;
-
-        let diffs = [
-            optimizers_config
-                .clone()
-                .map(CollectionConfigDiff::Optimizers),
-            params.clone().map(CollectionConfigDiff::Params),
-            (*hnsw_config).map(CollectionConfigDiff::Hnsw),
-            vectors.clone().map(CollectionConfigDiff::Vectors),
-            quantization_config
-                .clone()
-                .map(CollectionConfigDiff::Quantization),
-            sparse_vectors
-                .clone()
-                .map(CollectionConfigDiff::SparseVectors),
-            strict_mode_config
-                .clone()
-                .map(CollectionConfigDiff::StrictMode),
-            metadata.clone().map(CollectionConfigDiff::Metadata),
-        ];
-
-        let mut planned = Actions::new();
-
-        for diff in diffs.into_iter().flatten() {
-            diff.apply(&mut config)?;
-
-            planned.push(Action::UpdateCollectionConfig {
+        let planned = apply_collection_config_diffs(&mut config, update_collection)?
+            .into_iter()
+            .map(|diff| Action::UpdateCollectionConfig {
                 collection: collection.clone(),
                 diff: Box::new(diff),
-            });
-        }
+            })
+            .collect();
 
         Ok(planned)
     }

--- a/lib/storage/src/content_manager/toc/collection_meta_ops.rs
+++ b/lib/storage/src/content_manager/toc/collection_meta_ops.rs
@@ -18,6 +18,7 @@ use crate::content_manager::alias_mapping::AliasMapping;
 use crate::content_manager::collection_meta_ops::*;
 use crate::content_manager::collections_ops::Checker as _;
 use crate::content_manager::consensus_ops::ConsensusOperations;
+use crate::content_manager::consensus_state_machine::apply_collection_config_diffs;
 use crate::content_manager::errors::StorageError;
 use crate::content_manager::shard_distribution::ShardDistributionProposal;
 
@@ -155,6 +156,21 @@ impl TableOfContent {
         mut operation: UpdateCollectionOperation,
     ) -> Result<bool, StorageError> {
         let replica_changes = operation.take_shard_replica_changes();
+        let collection = self
+            .get_collection_unchecked(&operation.collection_name)
+            .await?;
+
+        // Check every diff against a copy of the config first. A diff rejected in the middle of
+        // the operation must not keep the diffs saved before it.
+        //
+        // `ClusterState::plan_update_collection` checks an operation with the same call, so both
+        // reject the same ones. Once the state machine drives consensus, this call is the only
+        // thing checking a diff on this path, and it goes with the code below it.
+        apply_collection_config_diffs(
+            &mut collection.config().await,
+            &operation.update_collection,
+        )?;
+
         let UpdateCollection {
             vectors,
             hnsw_config,
@@ -165,9 +181,6 @@ impl TableOfContent {
             strict_mode_config: strict_mode,
             metadata,
         } = operation.update_collection;
-        let collection = self
-            .get_collection_unchecked(&operation.collection_name)
-            .await?;
         let mut recreate_optimizers = false;
 
         if let Some(diff) = optimizers_config {

--- a/lib/storage/tests/integration/main.rs
+++ b/lib/storage/tests/integration/main.rs
@@ -1,2 +1,3 @@
 mod alias_tests;
 mod quota_snapshot_compat;
+mod update_collection_tests;

--- a/lib/storage/tests/integration/update_collection_tests.rs
+++ b/lib/storage/tests/integration/update_collection_tests.rs
@@ -1,0 +1,212 @@
+// Deprecated storage placement params (`on_disk`, `always_ram`, `on_disk_payload`) are still
+// handled here for backward compatibility with the new `memory` parameter
+#![allow(deprecated)]
+
+use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use collection::collection::Collection;
+use collection::operations::config_diff::HnswConfigDiff;
+use collection::operations::types::{VectorParamsDiff, VectorsConfigDiff};
+use collection::operations::vector_params_builder::VectorParamsBuilder;
+use collection::operations::verification::new_unchecked_verification_pass;
+use collection::optimizers_builder::OptimizersConfig;
+use collection::shards::channel_service::ChannelService;
+use common::budget::ResourceBudget;
+use common::load_concurrency::LoadConcurrencyConfig;
+use common::mmap;
+use segment::types::Distance;
+use storage::content_manager::collection_meta_ops::{
+    CollectionMetaOperations, CreateCollection, CreateCollectionOperation, UpdateCollection,
+    UpdateCollectionOperation,
+};
+use storage::content_manager::consensus::operation_sender::OperationSender;
+use storage::content_manager::errors::StorageError;
+use storage::content_manager::toc::TableOfContent;
+use storage::dispatcher::Dispatcher;
+use storage::rbac::{Access, AccessRequirements, Auth};
+use storage::types::{PerformanceConfig, StorageConfig};
+use tempfile::{Builder, TempDir};
+use tokio::runtime::Handle;
+
+const FULL_ACCESS: Auth = Auth::new_internal(Access::full("For test"));
+
+#[test]
+fn update_collection_reject_mid_operation() {
+    let (_storage_dir, handle, dispatcher) = new_dispatcher();
+
+    create_collection(&handle, &dispatcher, "test");
+
+    let collection = get_collection(&handle, &dispatcher, "test");
+    let hnsw_config = handle.block_on(collection.config()).hnsw_config;
+
+    // Second diff names a vector that does not exist, so the operation is rejected
+    let update = UpdateCollection {
+        hnsw_config: Some(HnswConfigDiff {
+            m: Some(hnsw_config.m + 1),
+            ..Default::default()
+        }),
+        vectors: Some(VectorsConfigDiff(BTreeMap::from([(
+            "missing".into(),
+            VectorParamsDiff {
+                hnsw_config: None,
+                quantization_config: None,
+                on_disk: None,
+                memory: None,
+            },
+        )]))),
+        params: None,
+        optimizers_config: None,
+        quantization_config: None,
+        sparse_vectors: None,
+        strict_mode_config: None,
+        metadata: None,
+    };
+
+    let error = handle
+        .block_on(dispatcher.submit_collection_meta_op(
+            CollectionMetaOperations::UpdateCollection(
+                UpdateCollectionOperation::new("test".to_string(), update).unwrap(),
+            ),
+            FULL_ACCESS,
+            None,
+        ))
+        .unwrap_err();
+
+    assert!(
+        matches!(error, StorageError::BadInput { .. }),
+        "updating a missing vector should be rejected as bad input, got {error:?}"
+    );
+
+    // Rejected operation must not save the HNSW diff it carries
+    assert_eq!(
+        handle.block_on(collection.config()).hnsw_config,
+        hnsw_config
+    );
+}
+
+fn new_dispatcher() -> (TempDir, Handle, Dispatcher) {
+    let storage_dir = Builder::new().prefix("storage").tempdir().unwrap();
+
+    let config = StorageConfig {
+        storage_path: storage_dir.path().to_path_buf(),
+        snapshots_path: storage_dir.path().join("snapshots"),
+        snapshots_config: Default::default(),
+        temp_path: None,
+        on_disk_payload: false,
+        payload: None,
+        optimizers: OptimizersConfig {
+            deleted_threshold: 0.5,
+            vacuum_min_vector_number: 100,
+            default_segment_number: 2,
+            max_segment_size: None,
+            #[expect(deprecated)]
+            memmap_threshold: Some(100),
+            indexing_threshold: Some(100),
+            flush_interval_sec: 2,
+            max_optimization_threads: Some(2),
+            prevent_unoptimized: None,
+        },
+        optimizers_overwrite: None,
+        wal: Default::default(),
+        performance: PerformanceConfig {
+            max_search_threads: 1,
+            max_optimization_runtime_threads: 1,
+            optimizer_cpu_budget: 0,
+            optimizer_io_budget: 0,
+            update_rate_limit: None,
+            search_timeout_sec: None,
+            incoming_shard_transfers_limit: Some(1),
+            outgoing_shard_transfers_limit: Some(1),
+            async_scorer: None,
+            io_uring: None,
+            load_concurrency: LoadConcurrencyConfig::default(),
+        },
+        hnsw_index: Default::default(),
+        hnsw_global_config: Default::default(),
+        mmap_advice: mmap::Advice::Random,
+        low_memory_mode: Default::default(),
+        node_type: Default::default(),
+        update_queue_size: Default::default(),
+        handle_collection_load_errors: false,
+        recovery_mode: None,
+        update_concurrency: Some(NonZeroUsize::new(2).unwrap()),
+        shard_transfer_method: None,
+        collection: None,
+        max_collections: None,
+        quotas: Default::default(),
+    };
+
+    let (propose_sender, _propose_receiver) = std::sync::mpsc::channel();
+    let propose_operation_sender = OperationSender::new(propose_sender);
+
+    let toc = Arc::new(
+        TableOfContent::new(
+            &config,
+            ResourceBudget::default(),
+            ChannelService::new(6333, false, None, None),
+            0,
+            Some(propose_operation_sender),
+        )
+        .unwrap(),
+    );
+    let handle = toc.general_runtime_handle().clone();
+
+    (storage_dir, handle, Dispatcher::new(toc))
+}
+
+fn create_collection(handle: &Handle, dispatcher: &Dispatcher, collection_name: &str) {
+    handle
+        .block_on(
+            dispatcher.submit_collection_meta_op(
+                CollectionMetaOperations::CreateCollection(
+                    CreateCollectionOperation::new(
+                        collection_name.to_string(),
+                        CreateCollection {
+                            vectors: VectorParamsBuilder::new(10, Distance::Cosine)
+                                .build()
+                                .into(),
+                            sparse_vectors: None,
+                            hnsw_config: None,
+                            wal_config: None,
+                            optimizers_config: None,
+                            shard_number: Some(1),
+                            on_disk_payload: None,
+                            payload: None,
+                            replication_factor: None,
+                            write_consistency_factor: None,
+                            quantization_config: None,
+                            sharding_method: None,
+                            strict_mode_config: None,
+                            uuid: None,
+                            metadata: None,
+                        },
+                    )
+                    .unwrap(),
+                ),
+                FULL_ACCESS,
+                None,
+            ),
+        )
+        .unwrap();
+}
+
+fn get_collection(
+    handle: &Handle,
+    dispatcher: &Dispatcher,
+    collection_name: &str,
+) -> Arc<Collection> {
+    // Nothing to verify here.
+    let pass = new_unchecked_verification_pass();
+
+    handle
+        .block_on(
+            dispatcher.toc(&FULL_ACCESS, &pass).get_collection(
+                &FULL_ACCESS
+                    .check_collection_access(collection_name, AccessRequirements::new(), "test")
+                    .unwrap(),
+            ),
+        )
+        .unwrap()
+}


### PR DESCRIPTION
`UpdateCollection` operation contains diffs for every field of collection config and applies these diffs one-by-one.

E.g., `CollectionConfigInternal::optimizer_config` is updated and *saved* first, then `params`, then `hnsw_config`, etc. Config is saved after each field update.

There are two diffs that might fail to apply: `vectors` and `sparse_vectors`. These specify vector names, and if specified vector does not exist, operation returns an error.

So, if operation contains invalid vector name, then it might be *partially* applied. It will update and persist some fields, then check `vectors`/`sparse_vectors` names, return an error and ignore other fields.

This PR validates vector names *before* updating fields, so `UpdateCollection` should either apply fully or not at all.

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
