### PR TITLE
Document cancel safety for shard initialization

### DIFF
--- a/lib/collection/src/collection/shard_transfer.rs
+++ b/lib/collection/src/collection/shard_transfer.rs
@@ -665,12 +665,18 @@ impl Collection {
     }
 
     /// Initiate local partial shard
+    ///
+    /// # Cancel safety
+    ///
+    /// This is cancel safe. If the future is dropped, initialization is aborted.
+    ///
+    /// If the shard was in dummy state, it will be recreated. Aborting this may leave it in
+    /// partial state. In that case it will remain a dummy shard, signaled by the initialization
+    /// flag on disk. It may then be fully reinitialized on the next transfer attempt.
     pub fn initiate_shard_transfer(
         &self,
         shard_id: ShardId,
     ) -> impl Future<Output = CollectionResult<()>> + 'static {
-        // TODO: Ensure cancel safety!
-
         let shards_holder = self.shards_holder.clone();
 
         let collection_path = self.path.clone();

--- a/lib/collection/src/shards/replica_set/mod.rs
+++ b/lib/collection/src/shards/replica_set/mod.rs
@@ -600,14 +600,34 @@ impl ShardReplicaSet {
     }
 
     /// Clears the local shard data and loads an empty local shard
+    ///
+    /// # Cancel safety
+    ///
+    /// This is cancel safe. If the future is dropped, `local` is left holding a dummy shard rather
+    /// than the real thing. That dummy state is picked up like any other initialization failure: a
+    /// retried call to this method clears it and tries again.
     pub async fn init_empty_local_shard(&self) -> CollectionResult<()> {
         let mut local = self.local.write().await;
 
-        let current_shard = local.take();
+        // Keep a dummy placeholder because every await below may drop the future early on
+        // cancellation, we must never leave this at None
+        let current_shard = local.replace(Shard::Dummy(DummyShard::new(
+            "Local shard is being initialized",
+        )));
+
         if let Some(current_shard) = current_shard {
             current_shard.stop_gracefully().await;
         }
-        LocalShard::clear(&self.shard_path).await?;
+
+        if let Err(err) = LocalShard::clear(&self.shard_path).await {
+            let error = format!(
+                "Failed to clear local shard at {:?}: {err}",
+                self.shard_path,
+            );
+            log::error!("{error}");
+            local.replace(Shard::Dummy(DummyShard::new(error)));
+            return Err(err);
+        }
 
         let local_shard_res = LocalShard::build(
             self.shard_id,
@@ -625,16 +645,16 @@ impl ShardReplicaSet {
 
         match local_shard_res {
             Ok(local_shard) => {
-                *local = Some(Shard::Local(local_shard));
+                local.replace(Shard::Local(local_shard));
                 Ok(())
             }
             Err(err) => {
                 let error = format!(
                     "Failed to initialize local shard at {:?}: {err}",
-                    self.shard_path
+                    self.shard_path,
                 );
                 log::error!("{error}");
-                *local = Some(Shard::Dummy(DummyShard::new(error)));
+                local.replace(Shard::Dummy(DummyShard::new(error)));
                 Err(err)
             }
         }

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -580,16 +580,21 @@ impl TableOfContent {
     /// Initiate receiving shard.
     ///
     /// Fails if the collection does not exist
+    ///
+    /// # Cancel safety
+    ///
+    /// This is cancel safe. If the future is dropped, initialization is aborted.
+    ///
+    /// If the shard was in dummy state, it will be recreated. Aborting this may leave it in
+    /// partial state. In that case it will remain a dummy shard, signaled by the initialization
+    /// flag on disk. It may then be fully reinitialized on the next transfer attempt.
     pub async fn initiate_receiving_shard(
         &self,
         collection_name: String,
         shard_id: ShardId,
     ) -> Result<(), StorageError> {
-        // TODO: Ensure cancel safety!
-
         log::info!("Initiating receiving shard {collection_name}:{shard_id}");
 
-        // TODO: Ensure cancel safety!
         let initiate_shard_transfer_future = self
             .get_collection_unchecked(&collection_name)
             .await?


### PR DESCRIPTION
The internal API for shard initialization is cancel safe. This API is used in shard transfers.

Dropping the initialization call (over gRPC) may abort reinitialization of the shard mid way. It will leave the shard in dummy state signaled by an initialization flag on disk. So normally we don't like to leave partial shards on disk, but here the flag file covers us.

This reinitialization can only happen if the shard was already in dummy state though. And so it will not get any worse.

On the next transfer attempt the shard can be fully reinitialized again.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
