### PR TITLE
[updater] strip `fs` from components

### DIFF
--- a/lib/blobstore/src/blobstore/gridstore/mod.rs
+++ b/lib/blobstore/src/blobstore/gridstore/mod.rs
@@ -42,7 +42,6 @@ pub struct Gridstore<V, S>
 where
     S: UniversalWrite + 'static,
 {
-    pub(super) fs: S::Fs,
     pub(super) config: GridstoreConfig,
     pub(super) tracker: Arc<RwLock<Tracker<S>>>,
     pub(super) pages: Arc<RwLock<Pages<S>>>,
@@ -104,17 +103,16 @@ where
     ///
     /// `base_path` is the directory where the storage files will be stored.
     /// It should exist already.
-    pub(super) fn new(fs: S::Fs, base_path: PathBuf, config: GridstoreConfig) -> Result<Self> {
+    pub(super) fn new(fs: &S::Fs, base_path: PathBuf, config: GridstoreConfig) -> Result<Self> {
         let config_path = base_path.join(CONFIG_FILENAME);
 
-        let bitmask = Bitmask::create(&fs, &base_path, config.clone())?;
+        let bitmask = Bitmask::create(fs, &base_path, config.clone())?;
 
         let storage = Self {
-            tracker: Arc::new(RwLock::new(Tracker::new(&fs, &base_path, None)?)),
+            tracker: Arc::new(RwLock::new(Tracker::new(fs, &base_path, None)?)),
             pages: Arc::new(RwLock::new(Pages::new(base_path.clone(), true))),
             base_path,
             config,
-            fs,
             _value_type: std::marker::PhantomData,
             bitmask: Arc::new(RwLock::new(bitmask)),
             is_alive_flush_lock: IsAliveLock::new(),
@@ -123,14 +121,11 @@ where
 
         let new_page_id = storage.next_page_id();
         let path = page_path(&storage.base_path, new_page_id);
-        storage.create_page_file(&path)?;
-        storage
-            .pages
-            .write()
-            .attach_page(&storage.fs, &path, Populate::No)?;
+        storage.create_page_file(fs, &path)?;
+        storage.pages.write().attach_page(fs, &path, Populate::No)?;
 
         let config_bytes = serde_json::to_vec(&StorageConfig::Mutable(storage.config.clone()))?;
-        storage.fs.atomic_save(&config_path, &config_bytes)?;
+        fs.atomic_save(&config_path, &config_bytes)?;
 
         Ok(storage)
     }
@@ -139,17 +134,17 @@ where
     ///
     /// Uses the bitmask to infer page count for consistency with the write path.
     pub(super) fn open(
-        fs: S::Fs,
+        fs: &S::Fs,
         base_path: PathBuf,
         config: GridstoreConfig,
         populate: Populate,
     ) -> Result<Self> {
         // Writable store: open pages and tracker writable so it can append.
-        let tracker = Tracker::open(&fs, &base_path, populate, true)?;
-        let mut bitmask = Bitmask::open(&fs, &base_path, config.clone())?;
+        let tracker = Tracker::open(fs, &base_path, populate, true)?;
+        let mut bitmask = Bitmask::open(fs, &base_path, config.clone())?;
         let num_pages = bitmask.infer_num_pages();
 
-        let pages = Pages::open(&fs, &base_path, true, populate)?;
+        let pages = Pages::open(fs, &base_path, true, populate)?;
         let loaded_pages = pages.num_pages();
 
         if loaded_pages != num_pages {
@@ -170,12 +165,11 @@ where
                 "Detected region gaps length mismatch for Gridstore bitmask at {base_path:?}, rebuilding gaps from the bitmask",
             );
             // Replaces the gaps file, which must happen before anything else can map it.
-            bitmask = bitmask.into_rebuilt_gaps(&fs)?;
+            bitmask = bitmask.into_rebuilt_gaps(fs)?;
             gaps_rebuilt = true;
         }
 
         Ok(Self {
-            fs,
             config,
             tracker: Arc::new(RwLock::new(tracker)),
             pages: Arc::new(RwLock::new(pages)),
@@ -189,31 +183,30 @@ where
 
     /// Create a new page and return its id.
     #[allow(clippy::needless_pass_by_ref_mut)]
-    pub(super) fn create_new_page(&mut self) -> Result<u32> {
+    pub(super) fn create_new_page(&mut self, fs: &S::Fs) -> Result<u32> {
         let new_page_id = self.next_page_id();
         let path = page_path(&self.base_path, new_page_id);
-        self.create_page_file(&path)?;
-        self.pages
-            .write()
-            .attach_page(&self.fs, &path, Populate::No)?;
+        self.create_page_file(fs, &path)?;
+        self.pages.write().attach_page(fs, &path, Populate::No)?;
 
         self.bitmask.write().cover_new_page()?;
 
         Ok(new_page_id)
     }
 
-    fn create_page_file(&self, path: &std::path::Path) -> Result<()> {
-        self.fs.create(path, self.config.page_size_bytes)?;
+    fn create_page_file(&self, fs: &S::Fs, path: &std::path::Path) -> Result<()> {
+        fs.create(path, self.config.page_size_bytes)?;
         Ok(())
     }
 
     fn find_or_create_available_blocks(
         &mut self,
+        fs: &S::Fs,
         num_blocks: u32,
     ) -> Result<(PageId, BlockOffset)> {
         debug_assert!(num_blocks > 0, "num_blocks must be greater than 0");
 
-        if let Some(available) = self.try_find_or_create_available_blocks(num_blocks)? {
+        if let Some(available) = self.try_find_or_create_available_blocks(fs, num_blocks)? {
             return Ok(available);
         }
 
@@ -236,7 +229,7 @@ where
         self.bitmask.write().rebuild_gaps()?;
 
         Ok(self
-            .try_find_or_create_available_blocks(num_blocks)?
+            .try_find_or_create_available_blocks(fs, num_blocks)?
             .expect("New page has just been created and gaps have just been rebuilt"))
     }
 
@@ -246,6 +239,7 @@ where
     /// region gaps are inconsistent with the bitmask.
     fn try_find_or_create_available_blocks(
         &mut self,
+        fs: &S::Fs,
         num_blocks: u32,
     ) -> Result<Option<(PageId, BlockOffset)>> {
         let bitmask_guard = self.bitmask.read();
@@ -261,7 +255,7 @@ where
         let num_pages =
             (missing_blocks * self.config.block_size_bytes).div_ceil(self.config.page_size_bytes);
         for _ in 0..num_pages {
-            self.create_new_page()?;
+            self.create_new_page(fs)?;
         }
 
         self.bitmask.read().find_available_blocks(num_blocks)
@@ -286,11 +280,12 @@ where
     /// Returns true if the value existed previously and was updated, false if it was newly inserted.
     pub(super) fn put_value(
         &mut self,
+        fs: &S::Fs,
         point_offset: PointOffset,
         value: &V,
         hw_counter: HwMetricRefCounter,
     ) -> Result<bool> {
-        self.put_value_bytes(point_offset, value.to_bytes(), hw_counter)
+        self.put_value_bytes(fs, point_offset, value.to_bytes(), hw_counter)
     }
 
     /// Put an already serialized value in the storage.
@@ -301,6 +296,7 @@ where
     /// Returns true if the value existed previously and was updated, false if it was newly inserted.
     pub(super) fn put_value_bytes(
         &mut self,
+        fs: &S::Fs,
         point_offset: PointOffset,
         value_bytes: Vec<u8>,
         hw_counter: HwMetricRefCounter,
@@ -360,7 +356,7 @@ where
 
         let required_blocks = Self::blocks_for_value(value_size, self.config.block_size_bytes);
         let (start_page_id, block_offset) =
-            self.find_or_create_available_blocks(required_blocks)?;
+            self.find_or_create_available_blocks(fs, required_blocks)?;
 
         self.write_into_pages(&comp_value, start_page_id, block_offset)?;
 
@@ -399,14 +395,14 @@ where
     /// Clear the storage, going back to the initial state.
     ///
     /// Completely wipes the storage, and recreates it with a single empty page.
-    pub(super) fn clear(&mut self) -> Result<()> {
+    pub(super) fn clear(&mut self, fs: &S::Fs) -> Result<()> {
         self.is_alive_flush_lock.blocking_mark_dead();
         self.pages.write().clear();
 
-        self.fs.remove_dir(&self.base_path)?;
-        self.fs.create_dir(&self.base_path)?;
+        fs.remove_dir(&self.base_path)?;
+        fs.create_dir(&self.base_path)?;
 
-        *self = Self::new(self.fs.clone(), self.base_path.clone(), self.config.clone())?;
+        *self = Self::new(fs, self.base_path.clone(), self.config.clone())?;
 
         Ok(())
     }
@@ -415,9 +411,8 @@ where
     ///
     /// Takes ownership because this function leaves Gridstore in an inconsistent state which does
     /// not allow further usage. Use [`clear`](Self::clear) instead to clear and reuse the storage.
-    pub(super) fn wipe(self) -> Result<()> {
+    pub(super) fn wipe(self, fs: &S::Fs) -> Result<()> {
         let Self {
-            fs,
             tracker,
             pages,
             bitmask,
@@ -689,7 +684,6 @@ impl<V, S: UniversalWrite + 'static> Gridstore<V, S> {
     /// Drop disk cache.
     pub(super) fn clear_cache(&self) -> crate::Result<()> {
         let Self {
-            fs: _,
             config: _,
             tracker: _,
             pages,

--- a/lib/blobstore/src/blobstore/logstore/mod.rs
+++ b/lib/blobstore/src/blobstore/logstore/mod.rs
@@ -91,7 +91,6 @@ pub struct Logstore<V, S>
 where
     S: UniversalAppend + 'static,
 {
-    fs: S::Fs,
     pub(super) config: LogstoreConfig,
     tracker: Arc<RwLock<AppendOnlyTracker<S>>>,
     pages: Arc<RwLock<AppendOnlyPages<S>>>,
@@ -122,16 +121,15 @@ where
     ///
     /// `base_path` is the directory where the storage files will be stored.
     /// It should exist already.
-    pub(super) fn new(fs: S::Fs, base_path: PathBuf, config: LogstoreConfig) -> Result<Self> {
-        let tracker = AppendOnlyTracker::new(&fs, &base_path)?;
-        let pages = AppendOnlyPages::new(&fs, &base_path)?;
+    pub(super) fn new(fs: &S::Fs, base_path: PathBuf, config: LogstoreConfig) -> Result<Self> {
+        let tracker = AppendOnlyTracker::new(fs, &base_path)?;
+        let pages = AppendOnlyPages::new(fs, &base_path)?;
 
         let config_path = base_path.join(CONFIG_FILENAME);
         let config_bytes = serde_json::to_vec(&StorageConfig::AppendOnly(config.clone()))?;
         fs.atomic_save(&config_path, &config_bytes)?;
 
         Ok(Self {
-            fs,
             config,
             tracker: Arc::new(RwLock::new(tracker)),
             pages: Arc::new(RwLock::new(pages)),
@@ -148,12 +146,12 @@ where
     /// In case of opening, it ignores the `config_if_create` parameter. A storage created in
     /// mutable mode is rejected, the two modes persist incompatible file formats.
     pub fn open_or_create(
-        fs: S::Fs,
+        fs: &S::Fs,
         base_path: PathBuf,
         config_if_create: LogstoreConfig,
         populate: Populate,
     ) -> Result<Self> {
-        match super::reader::read_config(&fs, &base_path).ok_not_found()? {
+        match super::reader::read_config(fs, &base_path).ok_not_found()? {
             Some(StorageConfig::AppendOnly(config)) => Self::open(fs, base_path, config, populate),
             Some(StorageConfig::Mutable(_)) => Err(BlobstoreError::unsupported_operation(format!(
                 "storage at {} was created in mutable mode, it cannot be opened append-only",
@@ -168,17 +166,16 @@ where
 
     /// Open an existing storage at the given path, with the already read config.
     pub(super) fn open(
-        fs: S::Fs,
+        fs: &S::Fs,
         base_path: PathBuf,
         config: LogstoreConfig,
         populate: Populate,
     ) -> Result<Self> {
-        let tracker = AppendOnlyTracker::open_writable(&fs, &base_path, populate)?;
-        let pages = AppendOnlyPages::open(&fs, &base_path, true, populate)?;
+        let tracker = AppendOnlyTracker::open_writable(fs, &base_path, populate)?;
+        let pages = AppendOnlyPages::open(fs, &base_path, true, populate)?;
         validate_consistency(&tracker, &pages)?;
 
         Ok(Self {
-            fs,
             config,
             tracker: Arc::new(RwLock::new(tracker)),
             pages: Arc::new(RwLock::new(pages)),
@@ -209,11 +206,12 @@ where
     /// Always returns false on success, as values can never be updated.
     pub fn put_value(
         &mut self,
+        fs: &S::Fs,
         point_offset: PointOffset,
         value: &V,
         hw_counter: HwMetricRefCounter,
     ) -> Result<bool> {
-        self.put_value_bytes(point_offset, value.to_bytes(), hw_counter)
+        self.put_value_bytes(fs, point_offset, value.to_bytes(), hw_counter)
     }
 
     /// Put an already serialized value in the storage.
@@ -226,6 +224,7 @@ where
     #[allow(clippy::needless_pass_by_ref_mut)]
     pub(super) fn put_value_bytes(
         &mut self,
+        fs: &S::Fs,
         point_offset: PointOffset,
         value_bytes: Vec<u8>,
         hw_counter: HwMetricRefCounter,
@@ -252,7 +251,7 @@ where
         let (page_id, offset) =
             self.pages
                 .write()
-                .append_value(&self.fs, &comp_value, page_capacity_bytes)?;
+                .append_value(fs, &comp_value, page_capacity_bytes)?;
 
         self.tracker
             .write()
@@ -271,13 +270,13 @@ where
     /// Clear the storage, going back to the initial state.
     ///
     /// Completely wipes the storage, and recreates it in append-only mode.
-    pub(super) fn clear(&mut self) -> Result<()> {
+    pub(super) fn clear(&mut self, fs: &S::Fs) -> Result<()> {
         self.is_alive_flush_lock.blocking_mark_dead();
 
-        self.fs.remove_dir(&self.base_path)?;
-        self.fs.create_dir(&self.base_path)?;
+        fs.remove_dir(&self.base_path)?;
+        fs.create_dir(&self.base_path)?;
 
-        *self = Self::new(self.fs.clone(), self.base_path.clone(), self.config.clone())?;
+        *self = Self::new(fs, self.base_path.clone(), self.config.clone())?;
 
         Ok(())
     }
@@ -287,9 +286,8 @@ where
     /// Takes ownership because this function leaves the storage in an inconsistent state which
     /// does not allow further usage. Use [`clear`](Self::clear) instead to clear and reuse the
     /// storage.
-    pub(super) fn wipe(self) -> Result<()> {
+    pub(super) fn wipe(self, fs: &S::Fs) -> Result<()> {
         let Self {
-            fs,
             config: _,
             tracker,
             pages,
@@ -507,7 +505,6 @@ impl<V, S: UniversalAppend + 'static> Logstore<V, S> {
     /// Ask to evict the tracker and all pages from the RAM cache.
     pub(super) fn clear_cache(&self) -> crate::Result<()> {
         let Self {
-            fs: _,
             config: _,
             tracker,
             pages,

--- a/lib/blobstore/src/blobstore/mod.rs
+++ b/lib/blobstore/src/blobstore/mod.rs
@@ -44,7 +44,18 @@ pub type Flusher = Box<dyn FnOnce() -> std::result::Result<(), BlobstoreError> +
 ///
 /// Assumes sequential IDs to the values (0, 1, 2, 3, ...)
 #[derive(Debug)]
-pub enum Blobstore<V, S = MmapFile>
+pub struct Blobstore<V, S = MmapFile>
+where
+    S: UniversalWrite + UniversalAppend + 'static,
+{
+    /// The inner storages hold no filesystem of their own: opens, creates and
+    /// removes go through this one, passed down per call.
+    fs: S::Fs,
+    inner: BlobstoreInner<V, S>,
+}
+
+#[derive(Debug)]
+enum BlobstoreInner<V, S>
 where
     S: UniversalWrite + UniversalAppend + 'static,
 {
@@ -59,16 +70,16 @@ where
 {
     /// List all files belonging to this storage.
     pub fn files(&self) -> Vec<PathBuf> {
-        match self {
-            Blobstore::Gridstore(storage) => storage.files(),
-            Blobstore::Logstore(storage) => storage.files(),
+        match &self.inner {
+            BlobstoreInner::Gridstore(storage) => storage.files(),
+            BlobstoreInner::Logstore(storage) => storage.files(),
         }
     }
 
     pub fn immutable_files(&self) -> Vec<PathBuf> {
-        match self {
-            Blobstore::Gridstore(storage) => storage.immutable_files(),
-            Blobstore::Logstore(storage) => storage.immutable_files(),
+        match &self.inner {
+            BlobstoreInner::Gridstore(storage) => storage.immutable_files(),
+            BlobstoreInner::Logstore(storage) => storage.immutable_files(),
         }
     }
 
@@ -99,32 +110,30 @@ where
         config
             .validate()
             .map_err(BlobstoreError::validation_error)?;
-        match config {
+        let inner = match config {
             StorageConfig::Mutable(config) => {
-                let storage = Gridstore::new(fs, base_path, config)?;
-                Ok(Self::Gridstore(storage))
+                BlobstoreInner::Gridstore(Gridstore::new(&fs, base_path, config)?)
             }
             StorageConfig::AppendOnly(config) => {
-                let storage = Logstore::new(fs, base_path, config)?;
-                Ok(Self::Logstore(storage))
+                BlobstoreInner::Logstore(Logstore::new(&fs, base_path, config)?)
             }
-        }
+        };
+        Ok(Self { fs, inner })
     }
 
     /// Open an existing storage at the given path.
     ///
     /// The operating mode is automatically selected based on the persisted config.
     pub fn open(fs: S::Fs, base_path: PathBuf, populate: Populate) -> Result<Self> {
-        match reader::read_config(&fs, &base_path)? {
+        let inner = match reader::read_config(&fs, &base_path)? {
             StorageConfig::Mutable(config) => {
-                let storage = Gridstore::open(fs, base_path, config, populate)?;
-                Ok(Self::Gridstore(storage))
+                BlobstoreInner::Gridstore(Gridstore::open(&fs, base_path, config, populate)?)
             }
             StorageConfig::AppendOnly(config) => {
-                let storage = Logstore::open(fs, base_path, config, populate)?;
-                Ok(Self::Logstore(storage))
+                BlobstoreInner::Logstore(Logstore::open(&fs, base_path, config, populate)?)
             }
-        }
+        };
+        Ok(Self { fs, inner })
     }
 
     /// Put a value in the storage.
@@ -139,9 +148,13 @@ where
         value: &V,
         hw_counter: HwMetricRefCounter,
     ) -> Result<bool> {
-        match self {
-            Blobstore::Gridstore(storage) => storage.put_value(point_offset, value, hw_counter),
-            Blobstore::Logstore(storage) => storage.put_value(point_offset, value, hw_counter),
+        match &mut self.inner {
+            BlobstoreInner::Gridstore(storage) => {
+                storage.put_value(&self.fs, point_offset, value, hw_counter)
+            }
+            BlobstoreInner::Logstore(storage) => {
+                storage.put_value(&self.fs, point_offset, value, hw_counter)
+            }
         }
     }
 
@@ -161,12 +174,12 @@ where
         value_bytes: Vec<u8>,
         hw_counter: HwMetricRefCounter,
     ) -> Result<bool> {
-        match self {
-            Blobstore::Gridstore(storage) => {
-                storage.put_value_bytes(point_offset, value_bytes, hw_counter)
+        match &mut self.inner {
+            BlobstoreInner::Gridstore(storage) => {
+                storage.put_value_bytes(&self.fs, point_offset, value_bytes, hw_counter)
             }
-            Blobstore::Logstore(storage) => {
-                storage.put_value_bytes(point_offset, value_bytes, hw_counter)
+            BlobstoreInner::Logstore(storage) => {
+                storage.put_value_bytes(&self.fs, point_offset, value_bytes, hw_counter)
             }
         }
     }
@@ -178,9 +191,9 @@ where
     ///
     /// Not supported in append-only mode, returns an error.
     pub fn delete_value(&mut self, point_offset: PointOffset) -> Result<Option<V>> {
-        match self {
-            Blobstore::Gridstore(storage) => storage.delete_value(point_offset),
-            Blobstore::Logstore(storage) => storage.delete_value(point_offset),
+        match &mut self.inner {
+            BlobstoreInner::Gridstore(storage) => storage.delete_value(point_offset),
+            BlobstoreInner::Logstore(storage) => storage.delete_value(point_offset),
         }
     }
 
@@ -188,9 +201,9 @@ where
     ///
     /// Completely wipes the storage, and recreates it in the same mode.
     pub fn clear(&mut self) -> Result<()> {
-        match self {
-            Blobstore::Gridstore(storage) => storage.clear(),
-            Blobstore::Logstore(storage) => storage.clear(),
+        match &mut self.inner {
+            BlobstoreInner::Gridstore(storage) => storage.clear(&self.fs),
+            BlobstoreInner::Logstore(storage) => storage.clear(&self.fs),
         }
     }
 
@@ -199,17 +212,18 @@ where
     /// Takes ownership because this function leaves Blobstore in an inconsistent state which does
     /// not allow further usage. Use [`clear`](Self::clear) instead to clear and reuse the storage.
     pub fn wipe(self) -> Result<()> {
-        match self {
-            Blobstore::Gridstore(storage) => storage.wipe(),
-            Blobstore::Logstore(storage) => storage.wipe(),
+        let Self { fs, inner } = self;
+        match inner {
+            BlobstoreInner::Gridstore(storage) => storage.wipe(&fs),
+            BlobstoreInner::Logstore(storage) => storage.wipe(&fs),
         }
     }
 
     /// Return the storage size in bytes.
     pub fn get_storage_size_bytes(&self) -> Result<usize> {
-        match self {
-            Blobstore::Gridstore(storage) => storage.get_storage_size_bytes(),
-            Blobstore::Logstore(storage) => storage.get_storage_size_bytes(),
+        match &self.inner {
+            BlobstoreInner::Gridstore(storage) => storage.get_storage_size_bytes(),
+            BlobstoreInner::Logstore(storage) => storage.get_storage_size_bytes(),
         }
     }
 
@@ -218,9 +232,9 @@ where
         point_offset: PointOffset,
         hw_counter: &HardwareCounterCell,
     ) -> Result<Option<V>> {
-        match self {
-            Blobstore::Gridstore(storage) => storage.get_value::<P>(point_offset, hw_counter),
-            Blobstore::Logstore(storage) => storage.get_value::<P>(point_offset, hw_counter),
+        match &self.inner {
+            BlobstoreInner::Gridstore(storage) => storage.get_value::<P>(point_offset, hw_counter),
+            BlobstoreInner::Logstore(storage) => storage.get_value::<P>(point_offset, hw_counter),
         }
     }
 
@@ -234,9 +248,13 @@ where
         point_offset: PointOffset,
         hw_counter: &HardwareCounterCell,
     ) -> Result<Option<Vec<u8>>> {
-        match self {
-            Blobstore::Gridstore(storage) => storage.get_value_bytes::<P>(point_offset, hw_counter),
-            Blobstore::Logstore(storage) => storage.get_value_bytes::<P>(point_offset, hw_counter),
+        match &self.inner {
+            BlobstoreInner::Gridstore(storage) => {
+                storage.get_value_bytes::<P>(point_offset, hw_counter)
+            }
+            BlobstoreInner::Logstore(storage) => {
+                storage.get_value_bytes::<P>(point_offset, hw_counter)
+            }
         }
     }
 
@@ -254,11 +272,11 @@ where
         U: UserData,
         E: From<BlobstoreError>,
     {
-        match self {
-            Blobstore::Gridstore(storage) => {
+        match &self.inner {
+            BlobstoreInner::Gridstore(storage) => {
                 storage.read_values::<P, U, E>(point_offsets, callback, hw_counter_cell)
             }
-            Blobstore::Logstore(storage) => {
+            BlobstoreInner::Logstore(storage) => {
                 storage.read_values::<P, U, E>(point_offsets, callback, hw_counter_cell)
             }
         }
@@ -279,11 +297,11 @@ where
         U: UserData,
         E: From<BlobstoreError>,
     {
-        match self {
-            Blobstore::Gridstore(storage) => {
+        match &self.inner {
+            BlobstoreInner::Gridstore(storage) => {
                 storage.read_values_bytes::<P, U, E>(point_offsets, callback, hw_counter_cell)
             }
-            Blobstore::Logstore(storage) => {
+            BlobstoreInner::Logstore(storage) => {
                 storage.read_values_bytes::<P, U, E>(point_offsets, callback, hw_counter_cell)
             }
         }
@@ -291,16 +309,16 @@ where
 
     #[cfg(test)]
     pub fn get_pointer(&self, point_offset: PointOffset) -> Option<ValuePointer> {
-        match self {
-            Blobstore::Gridstore(storage) => storage.get_pointer(point_offset),
-            Blobstore::Logstore(storage) => storage.get_pointer(point_offset),
+        match &self.inner {
+            BlobstoreInner::Gridstore(storage) => storage.get_pointer(point_offset),
+            BlobstoreInner::Logstore(storage) => storage.get_pointer(point_offset),
         }
     }
 
     pub fn max_point_offset(&self) -> PointOffset {
-        match self {
-            Blobstore::Gridstore(storage) => storage.max_point_offset(),
-            Blobstore::Logstore(storage) => storage.max_point_offset(),
+        match &self.inner {
+            BlobstoreInner::Gridstore(storage) => storage.max_point_offset(),
+            BlobstoreInner::Logstore(storage) => storage.max_point_offset(),
         }
     }
 
@@ -312,9 +330,9 @@ where
         F: FnMut(PointOffset, V) -> Result<bool, E>,
         E: From<BlobstoreError>,
     {
-        match self {
-            Blobstore::Gridstore(storage) => storage.iter(callback, hw_counter),
-            Blobstore::Logstore(storage) => storage.iter(callback, hw_counter),
+        match &self.inner {
+            BlobstoreInner::Gridstore(storage) => storage.iter(callback, hw_counter),
+            BlobstoreInner::Logstore(storage) => storage.iter(callback, hw_counter),
         }
     }
 }
@@ -322,25 +340,25 @@ where
 impl<V, S: UniversalWrite + UniversalAppend + 'static> Blobstore<V, S> {
     /// Create flusher that durably persists all pending changes when invoked.
     pub fn flusher(&self) -> Flusher {
-        match self {
-            Blobstore::Gridstore(storage) => storage.flusher(),
-            Blobstore::Logstore(storage) => storage.flusher(),
+        match &self.inner {
+            BlobstoreInner::Gridstore(storage) => storage.flusher(),
+            BlobstoreInner::Logstore(storage) => storage.flusher(),
         }
     }
 
     /// Populate all parts of the storage into the RAM cache.
     pub fn populate(&self) -> Result<()> {
-        match self {
-            Blobstore::Gridstore(storage) => storage.populate(),
-            Blobstore::Logstore(storage) => storage.populate(),
+        match &self.inner {
+            BlobstoreInner::Gridstore(storage) => storage.populate(),
+            BlobstoreInner::Logstore(storage) => storage.populate(),
         }
     }
 
     /// Drop disk cache.
     pub fn clear_cache(&self) -> crate::Result<()> {
-        match self {
-            Blobstore::Gridstore(storage) => storage.clear_cache(),
-            Blobstore::Logstore(storage) => storage.clear_cache(),
+        match &self.inner {
+            BlobstoreInner::Gridstore(storage) => storage.clear_cache(),
+            BlobstoreInner::Logstore(storage) => storage.clear_cache(),
         }
     }
 }
@@ -349,25 +367,25 @@ impl<V, S: UniversalWrite + UniversalAppend + 'static> Blobstore<V, S> {
 impl<V, S: UniversalWrite + UniversalAppend + 'static> Blobstore<V, S> {
     /// Get the inner Gridstore (mutable mode storage), panics if the storage is in another mode.
     fn as_gridstore(&self) -> &Gridstore<V, S> {
-        match self {
-            Blobstore::Gridstore(storage) => storage,
-            Blobstore::Logstore(_) => panic!("storage is not in mutable mode"),
+        match &self.inner {
+            BlobstoreInner::Gridstore(storage) => storage,
+            BlobstoreInner::Logstore(_) => panic!("storage is not in mutable mode"),
         }
     }
 
     /// Get the inner Gridstore (mutable mode storage), panics if the storage is in another mode.
     fn as_gridstore_mut(&mut self) -> &mut Gridstore<V, S> {
-        match self {
-            Blobstore::Gridstore(storage) => storage,
-            Blobstore::Logstore(_) => panic!("storage is not in mutable mode"),
+        match &mut self.inner {
+            BlobstoreInner::Gridstore(storage) => storage,
+            BlobstoreInner::Logstore(_) => panic!("storage is not in mutable mode"),
         }
     }
 
     /// Get the inner Logstore (append-only mode storage), panics if the storage is in another mode.
     fn as_logstore(&self) -> &Logstore<V, S> {
-        match self {
-            Blobstore::Gridstore(_) => panic!("storage is not in append-only mode"),
-            Blobstore::Logstore(storage) => storage,
+        match &self.inner {
+            BlobstoreInner::Gridstore(_) => panic!("storage is not in append-only mode"),
+            BlobstoreInner::Logstore(storage) => storage,
         }
     }
 }

--- a/lib/blobstore/src/blobstore/tests.rs
+++ b/lib/blobstore/src/blobstore/tests.rs
@@ -441,7 +441,7 @@ fn test_write_across_pages() {
         compression: Compression::None,
     };
 
-    storage.as_gridstore_mut().create_new_page().unwrap();
+    storage.as_gridstore_mut().create_new_page(&MmapFs).unwrap();
 
     let value_len = 1000;
 

--- a/lib/edge/src/update_only/tests.rs
+++ b/lib/edge/src/update_only/tests.rs
@@ -195,7 +195,7 @@ fn delete_batch_tombstones_points_in_immutable_segments() {
 mod store {
     use std::path::Path;
 
-    use common::universal_io::MmapFs;
+    use common::universal_io::{MmapFile, MmapFs};
     use segment::payload_json;
     use segment::payload_storage::update_only::UpdateOnlyPayloadStorage;
     use segment::types::{Filter, Payload, WithPayloadInterface, WithVector};
@@ -223,7 +223,7 @@ mod store {
             if payload_storage.is_dir() {
                 fs_err::remove_dir_all(&payload_storage).unwrap();
                 // Opening the writer creates the storage in append-only mode.
-                UpdateOnlyPayloadStorage::<MmapFile>::open(MmapFs, &segment_path).unwrap();
+                UpdateOnlyPayloadStorage::<MmapFile>::open(&MmapFs, &segment_path).unwrap();
             }
         }
     }

--- a/lib/segment/src/common/flags/update_only_stored_flags.rs
+++ b/lib/segment/src/common/flags/update_only_stored_flags.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::stored_bitmask::MutableStoredBitmask;
 use common::types::PointOffsetType;
-use common::universal_io::{Populate, UniversalAppend};
+use common::universal_io::{Populate, UniversalReadFs, UniversalWriteFileOps};
 
 use super::compact_stored_flags::{COMPACT_FLAGS_FILE, open_or_create_compact_mask};
 use super::mode::FlagsMode;
@@ -23,23 +23,25 @@ use crate::common::operation_error::{OperationError, OperationResult};
 /// files of both modes behind; rebuild such a segment to migrate its flags.
 ///
 /// [1]: super::compact_stored_flags::CompactStoredFlags
-pub struct UpdateOnlyStoredFlags<S: UniversalAppend + 'static> {
-    fs: S::Fs,
+pub struct UpdateOnlyStoredFlags {
     /// Path of the mask file inside the flags directory.
     path: PathBuf,
     /// The mask, resident in RAM; tracks its own effective dirtiness.
     mask: MutableStoredBitmask,
 }
 
-impl<S: UniversalAppend + 'static> UpdateOnlyStoredFlags<S> {
+impl UpdateOnlyStoredFlags {
     /// Read the flags at `directory` into memory, ready to be extended. A
     /// directory that holds none yet opens empty, and is created — mask file
     /// included — right away, because storages take the directory as the
     /// marker that they exist at all.
     ///
     /// Errors when the directory holds flags of the dynamic mode.
-    pub fn open(fs: S::Fs, directory: &Path) -> OperationResult<Self> {
-        if FlagsMode::detect(&fs, directory)? == Some(FlagsMode::Dynamic) {
+    pub fn open<Fs: UniversalReadFs + UniversalWriteFileOps>(
+        fs: &Fs,
+        directory: &Path,
+    ) -> OperationResult<Self> {
+        if FlagsMode::detect(fs, directory)? == Some(FlagsMode::Dynamic) {
             return Err(OperationError::service_error(format!(
                 "flags in {} are in the dynamic mode, which the update-only writer does not \
                  support; rebuild the segment to migrate its flags",
@@ -47,10 +49,9 @@ impl<S: UniversalAppend + 'static> UpdateOnlyStoredFlags<S> {
             )));
         }
 
-        let mask = open_or_create_compact_mask(&fs, directory, Populate::Blocking)?;
+        let mask = open_or_create_compact_mask(fs, directory, Populate::Blocking)?;
 
         Ok(Self {
-            fs,
             path: directory.join(COMPACT_FLAGS_FILE),
             mask,
         })
@@ -69,8 +70,12 @@ impl<S: UniversalAppend + 'static> UpdateOnlyStoredFlags<S> {
 
     /// Persist the mask in one atomic whole-file write, or write nothing when
     /// it has not effectively changed since it was opened or last flushed.
-    pub fn flush(&mut self, hw_counter: &HardwareCounterCell) -> OperationResult<()> {
-        let bytes_written = self.mask.save(&self.fs, &self.path)?;
+    pub fn flush<Fs: UniversalWriteFileOps>(
+        &mut self,
+        fs: &Fs,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let bytes_written = self.mask.save(fs, &self.path)?;
         hw_counter
             .payload_index_io_write_counter()
             .incr_delta(bytes_written);
@@ -98,12 +103,14 @@ mod tests_mod {
     use crate::common::flags::dynamic_stored_flags::DynamicStoredFlags;
     use crate::common::flags::update_only_stored_flags::UpdateOnlyStoredFlags;
 
-    fn open(dir: &std::path::Path) -> UpdateOnlyStoredFlags<S> {
-        UpdateOnlyStoredFlags::open(Fs::default(), dir).unwrap()
+    fn open(dir: &std::path::Path) -> UpdateOnlyStoredFlags {
+        UpdateOnlyStoredFlags::open(&Fs::default(), dir).unwrap()
     }
 
-    fn flush(flags: &mut UpdateOnlyStoredFlags<S>) {
-        flags.flush(&HardwareCounterCell::new()).unwrap();
+    fn flush(flags: &mut UpdateOnlyStoredFlags) {
+        flags
+            .flush(&Fs::default(), &HardwareCounterCell::new())
+            .unwrap();
     }
 
     /// Reader for what the writer left behind, through the type the writable
@@ -221,7 +228,7 @@ mod tests_mod {
         let dir = TempDir::new().unwrap();
         DynamicStoredFlags::<S>::open(&Fs::default(), dir.path(), Populate::No).unwrap();
 
-        let result = UpdateOnlyStoredFlags::<S>::open(Fs::default(), dir.path());
+        let result = UpdateOnlyStoredFlags::open(&Fs::default(), dir.path());
         let message = result
             .err()
             .expect("dynamic flags must be refused")

--- a/lib/segment/src/common/update_only_blobstore.rs
+++ b/lib/segment/src/common/update_only_blobstore.rs
@@ -25,6 +25,9 @@ use crate::common::operation_error::OperationResult;
 /// [`BlobstoreReader`]: blobstore::BlobstoreReader
 pub struct UpdateOnlyBlobstore<V, S: UniversalAppend + 'static> {
     storage: Logstore<V, S>,
+    /// Opens the new page file on a rollover; the storage holds no filesystem
+    /// of its own.
+    fs: S::Fs,
     buffered: bool,
 }
 
@@ -34,7 +37,7 @@ impl<V: Blob, S: UniversalAppend + 'static> UpdateOnlyBlobstore<V, S> {
     /// so `config_if_create` only decides the layout of a brand new one.
     pub fn open(fs: S::Fs, path: &Path, config_if_create: LogstoreConfig) -> OperationResult<Self> {
         let storage = Logstore::open_or_create(
-            fs,
+            &fs,
             path.to_path_buf(),
             config_if_create,
             // Appends never read back, and on a remote backend populating would
@@ -44,6 +47,7 @@ impl<V: Blob, S: UniversalAppend + 'static> UpdateOnlyBlobstore<V, S> {
 
         Ok(Self {
             storage,
+            fs,
             buffered: false,
         })
     }
@@ -56,7 +60,7 @@ impl<V: Blob, S: UniversalAppend + 'static> UpdateOnlyBlobstore<V, S> {
         value: &V,
         hw_counter: HwMetricRefCounter,
     ) -> OperationResult<()> {
-        self.storage.put_value(slot, value, hw_counter)?;
+        self.storage.put_value(&self.fs, slot, value, hw_counter)?;
         self.buffered = true;
         Ok(())
     }

--- a/lib/segment/src/common/update_only_blobstore.rs
+++ b/lib/segment/src/common/update_only_blobstore.rs
@@ -25,9 +25,6 @@ use crate::common::operation_error::OperationResult;
 /// [`BlobstoreReader`]: blobstore::BlobstoreReader
 pub struct UpdateOnlyBlobstore<V, S: UniversalAppend + 'static> {
     storage: Logstore<V, S>,
-    /// Opens the new page file on a rollover; the storage holds no filesystem
-    /// of its own.
-    fs: S::Fs,
     buffered: bool,
 }
 
@@ -35,9 +32,13 @@ impl<V: Blob, S: UniversalAppend + 'static> UpdateOnlyBlobstore<V, S> {
     /// Open the storage directory at `path` for appending, creating it if it is
     /// not there yet. An existing storage keeps the config it was created with,
     /// so `config_if_create` only decides the layout of a brand new one.
-    pub fn open(fs: S::Fs, path: &Path, config_if_create: LogstoreConfig) -> OperationResult<Self> {
+    pub fn open(
+        fs: &S::Fs,
+        path: &Path,
+        config_if_create: LogstoreConfig,
+    ) -> OperationResult<Self> {
         let storage = Logstore::open_or_create(
-            &fs,
+            fs,
             path.to_path_buf(),
             config_if_create,
             // Appends never read back, and on a remote backend populating would
@@ -47,20 +48,21 @@ impl<V: Blob, S: UniversalAppend + 'static> UpdateOnlyBlobstore<V, S> {
 
         Ok(Self {
             storage,
-            fs,
             buffered: false,
         })
     }
 
     /// Buffer `value` at `slot`. Nothing reaches the files until
-    /// [`flush`](Self::flush).
+    /// [`flush`](Self::flush); `fs` only opens the next page file on a
+    /// rollover.
     pub fn put(
         &mut self,
+        fs: &S::Fs,
         slot: PointOffsetType,
         value: &V,
         hw_counter: HwMetricRefCounter,
     ) -> OperationResult<()> {
-        self.storage.put_value(&self.fs, slot, value, hw_counter)?;
+        self.storage.put_value(fs, slot, value, hw_counter)?;
         self.buffered = true;
         Ok(())
     }

--- a/lib/segment/src/id_tracker/mutable_id_tracker/update_only/heal.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/update_only/heal.rs
@@ -2,13 +2,13 @@ use std::cmp::Ordering;
 use std::path::Path;
 
 use common::generic_consts::Sequential;
-use common::universal_io::{UniversalAppend, UniversalWriteFileOps as _};
+use common::universal_io::{UniversalRead as _, UniversalWriteFileOps};
 
 use super::UpdateOnlyAppendableIdTracker;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::id_tracker::mutable_id_tracker::versions_storage::heal_versions_tail;
 
-impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
+impl UpdateOnlyAppendableIdTracker {
     /// Heal a versions file that ends mid-entry, per [`heal_versions_tail`].
     ///
     /// An append-only backend cannot truncate, so the file is shrunk the only way it can be: the
@@ -16,14 +16,19 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
     ///
     /// Takes ownership of `file` and drops it before the rewrite, Windows cannot replace a path
     /// that still has an mmap open. Callers open a fresh handle afterwards.
-    pub(super) fn heal_versions(&self, path: &Path, file: S, file_len: u64) -> OperationResult<()> {
+    pub(super) fn heal_versions<Fs: UniversalWriteFileOps>(
+        fs: &Fs,
+        path: &Path,
+        file: Fs::AppendFile,
+        file_len: u64,
+    ) -> OperationResult<()> {
         heal_versions_tail(path, file_len, move |healthy_len| {
             let committed = file
                 .read_bytes(0..healthy_len, Sequential, align_of::<u8>())?
                 .to_vec();
             // Release the mmap before replacing the path.
             drop(file);
-            self.fs.atomic_save(path, &committed)?;
+            fs.atomic_save(path, &committed)?;
             Ok(())
         })
     }
@@ -43,8 +48,12 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
     /// The caller must drop any open handle on `path` first, Windows cannot replace a path that
     /// still has an mmap open. Opens its own handle, drops it before the rewrite, and leaves the
     /// caller to open a fresh one.
-    pub(super) fn heal_mappings(&self, path: &Path) -> OperationResult<()> {
-        let file = self.open_append(path)?;
+    pub(super) fn heal_mappings<Fs: UniversalWriteFileOps>(
+        &self,
+        fs: &Fs,
+        path: &Path,
+    ) -> OperationResult<()> {
+        let file = Self::open_append(fs, path)?;
         let file_len = Self::end_of_file(&file)?;
 
         match file_len.cmp(&self.mappings_end) {
@@ -59,7 +68,7 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
                     .to_vec();
                 // Release the mmap before replacing the path.
                 drop(file);
-                self.fs.atomic_save(path, &log)?;
+                fs.atomic_save(path, &log)?;
                 Ok(())
             }
             // Entries the log counts on are not in the file: it was truncated under us, or this

--- a/lib/segment/src/id_tracker/mutable_id_tracker/update_only/mod.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/update_only/mod.rs
@@ -8,8 +8,8 @@ use std::path::{Path, PathBuf};
 use common::mmap::{Advice, AdviceSetting};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    IsNotFound as _, OkNotFound as _, OpenOptions, Populate, UniversalAppend,
-    UniversalWriteFileOps as _,
+    IsNotFound as _, OkNotFound as _, OpenOptions, Populate, UniversalAppend, UniversalFlush as _,
+    UniversalWriteFileOps,
 };
 
 use super::change::{MappingChange, write_entry};
@@ -50,7 +50,7 @@ pub enum MappingOperation {
 /// [`heal_versions`](Self::heal_versions) and [`heal_mappings`](Self::heal_mappings).
 ///
 /// [`Flusher`]: common::universal_io::Flusher
-pub struct UpdateOnlyAppendableIdTracker<S: UniversalAppend> {
+pub struct UpdateOnlyAppendableIdTracker {
     segment_path: PathBuf,
     /// Highest slot the mappings log has claimed, `None` while it has claimed none; advanced only
     /// once the entries claiming the new slots are durable.
@@ -65,11 +65,9 @@ pub struct UpdateOnlyAppendableIdTracker<S: UniversalAppend> {
     /// about where its last one ends. Appending here rather than at the end of the file makes a
     /// file that ends elsewhere a conflict.
     mappings_end: u64,
-    /// Opens the two files, each created on its first write.
-    fs: S::Fs,
 }
 
-impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
+impl UpdateOnlyAppendableIdTracker {
     /// All three of `max_claimed_internal_id`, `pending_inserts` and `mappings_end` must come from
     /// one and the same read of the mappings log, as exposed by the read-only tracker. A segment
     /// with no log yet starts at `(None, [], 0)`.
@@ -87,8 +85,8 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
     /// `mappings_end` is not a hint: the first append cuts the file back to it (see
     /// [`heal_mappings`](Self::heal_mappings)), which drops a torn entry, or good data if it lags
     /// for any other reason.
-    pub fn new(
-        fs: S::Fs,
+    pub fn new<Fs: UniversalWriteFileOps>(
+        fs: &Fs,
         segment_path: impl Into<PathBuf>,
         max_claimed_internal_id: Option<PointOffsetType>,
         pending_inserts: impl IntoIterator<Item = PointIdType>,
@@ -98,9 +96,8 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
             segment_path: segment_path.into(),
             max_claimed_internal_id,
             mappings_end,
-            fs,
         };
-        tracker.retire_pending_inserts(pending_inserts)?;
+        tracker.retire_pending_inserts(fs, pending_inserts)?;
 
         Ok(tracker)
     }
@@ -120,8 +117,9 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
     /// opened.
     ///
     /// [`DELETED_POINT_VERSION`]: crate::id_tracker::DELETED_POINT_VERSION
-    pub fn set_internal_versions(
+    pub fn set_internal_versions<Fs: UniversalWriteFileOps>(
         &mut self,
+        fs: &Fs,
         internal_ids: &[PointOffsetType],
         versions: &[SeqNumberType],
     ) -> OperationResult<()> {
@@ -138,15 +136,15 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
         }
 
         let path = versions_path(&self.segment_path);
-        let mut file = self.open_append(&path)?;
+        let mut file = Self::open_append(fs, &path)?;
 
         // A torn tail is healed rather than refused: those bytes are a slot no reader ever saw, and
         // the entries below take their place. `heal_versions` drops the handle before rewriting.
         let file_len = Self::end_of_file(&file)?;
         let committed_len = file_len - file_len % VERSION_ELEMENT_SIZE;
         if committed_len != file_len {
-            self.heal_versions(&path, file, file_len)?;
-            file = self.open_append(&path)?;
+            Self::heal_versions(fs, &path, file, file_len)?;
+            file = Self::open_append(fs, &path)?;
         }
         let covered_slots = committed_len / VERSION_ELEMENT_SIZE;
 
@@ -210,8 +208,9 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
     ///
     /// Slots are consecutive above every slot the log has claimed, and stay invisible to readers
     /// until [`set_internal_versions`](Self::set_internal_versions) covers them.
-    pub fn insert_operations(
+    pub fn insert_operations<Fs: UniversalWriteFileOps>(
         &mut self,
+        fs: &Fs,
         operations: &[MappingOperation],
     ) -> OperationResult<Vec<(PointIdType, PointOffsetType)>> {
         if operations.is_empty() {
@@ -252,7 +251,7 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
         }
 
         let path = mappings_path(&self.segment_path);
-        let mut file = self.open_append(&path)?;
+        let mut file = Self::open_append(fs, &path)?;
 
         // One entry per buffer, appended in order in a single operation, at the end of the log
         // rather than the end of the file. The two part ways only after a write that tore or landed
@@ -266,8 +265,8 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
             // batch appended anew. Drop this handle first, healing replaces the path, which Windows
             // refuses while an mmap is still open.
             drop(file);
-            self.heal_mappings(&path)?;
-            file = self.open_append(&path)?;
+            self.heal_mappings(fs, &path)?;
+            file = Self::open_append(fs, &path)?;
             file.append_batch(self.mappings_end, batch())?;
         }
         (file.flusher())()?;
@@ -297,17 +296,19 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
     ///
     /// Runs at construction rather than lazily on the first write, so that no later write path can
     /// be added that forgets it and publishes one of these points.
-    fn retire_pending_inserts(
+    fn retire_pending_inserts<Fs: UniversalWriteFileOps>(
         &mut self,
+        fs: &Fs,
         pending_inserts: impl IntoIterator<Item = PointIdType>,
     ) -> OperationResult<()> {
-        self.delete_points(pending_inserts)
+        self.delete_points(fs, pending_inserts)
     }
 
     /// Retire `point_ids`: each stops resolving, and the slot it held keeps its data and is never
     /// handed out again. Tombstoning that data is the caller's business.
-    pub fn delete_points(
+    pub fn delete_points<Fs: UniversalWriteFileOps>(
         &mut self,
+        fs: &Fs,
         point_ids: impl IntoIterator<Item = PointIdType>,
     ) -> OperationResult<()> {
         let operations: Vec<MappingOperation> = point_ids
@@ -316,7 +317,7 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
             .collect();
 
         // Deletes claim no slots, so the returned mappings are empty.
-        self.insert_operations(&operations)?;
+        self.insert_operations(fs, &operations)?;
 
         Ok(())
     }
@@ -333,12 +334,15 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
     }
 
     /// Open the append handle for `path`, creating the file if it is not there yet.
-    fn open_append(&self, path: &Path) -> OperationResult<S> {
-        match self.fs.open_append(path, Self::open_options()) {
+    fn open_append<Fs: UniversalWriteFileOps>(
+        fs: &Fs,
+        path: &Path,
+    ) -> OperationResult<Fs::AppendFile> {
+        match fs.open_append(path, Self::open_options()) {
             Ok(file) => Ok(file),
             Err(err) if err.is_not_found() => {
-                self.fs.create(path, 0)?;
-                Ok(self.fs.open_append(path, Self::open_options())?)
+                fs.create(path, 0)?;
+                Ok(fs.open_append(path, Self::open_options())?)
             }
             Err(err) => Err(err.into()),
         }
@@ -348,7 +352,7 @@ impl<S: UniversalAppend> UpdateOnlyAppendableIdTracker<S> {
     ///
     /// `NotFound` means a lazy backend has not materialized the object yet, so it is empty and the
     /// append at 0 creates it.
-    fn end_of_file(file: &S) -> OperationResult<u64> {
+    fn end_of_file<S: UniversalAppend>(file: &S) -> OperationResult<u64> {
         Ok(file.len::<u8>().ok_not_found()?.unwrap_or(0))
     }
 }

--- a/lib/segment/src/id_tracker/mutable_id_tracker/update_only/tests.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/update_only/tests.rs
@@ -18,7 +18,7 @@ use crate::id_tracker::mutable_id_tracker::versions_storage::{
 use crate::id_tracker::{DELETED_POINT_VERSION, IdTracker, IdTrackerRead};
 use crate::types::{PointIdType, SeqNumberType};
 
-type Tracker = UpdateOnlyAppendableIdTracker<MmapFile>;
+type Tracker = UpdateOnlyAppendableIdTracker;
 type ReadOnlyTracker = ReadOnlyAppendableIdTracker<MmapFile>;
 
 fn num(id: u64) -> PointIdType {
@@ -41,40 +41,43 @@ fn log_end(segment_path: &Path) -> u64 {
 fn allocates_consecutive_slots() {
     let dir = Builder::new().prefix("update_only").tempdir().unwrap();
 
-    let mut tracker = Tracker::new(MmapFs, dir.path(), None, [], 0).unwrap();
+    let mut tracker = Tracker::new(&MmapFs, dir.path(), None, [], 0).unwrap();
 
     // Deletes are recorded but claim no slot, so only inserts come back.
     assert_eq!(
-        tracker.insert_operations(&[Insert(num(10)), Delete(num(20)), Insert(uuid(11))]),
+        tracker.insert_operations(
+            &MmapFs,
+            &[Insert(num(10)), Delete(num(20)), Insert(uuid(11))]
+        ),
         Ok(vec![(num(10), 0), (uuid(11), 1)]),
     );
     // A batch of deletes alone allocates nothing, and the next insert still
     // takes the slot right above the last one claimed.
     assert_eq!(
-        tracker.insert_operations(&[Delete(num(10))]),
+        tracker.insert_operations(&MmapFs, &[Delete(num(10))]),
         Ok(Vec::new()),
     );
     assert_eq!(
-        tracker.insert_operations(&[Insert(num(12))]),
+        tracker.insert_operations(&MmapFs, &[Insert(num(12))]),
         Ok(vec![(num(12), 2)]),
     );
 
     // Re-inserting a live id moves it to a fresh slot rather than rewriting its mapping.
     assert_eq!(
-        tracker.insert_operations(&[Insert(uuid(11))]),
+        tracker.insert_operations(&MmapFs, &[Insert(uuid(11))]),
         Ok(vec![(uuid(11), 3)]),
     );
 
     // A fresh tracker resuming from slot 3, and from the end of the log that handed it out,
     // continues above both.
-    let mut resumed = Tracker::new(MmapFs, dir.path(), Some(3), [], log_end(dir.path())).unwrap();
+    let mut resumed = Tracker::new(&MmapFs, dir.path(), Some(3), [], log_end(dir.path())).unwrap();
     assert_eq!(
-        resumed.insert_operations(&[Insert(num(13))]),
+        resumed.insert_operations(&MmapFs, &[Insert(num(13))]),
         Ok(vec![(num(13), 4)]),
     );
 
     // Nothing to record, nothing written.
-    assert_eq!(tracker.insert_operations(&[]), Ok(Vec::new()));
+    assert_eq!(tracker.insert_operations(&MmapFs, &[]), Ok(Vec::new()));
 }
 
 /// Append a torn entry to the mappings log: a valid entry header and part of the payload it
@@ -96,17 +99,19 @@ fn heals_a_torn_mappings_tail() {
     let dir = Builder::new().prefix("update_only").tempdir().unwrap();
     let path = mappings_path(dir.path());
 
-    let mut tracker = Tracker::new(MmapFs, dir.path(), None, [], 0).unwrap();
-    tracker.insert_operations(&[Insert(num(10))]).unwrap();
+    let mut tracker = Tracker::new(&MmapFs, dir.path(), None, [], 0).unwrap();
+    tracker
+        .insert_operations(&MmapFs, &[Insert(num(10))])
+        .unwrap();
 
     let committed = fs_err::read(&path).unwrap();
     tear_the_log(dir.path());
 
     // A writer resumes from the log's end, which is below the torn bytes.
     let mut resumed =
-        Tracker::new(MmapFs, dir.path(), Some(0), [], committed.len() as u64).unwrap();
+        Tracker::new(&MmapFs, dir.path(), Some(0), [], committed.len() as u64).unwrap();
     assert_eq!(
-        resumed.insert_operations(&[Insert(num(11))]),
+        resumed.insert_operations(&MmapFs, &[Insert(num(11))]),
         Ok(vec![(num(11), 1)]),
     );
 
@@ -139,15 +144,15 @@ fn re_appends_a_batch_that_landed_unacknowledged() {
 
     // One writer gets through the batch; another is left believing it did not, and runs the same
     // batch against the file the first one wrote.
-    let mut writer = Tracker::new(MmapFs, landed.path(), None, [], 0).unwrap();
-    let inserted = writer.insert_operations(&batch).unwrap();
+    let mut writer = Tracker::new(&MmapFs, landed.path(), None, [], 0).unwrap();
+    let inserted = writer.insert_operations(&MmapFs, &batch).unwrap();
 
     fs_err::copy(mappings_path(landed.path()), mappings_path(retried.path())).unwrap();
-    let mut retry = Tracker::new(MmapFs, retried.path(), None, [], 0).unwrap();
+    let mut retry = Tracker::new(&MmapFs, retried.path(), None, [], 0).unwrap();
 
     // Same slots, and the same bytes in the log: the second attempt is the first one, not a
     // duplicate of it.
-    assert_eq!(retry.insert_operations(&batch), Ok(inserted));
+    assert_eq!(retry.insert_operations(&MmapFs, &batch), Ok(inserted));
     assert_eq!(
         fs_err::read(mappings_path(retried.path())).unwrap(),
         fs_err::read(mappings_path(landed.path())).unwrap(),
@@ -160,9 +165,9 @@ fn re_appends_a_batch_that_landed_unacknowledged() {
 fn rejects_a_mappings_file_shorter_than_the_log() {
     let dir = Builder::new().prefix("update_only").tempdir().unwrap();
 
-    let mut tracker = Tracker::new(MmapFs, dir.path(), None, [], 64).unwrap();
+    let mut tracker = Tracker::new(&MmapFs, dir.path(), None, [], 64).unwrap();
     tracker
-        .insert_operations(&[Insert(num(10))])
+        .insert_operations(&MmapFs, &[Insert(num(10))])
         .expect_err("a log longer than its file must be rejected");
 
     assert_eq!(log_end(dir.path()), 0, "nothing may be appended");
@@ -176,30 +181,34 @@ fn versions_reject_rewrites_duplicates_and_unclaimed_slots() {
     let dir = Builder::new().prefix("update_only").tempdir().unwrap();
     let path = versions_path(dir.path());
 
-    let mut tracker = Tracker::new(MmapFs, dir.path(), Some(2), [], 0).unwrap();
-    tracker.set_internal_versions(&[0, 1], &[100, 101]).unwrap();
+    let mut tracker = Tracker::new(&MmapFs, dir.path(), Some(2), [], 0).unwrap();
+    tracker
+        .set_internal_versions(&MmapFs, &[0, 1], &[100, 101])
+        .unwrap();
 
     // The log claimed up to slot 2, so slot 3 is nobody's.
     tracker
-        .set_internal_versions(&[3], &[103])
+        .set_internal_versions(&MmapFs, &[3], &[103])
         .expect_err("an unclaimed slot must be rejected");
     // Slot 1 is already committed.
     tracker
-        .set_internal_versions(&[1], &[111])
+        .set_internal_versions(&MmapFs, &[1], &[111])
         .expect_err("a rewrite must be rejected");
     // The same slot twice in one call.
     tracker
-        .set_internal_versions(&[2, 2], &[102, 102])
+        .set_internal_versions(&MmapFs, &[2, 2], &[102, 102])
         .expect_err("a duplicate must be rejected");
     // One id short of the versions it is paired with.
     tracker
-        .set_internal_versions(&[2], &[102, 103])
+        .set_internal_versions(&MmapFs, &[2], &[102, 103])
         .expect_err("mismatched lengths must be rejected");
 
     assert_eq!(load_versions(&path).unwrap(), vec![100, 101]);
 
     // The rejections left the array appendable.
-    tracker.set_internal_versions(&[2], &[102]).unwrap();
+    tracker
+        .set_internal_versions(&MmapFs, &[2], &[102])
+        .unwrap();
     assert_eq!(load_versions(&path).unwrap(), vec![100, 101, 102]);
 }
 
@@ -208,7 +217,7 @@ fn versions_reject_rewrites_duplicates_and_unclaimed_slots() {
 fn resume(segment_path: &Path) -> Tracker {
     let reader = ReadOnlyTracker::open(&MmapFs, segment_path, None).unwrap();
     Tracker::new(
-        MmapFs,
+        &MmapFs,
         segment_path,
         reader.max_claimed_internal_id(),
         reader.pending_inserts(),
@@ -226,18 +235,23 @@ fn fills_skipped_slots() {
     let dir = Builder::new().prefix("update_only").tempdir().unwrap();
     let path = versions_path(dir.path());
 
-    let mut tracker = Tracker::new(MmapFs, dir.path(), None, [], 0).unwrap();
+    let mut tracker = Tracker::new(&MmapFs, dir.path(), None, [], 0).unwrap();
     tracker
-        .insert_operations(&[
-            Insert(num(10)),
-            Insert(num(11)),
-            Insert(num(12)),
-            Insert(num(13)),
-        ])
+        .insert_operations(
+            &MmapFs,
+            &[
+                Insert(num(10)),
+                Insert(num(11)),
+                Insert(num(12)),
+                Insert(num(13)),
+            ],
+        )
         .unwrap();
 
     // Slots 1 and 2 are skipped, one below the committed slot and one between.
-    tracker.set_internal_versions(&[0, 3], &[100, 103]).unwrap();
+    tracker
+        .set_internal_versions(&MmapFs, &[0, 3], &[100, 103])
+        .unwrap();
 
     assert_eq!(
         load_versions(&path).unwrap(),
@@ -252,12 +266,16 @@ fn fills_skipped_slots() {
 fn resumes_above_a_slot_claimed_and_then_deleted() {
     let dir = Builder::new().prefix("update_only").tempdir().unwrap();
 
-    let mut crashed = Tracker::new(MmapFs, dir.path(), None, [], 0).unwrap();
-    crashed.insert_operations(&[Insert(num(10))]).unwrap();
-    crashed.set_internal_versions(&[0], &[100]).unwrap();
+    let mut crashed = Tracker::new(&MmapFs, dir.path(), None, [], 0).unwrap();
+    crashed
+        .insert_operations(&MmapFs, &[Insert(num(10))])
+        .unwrap();
+    crashed
+        .set_internal_versions(&MmapFs, &[0], &[100])
+        .unwrap();
     // Slot 1 is claimed, never versioned, and then retired.
     crashed
-        .insert_operations(&[Insert(num(11)), Delete(num(11))])
+        .insert_operations(&MmapFs, &[Insert(num(11)), Delete(num(11))])
         .unwrap();
 
     let reader = ReadOnlyTracker::open(&MmapFs, dir.path(), None).unwrap();
@@ -274,7 +292,7 @@ fn resumes_above_a_slot_claimed_and_then_deleted() {
     );
 
     assert_eq!(
-        resume(dir.path()).insert_operations(&[Insert(num(12))]),
+        resume(dir.path()).insert_operations(&MmapFs, &[Insert(num(12))]),
         Ok(vec![(num(12), 2)]),
     );
 }
@@ -290,11 +308,17 @@ fn resumes_above_a_slot_claimed_and_then_deleted() {
 fn retires_inherited_pending_inserts() {
     let dir = Builder::new().prefix("update_only").tempdir().unwrap();
 
-    let mut crashed = Tracker::new(MmapFs, dir.path(), None, [], 0).unwrap();
-    crashed.insert_operations(&[Insert(num(10))]).unwrap();
-    crashed.set_internal_versions(&[0], &[100]).unwrap();
+    let mut crashed = Tracker::new(&MmapFs, dir.path(), None, [], 0).unwrap();
+    crashed
+        .insert_operations(&MmapFs, &[Insert(num(10))])
+        .unwrap();
+    crashed
+        .set_internal_versions(&MmapFs, &[0], &[100])
+        .unwrap();
     // Slot 1 is claimed and its data left half-written; the writer stops here.
-    crashed.insert_operations(&[Insert(num(11))]).unwrap();
+    crashed
+        .insert_operations(&MmapFs, &[Insert(num(11))])
+        .unwrap();
 
     let inherited = ReadOnlyTracker::open(&MmapFs, dir.path(), None).unwrap();
     assert_eq!(
@@ -314,10 +338,12 @@ fn retires_inherited_pending_inserts() {
 
     // Slot 1 has to be covered for slot 2 to be published, and gets a version of its own here.
     assert_eq!(
-        resumed.insert_operations(&[Insert(num(12))]),
+        resumed.insert_operations(&MmapFs, &[Insert(num(12))]),
         Ok(vec![(num(12), 2)]),
     );
-    resumed.set_internal_versions(&[1, 2], &[101, 102]).unwrap();
+    resumed
+        .set_internal_versions(&MmapFs, &[1, 2], &[101, 102])
+        .unwrap();
 
     let reader = ReadOnlyTracker::open(&MmapFs, dir.path(), None).unwrap();
     assert_eq!(
@@ -345,19 +371,27 @@ fn retires_inherited_pending_inserts() {
 fn an_abandoned_update_retires_the_point() {
     let dir = Builder::new().prefix("update_only").tempdir().unwrap();
 
-    let mut crashed = Tracker::new(MmapFs, dir.path(), None, [], 0).unwrap();
-    crashed.insert_operations(&[Insert(num(10))]).unwrap();
-    crashed.set_internal_versions(&[0], &[100]).unwrap();
+    let mut crashed = Tracker::new(&MmapFs, dir.path(), None, [], 0).unwrap();
+    crashed
+        .insert_operations(&MmapFs, &[Insert(num(10))])
+        .unwrap();
+    crashed
+        .set_internal_versions(&MmapFs, &[0], &[100])
+        .unwrap();
     // Re-inserting moves the id to a fresh slot; the writer stops before the version that would
     // publish it.
     assert_eq!(
-        crashed.insert_operations(&[Insert(num(10))]),
+        crashed.insert_operations(&MmapFs, &[Insert(num(10))]),
         Ok(vec![(num(10), 1)]),
     );
 
     let mut resumed = resume(dir.path());
-    resumed.insert_operations(&[Insert(num(11))]).unwrap();
-    resumed.set_internal_versions(&[2], &[102]).unwrap();
+    resumed
+        .insert_operations(&MmapFs, &[Insert(num(11))])
+        .unwrap();
+    resumed
+        .set_internal_versions(&MmapFs, &[2], &[102])
+        .unwrap();
 
     let reader = ReadOnlyTracker::open(&MmapFs, dir.path(), None).unwrap();
     assert_eq!(
@@ -380,15 +414,19 @@ fn heals_a_partial_versions_tail() {
     let dir = Builder::new().prefix("update_only").tempdir().unwrap();
     let path = versions_path(dir.path());
 
-    let mut tracker = Tracker::new(MmapFs, dir.path(), Some(3), [], 0).unwrap();
-    tracker.set_internal_versions(&[0, 1], &[100, 101]).unwrap();
+    let mut tracker = Tracker::new(&MmapFs, dir.path(), Some(3), [], 0).unwrap();
+    tracker
+        .set_internal_versions(&MmapFs, &[0, 1], &[100, 101])
+        .unwrap();
 
     // Three bytes into slot 2, as a torn write would leave it.
     let mut torn = fs_err::read(&path).unwrap();
     torn.extend_from_slice(&[0xFF; 3]);
     fs_err::write(&path, &torn).unwrap();
 
-    tracker.set_internal_versions(&[2, 3], &[102, 103]).unwrap();
+    tracker
+        .set_internal_versions(&MmapFs, &[2, 3], &[102, 103])
+        .unwrap();
 
     // The committed slots survived, and the appended ones landed where the stray bytes were rather
     // than after them.
@@ -408,8 +446,10 @@ fn heals_a_versions_file_of_only_a_partial_tail() {
 
     fs_err::write(&path, [0xFF; 5]).unwrap();
 
-    let mut tracker = Tracker::new(MmapFs, dir.path(), Some(0), [], 0).unwrap();
-    tracker.set_internal_versions(&[0], &[100]).unwrap();
+    let mut tracker = Tracker::new(&MmapFs, dir.path(), Some(0), [], 0).unwrap();
+    tracker
+        .set_internal_versions(&MmapFs, &[0], &[100])
+        .unwrap();
 
     assert_eq!(load_versions(&path).unwrap(), vec![100]);
 }
@@ -424,9 +464,9 @@ fn both_writers_produce_the_same_versions_file() {
     let internal_ids: Vec<PointOffsetType> = vec![0, 1, 2, 3];
     let versions: Vec<SeqNumberType> = vec![100, 7, u64::MAX, 0];
 
-    let mut tracker = Tracker::new(MmapFs, appended.path(), Some(3), [], 0).unwrap();
+    let mut tracker = Tracker::new(&MmapFs, appended.path(), Some(3), [], 0).unwrap();
     tracker
-        .set_internal_versions(&internal_ids, &versions)
+        .set_internal_versions(&MmapFs, &internal_ids, &versions)
         .unwrap();
 
     let changes: BTreeMap<PointOffsetType, SeqNumberType> = internal_ids
@@ -499,23 +539,28 @@ fn matches_the_mutable_tracker() {
     let appended_dir = Builder::new().prefix("update_only").tempdir().unwrap();
     let mutated_dir = Builder::new().prefix("mutable").tempdir().unwrap();
 
-    let mut writer = Tracker::new(MmapFs, appended_dir.path(), None, [], 0).unwrap();
+    let mut writer = Tracker::new(&MmapFs, appended_dir.path(), None, [], 0).unwrap();
     let mut mutable = MutableIdTracker::open(mutated_dir.path(), None).unwrap();
 
     // The append-only writer hands out the slots; the mutable tracker is told to use exactly the
     // ones it handed out. A delete of an id that was never inserted is recorded by both and must
     // change nothing.
     let inserted = writer
-        .insert_operations(&[
-            Insert(num(10)),
-            Insert(uuid(11)),
-            Insert(num(12)),
-            Delete(num(99)),
-        ])
+        .insert_operations(
+            &MmapFs,
+            &[
+                Insert(num(10)),
+                Insert(uuid(11)),
+                Insert(num(12)),
+                Delete(num(99)),
+            ],
+        )
         .unwrap();
     let versions: Vec<SeqNumberType> = vec![100, 101, 102];
     let slots: Vec<PointOffsetType> = inserted.iter().map(|(_, slot)| *slot).collect();
-    writer.set_internal_versions(&slots, &versions).unwrap();
+    writer
+        .set_internal_versions(&MmapFs, &slots, &versions)
+        .unwrap();
 
     for ((external_id, slot), version) in inserted.iter().zip(&versions) {
         mutable.set_link(*external_id, *slot).unwrap();
@@ -524,7 +569,9 @@ fn matches_the_mutable_tracker() {
     mutable.drop(num(99)).unwrap();
 
     // Then retire a live point through both.
-    writer.insert_operations(&[Delete(uuid(11))]).unwrap();
+    writer
+        .insert_operations(&MmapFs, &[Delete(uuid(11))])
+        .unwrap();
     mutable.drop(uuid(11)).unwrap();
 
     mutable.mapping_flusher()().unwrap();

--- a/lib/segment/src/index/field_index/bool_index/mutable_bool_index/update_only/mod.rs
+++ b/lib/segment/src/index/field_index/bool_index/mutable_bool_index/update_only/mod.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalAppend;
+use common::universal_io::{UniversalReadFs, UniversalWriteFileOps};
 use serde_json::Value;
 
 use super::super::MutableBoolIndex;
@@ -14,16 +14,19 @@ use crate::index::field_index::ValueIndexer;
 /// Writes what [`MutableBoolIndex`] persists: the two masks saying, per point,
 /// whether its field holds a true and whether it holds a false. A point whose
 /// field holds both is set in both.
-pub struct UpdateOnlyBoolIndex<S: UniversalAppend + 'static> {
-    trues: UpdateOnlyStoredFlags<S>,
-    falses: UpdateOnlyStoredFlags<S>,
+pub struct UpdateOnlyBoolIndex {
+    trues: UpdateOnlyStoredFlags,
+    falses: UpdateOnlyStoredFlags,
 }
 
-impl<S: UniversalAppend + 'static> UpdateOnlyBoolIndex<S> {
+impl UpdateOnlyBoolIndex {
     /// Open the index at `dir` for writing, reading both masks into memory.
-    pub fn open(fs: S::Fs, dir: &Path) -> OperationResult<Self> {
+    pub fn open<Fs: UniversalReadFs + UniversalWriteFileOps>(
+        fs: &Fs,
+        dir: &Path,
+    ) -> OperationResult<Self> {
         Ok(Self {
-            trues: UpdateOnlyStoredFlags::open(fs.clone(), &dir.join(TRUES_DIRNAME))?,
+            trues: UpdateOnlyStoredFlags::open(fs, &dir.join(TRUES_DIRNAME))?,
             falses: UpdateOnlyStoredFlags::open(fs, &dir.join(FALSES_DIRNAME))?,
         })
     }
@@ -41,8 +44,12 @@ impl<S: UniversalAppend + 'static> UpdateOnlyBoolIndex<S> {
     }
 
     /// Persist both masks.
-    pub fn flush(&mut self, hw_counter: &HardwareCounterCell) -> OperationResult<()> {
-        self.trues.flush(hw_counter)?;
-        self.falses.flush(hw_counter)
+    pub fn flush<Fs: UniversalWriteFileOps>(
+        &mut self,
+        fs: &Fs,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.trues.flush(fs, hw_counter)?;
+        self.falses.flush(fs, hw_counter)
     }
 }

--- a/lib/segment/src/index/field_index/field_index_base/update_only/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/update_only/mod.rs
@@ -75,31 +75,31 @@ impl<S: UniversalAppend + 'static> UpdateOnlyFieldIndex<S> {
 
         let index = match index_type {
             PayloadIndexType::IntIndex => {
-                Self::IntIndex(UpdateOnlyValueIndex::open(fs, dir, Default::default())?)
+                Self::IntIndex(UpdateOnlyValueIndex::open(&fs, dir, Default::default())?)
             }
             PayloadIndexType::DatetimeIndex => {
-                Self::DatetimeIndex(UpdateOnlyValueIndex::open(fs, dir, Default::default())?)
+                Self::DatetimeIndex(UpdateOnlyValueIndex::open(&fs, dir, Default::default())?)
             }
             PayloadIndexType::FloatIndex => {
-                Self::FloatIndex(UpdateOnlyValueIndex::open(fs, dir, Default::default())?)
+                Self::FloatIndex(UpdateOnlyValueIndex::open(&fs, dir, Default::default())?)
             }
             PayloadIndexType::IntMapIndex => {
-                Self::IntMapIndex(UpdateOnlyValueIndex::open(fs, dir, Default::default())?)
+                Self::IntMapIndex(UpdateOnlyValueIndex::open(&fs, dir, Default::default())?)
             }
             PayloadIndexType::KeywordIndex => {
-                Self::KeywordIndex(UpdateOnlyValueIndex::open(fs, dir, Default::default())?)
+                Self::KeywordIndex(UpdateOnlyValueIndex::open(&fs, dir, Default::default())?)
             }
             // The `UuidIndex` discriminant is historically map-backed
             PayloadIndexType::UuidIndex | PayloadIndexType::UuidMapIndex => {
-                Self::UuidMapIndex(UpdateOnlyValueIndex::open(fs, dir, Default::default())?)
+                Self::UuidMapIndex(UpdateOnlyValueIndex::open(&fs, dir, Default::default())?)
             }
             PayloadIndexType::GeoIndex => {
-                Self::GeoIndex(UpdateOnlyValueIndex::open(fs, dir, UpdateOnlyGeoKind)?)
+                Self::GeoIndex(UpdateOnlyValueIndex::open(&fs, dir, UpdateOnlyGeoKind)?)
             }
             PayloadIndexType::FullTextIndex => {
                 let config = TextIndexParams::try_from(schema)?;
                 Self::FullTextIndex(UpdateOnlyValueIndex::open(
-                    fs,
+                    &fs,
                     dir,
                     UpdateOnlyTextKind::new(&config),
                 )?)
@@ -116,19 +116,20 @@ impl<S: UniversalAppend + 'static> UpdateOnlyFieldIndex<S> {
     /// [`flush`](Self::flush).
     pub fn add_point(
         &mut self,
+        fs: &S::Fs,
         slot: PointOffsetType,
         values: &[&Value],
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         match self {
-            Self::IntIndex(index) => index.add_point(slot, values, hw_counter),
-            Self::DatetimeIndex(index) => index.add_point(slot, values, hw_counter),
-            Self::FloatIndex(index) => index.add_point(slot, values, hw_counter),
-            Self::IntMapIndex(index) => index.add_point(slot, values, hw_counter),
-            Self::KeywordIndex(index) => index.add_point(slot, values, hw_counter),
-            Self::UuidMapIndex(index) => index.add_point(slot, values, hw_counter),
-            Self::GeoIndex(index) => index.add_point(slot, values, hw_counter),
-            Self::FullTextIndex(index) => index.add_point(slot, values, hw_counter),
+            Self::IntIndex(index) => index.add_point(fs, slot, values, hw_counter),
+            Self::DatetimeIndex(index) => index.add_point(fs, slot, values, hw_counter),
+            Self::FloatIndex(index) => index.add_point(fs, slot, values, hw_counter),
+            Self::IntMapIndex(index) => index.add_point(fs, slot, values, hw_counter),
+            Self::KeywordIndex(index) => index.add_point(fs, slot, values, hw_counter),
+            Self::UuidMapIndex(index) => index.add_point(fs, slot, values, hw_counter),
+            Self::GeoIndex(index) => index.add_point(fs, slot, values, hw_counter),
+            Self::FullTextIndex(index) => index.add_point(fs, slot, values, hw_counter),
             Self::BoolIndex(index) => index.add_point(slot, values),
             Self::NullIndex(index) => index.add_point(slot, values),
         }

--- a/lib/segment/src/index/field_index/field_index_base/update_only/mod.rs
+++ b/lib/segment/src/index/field_index/field_index_base/update_only/mod.rs
@@ -56,15 +56,15 @@ pub enum UpdateOnlyFieldIndex<S: UniversalAppend + 'static> {
     UuidMapIndex(UpdateOnlyValueIndex<UpdateOnlyMapKind<UuidIntType>, S>),
     GeoIndex(UpdateOnlyValueIndex<UpdateOnlyGeoKind, S>),
     FullTextIndex(UpdateOnlyValueIndex<UpdateOnlyTextKind, S>),
-    BoolIndex(UpdateOnlyBoolIndex<S>),
-    NullIndex(UpdateOnlyNullIndex<S>),
+    BoolIndex(UpdateOnlyBoolIndex),
+    NullIndex(UpdateOnlyNullIndex),
 }
 
 impl<S: UniversalAppend + 'static> UpdateOnlyFieldIndex<S> {
     /// Open the writer for `field`'s index of type `index_type`, under the
     /// payload index root `dir`, creating its storage if it is not there yet.
     pub fn open(
-        fs: S::Fs,
+        fs: &S::Fs,
         dir: &Path,
         field: &JsonPath,
         schema: &PayloadFieldSchema,
@@ -75,31 +75,31 @@ impl<S: UniversalAppend + 'static> UpdateOnlyFieldIndex<S> {
 
         let index = match index_type {
             PayloadIndexType::IntIndex => {
-                Self::IntIndex(UpdateOnlyValueIndex::open(&fs, dir, Default::default())?)
+                Self::IntIndex(UpdateOnlyValueIndex::open(fs, dir, Default::default())?)
             }
             PayloadIndexType::DatetimeIndex => {
-                Self::DatetimeIndex(UpdateOnlyValueIndex::open(&fs, dir, Default::default())?)
+                Self::DatetimeIndex(UpdateOnlyValueIndex::open(fs, dir, Default::default())?)
             }
             PayloadIndexType::FloatIndex => {
-                Self::FloatIndex(UpdateOnlyValueIndex::open(&fs, dir, Default::default())?)
+                Self::FloatIndex(UpdateOnlyValueIndex::open(fs, dir, Default::default())?)
             }
             PayloadIndexType::IntMapIndex => {
-                Self::IntMapIndex(UpdateOnlyValueIndex::open(&fs, dir, Default::default())?)
+                Self::IntMapIndex(UpdateOnlyValueIndex::open(fs, dir, Default::default())?)
             }
             PayloadIndexType::KeywordIndex => {
-                Self::KeywordIndex(UpdateOnlyValueIndex::open(&fs, dir, Default::default())?)
+                Self::KeywordIndex(UpdateOnlyValueIndex::open(fs, dir, Default::default())?)
             }
             // The `UuidIndex` discriminant is historically map-backed
             PayloadIndexType::UuidIndex | PayloadIndexType::UuidMapIndex => {
-                Self::UuidMapIndex(UpdateOnlyValueIndex::open(&fs, dir, Default::default())?)
+                Self::UuidMapIndex(UpdateOnlyValueIndex::open(fs, dir, Default::default())?)
             }
             PayloadIndexType::GeoIndex => {
-                Self::GeoIndex(UpdateOnlyValueIndex::open(&fs, dir, UpdateOnlyGeoKind)?)
+                Self::GeoIndex(UpdateOnlyValueIndex::open(fs, dir, UpdateOnlyGeoKind)?)
             }
             PayloadIndexType::FullTextIndex => {
                 let config = TextIndexParams::try_from(schema)?;
                 Self::FullTextIndex(UpdateOnlyValueIndex::open(
-                    &fs,
+                    fs,
                     dir,
                     UpdateOnlyTextKind::new(&config),
                 )?)
@@ -139,7 +139,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyFieldIndex<S> {
     ///
     /// `hw_counter` is charged only by the bitmask-backed indexes, which do
     /// their writing here; the rest charge each value as it is put.
-    pub fn flush(&mut self, hw_counter: &HardwareCounterCell) -> OperationResult<()> {
+    pub fn flush(&mut self, fs: &S::Fs, hw_counter: &HardwareCounterCell) -> OperationResult<()> {
         match self {
             Self::IntIndex(index) => index.flush(),
             Self::DatetimeIndex(index) => index.flush(),
@@ -149,8 +149,8 @@ impl<S: UniversalAppend + 'static> UpdateOnlyFieldIndex<S> {
             Self::UuidMapIndex(index) => index.flush(),
             Self::GeoIndex(index) => index.flush(),
             Self::FullTextIndex(index) => index.flush(),
-            Self::BoolIndex(index) => index.flush(hw_counter),
-            Self::NullIndex(index) => index.flush(hw_counter),
+            Self::BoolIndex(index) => index.flush(fs, hw_counter),
+            Self::NullIndex(index) => index.flush(fs, hw_counter),
         }
     }
 }

--- a/lib/segment/src/index/field_index/field_index_base/update_only/tests.rs
+++ b/lib/segment/src/index/field_index/field_index_base/update_only/tests.rs
@@ -55,7 +55,9 @@ fn write(
 
     let mut writer = Writer::open(MmapFs, dir, &field(), schema, &index_type).unwrap();
     for (slot, value) in points {
-        writer.add_point(*slot, &[value], &hw_counter).unwrap();
+        writer
+            .add_point(&MmapFs, *slot, &[value], &hw_counter)
+            .unwrap();
     }
     writer.flush(&hw_counter).unwrap();
 
@@ -221,8 +223,14 @@ fn rewriting_a_slot_is_rejected() {
     )
     .unwrap();
 
-    writer.add_point(1, &[&json!(1)], &hw_counter).unwrap();
-    assert!(writer.add_point(0, &[&json!(0)], &hw_counter).is_err());
+    writer
+        .add_point(&MmapFs, 1, &[&json!(1)], &hw_counter)
+        .unwrap();
+    assert!(
+        writer
+            .add_point(&MmapFs, 0, &[&json!(0)], &hw_counter)
+            .is_err()
+    );
 }
 
 /// The boolean index is mask-backed: its writer rewrites both masks whole,

--- a/lib/segment/src/index/field_index/field_index_base/update_only/tests.rs
+++ b/lib/segment/src/index/field_index/field_index_base/update_only/tests.rs
@@ -53,13 +53,13 @@ fn write(
     let storage = kind.storage_dir(dir, &field());
     let index_type = index_type(kind);
 
-    let mut writer = Writer::open(MmapFs, dir, &field(), schema, &index_type).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir, &field(), schema, &index_type).unwrap();
     for (slot, value) in points {
         writer
             .add_point(&MmapFs, *slot, &[value], &hw_counter)
             .unwrap();
     }
-    writer.flush(&hw_counter).unwrap();
+    writer.flush(&MmapFs, &hw_counter).unwrap();
 
     storage
 }
@@ -215,7 +215,7 @@ fn rewriting_a_slot_is_rejected() {
     let schema = schema(PayloadSchemaType::Integer);
 
     let mut writer = Writer::open(
-        MmapFs,
+        &MmapFs,
         dir.path(),
         &field(),
         &schema,

--- a/lib/segment/src/index/field_index/field_index_base/update_only/writer.rs
+++ b/lib/segment/src/index/field_index/field_index_base/update_only/writer.rs
@@ -48,7 +48,7 @@ pub struct UpdateOnlyValueIndex<K: UpdateOnlyIndexKind, S: UniversalAppend + 'st
 impl<K: UpdateOnlyIndexKind, S: UniversalAppend + 'static> UpdateOnlyValueIndex<K, S> {
     /// Open the index storage directory at `dir` for appending, creating it if
     /// the field has no index there yet.
-    pub fn open(fs: S::Fs, dir: &Path, kind: K) -> OperationResult<Self> {
+    pub fn open(fs: &S::Fs, dir: &Path, kind: K) -> OperationResult<Self> {
         let storage = UpdateOnlyBlobstore::open(fs, dir, INDEX_LOGSTORE_CONFIG)?;
         Ok(Self { kind, storage })
     }
@@ -64,6 +64,7 @@ impl<K: UpdateOnlyIndexKind, S: UniversalAppend + 'static> UpdateOnlyValueIndex<
     /// empty slot reads back as a point this index does not cover.
     pub fn add_point(
         &mut self,
+        fs: &S::Fs,
         slot: PointOffsetType,
         values: &[&Value],
         hw_counter: &HardwareCounterCell,
@@ -73,6 +74,7 @@ impl<K: UpdateOnlyIndexKind, S: UniversalAppend + 'static> UpdateOnlyValueIndex<
         };
 
         self.storage.put(
+            fs,
             slot,
             &stored,
             hw_counter.ref_payload_index_io_write_counter(),

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/update_only/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/update_only/mod.rs
@@ -78,7 +78,7 @@ mod tests {
         let storage = index_type.index_type.storage_dir(dir.path(), &field);
 
         let mut writer: UpdateOnlyFieldIndex<MmapFile> = UpdateOnlyFieldIndex::open(
-            MmapFs,
+            &MmapFs,
             dir.path(),
             &field,
             &PayloadFieldSchema::FieldParams(PayloadSchemaParams::Text(params.clone())),
@@ -93,7 +93,7 @@ mod tests {
         writer
             .add_point(&MmapFs, 1, &[&json!(42)], &hw_counter)
             .unwrap();
-        writer.flush(&hw_counter).unwrap();
+        writer.flush(&MmapFs, &hw_counter).unwrap();
 
         let index = MutableFullTextIndex::open_gridstore(storage, params, false)
             .unwrap()

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/update_only/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/update_only/mod.rs
@@ -87,10 +87,12 @@ mod tests {
         .unwrap();
 
         writer
-            .add_point(0, &[&json!("the quick brown fox")], &hw_counter)
+            .add_point(&MmapFs, 0, &[&json!("the quick brown fox")], &hw_counter)
             .unwrap();
         // A value the text index cannot read stores nothing.
-        writer.add_point(1, &[&json!(42)], &hw_counter).unwrap();
+        writer
+            .add_point(&MmapFs, 1, &[&json!(42)], &hw_counter)
+            .unwrap();
         writer.flush(&hw_counter).unwrap();
 
         let index = MutableFullTextIndex::open_gridstore(storage, params, false)

--- a/lib/segment/src/index/field_index/null_index/mutable_null_index/update_only/mod.rs
+++ b/lib/segment/src/index/field_index/null_index/mutable_null_index/update_only/mod.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalAppend;
+use common::universal_io::{UniversalReadFs, UniversalWriteFileOps};
 use serde_json::Value;
 
 use super::lifecycle::classify_payload;
@@ -14,16 +14,19 @@ use crate::common::operation_error::OperationResult;
 /// whether its field holds any value and whether any of them is null.
 ///
 /// [`MutableNullIndex`]: super::MutableNullIndex
-pub struct UpdateOnlyNullIndex<S: UniversalAppend + 'static> {
-    has_values: UpdateOnlyStoredFlags<S>,
-    is_null: UpdateOnlyStoredFlags<S>,
+pub struct UpdateOnlyNullIndex {
+    has_values: UpdateOnlyStoredFlags,
+    is_null: UpdateOnlyStoredFlags,
 }
 
-impl<S: UniversalAppend + 'static> UpdateOnlyNullIndex<S> {
+impl UpdateOnlyNullIndex {
     /// Open the index at `dir` for writing, reading both masks into memory.
-    pub fn open(fs: S::Fs, dir: &Path) -> OperationResult<Self> {
+    pub fn open<Fs: UniversalReadFs + UniversalWriteFileOps>(
+        fs: &Fs,
+        dir: &Path,
+    ) -> OperationResult<Self> {
         Ok(Self {
-            has_values: UpdateOnlyStoredFlags::open(fs.clone(), &dir.join(HAS_VALUES_DIRNAME))?,
+            has_values: UpdateOnlyStoredFlags::open(fs, &dir.join(HAS_VALUES_DIRNAME))?,
             is_null: UpdateOnlyStoredFlags::open(fs, &dir.join(IS_NULL_DIRNAME))?,
         })
     }
@@ -44,8 +47,12 @@ impl<S: UniversalAppend + 'static> UpdateOnlyNullIndex<S> {
     }
 
     /// Persist both masks.
-    pub fn flush(&mut self, hw_counter: &HardwareCounterCell) -> OperationResult<()> {
-        self.has_values.flush(hw_counter)?;
-        self.is_null.flush(hw_counter)
+    pub fn flush<Fs: UniversalWriteFileOps>(
+        &mut self,
+        fs: &Fs,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        self.has_values.flush(fs, hw_counter)?;
+        self.is_null.flush(fs, hw_counter)
     }
 }

--- a/lib/segment/src/index/struct_payload_index/update_only/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/update_only/mod.rs
@@ -40,9 +40,9 @@ impl<S: UniversalAppend + 'static> UpdateOnlyStructPayloadIndex<S> {
     /// is a config from before those types were recorded, which only the
     /// writable index can repair, by deriving them from the schema on its next
     /// open.
-    pub fn open(fs: S::Fs, segment_path: &Path) -> OperationResult<Self> {
+    pub fn open(fs: &S::Fs, segment_path: &Path) -> OperationResult<Self> {
         let path = get_payload_index_path(segment_path);
-        let config = PayloadConfig::load_universal(&fs, &PayloadConfig::get_config_path(&path))?
+        let config = PayloadConfig::load_universal(fs, &PayloadConfig::get_config_path(&path))?
             .unwrap_or_default();
 
         let mut field_indexes = AHashMap::with_capacity(config.indices.len());
@@ -58,13 +58,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyStructPayloadIndex<S> {
                 .types
                 .iter()
                 .map(|index_type| {
-                    UpdateOnlyFieldIndex::open(
-                        fs.clone(),
-                        &path,
-                        field,
-                        &indexed.schema,
-                        index_type,
-                    )
+                    UpdateOnlyFieldIndex::open(fs, &path, field, &indexed.schema, index_type)
                 })
                 .collect::<OperationResult<Vec<_>>>()?;
 
@@ -103,7 +97,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyStructPayloadIndex<S> {
         // Once per index per batch: for the bitmask-backed indexes a flush
         // rewrites a whole mask
         for index in self.field_indexes.values_mut().flatten() {
-            index.flush(hw_counter)?;
+            index.flush(fs, hw_counter)?;
         }
 
         Ok(())

--- a/lib/segment/src/index/struct_payload_index/update_only/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/update_only/mod.rs
@@ -87,6 +87,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyStructPayloadIndex<S> {
     /// value there.
     pub fn append_many<'a>(
         &mut self,
+        fs: &S::Fs,
         points: impl IntoIterator<Item = (PointOffsetType, &'a Payload)>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
@@ -94,7 +95,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyStructPayloadIndex<S> {
             for (field, indexes) in &mut self.field_indexes {
                 let values = payload.get_value(field);
                 for index in indexes.iter_mut() {
-                    index.add_point(slot, &values, hw_counter)?;
+                    index.add_point(fs, slot, &values, hw_counter)?;
                 }
             }
         }

--- a/lib/segment/src/index/struct_payload_index/update_only/tests.rs
+++ b/lib/segment/src/index/struct_payload_index/update_only/tests.rs
@@ -73,7 +73,7 @@ fn batch_reaches_every_index_of_a_field() {
         payload_json! { "f": null },
     ];
 
-    let mut index = Index::open(MmapFs, dir.path()).unwrap();
+    let mut index = Index::open(&MmapFs, dir.path()).unwrap();
     index
         .append_many(
             &MmapFs,
@@ -129,7 +129,7 @@ fn batches_resume() {
 
     for (slot, value) in [(0, "alpha"), (1, "beta")] {
         let payload = payload_json! { "f": value };
-        let mut index = Index::open(MmapFs, dir.path()).unwrap();
+        let mut index = Index::open(&MmapFs, dir.path()).unwrap();
         index
             .append_many(&MmapFs, [(slot, &payload)], &hw_counter)
             .unwrap();
@@ -172,7 +172,7 @@ fn segment_without_indexes_opens_empty() {
     let hw_counter = HardwareCounterCell::new();
 
     let payload = payload_json! { "f": "alpha" };
-    let mut index = Index::open(MmapFs, dir.path()).unwrap();
+    let mut index = Index::open(&MmapFs, dir.path()).unwrap();
     index
         .append_many(&MmapFs, [(0, &payload)], &hw_counter)
         .unwrap();
@@ -185,7 +185,7 @@ fn undeclared_index_types_are_refused() {
     let dir = TempDir::with_prefix("update_only_struct_index").unwrap();
     write_config(dir.path(), vec![]);
 
-    let Err(err) = Index::open(MmapFs, dir.path()) else {
+    let Err(err) = Index::open(&MmapFs, dir.path()) else {
         panic!("a field with no declared index types must be refused");
     };
     assert!(

--- a/lib/segment/src/index/struct_payload_index/update_only/tests.rs
+++ b/lib/segment/src/index/struct_payload_index/update_only/tests.rs
@@ -76,6 +76,7 @@ fn batch_reaches_every_index_of_a_field() {
     let mut index = Index::open(MmapFs, dir.path()).unwrap();
     index
         .append_many(
+            &MmapFs,
             payloads.iter().enumerate().map(|(i, p)| (i as u32, p)),
             &hw_counter,
         )
@@ -129,7 +130,9 @@ fn batches_resume() {
     for (slot, value) in [(0, "alpha"), (1, "beta")] {
         let payload = payload_json! { "f": value };
         let mut index = Index::open(MmapFs, dir.path()).unwrap();
-        index.append_many([(slot, &payload)], &hw_counter).unwrap();
+        index
+            .append_many(&MmapFs, [(slot, &payload)], &hw_counter)
+            .unwrap();
     }
 
     let path = get_payload_index_path(dir.path());
@@ -170,7 +173,9 @@ fn segment_without_indexes_opens_empty() {
 
     let payload = payload_json! { "f": "alpha" };
     let mut index = Index::open(MmapFs, dir.path()).unwrap();
-    index.append_many([(0, &payload)], &hw_counter).unwrap();
+    index
+        .append_many(&MmapFs, [(0, &payload)], &hw_counter)
+        .unwrap();
 }
 
 /// A config that does not say which indexes a field has is refused: this writer

--- a/lib/segment/src/payload_storage/update_only/mod.rs
+++ b/lib/segment/src/payload_storage/update_only/mod.rs
@@ -35,7 +35,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyPayloadStorage<S> {
     /// its file format is not one this writer can append to.
     ///
     /// [1]: crate::payload_storage::payload_storage_impl::PayloadStorageImpl::open_or_create
-    pub fn open(fs: S::Fs, segment_path: &Path) -> OperationResult<Self> {
+    pub fn open(fs: &S::Fs, segment_path: &Path) -> OperationResult<Self> {
         let storage =
             UpdateOnlyBlobstore::open(fs, &storage_dir(segment_path), LogstoreConfig::DEFAULT)?;
 
@@ -54,6 +54,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyPayloadStorage<S> {
     /// an unwritten slot already reads back as an empty payload.
     pub fn append_many<'a>(
         &mut self,
+        fs: &S::Fs,
         payloads: impl IntoIterator<Item = (PointOffsetType, &'a Payload)>,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
@@ -63,6 +64,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyPayloadStorage<S> {
             }
 
             self.storage.put(
+                fs,
                 internal_id,
                 payload,
                 hw_counter.ref_payload_io_write_counter(),

--- a/lib/segment/src/payload_storage/update_only/tests.rs
+++ b/lib/segment/src/payload_storage/update_only/tests.rs
@@ -46,9 +46,10 @@ fn batches_are_durable_and_resume() {
     let hw_counter = HardwareCounterCell::new();
 
     let first: Vec<Payload> = (0..3).map(payload).collect();
-    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path()).unwrap();
     writer
         .append_many(
+            &MmapFs,
             first.iter().enumerate().map(|(i, p)| (i as u32, p)),
             &hw_counter,
         )
@@ -58,9 +59,10 @@ fn batches_are_durable_and_resume() {
     assert_eq!(read_back(dir.path(), 0..3), first);
 
     let second: Vec<Payload> = (10..13).map(payload).collect();
-    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path()).unwrap();
     writer
         .append_many(
+            &MmapFs,
             second.iter().enumerate().map(|(i, p)| (i as u32 + 3, p)),
             &hw_counter,
         )
@@ -81,9 +83,10 @@ fn empty_payloads_and_gaps_read_back_empty() {
     let hw_counter = HardwareCounterCell::new();
 
     let empty = Payload::default();
-    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path()).unwrap();
     writer
         .append_many(
+            &MmapFs,
             [(0, &payload(0)), (1, &empty), (4, &payload(4))],
             &hw_counter,
         )
@@ -110,9 +113,9 @@ fn first_payload_may_land_on_a_high_slot() {
     let dir = TempDir::with_prefix("update_only_payload").unwrap();
     let hw_counter = HardwareCounterCell::new();
 
-    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path()).unwrap();
     writer
-        .append_many([(1_000, &payload(1_000))], &hw_counter)
+        .append_many(&MmapFs, [(1_000, &payload(1_000))], &hw_counter)
         .unwrap();
     drop(writer);
 
@@ -129,22 +132,26 @@ fn rewriting_a_slot_is_rejected() {
     let dir = TempDir::with_prefix("update_only_payload").unwrap();
     let hw_counter = HardwareCounterCell::new();
 
-    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path()).unwrap();
     writer
-        .append_many([(0, &payload(0)), (1, &payload(1))], &hw_counter)
+        .append_many(&MmapFs, [(0, &payload(0)), (1, &payload(1))], &hw_counter)
         .unwrap();
 
     // Out of order within a batch
     assert!(
         writer
-            .append_many([(3, &payload(3)), (2, &payload(2))], &hw_counter)
+            .append_many(&MmapFs, [(3, &payload(3)), (2, &payload(2))], &hw_counter)
             .is_err(),
     );
     drop(writer);
 
     // And a slot a previous writer already used
-    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
-    assert!(writer.append_many([(0, &payload(0))], &hw_counter).is_err());
+    let mut writer = Writer::open(&MmapFs, dir.path()).unwrap();
+    assert!(
+        writer
+            .append_many(&MmapFs, [(0, &payload(0))], &hw_counter)
+            .is_err()
+    );
 }
 
 /// A payload storage created in mutable mode is refused rather than opened.
@@ -156,5 +163,5 @@ fn mutable_storage_is_refused() {
         PayloadStorageImpl::open_or_create(dir.path().to_path_buf(), false).unwrap();
     drop(storage);
 
-    assert!(Writer::open(MmapFs, dir.path()).is_err());
+    assert!(Writer::open(&MmapFs, dir.path()).is_err());
 }

--- a/lib/segment/src/segment/update_only/appendable/mod.rs
+++ b/lib/segment/src/segment/update_only/appendable/mod.rs
@@ -40,6 +40,8 @@ pub struct AppendableSegment<S: UniversalAppend + 'static> {
 /// point is not here: it belongs to the segment itself, since deletes need it
 /// too.
 struct StoreComponents<S: UniversalAppend + 'static> {
+    /// What the components write through, passed down per call.
+    fs: S::Fs,
     payload_storage: UpdateOnlyPayloadStorage<S>,
     payload_indexes: UpdateOnlyStructPayloadIndex<S>,
     /// One writer per named vector, dense and sparse alike.
@@ -54,8 +56,8 @@ struct StoreComponents<S: UniversalAppend + 'static> {
 }
 
 impl<S: UniversalAppend + 'static> StoreComponents<S> {
-    fn open(fs: &S::Fs, segment_path: &Path, config: &SegmentConfig) -> OperationResult<Self> {
-        let payload_storage = UpdateOnlyPayloadStorage::open(fs.clone(), segment_path)?;
+    fn open(fs: S::Fs, segment_path: &Path, config: &SegmentConfig) -> OperationResult<Self> {
+        let payload_storage = UpdateOnlyPayloadStorage::open(&fs, segment_path)?;
         let payload_indexes = UpdateOnlyStructPayloadIndex::open(fs.clone(), segment_path)?;
 
         let mut vector_storages =
@@ -79,6 +81,7 @@ impl<S: UniversalAppend + 'static> StoreComponents<S> {
         }
 
         Ok(Self {
+            fs,
             payload_storage,
             payload_indexes,
             vector_storages,
@@ -126,7 +129,7 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
     fn store_components(&mut self) -> OperationResult<&mut StoreComponents<S>> {
         if self.store.is_none() {
             self.store = Some(StoreComponents::open(
-                &self.fs,
+                self.fs.clone(),
                 &self.segment_path,
                 &self.config,
             )?);
@@ -184,7 +187,7 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
                     }
                 })
                 .collect();
-            storage.append_many(start_slot, vectors.iter().copied(), hw_counter)?;
+            storage.append_many(&store.fs, start_slot, vectors.iter().copied(), hw_counter)?;
 
             // The quantized storage takes the same run, row-for-row with the raw storage.
             if let Some(quantized) = store.quantized_vectors.get_mut(vector_name) {
@@ -200,10 +203,10 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
         };
         store
             .payload_storage
-            .append_many(slot_payloads(), hw_counter)?;
+            .append_many(&store.fs, slot_payloads(), hw_counter)?;
         store
             .payload_indexes
-            .append_many(slot_payloads(), hw_counter)?;
+            .append_many(&store.fs, slot_payloads(), hw_counter)?;
 
         // Publish: covering the slots with their versions is what makes the
         // points visible, so everything above must already be durable.

--- a/lib/segment/src/segment/update_only/appendable/mod.rs
+++ b/lib/segment/src/segment/update_only/appendable/mod.rs
@@ -24,8 +24,9 @@ use crate::vector_storage::update_only::{UpdateOnlyVectorStorage, VectorToStore}
 /// A segment open for appends: the write target. Every point a batch stores
 /// lands here, in a fresh slot — nothing is ever rewritten in place.
 pub struct AppendableSegment<S: UniversalAppend + 'static> {
-    id_tracker: UpdateOnlyAppendableIdTracker<S>,
-    /// What [`store_components`](Self::store_components) opens with.
+    id_tracker: UpdateOnlyAppendableIdTracker,
+    /// What the id tracker appends through and
+    /// [`store_components`](Self::store_components) opens with.
     fs: S::Fs,
     segment_path: PathBuf,
     config: SegmentConfig,
@@ -106,7 +107,7 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
         } = state;
 
         let id_tracker = UpdateOnlyAppendableIdTracker::new(
-            fs.clone(),
+            &fs,
             segment_path,
             max_claimed_internal_id,
             pending_inserts,
@@ -157,7 +158,7 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
             .iter()
             .map(|point| MappingOperation::Insert(point.id))
             .collect();
-        let inserted = self.id_tracker.insert_operations(&operations)?;
+        let inserted = self.id_tracker.insert_operations(&self.fs, &operations)?;
         let (_, start_slot) = *inserted.first().expect("one slot per insert");
 
         let store = self.store_components()?;
@@ -208,7 +209,8 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
         // points visible, so everything above must already be durable.
         let slots: Vec<PointOffsetType> = inserted.iter().map(|(_, slot)| *slot).collect();
         let versions: Vec<SeqNumberType> = points.iter().map(|point| point.version).collect();
-        self.id_tracker.set_internal_versions(&slots, &versions)?;
+        self.id_tracker
+            .set_internal_versions(&self.fs, &slots, &versions)?;
 
         Ok(())
     }
@@ -225,7 +227,9 @@ impl<S: UniversalAppend + 'static> AppendableSegment<S> {
         &mut self,
         points: &[(PointIdType, PointOffsetType)],
     ) -> OperationResult<()> {
-        self.id_tracker
-            .delete_points(points.iter().map(|(point_id, _internal_id)| *point_id))
+        self.id_tracker.delete_points(
+            &self.fs,
+            points.iter().map(|(point_id, _internal_id)| *point_id),
+        )
     }
 }

--- a/lib/segment/src/segment/update_only/appendable/mod.rs
+++ b/lib/segment/src/segment/update_only/appendable/mod.rs
@@ -58,7 +58,7 @@ struct StoreComponents<S: UniversalAppend + 'static> {
 impl<S: UniversalAppend + 'static> StoreComponents<S> {
     fn open(fs: S::Fs, segment_path: &Path, config: &SegmentConfig) -> OperationResult<Self> {
         let payload_storage = UpdateOnlyPayloadStorage::open(&fs, segment_path)?;
-        let payload_indexes = UpdateOnlyStructPayloadIndex::open(fs.clone(), segment_path)?;
+        let payload_indexes = UpdateOnlyStructPayloadIndex::open(&fs, segment_path)?;
 
         let mut vector_storages =
             Vec::with_capacity(config.vector_data.len() + config.sparse_vector_data.len());
@@ -76,7 +76,7 @@ impl<S: UniversalAppend + 'static> StoreComponents<S> {
         }
         for vector_name in config.sparse_vector_data.keys() {
             let path = get_vector_storage_path(segment_path, vector_name);
-            let storage = UpdateOnlyVectorStorage::open_sparse(fs.clone(), &path)?;
+            let storage = UpdateOnlyVectorStorage::open_sparse(&fs, &path)?;
             vector_storages.push((vector_name.clone(), storage));
         }
 

--- a/lib/segment/src/segment/update_only/appendable/mod.rs
+++ b/lib/segment/src/segment/update_only/appendable/mod.rs
@@ -65,7 +65,7 @@ impl<S: UniversalAppend + 'static> StoreComponents<S> {
         let mut quantized_vectors = HashMap::new();
         for (vector_name, vector_config) in &config.vector_data {
             let path = get_vector_storage_path(segment_path, vector_name);
-            let storage = UpdateOnlyVectorStorage::open(fs.clone(), &path, vector_config)?;
+            let storage = UpdateOnlyVectorStorage::open(&fs, &path, vector_config)?;
             vector_storages.push((vector_name.clone(), storage));
 
             if let Some(quantized) =

--- a/lib/segment/src/vector_storage/chunked_vectors/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/read_only/mod.rs
@@ -65,8 +65,7 @@ mod tests {
         let dir = Builder::new().prefix("chunked_reload").tempdir().unwrap();
         let hw = HardwareCounterCell::disposable();
 
-        let mut writer =
-            UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, dir.path(), DIM).unwrap();
+        let mut writer = UpdateOnlyChunkedVectors::<f32>::open(&MmapFs, dir.path(), DIM).unwrap();
         append_range(&mut writer, 0, 0..100, DIM, &hw);
 
         let mut reader = ReadOnlyChunkedVectors::<f32, MmapFile>::open(
@@ -102,8 +101,7 @@ mod tests {
         let dir = Builder::new().prefix("chunked_preload").tempdir().unwrap();
         let hw = HardwareCounterCell::disposable();
 
-        let mut writer =
-            UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, dir.path(), DIM).unwrap();
+        let mut writer = UpdateOnlyChunkedVectors::<f32>::open(&MmapFs, dir.path(), DIM).unwrap();
         append_range(&mut writer, 0, 0..100, DIM, &hw);
 
         let mut reader = ReadOnlyChunkedVectors::<f32, MmapFile>::open(
@@ -148,8 +146,7 @@ mod tests {
         let dir = Builder::new().prefix("chunked_boundary").tempdir().unwrap();
         let hw = HardwareCounterCell::disposable();
 
-        let mut writer =
-            UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, dir.path(), DIM).unwrap();
+        let mut writer = UpdateOnlyChunkedVectors::<f32>::open(&MmapFs, dir.path(), DIM).unwrap();
         append_range(&mut writer, 0, 0..4096, DIM, &hw);
 
         let mut reader = ReadOnlyChunkedVectors::<f32, MmapFile>::open(
@@ -201,8 +198,7 @@ mod tests {
         let dir = Builder::new().prefix("chunked_shrink").tempdir().unwrap();
         let hw = HardwareCounterCell::disposable();
 
-        let mut writer =
-            UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, dir.path(), DIM).unwrap();
+        let mut writer = UpdateOnlyChunkedVectors::<f32>::open(&MmapFs, dir.path(), DIM).unwrap();
         append_range(&mut writer, 0, 0..100, DIM, &hw);
 
         // Crash leftover: a chunk file past the committed watermark.
@@ -269,8 +265,7 @@ mod tests {
 
         // The writer works on the "remote" directly; the reader mirrors it
         // into `local_root` through the disk cache.
-        let mut writer =
-            UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, &dir, DIM).unwrap();
+        let mut writer = UpdateOnlyChunkedVectors::<f32>::open(&MmapFs, &dir, DIM).unwrap();
         append_range(&mut writer, 0, 0..100, DIM, &hw);
 
         let cache_fs = DiskCacheFs::<MmapFile>::from_context(DiskCacheFsContext {
@@ -322,8 +317,7 @@ mod tests {
             .unwrap();
         let hw = HardwareCounterCell::disposable();
 
-        let mut writer =
-            UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, dir.path(), DIM).unwrap();
+        let mut writer = UpdateOnlyChunkedVectors::<f32>::open(&MmapFs, dir.path(), DIM).unwrap();
         append_range(&mut writer, 0, 0..4000, DIM, &hw);
 
         let mut reader = ReadOnlyChunkedVectors::<f32, MmapFile>::open(
@@ -370,8 +364,7 @@ mod tests {
             .unwrap();
         let hw = HardwareCounterCell::disposable();
 
-        let mut writer =
-            UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, dir.path(), DIM).unwrap();
+        let mut writer = UpdateOnlyChunkedVectors::<f32>::open(&MmapFs, dir.path(), DIM).unwrap();
         append_range(&mut writer, 0, 0..100, DIM, &hw);
 
         let mut reader = ReadOnlyChunkedVectors::<f32, MmapFile>::open(

--- a/lib/segment/src/vector_storage/chunked_vectors/test_utils.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/test_utils.rs
@@ -1,7 +1,7 @@
 //! Helpers shared by the `read_only` and `update_only` test modules.
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::universal_io::MmapFile;
+use common::universal_io::MmapFs;
 
 use super::update_only::UpdateOnlyChunkedVectors;
 use crate::vector_storage::VectorOffsetType;
@@ -12,7 +12,7 @@ pub(super) fn make_vec(seed: usize, dim: usize) -> Vec<f32> {
 
 /// Append one durable batch of `make_vec(seed)` vectors through the writer.
 pub(super) fn append_range(
-    writer: &mut UpdateOnlyChunkedVectors<f32, MmapFile>,
+    writer: &mut UpdateOnlyChunkedVectors<f32>,
     start_key: VectorOffsetType,
     seeds: std::ops::Range<usize>,
     dim: usize,
@@ -20,6 +20,11 @@ pub(super) fn append_range(
 ) {
     let batch: Vec<Vec<f32>> = seeds.map(|seed| make_vec(seed, dim)).collect();
     writer
-        .append_many(start_key, batch.iter().map(|vector| vector.as_slice()), hw)
+        .append_many(
+            &MmapFs,
+            start_key,
+            batch.iter().map(|vector| vector.as_slice()),
+            hw,
+        )
         .unwrap();
 }

--- a/lib/segment/src/vector_storage/chunked_vectors/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/update_only/mod.rs
@@ -7,8 +7,8 @@ use std::path::{Path, PathBuf};
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::mmap::AdviceSetting;
 use common::universal_io::{
-    OpenOptions, Populate, UniversalAppend, UniversalReadFileOps, UniversalReadFs,
-    UniversalWriteFileOps,
+    OpenOptions, Populate, UniversalAppend, UniversalFlush as _, UniversalRead as _,
+    UniversalReadFs, UniversalWriteFileOps,
 };
 
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -24,10 +24,9 @@ use crate::vector_storage::chunked_vectors::config::{
 /// touched chunks, appends, and persists the vector count, so a batch is
 /// durable when it returns and there is nothing to flush.
 #[derive(Debug)]
-pub struct UpdateOnlyChunkedVectors<T, S: UniversalAppend> {
+pub struct UpdateOnlyChunkedVectors<T> {
     directory: PathBuf,
     config: ChunkedVectorsConfig,
-    fs: S::Fs,
     _t: PhantomData<T>,
 }
 
@@ -41,13 +40,16 @@ fn append_options() -> OpenOptions {
     }
 }
 
-impl<T, S> UpdateOnlyChunkedVectors<T, S>
+impl<T> UpdateOnlyChunkedVectors<T>
 where
     T: bytemuck::Pod + Send,
-    S: UniversalAppend + 'static,
 {
     /// Open a chunked-vectors directory for appending, creating it if missing.
-    pub fn open(fs: S::Fs, directory: &Path, dim: usize) -> OperationResult<Self> {
+    pub fn open<Fs: UniversalReadFs + UniversalWriteFileOps>(
+        fs: &Fs,
+        directory: &Path,
+        dim: usize,
+    ) -> OperationResult<Self> {
         let status_path = status_file(directory);
         // An absent status file marks the first open. Writing it eagerly keeps
         // the directory readable even if no batch ever lands.
@@ -55,12 +57,11 @@ where
             fs.create_dir(directory)?;
             fs.atomic_save(&status_path, bytemuck::bytes_of(&Status { len: 0 }))?;
         }
-        let config = ensure_config::<T, _>(&fs, directory, dim, false)?;
+        let config = ensure_config::<T, _>(fs, directory, dim, false)?;
 
         Ok(Self {
             directory: directory.to_owned(),
             config,
-            fs,
             _t: PhantomData,
         })
     }
@@ -71,13 +72,13 @@ where
     ///
     /// Needed where a storage's rows are not indexed by point slot — the
     /// multivector ones — so a batch knows where the row space ends.
-    pub fn stored_len(&self) -> OperationResult<usize> {
-        Ok(read_status_len(&self.fs, &status_file(&self.directory))?)
+    pub fn stored_len<Fs: UniversalReadFs>(&self, fs: &Fs) -> OperationResult<usize> {
+        Ok(read_status_len(fs, &status_file(&self.directory))?)
     }
 
     /// Replace the stored vector count.
-    fn save_len(&self, len: usize) -> OperationResult<()> {
-        self.fs.atomic_save(
+    fn save_len<Fs: UniversalWriteFileOps>(&self, fs: &Fs, len: usize) -> OperationResult<()> {
+        fs.atomic_save(
             &status_file(&self.directory),
             bytemuck::bytes_of(&Status { len }),
         )?;
@@ -87,11 +88,14 @@ where
     /// Compare every chunk file's length against an external total length.
     ///
     /// Ensures every file is at the expected length by truncating or filling with zeroes.
-    fn ensure_chunk_lengths(&self, target_len: usize) -> OperationResult<()> {
+    fn ensure_chunk_lengths<Fs>(&self, fs: &Fs, target_len: usize) -> OperationResult<()>
+    where
+        Fs: UniversalReadFs<File: UniversalAppend> + UniversalWriteFileOps,
+    {
         let total_bytes = target_len * self.config.dim * size_of::<T>();
         let num_chunks = target_len.div_ceil(self.config.chunk_size_vectors);
 
-        let mut listed = list_chunk_files(&self.fs, &self.directory)?;
+        let mut listed = list_chunk_files(fs, &self.directory)?;
 
         for chunk_id in 0..num_chunks {
             let expected = self
@@ -111,15 +115,14 @@ where
                                 "Expected larger chunk, filling chunk {chunk_id} with zeroes"
                             );
                             let data = vec![0u8; (expected - file_info.size) as usize];
-                            let mut file =
-                                self.fs.open_append(&file_info.path, append_options())?;
+                            let mut file = fs.open_append(&file_info.path, append_options())?;
                             file.append(file_info.size, &data)?;
                             file.flusher()()?;
                         }
                         std::cmp::Ordering::Greater => {
                             // truncate
                             log::warn!("Expected smaller chunk, truncating chunk {chunk_id}");
-                            let file = self.fs.open_append(&file_info.path, append_options())?;
+                            let file = fs.open_append(&file_info.path, append_options())?;
                             let content = file.read_whole::<u8>()?;
                             let Some(truncated) = content.get(..expected as usize) else {
                                 return Err(OperationError::service_error(format!(
@@ -130,7 +133,7 @@ where
                             };
                             let truncated = truncated.to_vec();
                             drop(file);
-                            self.fs.atomic_save(&file_info.path, &truncated)?;
+                            fs.atomic_save(&file_info.path, &truncated)?;
                         }
                     }
                 }
@@ -139,7 +142,7 @@ where
                     log::warn!(
                         "Expected non-existing chunk {chunk_id}, creating and filling with zeroes"
                     );
-                    let mut file = self.open_chunk_for_append(chunk_id, true)?;
+                    let mut file = self.open_chunk_for_append(fs, chunk_id, true)?;
                     file.append(0, &vec![0u8; expected as usize])?;
                     file.flusher()()?;
                 }
@@ -152,10 +155,10 @@ where
                 "Chunk {chunk_id} past the target vector count ({} bytes). Removing.",
                 file.size,
             );
-            self.fs.remove(&file.path)?;
+            fs.remove(&file.path)?;
         }
 
-        self.save_len(target_len)?;
+        self.save_len(fs, target_len)?;
 
         Ok(())
     }
@@ -168,8 +171,9 @@ where
     /// match the argument
     // Takes &mut self to enforce the single-writer contract the appends rest on
     #[allow(clippy::needless_pass_by_ref_mut)]
-    pub fn append_many<'a, I>(
+    pub fn append_many<'a, I, Fs>(
         &mut self,
+        fs: &Fs,
         start_key: VectorOffsetType,
         vectors: I,
         hw_counter: &HardwareCounterCell,
@@ -177,8 +181,9 @@ where
     where
         I: IntoIterator<Item = &'a [T]>,
         I::IntoIter: ExactSizeIterator,
+        Fs: UniversalReadFs<File: UniversalAppend> + UniversalWriteFileOps,
     {
-        self.ensure_chunk_lengths(start_key)?;
+        self.ensure_chunk_lengths(fs, start_key)?;
 
         let mut vectors = vectors.into_iter();
         let count = vectors.len();
@@ -196,7 +201,8 @@ where
             }
             let batch_bytes = batch.len() * self.config.dim * size_of::<T>();
 
-            let mut chunk = self.open_chunk_for_append(part.chunk_idx, part.element_offset == 0)?;
+            let mut chunk =
+                self.open_chunk_for_append(fs, part.chunk_idx, part.element_offset == 0)?;
             chunk.append_batch(
                 (part.element_offset * size_of::<T>()) as u64,
                 batch.iter().copied(),
@@ -208,18 +214,26 @@ where
         }
 
         // Persist the watermark only after the data landed
-        self.save_len(start_key + count)?;
+        self.save_len(fs, start_key + count)?;
 
         Ok(())
     }
 
     /// Open the chunk for appending; a `new` chunk is past the watermark, so
     /// it is created, truncating any leftover from a crashed writer.
-    fn open_chunk_for_append(&self, chunk_idx: usize, new: bool) -> OperationResult<S> {
+    fn open_chunk_for_append<Fs>(
+        &self,
+        fs: &Fs,
+        chunk_idx: usize,
+        new: bool,
+    ) -> OperationResult<Fs::File>
+    where
+        Fs: UniversalReadFs<File: UniversalAppend> + UniversalWriteFileOps,
+    {
         let path = chunk_name(&self.directory, chunk_idx);
         if new {
-            self.fs.create(&path, 0)?;
+            fs.create(&path, 0)?;
         }
-        Ok(self.fs.open(&path, append_options(), Default::default())?)
+        Ok(fs.open(&path, append_options(), Default::default())?)
     }
 }

--- a/lib/segment/src/vector_storage/chunked_vectors/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/chunked_vectors/update_only/tests.rs
@@ -39,8 +39,7 @@ fn write_both() -> (TempDir, TempDir) {
 
     for range in [0..COUNT / 2, COUNT / 2..COUNT] {
         let mut writer =
-            UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, appended_dir.path(), DIM)
-                .unwrap();
+            UpdateOnlyChunkedVectors::<f32>::open(&MmapFs, appended_dir.path(), DIM).unwrap();
         append_range(&mut writer, range.start, range, DIM, &hw);
     }
 
@@ -147,8 +146,7 @@ fn repairs_preallocated_chunks() {
         "chunk must be preallocated past the single stored vector",
     );
 
-    let mut writer =
-        UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, dir.path(), DIM).unwrap();
+    let mut writer = UpdateOnlyChunkedVectors::<f32>::open(&MmapFs, dir.path(), DIM).unwrap();
 
     // Appends continue after it
     append_range(&mut writer, 1, 1..3, DIM, &hw);
@@ -187,8 +185,7 @@ fn replaying_an_already_applied_range_overwrites_it() {
     let hw = HardwareCounterCell::disposable();
     let dir = Builder::new().prefix("chunked_replay").tempdir().unwrap();
 
-    let mut writer =
-        UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, dir.path(), DIM).unwrap();
+    let mut writer = UpdateOnlyChunkedVectors::<f32>::open(&MmapFs, dir.path(), DIM).unwrap();
     append_range(&mut writer, 0, 0..100, DIM, &hw);
 
     // Replay offsets 50..100 with different vectors than landed the first
@@ -236,8 +233,7 @@ fn extends_across_a_gap_with_zeroes() {
     let hw = HardwareCounterCell::disposable();
     let dir = Builder::new().prefix("chunked_gap").tempdir().unwrap();
 
-    let mut writer =
-        UpdateOnlyChunkedVectors::<f32, MmapFile>::open(MmapFs, dir.path(), DIM).unwrap();
+    let mut writer = UpdateOnlyChunkedVectors::<f32>::open(&MmapFs, dir.path(), DIM).unwrap();
     append_range(&mut writer, 0, 0..10, DIM, &hw);
     // Offsets 10..15 are skipped; the next batch picks up at 15.
     append_range(&mut writer, 15, 15..20, DIM, &hw);

--- a/lib/segment/src/vector_storage/dense/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/dense/update_only/mod.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalAppend;
+use common::universal_io::{UniversalAppend, UniversalReadFs, UniversalWriteFileOps};
 
 use super::appendable_dense_vector_storage::{DELETED_DIR_PATH, VECTORS_DIR_PATH};
 use crate::common::flags::update_only_stored_flags::UpdateOnlyStoredFlags;
@@ -21,18 +21,22 @@ use crate::vector_storage::update_only::VectorToStore;
 /// the flags marking which slots hold no vector of their own.
 ///
 /// [`AppendableMmapDenseVectorStorage`]: super::appendable_dense_vector_storage::AppendableMmapDenseVectorStorage
-pub struct UpdateOnlyDenseVectorStorage<T: PrimitiveVectorElement, S: UniversalAppend + 'static> {
-    vectors: UpdateOnlyChunkedVectors<T, S>,
+pub struct UpdateOnlyDenseVectorStorage<T: PrimitiveVectorElement> {
+    vectors: UpdateOnlyChunkedVectors<T>,
     deleted: UpdateOnlyStoredFlags,
     dim: usize,
 }
 
-impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static> UpdateOnlyDenseVectorStorage<T, S> {
+impl<T: PrimitiveVectorElement> UpdateOnlyDenseVectorStorage<T> {
     /// Open the storage at `path` for appending, creating it if it is not there
     /// yet.
-    pub fn open(fs: S::Fs, path: &Path, dim: usize) -> OperationResult<Self> {
+    pub fn open<Fs: UniversalReadFs + UniversalWriteFileOps>(
+        fs: &Fs,
+        path: &Path,
+        dim: usize,
+    ) -> OperationResult<Self> {
         Ok(Self {
-            deleted: UpdateOnlyStoredFlags::open(&fs, &path.join(DELETED_DIR_PATH))?,
+            deleted: UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIR_PATH))?,
             vectors: UpdateOnlyChunkedVectors::open(fs, &path.join(VECTORS_DIR_PATH), dim)?,
             dim,
         })
@@ -44,9 +48,9 @@ impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static> UpdateOnlyDenseVec
     /// Slots are consecutive from `start_slot`: every point of the batch takes
     /// one, whether or not it has a vector here. `start_slot` must be the slot
     /// this storage ends at, since the vectors are stored positionally.
-    pub fn append_many<'a>(
+    pub fn append_many<'a, Fs: UniversalReadFs<File: UniversalAppend> + UniversalWriteFileOps>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         start_slot: PointOffsetType,
         vectors: impl IntoIterator<Item = VectorToStore<'a>>,
         hw_counter: &HardwareCounterCell,
@@ -82,6 +86,7 @@ impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static> UpdateOnlyDenseVec
         }
 
         self.vectors.append_many(
+            fs,
             start_slot as VectorOffsetType,
             run.iter().map(Vec::as_slice),
             hw_counter,

--- a/lib/segment/src/vector_storage/dense/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/dense/update_only/mod.rs
@@ -23,7 +23,7 @@ use crate::vector_storage::update_only::VectorToStore;
 /// [`AppendableMmapDenseVectorStorage`]: super::appendable_dense_vector_storage::AppendableMmapDenseVectorStorage
 pub struct UpdateOnlyDenseVectorStorage<T: PrimitiveVectorElement, S: UniversalAppend + 'static> {
     vectors: UpdateOnlyChunkedVectors<T, S>,
-    deleted: UpdateOnlyStoredFlags<S>,
+    deleted: UpdateOnlyStoredFlags,
     dim: usize,
 }
 
@@ -32,8 +32,8 @@ impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static> UpdateOnlyDenseVec
     /// yet.
     pub fn open(fs: S::Fs, path: &Path, dim: usize) -> OperationResult<Self> {
         Ok(Self {
-            vectors: UpdateOnlyChunkedVectors::open(fs.clone(), &path.join(VECTORS_DIR_PATH), dim)?,
-            deleted: UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIR_PATH))?,
+            deleted: UpdateOnlyStoredFlags::open(&fs, &path.join(DELETED_DIR_PATH))?,
+            vectors: UpdateOnlyChunkedVectors::open(fs, &path.join(VECTORS_DIR_PATH), dim)?,
             dim,
         })
     }
@@ -46,6 +46,7 @@ impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static> UpdateOnlyDenseVec
     /// this storage ends at, since the vectors are stored positionally.
     pub fn append_many<'a>(
         &mut self,
+        fs: &S::Fs,
         start_slot: PointOffsetType,
         vectors: impl IntoIterator<Item = VectorToStore<'a>>,
         hw_counter: &HardwareCounterCell,
@@ -94,7 +95,7 @@ impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static> UpdateOnlyDenseVec
             self.deleted.set(slot, true);
         }
 
-        self.deleted.flush(hw_counter)
+        self.deleted.flush(fs, hw_counter)
     }
 
     /// Storage-native bytes are a packed `[T]` of exactly one vector, the form

--- a/lib/segment/src/vector_storage/dense/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/dense/update_only/tests.rs
@@ -4,7 +4,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::mmap::AdviceSetting;
-use common::universal_io::{MmapFile, MmapFs};
+use common::universal_io::MmapFs;
 use tempfile::TempDir;
 
 use super::UpdateOnlyDenseVectorStorage;
@@ -14,7 +14,7 @@ use crate::vector_storage::dense::appendable_dense_vector_storage::open_appendab
 use crate::vector_storage::update_only::VectorToStore;
 use crate::vector_storage::{DenseVectorStorageRead, VectorStorageRead};
 
-type Writer = UpdateOnlyDenseVectorStorage<VectorElementType, MmapFile>;
+type Writer = UpdateOnlyDenseVectorStorage<VectorElementType>;
 
 const DIM: usize = 4;
 
@@ -41,7 +41,7 @@ fn decoded_vectors_round_trip() {
         vec![9.0, 10.0, 11.0, 12.0],
     ];
 
-    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
             &MmapFs,
@@ -73,7 +73,7 @@ fn missing_vectors_take_their_slot_and_are_flagged() {
     let hw_counter = HardwareCounterCell::new();
 
     let present = vec![1.0, 2.0, 3.0, 4.0];
-    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
             &MmapFs,
@@ -109,7 +109,7 @@ fn raw_bytes_round_trip() {
     let vector: Vec<VectorElementType> = vec![1.5, 2.5, 3.5, 4.5];
     let bytes = bytemuck::cast_slice(&vector).to_vec();
 
-    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(&MmapFs, 0, [VectorToStore::Raw(&bytes)], &hw_counter)
         .unwrap();
@@ -128,7 +128,7 @@ fn batches_resume() {
     let first = vec![1.0, 1.0, 1.0, 1.0];
     let second = vec![2.0, 2.0, 2.0, 2.0];
 
-    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
             &MmapFs,
@@ -139,7 +139,7 @@ fn batches_resume() {
         .unwrap();
     drop(writer);
 
-    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
             &MmapFs,
@@ -163,7 +163,7 @@ fn malformed_raw_bytes_are_rejected() {
     let dir = TempDir::with_prefix("update_only_dense").unwrap();
     let hw_counter = HardwareCounterCell::new();
 
-    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path(), DIM).unwrap();
     let err = writer
         .append_many(&MmapFs, 0, [VectorToStore::Raw(&[1, 2, 3])], &hw_counter)
         .unwrap_err();

--- a/lib/segment/src/vector_storage/dense/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/dense/update_only/tests.rs
@@ -44,6 +44,7 @@ fn decoded_vectors_round_trip() {
     let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
+            &MmapFs,
             0,
             vectors
                 .iter()
@@ -75,6 +76,7 @@ fn missing_vectors_take_their_slot_and_are_flagged() {
     let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
+            &MmapFs,
             0,
             [
                 VectorToStore::Decoded(VectorRef::from(present.as_slice())),
@@ -109,7 +111,7 @@ fn raw_bytes_round_trip() {
 
     let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
     writer
-        .append_many(0, [VectorToStore::Raw(&bytes)], &hw_counter)
+        .append_many(&MmapFs, 0, [VectorToStore::Raw(&bytes)], &hw_counter)
         .unwrap();
     drop(writer);
 
@@ -129,6 +131,7 @@ fn batches_resume() {
     let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
+            &MmapFs,
             0,
             [VectorToStore::Decoded(VectorRef::from(first.as_slice()))],
             &hw_counter,
@@ -139,6 +142,7 @@ fn batches_resume() {
     let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
+            &MmapFs,
             1,
             [VectorToStore::Decoded(VectorRef::from(second.as_slice()))],
             &hw_counter,
@@ -161,7 +165,7 @@ fn malformed_raw_bytes_are_rejected() {
 
     let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
     let err = writer
-        .append_many(0, [VectorToStore::Raw(&[1, 2, 3])], &hw_counter)
+        .append_many(&MmapFs, 0, [VectorToStore::Raw(&[1, 2, 3])], &hw_counter)
         .unwrap_err();
     assert!(
         format!("{err}").contains("Malformed dense vector blob"),

--- a/lib/segment/src/vector_storage/multi_dense/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/update_only/mod.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalAppend;
+use common::universal_io::{UniversalAppend, UniversalReadFs, UniversalWriteFileOps};
 
 use super::appendable_mmap_multi_dense_vector_storage::{
     DELETED_DIR_PATH, MultivectorMmapOffset, OFFSETS_DIR_PATH, VECTORS_DIR_PATH,
@@ -26,32 +26,30 @@ use crate::vector_storage::update_only::VectorToStore;
 /// point owns a run of them — so this writer tracks where the row space ends.
 ///
 /// [`AppendableMmapMultiDenseVectorStorage`]: super::appendable_mmap_multi_dense_vector_storage::AppendableMmapMultiDenseVectorStorage
-pub struct UpdateOnlyMultiDenseVectorStorage<
-    T: PrimitiveVectorElement,
-    S: UniversalAppend + 'static,
-> {
+pub struct UpdateOnlyMultiDenseVectorStorage<T: PrimitiveVectorElement> {
     /// Flat inner-vector space: one row per inner vector.
-    vectors: UpdateOnlyChunkedVectors<T, S>,
+    vectors: UpdateOnlyChunkedVectors<T>,
     /// Maps each point slot to its row range.
-    offsets: UpdateOnlyChunkedVectors<MultivectorMmapOffset, S>,
+    offsets: UpdateOnlyChunkedVectors<MultivectorMmapOffset>,
     deleted: UpdateOnlyStoredFlags,
     dim: usize,
     /// One past the last row in use, carried across the batch.
     next_row: usize,
 }
 
-impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static>
-    UpdateOnlyMultiDenseVectorStorage<T, S>
-{
+impl<T: PrimitiveVectorElement> UpdateOnlyMultiDenseVectorStorage<T> {
     /// Open the storage at `path` for appending, creating it if it is not there
     /// yet.
-    pub fn open(fs: S::Fs, path: &Path, dim: usize) -> OperationResult<Self> {
-        let deleted = UpdateOnlyStoredFlags::open(&fs, &path.join(DELETED_DIR_PATH))?;
-        let vectors =
-            UpdateOnlyChunkedVectors::open(fs.clone(), &path.join(VECTORS_DIR_PATH), dim)?;
+    pub fn open<Fs: UniversalReadFs + UniversalWriteFileOps>(
+        fs: &Fs,
+        path: &Path,
+        dim: usize,
+    ) -> OperationResult<Self> {
+        let deleted = UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIR_PATH))?;
+        let vectors = UpdateOnlyChunkedVectors::open(fs, &path.join(VECTORS_DIR_PATH), dim)?;
         // One offset entry per point, so the "vector" is a single element.
         let offsets = UpdateOnlyChunkedVectors::open(fs, &path.join(OFFSETS_DIR_PATH), 1)?;
-        let next_row = vectors.stored_len()?;
+        let next_row = vectors.stored_len(fs)?;
 
         Ok(Self {
             vectors,
@@ -64,9 +62,9 @@ impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static>
 
     /// Append one multi-vector per point of a batch, starting at `start_slot`,
     /// and persist them.
-    pub fn append_many<'a>(
+    pub fn append_many<'a, Fs: UniversalReadFs<File: UniversalAppend> + UniversalWriteFileOps>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         start_slot: PointOffsetType,
         vectors: impl IntoIterator<Item = VectorToStore<'a>>,
         hw_counter: &HardwareCounterCell,
@@ -100,12 +98,14 @@ impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static>
         }
 
         self.vectors.append_many(
+            fs,
             batch_start as VectorOffsetType,
             rows.chunks_exact(self.dim),
             hw_counter,
         )?;
 
         self.offsets.append_many(
+            fs,
             start_slot as VectorOffsetType,
             offsets.iter().map(std::slice::from_ref),
             hw_counter,

--- a/lib/segment/src/vector_storage/multi_dense/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/multi_dense/update_only/mod.rs
@@ -34,7 +34,7 @@ pub struct UpdateOnlyMultiDenseVectorStorage<
     vectors: UpdateOnlyChunkedVectors<T, S>,
     /// Maps each point slot to its row range.
     offsets: UpdateOnlyChunkedVectors<MultivectorMmapOffset, S>,
-    deleted: UpdateOnlyStoredFlags<S>,
+    deleted: UpdateOnlyStoredFlags,
     dim: usize,
     /// One past the last row in use, carried across the batch.
     next_row: usize,
@@ -46,11 +46,11 @@ impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static>
     /// Open the storage at `path` for appending, creating it if it is not there
     /// yet.
     pub fn open(fs: S::Fs, path: &Path, dim: usize) -> OperationResult<Self> {
+        let deleted = UpdateOnlyStoredFlags::open(&fs, &path.join(DELETED_DIR_PATH))?;
         let vectors =
             UpdateOnlyChunkedVectors::open(fs.clone(), &path.join(VECTORS_DIR_PATH), dim)?;
         // One offset entry per point, so the "vector" is a single element.
-        let offsets = UpdateOnlyChunkedVectors::open(fs.clone(), &path.join(OFFSETS_DIR_PATH), 1)?;
-        let deleted = UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIR_PATH))?;
+        let offsets = UpdateOnlyChunkedVectors::open(fs, &path.join(OFFSETS_DIR_PATH), 1)?;
         let next_row = vectors.stored_len()?;
 
         Ok(Self {
@@ -66,6 +66,7 @@ impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static>
     /// and persist them.
     pub fn append_many<'a>(
         &mut self,
+        fs: &S::Fs,
         start_slot: PointOffsetType,
         vectors: impl IntoIterator<Item = VectorToStore<'a>>,
         hw_counter: &HardwareCounterCell,
@@ -114,7 +115,7 @@ impl<T: PrimitiveVectorElement, S: UniversalAppend + 'static>
             self.deleted.set(slot, true);
         }
 
-        self.deleted.flush(hw_counter)
+        self.deleted.flush(fs, hw_counter)
     }
 
     fn flatten_decoded(&self, vector: VectorRef<'_>) -> OperationResult<Vec<T>> {

--- a/lib/segment/src/vector_storage/multi_dense/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/multi_dense/update_only/tests.rs
@@ -63,6 +63,7 @@ fn multi_vectors_round_trip() {
     let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
+            &MmapFs,
             0,
             [
                 VectorToStore::Decoded(VectorRef::from(&first)),
@@ -89,6 +90,7 @@ fn missing_multi_vectors_own_no_rows() {
     let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
+            &MmapFs,
             0,
             [
                 VectorToStore::Missing,
@@ -122,6 +124,7 @@ fn batches_resume_at_the_row_space_end() {
     let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
+            &MmapFs,
             0,
             [VectorToStore::Decoded(VectorRef::from(&first))],
             &hw_counter,
@@ -132,6 +135,7 @@ fn batches_resume_at_the_row_space_end() {
     let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
+            &MmapFs,
             1,
             [VectorToStore::Decoded(VectorRef::from(&second))],
             &hw_counter,
@@ -160,11 +164,11 @@ fn raw_multi_bytes_round_trip() {
 
     let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
     writer
-        .append_many(0, [VectorToStore::Raw(&bytes)], &hw_counter)
+        .append_many(&MmapFs, 0, [VectorToStore::Raw(&bytes)], &hw_counter)
         .unwrap();
 
     let err = writer
-        .append_many(1, [VectorToStore::Raw(&bytes[..5])], &hw_counter)
+        .append_many(&MmapFs, 1, [VectorToStore::Raw(&bytes[..5])], &hw_counter)
         .unwrap_err();
     assert!(
         format!("{err}").contains("Malformed multi vector blob"),

--- a/lib/segment/src/vector_storage/multi_dense/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/multi_dense/update_only/tests.rs
@@ -4,7 +4,7 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::mmap::AdviceSetting;
-use common::universal_io::{MmapFile, MmapFs};
+use common::universal_io::MmapFs;
 use tempfile::TempDir;
 
 use super::UpdateOnlyMultiDenseVectorStorage;
@@ -14,7 +14,7 @@ use crate::vector_storage::multi_dense::appendable_mmap_multi_dense_vector_stora
 use crate::vector_storage::update_only::VectorToStore;
 use crate::vector_storage::{MultiVectorStorageRead, VectorStorageRead};
 
-type Writer = UpdateOnlyMultiDenseVectorStorage<VectorElementType, MmapFile>;
+type Writer = UpdateOnlyMultiDenseVectorStorage<VectorElementType>;
 
 const DIM: usize = 2;
 
@@ -60,7 +60,7 @@ fn multi_vectors_round_trip() {
     let first = multi(&[[1.0, 2.0], [3.0, 4.0]]);
     let second = multi(&[[5.0, 6.0]]);
 
-    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
             &MmapFs,
@@ -87,7 +87,7 @@ fn missing_multi_vectors_own_no_rows() {
     let hw_counter = HardwareCounterCell::new();
 
     let present = multi(&[[1.0, 2.0]]);
-    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
             &MmapFs,
@@ -121,7 +121,7 @@ fn batches_resume_at_the_row_space_end() {
     let first = multi(&[[1.0, 1.0], [2.0, 2.0]]);
     let second = multi(&[[3.0, 3.0]]);
 
-    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
             &MmapFs,
@@ -132,7 +132,7 @@ fn batches_resume_at_the_row_space_end() {
         .unwrap();
     drop(writer);
 
-    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(
             &MmapFs,
@@ -162,7 +162,7 @@ fn raw_multi_bytes_round_trip() {
     let flattened: Vec<VectorElementType> = vec![1.0, 2.0, 3.0, 4.0];
     let bytes = bytemuck::cast_slice(&flattened).to_vec();
 
-    let mut writer = Writer::open(MmapFs, dir.path(), DIM).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path(), DIM).unwrap();
     writer
         .append_many(&MmapFs, 0, [VectorToStore::Raw(&bytes)], &hw_counter)
         .unwrap();

--- a/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/update_only.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_chunked_mmap_storage/update_only.rs
@@ -32,13 +32,17 @@ use crate::vector_storage::chunked_vectors::update_only::UpdateOnlyChunkedVector
 ///
 /// [`UpdateOnlyDenseVectorStorage`]: crate::vector_storage::dense::update_only::UpdateOnlyDenseVectorStorage
 pub struct UpdateOnlyQuantizedChunkedStorage<S: UniversalAppend + 'static> {
-    vectors: UpdateOnlyChunkedVectors<u8, S>,
+    vectors: UpdateOnlyChunkedVectors<u8>,
+    /// Owned rather than passed down: [`EncodedStorageWrite`] cannot carry a
+    /// filesystem per call.
+    fs: S::Fs,
 }
 
 impl<S: UniversalAppend + 'static> UpdateOnlyQuantizedChunkedStorage<S> {
     pub fn open(fs: S::Fs, path: &Path, quantized_vector_size: usize) -> OperationResult<Self> {
         Ok(Self {
-            vectors: UpdateOnlyChunkedVectors::open(fs, path, quantized_vector_size)?,
+            vectors: UpdateOnlyChunkedVectors::open(&fs, path, quantized_vector_size)?,
+            fs,
         })
     }
 }
@@ -75,12 +79,12 @@ impl<S: UniversalAppend + 'static> EncodedStorageWrite for UpdateOnlyQuantizedCh
         // `id` is always the current end of the storage — a genuine append, matching what
         // `UpdateOnlyChunkedVectors::append_many` requires of `start_key`.
         self.vectors
-            .append_many(start_id as VectorOffsetType, vectors, hw_counter)
+            .append_many(&self.fs, start_id as VectorOffsetType, vectors, hw_counter)
             .map_err(std::io::Error::other)
     }
 
     fn vectors_count(&self) -> usize {
-        self.vectors.stored_len().unwrap_or(0)
+        self.vectors.stored_len(&self.fs).unwrap_or(0)
     }
 
     fn flusher(&self) -> Flusher {

--- a/lib/segment/src/vector_storage/sparse/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/sparse/update_only/mod.rs
@@ -39,11 +39,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlySparseVectorStorage<S> {
     /// yet.
     pub fn open(fs: S::Fs, path: &Path) -> OperationResult<Self> {
         Ok(Self {
-            storage: UpdateOnlyBlobstore::open(
-                fs.clone(),
-                &path.join(STORAGE_DIRNAME),
-                STORAGE_CONFIG,
-            )?,
+            storage: UpdateOnlyBlobstore::open(&fs, &path.join(STORAGE_DIRNAME), STORAGE_CONFIG)?,
             deleted: UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIRNAME))?,
         })
     }
@@ -56,6 +52,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlySparseVectorStorage<S> {
     /// deleted, which is what the writable side records for it.
     pub fn append_many<'a>(
         &mut self,
+        fs: &S::Fs,
         start_slot: PointOffsetType,
         vectors: impl IntoIterator<Item = VectorToStore<'a>>,
         hw_counter: &HardwareCounterCell,
@@ -80,7 +77,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlySparseVectorStorage<S> {
             };
 
             self.storage
-                .put(slot, &stored, hw_counter.ref_vector_io_write_counter())?;
+                .put(fs, slot, &stored, hw_counter.ref_vector_io_write_counter())?;
         }
 
         self.storage.flush()?;

--- a/lib/segment/src/vector_storage/sparse/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/sparse/update_only/mod.rs
@@ -31,15 +31,15 @@ const STORAGE_CONFIG: LogstoreConfig = LogstoreConfig {
 /// [`MmapSparseVectorStorage`]: super::mmap_sparse_vector_storage::MmapSparseVectorStorage
 pub struct UpdateOnlySparseVectorStorage<S: UniversalAppend + 'static> {
     storage: UpdateOnlyBlobstore<StoredSparseVector, S>,
-    deleted: UpdateOnlyStoredFlags<S>,
+    deleted: UpdateOnlyStoredFlags,
 }
 
 impl<S: UniversalAppend + 'static> UpdateOnlySparseVectorStorage<S> {
     /// Open the storage at `path` for appending, creating it if it is not there
     /// yet.
-    pub fn open(fs: S::Fs, path: &Path) -> OperationResult<Self> {
+    pub fn open(fs: &S::Fs, path: &Path) -> OperationResult<Self> {
         Ok(Self {
-            storage: UpdateOnlyBlobstore::open(&fs, &path.join(STORAGE_DIRNAME), STORAGE_CONFIG)?,
+            storage: UpdateOnlyBlobstore::open(fs, &path.join(STORAGE_DIRNAME), STORAGE_CONFIG)?,
             deleted: UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIRNAME))?,
         })
     }
@@ -81,6 +81,6 @@ impl<S: UniversalAppend + 'static> UpdateOnlySparseVectorStorage<S> {
         }
 
         self.storage.flush()?;
-        self.deleted.flush(hw_counter)
+        self.deleted.flush(fs, hw_counter)
     }
 }

--- a/lib/segment/src/vector_storage/sparse/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/sparse/update_only/tests.rs
@@ -32,6 +32,7 @@ fn sparse_vectors_round_trip() {
     let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
     writer
         .append_many(
+            &MmapFs,
             0,
             [
                 VectorToStore::Decoded(VectorRef::from(&first)),
@@ -63,6 +64,7 @@ fn batches_resume() {
     let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
     writer
         .append_many(
+            &MmapFs,
             0,
             [VectorToStore::Decoded(VectorRef::from(&first))],
             &hw_counter,
@@ -73,6 +75,7 @@ fn batches_resume() {
     let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
     writer
         .append_many(
+            &MmapFs,
             1,
             [VectorToStore::Decoded(VectorRef::from(&second))],
             &hw_counter,

--- a/lib/segment/src/vector_storage/sparse/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/sparse/update_only/tests.rs
@@ -29,7 +29,7 @@ fn sparse_vectors_round_trip() {
     let first = sparse(&[1, 5], &[1.0, 2.0]);
     let second = sparse(&[3], &[3.0]);
 
-    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path()).unwrap();
     writer
         .append_many(
             &MmapFs,
@@ -61,7 +61,7 @@ fn batches_resume() {
     let first = sparse(&[1], &[1.0]);
     let second = sparse(&[2], &[2.0]);
 
-    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path()).unwrap();
     writer
         .append_many(
             &MmapFs,
@@ -72,7 +72,7 @@ fn batches_resume() {
         .unwrap();
     drop(writer);
 
-    let mut writer = Writer::open(MmapFs, dir.path()).unwrap();
+    let mut writer = Writer::open(&MmapFs, dir.path()).unwrap();
     writer
         .append_many(
             &MmapFs,

--- a/lib/segment/src/vector_storage/turbo/multi_turbo/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/multi_turbo/update_only/mod.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalAppend;
+use common::universal_io::{UniversalAppend, UniversalReadFs, UniversalWriteFileOps};
 use quantization::turboquant::quantization::TurboQuantizer;
 
 use super::super::shared::{self, DELETED_DIR_PATH, VECTORS_DIR_PATH};
@@ -27,9 +27,9 @@ use crate::vector_storage::update_only::VectorToStore;
 /// [`AppendableMmapMultiTurboVectorStorage`]: super::appendable_mmap_multi_turbo_vector_storage::AppendableMmapMultiTurboVectorStorage
 /// [1]: crate::vector_storage::turbo::update_only::UpdateOnlyTurboVectorStorage
 /// [2]: crate::vector_storage::multi_dense::update_only::UpdateOnlyMultiDenseVectorStorage
-pub struct UpdateOnlyMultiTurboVectorStorage<S: UniversalAppend + 'static> {
-    vectors: UpdateOnlyChunkedVectors<u8, S>,
-    offsets: UpdateOnlyChunkedVectors<MultivectorMmapOffset, S>,
+pub struct UpdateOnlyMultiTurboVectorStorage {
+    vectors: UpdateOnlyChunkedVectors<u8>,
+    offsets: UpdateOnlyChunkedVectors<MultivectorMmapOffset>,
     deleted: UpdateOnlyStoredFlags,
     quantizer: TurboQuantizer,
     quantization_buffer: Vec<f64>,
@@ -38,20 +38,25 @@ pub struct UpdateOnlyMultiTurboVectorStorage<S: UniversalAppend + 'static> {
     next_row: usize,
 }
 
-impl<S: UniversalAppend + 'static> UpdateOnlyMultiTurboVectorStorage<S> {
+impl UpdateOnlyMultiTurboVectorStorage {
     /// Open the storage at `path` for appending, creating it if it is not there
     /// yet.
-    pub fn open(fs: S::Fs, path: &Path, dim: usize, distance: Distance) -> OperationResult<Self> {
+    pub fn open<Fs: UniversalReadFs + UniversalWriteFileOps>(
+        fs: &Fs,
+        path: &Path,
+        dim: usize,
+        distance: Distance,
+    ) -> OperationResult<Self> {
         let quantizer = shared::build_quantizer(dim, distance);
         let quantization_buffer = vec![0.0; quantizer.get_padded_dim()];
-        let deleted = UpdateOnlyStoredFlags::open(&fs, &path.join(DELETED_DIR_PATH))?;
+        let deleted = UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIR_PATH))?;
         let vectors = UpdateOnlyChunkedVectors::open(
-            fs.clone(),
+            fs,
             &path.join(VECTORS_DIR_PATH),
             quantizer.quantized_size(),
         )?;
         let offsets = UpdateOnlyChunkedVectors::open(fs, &path.join(OFFSETS_DIR_PATH), 1)?;
-        let next_row = vectors.stored_len()?;
+        let next_row = vectors.stored_len(fs)?;
 
         Ok(Self {
             vectors,
@@ -66,9 +71,9 @@ impl<S: UniversalAppend + 'static> UpdateOnlyMultiTurboVectorStorage<S> {
 
     /// Append one encoded multi-vector per point of a batch, starting at
     /// `start_slot`, and persist them.
-    pub fn append_many<'a>(
+    pub fn append_many<'a, Fs: UniversalReadFs<File: UniversalAppend> + UniversalWriteFileOps>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         start_slot: PointOffsetType,
         vectors: impl IntoIterator<Item = VectorToStore<'a>>,
         hw_counter: &HardwareCounterCell,
@@ -100,12 +105,14 @@ impl<S: UniversalAppend + 'static> UpdateOnlyMultiTurboVectorStorage<S> {
         }
 
         self.vectors.append_many(
+            fs,
             batch_start as VectorOffsetType,
             rows.chunks_exact(encoded_size),
             hw_counter,
         )?;
 
         self.offsets.append_many(
+            fs,
             start_slot as VectorOffsetType,
             offsets.iter().map(std::slice::from_ref),
             hw_counter,

--- a/lib/segment/src/vector_storage/turbo/multi_turbo/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/multi_turbo/update_only/mod.rs
@@ -30,7 +30,7 @@ use crate::vector_storage::update_only::VectorToStore;
 pub struct UpdateOnlyMultiTurboVectorStorage<S: UniversalAppend + 'static> {
     vectors: UpdateOnlyChunkedVectors<u8, S>,
     offsets: UpdateOnlyChunkedVectors<MultivectorMmapOffset, S>,
-    deleted: UpdateOnlyStoredFlags<S>,
+    deleted: UpdateOnlyStoredFlags,
     quantizer: TurboQuantizer,
     quantization_buffer: Vec<f64>,
     dim: usize,
@@ -44,13 +44,13 @@ impl<S: UniversalAppend + 'static> UpdateOnlyMultiTurboVectorStorage<S> {
     pub fn open(fs: S::Fs, path: &Path, dim: usize, distance: Distance) -> OperationResult<Self> {
         let quantizer = shared::build_quantizer(dim, distance);
         let quantization_buffer = vec![0.0; quantizer.get_padded_dim()];
+        let deleted = UpdateOnlyStoredFlags::open(&fs, &path.join(DELETED_DIR_PATH))?;
         let vectors = UpdateOnlyChunkedVectors::open(
             fs.clone(),
             &path.join(VECTORS_DIR_PATH),
             quantizer.quantized_size(),
         )?;
-        let offsets = UpdateOnlyChunkedVectors::open(fs.clone(), &path.join(OFFSETS_DIR_PATH), 1)?;
-        let deleted = UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIR_PATH))?;
+        let offsets = UpdateOnlyChunkedVectors::open(fs, &path.join(OFFSETS_DIR_PATH), 1)?;
         let next_row = vectors.stored_len()?;
 
         Ok(Self {
@@ -68,6 +68,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyMultiTurboVectorStorage<S> {
     /// `start_slot`, and persist them.
     pub fn append_many<'a>(
         &mut self,
+        fs: &S::Fs,
         start_slot: PointOffsetType,
         vectors: impl IntoIterator<Item = VectorToStore<'a>>,
         hw_counter: &HardwareCounterCell,
@@ -114,7 +115,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyMultiTurboVectorStorage<S> {
             self.deleted.set(slot, true);
         }
 
-        self.deleted.flush(hw_counter)
+        self.deleted.flush(fs, hw_counter)
     }
 
     /// Encode every inner vector, back to back.

--- a/lib/segment/src/vector_storage/turbo/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/update_only/mod.rs
@@ -27,7 +27,7 @@ use crate::vector_storage::update_only::VectorToStore;
 /// [`AppendableMmapTurboVectorStorage`]: super::appendable_turbo_vector_storage::AppendableMmapTurboVectorStorage
 pub struct UpdateOnlyTurboVectorStorage<S: UniversalAppend + 'static> {
     vectors: UpdateOnlyChunkedVectors<u8, S>,
-    deleted: UpdateOnlyStoredFlags<S>,
+    deleted: UpdateOnlyStoredFlags,
     quantizer: TurboQuantizer,
     /// Scratch for the padded, rotated vector `quantize` writes through.
     quantization_buffer: Vec<f64>,
@@ -40,12 +40,12 @@ impl<S: UniversalAppend + 'static> UpdateOnlyTurboVectorStorage<S> {
     pub fn open(fs: S::Fs, path: &Path, dim: usize, distance: Distance) -> OperationResult<Self> {
         let quantizer = shared::build_quantizer(dim, distance);
         let quantization_buffer = vec![0.0; quantizer.get_padded_dim()];
+        let deleted = UpdateOnlyStoredFlags::open(&fs, &path.join(DELETED_DIR_PATH))?;
         let vectors = UpdateOnlyChunkedVectors::open(
-            fs.clone(),
+            fs,
             &path.join(VECTORS_DIR_PATH),
             quantizer.quantized_size(),
         )?;
-        let deleted = UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIR_PATH))?;
 
         Ok(Self {
             vectors,
@@ -63,6 +63,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyTurboVectorStorage<S> {
     /// its slot — holding an encoded zero vector — and is flagged deleted.
     pub fn append_many<'a>(
         &mut self,
+        fs: &S::Fs,
         start_slot: PointOffsetType,
         vectors: impl IntoIterator<Item = VectorToStore<'a>>,
         hw_counter: &HardwareCounterCell,
@@ -107,6 +108,6 @@ impl<S: UniversalAppend + 'static> UpdateOnlyTurboVectorStorage<S> {
             self.deleted.set(slot, true);
         }
 
-        self.deleted.flush(hw_counter)
+        self.deleted.flush(fs, hw_counter)
     }
 }

--- a/lib/segment/src/vector_storage/turbo/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/update_only/mod.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalAppend;
+use common::universal_io::{UniversalAppend, UniversalReadFs, UniversalWriteFileOps};
 use quantization::turboquant::quantization::TurboQuantizer;
 
 use super::shared::{self, DELETED_DIR_PATH, VECTORS_DIR_PATH};
@@ -25,8 +25,8 @@ use crate::vector_storage::update_only::VectorToStore;
 /// so the two encode identically.
 ///
 /// [`AppendableMmapTurboVectorStorage`]: super::appendable_turbo_vector_storage::AppendableMmapTurboVectorStorage
-pub struct UpdateOnlyTurboVectorStorage<S: UniversalAppend + 'static> {
-    vectors: UpdateOnlyChunkedVectors<u8, S>,
+pub struct UpdateOnlyTurboVectorStorage {
+    vectors: UpdateOnlyChunkedVectors<u8>,
     deleted: UpdateOnlyStoredFlags,
     quantizer: TurboQuantizer,
     /// Scratch for the padded, rotated vector `quantize` writes through.
@@ -34,13 +34,18 @@ pub struct UpdateOnlyTurboVectorStorage<S: UniversalAppend + 'static> {
     dim: usize,
 }
 
-impl<S: UniversalAppend + 'static> UpdateOnlyTurboVectorStorage<S> {
+impl UpdateOnlyTurboVectorStorage {
     /// Open the storage at `path` for appending, creating it if it is not there
     /// yet.
-    pub fn open(fs: S::Fs, path: &Path, dim: usize, distance: Distance) -> OperationResult<Self> {
+    pub fn open<Fs: UniversalReadFs + UniversalWriteFileOps>(
+        fs: &Fs,
+        path: &Path,
+        dim: usize,
+        distance: Distance,
+    ) -> OperationResult<Self> {
         let quantizer = shared::build_quantizer(dim, distance);
         let quantization_buffer = vec![0.0; quantizer.get_padded_dim()];
-        let deleted = UpdateOnlyStoredFlags::open(&fs, &path.join(DELETED_DIR_PATH))?;
+        let deleted = UpdateOnlyStoredFlags::open(fs, &path.join(DELETED_DIR_PATH))?;
         let vectors = UpdateOnlyChunkedVectors::open(
             fs,
             &path.join(VECTORS_DIR_PATH),
@@ -61,9 +66,9 @@ impl<S: UniversalAppend + 'static> UpdateOnlyTurboVectorStorage<S> {
     ///
     /// As in the plain dense storage, a point with no vector here still takes
     /// its slot — holding an encoded zero vector — and is flagged deleted.
-    pub fn append_many<'a>(
+    pub fn append_many<'a, Fs: UniversalReadFs<File: UniversalAppend> + UniversalWriteFileOps>(
         &mut self,
-        fs: &S::Fs,
+        fs: &Fs,
         start_slot: PointOffsetType,
         vectors: impl IntoIterator<Item = VectorToStore<'a>>,
         hw_counter: &HardwareCounterCell,
@@ -99,6 +104,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyTurboVectorStorage<S> {
         }
 
         self.vectors.append_many(
+            fs,
             start_slot as VectorOffsetType,
             run.iter().map(Vec::as_slice),
             hw_counter,

--- a/lib/segment/src/vector_storage/turbo/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/turbo/update_only/tests.rs
@@ -2,7 +2,7 @@
 //! appendable TurboQuant storage opened on the same directory.
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::universal_io::{MmapFile, MmapFs};
+use common::universal_io::MmapFs;
 use tempfile::TempDir;
 
 use super::UpdateOnlyTurboVectorStorage;
@@ -12,7 +12,7 @@ use crate::vector_storage::VectorStorageRead;
 use crate::vector_storage::turbo::appendable_turbo_vector_storage::open_appendable_turbo_vector_storage;
 use crate::vector_storage::update_only::VectorToStore;
 
-type Writer = UpdateOnlyTurboVectorStorage<MmapFile>;
+type Writer = UpdateOnlyTurboVectorStorage;
 
 const DIM: usize = 8;
 
@@ -25,7 +25,7 @@ fn encoded_vectors_match_the_writable_side() {
 
     // Written by the update-only writer.
     let ours = TempDir::with_prefix("update_only_turbo").unwrap();
-    let mut writer = Writer::open(MmapFs, ours.path(), DIM, Distance::Dot).unwrap();
+    let mut writer = Writer::open(&MmapFs, ours.path(), DIM, Distance::Dot).unwrap();
     writer
         .append_many(
             &MmapFs,
@@ -73,7 +73,7 @@ fn batches_resume() {
     let vector: Vec<VectorElementType> = vec![1.0; DIM];
 
     for slot in 0..2 {
-        let mut writer = Writer::open(MmapFs, dir.path(), DIM, Distance::Dot).unwrap();
+        let mut writer = Writer::open(&MmapFs, dir.path(), DIM, Distance::Dot).unwrap();
         writer
             .append_many(
                 &MmapFs,

--- a/lib/segment/src/vector_storage/turbo/update_only/tests.rs
+++ b/lib/segment/src/vector_storage/turbo/update_only/tests.rs
@@ -28,6 +28,7 @@ fn encoded_vectors_match_the_writable_side() {
     let mut writer = Writer::open(MmapFs, ours.path(), DIM, Distance::Dot).unwrap();
     writer
         .append_many(
+            &MmapFs,
             0,
             [
                 VectorToStore::Decoded(VectorRef::from(vector.as_slice())),
@@ -75,6 +76,7 @@ fn batches_resume() {
         let mut writer = Writer::open(MmapFs, dir.path(), DIM, Distance::Dot).unwrap();
         writer
             .append_many(
+                &MmapFs,
                 slot,
                 [VectorToStore::Decoded(VectorRef::from(vector.as_slice()))],
                 &hw_counter,

--- a/lib/segment/src/vector_storage/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/update_only/mod.rs
@@ -63,14 +63,14 @@ pub enum VectorToStore<'a> {
 ///
 /// [1]: crate::vector_storage::VectorStorageEnum
 pub enum UpdateOnlyVectorStorage<S: UniversalAppend + 'static> {
-    Dense(Box<UpdateOnlyDenseVectorStorage<VectorElementType, S>>),
-    DenseByte(Box<UpdateOnlyDenseVectorStorage<VectorElementTypeByte, S>>),
-    DenseHalf(Box<UpdateOnlyDenseVectorStorage<VectorElementTypeHalf, S>>),
-    MultiDense(Box<UpdateOnlyMultiDenseVectorStorage<VectorElementType, S>>),
-    MultiDenseByte(Box<UpdateOnlyMultiDenseVectorStorage<VectorElementTypeByte, S>>),
-    MultiDenseHalf(Box<UpdateOnlyMultiDenseVectorStorage<VectorElementTypeHalf, S>>),
-    Turbo(Box<UpdateOnlyTurboVectorStorage<S>>),
-    MultiTurbo(Box<UpdateOnlyMultiTurboVectorStorage<S>>),
+    Dense(Box<UpdateOnlyDenseVectorStorage<VectorElementType>>),
+    DenseByte(Box<UpdateOnlyDenseVectorStorage<VectorElementTypeByte>>),
+    DenseHalf(Box<UpdateOnlyDenseVectorStorage<VectorElementTypeHalf>>),
+    MultiDense(Box<UpdateOnlyMultiDenseVectorStorage<VectorElementType>>),
+    MultiDenseByte(Box<UpdateOnlyMultiDenseVectorStorage<VectorElementTypeByte>>),
+    MultiDenseHalf(Box<UpdateOnlyMultiDenseVectorStorage<VectorElementTypeHalf>>),
+    Turbo(Box<UpdateOnlyTurboVectorStorage>),
+    MultiTurbo(Box<UpdateOnlyMultiTurboVectorStorage>),
     Sparse(Box<UpdateOnlySparseVectorStorage<S>>),
 }
 
@@ -80,7 +80,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyVectorStorage<S> {
     ///
     /// Fails for a storage type an update-only segment cannot have: the mmap
     /// ones are immutable, built whole rather than appended to.
-    pub fn open(fs: S::Fs, path: &Path, config: &VectorDataConfig) -> OperationResult<Self> {
+    pub fn open(fs: &S::Fs, path: &Path, config: &VectorDataConfig) -> OperationResult<Self> {
         match config.storage_type {
             VectorStorageType::ChunkedMmap | VectorStorageType::InRamChunkedMmap => {}
             storage_type @ (VectorStorageType::Mmap

--- a/lib/segment/src/vector_storage/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/update_only/mod.rs
@@ -128,7 +128,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyVectorStorage<S> {
     /// Open the writer for a sparse vector storage at `path`. Sparse vectors
     /// are configured separately from dense ones, so they do not go through
     /// [`open`](Self::open).
-    pub fn open_sparse(fs: S::Fs, path: &Path) -> OperationResult<Self> {
+    pub fn open_sparse(fs: &S::Fs, path: &Path) -> OperationResult<Self> {
         Ok(Self::Sparse(Box::new(UpdateOnlySparseVectorStorage::open(
             fs, path,
         )?)))
@@ -144,14 +144,14 @@ impl<S: UniversalAppend + 'static> UpdateOnlyVectorStorage<S> {
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<()> {
         match self {
-            Self::Dense(s) => s.append_many(start_slot, vectors, hw_counter),
-            Self::DenseByte(s) => s.append_many(start_slot, vectors, hw_counter),
-            Self::DenseHalf(s) => s.append_many(start_slot, vectors, hw_counter),
-            Self::MultiDense(s) => s.append_many(start_slot, vectors, hw_counter),
-            Self::MultiDenseByte(s) => s.append_many(start_slot, vectors, hw_counter),
-            Self::MultiDenseHalf(s) => s.append_many(start_slot, vectors, hw_counter),
-            Self::Turbo(s) => s.append_many(start_slot, vectors, hw_counter),
-            Self::MultiTurbo(s) => s.append_many(start_slot, vectors, hw_counter),
+            Self::Dense(s) => s.append_many(fs, start_slot, vectors, hw_counter),
+            Self::DenseByte(s) => s.append_many(fs, start_slot, vectors, hw_counter),
+            Self::DenseHalf(s) => s.append_many(fs, start_slot, vectors, hw_counter),
+            Self::MultiDense(s) => s.append_many(fs, start_slot, vectors, hw_counter),
+            Self::MultiDenseByte(s) => s.append_many(fs, start_slot, vectors, hw_counter),
+            Self::MultiDenseHalf(s) => s.append_many(fs, start_slot, vectors, hw_counter),
+            Self::Turbo(s) => s.append_many(fs, start_slot, vectors, hw_counter),
+            Self::MultiTurbo(s) => s.append_many(fs, start_slot, vectors, hw_counter),
             Self::Sparse(s) => s.append_many(fs, start_slot, vectors, hw_counter),
         }
     }

--- a/lib/segment/src/vector_storage/update_only/mod.rs
+++ b/lib/segment/src/vector_storage/update_only/mod.rs
@@ -138,6 +138,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyVectorStorage<S> {
     /// persist them.
     pub fn append_many<'a>(
         &mut self,
+        fs: &S::Fs,
         start_slot: PointOffsetType,
         vectors: impl IntoIterator<Item = VectorToStore<'a>>,
         hw_counter: &HardwareCounterCell,
@@ -151,7 +152,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyVectorStorage<S> {
             Self::MultiDenseHalf(s) => s.append_many(start_slot, vectors, hw_counter),
             Self::Turbo(s) => s.append_many(start_slot, vectors, hw_counter),
             Self::MultiTurbo(s) => s.append_many(start_slot, vectors, hw_counter),
-            Self::Sparse(s) => s.append_many(start_slot, vectors, hw_counter),
+            Self::Sparse(s) => s.append_many(fs, start_slot, vectors, hw_counter),
         }
     }
 }


### PR DESCRIPTION
This PR does a lot of _almost_ mechanical groundwork to remove the stored `fs: S::Fs` from components in update-only segments.

Initially, it was easy to clone the Fs type into every structure, but it is not really necessary. In upstack PRs, this will be used to have only a top-level CachedFs that every component can reference.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>