### PR TITLE
test: cover Bits1_5 in TurboQuant test matrices

### DIFF
--- a/lib/quantization/src/turboquant/quantization.rs
+++ b/lib/quantization/src/turboquant/quantization.rs
@@ -790,7 +790,7 @@ mod tests {
     #[test]
     fn quantize_extreme_values() {
         for &dim in &[127, 128, 513] {
-            for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
+            for &bits in &[TQBits::Bits1, TQBits::Bits1_5, TQBits::Bits2, TQBits::Bits4] {
                 let tq = make_tq(dim, bits, DistanceType::Cosine);
                 let mut buf = vec![0.0f64; tq.padded_dim];
                 let n_centroids = 1u8 << bits.bit_size();
@@ -842,7 +842,7 @@ mod tests {
 
         let mut rng = StdRng::seed_from_u64(123);
 
-        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
+        for &bits in &[TQBits::Bits1, TQBits::Bits1_5, TQBits::Bits2, TQBits::Bits4] {
             for &dim in &[127, 128, 300, 513, 768] {
                 let tq = make_tq(dim, bits, DistanceType::Cosine);
                 let mut buf = vec![0.0f64; tq.padded_dim];
@@ -859,7 +859,7 @@ mod tests {
     /// middle boundary region (centroids are symmetric around 0).
     #[test]
     fn quantize_zero_vector() {
-        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
+        for &bits in &[TQBits::Bits1, TQBits::Bits1_5, TQBits::Bits2, TQBits::Bits4] {
             let n_centroids = 1u8 << bits.bit_size();
             // For symmetric centroids around 0, zero maps to either of the two
             // middle indices. With boundaries being midpoints of consecutive
@@ -899,7 +899,7 @@ mod tests {
         let odd_dims = [3, 50, 127, 700, 1025];
 
         for &dim in &odd_dims {
-            for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
+            for &bits in &[TQBits::Bits1, TQBits::Bits1_5, TQBits::Bits2, TQBits::Bits4] {
                 let tq = make_tq(dim, bits, DistanceType::Cosine);
                 let n_centroids = 1u8 << bits.bit_size();
                 let vec: Vec<f32> = (0..dim).map(|_| rng.random_range(-1.0..1.0)).collect();
@@ -933,7 +933,7 @@ mod tests {
 
         let mut rng = StdRng::seed_from_u64(321);
 
-        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
+        for &bits in &[TQBits::Bits1, TQBits::Bits1_5, TQBits::Bits2, TQBits::Bits4] {
             let centroids = bits.get_centroids();
             let n_centroids = 1u8 << bits.bit_size();
 
@@ -1320,7 +1320,7 @@ mod tests {
     /// centroid values exercise the bit-packing boundaries.
     #[test]
     fn pack_unpack_vector_uniform_indices() {
-        for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
+        for &bits in &[TQBits::Bits1, TQBits::Bits1_5, TQBits::Bits2, TQBits::Bits4] {
             let centroids = bits.get_centroids();
             let max_idx = (1u8 << bits.bit_size()) - 1;
 
@@ -1357,6 +1357,8 @@ mod tests {
     fn unpadded_rotation_keeps_padding_zero() {
         let mut rng = StdRng::seed_from_u64(42);
 
+        // `Bits1_5` is absent: it rotates into its x1.5 padding, so
+        // `TurboQuantizer::new` requires `TQRotation::Padded` for it.
         for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
             // All odd, so every bit width gets a non-empty padding tail.
             for &dim in &[3usize, 7, 127, 513, 1025] {
@@ -1389,8 +1391,11 @@ mod tests {
     fn unpadded_rotation_matches_padded_for_padding_free_dims() {
         let mut rng = StdRng::seed_from_u64(7);
 
+        // `Bits1_5` is absent: it rotates into its x1.5 padding, so
+        // `TurboQuantizer::new` requires `TQRotation::Padded` for it — and it has
+        // no padding-free dims anyway, since `padded_dim(8)` is 16.
         for &bits in &[TQBits::Bits1, TQBits::Bits2, TQBits::Bits4] {
-            // Multiples of 8 are padding-free for every supported bit width.
+            // Multiples of 8 are padding-free for these bit widths.
             for &dim in &[8usize, 64, 128, 512] {
                 for &distance in &[DistanceType::Dot, DistanceType::Cosine] {
                     let padded = make_tq(dim, bits, distance);
@@ -1536,6 +1541,7 @@ mod tests {
     /// antipodal negative, and a non-trivial gap between the two.
     #[rstest::rstest]
     #[case::bits1(TQBits::Bits1)]
+    #[case::bits1_5(TQBits::Bits1_5)]
     #[case::bits2(TQBits::Bits2)]
     #[case::bits4(TQBits::Bits4)]
     fn score_precomputed_dispatches_all_bit_widths(#[case] bits: TQBits) {


### PR DESCRIPTION
## Summary

Nine bit-width matrices in `lib/quantization/src/turboquant/quantization.rs` omit `TQBits::Bits1_5`, so that variant is never exercised by them.

This is the same enumeration gap #10390 closed for `quantize_output_byte_length`: the `quantized_size` double-padding bug was invisible because the one test that would have caught it did not list the affected variant. The rest of the module still has that gap, while `score_precomputed_batch_matches_single` already enumerates `Bits1_5` — so the inconsistency sits inside a single file.

Test-only change; no production code is touched.

## Changes

`Bits1_5` added to the seven matrices where it applies:

- `quantize_extreme_values`
- `quantize_deterministic`
- `quantize_zero_vector`
- `quantize_non_power_of_two_dims`
- `pack_unpack_vector_roundtrip`
- `pack_unpack_vector_uniform_indices`
- `score_precomputed_dispatches_all_bit_widths` — the name already claims to cover all bit widths

The two `Unpadded` rotation tests cannot take it, and now say so:

- `unpadded_rotation_keeps_padding_zero` and `unpadded_rotation_matches_padded_for_padding_free_dims` both build quantizers with `TQRotation::Unpadded`, and `TurboQuantizer::new` asserts `Bits1_5 requires TQRotation::Padded` — `Bits1_5` rotates *into* its x1.5 padding, so an unpadded rotation would leave half the codes carrying nothing. Adding it there panics; each list now carries a one-line comment naming the invariant, so the omission reads as deliberate.
- `unpadded_rotation_matches_padded_for_padding_free_dims` also claimed multiples of 8 are padding-free "for every supported bit width". That stopped being true when `Bits1_5` was added — `padded_dim(8)` is 16 — so the comment now names the bit widths it actually covers.

Left alone as out of scope: `higher_bits_reduce_error` asserts the ordering `MAE(Bits4) <= MAE(Bits2) <= MAE(Bits1)`. Placing `Bits1_5` in that chain is an accuracy claim that deserves its own justification rather than being folded into a coverage change.

## Verification

Run on stable 1.98.0, the toolchain `.github/workflows/rust.yml` uses.

| command | result |
| --- | --- |
| `cargo test -p quantization --lib turboquant` | 90 passed, 0 failed, 18 filtered out |
| `cargo +nightly fmt --all -- --check` | clean |
| `cargo clippy -p quantization --all-features --all-targets` | clean |

Before the change the same filter reports 89 tests; the extra one is the new `score_precomputed_dispatches_all_bit_widths::bits1_5` case.

## AI contribution

Prepared with Claude Code: it audited the bit-width matrices in the module, made the edits, and ran the commands above.

The first attempt added `Bits1_5` to `unpadded_rotation_keeps_padding_zero` as well; the test run caught the `Bits1_5 requires TQRotation::Padded` assertion in `TurboQuantizer::new`, which is what established that both `Unpadded` tests must keep their current lists. The scope call on `higher_bits_reduce_error` was made against `TQBits::bit_size` and the centroid tables.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
