### PR TITLE
Validate consensus against `ConsensusStateMachine`

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -445,6 +445,12 @@ cluster:
     # If 0 - disable compaction
     compact_wal_entries: 128
 
+    # Apply every consensus operation to an in-memory state machine as well, and
+    # compare its state against the applied one, to validate the state machine
+    # against the implementation it is going to replace. One of `disabled`,
+    # `log` the difference, or `panic` on it.
+    shadow_state_machine: disabled
+
 # Set to true to prevent service from sending usage statistics to the developers.
 # Read more: https://qdrant.tech/documentation/guides/telemetry
 telemetry_disabled: false

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -373,6 +373,18 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     /// Return `true` if consensus should be stopped (peer removed)
     /// Return `false` if everything is ok.
     pub fn apply_entries<T: Storage>(&self, raw_node: &mut RawNode<T>) -> anyhow::Result<bool> {
+        let result = self.apply_entries_impl(raw_node);
+
+        // An entry that failed here is applied again after the restart, on top of whatever it
+        // wrote before it failed
+        if result.is_err() {
+            self.invalidate_shadow();
+        }
+
+        result
+    }
+
+    fn apply_entries_impl<T: Storage>(&self, raw_node: &mut RawNode<T>) -> anyhow::Result<bool> {
         use raft::eraftpb::EntryType;
 
         self.persistent
@@ -460,6 +472,10 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         raw_node: &mut RawNode<T>,
     ) -> Result<bool, StorageError> {
         let change: ConfChangeV2 = prost_for_raft::Message::decode(entry.get_data())?;
+
+        // Peer changes are not modeled yet, and removing one drops its replicas from every
+        // collection
+        self.invalidate_shadow();
 
         let conf_state = raw_node.apply_conf_change(&change)?;
         log::debug!("Applied conf state {conf_state:?}");
@@ -619,6 +635,13 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         Some(outcome)
     }
 
+    /// Drop the shadow state, so the next entry builds a machine from `TableOfContent`
+    fn invalidate_shadow(&self) {
+        if let Some(shadow) = &self.shadow {
+            shadow.lock().invalidate();
+        }
+    }
+
     /// Compare the shadow against what the authoritative apply left behind
     fn shadow_compare(&self, outcome: &ApplyOutcome, result: &Result<bool, StorageError>) {
         let Some(shadow) = self.shadow.as_ref() else {
@@ -636,6 +659,10 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         snapshot: &raft::eraftpb::Snapshot,
     ) -> Result<Result<(), StorageError>, StorageError> {
         let meta = snapshot.get_metadata();
+
+        // Recovery deliberately leaves state no operation asked for: it discards proxies,
+        // forces recovery of local replicas it just created and proposes transfer aborts
+        self.invalidate_shadow();
 
         let SnapshotData {
             collections_data,

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -30,6 +30,8 @@ use tonic::transport::Uri;
 use super::CollectionContainer;
 use super::alias_mapping::AliasMapping;
 use super::consensus_ops::{ConsensusOperations, SnapshotStatus};
+use super::consensus_shadow::{ShadowMode, ShadowStateMachine};
+use super::consensus_state_machine::ApplyOutcome;
 use super::errors::StorageError;
 use crate::content_manager::consensus::applied_log::{AppliedEntryRing, AppliedLog};
 use crate::content_manager::consensus::consensus_wal::ConsensusOpWal;
@@ -109,6 +111,9 @@ pub struct ConsensusManager<C: CollectionContainer> {
     next_peer_metadata_update_attempt: Mutex<Instant>,
     /// Recently applied entries, for `/profiler/consensus_lag`. Diagnostics only.
     applied_log: AppliedEntryRing,
+    /// State machine applying every entry alongside the handlers below, to compare the two.
+    /// `None` unless the shadow run is enabled.
+    shadow: Option<Mutex<ShadowStateMachine>>,
 }
 
 impl<C: CollectionContainer> ConsensusManager<C> {
@@ -153,7 +158,14 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             message_send_failures: Default::default(),
             next_peer_metadata_update_attempt: Mutex::new(Instant::now()),
             applied_log: Default::default(),
+            shadow: None,
         })
+    }
+
+    /// Run the state machine alongside this manager, comparing the two after every entry
+    pub fn with_shadow(mut self, mode: ShadowMode) -> Self {
+        self.shadow = mode.build();
+        self
     }
 
     /// Snapshot of the recently applied entries on this peer, oldest first.
@@ -542,6 +554,7 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     pub fn apply_normal_entry(&self, entry: &RaftEntry) -> Result<bool, StorageError> {
         let operation: ConsensusOperations = entry.try_into()?;
         let on_apply = self.on_consensus_op_apply.lock().remove(&operation);
+        let shadow = self.shadow_apply(&operation);
         let result = match operation {
             ConsensusOperations::CollectionMeta(operation) => {
                 self.toc.perform_collection_meta_op(*operation)
@@ -582,6 +595,10 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             }
         };
 
+        if let Some(outcome) = shadow {
+            self.shadow_compare(&outcome, &result);
+        }
+
         if let Some(on_apply) = on_apply
             && on_apply.send(result.clone()).is_err()
         {
@@ -590,6 +607,27 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             )
         }
         result
+    }
+
+    /// Apply `operation` to the shadow state, when the shadow run is enabled
+    fn shadow_apply(&self, operation: &ConsensusOperations) -> Option<ApplyOutcome> {
+        let shadow = self.shadow.as_ref()?;
+        let outcome = shadow
+            .lock()
+            .apply(&*self.toc, &self.persistent.read(), operation);
+
+        Some(outcome)
+    }
+
+    /// Compare the shadow against what the authoritative apply left behind
+    fn shadow_compare(&self, outcome: &ApplyOutcome, result: &Result<bool, StorageError>) {
+        let Some(shadow) = self.shadow.as_ref() else {
+            return;
+        };
+
+        shadow
+            .lock()
+            .compare(&*self.toc, &self.persistent.read(), outcome, result);
     }
 
     // Outer `Result` is "fatal" error, inner `Result` is "transient"/"local" error.
