### PR TITLE
Prevent wal ack before operation finish

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -26,7 +26,7 @@ mod wal_ops;
 use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use std::{cmp, thread};
 
@@ -146,6 +146,10 @@ pub struct LocalShard {
 
     /// Persist the applied op_num sequence number
     applied_seq_handler: Arc<AppliedSeqHandler>,
+
+    /// Version of the last operation the update worker finished applying, shared with the
+    /// update handler and its workers. See `UpdateHandler::applied_version`.
+    applied_version: Arc<AtomicU64>,
 }
 
 /// Shard holds information about segments and WAL.
@@ -329,6 +333,8 @@ impl LocalShard {
 
         drop(config); // release `shared_config` from borrow checker
 
+        let applied_version = update_handler.applied_version.clone();
+
         Self {
             collection_name,
             segments: segment_holder,
@@ -351,6 +357,7 @@ impl LocalShard {
             is_gracefully_stopped: false,
             update_operation_lock: scroll_read_lock,
             applied_seq_handler,
+            applied_version,
         }
     }
 
@@ -947,6 +954,12 @@ impl LocalShard {
             // version.
             segments.flush_all(FlushMode::Sync, true)?;
         }
+
+        // Everything before `to` is applied and flushed now, and whatever is queued to the
+        // update worker below starts at `to`. Let the flush worker acknowledge the replayed
+        // prefix in the WAL; the update worker takes over from here.
+        self.applied_version
+            .fetch_max(to.saturating_sub(1), Ordering::Release);
 
         bar.finish();
         if !show_progress_bar {

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -259,6 +259,7 @@ impl UpdateHandler {
         let segments = self.segments.clone();
         let wal = self.wal.clone();
         let wal_keep_from = self.wal_keep_from.clone();
+        let applied_version = self.applied_version.clone();
         let clocks = self.clocks.clone();
         let flush_interval_sec = self.flush_interval_sec;
         let shard_path = self.shard_path.clone();
@@ -267,6 +268,7 @@ impl UpdateHandler {
             segments,
             wal,
             wal_keep_from,
+            applied_version,
             clocks,
             flush_interval_sec,
             flush_rx,

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -108,6 +108,17 @@ pub struct UpdateHandler {
     /// queue proxy shard.
     /// Defaults to `u64::MAX` to allow acknowledging all confirmed versions.
     pub(super) wal_keep_from: Arc<AtomicU64>,
+    /// Version (`op_num`) of the last operation the update worker finished applying.
+    ///
+    /// An operation writes to segments in several separately locked steps, so a flush pass can
+    /// capture segments that already carry the version of an operation that is only partially
+    /// applied. The flush worker reads this before flushing and never acknowledges past it in
+    /// the WAL, so an operation that is still in flight stays replayable.
+    ///
+    /// Bumped by the update worker once an operation is done, whatever its outcome, and raised
+    /// by `LocalShard::load_from_wal` past the entries it replays synchronously. Starts at zero:
+    /// nothing has been applied by this process yet.
+    pub(super) applied_version: Arc<AtomicU64>,
     optimization_handles: Arc<TokioMutex<Vec<StoppableTaskHandle<bool>>>>,
     /// Maximum number of concurrent optimization jobs in this update handler.
     /// This parameter depends on the optimizer config and should be updated accordingly.
@@ -175,6 +186,7 @@ impl UpdateHandler {
             runtime_handle,
             wal,
             wal_keep_from: Arc::new(u64::MAX.into()),
+            applied_version: Arc::new(AtomicU64::new(0)),
             flush_interval_sec,
             optimization_handles: Arc::new(TokioMutex::new(vec![])),
             max_optimization_threads,
@@ -220,6 +232,7 @@ impl UpdateHandler {
         let update_tracker = self.update_tracker.clone();
         let collection_name = self.collection_name.clone();
         let applied_seq_handler = self.applied_seq_handler.clone();
+        let applied_version = self.applied_version.clone();
 
         // Cancel the old update worker and create a new cancellation token
         self.update_worker_cancel.cancel();
@@ -239,6 +252,7 @@ impl UpdateHandler {
             self.payload_index_schema.clone(),
             optimization_finished_receiver,
             applied_seq_handler,
+            applied_version,
             cancel,
         )));
 

--- a/lib/collection/src/update_workers/flush_workers.rs
+++ b/lib/collection/src/update_workers/flush_workers.rs
@@ -1,7 +1,7 @@
 use std::cmp::min;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use common::panic;
@@ -19,14 +19,30 @@ use crate::wal_delta::LockedWal;
 impl UpdateWorkers {
     /// Returns confirmed version after flush of all segments
     ///
+    /// The confirmed version never exceeds `applied_version`, which is read *before* flushing.
+    /// An operation writes to segments in several separately locked steps, so the pass may
+    /// capture an operation that is still in flight: its segments already carry the new version
+    /// while the update worker has not bumped `applied_version` yet. Acknowledging it would drop
+    /// the only replayable copy of whatever part of it is not on disk.
+    ///
+    /// This bounds the WAL acknowledge only. It does not keep a pass from capturing a segment in
+    /// the middle of an operation: such a segment is stamped with the in-flight version once its
+    /// flush completes, and later passes report it as persisted.
+    ///
     /// # Errors
     /// Returns an error on flush failure
-    fn flush_segments(segments: LockedSegmentHolder) -> OperationResult<SeqNumberType> {
+    fn flush_segments(
+        segments: LockedSegmentHolder,
+        applied_version: &AtomicU64,
+    ) -> OperationResult<SeqNumberType> {
+        // Read before flushing, so the bound predates anything this pass captures
+        let applied_version = applied_version.load(Ordering::Acquire);
         let read_segments = segments.read();
         let flushed_version = read_segments.flush_all(FlushMode::Background, false)?;
+        let confirmed_version = min(flushed_version, applied_version);
         Ok(match read_segments.failed_operation.iter().cloned().min() {
-            None => flushed_version,
-            Some(failed_operation) => min(failed_operation, flushed_version),
+            None => confirmed_version,
+            Some(failed_operation) => min(failed_operation, confirmed_version),
         })
     }
 
@@ -34,6 +50,7 @@ impl UpdateWorkers {
         segments: LockedSegmentHolder,
         wal: LockedWal,
         wal_keep_from: Arc<AtomicU64>,
+        applied_version: Arc<AtomicU64>,
         clocks: LocalShardClocks,
         shard_path: PathBuf,
     ) {
@@ -62,7 +79,7 @@ impl UpdateWorkers {
             return;
         }
 
-        let confirmed_version = Self::flush_segments(segments.clone());
+        let confirmed_version = Self::flush_segments(segments.clone(), &applied_version);
         let confirmed_version = match confirmed_version {
             Ok(version) => version,
             Err(err) => {
@@ -79,7 +96,7 @@ impl UpdateWorkers {
         // This is to prevent truncating WAL entries that other bits of code still depend on
         // such as the queue proxy shard.
         // Default keep_from is `u64::MAX` to allow acknowledging all confirmed.
-        let keep_from = wal_keep_from.load(std::sync::atomic::Ordering::Relaxed);
+        let keep_from = wal_keep_from.load(Ordering::Relaxed);
 
         // If we should keep the first message, do not acknowledge at all
         if keep_from == 0 {
@@ -99,10 +116,12 @@ impl UpdateWorkers {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn flush_worker_fn(
         segments: LockedSegmentHolder,
         wal: LockedWal,
         wal_keep_from: Arc<AtomicU64>,
+        applied_version: Arc<AtomicU64>,
         clocks: LocalShardClocks,
         flush_interval_sec: u64,
         mut stop_receiver: oneshot::Receiver<()>,
@@ -123,6 +142,7 @@ impl UpdateWorkers {
             let segments_clone = segments.clone();
             let wal_clone = wal.clone();
             let wal_keep_from_clone = wal_keep_from.clone();
+            let applied_version_clone = applied_version.clone();
             let clocks_clone = clocks.clone();
             let shard_path_clone = shard_path.clone();
 
@@ -131,6 +151,7 @@ impl UpdateWorkers {
                     segments_clone,
                     wal_clone,
                     wal_keep_from_clone,
+                    applied_version_clone,
                     clocks_clone,
                     shard_path_clone,
                 )
@@ -140,5 +161,53 @@ impl UpdateWorkers {
                 log::error!("Flush worker failed: {error}",);
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::collection_manager::fixtures::build_test_holder;
+
+    /// The confirmed version never exceeds `applied_version`, even once every segment change is
+    /// on disk: an operation that is still in flight has to stay replayable.
+    #[test]
+    fn flush_segments_caps_confirmed_version_at_applied_version() {
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let holder = build_test_holder(dir.path());
+        let max_version = holder
+            .read()
+            .iter()
+            .map(|(_, segment)| segment.get().read().version())
+            .max()
+            .unwrap();
+        assert!(max_version > 1);
+
+        // Persist everything up front, so the background passes below have nothing left to
+        // flush and report the full persisted version right away
+        holder.read().flush_all(FlushMode::Sync, true).unwrap();
+
+        // Everything applied: the persisted version is confirmed as is
+        let applied_version = AtomicU64::new(max_version);
+        assert_eq!(
+            UpdateWorkers::flush_segments(holder.clone(), &applied_version).unwrap(),
+            max_version,
+        );
+
+        // Last operation still in flight: it is on disk, but must not be confirmed
+        applied_version.store(max_version - 1, Ordering::Release);
+        assert_eq!(
+            UpdateWorkers::flush_segments(holder.clone(), &applied_version).unwrap(),
+            max_version - 1,
+        );
+
+        // Nothing applied by this process yet
+        applied_version.store(0, Ordering::Release);
+        assert_eq!(
+            UpdateWorkers::flush_segments(holder, &applied_version).unwrap(),
+            0,
+        );
     }
 }

--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use cancel::CancellationToken;
@@ -57,6 +58,7 @@ impl UpdateWorkers {
         payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
         optimization_finished_receiver: watch::Receiver<()>,
         applied_seq_handler: Arc<AppliedSeqHandler>,
+        applied_version: Arc<AtomicU64>,
         cancel: CancellationToken,
     ) -> Receiver<UpdateSignal> {
         // Take thresholds from the first optimizer, like the optimization worker does.
@@ -165,6 +167,11 @@ impl UpdateWorkers {
                         )
                     })
                     .await;
+
+                    // Done applying, whatever the outcome: no segment write for `op_num` can
+                    // follow, so the flush worker may acknowledge it in the WAL from now on.
+                    // Operations pass through here strictly in order, so a plain store suffices.
+                    applied_version.store(op_num, Ordering::Release);
 
                     let res = match operation_result {
                         Ok(Ok(update_res)) => optimize_sender
@@ -393,6 +400,7 @@ impl UpdateWorkers {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     use cancel::CancellationToken;
     use common::counter::hardware_accumulator::HwMeasurementAcc;
@@ -406,6 +414,9 @@ mod tests {
     use shard::fixtures::random_segment;
     use shard::operations::OperationWithClockTag;
     use shard::operations::payload_ops::{PayloadOps, SetPayloadOp};
+    use shard::operations::point_ops::{
+        PointInsertOperationsInternal, PointOperations, PointStructPersisted, VectorStructPersisted,
+    };
     use shard::segment_holder::SegmentHolder;
     use shard::wal::SerdeWal;
     use tempfile::Builder;
@@ -413,6 +424,7 @@ mod tests {
     use wal::WalOptions;
 
     use super::*;
+    use crate::collection_manager::fixtures::build_test_holder;
     use crate::config::CollectionConfigInternal;
     use crate::operations::types::VectorsConfig;
     use crate::operations::vector_params_builder::VectorParamsBuilder;
@@ -511,6 +523,7 @@ mod tests {
             payload_index_schema,
             finished_receiver,
             Arc::new(AppliedSeqHandler::load_or_init(dir.path(), 0)),
+            Arc::new(AtomicU64::new(0)),
             cancel.clone(),
         ));
 
@@ -557,6 +570,78 @@ mod tests {
                 .has_point(100.into(), common::types::DeferredBehavior::WithDeferred),
             "Moved point should not land in the full segment",
         );
+
+        cancel.cancel();
+        let _ = worker.await;
+    }
+
+    /// The worker publishes an operation as applied right after applying it, whether it
+    /// succeeded or failed, so the flush worker may acknowledge it in the WAL from then on.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_update_worker_publishes_applied_version() {
+        let dir = Builder::new().prefix("shard").tempdir().unwrap();
+        let segments = build_test_holder(dir.path());
+
+        let payload_index_schema =
+            Arc::new(SaveOnDisk::load_or_init_default(dir.path().join("payload.schema")).unwrap());
+        let wal: SerdeWal<OperationWithClockTag> =
+            SerdeWal::new(dir.path(), WalOptions::default()).unwrap();
+        let wal = Arc::new(TokioMutex::new(wal));
+
+        let (update_sender, update_receiver) = mpsc::channel(8);
+        let (optimize_sender, _optimize_receiver) = mpsc::channel(8);
+        let (_finished_sender, finished_receiver) = watch::channel(());
+        let cancel = CancellationToken::new();
+        let applied_version = Arc::new(AtomicU64::new(0));
+
+        let worker = tokio::spawn(UpdateWorkers::update_worker_fn(
+            "test".to_string(),
+            update_receiver,
+            optimize_sender,
+            wal,
+            segments,
+            Arc::new(TokioRwLock::new(())),
+            UpdateTracker::default(),
+            false,
+            Arc::new(vec![]),
+            payload_index_schema,
+            finished_receiver,
+            Arc::new(AppliedSeqHandler::load_or_init(dir.path(), 0)),
+            applied_version.clone(),
+            cancel.clone(),
+        ));
+
+        let upsert = |op_num, vector| {
+            let (feedback_sender, feedback_receiver) = oneshot::channel();
+            let signal = UpdateSignal::Operation(OperationData {
+                op_num,
+                operation: Some(Box::new(CollectionUpdateOperations::PointOperation(
+                    PointOperations::UpsertPoints(PointInsertOperationsInternal::PointsList(vec![
+                        PointStructPersisted {
+                            id: 100.into(),
+                            vector: VectorStructPersisted::Single(vector),
+                            payload: None,
+                        },
+                    ])),
+                ))),
+                sender: Some(feedback_sender),
+                wait_for_deferred: false,
+                hw_measurements: HwMeasurementAcc::new(),
+            });
+            (signal, feedback_receiver)
+        };
+
+        // A successful operation
+        let (signal, feedback) = upsert(10, vec![1.0, 0.0, 0.0, 0.0]);
+        update_sender.send(signal).await.unwrap();
+        feedback.await.unwrap().unwrap();
+        assert_eq!(applied_version.load(Ordering::Acquire), 10);
+
+        // A failed one (wrong vector dimension) is done applying all the same
+        let (signal, feedback) = upsert(11, vec![1.0, 0.0]);
+        update_sender.send(signal).await.unwrap();
+        assert!(feedback.await.unwrap().is_err());
+        assert_eq!(applied_version.load(Ordering::Acquire), 11);
 
         cancel.cancel();
         let _ = worker.await;


### PR DESCRIPTION
Alternative for <https://github.com/qdrant/qdrant/pull/10428>, as described [here](https://github.com/qdrant/qdrant/pull/10428#issuecomment-5510463211)

Prevent a data race between the updater and the flusher.

After fully applying an update, bump an `applied_version` value. When starting a flush, take this value and use it as ceiling for WAL ack's. Prevents ack'ing past operations that were still in flight while flushing.

I'm not confident this will completely fix the issue stated in <https://github.com/qdrant/qdrant/pull/10428>. But I'm leaving this here in case we want to test with it.

Please read this comment for more details: https://github.com/qdrant/qdrant/pull/10428#issuecomment-5510463211

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?