### PR TITLE
fix(segment): normalize small cosine vectors

### DIFF
--- a/lib/segment/src/spaces/simple.rs
+++ b/lib/segment/src/spaces/simple.rs
@@ -226,11 +226,10 @@ pub fn manhattan_similarity(v1: &[VectorElementType], v2: &[VectorElementType]) 
 }
 
 pub fn cosine_preprocess(vector: DenseVector) -> DenseVector {
-    let mut length: f32 = vector.iter().map(|x| x * x).sum();
+    let length: f32 = vector.iter().map(|x| x * x).sum::<f32>().sqrt();
     if is_length_zero_or_normalized(length) {
         return vector;
     }
-    length = length.sqrt();
     vector.iter().map(|x| x / length).collect()
 }
 
@@ -248,6 +247,21 @@ mod tests {
     fn test_cosine_preprocessing() {
         let res = <CosineMetric as Metric<VectorElementType>>::preprocess(vec![0.0, 0.0, 0.0, 0.0]);
         assert_eq!(res, vec![0.0, 0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn test_cosine_preprocessing_normalizes_small_vectors() {
+        let vector = vec![1.0e-4, 0.0];
+        let preprocessed = cosine_preprocess(vector);
+
+        assert_eq!(preprocessed, vec![1.0, 0.0]);
+
+        let mut vector = vec![0.0; MIN_DIM_SIZE_SIMD];
+        vector[0] = 1.0e-4;
+        let preprocessed = <CosineMetric as Metric<VectorElementType>>::preprocess(vector);
+
+        assert_eq!(preprocessed[0], 1.0);
+        assert!(preprocessed[1..].iter().all(|&value| value == 0.0));
     }
 
     /// If we preprocess a vector multiple times, we expect the same result.

--- a/lib/segment/src/spaces/simple_avx.rs
+++ b/lib/segment/src/spaces/simple_avx.rs
@@ -151,16 +151,17 @@ pub(crate) unsafe fn cosine_preprocess_avx(mut vector: DenseVector) -> DenseVect
             i += 32;
         }
 
-        let mut length = four_way_hsum(sum256_1, sum256_2, sum256_3, sum256_4);
+        let mut length_squared = four_way_hsum(sum256_1, sum256_2, sum256_3, sum256_4);
 
         for i in 0..n - m {
-            length += (*ptr.add(i)).powi(2);
+            length_squared += (*ptr.add(i)).powi(2);
         }
+        let length = length_squared.sqrt();
         if is_length_zero_or_normalized(length) {
             return vector;
         }
 
-        let inv_length = 1.0 / length.sqrt();
+        let inv_length = 1.0 / length;
         let v_inv_length = _mm256_set1_ps(inv_length);
         let mut_ptr: *mut f32 = vector.as_mut_ptr();
 
@@ -277,6 +278,12 @@ mod tests {
                 let tol = 1e-6_f32.max(8.0 * f32::EPSILON * a.abs().max(b.abs()).max(1.0));
                 assert!((a - b).abs() <= tol, "Cosine SIMD mismatch: {a} vs {b}",);
             }
+
+            let mut small_vector = vec![0.0; 32];
+            small_vector[0] = 1.0e-4;
+            let cosine_simd = unsafe { cosine_preprocess_avx(small_vector) };
+            assert_eq!(cosine_simd[0], 1.0);
+            assert!(cosine_simd[1..].iter().all(|&value| value == 0.0));
         } else {
             println!("avx test skipped");
         }

--- a/lib/segment/src/spaces/simple_neon.rs
+++ b/lib/segment/src/spaces/simple_neon.rs
@@ -120,16 +120,18 @@ pub(crate) unsafe fn cosine_preprocess_neon(mut vector: DenseVector) -> DenseVec
             i += 16;
         }
 
-        let mut length = vaddvq_f32(vaddq_f32(vaddq_f32(sum1, sum2), vaddq_f32(sum3, sum4)));
+        let mut length_squared =
+            vaddvq_f32(vaddq_f32(vaddq_f32(sum1, sum2), vaddq_f32(sum3, sum4)));
 
         for v in vector.iter().take(n).skip(m) {
-            length += v.powi(2);
+            length_squared += v.powi(2);
         }
+        let length = length_squared.sqrt();
         if is_length_zero_or_normalized(length) {
             return vector;
         }
 
-        let inv_length = 1.0 / length.sqrt();
+        let inv_length = 1.0 / length;
         let v_inv_length = vdupq_n_f32(inv_length);
         let mut_ptr: *mut f32 = vector.as_mut_ptr();
 
@@ -230,6 +232,12 @@ mod tests {
                 let tol = 1e-6_f32.max(8.0 * f32::EPSILON * a.abs().max(b.abs()).max(1.0));
                 assert!((a - b).abs() <= tol, "Cosine SIMD mismatch: {a} vs {b}",);
             }
+
+            let mut small_vector = vec![0.0; 16];
+            small_vector[0] = 1.0e-4;
+            let cosine_simd = unsafe { cosine_preprocess_neon(small_vector) };
+            assert_eq!(cosine_simd[0], 1.0);
+            assert!(cosine_simd[1..].iter().all(|&value| value == 0.0));
         } else {
             println!("neon test skipped");
         }

