### PR TITLE
perf: move update-path fsync off async Tokio workers

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -23,12 +23,12 @@ pub mod indexed_only;
 pub mod testing;
 mod wal_ops;
 
+use std::cmp;
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::time::{Duration, Instant};
-use std::{cmp, thread};
 
 use arc_swap::ArcSwap;
 use common::budget::ResourceBudget;
@@ -42,6 +42,7 @@ use common::{panic, tar_ext};
 use fs_err as fs;
 use fs_err::tokio as tokio_fs;
 use futures::StreamExt as _;
+use futures::future::join_all;
 use futures::stream::FuturesUnordered;
 use indicatif::{ProgressBar, ProgressStyle};
 use itertools::Itertools;
@@ -642,78 +643,70 @@ impl LocalShard {
             &config.hnsw_config,
             effective_optimizers_config.get_deferred_points_threshold_bytes(),
         );
-
-        // Segment create (thread join) + WAL/manifest fsync are blocking; keep them off the
-        // async runtime that hosts collection meta-ops.
-        let wal_config = config.wal_config.clone();
-        let params = config.params.clone();
-        let hnsw_config = config.hnsw_config;
-        let quantization_config = config.quantization_config.clone();
-        let hnsw_global_config = shared_storage_config.hnsw_global_config.clone();
-        let collection_config_for_optimizers = collection_config.clone();
-        let effective_optimizers_config_clone = effective_optimizers_config.clone();
-        let shard_path_owned = shard_path.to_path_buf();
-        let collection_id_for_build = collection_id.clone();
         let payload_storage_type = config.params.payload_storage_type();
 
-        drop(config); // release `shared_config` from borrow checker
+        // Segment create is blocking (mkdir + storage init + fsync): build on the blocking
+        // pool, then join the handles from async context.
+        for _sid in 0..segment_number {
+            let path_clone = segments_path.clone();
+            let segment_config = SegmentConfig {
+                vector_data: vector_params.clone(),
+                sparse_vector_data: sparse_vector_params.clone(),
+                payload_storage_type,
+            };
+            build_handlers.push(tokio::task::spawn_blocking(move || {
+                build_segment(&path_clone, &segment_config, deferred_internal_id, true)
+            }));
+        }
 
