### PR TITLE
Reject timeout=0 on write-operation query parameters

### DIFF
--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::time::Duration;
 
 use serde::Serialize;
 use validator::{Validate, ValidationError, ValidationErrors, ValidationErrorsKind};
@@ -229,6 +230,22 @@ pub fn validate_sha256_hash(value: &str) -> Result<(), ValidationError> {
             Cow::from("message"),
             &"invalid characters, expected 0-9, a-f, A-F",
         );
+        return Err(err);
+    }
+
+    Ok(())
+}
+
+/// Reject a `timeout=0` write-operation query parameter. The OpenAPI schema
+/// declares `timeout` as `minimum: 1` on every write endpoint, but the field
+/// itself is a plain `Option<Duration>`, so `timeout=0` deserializes to
+/// `Duration::ZERO` and is silently accepted instead of rejected as the
+/// schema promises.
+pub fn validate_write_timeout(timeout: &Duration) -> Result<(), ValidationError> {
+    if timeout.is_zero() {
+        let mut err = ValidationError::new("range");
+        err.add_param(Cow::from("min"), &1);
+        err.add_param(Cow::from("message"), &"timeout must be at least 1 second");
         return Err(err);
     }
 
@@ -499,5 +516,12 @@ mod tests {
             )
             .is_err(),
         );
+    }
+
+    #[test]
+    fn test_validate_write_timeout() {
+        assert!(validate_write_timeout(&Duration::from_secs(0)).is_err());
+        assert!(validate_write_timeout(&Duration::from_secs(1)).is_ok());
+        assert!(validate_write_timeout(&Duration::from_secs(30)).is_ok());
     }
 }

--- a/src/common/update.rs
+++ b/src/common/update.rs
@@ -41,6 +41,7 @@ pub struct UpdateParams {
     #[serde(default)]
     pub ordering: WriteOrdering,
     #[serde_as(as = "Option<DurationSeconds<String>>")]
+    #[validate(custom(function = "::common::validation::validate_write_timeout"))]
     pub timeout: Option<Duration>,
 }
 
@@ -1345,5 +1346,38 @@ fn get_shard_selector_for_update(
         }
         (None, Some(shard_key)) => ShardSelectorInternal::from(shard_key),
         (None, None) => ShardSelectorInternal::Empty,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use validator::Validate;
+
+    use super::*;
+
+    // Regression test for the write-operation `timeout` query parameter
+    // silently accepting `timeout=0` despite the OpenAPI schema declaring
+    // `minimum: 1` (see issue: write ops accept timeout=0 despite the
+    // schema forbidding it). `UpdateParams` backs every points/vectors
+    // write endpoint (upsert, delete, set/clear payload, update vectors).
+    #[test]
+    fn update_params_rejects_zero_timeout() {
+        let params: UpdateParams = serde_urlencoded::from_str("timeout=0").unwrap();
+        assert!(params.validate().is_err());
+    }
+
+    #[test]
+    fn update_params_accepts_positive_timeout() {
+        let params: UpdateParams = serde_urlencoded::from_str("timeout=1").unwrap();
+        assert!(params.validate().is_ok());
+
+        let params: UpdateParams = serde_urlencoded::from_str("timeout=30").unwrap();
+        assert!(params.validate().is_ok());
+    }
+
+    #[test]
+    fn update_params_accepts_missing_timeout() {
+        let params: UpdateParams = serde_urlencoded::from_str("").unwrap();
+        assert!(params.validate().is_ok());
     }
 }

--- a/tests/openapi/test_wait_timeout.py
+++ b/tests/openapi/test_wait_timeout.py
@@ -179,3 +179,30 @@ def test_wait_timeout_twice(collection_name):
     )
     assert sleep.ok and sleep.json()["result"]["status"] == "wait_timeout"
     assert op.ok and op.json()["result"]["status"] == "wait_timeout"
+
+
+def test_zero_timeout_rejected(collection_name):
+    # The OpenAPI schema declares `timeout` as `minimum: 1` on every write
+    # endpoint, but the server used to accept `timeout=0` as if it were a
+    # valid value instead of rejecting it per the published contract.
+    response = request_with_validation(
+        api="/collections/{collection_name}/points",
+        method="PUT",
+        path_params={"collection_name": collection_name},
+        query_params={"timeout": 0},
+        body={
+            "points": [
+                {
+                    "id": 1,
+                    "vector": {
+                        "bm25": {
+                            "text": "Lorem ipsum, dolor sit amet.",
+                            "model": "qdrant/bm25",
+                        }
+                    },
+                }
+            ]
+        },
+    )
+    assert not response.ok
+    assert response.status_code == 400


### PR DESCRIPTION
Fixes #9869.

## Root cause

Write endpoints (upsert, delete, set/clear payload, update vectors) accept `timeout=0` and treat it as a valid value, even though the OpenAPI schema declares `timeout` as `minimum: 1` on every one of them.

The gap is in `UpdateParams` (`src/common/update.rs`): its `timeout` field is a plain `Option<Duration>`, so `timeout=0` deserializes straight to `Duration::ZERO` and passes through uncaught.

The read path already solves the identical problem correctly — `ReadParams::timeout` (`src/actix/api/read_params.rs`) uses `Option<NonZeroU64>`, which rejects `0` at deserialization time. `Duration` can't be made `NonZero` the same way, so this adds a `validate_write_timeout` custom validator (`lib/common/common/src/validation.rs`), following the existing `validate_vector_name`/`validate_sha256_hash` pattern in that file, and wires it into `UpdateParams` via `#[validate(custom(...))]`.

One clarification on the issue's scope: collection-level endpoints (create/update/delete collection) already validate this correctly through a separate `WaitTimeout` struct with `#[validate(range(min = 1))]`. Only the points/vectors write endpoints backed by `UpdateParams` had the gap.

## Testing

- Added `lib/common/common/src/validation.rs::tests::test_validate_write_timeout` (unit test on the validator itself).
- Added three tests in `src/common/update.rs::tests` exercising `UpdateParams` through `serde_urlencoded` deserialization + `.validate()`, mirroring `read_params.rs`'s existing test style for the identical problem.
- Added `tests/openapi/test_zero_timeout_rejected` in `tests/openapi/test_wait_timeout.py`, matching the issue's exact repro against `PUT /collections/{c}/points`.
- `cargo check -p common -p qdrant` and `cargo test` (both crates) pass locally; `cargo +nightly fmt --all --check` passes (enforced by this repo's own pre-push hook).