### PR TITLE
[combined-storage] DenseVectorBlob

### DIFF
--- a/lib/segment/src/vector_storage/dense/dense_vectors.rs
+++ b/lib/segment/src/vector_storage/dense/dense_vectors.rs
@@ -1,0 +1,56 @@
+use std::borrow::Cow;
+
+use common::generic_consts::AccessPattern;
+use common::types::PointOffsetType;
+use common::universal_io::UniversalRead;
+
+use crate::common::operation_error::OperationResult;
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::vector_storage::dense::immutable_dense_vectors::ImmutableDenseVectorData;
+
+pub trait DenseVectorBlob {
+    type Element: PrimitiveVectorElement;
+    type File: UniversalRead;
+
+    fn dim(&self) -> usize;
+
+    fn num_vectors(&self) -> usize;
+
+    fn get_vector_opt<P: AccessPattern>(
+        &self,
+        key: PointOffsetType,
+    ) -> Option<Cow<'_, [Self::Element]>>;
+
+    fn for_each_in_batch<F: FnMut(usize, &[Self::Element])>(
+        &self,
+        keys: &[PointOffsetType],
+        f: F,
+    ) -> OperationResult<()>;
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorBlob
+    for ImmutableDenseVectorData<T, S>
+{
+    type Element = T;
+    type File = S;
+
+    fn dim(&self) -> usize {
+        self.dim
+    }
+
+    fn num_vectors(&self) -> usize {
+        self.num_vectors
+    }
+
+    fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<Cow<'_, [T]>> {
+        ImmutableDenseVectorData::get_vector_opt::<P>(self, key)
+    }
+
+    fn for_each_in_batch<F: FnMut(usize, &[T])>(
+        &self,
+        keys: &[PointOffsetType],
+        f: F,
+    ) -> OperationResult<()> {
+        ImmutableDenseVectorData::for_each_in_batch(self, keys, f)
+    }
+}

--- a/lib/segment/src/vector_storage/dense/mod.rs
+++ b/lib/segment/src/vector_storage/dense/mod.rs
@@ -1,5 +1,6 @@
 pub mod appendable_dense_vector_storage;
 pub mod dense_vector_storage;
+pub mod dense_vectors;
 pub mod empty_dense_vector_storage;
 pub mod immutable_dense_vectors;
 pub mod read_only;

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/lifecycle.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/lifecycle.rs
@@ -25,7 +25,9 @@ fn bitslice_open_options(populate: Populate) -> OpenOptions {
     }
 }
 
