### PR TITLE
feat(audit): optional stdout output for audit log

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -487,3 +487,6 @@ tls:
 #   # WARNING: Enabling this without a trusted proxy allows clients to spoof their IP.
 #   # Default: false
 #   trust_forwarded_headers: false
+#   # If true, write audit log entries to stdout in addition to the log file.
+#   # Default: false
+#   stdout: false

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12037,6 +12037,7 @@
           "log_api",
           "max_log_files",
           "rotation",
+          "stdout",
           "trust_forwarded_headers"
         ],
         "properties": {
@@ -12055,6 +12056,9 @@
             "type": "boolean"
           },
           "log_api": {
+            "type": "boolean"
+          },
+          "stdout": {
             "type": "boolean"
           },
           "dir_size_bytes": {

--- a/lib/storage/src/audit.rs
+++ b/lib/storage/src/audit.rs
@@ -77,6 +77,11 @@ pub struct AuditConfig {
     /// to the internal operation name.  Default: true.
     #[serde(default = "default_log_api")]
     pub log_api: bool,
+
+    /// If true, write every audit event to stdout in addition to the log file.
+    /// Default: false.
+    #[serde(default)]
+    pub stdout: bool,
 }
 
 fn default_audit_dir() -> PathBuf {
@@ -151,6 +156,7 @@ pub struct AuditEvent {
 
 struct AuditLogger {
     writer: Mutex<NonBlocking>,
+    stdout: bool,
 }
 
 impl AuditLogger {
@@ -162,6 +168,7 @@ impl AuditLogger {
             max_log_files,
             trust_forwarded_headers: _,
             log_api: _,
+            stdout,
         } = config;
 
         fs_err::create_dir_all(dir)?;
@@ -188,6 +195,7 @@ impl AuditLogger {
         Ok((
             Self {
                 writer: Mutex::new(non_blocking),
+                stdout: *stdout,
             },
             guard,
         ))
@@ -205,6 +213,14 @@ impl AuditLogger {
             }
         };
         buf.push(b'\n');
+
+        if self.stdout {
+            // `Stdout` is line-buffered and `buf` ends with a newline, so the
+            // event is flushed as a whole line.
+            if let Err(err) = std::io::stdout().write_all(&buf) {
+                log::error!("Failed to write audit log entry to stdout: {err}");
+            }
+        }
 
         let mut writer = self.writer.lock();
         if let Err(err) = writer.write_all(&buf) {
@@ -236,6 +252,7 @@ pub fn init_audit_logger(config: Option<&AuditConfig>) -> anyhow::Result<Option<
         max_log_files: _,
         trust_forwarded_headers,
         log_api,
+        stdout: _,
     } = config;
 
     if !enabled {
@@ -298,6 +315,17 @@ mod tests {
             out.len()
         );
         assert!(!out.is_empty());
+    }
+
+    #[test]
+    fn stdout_flag_is_off_by_default() {
+        let config: AuditConfig = serde_json::from_str("{}").expect("empty config is valid");
+        assert!(!config.stdout);
+        assert!(
+            serde_json::from_str::<AuditConfig>(r#"{"stdout": true}"#)
+                .expect("config is valid")
+                .stdout
+        );
     }
 
     #[test]

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -75,6 +75,7 @@ pub struct AuditTelemetry {
     pub max_log_files: usize,
     pub trust_forwarded_headers: bool,
     pub log_api: bool,
+    pub stdout: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dir_size_bytes: Option<usize>,
 }
@@ -161,6 +162,7 @@ fn collect_audit_telemetry(
         max_log_files: config.max_log_files,
         trust_forwarded_headers: config.trust_forwarded_headers,
         log_api: config.log_api,
+        stdout: config.stdout,
         dir_size_bytes,
     })
 }


### PR DESCRIPTION
Adds `audit.stdout` (default `false`): when enabled, every audit event is written to stdout as a JSON line in addition to the rolling audit log file. Useful where logs are collected from the container's output stream rather than a mounted directory.

```yaml
audit:
  enabled: true
  stdout: true
```

The file appender is unchanged — stdout is an additional sink, not a replacement. Reported in telemetry alongside the other audit settings.

Skipped a stdout-only mode (no file output) and a separate format/level for the stdout sink — can be added if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)