### PR TITLE
Bump dev version to 1.19.2-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "api"
-version = "1.19.1-dev"
+version = "1.19.2-dev"
 dependencies = [
  "ahash",
  "chrono",
@@ -6005,7 +6005,7 @@ dependencies = [
 
 [[package]]
 name = "qdrant"
-version = "1.19.1-dev"
+version = "1.19.2-dev"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qdrant"
-version = "1.19.1-dev"
+version = "1.19.2-dev"
 description = "Qdrant - Vector Search engine"
 authors = [
     "Andrey Vasnetsov <andrey@vasnetsov.com>",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "1.19.1-dev"
+version = "1.19.2-dev"
 authors = [
     "Andrey Vasnetsov <vasnetsov93@gmail.com>",
     "Qdrant Team <info@qdrant.tech>",

--- a/lib/common/common/src/defaults.rs
+++ b/lib/common/common/src/defaults.rs
@@ -7,7 +7,7 @@ use semver::Version;
 use crate::cpu;
 
 /// Current Qdrant version string
-pub const QDRANT_VERSION_STRING: &str = "1.19.1-dev";
+pub const QDRANT_VERSION_STRING: &str = "1.19.2-dev";
 
 /// Current Qdrant semver version
 pub static QDRANT_VERSION: LazyLock<Version> =


### PR DESCRIPTION
Bump development version to 1.19.2-dev after <https://github.com/qdrant/qdrant/pull/10463>.