### PR TITLE
Probe segment memory outside read locks

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1241,15 +1241,21 @@ impl LocalShard {
     pub async fn memory_report(&self) -> CollectionResult<CollectionMemoryReport> {
         let segments = self.segments.clone();
         tokio::task::spawn_blocking(move || {
-            let segments_read = segments.read();
-            let mut reports = Vec::new();
+            // Collect metadata while the segments are stable, then release all
+            // segment locks before issuing page-cache probes.
+            let segment_reports = {
+                let segments_read = segments.read();
+                let mut reports = Vec::new();
+                for (_id, locked_segment) in segments_read.iter() {
+                    collect_segment_memory_metadata(locked_segment, &mut reports);
+                }
+                reports
+            };
 
-            // Collect from all segments, including those wrapped in proxies.
-            // During optimization, original segments become proxy-wrapped while
-            // a new empty segment is built. We must report from both.
-            for (_id, locked_segment) in segments_read.iter() {
-                collect_memory_reports(locked_segment, &mut reports)?;
-            }
+            let reports = segment_reports
+                .into_iter()
+                .map(crate::common::memory_reporter::report_from_segment)
+                .collect::<CollectionResult<Vec<_>>>()?;
 
             Ok(CollectionMemoryReport::merge_all(reports))
         })
@@ -1694,27 +1700,23 @@ fn desired_vector_names_from_config(
     desired
 }
 
-/// Recursively collect memory reports from a `LockedSegment`.
+/// Recursively collect memory metadata from a `LockedSegment`.
 ///
 /// For `Original` segments, collects directly.
 /// For `Proxy` segments, collects from the wrapped segment
 /// (which is the real data holder during optimization).
-fn collect_memory_reports(
+fn collect_segment_memory_metadata(
     locked_segment: &LockedSegment,
-    reports: &mut Vec<CollectionMemoryReport>,
-) -> CollectionResult<()> {
+    reports: &mut Vec<segment::segment::memory::SegmentMemoryReport>,
+) {
     match locked_segment {
         LockedSegment::Original(segment) => {
             let segment_guard = segment.read();
-            let seg_report = segment_guard.memory_report();
-            reports.push(crate::common::memory_reporter::report_from_segment(
-                seg_report,
-            )?);
+            reports.push(segment_guard.memory_report());
         }
         LockedSegment::Proxy(proxy) => {
             let proxy_guard = proxy.read();
-            collect_memory_reports(&proxy_guard.wrapped_segment, reports)?;
+            collect_segment_memory_metadata(&proxy_guard.wrapped_segment, reports);
         }
     }
-    Ok(())
 }

--- a/lib/segment/src/segment/memory.rs
+++ b/lib/segment/src/segment/memory.rs
@@ -35,7 +35,7 @@ impl Segment {
     /// Collect memory usage from all sub-components.
     ///
     /// This method only collects file lists and RAM estimates (no I/O).
-    /// The actual `mincore` measurement happens at a higher layer.
+    /// The actual page-cache measurement happens at a higher layer, outside locks.
     pub fn memory_report(&self) -> SegmentMemoryReport {
         let Segment {
             uuid: _,


### PR DESCRIPTION
Stacked on #10455; split from #10454.

Collects segment memory metadata while segments are stable, releases segment and holder read locks, and only then performs page-cache probes. Probe behavior and error semantics are otherwise unchanged.

Stack: #10455 → #10457 → #10458 → #10456.