### PR TITLE
TurboQuant AVX512 + Neon reduce four vectors at once

### DIFF
--- a/lib/quantization/src/turboquant/simd/query/arm.rs
+++ b/lib/quantization/src/turboquant/simd/query/arm.rs
@@ -215,19 +215,25 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
     #[target_feature(enable = "neon")]
     pub unsafe fn dotprod_batch_neon(&self, data: &[u8], stride: usize, out: &mut [f32]) {
         unsafe {
+            let (groups, rest) = out.as_chunks_mut::<GROUP_128>();
+            let interleave = self.vector_bytes <= INTERLEAVE_MAX_BYTES;
             let mut v = 0;
-            if self.vector_bytes <= INTERLEAVE_MAX_BYTES {
-                let (groups, _) = out.as_chunks_mut::<GROUP_128>();
-                for group in groups {
-                    let accs =
-                        self.accumulate_neon::<GROUP_128>(data.as_ptr().add(v * stride), stride);
-                    for (out, acc) in group.iter_mut().zip(accs) {
-                        *out = self.postprocess(Self::reduce_neon(acc));
+            for group in groups {
+                let accs = if interleave {
+                    self.accumulate_neon::<GROUP_128>(data.as_ptr().add(v * stride), stride)
+                } else {
+                    let mut accs = [Acc128::zero(); GROUP_128];
+                    for (i, acc) in accs.iter_mut().enumerate() {
+                        let [single] =
+                            self.accumulate_neon::<1>(data.as_ptr().add((v + i) * stride), stride);
+                        *acc = single;
                     }
-                    v += GROUP_128;
-                }
+                    accs
+                };
+                vst1q_f32(group.as_mut_ptr(), self.postprocess_x4_neon(accs));
+                v += GROUP_128;
             }
-            for out in &mut out[v..] {
+            for out in rest {
                 let [acc] = self.accumulate_neon::<1>(data.as_ptr().add(v * stride), stride);
                 *out = self.postprocess(Self::reduce_neon(acc));
                 v += 1;
@@ -305,8 +311,14 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
     /// Vectors up to [`INTERLEAVE_MAX_BYTES`] are scored in groups of
     /// [`GROUP_128`]: the group shares each query block load, and its
     /// independent accumulators keep the multi-cycle `SDOT` latency off the
-    /// critical path.  Longer vectors keep the one-vector-at-a-time walk so
-    /// the hardware prefetcher sees a single sequential stream.
+    /// critical path.  Longer vectors walk the block loop one vector at a
+    /// time so the hardware prefetcher sees a single sequential stream.
+    ///
+    /// Either way the reduction is shared across the group (see
+    /// [`Self::postprocess_x4_neon`]): the per-vector chain of horizontal
+    /// add, scalar combine, convert, multiply and store retires in order
+    /// behind the next vector's block loop, so one four-wide pass per group
+    /// replaces four serial ones.
     ///
     /// # Safety
     /// CPU must support `dotprod`; `data` must hold `out.len()` vectors at
@@ -314,19 +326,25 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
     #[target_feature(enable = "neon,dotprod")]
     pub unsafe fn dotprod_batch_neon_sdot(&self, data: &[u8], stride: usize, out: &mut [f32]) {
         unsafe {
+            let (groups, rest) = out.as_chunks_mut::<GROUP_128>();
+            let interleave = self.vector_bytes <= INTERLEAVE_MAX_BYTES;
             let mut v = 0;
-            if self.vector_bytes <= INTERLEAVE_MAX_BYTES {
-                let (groups, _) = out.as_chunks_mut::<GROUP_128>();
-                for group in groups {
-                    let accs = self
-                        .accumulate_neon_sdot::<GROUP_128>(data.as_ptr().add(v * stride), stride);
-                    for (out, acc) in group.iter_mut().zip(accs) {
-                        *out = self.postprocess(Self::reduce_neon(acc));
+            for group in groups {
+                let accs = if interleave {
+                    self.accumulate_neon_sdot::<GROUP_128>(data.as_ptr().add(v * stride), stride)
+                } else {
+                    let mut accs = [Acc128::zero(); GROUP_128];
+                    for (i, acc) in accs.iter_mut().enumerate() {
+                        let [single] = self
+                            .accumulate_neon_sdot::<1>(data.as_ptr().add((v + i) * stride), stride);
+                        *acc = single;
                     }
-                    v += GROUP_128;
-                }
+                    accs
+                };
+                vst1q_f32(group.as_mut_ptr(), self.postprocess_x4_neon(accs));
+                v += GROUP_128;
             }
-            for out in &mut out[v..] {
+            for out in rest {
                 let [acc] = self.accumulate_neon_sdot::<1>(data.as_ptr().add(v * stride), stride);
                 *out = self.postprocess(Self::reduce_neon(acc));
                 v += 1;
@@ -381,6 +399,47 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
     fn reduce_neon(acc: Acc128<QUERY_BYTES>) -> i64 {
         Self::combine_bytes(acc.fold().map(|total| i64::from(vaddvq_s32(total))))
     }
+
+    /// [`Self::postprocess`] of a group's accumulators in one pass: per query
+    /// byte, two rounds of pairwise adds turn the four vectors' lane totals
+    /// into one register of per-vector sums (the same wrapping i32 sum as
+    /// `vaddvq_s32`), which are widened to i64, combined across the query
+    /// bytes, bias-corrected and converted through f64 — exact, with a
+    /// single rounding to f32 like the scalar `as f32`.
+    #[inline]
+    #[target_feature(enable = "neon")]
+    fn postprocess_x4_neon(&self, accs: [Acc128<QUERY_BYTES>; GROUP_128]) -> float32x4_t {
+        let totals = accs.map(|acc| acc.fold());
+        let low = sum_lanes_x4(totals.map(|total| total[0]));
+        let mut lo = vmovl_s32(vget_low_s32(low));
+        let mut hi = vmovl_high_s32(low);
+        if QUERY_BYTES == 2 {
+            let high = sum_lanes_x4(totals.map(|total| total[1]));
+            let high_lo = vmovl_s32(vget_low_s32(high));
+            let high_hi = vmovl_high_s32(high);
+            // The radix is a power of two (128 or 256); the shift is an immediate.
+            let (scaled_lo, scaled_hi) = match const { encoding(PLANES).query_high_coef } {
+                128 => (vshlq_n_s64::<7>(high_lo), vshlq_n_s64::<7>(high_hi)),
+                _ => (vshlq_n_s64::<8>(high_lo), vshlq_n_s64::<8>(high_hi)),
+            };
+            lo = vaddq_s64(lo, scaled_lo);
+            hi = vaddq_s64(hi, scaled_hi);
+        }
+        let bias = vdupq_n_s64(self.bias_correction);
+        let lo = vcvtq_f64_s64(vsubq_s64(lo, bias));
+        let hi = vcvtq_f64_s64(vsubq_s64(hi, bias));
+        let scores = vcvt_high_f32_f64(vcvt_f32_f64(lo), hi);
+        vmulq_n_f32(scores, self.postprocess_scale)
+    }
+}
+
+/// The lane sums of four i32 vectors, one per output lane: the first
+/// pairwise add leaves `[a0+a1, a2+a3, b0+b1, b2+b3]`, the second finishes
+/// each vector's sum.
+#[inline]
+#[target_feature(enable = "neon")]
+fn sum_lanes_x4([a, b, c, d]: [int32x4_t; 4]) -> int32x4_t {
+    vpaddq_s32(vpaddq_s32(a, b), vpaddq_s32(c, d))
 }
 
 /// Vectors per interleaved group of the NEON batch kernels: 4 × 4

--- a/lib/quantization/src/turboquant/simd/query/x64.rs
+++ b/lib/quantization/src/turboquant/simd/query/x64.rs
@@ -652,9 +652,19 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
                     }
                     accs
                 };
-                let lanes = accs.map(|acc| self.widen_avx512(acc));
-                let scores = self.postprocess_x4_avx2(transpose_sum_4x64(lanes));
-                _mm_storeu_ps(group.as_mut_ptr(), scores);
+                // Reduce the group together only for a one-byte query. With two
+                // bytes each vector carries twice the accumulator state, so
+                // holding all four until the transpose spills the register file
+                // and costs more than sharing the reduction saves.
+                if QUERY_BYTES == 1 {
+                    let lanes = accs.map(|acc| self.widen_avx512(acc));
+                    let scores = self.postprocess_x4_avx2(transpose_sum_4x64(lanes));
+                    _mm_storeu_ps(group.as_mut_ptr(), scores);
+                } else {
+                    for (out, acc) in group.iter_mut().zip(accs) {
+                        *out = self.postprocess(self.reduce_avx512(acc));
+                    }
+                }
                 v += GROUP_512;
             }
             for out in rest {

--- a/lib/quantization/src/turboquant/simd/query/x64.rs
+++ b/lib/quantization/src/turboquant/simd/query/x64.rs
@@ -637,20 +637,45 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
     #[target_feature(enable = "avx512f,avx512bw,avx512vnni")]
     pub unsafe fn dotprod_batch_avx512_vnni(&self, data: &[u8], stride: usize, out: &mut [f32]) {
         unsafe {
+            // Resolve the interleave choice here, so the group loop holds one
+            // shape only: a runtime test inside it keeps the untaken arm live
+            // for the register allocator, which costs the narrow widths a few
+            // percent even when they never take it.
+            if self.vector_bytes <= INTERLEAVE_MAX_BYTES {
+                self.dotprod_batch_avx512_groups::<true>(data, stride, out);
+            } else {
+                self.dotprod_batch_avx512_groups::<false>(data, stride, out);
+            }
+        }
+    }
+
+    /// [`Self::dotprod_batch_avx512_vnni`] with the interleave choice fixed:
+    /// `INTERLEAVE` groups score [`GROUP_512`] vectors through one block loop,
+    /// otherwise each vector walks the blocks on its own and the group only
+    /// shares the reduction.
+    ///
+    /// # Safety
+    /// CPU must support `avx512f`, `avx512bw`, and `avx512vnni`; `data` must
+    /// hold `out.len()` vectors at `stride`.
+    #[target_feature(enable = "avx512f,avx512bw,avx512vnni")]
+    unsafe fn dotprod_batch_avx512_groups<const INTERLEAVE: bool>(
+        &self,
+        data: &[u8],
+        stride: usize,
+        out: &mut [f32],
+    ) {
+        unsafe {
             let (groups, rest) = out.as_chunks_mut::<GROUP_512>();
-            let interleave = self.vector_bytes <= INTERLEAVE_MAX_BYTES;
             let mut v = 0;
             for group in groups {
-                let accs = if interleave {
+                let accs = if INTERLEAVE {
                     self.accumulate_avx512::<GROUP_512>(data.as_ptr().add(v * stride), stride)
                 } else {
-                    let mut accs = [Acc512::zero(); GROUP_512];
-                    for (i, acc) in accs.iter_mut().enumerate() {
+                    std::array::from_fn(|i| {
                         let [single] = self
                             .accumulate_avx512::<1>(data.as_ptr().add((v + i) * stride), stride);
-                        *acc = single;
-                    }
-                    accs
+                        single
+                    })
                 };
                 // Reduce the group together only for a one-byte query. With two
                 // bytes each vector carries twice the accumulator state, so

--- a/lib/quantization/src/turboquant/simd/query/x64.rs
+++ b/lib/quantization/src/turboquant/simd/query/x64.rs
@@ -665,9 +665,10 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
         }
     }
 
-    /// [`Self::widen_avx2`] for ZMM accumulators: each total is folded to
-    /// 256 bits first, which halves the lanes and doubles their values —
-    /// the per-byte bound behind [`fused_reduction_max_bytes`] is unchanged.
+    /// [`Self::widen_avx2`] for ZMM accumulators.  Within the fused bound the
+    /// query bytes are combined in 512-bit and only then folded to 256 and
+    /// widened, so the per-vector narrowing runs once rather than once per
+    /// query byte; out of the bound it falls back to the per-byte i64 combine.
     ///
     /// # Safety
     /// CPU must support `avx512f`.
@@ -675,7 +676,18 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
     #[target_feature(enable = "avx512f")]
     unsafe fn widen_avx512(&self, acc: Acc512<QUERY_BYTES>) -> __m256i {
         unsafe {
-            let totals = acc.fold().map(|total| {
+            let totals = acc.fold();
+            // Fuse the query bytes in 512-bit first, so the 512 -> 256 narrowing
+            // and the i64 widening run once per vector instead of once per query
+            // byte.  Folding after the fuse leaves the same four i32 lanes the
+            // per-byte path produced, so the result and the
+            // [`fused_reduction_max_bytes`] bound are unchanged.
+            if self.vector_bytes <= Self::FUSED_REDUCTION_MAX_BYTES {
+                return widen_i64_512(combine_fused_512::<PLANES, QUERY_BYTES>(totals));
+            }
+            // Out of the fused bound: narrow each query byte on its own and let
+            // [`Self::widen_totals_256`] combine them in i64.
+            let totals = totals.map(|total| {
                 _mm256_add_epi32(
                     _mm512_castsi512_si256(total),
                     _mm512_extracti64x4_epi64(total, 1),
@@ -892,6 +904,47 @@ unsafe fn reduce_fused_512<const PLANES: usize, const QUERY_BYTES: usize>(
                 _mm512_extracti64x4_epi64(total, 1),
             )
         }))
+    }
+}
+
+/// [`combine_fused_256`] for ZMM totals: the high query byte's i32 lanes
+/// shifted by `log2(K)` and added to the low byte's, staying in 512-bit.
+///
+/// # Safety
+/// CPU must support `avx512f`; the totals must come from a vector within the
+/// width's [`fused_reduction_max_bytes`].
+#[inline]
+#[target_feature(enable = "avx512f")]
+unsafe fn combine_fused_512<const PLANES: usize, const QUERY_BYTES: usize>(
+    totals: [__m512i; QUERY_BYTES],
+) -> __m512i {
+    let mut combined = totals[0];
+    if QUERY_BYTES == 2 {
+        // The radix is a power of two (128 or 256); the shift is an immediate.
+        let high = totals[1];
+        let scaled = match const { encoding(PLANES).query_high_coef } {
+            128 => _mm512_slli_epi32(high, 7),
+            _ => _mm512_slli_epi32(high, 8),
+        };
+        combined = _mm512_add_epi32(combined, scaled);
+    }
+    combined
+}
+
+/// A fused 512-bit total's sixteen i32 lanes folded to four i64 lanes: the
+/// 512-bit halves add to 256 bits, then [`widen_i64_256`].
+///
+/// # Safety
+/// CPU must support `avx512f`.
+#[inline]
+#[target_feature(enable = "avx512f")]
+unsafe fn widen_i64_512(combined: __m512i) -> __m256i {
+    unsafe {
+        let folded = _mm256_add_epi32(
+            _mm512_castsi512_si256(combined),
+            _mm512_extracti64x4_epi64(combined, 1),
+        );
+        widen_i64_256(folded)
     }
 }
 

--- a/lib/quantization/src/turboquant/simd/query/x64.rs
+++ b/lib/quantization/src/turboquant/simd/query/x64.rs
@@ -665,10 +665,9 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
         }
     }
 
-    /// [`Self::widen_avx2`] for ZMM accumulators.  Within the fused bound the
-    /// query bytes are combined in 512-bit and only then folded to 256 and
-    /// widened, so the per-vector narrowing runs once rather than once per
-    /// query byte; out of the bound it falls back to the per-byte i64 combine.
+    /// [`Self::widen_avx2`] for ZMM accumulators: each total is folded to
+    /// 256 bits first, which halves the lanes and doubles their values —
+    /// the per-byte bound behind [`fused_reduction_max_bytes`] is unchanged.
     ///
     /// # Safety
     /// CPU must support `avx512f`.
@@ -676,18 +675,7 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
     #[target_feature(enable = "avx512f")]
     unsafe fn widen_avx512(&self, acc: Acc512<QUERY_BYTES>) -> __m256i {
         unsafe {
-            let totals = acc.fold();
-            // Fuse the query bytes in 512-bit first, so the 512 -> 256 narrowing
-            // and the i64 widening run once per vector instead of once per query
-            // byte.  Folding after the fuse leaves the same four i32 lanes the
-            // per-byte path produced, so the result and the
-            // [`fused_reduction_max_bytes`] bound are unchanged.
-            if self.vector_bytes <= Self::FUSED_REDUCTION_MAX_BYTES {
-                return widen_i64_512(combine_fused_512::<PLANES, QUERY_BYTES>(totals));
-            }
-            // Out of the fused bound: narrow each query byte on its own and let
-            // [`Self::widen_totals_256`] combine them in i64.
-            let totals = totals.map(|total| {
+            let totals = acc.fold().map(|total| {
                 _mm256_add_epi32(
                     _mm512_castsi512_si256(total),
                     _mm512_extracti64x4_epi64(total, 1),
@@ -904,47 +892,6 @@ unsafe fn reduce_fused_512<const PLANES: usize, const QUERY_BYTES: usize>(
                 _mm512_extracti64x4_epi64(total, 1),
             )
         }))
-    }
-}
-
-/// [`combine_fused_256`] for ZMM totals: the high query byte's i32 lanes
-/// shifted by `log2(K)` and added to the low byte's, staying in 512-bit.
-///
-/// # Safety
-/// CPU must support `avx512f`; the totals must come from a vector within the
-/// width's [`fused_reduction_max_bytes`].
-#[inline]
-#[target_feature(enable = "avx512f")]
-unsafe fn combine_fused_512<const PLANES: usize, const QUERY_BYTES: usize>(
-    totals: [__m512i; QUERY_BYTES],
-) -> __m512i {
-    let mut combined = totals[0];
-    if QUERY_BYTES == 2 {
-        // The radix is a power of two (128 or 256); the shift is an immediate.
-        let high = totals[1];
-        let scaled = match const { encoding(PLANES).query_high_coef } {
-            128 => _mm512_slli_epi32(high, 7),
-            _ => _mm512_slli_epi32(high, 8),
-        };
-        combined = _mm512_add_epi32(combined, scaled);
-    }
-    combined
-}
-
-/// A fused 512-bit total's sixteen i32 lanes folded to four i64 lanes: the
-/// 512-bit halves add to 256 bits, then [`widen_i64_256`].
-///
-/// # Safety
-/// CPU must support `avx512f`.
-#[inline]
-#[target_feature(enable = "avx512f")]
-unsafe fn widen_i64_512(combined: __m512i) -> __m256i {
-    unsafe {
-        let folded = _mm256_add_epi32(
-            _mm512_castsi512_si256(combined),
-            _mm512_extracti64x4_epi64(combined, 1),
-        );
-        widen_i64_256(folded)
     }
 }
 

--- a/lib/quantization/src/turboquant/simd/query/x64.rs
+++ b/lib/quantization/src/turboquant/simd/query/x64.rs
@@ -489,8 +489,17 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
     #[inline]
     #[target_feature(enable = "avx2")]
     unsafe fn widen_avx2(&self, acc: Acc256<QUERY_BYTES>) -> __m256i {
+        unsafe { self.widen_totals_256(acc.fold()) }
+    }
+
+    /// [`Self::widen_avx2`] on the per-byte lane totals.
+    ///
+    /// # Safety
+    /// CPU must support `avx2`.
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn widen_totals_256(&self, totals: [__m256i; QUERY_BYTES]) -> __m256i {
         unsafe {
-            let totals = acc.fold();
             if self.vector_bytes <= Self::FUSED_REDUCTION_MAX_BYTES {
                 return widen_i64_256(combine_fused_256::<PLANES, QUERY_BYTES>(totals));
             }
@@ -611,12 +620,16 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
     ///
     /// Vectors up to [`INTERLEAVE_MAX_BYTES`] are scored in groups of
     /// [`GROUP_512`]: the group shares each query block load and its tail
-    /// mask, and its independent accumulators keep `VPDPBUSD` saturated
-    /// while the per-vector reductions overlap with the next group's loads.
-    /// Longer vectors keep the one-vector-at-a-time walk: the group reads
-    /// [`GROUP_512`] interleaved byte streams, which hardware prefetchers
-    /// stream far worse than a single sequential one once each vector spans
-    /// more than a couple of cache lines.
+    /// mask, and its independent accumulators keep `VPDPBUSD` saturated.
+    /// Longer vectors walk the block loop one vector at a time: the group
+    /// reads [`GROUP_512`] interleaved byte streams, which hardware
+    /// prefetchers stream far worse than a single sequential one once each
+    /// vector spans more than a couple of cache lines.
+    ///
+    /// Either way the reduction is shared across the group as in
+    /// [`Self::dotprod_batch_avx2`]: each vector's accumulators are folded
+    /// to four i64 lanes, the group's lanes are transposed into one YMM of
+    /// sums, bias-corrected, converted and stored four-wide.
     ///
     /// # Safety
     /// CPU must support `avx512f`, `avx512bw`, and `avx512vnni`; `data` must
@@ -624,23 +637,51 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
     #[target_feature(enable = "avx512f,avx512bw,avx512vnni")]
     pub unsafe fn dotprod_batch_avx512_vnni(&self, data: &[u8], stride: usize, out: &mut [f32]) {
         unsafe {
+            let (groups, rest) = out.as_chunks_mut::<GROUP_512>();
+            let interleave = self.vector_bytes <= INTERLEAVE_MAX_BYTES;
             let mut v = 0;
-            if self.vector_bytes <= INTERLEAVE_MAX_BYTES {
-                let (groups, _) = out.as_chunks_mut::<GROUP_512>();
-                for group in groups {
-                    let accs =
-                        self.accumulate_avx512::<GROUP_512>(data.as_ptr().add(v * stride), stride);
-                    for (out, acc) in group.iter_mut().zip(accs) {
-                        *out = self.postprocess(self.reduce_avx512(acc));
+            for group in groups {
+                let accs = if interleave {
+                    self.accumulate_avx512::<GROUP_512>(data.as_ptr().add(v * stride), stride)
+                } else {
+                    let mut accs = [Acc512::zero(); GROUP_512];
+                    for (i, acc) in accs.iter_mut().enumerate() {
+                        let [single] = self
+                            .accumulate_avx512::<1>(data.as_ptr().add((v + i) * stride), stride);
+                        *acc = single;
                     }
-                    v += GROUP_512;
-                }
+                    accs
+                };
+                let lanes = accs.map(|acc| self.widen_avx512(acc));
+                let scores = self.postprocess_x4_avx2(transpose_sum_4x64(lanes));
+                _mm_storeu_ps(group.as_mut_ptr(), scores);
+                v += GROUP_512;
             }
-            for out in &mut out[v..] {
+            for out in rest {
                 let [acc] = self.accumulate_avx512::<1>(data.as_ptr().add(v * stride), stride);
                 *out = self.postprocess(self.reduce_avx512(acc));
                 v += 1;
             }
+        }
+    }
+
+    /// [`Self::widen_avx2`] for ZMM accumulators: each total is folded to
+    /// 256 bits first, which halves the lanes and doubles their values —
+    /// the per-byte bound behind [`fused_reduction_max_bytes`] is unchanged.
+    ///
+    /// # Safety
+    /// CPU must support `avx512f`.
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn widen_avx512(&self, acc: Acc512<QUERY_BYTES>) -> __m256i {
+        unsafe {
+            let totals = acc.fold().map(|total| {
+                _mm256_add_epi32(
+                    _mm512_castsi512_si256(total),
+                    _mm512_extracti64x4_epi64(total, 1),
+                )
+            });
+            self.widen_totals_256(totals)
         }
     }
 
@@ -713,8 +754,9 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
 
 /// Vectors per interleaved group of the AVX-512 batch kernel: 4 × 4
 /// accumulators plus the query block, codebook and mask fit the 32 ZMM
-/// registers without spilling.
-const GROUP_512: usize = 4;
+/// registers without spilling.  Equal to [`REDUCE_GROUP_256`] so one
+/// interleaved group feeds one shared reduction.
+const GROUP_512: usize = REDUCE_GROUP_256;
 
 /// Longest encoded vector (bytes) the AVX-512 batch kernel scores in
 /// interleaved groups: four cache lines per vector.  Measured streaming


### PR DESCRIPTION
Same changes as #10437 but for Avx512 and neon kernels.
