### PR TITLE
QuerySimd: hold the query planes in one allocation

### DIFF
--- a/lib/quantization/src/turboquant/simd/query/arm.rs
+++ b/lib/quantization/src/turboquant/simd/query/arm.rs
@@ -42,7 +42,7 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QueryBlock128<PLANES, QUERY_
         };
         for (b, byte_planes) in block.bytes.iter_mut().enumerate() {
             for (k, plane) in byte_planes.iter_mut().enumerate() {
-                *plane = unsafe { load_plane_128(&planes.bytes[b][k], offset) };
+                *plane = unsafe { load_plane_128(planes.plane(b, k), offset) };
             }
         }
         block

--- a/lib/quantization/src/turboquant/simd/query/mod.rs
+++ b/lib/quantization/src/turboquant/simd/query/mod.rs
@@ -147,7 +147,16 @@ unsafe fn tail_block<const N: usize>(data: *const u8, len: usize) -> [u8; N] {
 /// kernel can always load a whole block on the query side; whatever the
 /// data lanes past the vector's end hold, they multiply against zeros.
 pub(crate) struct QueryPlanes<const PLANES: usize, const QUERY_BYTES: usize> {
-    bytes: [[Vec<i8>; PLANES]; QUERY_BYTES],
+    /// Every plane in one allocation, plane `(b, k)` at
+    /// `data[(b * PLANES + k) * plane_len..][..plane_len]`.
+    ///
+    /// One allocation rather than `PLANES * QUERY_BYTES` separate `Vec`s so
+    /// the planes land on neighbouring pages: a scoring loop that re-reads
+    /// them per vector then touches one TLB region and one prefetch stream
+    /// instead of up to sixteen scattered ones.
+    data: Vec<i8>,
+    /// Padded length of a single plane, in bytes.
+    plane_len: usize,
 }
 
 impl<const PLANES: usize, const QUERY_BYTES: usize> QueryPlanes<PLANES, QUERY_BYTES> {
@@ -156,16 +165,28 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QueryPlanes<PLANES, QUERY_BY
     fn new(encoded: impl ExactSizeIterator<Item = [i8; QUERY_BYTES]>) -> Self {
         let dim = encoded.len();
         debug_assert!(dim.is_multiple_of(PLANES));
-        let len = (dim / PLANES).next_multiple_of(PLANE_BLOCK);
-        let mut bytes: [[Vec<i8>; PLANES]; QUERY_BYTES] =
-            std::array::from_fn(|_| std::array::from_fn(|_| vec![0; len]));
+        let plane_len = (dim / PLANES).next_multiple_of(PLANE_BLOCK);
+        let mut data = vec![0; QUERY_BYTES * PLANES * plane_len];
         for (i, dim_bytes) in encoded.enumerate() {
             let (j, k) = (i / PLANES, i % PLANES);
             for (b, &byte) in dim_bytes.iter().enumerate() {
-                bytes[b][k][j] = byte;
+                data[(b * PLANES + k) * plane_len + j] = byte;
             }
         }
-        Self { bytes }
+        Self { data, plane_len }
+    }
+
+    /// The plane holding query byte `b` of the dims whose code sits at
+    /// position `k`, zero-padded to a multiple of [`PLANE_BLOCK`].
+    #[inline(always)]
+    pub(crate) fn plane(&self, b: usize, k: usize) -> &[i8] {
+        debug_assert!(b < QUERY_BYTES && k < PLANES);
+        let start = (b * PLANES + k) * self.plane_len;
+        // SAFETY: `data` holds `QUERY_BYTES * PLANES` planes of `plane_len`
+        // bytes, and both indices are in range by the assert above. Bounds
+        // checks here cost 28-36% of the kernel: the slice is re-taken for
+        // every block of every vector.
+        unsafe { self.data.get_unchecked(start..start + self.plane_len) }
     }
 }
 
@@ -373,8 +394,8 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QuerySimd<PLANES, QUERY_BYTE
             for k in 0..PLANES {
                 let code = (byte >> (k * Self::BITS)) & mask;
                 let c = i64::from(encoding.codebook[code as usize]);
-                for (sum, planes) in sums.iter_mut().zip(&self.planes.bytes) {
-                    *sum += i64::from(planes[k][j]) * c;
+                for (b, sum) in sums.iter_mut().enumerate() {
+                    *sum += i64::from(self.planes.plane(b, k)[j]) * c;
                 }
             }
         }

--- a/lib/quantization/src/turboquant/simd/query/x64.rs
+++ b/lib/quantization/src/turboquant/simd/query/x64.rs
@@ -51,7 +51,7 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QueryBlock128<PLANES, QUERY_
         };
         for (b, byte_planes) in block.bytes.iter_mut().enumerate() {
             for (k, plane) in byte_planes.iter_mut().enumerate() {
-                *plane = unsafe { load_plane_128(&planes.bytes[b][k], offset) };
+                *plane = unsafe { load_plane_128(planes.plane(b, k), offset) };
             }
         }
         block