--- a/lib/segment/src/spaces/simple_sse.rs
+++ b/lib/segment/src/spaces/simple_sse.rs
@@ -135,17 +135,17 @@ pub(crate) unsafe fn cosine_preprocess_sse(vector: DenseVector) -> DenseVector {
             i += 16;
         }
 
-        let mut length = hsum128_ps_sse(sum128_1)
+        let mut length_squared = hsum128_ps_sse(sum128_1)
             + hsum128_ps_sse(sum128_2)
             + hsum128_ps_sse(sum128_3)
             + hsum128_ps_sse(sum128_4);
         for i in 0..n - m {
-            length += (*ptr.add(i)).powi(2);
+            length_squared += (*ptr.add(i)).powi(2);
         }
+        let length = length_squared.sqrt();
         if is_length_zero_or_normalized(length) {
             return vector;
         }
-        length = length.sqrt();
         vector.into_iter().map(|x| x / length).collect()
     }
 }
@@ -236,6 +236,12 @@ mod tests {
             let cosine_simd = unsafe { cosine_preprocess_sse(v1.clone()) };
             let cosine = cosine_preprocess(v1);
             assert_eq!(cosine_simd, cosine);
+
+            let mut small_vector = vec![0.0; 16];
+            small_vector[0] = 1.0e-4;
+            let cosine_simd = unsafe { cosine_preprocess_sse(small_vector) };
+            assert_eq!(cosine_simd[0], 1.0);
+            assert!(cosine_simd[1..].iter().all(|&value| value == 0.0));
         } else {
             println!("sse test skipped");
         }


### PR DESCRIPTION
Fixes #10465

### Summary

Normalize small non-zero cosine vectors consistently in the scalar and SIMD preprocessing paths. The change also adds regression coverage for the scalar dispatcher and the SSE, AVX/FMA, and NEON implementations.

### Root cause

The preprocessing code accumulated the squared norm (`sum(x²)`) but passed it directly to `is_length_zero_or_normalized`. That helper compares its argument with `f32::EPSILON`, a threshold expressed in norm—not squared-norm—units. Consequently, vectors with norm below `sqrt(f32::EPSILON)` (about `3.45e-4`) were treated as zero and skipped normalization. For example, `[1e-4, 0.0]` remained `[1e-4, 0.0]` instead of becoming `[1.0, 0.0]`, making cosine scores magnitude-dependent.

### Fix

Take the square root of the accumulated squared norm before applying the existing zero/already-normalized check. This preserves the intended behavior for zero, near-zero, and unit-length vectors while correctly normalizing small non-zero vectors. The same correction is applied to scalar, SSE, AVX/FMA, and NEON code paths.

### Verification

- Reproduced the original behavior with `cosine_preprocess(vec![1e-4, 0.0])`, which returned `[1e-4, 0.0]` before the fix.
- `cargo test -q -p segment spaces::simple -- --nocapture`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p segment --lib --tests --no-deps -- -D warnings`
- `git diff --check`

### All Submissions:

* [x] I have created this PR from the `dev` branch (not `master`).
* [x] I have followed the contributing guidelines in this repository.
* [x] I have checked that there are no other open [Pull Requests](../../../pulls) for the same update/change.

### Changes to Core Features:

* [x] I have added an explanation of the change and its root cause to the PR description.
* [x] I have added tests to cover the changes.
* [x] I have run tests locally to verify the change.
