### PR TITLE
[updater] use CachedFs per segment

### DIFF
--- a/lib/edge/src/update_only/apply.rs
+++ b/lib/edge/src/update_only/apply.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalAppendFs, UniversalRead};
+use common::universal_io::{UniversalAppendFs, UniversalReadFsAsync};
 use rayon::ThreadPool;
 use rayon::prelude::*;
 use segment::common::operation_error::{OperationError, OperationResult};
@@ -295,10 +295,7 @@ impl<Fs: UniversalAppendFs> UpdateOnlyEdgeShard<Fs> {
                 // Not shared across segments: `HardwareCounterCell` is not
                 // `Sync`, and the writer's accounting is disposable.
                 let hw_counter = HardwareCounterCell::disposable();
-                segments
-                    .get(uuid)?
-                    .write()
-                    .live_reload(&self.fs, &hw_counter)
+                segments.get(uuid)?.write().live_reload(&hw_counter)
             })
         })
     }
@@ -318,8 +315,8 @@ fn get_writer<Fs: UniversalAppendFs>(
 /// Locate every point the batch touches: every slot it occupies, with the
 /// newest copy marked, when more than one segment holds the point. Segments
 /// are visited in parallel on `pool`.
-pub(super) fn locate_points<S: UniversalRead + 'static>(
-    segments: &LookupSegmentHolder<S>,
+pub(super) fn locate_points<Fs: UniversalReadFsAsync>(
+    segments: &LookupSegmentHolder<Fs>,
     plan: &UpdateBatchPlan,
     pool: &ThreadPool,
 ) -> OperationResult<AHashMap<PointIdType, PointLocations>> {
@@ -384,8 +381,8 @@ pub(super) fn locate_points<S: UniversalRead + 'static>(
 
 /// Read the stored form of the points whose mutations need it, one batched
 /// pass per segment; segments are read in parallel on `pool`.
-pub(super) fn read_stored_points<S: UniversalRead + 'static>(
-    segments: &LookupSegmentHolder<S>,
+pub(super) fn read_stored_points<Fs: UniversalReadFsAsync>(
+    segments: &LookupSegmentHolder<Fs>,
     plan: &UpdateBatchPlan,
     locations: &AHashMap<PointIdType, PointLocations>,
     pool: &ThreadPool,

--- a/lib/edge/src/update_only/holder.rs
+++ b/lib/edge/src/update_only/holder.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use common::universal_io::UniversalRead;
+use common::universal_io::UniversalReadFsAsync;
 use parking_lot::RwLock;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::segment::update_only::LookupSegment;
@@ -9,13 +9,13 @@ use uuid::Uuid;
 
 /// In-memory inventory of the segments a writer updates, keyed by segment
 /// UUID, with at most one — the appendable one — as the write target.
-pub(crate) struct LookupSegmentHolder<S: UniversalRead + 'static> {
-    by_uuid: HashMap<Uuid, Arc<RwLock<LookupSegment<S>>>>,
+pub(crate) struct LookupSegmentHolder<Fs: UniversalReadFsAsync + 'static> {
+    by_uuid: HashMap<Uuid, Arc<RwLock<LookupSegment<Fs>>>>,
     /// UUID of the single segment that accepts appends.
     write_target: Option<Uuid>,
 }
 
-impl<S: UniversalRead + 'static> Default for LookupSegmentHolder<S> {
+impl<Fs: UniversalReadFsAsync> Default for LookupSegmentHolder<Fs> {
     fn default() -> Self {
         Self {
             by_uuid: HashMap::new(),
@@ -24,9 +24,9 @@ impl<S: UniversalRead + 'static> Default for LookupSegmentHolder<S> {
     }
 }
 
-impl<S: UniversalRead + 'static> LookupSegmentHolder<S> {
+impl<Fs: UniversalReadFsAsync> LookupSegmentHolder<Fs> {
     /// A non-`writable` segment (claimed by a rebuild) never becomes the target.
-    pub(crate) fn insert(&mut self, uuid: Uuid, segment: LookupSegment<S>, writable: bool) {
+    pub(crate) fn insert(&mut self, uuid: Uuid, segment: LookupSegment<Fs>, writable: bool) {
         if segment.appendable && writable {
             self.write_target = Some(uuid);
         }
@@ -38,13 +38,15 @@ impl<S: UniversalRead + 'static> LookupSegmentHolder<S> {
     }
 
     /// Every segment, paired with its UUID. Order is unspecified.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (Uuid, &Arc<RwLock<LookupSegment<S>>>)> + '_ {
+    pub(crate) fn iter(
+        &self,
+    ) -> impl Iterator<Item = (Uuid, &Arc<RwLock<LookupSegment<Fs>>>)> + '_ {
         self.by_uuid.iter().map(|(uuid, segment)| (*uuid, segment))
     }
 
     /// The segment `uuid` names; an error when the holder has no such segment,
     /// which can only mean it changed under a batch in flight.
-    pub(crate) fn get(&self, uuid: Uuid) -> OperationResult<&Arc<RwLock<LookupSegment<S>>>> {
+    pub(crate) fn get(&self, uuid: Uuid) -> OperationResult<&Arc<RwLock<LookupSegment<Fs>>>> {
         self.by_uuid.get(&uuid).ok_or_else(|| {
             OperationError::service_error(format!("Segment {uuid} disappeared mid-batch"))
         })

--- a/lib/edge/src/update_only/lifecycle.rs
+++ b/lib/edge/src/update_only/lifecycle.rs
@@ -68,7 +68,7 @@ impl<Fs: UniversalAppendFs> UpdateOnlyEdgeShard<Fs> {
                     // No deferred threshold yet: it belongs to the coordination
                     // with an external rebuilder, which does not exist in this
                     // iteration.
-                    let segment = LookupSegment::open(&fs, &path, None)?;
+                    let segment = LookupSegment::open(fs.clone(), &path, None)?;
                     let writer = UpdateOnlySegmentEnum::open(
                         fs.clone(),
                         &path,
@@ -151,7 +151,7 @@ where
         let remote = self.path.join(SEGMENTS_PATH).join(uuid.to_string());
         copy_dir_via(&self.fs, &local, &remote)?;
 
-        let lookup = LookupSegment::<Fs::File>::open(&self.fs, &remote, None)?;
+        let lookup = LookupSegment::<Fs>::open(self.fs.clone(), &remote, None)?;
         let writer = UpdateOnlySegmentEnum::open(
             self.fs.clone(),
             &remote,

--- a/lib/edge/src/update_only/mod.rs
+++ b/lib/edge/src/update_only/mod.rs
@@ -58,7 +58,7 @@ pub struct UpdateOnlyEdgeShard<Fs: UniversalAppendFs> {
     /// Backend the segments were opened on; live-reloads their lookup
     /// halves after a batch writes to them.
     fs: Fs,
-    segments: RwLock<LookupSegmentHolder<Fs::File>>,
+    segments: RwLock<LookupSegmentHolder<Fs>>,
     /// One writer per segment, opened at shard open from the state its
     /// [`LookupSegment`](segment::segment::update_only::LookupSegment)
     /// observed — which also decided whether the segment accepts appends or

--- a/lib/edge/src/update_only/preview.rs
+++ b/lib/edge/src/update_only/preview.rs
@@ -8,7 +8,7 @@
 //! [`apply_batch`]: UpdateOnlyEdgeShard::apply_batch
 
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalAppendFs, UniversalRead};
+use common::universal_io::{UniversalAppendFs, UniversalReadFsAsync};
 use rayon::ThreadPool;
 use segment::common::operation_error::OperationResult;
 use segment::data_types::fully_qualified_point::FullyQualifiedPoint;
@@ -71,8 +71,8 @@ pub enum PointAction {
 /// into its [`PointAction`]. Reads only — the single decision stage behind
 /// both [`UpdateOnlyEdgeShard::preview_batch`] and
 /// [`UpdateOnlyEdgeShard::apply_batch`].
-pub(super) fn resolve_batch<S: UniversalRead + 'static>(
-    segments: &LookupSegmentHolder<S>,
+pub(super) fn resolve_batch<Fs: UniversalReadFsAsync>(
+    segments: &LookupSegmentHolder<Fs>,
     plan: UpdateBatchPlan,
     pool: &ThreadPool,
 ) -> OperationResult<Vec<PointPreview>> {

--- a/lib/segment/src/id_tracker/disk_id_tracker/update_only.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/update_only.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use common::bitvec::BitVec;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalAppendFs;
+use common::universal_io::{UniversalReadFs, UniversalWriteFileOps};
 
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::immutable_id_tracker::tombstone_points_in_stored_mask;
@@ -16,23 +16,21 @@ use crate::types::PointIdType;
 /// [`atomic_save`] from the backend, so object stores qualify.
 ///
 /// [`atomic_save`]: UniversalWriteFileOps::atomic_save
-pub struct UpdateOnlyDiskIdTracker<Fs: UniversalAppendFs> {
-    fs: Fs,
+pub struct UpdateOnlyDiskIdTracker {
     segment_path: PathBuf,
     /// Consumed by the first [`tombstone_points`](Self::tombstone_points) in
     /// place of reading the mask file.
     deleted: Option<BitVec>,
 }
 
-impl<Fs: UniversalAppendFs> UpdateOnlyDiskIdTracker<Fs> {
+impl UpdateOnlyDiskIdTracker {
     /// `deleted` is the mask as the read phase held it in memory, when it
     /// did; nothing is read here.
-    pub fn new(fs: Fs, segment_path: &Path, deleted: Option<BitVec>) -> Self {
-        Self {
-            fs,
+    pub fn new(segment_path: &Path, deleted: Option<BitVec>) -> OperationResult<Self> {
+        Ok(Self {
             segment_path: segment_path.to_path_buf(),
             deleted,
-        }
+        })
     }
 
     /// Retire the given points by marking the slots they occupy in the stored
@@ -40,10 +38,14 @@ impl<Fs: UniversalAppendFs> UpdateOnlyDiskIdTracker<Fs> {
     /// The mask is replaced whole, see [`StoredBitSlice::atomic_update`].
     ///
     /// [`StoredBitSlice::atomic_update`]: common::stored_bitslice::StoredBitSlice::atomic_update
-    pub fn tombstone_points(
+    pub fn tombstone_points<Fs>(
         &mut self,
+        fs: &Fs,
         points: &[(PointIdType, PointOffsetType)],
-    ) -> OperationResult<()> {
-        tombstone_points_in_stored_mask(&self.fs, &self.segment_path, &mut self.deleted, points)
+    ) -> OperationResult<()>
+    where
+        Fs: UniversalReadFs + UniversalWriteFileOps,
+    {
+        tombstone_points_in_stored_mask(fs, &self.segment_path, &mut self.deleted, points)
     }
 }

--- a/lib/segment/src/id_tracker/id_tracker_base/delete_only_tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/delete_only_tracker_enum.rs
@@ -1,5 +1,5 @@
 use common::types::PointOffsetType;
-use common::universal_io::UniversalAppendFs;
+use common::universal_io::{UniversalReadFs, UniversalWriteFileOps};
 
 use crate::common::operation_error::OperationResult;
 use crate::id_tracker::disk_id_tracker::update_only::UpdateOnlyDiskIdTracker;
@@ -8,21 +8,25 @@ use crate::types::PointIdType;
 
 /// The update-only tracker of whichever immutable id-tracker format a segment
 /// holds. Each variant decides where its tombstones go.
-pub enum DeleteOnlyIdTrackerEnum<Fs: UniversalAppendFs> {
-    Immutable(UpdateOnlyImmutableIdTracker<Fs>),
-    DiskResident(UpdateOnlyDiskIdTracker<Fs>),
+pub enum DeleteOnlyIdTrackerEnum {
+    Immutable(UpdateOnlyImmutableIdTracker),
+    DiskResident(UpdateOnlyDiskIdTracker),
 }
 
-impl<Fs: UniversalAppendFs> DeleteOnlyIdTrackerEnum<Fs> {
+impl DeleteOnlyIdTrackerEnum {
     /// Retire the given points by marking the slots they occupy in the stored
     /// deleted mask — the only thing written, the data on those slots stays.
-    pub fn tombstone_points(
+    pub fn tombstone_points<Fs>(
         &mut self,
+        fs: &Fs,
         points: &[(PointIdType, PointOffsetType)],
-    ) -> OperationResult<()> {
+    ) -> OperationResult<()>
+    where
+        Fs: UniversalReadFs + UniversalWriteFileOps,
+    {
         match self {
-            Self::Immutable(id_tracker) => id_tracker.tombstone_points(points),
-            Self::DiskResident(id_tracker) => id_tracker.tombstone_points(points),
+            Self::Immutable(id_tracker) => id_tracker.tombstone_points(fs, points),
+            Self::DiskResident(id_tracker) => id_tracker.tombstone_points(fs, points),
         }
     }
 }

--- a/lib/segment/src/id_tracker/immutable_id_tracker/deleted_storage.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/deleted_storage.rs
@@ -20,12 +20,15 @@ pub(crate) fn deleted_path(base: &Path) -> PathBuf {
 /// [`StoredBitSlice::atomic_update`]; `seed` is consumed in place of reading
 /// the mask file when the caller held it in memory — and kept for a later
 /// call when `points` is empty and nothing is written.
-pub(crate) fn tombstone_points_in_stored_mask<Fs: UniversalReadFs + UniversalWriteFileOps>(
+pub(crate) fn tombstone_points_in_stored_mask<Fs>(
     fs: &Fs,
     segment_path: &Path,
     seed: &mut Option<BitVec>,
     points: &[(PointIdType, PointOffsetType)],
-) -> OperationResult<()> {
+) -> OperationResult<()>
+where
+    Fs: UniversalReadFs + UniversalWriteFileOps,
+{
     if points.is_empty() {
         return Ok(());
     }

--- a/lib/segment/src/id_tracker/immutable_id_tracker/update_only.rs
+++ b/lib/segment/src/id_tracker/immutable_id_tracker/update_only.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use common::bitvec::BitVec;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalAppendFs;
+use common::universal_io::{UniversalReadFs, UniversalWriteFileOps};
 
 use super::deleted_storage::tombstone_points_in_stored_mask;
 use crate::common::operation_error::OperationResult;
@@ -16,23 +16,21 @@ use crate::types::PointIdType;
 /// plus [`atomic_save`] from the backend, so object stores qualify.
 ///
 /// [`atomic_save`]: UniversalWriteFileOps::atomic_save
-pub struct UpdateOnlyImmutableIdTracker<Fs: UniversalAppendFs> {
-    fs: Fs,
+pub struct UpdateOnlyImmutableIdTracker {
     segment_path: PathBuf,
     /// Consumed by the first [`tombstone_points`](Self::tombstone_points) in
     /// place of reading the mask file.
     deleted: Option<BitVec>,
 }
 
-impl<Fs: UniversalAppendFs> UpdateOnlyImmutableIdTracker<Fs> {
+impl UpdateOnlyImmutableIdTracker {
     /// `deleted` is the mask as the read phase held it in memory, when it
     /// did; nothing is read here.
-    pub fn new(fs: Fs, segment_path: &Path, deleted: Option<BitVec>) -> Self {
-        Self {
-            fs,
+    pub fn new(segment_path: &Path, deleted: Option<BitVec>) -> OperationResult<Self> {
+        Ok(Self {
             segment_path: segment_path.to_path_buf(),
             deleted,
-        }
+        })
     }
 
     /// Retire the given points by marking the slots they occupy in the stored
@@ -40,10 +38,14 @@ impl<Fs: UniversalAppendFs> UpdateOnlyImmutableIdTracker<Fs> {
     /// The mask is replaced whole, see [`StoredBitSlice::atomic_update`].
     ///
     /// [`StoredBitSlice::atomic_update`]: common::stored_bitslice::StoredBitSlice::atomic_update
-    pub fn tombstone_points(
+    pub fn tombstone_points<Fs>(
         &mut self,
+        fs: &Fs,
         points: &[(PointIdType, PointOffsetType)],
-    ) -> OperationResult<()> {
-        tombstone_points_in_stored_mask(&self.fs, &self.segment_path, &mut self.deleted, points)
+    ) -> OperationResult<()>
+    where
+        Fs: UniversalReadFs + UniversalWriteFileOps,
+    {
+        tombstone_points_in_stored_mask(fs, &self.segment_path, &mut self.deleted, points)
     }
 }

--- a/lib/segment/src/segment/update_only/appendable/mod.rs
+++ b/lib/segment/src/segment/update_only/appendable/mod.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
-use common::universal_io::UniversalAppendFs;
+use common::universal_io::{CachedFs, CachedReadFs, UniversalAppendFs};
 
 use super::AppendableIdTrackerState;
 use crate::common::operation_error::OperationResult;
@@ -27,21 +27,19 @@ pub struct AppendableSegment<Fs: UniversalAppendFs> {
     id_tracker: UpdateOnlyAppendableIdTracker,
     /// What the id tracker appends through and
     /// [`store_components`](Self::store_components) opens with.
-    fs: Fs,
+    fs: CachedFs<Fs>,
     segment_path: PathBuf,
     config: SegmentConfig,
     /// The components a stored point's data goes into, opened on the first
     /// [`store_points`](Self::store_points). A batch that only deletes writes
     /// nothing but the mappings log, so it never pays for these opens.
-    store: Option<StoreComponents<Fs>>,
+    store: Option<StoreComponents<CachedFs<Fs>>>,
 }
 
 /// Everywhere a stored point's data goes. The mappings log that publishes the
 /// point is not here: it belongs to the segment itself, since deletes need it
 /// too.
 struct StoreComponents<Fs: UniversalAppendFs> {
-    /// What the components write through, passed down per call.
-    fs: Fs,
     payload_storage: UpdateOnlyPayloadStorage<Fs::File>,
     payload_indexes: UpdateOnlyStructPayloadIndex<Fs::File>,
     /// One writer per named vector, dense and sparse alike.
@@ -56,16 +54,16 @@ struct StoreComponents<Fs: UniversalAppendFs> {
 }
 
 impl<Fs: UniversalAppendFs> StoreComponents<Fs> {
-    fn open(fs: Fs, segment_path: &Path, config: &SegmentConfig) -> OperationResult<Self> {
-        let payload_storage = UpdateOnlyPayloadStorage::open(&fs, segment_path)?;
-        let payload_indexes = UpdateOnlyStructPayloadIndex::open(&fs, segment_path)?;
+    fn open(fs: &Fs, segment_path: &Path, config: &SegmentConfig) -> OperationResult<Self> {
+        let payload_storage = UpdateOnlyPayloadStorage::open(fs, segment_path)?;
+        let payload_indexes = UpdateOnlyStructPayloadIndex::open(fs, segment_path)?;
 
         let mut vector_storages =
             Vec::with_capacity(config.vector_data.len() + config.sparse_vector_data.len());
         let mut quantized_vectors = HashMap::new();
         for (vector_name, vector_config) in &config.vector_data {
             let path = get_vector_storage_path(segment_path, vector_name);
-            let storage = UpdateOnlyVectorStorage::open(&fs, &path, vector_config)?;
+            let storage = UpdateOnlyVectorStorage::open(fs, &path, vector_config)?;
             vector_storages.push((vector_name.clone(), storage));
 
             if let Some(quantized) =
@@ -76,12 +74,11 @@ impl<Fs: UniversalAppendFs> StoreComponents<Fs> {
         }
         for vector_name in config.sparse_vector_data.keys() {
             let path = get_vector_storage_path(segment_path, vector_name);
-            let storage = UpdateOnlyVectorStorage::open_sparse(&fs, &path)?;
+            let storage = UpdateOnlyVectorStorage::open_sparse(fs, &path)?;
             vector_storages.push((vector_name.clone(), storage));
         }
 
         Ok(Self {
-            fs,
             payload_storage,
             payload_indexes,
             vector_storages,
@@ -117,6 +114,8 @@ impl<Fs: UniversalAppendFs> AppendableSegment<Fs> {
             mappings_end,
         )?;
 
+        let fs = CachedFs::new(fs, segment_path)?;
+
         Ok(Self {
             id_tracker,
             fs,
@@ -126,15 +125,19 @@ impl<Fs: UniversalAppendFs> AppendableSegment<Fs> {
         })
     }
 
-    fn store_components(&mut self) -> OperationResult<&mut StoreComponents<Fs>> {
+    /// Lends the fs alongside the components, so a caller holding the mutable
+    /// borrow can still pass it down per call.
+    fn store_components(
+        &mut self,
+    ) -> OperationResult<(&CachedFs<Fs>, &mut StoreComponents<CachedFs<Fs>>)> {
         if self.store.is_none() {
             self.store = Some(StoreComponents::open(
-                self.fs.clone(),
+                &self.fs,
                 &self.segment_path,
                 &self.config,
             )?);
         }
-        Ok(self.store.as_mut().expect("just opened"))
+        Ok((&self.fs, self.store.as_mut().expect("just opened")))
     }
 
     /// Append `points` to this segment, each into a fresh slot, and repoint
@@ -157,6 +160,10 @@ impl<Fs: UniversalAppendFs> AppendableSegment<Fs> {
             return Ok(());
         }
 
+        // Ensure fresh new view of the files
+        self.fs.rotate_cache_file_info();
+        self.fs.cache_file_info()?;
+
         let operations: Vec<MappingOperation> = points
             .iter()
             .map(|point| MappingOperation::Insert(point.id))
@@ -164,7 +171,7 @@ impl<Fs: UniversalAppendFs> AppendableSegment<Fs> {
         let inserted = self.id_tracker.insert_operations(&self.fs, &operations)?;
         let (_, start_slot) = *inserted.first().expect("one slot per insert");
 
-        let store = self.store_components()?;
+        let (fs, store) = self.store_components()?;
 
         // Each named vector, from whichever half of the point holds it: the
         // batch's own decoded vectors win over the bytes carried from the
@@ -187,7 +194,7 @@ impl<Fs: UniversalAppendFs> AppendableSegment<Fs> {
                     }
                 })
                 .collect();
-            storage.append_many(&store.fs, start_slot, vectors.iter().copied(), hw_counter)?;
+            storage.append_many(fs, start_slot, vectors.iter().copied(), hw_counter)?;
 
             // The quantized storage takes the same run, row-for-row with the raw storage.
             if let Some(quantized) = store.quantized_vectors.get_mut(vector_name) {
@@ -203,10 +210,10 @@ impl<Fs: UniversalAppendFs> AppendableSegment<Fs> {
         };
         store
             .payload_storage
-            .append_many(&store.fs, slot_payloads(), hw_counter)?;
+            .append_many(fs, slot_payloads(), hw_counter)?;
         store
             .payload_indexes
-            .append_many(&store.fs, slot_payloads(), hw_counter)?;
+            .append_many(fs, slot_payloads(), hw_counter)?;
 
         // Publish: covering the slots with their versions is what makes the
         // points visible, so everything above must already be durable.

--- a/lib/segment/src/segment/update_only/delete_only/mod.rs
+++ b/lib/segment/src/segment/update_only/delete_only/mod.rs
@@ -17,27 +17,32 @@ use crate::types::PointIdType;
 /// batch can do here is retire points that are already there. Where their
 /// tombstones go is the id tracker's decision.
 pub struct DeleteOnlySegment<Fs: UniversalAppendFs> {
-    id_tracker: DeleteOnlyIdTrackerEnum<Fs>,
+    fs: Fs,
+    id_tracker: DeleteOnlyIdTrackerEnum,
 }
 
 impl<Fs: UniversalAppendFs> DeleteOnlySegment<Fs> {
     /// Open the segment directory at `segment_path` for deletes, resuming the
     /// tracker kind its [`DeleteOnlyIdTrackerState`] variant names; nothing is
     /// read.
-    pub fn open(fs: Fs, segment_path: &Path, id_tracker_state: DeleteOnlyIdTrackerState) -> Self {
+    pub fn open(
+        fs: Fs,
+        segment_path: &Path,
+        id_tracker_state: DeleteOnlyIdTrackerState,
+    ) -> OperationResult<Self> {
         let id_tracker = match id_tracker_state {
             DeleteOnlyIdTrackerState::Immutable(deleted) => DeleteOnlyIdTrackerEnum::Immutable(
-                UpdateOnlyImmutableIdTracker::new(fs, segment_path, deleted),
+                UpdateOnlyImmutableIdTracker::new(segment_path, deleted)?,
             ),
             DeleteOnlyIdTrackerState::DiskResident(deleted) => {
                 DeleteOnlyIdTrackerEnum::DiskResident(UpdateOnlyDiskIdTracker::new(
-                    fs,
                     segment_path,
                     deleted,
-                ))
+                )?)
             }
         };
-        Self { id_tracker }
+
+        Ok(Self { fs, id_tracker })
     }
 
     /// Retire the given points by marking the slots they occupy in the id
@@ -47,6 +52,6 @@ impl<Fs: UniversalAppendFs> DeleteOnlySegment<Fs> {
         &mut self,
         points: &[(PointIdType, PointOffsetType)],
     ) -> OperationResult<()> {
-        self.id_tracker.tombstone_points(points)
+        self.id_tracker.tombstone_points(&self.fs, points)
     }
 }

--- a/lib/segment/src/segment/update_only/lookup/lifecycle.rs
+++ b/lib/segment/src/segment/update_only/lookup/lifecycle.rs
@@ -5,10 +5,7 @@ use std::sync::Arc;
 use atomic_refcell::AtomicRefCell;
 use common::storage_version::{StorageVersion, VERSION_FILE};
 use common::types::PointOffsetType;
-use common::universal_io::{
-    CachedFs, CachedReadFs, Populate, UniversalRead, UniversalReadFs, UniversalReadFsAsync,
-    read_json_via,
-};
+use common::universal_io::{CachedFs, CachedReadFs, Populate, UniversalReadFsAsync, read_json_via};
 
 use super::LookupSegment;
 use crate::common::operation_error::{OperationError, OperationResult};
@@ -39,10 +36,10 @@ const WRITER_POPULATE: Populate = Populate::No;
 /// Mirror of the read-only segment's `build_cached_fs`, minus the payload index
 /// config the writer never opens.
 fn build_cached_fs<Fs: UniversalReadFsAsync>(
-    fs: &Fs,
+    fs: Fs,
     segment_path: &Path,
 ) -> OperationResult<CachedFs<Fs>> {
-    let mut cached_fs = CachedFs::new(fs.clone(), segment_path)?;
+    let mut cached_fs = CachedFs::new(fs, segment_path)?;
 
     cached_fs.cache_file_info()?;
 
@@ -54,7 +51,7 @@ fn build_cached_fs<Fs: UniversalReadFsAsync>(
     Ok(cached_fs)
 }
 
-impl<S: UniversalRead + 'static> LookupSegment<S> {
+impl<Fs: UniversalReadFsAsync> LookupSegment<Fs> {
     /// Open the segment over a per-segment [`CachedFs`]: every file the
     /// components will read is prefetched concurrently
     /// ([`preopen`](Self::preopen)) before the component opens consume it, so
@@ -67,13 +64,13 @@ impl<S: UniversalRead + 'static> LookupSegment<S> {
     /// `deferred_internal_id` is the cutoff agreed with an external rebuilder
     /// working the same directory — see [`open_via`](Self::open_via).
     pub fn open(
-        fs: &impl UniversalReadFsAsync<File = S>,
+        fs: Fs,
         segment_path: &Path,
         deferred_internal_id: Option<PointOffsetType>,
     ) -> OperationResult<Self> {
         let cached_fs = build_cached_fs(fs, segment_path)?;
         let config = Self::preopen(&cached_fs, segment_path)?;
-        Self::open_via(&cached_fs, segment_path, config, deferred_internal_id)
+        Self::open_via(cached_fs, segment_path, config, deferred_internal_id)
     }
 
     /// Open the segment's components: the id tracker, the payload storage and
@@ -93,12 +90,14 @@ impl<S: UniversalRead + 'static> LookupSegment<S> {
     /// appendable segment has a deferred track; on any other segment the
     /// cutoff is ignored.
     pub fn open_via(
-        fs: &impl UniversalReadFs<File = S>,
+        fs: CachedFs<Fs>,
         segment_path: &Path,
         config: SegmentConfig,
         deferred_internal_id: Option<PointOffsetType>,
     ) -> OperationResult<Self> {
-        if SegmentVersion::load_universal(fs, segment_path)?.is_none() {
+        futures::executor::block_on(fs.wait_all());
+
+        if SegmentVersion::load_universal(&fs, segment_path)?.is_none() {
             // `FileNotFound`, not a service error: the version file is written
             // last, so its absence means the segment vanished mid-open (or was
             // never completed).
@@ -108,7 +107,7 @@ impl<S: UniversalRead + 'static> LookupSegment<S> {
         }
 
         let payload_storage = Arc::new(AtomicRefCell::new(ReadOnlyPayloadStorage::open(
-            fs,
+            &fs,
             segment_path.to_path_buf(),
             WRITER_POPULATE,
         )?));
@@ -119,7 +118,7 @@ impl<S: UniversalRead + 'static> LookupSegment<S> {
         // deferred threshold applies to the appendable tracker only, mirroring
         // `ReadOnlySegment::open_via`.
         let id_tracker = Arc::new(AtomicRefCell::new(ReadOnlyIdTrackerEnum::detect_and_load(
-            fs,
+            &fs,
             segment_path,
             deferred_internal_id.filter(|_| appendable),
         )?));
@@ -129,7 +128,7 @@ impl<S: UniversalRead + 'static> LookupSegment<S> {
             let path = get_vector_storage_path(segment_path, vector_name);
             let index_path = get_vector_index_path(segment_path, vector_name);
             let storage = VectorStorageReadEnum::open(
-                fs,
+                &fs,
                 vector_config,
                 &path,
                 &index_path,
@@ -145,12 +144,13 @@ impl<S: UniversalRead + 'static> LookupSegment<S> {
         for vector_name in config.sparse_vector_data.keys() {
             let path = get_vector_storage_path(segment_path, vector_name);
             let storage = VectorStorageReadEnum::Sparse(Box::new(
-                ReadOnlySparseVectorStorage::open(fs, &path, WRITER_POPULATE)?,
+                ReadOnlySparseVectorStorage::open(&fs, &path, WRITER_POPULATE)?,
             ));
             vector_data.insert(vector_name.clone(), Arc::new(AtomicRefCell::new(storage)));
         }
 
         Ok(Self {
+            fs,
             segment_path: segment_path.to_path_buf(),
             id_tracker,
             payload_storage,
@@ -164,10 +164,7 @@ impl<S: UniversalRead + 'static> LookupSegment<S> {
     /// caching filesystem can fetch them concurrently instead of one blocking
     /// round-trip at a time. Returns the segment config parsed along the way,
     /// so the open does not read it twice.
-    pub fn preopen(
-        fs: &impl CachedReadFs<File = S>,
-        segment_path: &Path,
-    ) -> OperationResult<SegmentConfig> {
+    pub fn preopen(fs: &CachedFs<Fs>, segment_path: &Path) -> OperationResult<SegmentConfig> {
         let SegmentState {
             initial_version: _,
             version: _,
@@ -180,7 +177,7 @@ impl<S: UniversalRead + 'static> LookupSegment<S> {
         for (vector_name, vector_config) in &config.vector_data {
             let path = get_vector_storage_path(segment_path, vector_name);
             let index_path = get_vector_index_path(segment_path, vector_name);
-            VectorStorageReadEnum::<S>::preopen(
+            VectorStorageReadEnum::<Fs::File>::preopen(
                 fs,
                 vector_config,
                 &path,
@@ -190,7 +187,7 @@ impl<S: UniversalRead + 'static> LookupSegment<S> {
         }
         for vector_name in config.sparse_vector_data.keys() {
             let path = get_vector_storage_path(segment_path, vector_name);
-            ReadOnlySparseVectorStorage::<S>::preopen(fs, &path, WRITER_POPULATE)?;
+            ReadOnlySparseVectorStorage::<Fs::File>::preopen(fs, &path, WRITER_POPULATE)?;
         }
 
         Ok(config)

--- a/lib/segment/src/segment/update_only/lookup/live_reload.rs
+++ b/lib/segment/src/segment/update_only/lookup/live_reload.rs
@@ -1,12 +1,12 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
-use common::universal_io::{UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalReadFsAsync};
 
 use super::LookupSegment;
 use crate::common::live_reload::LiveReload as _;
 use crate::common::operation_error::OperationResult;
 
-impl<S: UniversalRead + 'static> LookupSegment<S> {
+impl<Fs: UniversalReadFsAsync> LookupSegment<Fs> {
     /// Refresh every component to the current on-disk state (id-tracker
     /// delta → payload storage and vector storages) without re-opening the
     /// segment — the mirror of [`ReadOnlySegment::live_reload`], over the
@@ -18,12 +18,9 @@ impl<S: UniversalRead + 'static> LookupSegment<S> {
     /// reloaded again.
     ///
     /// [`ReadOnlySegment::live_reload`]: crate::segment::read_only::ReadOnlySegment::live_reload
-    pub fn live_reload(
-        &mut self,
-        fs: &impl UniversalReadFs<File = S>,
-        hw_counter: &HardwareCounterCell,
-    ) -> OperationResult<()> {
+    pub fn live_reload(&mut self, hw_counter: &HardwareCounterCell) -> OperationResult<()> {
         let Self {
+            fs,
             segment_path: _,
             id_tracker,
             payload_storage,
@@ -32,6 +29,23 @@ impl<S: UniversalRead + 'static> LookupSegment<S> {
             appendable: _,
         } = self;
 
+        // Prepare new LIST snapshot
+        fs.rotate_cache_file_info();
+        fs.cache_file_info()?;
+
+        // Live preload: schedule everything
+        let mut futs = id_tracker.borrow().live_preload(fs)?;
+        futs.extend(payload_storage.borrow_mut().live_preload(fs)?);
+        for vector_storage in vector_data.values() {
+            futs.extend(vector_storage.borrow_mut().live_preload(fs)?);
+        }
+
+        // Wait for preload
+        futures::executor::block_on(async {
+            futures::join!(fs.wait_all(), futures::future::join_all(futs))
+        });
+
+        // Live reload: apply updates
         let delta = id_tracker.borrow_mut().live_reload(fs)?;
 
         // SAFETY: `LiveReloadResult` keeps both lists sorted ascending.

--- a/lib/segment/src/segment/update_only/lookup/mod.rs
+++ b/lib/segment/src/segment/update_only/lookup/mod.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
-use common::universal_io::UniversalRead;
+use common::universal_io::{CachedFs, UniversalReadFsAsync};
 
 use super::{AppendableIdTrackerState, DeleteOnlyIdTrackerState, WriterIdTrackerState};
 use crate::id_tracker::IdTrackerRead as _;
@@ -23,14 +23,16 @@ use crate::vector_storage::read_only::VectorStorageReadEnum;
 /// over the backend `S`, like `ReadOnlySegment`, and requiring no more of it
 /// than reads — every segment of a shard is opened this way, including those a
 /// batch never writes to.
-pub struct LookupSegment<S: UniversalRead + 'static> {
+pub struct LookupSegment<Fs: UniversalReadFsAsync> {
+    fs: CachedFs<Fs>,
+
     /// Path to the segment directory.
     pub segment_path: PathBuf,
 
-    pub id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<S>>>,
-    pub payload_storage: Arc<AtomicRefCell<ReadOnlyPayloadStorage<S>>>,
+    pub id_tracker: Arc<AtomicRefCell<ReadOnlyIdTrackerEnum<Fs::File>>>,
+    pub payload_storage: Arc<AtomicRefCell<ReadOnlyPayloadStorage<Fs::File>>>,
     /// One storage per named vector — no vector index, no quantized vectors.
-    pub vector_data: HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageReadEnum<S>>>>,
+    pub vector_data: HashMap<VectorNameBuf, Arc<AtomicRefCell<VectorStorageReadEnum<Fs::File>>>>,
 
     pub segment_config: SegmentConfig,
     /// Whether this segment accepts appends, and can therefore be the target
@@ -38,7 +40,7 @@ pub struct LookupSegment<S: UniversalRead + 'static> {
     pub appendable: bool,
 }
 
-impl<S: UniversalRead + 'static> LookupSegment<S> {
+impl<Fs: UniversalReadFsAsync> LookupSegment<Fs> {
     /// The id-tracker state a writer resuming this segment picks up from, for
     /// [`UpdateOnlySegmentEnum::open`](super::UpdateOnlySegmentEnum::open).
     ///

--- a/lib/segment/src/segment/update_only/lookup/resolve.rs
+++ b/lib/segment/src/segment/update_only/lookup/resolve.rs
@@ -7,7 +7,7 @@ use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::generic_consts::Random;
 use common::types::{DeferredBehavior, PointOffsetType};
-use common::universal_io::UniversalRead;
+use common::universal_io::UniversalReadFsAsync;
 
 use super::LookupSegment;
 use crate::common::operation_error::OperationResult;
@@ -18,7 +18,7 @@ use crate::payload_storage::PayloadStorageRead;
 use crate::types::{Payload, PointIdType, SeqNumberType};
 use crate::vector_storage::VectorStorageRead;
 
-impl<S: UniversalRead + 'static> LookupSegment<S> {
+impl<Fs: UniversalReadFsAsync> LookupSegment<Fs> {
     /// Locate `point_ids` in this segment, streaming each `(point_id,
     /// internal_id)` pair that resolves; ids the segment does not hold are
     /// skipped. Deferred heads are included, so a point shadowed by an

--- a/lib/segment/src/segment/update_only/segment_enum.rs
+++ b/lib/segment/src/segment/update_only/segment_enum.rs
@@ -30,7 +30,7 @@ impl<Fs: UniversalAppendFs> UpdateOnlySegmentEnum<Fs> {
                 AppendableSegment::open(fs, segment_path, config, state)?,
             )),
             WriterIdTrackerState::DeleteOnly(state) => {
-                Self::DeleteOnly(DeleteOnlySegment::open(fs, segment_path, state))
+                Self::DeleteOnly(DeleteOnlySegment::open(fs, segment_path, state)?)
             }
         })
     }


### PR DESCRIPTION
Here, we finally instantiate and use one `CachedFs` per `AppendableSegment` and `LookupSegment`. This cuts down a portion of `len::<u8>()` calls that were easily avoidable with an initial LIST operation.

Disclaimer: there will still be a number of synchronous `len` and `read` calls because of how appending works, specially when it rewrites files. But, in local testing, this already reduces the total time for updates.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>