@@ -1488,6 +1526,11 @@ mod tests {
 
         fn collections_snapshot(&self) -> super::CollectionsSnapshot {
             super::CollectionsSnapshot::default()
+        }
+
+        // Only the shadow run reads the node config, and these tests never enable it
+        fn node_context(&self) -> crate::content_manager::consensus_state_machine::NodeContext {
+            unimplemented!()
         }
 
         fn apply_collections_snapshot(

--- a/lib/storage/src/content_manager/consensus_shadow/diff.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/diff.rs
@@ -1,0 +1,96 @@
+//! Compare the shadow state against the state `TableOfContent` holds
+
+use std::mem;
+
+use crate::content_manager::consensus_state_machine::{ApplyOutcome, ClusterState};
+use crate::content_manager::errors::StorageResult;
+
+/// How `shadow` differs from `actual`, `None` when the two match.
+///
+/// Both sides are printed whole. The derived `PartialEq` covers a field added to
+/// [`ClusterState`] or to the collection state under it without anyone having to remember it.
+/// Naming the fields that differ, rather than printing everything, is worth doing once a field
+/// turns up that consensus does not decide and the compare has to skip.
+pub fn cluster(shadow: &ClusterState, actual: &ClusterState) -> Option<String> {
+    if shadow == actual {
+        return None;
+    }
+
+    Some(format!("shadow {shadow:#?} against applied {actual:#?}"))
+}
+
+/// How the machine's decision differs from what the apply path answered.
+///
+/// Only the class of the answer is compared. A rejection message reaches the client, so the
+/// machine reproduces the wording of the handler it replaces, but a difference in wording is
+/// for the soak to collect rather than for this to report.
+pub fn outcome(shadow: &ApplyOutcome, actual: &StorageResult<bool>) -> Option<String> {
+    match (shadow, actual) {
+        (ApplyOutcome::Accepted(_), Ok(_)) => None,
+
+        (ApplyOutcome::Rejected(shadow), Err(actual))
+            if mem::discriminant(shadow) == mem::discriminant(actual) =>
+        {
+            None
+        }
+
+        (ApplyOutcome::Accepted(_), Err(actual)) => {
+            Some(format!("machine accepted, apply rejected it: {actual}"))
+        }
+
+        (ApplyOutcome::Rejected(shadow), Ok(_)) => Some(format!(
+            "machine rejected it with `{shadow}`, apply accepted"
+        )),
+
+        (ApplyOutcome::Rejected(shadow), Err(actual)) => Some(format!(
+            "machine and apply rejected it differently: `{shadow}` against `{actual}`"
+        )),
+
+        // Caller invalidates the machine rather than comparing
+        (ApplyOutcome::NotCovered, Ok(_) | Err(_)) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use segment::types::PayloadSchemaType;
+
+    use super::*;
+    use crate::content_manager::consensus_state_machine::tests::collection_state;
+
+    const COLLECTION: &str = "books";
+
+    #[test]
+    fn cluster_match() {
+        let state = cluster_state();
+
+        assert_eq!(cluster(&state, &state), None);
+    }
+
+    /// A collection both sides hold, differing inside. The compare reads collection state, not
+    /// just the names.
+    #[test]
+    fn cluster_collection_differs() {
+        let field = "city".parse().expect("valid field name");
+
+        let mut actual = cluster_state();
+        actual
+            .collections
+            .get_mut(COLLECTION)
+            .expect("collection exists")
+            .payload_index_schema
+            .schema
+            .insert(field, PayloadSchemaType::Keyword.into());
+
+        assert!(cluster(&cluster_state(), &actual).is_some());
+    }
+
+    fn cluster_state() -> ClusterState {
+        ClusterState {
+            collections: HashMap::from([(COLLECTION.to_string(), collection_state(Vec::new()))]),
+            ..Default::default()
+        }
+    }
+}

--- a/lib/storage/src/content_manager/consensus_shadow/mod.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/mod.rs
@@ -1,0 +1,6 @@
+//! Shadow run of the consensus state machine against the legacy apply path.
+//!
+//! `TableOfContent` stays authoritative. The machine applies every entry to its own copy of the
+//! state, and a compare after the entry reports where the two disagree.
+
+pub mod diff;

--- a/lib/storage/src/content_manager/consensus_shadow/mod.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/mod.rs
@@ -4,3 +4,33 @@
 //! state, and a compare after the entry reports where the two disagree.
 
 pub mod diff;
+
+#[cfg(test)]
+mod tests;
+
+use crate::content_manager::CollectionContainer;
+use crate::content_manager::consensus::persistent::Persistent;
+use crate::content_manager::consensus_manager::CollectionsSnapshot;
+use crate::content_manager::consensus_state_machine::ClusterState;
+
+/// Read the state consensus decides on back out of the node that applied it.
+///
+/// Reads the state of every collection, which is what one compare costs.
+pub fn scrape_cluster_state(
+    toc: &impl CollectionContainer,
+    persistent: &Persistent,
+) -> ClusterState {
+    let CollectionsSnapshot {
+        collections,
+        aliases,
+    } = toc.collections_snapshot();
+
+    ClusterState {
+        collections,
+        aliases,
+        peer_address_by_id: persistent.peer_address_by_id.read().clone(),
+        peer_metadata_by_id: persistent.peer_metadata_by_id.read().clone(),
+        cluster_metadata: persistent.cluster_metadata.clone(),
+        quota_config: toc.quota_config(),
+    }
+}

--- a/lib/storage/src/content_manager/consensus_shadow/mod.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/mod.rs
@@ -8,10 +8,131 @@ pub mod diff;
 #[cfg(test)]
 mod tests;
 
+use parking_lot::Mutex;
+use serde::Deserialize;
+
 use crate::content_manager::CollectionContainer;
 use crate::content_manager::consensus::persistent::Persistent;
 use crate::content_manager::consensus_manager::CollectionsSnapshot;
-use crate::content_manager::consensus_state_machine::ClusterState;
+use crate::content_manager::consensus_ops::ConsensusOperations;
+use crate::content_manager::consensus_state_machine::{
+    ApplyOutcome, ClusterState, ConsensusStateMachine,
+};
+use crate::content_manager::errors::{StorageError, StorageResult};
+
+/// State machine applying every entry alongside the legacy handlers
+pub struct ShadowStateMachine {
+    /// Built from `TableOfContent` on first use, and again after every invalidation
+    machine: Option<ConsensusStateMachine>,
+    /// Fail the peer on a divergence, rather than logging it and carrying on
+    panic_on_divergence: bool,
+}
+
+impl ShadowStateMachine {
+    fn new(panic_on_divergence: bool) -> Self {
+        Self {
+            machine: None,
+            panic_on_divergence,
+        }
+    }
+
+    /// Apply `operation` to the shadow state, building the machine when there is none
+    pub fn apply(
+        &mut self,
+        toc: &impl CollectionContainer,
+        persistent: &Persistent,
+        operation: &ConsensusOperations,
+    ) -> ApplyOutcome {
+        let machine = self.machine.get_or_insert_with(|| {
+            let state = scrape_cluster_state(toc, persistent);
+            ConsensusStateMachine::new(state, toc.node_context())
+        });
+
+        machine.apply(operation)
+    }
+
+    /// Compare the shadow against the state the authoritative apply left behind, and report a
+    /// divergence the way this node is configured to
+    pub fn compare(
+        &mut self,
+        toc: &impl CollectionContainer,
+        persistent: &Persistent,
+        outcome: &ApplyOutcome,
+        result: &StorageResult<bool>,
+    ) {
+        let Some(report) = self.diff(toc, persistent, outcome, result) else {
+            return;
+        };
+
+        if self.panic_on_divergence {
+            panic!("shadow state machine diverged: {report}");
+        }
+
+        log::error!("Shadow state machine diverged: {report}");
+    }
+
+    /// How the shadow differs from the state the authoritative apply left behind.
+    ///
+    /// The machine is invalidated whenever the two cannot be compared, and whenever they
+    /// disagree, so one bug is reported once.
+    fn diff(
+        &mut self,
+        toc: &impl CollectionContainer,
+        persistent: &Persistent,
+        outcome: &ApplyOutcome,
+        result: &StorageResult<bool>,
+    ) -> Option<String> {
+        let Some(machine) = &self.machine else {
+            return None;
+        };
+
+        // A service error kills the consensus thread and the entry is applied again after
+        // restart. What the failed apply wrote before it gave up is not something the machine
+        // predicts, and an operation it does not model leaves its state behind entirely.
+        let comparable = !matches!(result, Err(StorageError::ServiceError { .. }))
+            && !matches!(outcome, ApplyOutcome::NotCovered);
+
+        if !comparable {
+            self.machine = None;
+            return None;
+        }
+
+        let actual = scrape_cluster_state(toc, persistent);
+        let report = diff::cluster(machine.state(), &actual);
+
+        if report.is_some() {
+            self.machine = None;
+        }
+
+        report
+    }
+}
+
+/// Whether to run the shadow, and what it does with a divergence it finds
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ShadowMode {
+    /// Do not run the machine at all
+    #[default]
+    Disabled,
+    /// Log the difference and carry on, for production and cloud
+    Log,
+    /// Fail the peer, for chaos and end-to-end tests
+    Panic,
+}
+
+impl ShadowMode {
+    /// The shadow to run, `None` when it is disabled
+    pub fn build(self) -> Option<Mutex<ShadowStateMachine>> {
+        let panic_on_divergence = match self {
+            ShadowMode::Disabled => return None,
+            ShadowMode::Log => false,
+            ShadowMode::Panic => true,
+        };
+
+        Some(Mutex::new(ShadowStateMachine::new(panic_on_divergence)))
+    }
+}
 
 /// Read the state consensus decides on back out of the node that applied it.
 ///

--- a/lib/storage/src/content_manager/consensus_shadow/mod.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/mod.rs
@@ -98,13 +98,18 @@ impl ShadowStateMachine {
         }
 
         let actual = scrape_cluster_state(toc, persistent);
-        let report = diff::cluster(machine.state(), &actual);
+        let answer = diff::outcome(outcome, result);
+        let state = diff::cluster(machine.state(), &actual);
 
-        if report.is_some() {
-            self.machine = None;
+        let report: Vec<_> = [answer, state].into_iter().flatten().collect();
+
+        if report.is_empty() {
+            return None;
         }
 
-        report
+        self.machine = None;
+
+        Some(report.join("; "))
     }
 }
 

--- a/lib/storage/src/content_manager/consensus_shadow/mod.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/mod.rs
@@ -36,6 +36,11 @@ impl ShadowStateMachine {
         }
     }
 
+    /// Drop the state, so the next entry builds a machine out of `TableOfContent` again
+    pub fn invalidate(&mut self) {
+        self.machine = None;
+    }
+
     /// Apply `operation` to the shadow state, building the machine when there is none
     pub fn apply(
         &mut self,

--- a/lib/storage/src/content_manager/consensus_shadow/tests.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/tests.rs
@@ -1,36 +1,142 @@
-//! Reading state back out of `TableOfContent`
+//! Running the shadow alongside a stand-in for `TableOfContent`.
+//!
+//! What the shadow decides is asserted on the report [`ShadowStateMachine::diff`] returns.
+//! Driving an entry through `ConsensusManager` only covers the wiring, where the one thing a
+//! test can observe is whether the peer died.
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::{Arc, mpsc};
 
 use collection::collection_state;
+use collection::collection_state::ShardInfo;
 use collection::operations::types::PeerMetadata;
 use collection::shards::CollectionId;
-use collection::shards::shard::PeerId;
+use collection::shards::replica_set::replica_set_state::ReplicaState;
+use collection::shards::shard::{PeerId, ShardId};
+use raft::eraftpb::Entry as RaftEntry;
 use serde_json::json;
-use tempfile::Builder;
+use tempfile::{Builder, TempDir};
 
 use super::*;
 use crate::content_manager::alias_mapping::AliasMapping;
-use crate::content_manager::collection_meta_ops::CollectionMetaOperations;
-use crate::content_manager::consensus_state_machine::tests::{PEER_ID, collection_state};
-use crate::content_manager::errors::StorageError;
+use crate::content_manager::collection_meta_ops::{
+    CollectionMetaOperations, DropPayloadIndex, SetShardReplicaState,
+};
+use crate::content_manager::consensus::operation_sender::OperationSender;
+use crate::content_manager::consensus_manager::ConsensusManager;
+use crate::content_manager::consensus_state_machine::NodeContext;
+use crate::content_manager::consensus_state_machine::tests::{
+    PEER_ID, collection_state, node_context,
+};
 use crate::quota::QuotaConfig;
 
 const COLLECTION: &str = "books";
 const ALIAS: &str = "novels";
+const OTHER_ALIAS: &str = "crime";
 const METADATA_KEY: &str = "owner";
+
+/// Both sides record the same cluster metadata key: the machine in its own state, the apply
+/// path in `Persistent`, which the compare reads back. Needs the manager, since the applied
+/// side is what the handler writes.
+#[test]
+fn matching_entry() {
+    let container = Arc::new(container());
+    let dir = tempdir();
+    let manager = manager(container, ShadowMode::Panic, dir.path());
+
+    let operation = ConsensusOperations::UpdateClusterMetadata {
+        key: "answer".to_string(),
+        value: json!(42),
+    };
+
+    manager
+        .apply_normal_entry(&entry(&operation))
+        .expect("entry applied");
+}
+
+/// A collection differing inside is a divergence, so the compare reads collection state and not
+/// just the names
+#[test]
+fn diverged_collection() {
+    let shadow = Shadow::new(ShadowMode::Panic);
+
+    assert_eq!(shadow.apply(&nop()), None);
+
+    shadow.container.add_shard(0);
+
+    assert!(shadow.apply(&drop_payload_index()).is_some());
+}
+
+/// An operation the machine does not model leaves state it cannot predict
+#[test]
+fn not_covered_invalidates() {
+    invalidates(&set_replica_state(), &Ok(true));
+}
+
+/// A service error kills the consensus thread, and what the failed apply wrote before it gave
+/// up is not something the machine predicts
+#[test]
+fn service_error_invalidates() {
+    let failed = Err(StorageError::service_error("out of disk"));
+
+    invalidates(&nop(), &failed);
+}
+
+/// An entry the machine cannot be compared against drops the machine, so the next one builds
+/// a machine out of what the apply path holds.
+///
+/// The alias makes the two disagree, so a machine that survived the entry reports it.
+fn invalidates(operation: &ConsensusOperations, result: &StorageResult<bool>) {
+    let shadow = Shadow::new(ShadowMode::Panic);
+
+    assert_eq!(shadow.apply(&nop()), None);
+
+    shadow.container.add_alias(OTHER_ALIAS);
+    assert_eq!(shadow.apply_with(operation, result), None);
+
+    assert_eq!(shadow.apply(&nop()), None);
+}
+
+/// The peer dies on a divergence in panic mode, which is what the consensus test suite runs
+#[test]
+#[should_panic]
+fn manager_panics_on_divergence() {
+    let container = Arc::new(container());
+    let dir = tempdir();
+    let manager = manager(container.clone(), ShadowMode::Panic, dir.path());
+
+    manager.apply_normal_entry(&entry(&nop())).expect("nop");
+
+    container.add_alias(OTHER_ALIAS);
+
+    manager.apply_normal_entry(&entry(&nop())).expect("nop");
+}
+
+/// Same divergence with the shadow off, so a shadow that runs anyway fails this
+#[test]
+fn manager_disabled() {
+    let container = Arc::new(container());
+    let dir = tempdir();
+    let manager = manager(container.clone(), ShadowMode::Disabled, dir.path());
+
+    manager.apply_normal_entry(&entry(&nop())).expect("nop");
+
+    container.add_alias(OTHER_ALIAS);
+
+    manager.apply_normal_entry(&entry(&nop())).expect("nop");
+}
 
 #[test]
 fn scrape_cluster_state() {
-    let dir = Builder::new().prefix("shadow").tempdir().expect("temp dir");
+    let dir = tempdir();
     let persistent = persistent(dir.path());
     let container = container();
 
     let state = super::scrape_cluster_state(&container, &persistent);
 
-    assert_eq!(state.collections, container.collections);
-    assert_eq!(state.aliases, container.aliases);
+    assert_eq!(state.collections, *container.collections.lock());
+    assert_eq!(state.aliases, *container.aliases.lock());
     assert_eq!(state.quota_config, container.quota_config);
     assert_eq!(
         state.peer_address_by_id,
@@ -41,6 +147,105 @@ fn scrape_cluster_state() {
         *persistent.peer_metadata_by_id.read(),
     );
     assert_eq!(state.cluster_metadata, persistent.cluster_metadata);
+}
+
+/// Shadow over a container, without the manager in between
+struct Shadow {
+    machine: Mutex<ShadowStateMachine>,
+    container: Container,
+    persistent: Persistent,
+    /// Holds the state directory alive for as long as `persistent` reads it
+    _dir: TempDir,
+}
+
+impl Shadow {
+    fn new(mode: ShadowMode) -> Self {
+        let dir = tempdir();
+
+        Self {
+            machine: mode.build().expect("shadow enabled"),
+            container: container(),
+            persistent: persistent(dir.path()),
+            _dir: dir,
+        }
+    }
+
+    /// Plan `operation` and compare, as an entry the apply path answered `Ok` to
+    fn apply(&self, operation: &ConsensusOperations) -> Option<String> {
+        self.apply_with(operation, &Ok(true))
+    }
+
+    /// Plan `operation` and compare, as an entry the apply path answered `result` to
+    fn apply_with(
+        &self,
+        operation: &ConsensusOperations,
+        result: &StorageResult<bool>,
+    ) -> Option<String> {
+        let mut machine = self.machine.lock();
+        let outcome = machine.apply(&self.container, &self.persistent, operation);
+
+        machine.diff(&self.container, &self.persistent, &outcome, result)
+    }
+}
+
+fn tempdir() -> TempDir {
+    Builder::new().prefix("shadow").tempdir().expect("temp dir")
+}
+
+/// Manager over `container`, applying entries with the shadow running in `mode`
+fn manager(
+    container: Arc<Container>,
+    mode: ShadowMode,
+    path: &Path,
+) -> ConsensusManager<Container> {
+    let (sender, _receiver) = mpsc::channel();
+
+    ConsensusManager::new(
+        persistent(path),
+        container,
+        OperationSender::new(sender),
+        path,
+    )
+    .expect("manager initialized")
+    .with_shadow(mode)
+}
+
+fn entry(operation: &ConsensusOperations) -> RaftEntry {
+    RaftEntry {
+        data: serde_cbor::to_vec(operation).expect("operation serialized"),
+        ..Default::default()
+    }
+}
+
+fn nop() -> ConsensusOperations {
+    ConsensusOperations::CollectionMeta(Box::new(CollectionMetaOperations::Nop { token: 0 }))
+}
+
+/// Covered operation naming the collection, so the compare after it reads that collection
+fn drop_payload_index() -> ConsensusOperations {
+    let operation = DropPayloadIndex {
+        collection_name: COLLECTION.to_string(),
+        field_name: "city".parse().expect("valid field name"),
+    };
+
+    ConsensusOperations::CollectionMeta(Box::new(CollectionMetaOperations::DropPayloadIndex(
+        operation,
+    )))
+}
+
+/// Operation the machine does not model yet
+fn set_replica_state() -> ConsensusOperations {
+    let operation = SetShardReplicaState {
+        collection_name: COLLECTION.to_string(),
+        shard_id: 0,
+        peer_id: PEER_ID,
+        state: ReplicaState::Active,
+        from_state: None,
+    };
+
+    ConsensusOperations::CollectionMeta(Box::new(CollectionMetaOperations::SetShardReplicaState(
+        operation,
+    )))
 }
 
 /// Peer state holding this peer's address and metadata, and one cluster metadata key
@@ -66,8 +271,11 @@ fn container() -> Container {
     aliases.insert(ALIAS.to_string(), COLLECTION.to_string());
 
     Container {
-        collections: HashMap::from([(COLLECTION.to_string(), collection_state(Vec::new()))]),
-        aliases,
+        collections: Mutex::new(HashMap::from([(
+            COLLECTION.to_string(),
+            collection_state(Vec::new()),
+        )])),
+        aliases: Mutex::new(aliases),
         quota_config: QuotaConfig {
             enabled: true,
             ..Default::default()
@@ -75,33 +283,63 @@ fn container() -> Container {
     }
 }
 
-/// `TableOfContent` stand-in answering out of the state a test gives it
+/// `TableOfContent` stand-in answering out of the state a test gives it.
+///
+/// The state is behind locks, so a test can change it the way something other than the entry
+/// being applied would.
 struct Container {
-    collections: HashMap<CollectionId, collection_state::State>,
-    aliases: AliasMapping,
+    collections: Mutex<HashMap<CollectionId, collection_state::State>>,
+    aliases: Mutex<AliasMapping>,
     quota_config: QuotaConfig,
+}
+
+impl Container {
+    /// Point another alias at the collection, as an operation the machine never saw would
+    fn add_alias(&self, alias: &str) {
+        self.aliases
+            .lock()
+            .insert(alias.to_string(), COLLECTION.to_string());
+    }
+
+    /// Add a shard to the collection, as an operation the machine does not model would
+    fn add_shard(&self, shard_id: ShardId) {
+        let replicas = HashMap::from([(PEER_ID, ReplicaState::Active)]);
+
+        self.collections
+            .lock()
+            .get_mut(COLLECTION)
+            .expect("collection exists")
+            .shards
+            .insert(shard_id, ShardInfo { replicas });
+    }
 }
 
 impl CollectionContainer for Container {
     fn collections_snapshot(&self) -> CollectionsSnapshot {
         CollectionsSnapshot {
-            collections: self.collections.clone(),
-            aliases: self.aliases.clone(),
+            collections: self.collections.lock().clone(),
+            aliases: self.aliases.lock().clone(),
         }
+    }
+
+    fn node_context(&self) -> NodeContext {
+        node_context()
     }
 
     fn quota_config(&self) -> QuotaConfig {
         self.quota_config
     }
 
-    // Reading state back is all this test does
-
+    /// Answers and changes nothing: every test applies an operation whose effect on the
+    /// container a test writes by hand, or none at all
     fn perform_collection_meta_op(
         &self,
         _operation: CollectionMetaOperations,
     ) -> Result<bool, StorageError> {
-        unimplemented!()
+        Ok(true)
     }
+
+    // Never reached: no test recovers a snapshot, removes a peer or writes a quota config
 
     fn apply_collections_snapshot(&self, _data: CollectionsSnapshot) -> Result<(), StorageError> {
         unimplemented!()

--- a/lib/storage/src/content_manager/consensus_shadow/tests.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/tests.rs
@@ -1,0 +1,125 @@
+//! Reading state back out of `TableOfContent`
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use collection::collection_state;
+use collection::operations::types::PeerMetadata;
+use collection::shards::CollectionId;
+use collection::shards::shard::PeerId;
+use serde_json::json;
+use tempfile::Builder;
+
+use super::*;
+use crate::content_manager::alias_mapping::AliasMapping;
+use crate::content_manager::collection_meta_ops::CollectionMetaOperations;
+use crate::content_manager::consensus_state_machine::tests::{PEER_ID, collection_state};
+use crate::content_manager::errors::StorageError;
+use crate::quota::QuotaConfig;
+
+const COLLECTION: &str = "books";
+const ALIAS: &str = "novels";
+const METADATA_KEY: &str = "owner";
+
+#[test]
+fn scrape_cluster_state() {
+    let dir = Builder::new().prefix("shadow").tempdir().expect("temp dir");
+    let persistent = persistent(dir.path());
+    let container = container();
+
+    let state = super::scrape_cluster_state(&container, &persistent);
+
+    assert_eq!(state.collections, container.collections);
+    assert_eq!(state.aliases, container.aliases);
+    assert_eq!(state.quota_config, container.quota_config);
+    assert_eq!(
+        state.peer_address_by_id,
+        *persistent.peer_address_by_id.read(),
+    );
+    assert_eq!(
+        state.peer_metadata_by_id,
+        *persistent.peer_metadata_by_id.read(),
+    );
+    assert_eq!(state.cluster_metadata, persistent.cluster_metadata);
+}
+
+/// Peer state holding this peer's address and metadata, and one cluster metadata key
+fn persistent(path: &Path) -> Persistent {
+    let mut persistent =
+        Persistent::load_or_init(path, true, false, Some(PEER_ID)).expect("state initialized");
+
+    let address = "http://localhost:6335".parse().expect("valid uri");
+    persistent
+        .insert_peer(PEER_ID, address)
+        .expect("peer inserted");
+    persistent
+        .update_peer_metadata(PEER_ID, PeerMetadata::current())
+        .expect("metadata updated");
+    persistent.update_cluster_metadata_key(METADATA_KEY.to_string(), json!("qdrant"));
+
+    persistent
+}
+
+/// Container holding one collection under one alias, and a quota config away from its default
+fn container() -> Container {
+    let mut aliases = AliasMapping::default();
+    aliases.insert(ALIAS.to_string(), COLLECTION.to_string());
+
+    Container {
+        collections: HashMap::from([(COLLECTION.to_string(), collection_state(Vec::new()))]),
+        aliases,
+        quota_config: QuotaConfig {
+            enabled: true,
+            ..Default::default()
+        },
+    }
+}
+
+/// `TableOfContent` stand-in answering out of the state a test gives it
+struct Container {
+    collections: HashMap<CollectionId, collection_state::State>,
+    aliases: AliasMapping,
+    quota_config: QuotaConfig,
+}
+
+impl CollectionContainer for Container {
+    fn collections_snapshot(&self) -> CollectionsSnapshot {
+        CollectionsSnapshot {
+            collections: self.collections.clone(),
+            aliases: self.aliases.clone(),
+        }
+    }
+
+    fn quota_config(&self) -> QuotaConfig {
+        self.quota_config
+    }
+
+    // Reading state back is all this test does
+
+    fn perform_collection_meta_op(
+        &self,
+        _operation: CollectionMetaOperations,
+    ) -> Result<bool, StorageError> {
+        unimplemented!()
+    }
+
+    fn apply_collections_snapshot(&self, _data: CollectionsSnapshot) -> Result<(), StorageError> {
+        unimplemented!()
+    }
+
+    fn remove_peer(&self, _peer_id: PeerId) -> Result<(), StorageError> {
+        unimplemented!()
+    }
+
+    fn peer_has_shards(&self, _peer_id: PeerId) -> bool {
+        unimplemented!()
+    }
+
+    fn sync_local_state(&self) -> Result<(), StorageError> {
+        unimplemented!()
+    }
+
+    fn set_quota_config(&self, _config: QuotaConfig) -> Result<(), StorageError> {
+        unimplemented!()
+    }
+}

--- a/lib/storage/src/content_manager/consensus_shadow/tests.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/tests.rs
@@ -15,13 +15,14 @@ use collection::shards::CollectionId;
 use collection::shards::replica_set::replica_set_state::ReplicaState;
 use collection::shards::shard::{PeerId, ShardId};
 use raft::eraftpb::Entry as RaftEntry;
+use segment::types::PayloadSchemaType;
 use serde_json::json;
 use tempfile::{Builder, TempDir};
 
 use super::*;
 use crate::content_manager::alias_mapping::AliasMapping;
 use crate::content_manager::collection_meta_ops::{
-    CollectionMetaOperations, DropPayloadIndex, SetShardReplicaState,
+    CollectionMetaOperations, CreatePayloadIndex, DropPayloadIndex, SetShardReplicaState,
 };
 use crate::content_manager::consensus::operation_sender::OperationSender;
 use crate::content_manager::consensus_manager::ConsensusManager;
@@ -35,6 +36,8 @@ const COLLECTION: &str = "books";
 const ALIAS: &str = "novels";
 const OTHER_ALIAS: &str = "crime";
 const METADATA_KEY: &str = "owner";
+/// Collection neither side holds
+const MISSING: &str = "outis";
 
 /// Both sides record the same cluster metadata key: the machine in its own state, the apply
 /// path in `Persistent`, which the compare reads back. Needs the manager, since the applied
@@ -66,6 +69,45 @@ fn diverged_collection() {
     shadow.container.add_shard(0);
 
     assert!(shadow.apply(&drop_payload_index()).is_some());
+}
+
+/// Both sides reject a missing collection, and with the same error class
+#[test]
+fn matching_rejection() {
+    let shadow = Shadow::new(ShadowMode::Panic);
+
+    let rejection = Err(StorageError::not_found(format!(
+        "Collection `{MISSING}` doesn't exist!"
+    )));
+
+    assert_eq!(
+        shadow.apply_with(&create_payload_index(MISSING), &rejection),
+        None,
+    );
+}
+
+/// The machine rejects a missing collection as not-found, the apply path as bad-request. The
+/// class reaches the client, so the two have to agree on it.
+#[test]
+fn differing_rejection() {
+    let shadow = Shadow::new(ShadowMode::Panic);
+    let rejection = Err(StorageError::bad_request("no"));
+
+    assert!(
+        shadow
+            .apply_with(&create_payload_index(MISSING), &rejection)
+            .is_some()
+    );
+}
+
+/// The machine accepts what the apply path rejected, which no state compare catches: a
+/// rejection leaves the state alone on both sides
+#[test]
+fn rejected_by_apply_only() {
+    let shadow = Shadow::new(ShadowMode::Panic);
+    let rejection = Err(StorageError::bad_request("no"));
+
+    assert!(shadow.apply_with(&nop(), &rejection).is_some());
 }
 
 /// An operation the machine does not model leaves state it cannot predict
@@ -219,6 +261,19 @@ fn entry(operation: &ConsensusOperations) -> RaftEntry {
 
 fn nop() -> ConsensusOperations {
     ConsensusOperations::CollectionMeta(Box::new(CollectionMetaOperations::Nop { token: 0 }))
+}
+
+/// Covered operation naming `collection`, for a collection no side holds
+fn create_payload_index(collection: &str) -> ConsensusOperations {
+    let operation = CreatePayloadIndex {
+        collection_name: collection.to_string(),
+        field_name: "city".parse().expect("valid field name"),
+        field_schema: PayloadSchemaType::Keyword.into(),
+    };
+
+    ConsensusOperations::CollectionMeta(Box::new(CollectionMetaOperations::CreatePayloadIndex(
+        operation,
+    )))
 }
 
 /// Covered operation naming the collection, so the compare after it reads that collection

--- a/lib/storage/src/content_manager/consensus_state_machine/mod.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/mod.rs
@@ -25,7 +25,7 @@ pub mod action;
 pub mod state;
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 
 use std::num::NonZeroU32;
 

--- a/lib/storage/src/content_manager/consensus_state_machine/mod.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/mod.rs
@@ -47,6 +47,7 @@ use super::errors::StorageResult;
 use crate::content_manager::collection_meta_ops::*;
 use crate::content_manager::consensus_ops::ConsensusOperations;
 use crate::content_manager::errors::StorageError;
+use crate::types::StorageConfig;
 
 #[derive(Clone, Debug)]
 pub struct ConsensusStateMachine {
@@ -195,6 +196,57 @@ pub struct NodeContext {
 }
 
 impl NodeContext {
+    pub fn from_storage_config(
+        config: &StorageConfig,
+        peer_id: PeerId,
+        is_distributed: bool,
+    ) -> Self {
+        // Naming every field forces a new storage config option to be either read here, or
+        // dismissed as one no operation reads
+        #[expect(deprecated)]
+        let StorageConfig {
+            collection,
+            shard_transfer_method,
+            max_collections,
+            wal,
+            optimizers,
+            hnsw_index,
+            payload,
+            on_disk_payload,
+
+            storage_path: _,
+            snapshots_path: _,
+            snapshots_config: _,
+            temp_path: _,
+            optimizers_overwrite: _,
+            performance: _,
+            hnsw_global_config: _,
+            mmap_advice: _,
+            low_memory_mode: _,
+            node_type: _,
+            update_queue_size: _,
+            handle_collection_load_errors: _,
+            recovery_mode: _,
+            update_concurrency: _,
+            // Seeds the quota manager on first start only; `SetQuotaConfig` carries the config
+            // consensus decides on
+            quotas: _,
+        } = config;
+
+        Self {
+            peer_id,
+            is_distributed,
+            collection_defaults: collection.clone(),
+            default_shard_transfer_method: *shard_transfer_method,
+            max_collections: *max_collections,
+            wal: wal.clone(),
+            optimizers: optimizers.clone(),
+            hnsw_index: *hnsw_index,
+            payload: *payload,
+            on_disk_payload: *on_disk_payload,
+        }
+    }
+
     /// Shards a new collection starts with.
     ///
     /// The proposer picks them and the operation carries them. An operation proposed without a

--- a/lib/storage/src/content_manager/consensus_state_machine/state/apply.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/state/apply.rs
@@ -114,7 +114,7 @@ impl ClusterState {
             }
 
             Action::SetQuotaConfig { config } => {
-                self.quota_config = Some(*config);
+                self.quota_config = *config;
             }
 
             // Sleep on a peer, or fail at random. Neither changes the state.

--- a/lib/storage/src/content_manager/consensus_state_machine/state/mod.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/state/mod.rs
@@ -14,8 +14,10 @@ use crate::types::{PeerAddressById, PeerMetadataById};
 
 /// Cluster state consensus decides on.
 ///
-/// Same fields and types as [`SnapshotData`], the state we serialize into Raft snapshots,
-/// so a copy can be compared against state read back from `TableOfContent` field by field.
+/// Same fields as [`SnapshotData`], the state we serialize into Raft snapshots, so a copy can be
+/// compared against state read back from `TableOfContent` field by field. Types match too, except
+/// that `SnapshotData` wraps the quota config in an `Option` to read snapshots taken before
+/// global quotas existed.
 ///
 /// `TableOfContent` stays the source of truth; this is the copy we validate operations against.
 ///
@@ -27,7 +29,7 @@ pub struct ClusterState {
     pub peer_address_by_id: PeerAddressById,
     pub peer_metadata_by_id: PeerMetadataById,
     pub cluster_metadata: HashMap<String, serde_json::Value>,
-    pub quota_config: Option<QuotaConfig>,
+    pub quota_config: QuotaConfig,
 }
 
 impl ClusterState {

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/mod.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/mod.rs
@@ -27,7 +27,7 @@ fn state_machine(state: ClusterState) -> ConsensusStateMachine {
 }
 
 /// Node config is fixed, except for the parts used in tests. Extend it as needed.
-fn node_context() -> NodeContext {
+pub(crate) fn node_context() -> NodeContext {
     NodeContext {
         peer_id: PEER_ID,
         is_distributed: true,

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/mod.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/mod.rs
@@ -1,4 +1,7 @@
-//! Common test fixtures
+//! Common test fixtures.
+//!
+//! `consensus_shadow` builds collection states out of these too, so the two sides of a compare
+//! are the same shape.
 
 mod ops;
 mod prop;
@@ -16,7 +19,7 @@ use shard::operations::VectorNameConfig;
 
 use super::*;
 
-const PEER_ID: u64 = 42;
+pub(crate) const PEER_ID: u64 = 42;
 const OTHER_PEER_ID: u64 = 43;
 
 fn state_machine(state: ClusterState) -> ConsensusStateMachine {
@@ -61,7 +64,9 @@ fn create_collection_request() -> CreateCollection {
     }
 }
 
-fn collection_state(vectors: Vec<(VectorNameBuf, VectorNameConfig)>) -> collection_state::State {
+pub(crate) fn collection_state(
+    vectors: Vec<(VectorNameBuf, VectorNameConfig)>,
+) -> collection_state::State {
     let mut params = collection_params(VectorsConfig::Multi(Default::default()));
 
     for (name, config) in vectors {

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/ops.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/ops.rs
@@ -1172,13 +1172,13 @@ fn set_quota_config() {
         [Action::SetQuotaConfig { .. }],
     ));
 
-    assert_eq!(machine.state().quota_config, Some(quota_config(true)));
+    assert_eq!(machine.state().quota_config, quota_config(true));
 }
 
 #[test]
 fn set_quota_config_replace() {
     let state = ClusterState {
-        quota_config: Some(quota_config(true)),
+        quota_config: quota_config(true),
         ..Default::default()
     };
 
@@ -1194,13 +1194,13 @@ fn set_quota_config_replace() {
         [Action::SetQuotaConfig { .. }],
     ));
 
-    assert_eq!(machine.state().quota_config, Some(quota_config(false)));
+    assert_eq!(machine.state().quota_config, quota_config(false));
 }
 
 #[test]
 fn set_quota_config_replay() {
     let state = ClusterState {
-        quota_config: Some(quota_config(true)),
+        quota_config: quota_config(true),
         ..Default::default()
     };
 

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/prop.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/prop.rs
@@ -67,7 +67,7 @@ pub fn arb_cluster_state() -> impl Strategy<Value = ClusterState> {
             arb_aliases(names),
             arb_peer_metadata_by_id(),
             arb_cluster_metadata(),
-            proptest::option::of(arb_quota_config()),
+            arb_quota_config(),
         );
 
         state.prop_map(|state| {

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -11,6 +11,7 @@ pub mod collection_verification;
 mod collections_ops;
 pub mod consensus;
 pub mod consensus_manager;
+pub mod consensus_shadow;
 pub mod consensus_state_machine;
 pub mod conversions;
 pub mod errors;

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -2,6 +2,7 @@ use collection::shards::shard::PeerId;
 
 use self::collection_meta_ops::CollectionMetaOperations;
 use self::consensus_manager::CollectionsSnapshot;
+use self::consensus_state_machine::NodeContext;
 use self::errors::StorageError;
 use crate::quota::QuotaConfig;
 
@@ -210,6 +211,9 @@ pub trait CollectionContainer {
     ) -> Result<bool, StorageError>;
 
     fn collections_snapshot(&self) -> CollectionsSnapshot;
+
+    /// Node-local values operations read, from this node's storage config
+    fn node_context(&self) -> NodeContext;
 
     fn apply_collections_snapshot(&self, data: CollectionsSnapshot) -> Result<(), StorageError>;
 

--- a/lib/storage/src/content_manager/toc/collection_container.rs
+++ b/lib/storage/src/content_manager/toc/collection_container.rs
@@ -13,6 +13,7 @@ use crate::content_manager::collection_meta_ops::*;
 use crate::content_manager::collections_ops::Checker as _;
 use crate::content_manager::consensus::operation_sender::OperationSender;
 use crate::content_manager::consensus_ops::ConsensusOperations;
+use crate::content_manager::consensus_state_machine::NodeContext;
 use crate::content_manager::errors::StorageError;
 use crate::content_manager::{CollectionContainer, consensus_manager};
 use crate::quota::QuotaConfig;
@@ -27,6 +28,14 @@ impl CollectionContainer for TableOfContent {
 
     fn collections_snapshot(&self) -> consensus_manager::CollectionsSnapshot {
         self.collections_snapshot_sync()
+    }
+
+    fn node_context(&self) -> NodeContext {
+        NodeContext::from_storage_config(
+            &self.storage_config,
+            self.this_peer_id,
+            self.is_distributed(),
+        )
     }
 
     fn apply_collections_snapshot(

--- a/src/main.rs
+++ b/src/main.rs
@@ -584,6 +584,7 @@ fn main() -> anyhow::Result<()> {
             storage_path,
         )
         .expect("initialize consensus manager")
+        .with_shadow(settings.cluster.consensus.shadow_state_machine)
         .into();
         let is_new_deployment = consensus_state.is_new_deployment();
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -597,6 +597,21 @@ mod tests {
         assert!(config.load_errors.is_empty(), "must not have load errors")
     }
 
+    /// The consensus test suite turns the shadow run on through this variable, so a rename here
+    /// leaves that suite testing nothing.
+    #[expect(clippy::disallowed_types, reason = "#[sealed_test] uses std::fs::File")]
+    #[sealed_test]
+    fn shadow_state_machine_from_env() {
+        unsafe { env::set_var("QDRANT__CLUSTER__CONSENSUS__SHADOW_STATE_MACHINE", "panic") };
+
+        let settings = Settings::new(None).expect("failed to load config");
+
+        assert_eq!(
+            settings.cluster.consensus.shadow_state_machine,
+            ShadowMode::Panic,
+        );
+    }
+
     #[expect(clippy::disallowed_types, reason = "#[sealed_test] uses std::fs::File")]
     #[sealed_test]
     fn test_no_config_files() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,6 +9,7 @@ use collection::shards::shard::PeerId;
 use common::flags::FeatureFlags;
 use config::{Config, ConfigError, Environment, File, FileFormat, Source};
 use serde::Deserialize;
+use storage::content_manager::consensus_shadow::ShadowMode;
 use storage::types::StorageConfig;
 use validator::{Validate, ValidationError};
 
@@ -171,6 +172,9 @@ pub struct ConsensusConfig {
     /// Compact WAL when it grows to enough applied entries
     #[serde(default = "default_compact_wal_entries")]
     pub compact_wal_entries: u64,
+    /// Run the consensus state machine alongside the apply path and compare the two
+    #[serde(default)]
+    pub shadow_state_machine: ShadowMode,
 }
 
 impl Default for ConsensusConfig {
@@ -181,6 +185,7 @@ impl Default for ConsensusConfig {
             bootstrap_timeout_sec: default_bootstrap_timeout_sec(),
             message_timeout_ticks: default_message_timeout_tics(),
             compact_wal_entries: default_compact_wal_entries(),
+            shadow_state_machine: ShadowMode::default(),
         }
     }
 }

--- a/tests/consensus_tests/utils.py
+++ b/tests/consensus_tests/utils.py
@@ -185,6 +185,9 @@ def get_env(p2p_port: int, grpc_port: int, http_port: int) -> Dict[str, str]:
     env["QDRANT__SERVICE__GRPC_PORT"] = str(grpc_port)
     env["QDRANT__LOG_LEVEL"] = "TRACE,raft::raft=info,actix_http=info,tonic=info,want=info,mio=info"
     env["QDRANT__SERVICE__HARDWARE_REPORTING"] = "true"
+    # Apply every consensus operation to the state machine as well, and fail the peer when its
+    # state disagrees with the applied one
+    env["QDRANT__CLUSTER__CONSENSUS__SHADOW_STATE_MACHINE"] = "panic"
 
     if is_coverage_mode():
         env["LLVM_PROFILE_FILE"] = get_llvm_profile_file()


### PR DESCRIPTION
Basic integration of `ConsensusStateMachine` to be validated against "real" consensus (i.e., methods of `TableOfContent::perform_collection_meta_op`).

This is a "trivial" implementation that is not yet suitable for production, but it should already be good enough to run `ConsensusStateMachine` against `consensus_tests`. Optimizations and improvements would be implemented as follow-up PR(s).

**TODO:**
- [ ] de-slop 💀
- [x] split into parts 🪦

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