@@ -153,7 +153,7 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QueryBlock256<PLANES, QUERY_
         };
         for (b, byte_planes) in block.bytes.iter_mut().enumerate() {
             for (k, plane) in byte_planes.iter_mut().enumerate() {
-                *plane = unsafe { load_plane_256(&planes.bytes[b][k], offset) };
+                *plane = unsafe { load_plane_256(planes.plane(b, k), offset) };
             }
         }
         block
@@ -263,7 +263,7 @@ impl<const PLANES: usize, const QUERY_BYTES: usize> QueryBlock512<PLANES, QUERY_
         };
         for (b, byte_planes) in block.bytes.iter_mut().enumerate() {
             for (k, plane) in byte_planes.iter_mut().enumerate() {
-                *plane = unsafe { load_plane_512(&planes.bytes[b][k], offset) };
+                *plane = unsafe { load_plane_512(planes.plane(b, k), offset) };
             }
         }
         block


### PR DESCRIPTION
## Summary

`QueryPlanes` kept the encoded query as `PLANES * QUERY_BYTES` separate `Vec<i8>`s: four for the 4-bit width, eight for 2-bit and 1-bit, sixteen for a 16-bit query at the 1-bit width. This PR puts all planes into one allocation and hands the kernels their slice through an unchecked accessor. Scoring semantics are unchanged; the parity tests against the scalar reference still apply.

## Why

The planes are a small, permanently hot structure that every scored vector re-reads in full. With one allocation per plane they sit on as many separate pages as there are planes, so a scoring loop touches up to sixteen TLB entries and sixteen prefetch streams for what is logically a single contiguous buffer. Laying them out back to back puts the whole query in one TLB region and one stream, and adjacent planes share cache lines instead of each starting on its own.

## What changed

- `QueryPlanes` now holds `data: Vec<i8>` plus `plane_len`. Plane `(b, k)` lives at `data[(b * PLANES + k) * plane_len..][..plane_len]`, where `b` is the query byte and `k` the code position within a packed data byte. Each plane is still zero-padded to a multiple of `PLANE_BLOCK`, so the kernels' whole-block loads on the query side are unaffected.
- `QueryPlanes::plane(b, k) -> &[i8]` is the single accessor. It is `#[inline(always)]` and slices with `get_unchecked`: the slice is re-taken for every block of every vector, and a bounds-checked version measured 28-36% slower than the previous multi-`Vec` layout, which would have erased the point of the change. A `debug_assert!` on both indices keeps misuse visible in debug and test builds.
- All block loaders go through the accessor: `QueryBlock128` on both aarch64 and x86_64, `QueryBlock256`, `QueryBlock512`, and the scalar reference `dotprod_raw`.

## Safety

The `unsafe` in `plane()` relies on one invariant: `data.len() == QUERY_BYTES * PLANES * plane_len`. It is established once in `QueryPlanes::new`, the fields are private, and both indices are bounded by the const generics, so every `(b, k)` in range yields a slice inside `data`.