-impl<T: PrimitiveVectorElement, S: UniversalRead> ReadOnlyImmutableDenseVectorStorage<T, S> {
+impl<T: PrimitiveVectorElement, S: UniversalRead>
+    ReadOnlyImmutableDenseVectorStorage<ImmutableDenseVectorData<T, S>>
+{
     /// Schedule background prefetch of the files [`Self::open`] will read.
     ///
     /// Absent files are skipped rather than reported: the subsequent open is

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/live_reload.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/live_reload.rs
@@ -1,20 +1,18 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalReadFs};
 use futures::future::BoxFuture;
 
 use super::ReadOnlyImmutableDenseVectorStorage;
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
-use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::vector_storage::dense::dense_vectors::DenseVectorBlob;
 
-impl<T: PrimitiveVectorElement, S: UniversalRead> LiveReload
-    for ReadOnlyImmutableDenseVectorStorage<T, S>
-{
-    type File = S;
+impl<B: DenseVectorBlob> LiveReload for ReadOnlyImmutableDenseVectorStorage<B> {
+    type File = B::File;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(
+    fn live_preload<Fs: CachedReadFs<File = B::File>>(
         &self,
         _fs: &Fs,
     ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
@@ -24,7 +22,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> LiveReload
 
     /// Vector data is immutable, so only the in-memory deletion flags are patched
     /// from the authoritative `deleted_points`; `fs` and `new_points` are unused.
-    fn live_reload<Fs: UniversalReadFs<File = S>>(
+    fn live_reload<Fs: UniversalReadFs<File = B::File>>(
         &mut self,
         _fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/mod.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/mod.rs
@@ -1,9 +1,8 @@
-use common::universal_io::{Populate, UniversalRead};
+use common::universal_io::Populate;
 
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
-use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::types::Distance;
-use crate::vector_storage::dense::immutable_dense_vectors::ImmutableDenseVectorData;
+use crate::vector_storage::dense::dense_vectors::DenseVectorBlob;
 
 mod lifecycle;
 mod live_reload;
@@ -12,11 +11,11 @@ mod read_ops;
 /// Read-only counterpart of the immutable (mmap) dense vector storage.
 ///
 /// Vector data is immutable, so it is read straight from the shared
-/// [`ImmutableDenseVectorData`] blob; deletions are tracked in memory and folded
-/// from the live-reload delta.
+/// [`DenseVectorBlob`]; deletions are tracked in memory and folded from the
+/// live-reload delta.
 #[derive(Debug)]
-pub struct ReadOnlyImmutableDenseVectorStorage<T: PrimitiveVectorElement, S: UniversalRead> {
-    vectors: ImmutableDenseVectorData<T, S>,
+pub struct ReadOnlyImmutableDenseVectorStorage<B: DenseVectorBlob> {
+    vectors: B,
     /// Flags marking deleted vectors.
     deleted: InMemoryBitvecFlags,
     distance: Distance,
@@ -41,6 +40,7 @@ mod tests {
     use crate::segment_constructor::batched_reader::merge_from_single_source;
     use crate::types::Memory;
     use crate::vector_storage::dense::dense_vector_storage::open_dense_vector_storage;
+    use crate::vector_storage::dense::immutable_dense_vectors::ImmutableDenseVectorData;
     use crate::vector_storage::dense::volatile_dense_vector_storage::new_volatile_dense_vector_storage;
     use crate::vector_storage::{VectorStorage, VectorStorageRead};
 
@@ -84,13 +84,9 @@ mod tests {
             storage.flusher()().unwrap();
         }
 
-        let storage = ReadOnlyImmutableDenseVectorStorage::<VectorElementType, MmapFile>::open(
-            &MmapFs,
-            dir.path(),
-            DIM,
-            Distance::Dot,
-            Populate::No,
-        )
+        let storage = ReadOnlyImmutableDenseVectorStorage::<
+            ImmutableDenseVectorData<VectorElementType, MmapFile>,
+        >::open(&MmapFs, dir.path(), DIM, Distance::Dot, Populate::No)
         .unwrap();
 
         assert_eq!(storage.total_vector_count(), POINT_COUNT as usize);
@@ -138,13 +134,9 @@ mod tests {
             writer.flusher()().unwrap();
         }
 
-        let mut reader = ReadOnlyImmutableDenseVectorStorage::<VectorElementType, MmapFile>::open(
-            &MmapFs,
-            dir.path(),
-            DIM,
-            Distance::Dot,
-            Populate::No,
-        )
+        let mut reader = ReadOnlyImmutableDenseVectorStorage::<
+            ImmutableDenseVectorData<VectorElementType, MmapFile>,
+        >::open(&MmapFs, dir.path(), DIM, Distance::Dot, Populate::No)
         .unwrap();
         assert_eq!(reader.deleted_vector_count(), 0);
 

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/read_ops.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/read_ops.rs
@@ -3,23 +3,24 @@ use std::borrow::Cow;
 use common::bitvec::BitSlice;
 use common::generic_consts::AccessPattern;
 use common::types::PointOffsetType;
-use common::universal_io::{UniversalRead, UserData};
+use common::universal_io::UserData;
 
 use super::ReadOnlyImmutableDenseVectorStorage;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::primitive::PrimitiveVectorElement;
 use crate::types::{Distance, VectorStorageDatatype};
+use crate::vector_storage::dense::dense_vectors::DenseVectorBlob;
 use crate::vector_storage::{DenseVectorStorageRead, VectorStorageRead};
 
-impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorStorageRead<T>
-    for ReadOnlyImmutableDenseVectorStorage<T, S>
+impl<B: DenseVectorBlob> DenseVectorStorageRead<B::Element>
+    for ReadOnlyImmutableDenseVectorStorage<B>
 {
     fn vector_dim(&self) -> usize {
-        self.vectors.dim
+        self.vectors.dim()
     }
 
-    fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]> {
+    fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [B::Element]> {
         self.vectors
             .get_vector_opt::<P>(key)
             .expect("vector not found")
@@ -38,7 +39,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorStorageRead<T>
         })
     }
 
-    fn for_each_in_dense_batch<F: FnMut(usize, &[T])>(
+    fn for_each_in_dense_batch<F: FnMut(usize, &[B::Element])>(
         &self,
         keys: &[PointOffsetType],
         f: F,
@@ -47,11 +48,9 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorStorageRead<T>
     }
 }
 
-impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
-    for ReadOnlyImmutableDenseVectorStorage<T, S>
-{
+impl<B: DenseVectorBlob> VectorStorageRead for ReadOnlyImmutableDenseVectorStorage<B> {
     fn size_of_available_vectors_in_bytes(&self) -> usize {
-        self.available_vector_count() * self.vector_dim() * std::mem::size_of::<T>()
+        self.available_vector_count() * self.vector_dim() * std::mem::size_of::<B::Element>()
     }
 
     fn distance(&self) -> Distance {
@@ -59,21 +58,21 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     }
 
     fn datatype(&self) -> VectorStorageDatatype {
-        T::datatype()
+        B::Element::datatype()
     }
 
     fn is_on_disk(&self) -> bool {
-        !self.populate.to_bool::<S>()
+        !self.populate.to_bool::<B::File>()
     }
 
     fn total_vector_count(&self) -> usize {
-        self.vectors.num_vectors
+        self.vectors.num_vectors()
     }
 
     fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
         self.vectors
             .get_vector_opt::<P>(key)
-            .map(|vector| T::slice_to_float_cow(vector).into())
+            .map(|vector| CowVector::from(B::Element::slice_to_float_cow(vector)))
             .expect("Vector not found")
     }
 
@@ -88,7 +87,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
 
         self.vectors
             .for_each_in_batch(&point_offsets, |idx, vector| {
-                let vector = CowVector::from(T::slice_to_float_cow(Cow::Borrowed(vector)));
+                let vector = CowVector::from(B::Element::slice_to_float_cow(Cow::Borrowed(vector)));
                 callback(user_data[idx], point_offsets[idx], vector);
             })
             .expect("read vectors");
@@ -97,7 +96,7 @@ impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
     fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
         self.vectors
             .get_vector_opt::<P>(key)
-            .map(|vector| T::slice_to_float_cow(vector).into())
+            .map(|vector| CowVector::from(B::Element::slice_to_float_cow(vector)))
     }
 
     fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(

--- a/lib/segment/src/vector_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/read_only/lifecycle.rs
@@ -7,6 +7,7 @@ use super::VectorStorageReadEnum;
 use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte, VectorElementTypeHalf};
 use crate::types::{VectorDataConfig, VectorStorageDatatype, VectorStorageType};
+use crate::vector_storage::dense::immutable_dense_vectors::ImmutableDenseVectorData;
 use crate::vector_storage::dense::read_only::{
     ReadOnlyChunkedDenseVectorStorage, ReadOnlyImmutableDenseVectorStorage,
 };
@@ -113,16 +114,13 @@ impl<S: UniversalRead> VectorStorageReadEnum<S> {
         } else {
             match datatype {
                 VectorStorageDatatype::Float32 => ReadOnlyImmutableDenseVectorStorage::<
-                    VectorElementType,
-                    S,
+                    ImmutableDenseVectorData<VectorElementType, S>,
                 >::preopen(fs, path, populate),
                 VectorStorageDatatype::Uint8 => ReadOnlyImmutableDenseVectorStorage::<
-                    VectorElementTypeByte,
-                    S,
+                    ImmutableDenseVectorData<VectorElementTypeByte, S>,
                 >::preopen(fs, path, populate),
                 VectorStorageDatatype::Float16 => ReadOnlyImmutableDenseVectorStorage::<
-                    VectorElementTypeHalf,
-                    S,
+                    ImmutableDenseVectorData<VectorElementTypeHalf, S>,
                 >::preopen(fs, path, populate),
                 VectorStorageDatatype::Turbo4 => {
                     ReadOnlyImmutableTurboVectorStorage::<S>::preopen(fs, path, populate)

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -5,6 +5,7 @@ use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::{
     QueryVector, VectorElementType, VectorElementTypeByte, VectorElementTypeHalf,
 };
+use crate::vector_storage::dense::immutable_dense_vectors::ImmutableDenseVectorData;
 use crate::vector_storage::dense::read_only::{
     ReadOnlyChunkedDenseVectorStorage, ReadOnlyImmutableDenseVectorStorage,
 };
@@ -28,9 +29,17 @@ mod read_ops;
 /// Wraps each on-disk storage type with its [`super`] read-only variant.
 /// Volatile, empty and test-only variants are intentionally absent.
 pub enum VectorStorageReadEnum<S: UniversalRead> {
-    Dense(Box<ReadOnlyImmutableDenseVectorStorage<VectorElementType, S>>),
-    DenseByte(Box<ReadOnlyImmutableDenseVectorStorage<VectorElementTypeByte, S>>),
-    DenseHalf(Box<ReadOnlyImmutableDenseVectorStorage<VectorElementTypeHalf, S>>),
+    Dense(Box<ReadOnlyImmutableDenseVectorStorage<ImmutableDenseVectorData<VectorElementType, S>>>),
+    DenseByte(
+        Box<
+            ReadOnlyImmutableDenseVectorStorage<ImmutableDenseVectorData<VectorElementTypeByte, S>>,
+        >,
+    ),
+    DenseHalf(
+        Box<
+            ReadOnlyImmutableDenseVectorStorage<ImmutableDenseVectorData<VectorElementTypeHalf, S>>,
+        >,
+    ),
     DenseChunked(Box<ReadOnlyChunkedDenseVectorStorage<VectorElementType, S>>),
     DenseChunkedByte(Box<ReadOnlyChunkedDenseVectorStorage<VectorElementTypeByte, S>>),
     DenseChunkedHalf(Box<ReadOnlyChunkedDenseVectorStorage<VectorElementTypeHalf, S>>),

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -24,22 +24,16 @@ mod lifecycle;
 mod live_reload;
 mod read_ops;
 
+type Dense<T, S> = ReadOnlyImmutableDenseVectorStorage<ImmutableDenseVectorData<T, S>>;
+
 /// Read-only counterpart of [`super::super::VectorStorageEnum`].
 ///
 /// Wraps each on-disk storage type with its [`super`] read-only variant.
 /// Volatile, empty and test-only variants are intentionally absent.
 pub enum VectorStorageReadEnum<S: UniversalRead> {
-    Dense(Box<ReadOnlyImmutableDenseVectorStorage<ImmutableDenseVectorData<VectorElementType, S>>>),
-    DenseByte(
-        Box<
-            ReadOnlyImmutableDenseVectorStorage<ImmutableDenseVectorData<VectorElementTypeByte, S>>,
-        >,
-    ),
-    DenseHalf(
-        Box<
-            ReadOnlyImmutableDenseVectorStorage<ImmutableDenseVectorData<VectorElementTypeHalf, S>>,
-        >,
-    ),
+    Dense(Box<Dense<VectorElementType, S>>),
+    DenseByte(Box<Dense<VectorElementTypeByte, S>>),
+    DenseHalf(Box<Dense<VectorElementTypeHalf, S>>),
     DenseChunked(Box<ReadOnlyChunkedDenseVectorStorage<VectorElementType, S>>),
     DenseChunkedByte(Box<ReadOnlyChunkedDenseVectorStorage<VectorElementTypeByte, S>>),
     DenseChunkedHalf(Box<ReadOnlyChunkedDenseVectorStorage<VectorElementTypeHalf, S>>),


### PR DESCRIPTION
This PR introduces `DenseVectorBlob` helper trait.

The problem: the upcoming combined vector storage implementation (#10477) will need to implement the same set of traits that the current vector storages implement. And these implementations would be identical copy-pasta boilerplate.

Solution: this PR extracts that boilerplate into a common part. Pure refactoring change.

## Illustration: without `DenseVectorBlob` (without this PR)

```rust
// ────────── Current dense vector storage (current dev) ──────────
struct RoDenseVectorStorage<T, S> { // aka ReadOnlyImmutableDenseVectorStorage
    vectors: ImmutableDenseVectorData<T, S>,
    deleted,
    …
}
// Then 130 lines of boilerplate:
impl DenseVectorStorageRead<T> for RoDenseVectorStorage<T, S> { … }
impl VectorStorageRead         for RoDenseVectorStorage<T, S> { … }
impl LiveReload                for RoDenseVectorStorage<T, S> { … }


// ────────── Upcoming combined vector storage (next PRs) ──────────
struct RoGraphInlineVectorStorage<T, S> {
    vectors: GraphVectors<T, S>,
    deleted,
    …
}
// Then 130 lines of a similar boilerplate again:
impl DenseVectorStorageRead<T> for RoGraphInlineVectorStorage<T, S> { … }
impl VectorStorageRead         for RoGraphInlineVectorStorage<T, S> { … }
impl LiveReload                for RoGraphInlineVectorStorage<T, S> { … }
```