### PR TITLE
Probe large memory reports with temporary workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,6 +1344,7 @@ dependencies = [
  "proptest",
  "rand 0.10.2",
  "rand_distr",
+ "rayon",
  "ringbuffer",
  "rmp-serde",
  "rstest",

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7387,7 +7387,7 @@
             "minimum": 0
           },
           "max_segment_size": {
-            "description": "Do not create segments larger this size (in kilobytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.\n\nIf indexing speed is more important - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256 If not set, will be automatically selected considering the number of available CPUs.",
+            "description": "Do not create segments larger than this size (in kilobytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.\n\nIf indexing speed is more important - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256 If not set, will be automatically selected considering the number of available CPUs.",
             "default": null,
             "type": "integer",
             "format": "uint",
@@ -9812,7 +9812,7 @@
             "nullable": true
           },
           "max_segment_size": {
-            "description": "Do not create segments larger this size (in kilobytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.\n\nIf indexation speed have more priority for your - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256",
+            "description": "Do not create segments larger than this size (in kilobytes). Large segments might require disproportionately long indexation times, therefore it makes sense to limit the size of segments.\n\nIf indexation speed have more priority for your - make this parameter lower. If search speed is more important - make this parameter higher. Note: 1Kb = 1 vector of size 256",
             "type": "integer",
             "format": "uint",
             "minimum": 1,

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -41,6 +41,7 @@ fs-err = { workspace = true }
 parking_lot = { workspace = true }
 ahash = { workspace = true }
 rand = { workspace = true }
+rayon = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -108,4 +109,8 @@ harness = false
 
 [[bench]]
 name = "batch_query_bench"
+harness = false
+
+[[bench]]
+name = "memory_report"
 harness = false

--- a/lib/collection/benches/memory_report.rs
+++ b/lib/collection/benches/memory_report.rs
@@ -11,9 +11,13 @@ fn memory_report(c: &mut Criterion) {
     for (name, segments, files_per_segment, file_bytes) in [
         ("one_file", 1, 1, 4096),
         ("small_files", 1, 32, 4096),
+        ("below_parallel_threshold", 1, 127, 4096),
+        ("parallel_threshold", 1, 128, 4096),
         ("many_segments", 16, 32, 4096),
+        ("many_files", 16, 256, 4096),
         ("large_files", 1, 32, 64 * 1024 * 1024),
         ("large_files_many_segments", 16, 2, 64 * 1024 * 1024),
+        ("large_parallel_report", 16, 32, 4 * 1024 * 1024),
     ] {
         let dir = tempfile::tempdir().unwrap();
         let data = vec![1; file_bytes.min(1024 * 1024)];

--- a/lib/collection/benches/memory_report.rs
+++ b/lib/collection/benches/memory_report.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+use std::io::Write;
+
+use collection::common::memory_reporter::report_from_segments;
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use segment::common::memory_usage::{ComponentMemoryUsage, FileStorageIntent};
+use segment::segment::memory::SegmentMemoryReport;
+
+fn memory_report(c: &mut Criterion) {
+    let mut group = c.benchmark_group("memory_report");
+    for (name, segments, files_per_segment, file_bytes) in [
+        ("one_file", 1, 1, 4096),
+        ("small_files", 1, 32, 4096),
+        ("many_segments", 16, 32, 4096),
+        ("large_files", 1, 32, 64 * 1024 * 1024),
+        ("large_files_many_segments", 16, 2, 64 * 1024 * 1024),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        let data = vec![1; file_bytes.min(1024 * 1024)];
+        let paths: Vec<_> = (0..segments * files_per_segment)
+            .map(|i| {
+                let path = dir.path().join(i.to_string());
+                let mut file = fs_err::File::create(&path).unwrap();
+                for _ in 0..file_bytes / data.len() {
+                    file.write_all(&data).unwrap();
+                }
+                file.sync_all().unwrap();
+                path
+            })
+            .collect();
+
+        // File creation and metadata assembly are outside the measured interval.
+        group.bench_function(name, |b| {
+            b.iter_batched(
+                || {
+                    paths
+                        .chunks(files_per_segment)
+                        .map(|paths| SegmentMemoryReport {
+                            vectors: HashMap::new(),
+                            sparse_vectors: HashMap::new(),
+                            payload: ComponentMemoryUsage::from_files(
+                                paths.to_vec(),
+                                FileStorageIntent::Cached,
+                            ),
+                            payload_index: HashMap::new(),
+                            id_tracker: ComponentMemoryUsage::ram_only(42),
+                        })
+                        .collect()
+                },
+                report_from_segments,
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, memory_report);
+criterion_main!(benches);

--- a/lib/collection/src/common/memory_reporter.rs
+++ b/lib/collection/src/common/memory_reporter.rs
@@ -1,3 +1,10 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use rayon::prelude::*;
+use segment::common::memory_usage::{ComponentMemoryUsage, FileStorageIntent};
+use segment::segment::memory::SegmentMemoryReport;
 use serde::{Deserialize, Serialize};
 
 /// Memory usage stats for a single component, after page-cache measurement.
@@ -69,8 +76,7 @@ pub struct CollectionMemoryReport {
     pub payload: MemoryUsageReport,
     pub payload_index: Vec<NamedPayloadIndexMemoryReport>,
     pub other: OtherMemoryReport,
-    /// Non-fatal issues encountered while building the report (e.g. a remote
-    /// shard timed out). Present only when the response is partial.
+    /// Files or shards that could not be fully measured.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
 }
@@ -158,214 +164,128 @@ struct FileProbe {
     resident_bytes: u64,
 }
 
-/// Convert a `ComponentMemoryUsage` into a `MemoryUsageReport` using
-/// precomputed file probes (and optional disk-only fallback on non-unix).
-fn measure_component_with_probes(
-    usage: segment::common::memory_usage::ComponentMemoryUsage,
-    probes: &std::collections::HashMap<std::path::PathBuf, FileProbe>,
+/// Apply file probes and heap estimates to a component.
+fn measure_component(
+    usage: ComponentMemoryUsage,
+    probes: &HashMap<PathBuf, FileProbe>,
 ) -> MemoryUsageReport {
-    use segment::common::memory_usage::{
-        ComponentFileEntry, ComponentMemoryUsage, FileStorageIntent,
+    let mut report = MemoryUsageReport {
+        ram_bytes: usage.extra_ram_bytes.unwrap_or(0),
+        ..Default::default()
     };
-
-    let ComponentMemoryUsage {
-        files,
-        extra_ram_bytes,
-    } = usage;
-
-    let ram_bytes = extra_ram_bytes.unwrap_or(0);
-    let mut disk_bytes = 0u64;
-    let mut cached_bytes = 0u64;
-    let mut expected_cache_bytes = 0u64;
-
-    for entry in &files {
-        let ComponentFileEntry { path, intent } = entry;
-        let (file_disk, file_resident) = match probes.get(path) {
-            Some(probe) => (probe.disk_bytes, probe.resident_bytes),
-            None => {
-                // Non-unix / failed probe: disk size from metadata when possible.
-                match fs_err::metadata(path) {
-                    Ok(meta) => (meta.len(), 0),
-                    Err(_) => continue,
-                }
-            }
-        };
-        disk_bytes += file_disk;
-        match intent {
-            FileStorageIntent::Cached => {
-                expected_cache_bytes += file_disk;
-                cached_bytes += file_resident;
-            }
-            FileStorageIntent::OnDisk => {
-                cached_bytes += file_resident;
-            }
+    for entry in usage.files {
+        let probe = &probes[&entry.path];
+        report.disk_bytes += probe.disk_bytes;
+        report.cached_bytes += probe.resident_bytes;
+        if entry.intent == FileStorageIntent::Cached {
+            report.expected_cache_bytes += probe.disk_bytes;
         }
     }
-
-    MemoryUsageReport {
-        disk_bytes,
-        ram_bytes,
-        cached_bytes,
-        expected_cache_bytes,
-    }
+    report
 }
 
-/// Probe many files concurrently. Failures become warnings; successful probes
-/// are returned in the map.
-///
-/// Concurrency is capped to `available_parallelism`. Each worker probes one
-/// whole file at a time, so this is the only thread fan-out layer.
-#[cfg(unix)]
-fn parallel_probe_files(
-    paths: &[std::path::PathBuf],
-    warnings: &mut Vec<String>,
-) -> std::collections::HashMap<std::path::PathBuf, FileProbe> {
-    use std::collections::HashMap;
-    use std::sync::Mutex;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    use common::universal_io::MmapFile;
-
-    if paths.is_empty() {
-        return HashMap::new();
+/// Reuse workers across segments, shards and requests.
+static FILE_PROBE_POOL: LazyLock<Option<rayon::ThreadPool>> = LazyLock::new(|| {
+    // Bound scheduling overhead while retaining parallelism for large files.
+    let threads = std::thread::available_parallelism()
+        .map_or(1, |n| n.get())
+        .min(32);
+    if threads == 1 {
+        return None;
     }
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .thread_name(|i| format!("memory-probe-{i}"))
+        .build()
+        .ok()
+});
 
-    if paths.len() == 1 {
-        let path = &paths[0];
-        return match MmapFile::probe_memory_stats(path) {
-            Ok((disk_bytes, resident_bytes)) => HashMap::from([(
-                path.clone(),
+/// Probe each path once, retaining disk sizes when residency is unavailable.
+fn probe_files(paths: &[&Path], warnings: &mut Vec<String>) -> HashMap<PathBuf, FileProbe> {
+    let probe = |path: &&Path| {
+        #[cfg(unix)]
+        let result = common::universal_io::MmapFile::probe_memory_stats(path);
+        #[cfg(not(unix))]
+        let result = fs_err::metadata(path).map(|meta| (meta.len(), 0));
+
+        match result {
+            Ok((disk_bytes, resident_bytes)) => (
                 FileProbe {
                     disk_bytes,
                     resident_bytes,
                 },
-            )]),
-            Err(err) => {
-                warnings.push(format!(
+                None,
+            ),
+            Err(err) => (
+                FileProbe {
+                    disk_bytes: fs_err::metadata(path).map_or(0, |meta| meta.len()),
+                    resident_bytes: 0,
+                },
+                Some(format!(
                     "Failed to probe memory stats for {}: {err}",
                     path.display()
-                ));
-                HashMap::new()
-            }
-        };
-    }
-
-    let next = AtomicUsize::new(0);
-    let successes = Mutex::new(HashMap::new());
-    let failures = Mutex::new(Vec::new());
-
-    let workers = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(4)
-        .clamp(1, paths.len());
-
-    std::thread::scope(|scope| {
-        for _ in 0..workers {
-            scope.spawn(|| {
-                loop {
-                    let idx = next.fetch_add(1, Ordering::Relaxed);
-                    if idx >= paths.len() {
-                        break;
-                    }
-                    let path = &paths[idx];
-                    match MmapFile::probe_memory_stats(path) {
-                        Ok((disk_bytes, resident_bytes)) => {
-                            successes.lock().unwrap().insert(
-                                path.clone(),
-                                FileProbe {
-                                    disk_bytes,
-                                    resident_bytes,
-                                },
-                            );
-                        }
-                        Err(err) => {
-                            failures.lock().unwrap().push(format!(
-                                "Failed to probe memory stats for {}: {err}",
-                                path.display()
-                            ));
-                        }
-                    }
-                }
-            });
+                )),
+            ),
         }
-    });
-
-    warnings.extend(failures.into_inner().unwrap());
-    successes.into_inner().unwrap()
-}
-
-#[cfg(not(unix))]
-fn parallel_probe_files(
-    _paths: &[std::path::PathBuf],
-    _warnings: &mut Vec<String>,
-) -> std::collections::HashMap<std::path::PathBuf, FileProbe> {
-    std::collections::HashMap::new()
-}
-
-/// Collect every file path referenced by a segment memory report.
-fn collect_segment_paths(
-    segment_report: &segment::segment::memory::SegmentMemoryReport,
-) -> Vec<std::path::PathBuf> {
-    use segment::segment::memory::{
-        PayloadIndexMemoryReport, SegmentMemoryReport, VectorMemoryReport,
     };
-
-    let mut paths = Vec::new();
-    let SegmentMemoryReport {
-        vectors,
-        sparse_vectors,
-        payload,
-        payload_index,
-        id_tracker,
-    } = segment_report;
-
-    for vr in vectors.values() {
-        let VectorMemoryReport {
-            storage,
-            index,
-            quantized,
-        } = vr;
-        paths.extend(storage.files.iter().map(|f| f.path.clone()));
-        paths.extend(index.files.iter().map(|f| f.path.clone()));
-        if let Some(q) = quantized {
-            paths.extend(q.files.iter().map(|f| f.path.clone()));
-        }
-    }
-    for vr in sparse_vectors.values() {
-        let VectorMemoryReport {
-            storage,
-            index,
-            quantized: _,
-        } = vr;
-        paths.extend(storage.files.iter().map(|f| f.path.clone()));
-        paths.extend(index.files.iter().map(|f| f.path.clone()));
-    }
-    paths.extend(payload.files.iter().map(|f| f.path.clone()));
-    for pi in payload_index.values() {
-        let PayloadIndexMemoryReport { usage } = pi;
-        paths.extend(usage.files.iter().map(|f| f.path.clone()));
-    }
-    paths.extend(id_tracker.files.iter().map(|f| f.path.clone()));
-
-    paths.sort();
-    paths.dedup();
+    // Avoid initializing the pool for empty and single-file reports. If worker
+    // creation fails, measuring sequentially still produces a complete report.
+    let results: Vec<_> = if paths.len() > 1
+        && let Some(pool) = &*FILE_PROBE_POOL
+    {
+        pool.install(|| paths.par_iter().map(probe).collect())
+    } else {
+        paths.iter().map(probe).collect()
+    };
     paths
+        .iter()
+        .zip(results)
+        .map(|(path, (probe, warning))| {
+            warnings.extend(warning);
+            (path.to_path_buf(), probe)
+        })
+        .collect()
+}
+
+fn segment_paths(report: &SegmentMemoryReport) -> impl Iterator<Item = &Path> {
+    report
+        .vectors
+        .values()
+        .chain(report.sparse_vectors.values())
+        .flat_map(|vector| {
+            [&vector.storage, &vector.index]
+                .into_iter()
+                .chain(&vector.quantized)
+        })
+        .chain([&report.payload, &report.id_tracker])
+        .chain(report.payload_index.values().map(|index| &index.usage))
+        .flat_map(|usage| usage.files.iter().map(|file| file.path.as_path()))
+}
+
+/// Measure all segment files after the caller has released segment locks.
+pub fn report_from_segments(segment_reports: Vec<SegmentMemoryReport>) -> CollectionMemoryReport {
+    let mut paths: Vec<_> = segment_reports.iter().flat_map(segment_paths).collect();
+    paths.sort_unstable();
+    paths.dedup();
+    let mut warnings = Vec::new();
+    let probes = probe_files(&paths, &mut warnings);
+    let reports = segment_reports
+        .into_iter()
+        .map(|report| report_from_segment(report, &probes))
+        .collect();
+    let mut report = CollectionMemoryReport::merge_all(reports);
+    report.warnings = warnings;
+    report
 }
 
 /// Build a `CollectionMemoryReport` from a segment-level report.
-///
-/// Callers must invoke this **outside** segment locks: it performs page-cache
-/// probing I/O that can take a long time on large files.
-pub fn report_from_segment(
-    segment_report: segment::segment::memory::SegmentMemoryReport,
+fn report_from_segment(
+    segment_report: SegmentMemoryReport,
+    probes: &HashMap<PathBuf, FileProbe>,
 ) -> CollectionMemoryReport {
     use segment::segment::memory::{
         PayloadIndexMemoryReport, SegmentMemoryReport, VectorMemoryReport,
     };
-
-    let mut warnings = Vec::new();
-    let paths = collect_segment_paths(&segment_report);
-    let probes = parallel_probe_files(&paths, &mut warnings);
 
     let SegmentMemoryReport {
         vectors,
@@ -385,9 +305,9 @@ pub fn report_from_segment(
             } = vr;
             NamedVectorMemoryReport {
                 name,
-                storage: measure_component_with_probes(storage, &probes),
-                index: measure_component_with_probes(index, &probes),
-                quantized: quantized.map(|q| measure_component_with_probes(q, &probes)),
+                storage: measure_component(storage, probes),
+                index: measure_component(index, probes),
+                quantized: quantized.map(|q| measure_component(q, probes)),
             }
         })
         .collect::<Vec<_>>();
@@ -402,8 +322,8 @@ pub fn report_from_segment(
             } = vr;
             NamedSparseVectorMemoryReport {
                 name,
-                storage: measure_component_with_probes(storage, &probes),
-                index: measure_component_with_probes(index, &probes),
+                storage: measure_component(storage, probes),
+                index: measure_component(index, probes),
             }
         })
         .collect::<Vec<_>>();
@@ -414,14 +334,14 @@ pub fn report_from_segment(
             let PayloadIndexMemoryReport { usage } = pi;
             NamedPayloadIndexMemoryReport {
                 name,
-                usage: measure_component_with_probes(usage, &probes),
+                usage: measure_component(usage, probes),
             }
         })
         .collect::<Vec<_>>();
 
-    let payload = measure_component_with_probes(payload, &probes);
+    let payload = measure_component(payload, probes);
     let other = OtherMemoryReport {
-        id_tracker: measure_component_with_probes(id_tracker, &probes),
+        id_tracker: measure_component(id_tracker, probes),
     };
 
     let mut total = MemoryUsageReport::default();
@@ -462,6 +382,9 @@ pub fn report_from_segment(
         payload,
         payload_index,
         other,
-        warnings,
+        warnings: Vec::new(),
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/lib/collection/src/common/memory_reporter.rs
+++ b/lib/collection/src/common/memory_reporter.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::LazyLock;
 
 use rayon::prelude::*;
 use segment::common::memory_usage::{ComponentMemoryUsage, FileStorageIntent};
@@ -184,21 +183,31 @@ fn measure_component(
     report
 }
 
-/// Reuse workers across segments, shards and requests.
-static FILE_PROBE_POOL: LazyLock<Option<rayon::ThreadPool>> = LazyLock::new(|| {
-    // Bound scheduling overhead while retaining parallelism for large files.
-    let threads = std::thread::available_parallelism()
-        .map_or(1, |n| n.get())
+const MIN_PARALLEL_PROBE_FILES: usize = 128;
+
+/// Small reports run on the caller; large reports join temporary workers before returning.
+fn map_file_probes<T: Send>(paths: &[&Path], probe: impl Fn(&&Path) -> T + Sync) -> Vec<T> {
+    let sequential = || paths.iter().map(&probe).collect();
+    if paths.len() < MIN_PARALLEL_PROBE_FILES {
+        return sequential();
+    }
+
+    // Amortize thread creation over at least 32 files per worker.
+    let threads = (paths.len() / 32)
+        .min(std::thread::available_parallelism().map_or(1, |n| n.get()))
         .min(32);
-    if threads == 1 {
-        return None;
+    if threads <= 1 {
+        return sequential();
     }
     rayon::ThreadPoolBuilder::new()
         .num_threads(threads)
         .thread_name(|i| format!("memory-probe-{i}"))
-        .build()
-        .ok()
-});
+        .build_scoped(
+            |thread| thread.run(),
+            |pool| pool.install(|| paths.par_iter().map(&probe).collect()),
+        )
+        .unwrap_or_else(|_| sequential())
+}
 
 /// Probe each path once, retaining disk sizes when residency is unavailable.
 fn probe_files(paths: &[&Path], warnings: &mut Vec<String>) -> HashMap<PathBuf, FileProbe> {
@@ -228,15 +237,7 @@ fn probe_files(paths: &[&Path], warnings: &mut Vec<String>) -> HashMap<PathBuf, 
             ),
         }
     };
-    // Avoid initializing the pool for empty and single-file reports. If worker
-    // creation fails, measuring sequentially still produces a complete report.
-    let results: Vec<_> = if paths.len() > 1
-        && let Some(pool) = &*FILE_PROBE_POOL
-    {
-        pool.install(|| paths.par_iter().map(probe).collect())
-    } else {
-        paths.iter().map(probe).collect()
-    };
+    let results = map_file_probes(paths, probe);
     paths
         .iter()
         .zip(results)

--- a/lib/collection/src/common/memory_reporter.rs
+++ b/lib/collection/src/common/memory_reporter.rs
@@ -84,6 +84,17 @@ impl CollectionMemoryReport {
     /// Merge multiple reports (from different shards) into one.
     pub fn merge_all(reports: Vec<CollectionMemoryReport>) -> CollectionMemoryReport {
         let mut result = CollectionMemoryReport::default();
+        let CollectionMemoryReport {
+            total: result_total,
+            vectors: result_vectors,
+            sparse_vectors: result_sparse_vectors,
+            payload: result_payload,
+            payload_index: result_payload_index,
+            other: OtherMemoryReport {
+                id_tracker: result_id_tracker,
+            },
+            warnings: result_warnings,
+        } = &mut result;
 
         for report in reports {
             let CollectionMemoryReport {
@@ -96,7 +107,7 @@ impl CollectionMemoryReport {
                 warnings,
             } = report;
 
-            result.total.merge(&total);
+            result_total.merge(&total);
 
             // Merge vectors by name
             for vec_report in vectors {
@@ -107,7 +118,7 @@ impl CollectionMemoryReport {
                     quantized,
                 } = &vec_report;
 
-                if let Some(existing) = result.vectors.iter_mut().find(|v| v.name == *name) {
+                if let Some(existing) = result_vectors.iter_mut().find(|v| v.name == *name) {
                     existing.storage.merge(storage);
                     existing.index.merge(index);
                     match (&mut existing.quantized, quantized) {
@@ -116,7 +127,7 @@ impl CollectionMemoryReport {
                         _ => {}
                     }
                 } else {
-                    result.vectors.push(vec_report);
+                    result_vectors.push(vec_report);
                 }
             }
 
@@ -128,28 +139,28 @@ impl CollectionMemoryReport {
                     index,
                 } = &sv_report;
 
-                if let Some(existing) = result.sparse_vectors.iter_mut().find(|v| v.name == *name) {
+                if let Some(existing) = result_sparse_vectors.iter_mut().find(|v| v.name == *name) {
                     existing.storage.merge(storage);
                     existing.index.merge(index);
                 } else {
-                    result.sparse_vectors.push(sv_report);
+                    result_sparse_vectors.push(sv_report);
                 }
             }
 
-            result.payload.merge(&payload);
+            result_payload.merge(&payload);
 
             for pi_report in payload_index {
                 let NamedPayloadIndexMemoryReport { name, usage } = &pi_report;
 
-                if let Some(existing) = result.payload_index.iter_mut().find(|p| p.name == *name) {
+                if let Some(existing) = result_payload_index.iter_mut().find(|p| p.name == *name) {
                     existing.usage.merge(usage);
                 } else {
-                    result.payload_index.push(pi_report);
+                    result_payload_index.push(pi_report);
                 }
             }
 
-            result.other.id_tracker.merge(&id_tracker);
-            result.warnings.extend(warnings);
+            result_id_tracker.merge(&id_tracker);
+            result_warnings.extend(warnings);
         }
 
         result

--- a/lib/collection/src/common/memory_reporter.rs
+++ b/lib/collection/src/common/memory_reporter.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::operations::types::CollectionResult;
-
-/// Memory usage stats for a single component, after mincore measurement.
+/// Memory usage stats for a single component, after page-cache measurement.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MemoryUsageReport {
     /// Total bytes stored on disk (file sizes).
@@ -71,6 +69,10 @@ pub struct CollectionMemoryReport {
     pub payload: MemoryUsageReport,
     pub payload_index: Vec<NamedPayloadIndexMemoryReport>,
     pub other: OtherMemoryReport,
+    /// Non-fatal issues encountered while building the report (e.g. a remote
+    /// shard timed out). Present only when the response is partial.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
 }
 
 impl CollectionMemoryReport {
@@ -86,6 +88,7 @@ impl CollectionMemoryReport {
                 payload,
                 payload_index,
                 other: OtherMemoryReport { id_tracker },
+                warnings,
             } = report;
 
             result.total.merge(&total);
@@ -141,24 +144,29 @@ impl CollectionMemoryReport {
             }
 
             result.other.id_tracker.merge(&id_tracker);
+            result.warnings.extend(warnings);
         }
 
         result
     }
 }
 
-/// Convert a `ComponentMemoryUsage` into a `MemoryUsageReport` by measuring
-/// file residency via mincore and adding extra RAM.
-#[cfg(unix)]
-pub fn measure_component(
+/// Probe results for a single file.
+#[derive(Debug, Clone, Copy)]
+struct FileProbe {
+    disk_bytes: u64,
+    resident_bytes: u64,
+}
+
+/// Convert a `ComponentMemoryUsage` into a `MemoryUsageReport` using
+/// precomputed file probes (and optional disk-only fallback on non-unix).
+fn measure_component_with_probes(
     usage: segment::common::memory_usage::ComponentMemoryUsage,
-) -> CollectionResult<MemoryUsageReport> {
-    use common::universal_io::MmapFile;
+    probes: &std::collections::HashMap<std::path::PathBuf, FileProbe>,
+) -> MemoryUsageReport {
     use segment::common::memory_usage::{
         ComponentFileEntry, ComponentMemoryUsage, FileStorageIntent,
     };
-
-    use crate::operations::types::CollectionError;
 
     let ComponentMemoryUsage {
         files,
@@ -170,15 +178,18 @@ pub fn measure_component(
     let mut cached_bytes = 0u64;
     let mut expected_cache_bytes = 0u64;
 
-    for entry in files {
-        let ComponentFileEntry { path, intent } = &entry;
-        let (file_disk, file_resident) = MmapFile::probe_memory_stats(path).map_err(|err| {
-            CollectionError::service_error(format!(
-                "Failed to probe memory stats for {}: {err}",
-                path.display()
-            ))
-        })?;
-
+    for entry in &files {
+        let ComponentFileEntry { path, intent } = entry;
+        let (file_disk, file_resident) = match probes.get(path) {
+            Some(probe) => (probe.disk_bytes, probe.resident_bytes),
+            None => {
+                // Non-unix / failed probe: disk size from metadata when possible.
+                match fs_err::metadata(path) {
+                    Ok(meta) => (meta.len(), 0),
+                    Err(_) => continue,
+                }
+            }
+        };
         disk_bytes += file_disk;
         match intent {
             FileStorageIntent::Cached => {
@@ -191,57 +202,170 @@ pub fn measure_component(
         }
     }
 
-    Ok(MemoryUsageReport {
+    MemoryUsageReport {
         disk_bytes,
         ram_bytes,
         cached_bytes,
         expected_cache_bytes,
-    })
+    }
 }
 
-/// Non-unix fallback: report disk sizes only, no residency info.
-#[cfg(not(unix))]
-pub fn measure_component(
-    usage: segment::common::memory_usage::ComponentMemoryUsage,
-) -> CollectionResult<MemoryUsageReport> {
-    use segment::common::memory_usage::{
-        ComponentFileEntry, ComponentMemoryUsage, FileStorageIntent,
-    };
+/// Probe many files concurrently. Failures become warnings; successful probes
+/// are returned in the map.
+///
+/// Concurrency is capped to `available_parallelism`. Each worker probes one
+/// whole file at a time, so this is the only thread fan-out layer.
+#[cfg(unix)]
+fn parallel_probe_files(
+    paths: &[std::path::PathBuf],
+    warnings: &mut Vec<String>,
+) -> std::collections::HashMap<std::path::PathBuf, FileProbe> {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
-    let ComponentMemoryUsage {
-        files,
-        extra_ram_bytes,
-    } = usage;
+    use common::universal_io::MmapFile;
 
-    let ram_bytes = extra_ram_bytes.unwrap_or(0);
-    let mut disk_bytes = 0u64;
-    let mut expected_cache_bytes = 0u64;
-
-    for entry in files {
-        let ComponentFileEntry { path, intent } = &entry;
-        if let Ok(meta) = fs_err::metadata(path) {
-            disk_bytes += meta.len();
-            if *intent == FileStorageIntent::Cached {
-                expected_cache_bytes += meta.len();
-            }
-        }
+    if paths.is_empty() {
+        return HashMap::new();
     }
 
-    Ok(MemoryUsageReport {
-        disk_bytes,
-        ram_bytes,
-        cached_bytes: 0,
-        expected_cache_bytes,
-    })
+    if paths.len() == 1 {
+        let path = &paths[0];
+        return match MmapFile::probe_memory_stats(path) {
+            Ok((disk_bytes, resident_bytes)) => HashMap::from([(
+                path.clone(),
+                FileProbe {
+                    disk_bytes,
+                    resident_bytes,
+                },
+            )]),
+            Err(err) => {
+                warnings.push(format!(
+                    "Failed to probe memory stats for {}: {err}",
+                    path.display()
+                ));
+                HashMap::new()
+            }
+        };
+    }
+
+    let next = AtomicUsize::new(0);
+    let successes = Mutex::new(HashMap::new());
+    let failures = Mutex::new(Vec::new());
+
+    let workers = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4)
+        .clamp(1, paths.len());
+
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| {
+                loop {
+                    let idx = next.fetch_add(1, Ordering::Relaxed);
+                    if idx >= paths.len() {
+                        break;
+                    }
+                    let path = &paths[idx];
+                    match MmapFile::probe_memory_stats(path) {
+                        Ok((disk_bytes, resident_bytes)) => {
+                            successes.lock().unwrap().insert(
+                                path.clone(),
+                                FileProbe {
+                                    disk_bytes,
+                                    resident_bytes,
+                                },
+                            );
+                        }
+                        Err(err) => {
+                            failures.lock().unwrap().push(format!(
+                                "Failed to probe memory stats for {}: {err}",
+                                path.display()
+                            ));
+                        }
+                    }
+                }
+            });
+        }
+    });
+
+    warnings.extend(failures.into_inner().unwrap());
+    successes.into_inner().unwrap()
 }
 
-/// Build a `CollectionMemoryReport` from a segment-level report.
-pub fn report_from_segment(
-    segment_report: segment::segment::memory::SegmentMemoryReport,
-) -> CollectionResult<CollectionMemoryReport> {
+#[cfg(not(unix))]
+fn parallel_probe_files(
+    _paths: &[std::path::PathBuf],
+    _warnings: &mut Vec<String>,
+) -> std::collections::HashMap<std::path::PathBuf, FileProbe> {
+    std::collections::HashMap::new()
+}
+
+/// Collect every file path referenced by a segment memory report.
+fn collect_segment_paths(
+    segment_report: &segment::segment::memory::SegmentMemoryReport,
+) -> Vec<std::path::PathBuf> {
     use segment::segment::memory::{
         PayloadIndexMemoryReport, SegmentMemoryReport, VectorMemoryReport,
     };
+
+    let mut paths = Vec::new();
+    let SegmentMemoryReport {
+        vectors,
+        sparse_vectors,
+        payload,
+        payload_index,
+        id_tracker,
+    } = segment_report;
+
+    for vr in vectors.values() {
+        let VectorMemoryReport {
+            storage,
+            index,
+            quantized,
+        } = vr;
+        paths.extend(storage.files.iter().map(|f| f.path.clone()));
+        paths.extend(index.files.iter().map(|f| f.path.clone()));
+        if let Some(q) = quantized {
+            paths.extend(q.files.iter().map(|f| f.path.clone()));
+        }
+    }
+    for vr in sparse_vectors.values() {
+        let VectorMemoryReport {
+            storage,
+            index,
+            quantized: _,
+        } = vr;
+        paths.extend(storage.files.iter().map(|f| f.path.clone()));
+        paths.extend(index.files.iter().map(|f| f.path.clone()));
+    }
+    paths.extend(payload.files.iter().map(|f| f.path.clone()));
+    for pi in payload_index.values() {
+        let PayloadIndexMemoryReport { usage } = pi;
+        paths.extend(usage.files.iter().map(|f| f.path.clone()));
+    }
+    paths.extend(id_tracker.files.iter().map(|f| f.path.clone()));
+
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+/// Build a `CollectionMemoryReport` from a segment-level report.
+///
+/// Callers must invoke this **outside** segment locks: it performs page-cache
+/// probing I/O that can take a long time on large files.
+pub fn report_from_segment(
+    segment_report: segment::segment::memory::SegmentMemoryReport,
+) -> CollectionMemoryReport {
+    use segment::segment::memory::{
+        PayloadIndexMemoryReport, SegmentMemoryReport, VectorMemoryReport,
+    };
+
+    let mut warnings = Vec::new();
+    let paths = collect_segment_paths(&segment_report);
+    let probes = parallel_probe_files(&paths, &mut warnings);
 
     let SegmentMemoryReport {
         vectors,
@@ -259,14 +383,14 @@ pub fn report_from_segment(
                 index,
                 quantized,
             } = vr;
-            Ok(NamedVectorMemoryReport {
+            NamedVectorMemoryReport {
                 name,
-                storage: measure_component(storage)?,
-                index: measure_component(index)?,
-                quantized: quantized.map(measure_component).transpose()?,
-            })
+                storage: measure_component_with_probes(storage, &probes),
+                index: measure_component_with_probes(index, &probes),
+                quantized: quantized.map(|q| measure_component_with_probes(q, &probes)),
+            }
         })
-        .collect::<CollectionResult<Vec<_>>>()?;
+        .collect::<Vec<_>>();
 
     let sparse_vectors = sparse_vectors
         .into_iter()
@@ -276,28 +400,28 @@ pub fn report_from_segment(
                 index,
                 quantized: _,
             } = vr;
-            Ok(NamedSparseVectorMemoryReport {
+            NamedSparseVectorMemoryReport {
                 name,
-                storage: measure_component(storage)?,
-                index: measure_component(index)?,
-            })
+                storage: measure_component_with_probes(storage, &probes),
+                index: measure_component_with_probes(index, &probes),
+            }
         })
-        .collect::<CollectionResult<Vec<_>>>()?;
+        .collect::<Vec<_>>();
 
     let payload_index = payload_index
         .into_iter()
         .map(|(name, pi)| {
             let PayloadIndexMemoryReport { usage } = pi;
-            Ok(NamedPayloadIndexMemoryReport {
+            NamedPayloadIndexMemoryReport {
                 name,
-                usage: measure_component(usage)?,
-            })
+                usage: measure_component_with_probes(usage, &probes),
+            }
         })
-        .collect::<CollectionResult<Vec<_>>>()?;
+        .collect::<Vec<_>>();
 
-    let payload = measure_component(payload)?;
+    let payload = measure_component_with_probes(payload, &probes);
     let other = OtherMemoryReport {
-        id_tracker: measure_component(id_tracker)?,
+        id_tracker: measure_component_with_probes(id_tracker, &probes),
     };
 
     let mut total = MemoryUsageReport::default();
@@ -331,12 +455,13 @@ pub fn report_from_segment(
     let OtherMemoryReport { id_tracker: ref id } = other;
     total.merge(id);
 
-    Ok(CollectionMemoryReport {
+    CollectionMemoryReport {
         total,
         vectors,
         sparse_vectors,
         payload,
         payload_index,
         other,
-    })
+        warnings,
+    }
 }

--- a/lib/collection/src/common/memory_reporter/tests.rs
+++ b/lib/collection/src/common/memory_reporter/tests.rs
@@ -1,0 +1,164 @@
+use segment::segment::memory::{PayloadIndexMemoryReport, VectorMemoryReport};
+
+use super::*;
+
+fn segment_report() -> SegmentMemoryReport {
+    SegmentMemoryReport {
+        vectors: HashMap::new(),
+        sparse_vectors: HashMap::new(),
+        payload: ComponentMemoryUsage::empty(),
+        payload_index: HashMap::new(),
+        id_tracker: ComponentMemoryUsage::empty(),
+    }
+}
+
+#[test]
+fn empty_and_heap_only_reports() {
+    let empty = report_from_segments(Vec::new());
+    assert_eq!(empty.total.disk_bytes, 0);
+    assert!(empty.warnings.is_empty());
+    assert!(
+        serde_json::to_value(empty)
+            .unwrap()
+            .get("warnings")
+            .is_none()
+    );
+
+    let mut segment = segment_report();
+    segment.payload = ComponentMemoryUsage::ram_only(123);
+    segment.id_tracker = ComponentMemoryUsage::ram_only(456);
+    let report = report_from_segments(vec![segment]);
+    assert_eq!(report.total.ram_bytes, 579);
+    assert_eq!(report.total.disk_bytes, 0);
+    assert!(report.warnings.is_empty());
+}
+
+#[test]
+fn storage_intent_only_changes_expected_cache() {
+    let path = PathBuf::from("data");
+    let probes = HashMap::from([(
+        path.clone(),
+        FileProbe {
+            disk_bytes: 100,
+            resident_bytes: 40,
+        },
+    )]);
+    for intent in [FileStorageIntent::Cached, FileStorageIntent::OnDisk] {
+        let report = measure_component(
+            ComponentMemoryUsage::from_files_and_ram(vec![path.clone()], intent, 12),
+            &probes,
+        );
+        assert_eq!(report.disk_bytes, 100);
+        assert_eq!(report.cached_bytes, 40);
+        assert_eq!(report.ram_bytes, 12);
+        assert_eq!(
+            report.expected_cache_bytes,
+            if intent == FileStorageIntent::Cached {
+                100
+            } else {
+                0
+            }
+        );
+    }
+}
+
+#[test]
+fn measures_and_merges_every_component() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths: Vec<_> = (1..=8)
+        .map(|i| {
+            let path = dir.path().join(i.to_string());
+            fs_err::write(&path, vec![1; i * 4096]).unwrap();
+            path
+        })
+        .collect();
+    let make_segment = || {
+        let usage = |i: usize| {
+            ComponentMemoryUsage::from_files(vec![paths[i].clone()], FileStorageIntent::Cached)
+        };
+        let mut segment = segment_report();
+        segment.vectors.insert(
+            "dense".into(),
+            VectorMemoryReport {
+                storage: usage(0),
+                index: usage(1),
+                quantized: Some(usage(2)),
+            },
+        );
+        segment.sparse_vectors.insert(
+            "sparse".into(),
+            VectorMemoryReport {
+                storage: usage(3),
+                index: usage(4),
+                quantized: None,
+            },
+        );
+        segment.payload = usage(5);
+        segment
+            .payload_index
+            .insert("field".into(), PayloadIndexMemoryReport { usage: usage(6) });
+        segment.id_tracker = usage(7);
+        segment
+    };
+    let report = report_from_segments(vec![make_segment(), make_segment()]);
+    assert!(report.warnings.is_empty());
+    assert_eq!(report.vectors.len(), 1);
+    assert_eq!(report.vectors[0].storage.disk_bytes, 2 * 4096);
+    assert_eq!(report.vectors[0].index.disk_bytes, 4 * 4096);
+    assert_eq!(
+        report.vectors[0].quantized.as_ref().unwrap().disk_bytes,
+        6 * 4096
+    );
+    assert_eq!(report.sparse_vectors[0].storage.disk_bytes, 8 * 4096);
+    assert_eq!(report.sparse_vectors[0].index.disk_bytes, 10 * 4096);
+    assert_eq!(report.payload.disk_bytes, 12 * 4096);
+    assert_eq!(report.payload_index[0].usage.disk_bytes, 14 * 4096);
+    assert_eq!(report.other.id_tracker.disk_bytes, 16 * 4096);
+    assert_eq!(report.total.disk_bytes, 72 * 4096);
+    assert_eq!(report.total.expected_cache_bytes, report.total.disk_bytes);
+    assert!(report.total.cached_bytes <= report.total.disk_bytes);
+}
+
+#[test]
+fn missing_file_warns_once_across_segments() {
+    let dir = tempfile::tempdir().unwrap();
+    let present = dir.path().join("present");
+    fs_err::write(&present, [1; 4096]).unwrap();
+    let missing = dir.path().join("missing");
+    let make_segment = || {
+        let mut segment = segment_report();
+        segment.payload = ComponentMemoryUsage::from_files_and_ram(
+            vec![present.clone(), missing.clone(), missing.clone()],
+            FileStorageIntent::Cached,
+            42,
+        );
+        segment
+    };
+    let report = report_from_segments(vec![make_segment(), make_segment()]);
+    assert_eq!(report.total.disk_bytes, 8192);
+    assert_eq!(report.total.ram_bytes, 84);
+    assert_eq!(report.warnings.len(), 1);
+    assert!(report.warnings[0].contains(&missing.display().to_string()));
+    let merged = CollectionMemoryReport::merge_all(vec![report.clone(), report]);
+    assert_eq!(merged.warnings.len(), 2);
+}
+
+#[test]
+#[cfg(unix)]
+fn failed_probe_retains_available_disk_size() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("unreadable");
+    fs_err::write(&path, [1; 4096]).unwrap();
+    fs_err::set_permissions(&path, std::fs::Permissions::from_mode(0o0)).unwrap();
+    if fs_err::File::open(&path).is_ok() {
+        return; // Root can read files regardless of their permissions.
+    }
+    let mut warnings = Vec::new();
+    let probes = probe_files(&[&path], &mut warnings);
+    let probe = &probes[&path];
+    assert_eq!(probe.disk_bytes, 4096);
+    assert_eq!(probe.resident_bytes, 0);
+    assert_eq!(warnings.len(), 1);
+}

--- a/lib/collection/src/common/memory_reporter/tests.rs
+++ b/lib/collection/src/common/memory_reporter/tests.rs
@@ -2,6 +2,49 @@ use segment::segment::memory::{PayloadIndexMemoryReport, VectorMemoryReport};
 
 use super::*;
 
+#[test]
+fn small_reports_use_the_calling_thread() {
+    let paths = vec![Path::new("unused"); MIN_PARALLEL_PROBE_FILES - 1];
+    let caller = std::thread::current().id();
+    let threads = map_file_probes(&paths, |_| std::thread::current().id());
+    assert_eq!(threads.len(), paths.len());
+    assert!(threads.iter().all(|thread| *thread == caller));
+}
+
+#[test]
+fn large_reports_release_their_workers() {
+    use std::cell::RefCell;
+    use std::sync::{Arc, mpsc};
+    use std::time::Duration;
+
+    thread_local! {
+        static WORKER_LIFETIME: RefCell<Option<Arc<mpsc::Sender<()>>>> = const { RefCell::new(None) };
+    }
+
+    let (sender, receiver) = mpsc::channel();
+    let lifetime = Arc::new(sender);
+    let paths = vec![Path::new("unused"); MIN_PARALLEL_PROBE_FILES];
+    let caller = std::thread::current().id();
+    let threads = map_file_probes(&paths, |_| {
+        WORKER_LIFETIME.with(|guard| *guard.borrow_mut() = Some(lifetime.clone()));
+        std::thread::current().id()
+    });
+    assert_eq!(threads.len(), paths.len());
+    if std::thread::available_parallelism().unwrap().get() > 1 {
+        assert!(threads.iter().all(|thread| *thread != caller));
+    } else {
+        assert!(threads.iter().all(|thread| *thread == caller));
+        WORKER_LIFETIME.with(|guard| guard.borrow_mut().take());
+    }
+    // Scoped joins wait for worker functions; TLS destructors can finish later.
+    // The channel closes when all workers have released their TLS references.
+    drop(lifetime);
+    assert_eq!(
+        receiver.recv_timeout(Duration::from_secs(5)),
+        Err(mpsc::RecvTimeoutError::Disconnected)
+    );
+}
+
 fn segment_report() -> SegmentMemoryReport {
     SegmentMemoryReport {
         vectors: HashMap::new(),

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -134,7 +134,7 @@ pub struct OptimizersConfigDiff {
     /// so that each segment would be handled evenly by one of the threads
     /// If `default_segment_number = 0`, will be automatically selected by the number of available CPUs
     pub default_segment_number: Option<usize>,
-    /// Do not create segments larger this size (in kilobytes).
+    /// Do not create segments larger than this size (in kilobytes).
     /// Large segments might require disproportionately long indexation times,
     /// therefore it makes sense to limit the size of segments.
     ///

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -53,7 +53,7 @@ pub struct OptimizersConfig {
     /// so that each segment would be handled evenly by one of the threads.
     /// If `default_segment_number = 0`, will be automatically selected by the number of available CPUs.
     pub default_segment_number: usize,
-    /// Do not create segments larger this size (in kilobytes).
+    /// Do not create segments larger than this size (in kilobytes).
     /// Large segments might require disproportionately long indexation times,
     /// therefore it makes sense to limit the size of segments.
     ///

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1255,7 +1255,7 @@ impl LocalShard {
             let reports = segment_reports
                 .into_iter()
                 .map(crate::common::memory_reporter::report_from_segment)
-                .collect::<CollectionResult<Vec<_>>>()?;
+                .collect();
 
             Ok(CollectionMemoryReport::merge_all(reports))
         })

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1252,12 +1252,9 @@ impl LocalShard {
                 reports
             };
 
-            let reports = segment_reports
-                .into_iter()
-                .map(crate::common::memory_reporter::report_from_segment)
-                .collect();
-
-            Ok(CollectionMemoryReport::merge_all(reports))
+            Ok(crate::common::memory_reporter::report_from_segments(
+                segment_reports,
+            ))
         })
         .await
         .map_err(|e| CollectionError::service_error(format!("Memory report task failed: {e}")))?

--- a/lib/segment/src/common/memory_usage.rs
+++ b/lib/segment/src/common/memory_usage.rs
@@ -86,7 +86,7 @@ impl ComponentMemoryUsage {
 
 /// Trait for components to report their memory footprint.
 ///
-/// Implementations should be cheap (no I/O). The actual `mincore` measurement
+/// Implementations should be cheap (no I/O). The actual page-cache measurement
 /// happens in the aggregation layer after file entries are collected.
 pub trait MemoryReporter {
     fn memory_usage(&self) -> ComponentMemoryUsage;


### PR DESCRIPTION
Collects and deduplicates file paths across each local shard before probing. Reports with fewer than 128 unique files run on the existing blocking task. Larger reports create temporary workers: one per 32 files, capped at 32 and the available CPU count. All workers are scoped to that report and joined before it returns; no pool is retained. One CPU or a pool-creation failure uses sequential probing.

Failed probes retain available disk sizes and produce one warning per path. Component and heap totals are preserved.

Local report latency on Ryzen 7965WX (48 logical CPUs), Linux 6.12, ext4. Timings include worker creation and joining on every report. Median of 21 interleaved samples (7 for the 128 GiB sparse case), with warm file contents; all report totals matched the sequential base `6917a2694`. The `mincore` run blocks `cachestat` only in the benchmark process.

| Probe / segments × files × size | Sequential | Temporary workers |
|---|---:|---:|
| cachestat: 1x128x4KiB | 0.449 ms | 0.380 ms |
| cachestat: 16x256x4KiB | 14.562 ms | 5.141 ms |
| cachestat: 16x32x4MiB | 16.823 ms | 1.890 ms |
| mincore: 16x256x32MiB-sparse | 1301.008 ms | 855.767 ms |

Small-file mincore probes can still be slower when parallelized because of mmap contention. The file-count threshold favors predictable resource use for infrequent administrative requests.

Validation: seven regression tests cover accounting, failure handling, sequential execution below the threshold, and worker shutdown. Tests passed with cachestat, forced mincore, and single-CPU affinity; Clippy with warnings denied and workspace formatting pass. The Criterion benchmark includes both sides of the threshold and large reports: `cargo bench -p collection --bench memory_report --profile perf`.

Predecessors #10455 and #10457 are merged; #10456 follows this PR.