-        let (segment_holder, wal, optimizers) = tokio::task::spawn_blocking(move || {
-            for _sid in 0..segment_number {
-                let path_clone = segments_path.clone();
-                let segment_config = SegmentConfig {
-                    vector_data: vector_params.clone(),
-                    sparse_vector_data: sparse_vector_params.clone(),
-                    payload_storage_type,
-                };
-                let segment = thread::Builder::new()
-                    .name(format!("shard-build-{collection_id_for_build}-{id}"))
-                    .spawn(move || {
-                        build_segment(&path_clone, &segment_config, deferred_internal_id, true)
-                    })
-                    .unwrap();
-                build_handlers.push(segment);
-            }
-
-            let join_results = build_handlers
-                .into_iter()
-                .map(|handler| handler.join())
-                .collect_vec();
-
-            for join_result in join_results {
-                let (segment, _token) = join_result.map_err(|err| {
-                    let message = panic::downcast_str(&err).unwrap_or("");
+        // Join all builds before propagating the first error, so no build is left detached.
+        for join_result in join_all(build_handlers).await {
+            let (segment, _token) = join_result.map_err(|err| match err.try_into_panic() {
+                Ok(payload) => {
+                    let message = panic::downcast_str(&payload).unwrap_or("");
                     let separator = if !message.is_empty() { "with:\n" } else { "" };
 
                     CollectionError::service_error(format!(
-                        "Segment DB create panicked{separator}{message}",
+                        "Segment DB create panicked for shard {collection_id}:{id}{separator}{message}",
                     ))
-                })??;
+                }
+                Err(err) => CollectionError::service_error(format!(
+                    "Segment DB create for shard {collection_id}:{id} was cancelled: {err}",
+                )),
+            })??;
 
-                segment_holder.add_new(segment);
-            }
+            segment_holder.add_new(segment);
+        }
 
+        let optimizers = build_optimizers(
+            shard_path,
+            collection_config.clone(),
+            &config.params,
+            &effective_optimizers_config,
+            &config.hnsw_config,
+            &shared_storage_config.hnsw_global_config,
+            &config.quantization_config,
+        );
+
+        // WAL create preallocates segment files and the manifest write fsyncs; keep both off
+        // the async runtime that hosts collection meta-ops.
+        let wal_config = config.wal_config.clone();
+        let shard_path_owned = shard_path.to_path_buf();
+
+        drop(config); // release `shared_config` from borrow checker
+
+        let (segment_holder, wal) = tokio::task::spawn_blocking(move || {
             let wal: SerdeWal<OperationWithClockTag> =
                 SerdeWal::new(&wal_path, (&wal_config).into())?;
 
-            let optimizers = build_optimizers(
-                &shard_path_owned,
-                collection_config_for_optimizers,
-                &params,
-                &effective_optimizers_config_clone,
-                &hnsw_config,
-                &hnsw_global_config,
-                &quantization_config,
-            );
-
             // Finalize the holder, wiring up the segment manifest from the freshly populated set.
             let segment_holder = segment_holder.build(&shard_path_owned)?;
-            Ok::<_, CollectionError>((segment_holder, wal, optimizers))
+            Ok::<_, CollectionError>((segment_holder, wal))
         })
         .await
         .map_err(|err| {
             CollectionError::service_error(format!(
-                "LocalShard::build blocking task panicked: {err}"
+                "Shard WAL and manifest create task panicked: {err}"
             ))
         })??;
 

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -643,57 +643,79 @@ impl LocalShard {
             effective_optimizers_config.get_deferred_points_threshold_bytes(),
         );
 
-        for _sid in 0..segment_number {
-            let path_clone = segments_path.clone();
-            let segment_config = SegmentConfig {
-                vector_data: vector_params.clone(),
-                sparse_vector_data: sparse_vector_params.clone(),
-                payload_storage_type: config.params.payload_storage_type(),
-            };
-            let segment = thread::Builder::new()
-                .name(format!("shard-build-{collection_id}-{id}"))
-                .spawn(move || {
-                    build_segment(&path_clone, &segment_config, deferred_internal_id, true)
-                })
-                .unwrap();
-            build_handlers.push(segment);
-        }
-
-        let join_results = build_handlers
-            .into_iter()
-            .map(|handler| handler.join())
-            .collect_vec();
-
-        for join_result in join_results {
-            let (segment, _token) = join_result.map_err(|err| {
-                let message = panic::downcast_str(&err).unwrap_or("");
-                let separator = if !message.is_empty() { "with:\n" } else { "" };
-
-                CollectionError::service_error(format!(
-                    "Segment DB create panicked{separator}{message}",
-                ))
-            })??;
-
-            segment_holder.add_new(segment);
-        }
-
-        let wal: SerdeWal<OperationWithClockTag> =
-            SerdeWal::new(&wal_path, (&config.wal_config).into())?;
-
-        let optimizers = build_optimizers(
-            shard_path,
-            collection_config.clone(),
-            &config.params,
-            &effective_optimizers_config,
-            &config.hnsw_config,
-            &shared_storage_config.hnsw_global_config,
-            &config.quantization_config,
-        );
+        // Segment create (thread join) + WAL/manifest fsync are blocking; keep them off the
+        // async runtime that hosts collection meta-ops.
+        let wal_config = config.wal_config.clone();
+        let params = config.params.clone();
+        let hnsw_config = config.hnsw_config;
+        let quantization_config = config.quantization_config.clone();
+        let hnsw_global_config = shared_storage_config.hnsw_global_config.clone();
+        let collection_config_for_optimizers = collection_config.clone();
+        let effective_optimizers_config_clone = effective_optimizers_config.clone();
+        let shard_path_owned = shard_path.to_path_buf();
+        let collection_id_for_build = collection_id.clone();
+        let payload_storage_type = config.params.payload_storage_type();
 
         drop(config); // release `shared_config` from borrow checker
 
-        // Finalize the holder, wiring up the segment manifest from the freshly populated set.
-        let segment_holder = segment_holder.build(shard_path)?;
+        let (segment_holder, wal, optimizers) = tokio::task::spawn_blocking(move || {
+            for _sid in 0..segment_number {
+                let path_clone = segments_path.clone();
+                let segment_config = SegmentConfig {
+                    vector_data: vector_params.clone(),
+                    sparse_vector_data: sparse_vector_params.clone(),
+                    payload_storage_type,
+                };
+                let segment = thread::Builder::new()
+                    .name(format!("shard-build-{collection_id_for_build}-{id}"))
+                    .spawn(move || {
+                        build_segment(&path_clone, &segment_config, deferred_internal_id, true)
+                    })
+                    .unwrap();
+                build_handlers.push(segment);
+            }
+
+            let join_results = build_handlers
+                .into_iter()
+                .map(|handler| handler.join())
+                .collect_vec();
+
+            for join_result in join_results {
+                let (segment, _token) = join_result.map_err(|err| {
+                    let message = panic::downcast_str(&err).unwrap_or("");
+                    let separator = if !message.is_empty() { "with:\n" } else { "" };
+
+                    CollectionError::service_error(format!(
+                        "Segment DB create panicked{separator}{message}",
+                    ))
+                })??;
+
+                segment_holder.add_new(segment);
+            }
+
+            let wal: SerdeWal<OperationWithClockTag> =
+                SerdeWal::new(&wal_path, (&wal_config).into())?;
+
+            let optimizers = build_optimizers(
+                &shard_path_owned,
+                collection_config_for_optimizers,
+                &params,
+                &effective_optimizers_config_clone,
+                &hnsw_config,
+                &hnsw_global_config,
+                &quantization_config,
+            );
+
+            // Finalize the holder, wiring up the segment manifest from the freshly populated set.
+            let segment_holder = segment_holder.build(&shard_path_owned)?;
+            Ok::<_, CollectionError>((segment_holder, wal, optimizers))
+        })
+        .await
+        .map_err(|err| {
+            CollectionError::service_error(format!(
+                "LocalShard::build blocking task panicked: {err}"
+            ))
+        })??;
 
         let local_shard = LocalShard::new(
             collection_id,

--- a/lib/collection/src/update_workers/applied_seq.rs
+++ b/lib/collection/src/update_workers/applied_seq.rs
@@ -134,24 +134,34 @@ impl AppliedSeqHandler {
         }
     }
 
-    fn save(&self, op_num: u64) -> CollectionResult<()> {
+    /// Persist `op_num` to the underlying file. Uses fsync, so callers on an async
+    /// runtime must wrap this in `spawn_blocking`.
+    pub(super) fn save(&self, op_num: u64) -> CollectionResult<()> {
         if let Some(file) = self.file.as_ref() {
             file.write(|current| current.op_num = op_num)?;
         }
         Ok(())
     }
 
-    /// Update the underlying file every `APPLIED_SEQ_SAVE_INTERVAL` updates.
-    /// Always update memory representation
-    pub fn update(&self, op_num: u64) -> CollectionResult<()> {
-        // update in-memory
+    /// Update the memory representation and report whether it is time to persist.
+    ///
+    /// Returns `true` every `APPLIED_SEQ_SAVE_INTERVAL` updates, in which case the caller
+    /// is expected to call [`Self::save`] with the same `op_num`.
+    #[must_use]
+    pub fn update_in_memory(&self, op_num: u64) -> bool {
         self.op_num.store(op_num, Ordering::Relaxed);
         let prev_count = self.update_count.fetch_add(1, Ordering::Relaxed);
         if prev_count == 0 {
-            return Ok(());
+            return false;
         }
-        // update on disk according to interval to amortize fsync
-        if prev_count.is_multiple_of(APPLIED_SEQ_SAVE_INTERVAL) {
+        // persist according to interval to amortize fsync
+        prev_count.is_multiple_of(APPLIED_SEQ_SAVE_INTERVAL)
+    }
+
+    /// Update the underlying file every `APPLIED_SEQ_SAVE_INTERVAL` updates.
+    /// Always update memory representation
+    pub fn update(&self, op_num: u64) -> CollectionResult<()> {
+        if self.update_in_memory(op_num) {
             self.save(op_num)?;
         }
         Ok(())

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -109,14 +109,28 @@ impl UpdateWorkers {
             has_triggered_optimizers.store(true, Ordering::Relaxed);
 
             // Ensure we have at least one appendable segment with enough capacity
-            // Source required parameters from first optimizer
-            let result = Self::ensure_appendable_segment_with_capacity(
-                &segments,
-                some_optimizer.segments_path(),
-                some_optimizer.segment_optimizer_config(),
-                some_optimizer.threshold_config(),
-                payload_index_schema.clone(),
-            );
+            // Source required parameters from first optimizer.
+            // Disk I/O (segment create + manifest fsync) must not run on the async worker.
+            let segments_for_capacity = segments.clone();
+            let segments_path = some_optimizer.segments_path().to_path_buf();
+            let segment_config = some_optimizer.segment_optimizer_config().clone();
+            let thresholds_config = *some_optimizer.threshold_config();
+            let payload_index_schema_for_capacity = payload_index_schema.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                Self::ensure_appendable_segment_with_capacity(
+                    &segments_for_capacity,
+                    &segments_path,
+                    &segment_config,
+                    &thresholds_config,
+                    payload_index_schema_for_capacity,
+                )
+            })
+            .await
+            .unwrap_or_else(|err| {
+                Err(OperationError::service_error(format!(
+                    "ensure_appendable_segment_with_capacity task panicked: {err}"
+                )))
+            });
             if let Err(err) = result {
                 log::error!("Failed to ensure there are appendable segments with capacity: {err}");
                 panic!("Failed to ensure there are appendable segments with capacity: {err}");
@@ -125,8 +139,18 @@ impl UpdateWorkers {
             // Backstop: reconcile the segment manifest with the live segment set. Registration
             // normally happens at each publication site via the `NewSegmentToken`; this wake-up is
             // the recovery path that picks up any registration that was skipped (e.g. an ignored
-            // token). No-op if already in sync.
-            if let Err(err) = segments.read().sync_segment_manifest(None) {
+            // token). No-op if already in sync. Manifest write uses fsync — keep it off the
+            // async worker.
+            let segments_for_sync = segments.clone();
+            if let Err(err) = tokio::task::spawn_blocking(move || {
+                segments_for_sync.read().sync_segment_manifest(None)
+            })
+            .await
+            .unwrap_or_else(|err| {
+                Err(OperationError::service_error(format!(
+                    "sync_segment_manifest task panicked: {err}"
+                )))
+            }) {
                 log::error!("Failed to write segment manifest: {err}");
             }
 

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -185,18 +185,21 @@ impl UpdateWorkers {
                         }
                     };
 
-                    // `AppliedSeqHandler::update` may fsync every APPLIED_SEQ_SAVE_INTERVAL ops.
-                    let applied_seq_handler = applied_seq_handler.clone();
-                    if let Err(err) =
-                        tokio::task::spawn_blocking(move || applied_seq_handler.update(op_num))
-                            .await
-                            .unwrap_or_else(|join_err| {
-                                Err(CollectionError::service_error(format!(
-                                    "applied_seq update task panicked: {join_err}"
-                                )))
-                            })
-                    {
-                        log::error!("Can't update last applied_seq {err}")
+                    // The in-memory bump is a pair of atomics, but the interval-triggered
+                    // save fsyncs: keep only the save off the async worker.
+                    if applied_seq_handler.update_in_memory(op_num) {
+                        let applied_seq_handler = applied_seq_handler.clone();
+                        if let Err(err) =
+                            tokio::task::spawn_blocking(move || applied_seq_handler.save(op_num))
+                                .await
+                                .unwrap_or_else(|join_err| {
+                                    Err(CollectionError::service_error(format!(
+                                        "applied_seq save task panicked: {join_err}"
+                                    )))
+                                })
+                        {
+                            log::error!("Can't update last applied_seq {err}")
+                        }
                     }
 
                     if wait_for_deferred && prevent_unoptimized {

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -185,7 +185,17 @@ impl UpdateWorkers {
                         }
                     };
 
-                    if let Err(err) = applied_seq_handler.update(op_num) {
+                    // `AppliedSeqHandler::update` may fsync every APPLIED_SEQ_SAVE_INTERVAL ops.
+                    let applied_seq_handler = applied_seq_handler.clone();
+                    if let Err(err) =
+                        tokio::task::spawn_blocking(move || applied_seq_handler.update(op_num))
+                            .await
+                            .unwrap_or_else(|join_err| {
+                                Err(CollectionError::service_error(format!(
+                                    "applied_seq update task panicked: {join_err}"
+                                )))
+                            })
+                    {
                         log::error!("Can't update last applied_seq {err}")
                     }
 


### PR DESCRIPTION
Moves the fsync islands that dial9 flagged on the update workers into `spawn_blocking`. Split out of #10361.

What moves off the async workers:

- `LocalShard::build`: one `spawn_blocking` per segment create, joined from async, plus one blocking task covering the WAL create (segment preallocation + fsync) and the manifest write. `build_optimizers` stays on the async side, it is pure construction with no IO.
- `optimization_worker.rs:119`: `ensure_appendable_segment_with_capacity` (segment create + manifest fsync).
- `optimization_worker.rs:145`: the `sync_segment_manifest` backstop write.
- `update_worker.rs:193`: the `applied_seq` save, gated on `update_in_memory` reporting the interval is due, so the hop is paid on 1 op in 64 instead of every op.

TODO: bench again
