### PR TITLE
[combined-storage] TurboVectorBlob

### DIFF
--- a/lib/segment/benches/turbo_vector_search.rs
+++ b/lib/segment/benches/turbo_vector_search.rs
@@ -37,6 +37,7 @@ use segment::fixtures::payload_context_fixture::create_id_tracker_fixture;
 use segment::id_tracker::IdTrackerRead;
 use segment::index::hnsw_index::point_scorer::BatchFilteredSearcher;
 use segment::types::Distance;
+use segment::vector_storage::quantized::quantized_storage::QuantizedStorage;
 use segment::vector_storage::turbo::{
     TurboVectorStorageImpl, open_appendable_turbo_vector_storage,
     open_turbo_vector_storage_with_uring,
@@ -88,8 +89,9 @@ fn build_dataset(dir: &Path) {
             .expect("vector inserted");
     }
 
-    let mut storage = TurboVectorStorageImpl::<MmapFile>::open_mmap(dir, DIM, DISTANCE, false)
-        .expect("single-file storage created");
+    let mut storage =
+        TurboVectorStorageImpl::<QuantizedStorage<MmapFile>>::open_mmap(dir, DIM, DISTANCE, false)
+            .expect("single-file storage created");
     let mut encoded =
         (0..VECTORS as PointOffsetType).map(|key| (encoder.get_quantized_vector(key), false));
     DenseTQVectorStorage::update_from(&mut storage, &mut encoded, &DEFAULT_STOPPED)

--- a/lib/segment/src/vector_storage/quantized/mod.rs
+++ b/lib/segment/src/vector_storage/quantized/mod.rs
@@ -6,6 +6,6 @@ pub mod quantized_multivector_storage;
 pub mod quantized_query_scorer;
 pub(crate) mod quantized_ram_storage;
 mod quantized_scorer_builder;
-pub(crate) mod quantized_storage;
+pub mod quantized_storage;
 pub mod quantized_vectors;
 pub(crate) mod update_only;

--- a/lib/segment/src/vector_storage/read_only/lifecycle.rs
+++ b/lib/segment/src/vector_storage/read_only/lifecycle.rs
@@ -125,7 +125,7 @@ impl<S: UniversalRead> VectorStorageReadEnum<S> {
                     S,
                 >::preopen(fs, path, populate),
                 VectorStorageDatatype::Turbo4 => {
-                    ReadOnlyImmutableTurboVectorStorage::<S>::preopen(fs, path, populate)
+                    ReadOnlyImmutableTurboVectorStorage::preopen(fs, path, populate)
                 }
             }
         }

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -9,6 +9,7 @@ use crate::vector_storage::dense::read_only::{
     ReadOnlyChunkedDenseVectorStorage, ReadOnlyImmutableDenseVectorStorage,
 };
 use crate::vector_storage::multi_dense::read_only::ReadOnlyChunkedMultiDenseVectorStorage;
+use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
 use crate::vector_storage::sparse::read_only::ReadOnlySparseVectorStorage;
 use crate::vector_storage::turbo::multi_turbo::read_only::ReadOnlyChunkedMultiTurboVectorStorage;
 use crate::vector_storage::turbo::read_only::{
@@ -37,7 +38,7 @@ pub enum VectorStorageReadEnum<S: UniversalRead> {
     MultiDenseChunked(Box<ReadOnlyChunkedMultiDenseVectorStorage<VectorElementType, S>>),
     MultiDenseChunkedByte(Box<ReadOnlyChunkedMultiDenseVectorStorage<VectorElementTypeByte, S>>),
     MultiDenseChunkedHalf(Box<ReadOnlyChunkedMultiDenseVectorStorage<VectorElementTypeHalf, S>>),
-    DenseTurbo(Box<ReadOnlyImmutableTurboVectorStorage<S>>),
+    DenseTurbo(Box<ReadOnlyImmutableTurboVectorStorage<QuantizedStorage<S>>>),
     DenseTurboChunked(Box<ReadOnlyChunkedTurboVectorStorage<S>>),
     MultiDenseTurbo(Box<ReadOnlyChunkedMultiTurboVectorStorage<S>>),
     Sparse(Box<ReadOnlySparseVectorStorage<S>>),
@@ -665,13 +666,14 @@ mod tests {
             // matching read-only variant.
             match storage_type {
                 VectorStorageType::Mmap => {
-                    let mut target = TurboVectorStorageImpl::<MmapFile>::open_mmap(
-                        dir.path(),
-                        DIM,
-                        Distance::Dot,
-                        false,
-                    )
-                    .unwrap();
+                    let mut target =
+                        TurboVectorStorageImpl::<QuantizedStorage<MmapFile>>::open_mmap(
+                            dir.path(),
+                            DIM,
+                            Distance::Dot,
+                            false,
+                        )
+                        .unwrap();
                     build_target(&mut target, &encoded, &stopped);
                 }
                 VectorStorageType::ChunkedMmap => {

--- a/lib/segment/src/vector_storage/tests/test_appendable_turbo_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_turbo_vector_storage.rs
@@ -24,6 +24,7 @@ use crate::common::operation_error::OperationResult;
 use crate::data_types::vectors::DenseVector;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::prefill_deleted::fill_turbo;
+use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
 use crate::vector_storage::turbo::shared::{
     DELETED_DIR_PATH, TQDT_BITS, TQDT_MODE, TQDT_ROTATION, VECTORS_DIR_PATH,
 };
@@ -43,8 +44,8 @@ fn open_turbo_vector_storage(
     dim: usize,
     distance: Distance,
     populate: bool,
-) -> OperationResult<TurboVectorStorageImpl<MmapFile>> {
-    TurboVectorStorageImpl::<MmapFile>::open_mmap(path, dim, distance, populate)
+) -> OperationResult<TurboVectorStorageImpl<QuantizedStorage<MmapFile>>> {
+    TurboVectorStorageImpl::<QuantizedStorage<MmapFile>>::open_mmap(path, dim, distance, populate)
 }
 
 /// Concrete single-file opener with an explicit backend. Only the mmap
@@ -56,12 +57,12 @@ fn open_turbo_vector_storage_with_uring(
     distance: Distance,
     populate: bool,
     with_uring: bool,
-) -> OperationResult<TurboVectorStorageImpl<MmapFile>> {
+) -> OperationResult<TurboVectorStorageImpl<QuantizedStorage<MmapFile>>> {
     assert!(
         !with_uring,
         "use `open_turbo_single_uring` for the io_uring backend in tests",
     );
-    TurboVectorStorageImpl::<MmapFile>::open_mmap(path, dim, distance, populate)
+    TurboVectorStorageImpl::<QuantizedStorage<MmapFile>>::open_mmap(path, dim, distance, populate)
 }
 
 /// Concrete single-file io_uring opener for the tests.
@@ -71,8 +72,10 @@ fn open_turbo_single_uring(
     dim: usize,
     distance: Distance,
     populate: bool,
-) -> OperationResult<TurboVectorStorageImpl<IoUringFile>> {
-    TurboVectorStorageImpl::<IoUringFile>::open_uring(path, dim, distance, populate)
+) -> OperationResult<TurboVectorStorageImpl<QuantizedStorage<IoUringFile>>> {
+    TurboVectorStorageImpl::<QuantizedStorage<IoUringFile>>::open_uring(
+        path, dim, distance, populate,
+    )
 }
 
 /// Deterministic test vectors in `[-1, 1]`, seeded so that the storage and
@@ -1078,7 +1081,7 @@ fn optimizer_copy(
     dim: usize,
     distance: Distance,
     stopped: &AtomicBool,
-) -> TurboVectorStorageImpl<MmapFile> {
+) -> TurboVectorStorageImpl<QuantizedStorage<MmapFile>> {
     let count = src.total_vector_count() as PointOffsetType;
     {
         let mut dst = open_turbo_vector_storage(dst_dir, dim, distance, false).unwrap();

--- a/lib/segment/src/vector_storage/turbo/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/mod.rs
@@ -18,6 +18,7 @@ pub mod multi_turbo;
 pub mod read_only;
 pub(crate) mod shared;
 pub mod turbo_vector_storage;
+pub(crate) mod turbo_vectors;
 pub mod update_only;
 
 pub use self::appendable_turbo_vector_storage::{

--- a/lib/segment/src/vector_storage/turbo/read_only/immutable/lifecycle.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/immutable/lifecycle.rs
@@ -9,7 +9,7 @@ use crate::types::Distance;
 use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
 use crate::vector_storage::turbo::shared::{self, DELETED_DIR_PATH, VECTORS_PATH};
 
-impl<S: UniversalRead> ReadOnlyImmutableTurboVectorStorage<S> {
+impl<S: UniversalRead> ReadOnlyImmutableTurboVectorStorage<QuantizedStorage<S>> {
     /// Schedule background prefetch of the files [`Self::open`] will read.
     ///
     /// Absent files are skipped rather than reported: the subsequent open is
@@ -49,6 +49,7 @@ impl<S: UniversalRead> ReadOnlyImmutableTurboVectorStorage<S> {
             storage,
             quantizer,
             deleted,
+            on_disk: true,
             distance,
             dim,
         })

--- a/lib/segment/src/vector_storage/turbo/read_only/immutable/live_reload.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/immutable/live_reload.rs
@@ -1,17 +1,18 @@
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::sorted_slice::SortedSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, UniversalReadFs};
 use futures::future::BoxFuture;
 
 use super::ReadOnlyImmutableTurboVectorStorage;
 use crate::common::live_reload::LiveReload;
 use crate::common::operation_error::OperationResult;
+use crate::vector_storage::turbo::turbo_vectors::TurboVectorBlob;
 
-impl<S: UniversalRead> LiveReload for ReadOnlyImmutableTurboVectorStorage<S> {
-    type File = S;
+impl<B: TurboVectorBlob> LiveReload for ReadOnlyImmutableTurboVectorStorage<B> {
+    type File = B::File;
 
-    fn live_preload<Fs: CachedReadFs<File = S>>(
+    fn live_preload<Fs: CachedReadFs<File = B::File>>(
         &self,
         _fs: &Fs,
     ) -> OperationResult<Vec<BoxFuture<'static, ()>>> {
@@ -21,7 +22,7 @@ impl<S: UniversalRead> LiveReload for ReadOnlyImmutableTurboVectorStorage<S> {
 
     /// Vector data is immutable, so only the in-memory deletion flags are patched
     /// from the authoritative `deleted_points`; `fs` and `new_points` are unused.
-    fn live_reload<Fs: UniversalReadFs<File = S>>(
+    fn live_reload<Fs: UniversalReadFs<File = B::File>>(
         &mut self,
         _fs: &Fs,
         deleted_points: &SortedSlice<'_, PointOffsetType>,

--- a/lib/segment/src/vector_storage/turbo/read_only/immutable/mod.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/immutable/mod.rs
@@ -1,42 +1,41 @@
 //! Read-only counterpart of the single-file (immutable) dense TurboQuant
 //! storage.
 //!
-//! Vector data is immutable, so it is read straight from the single-file
-//! [`QuantizedStorage`] blob; deletions are tracked in memory and folded from
+//! Vector data is immutable, so it is read straight from the shared
+//! [`TurboVectorBlob`] blob; deletions are tracked in memory and folded from
 //! the live-reload delta. Split across submodules the same way the other
 //! read-only vector storages are: [`lifecycle`] (`preopen` / `open`),
 //! [`read_ops`] (retrieval + scoring), [`live_reload`] (picking up a writer's
 //! deletions).
 
-use common::universal_io::UniversalRead;
-use quantization::EncodedStorageWrite;
 use quantization::turboquant::quantization::TurboQuantizer;
 
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
 use crate::types::Distance;
-use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
+use crate::vector_storage::turbo::turbo_vectors::TurboVectorBlob;
 
 mod lifecycle;
 mod live_reload;
 mod read_ops;
 
-/// Read-only single-file TurboQuant dense vector storage over a [`UniversalRead`]
-/// backend `S`. Read-only counterpart of the writable
+/// Read-only single-file TurboQuant dense vector storage over the
+/// encoded-vector blob `B`. Read-only counterpart of the writable
 /// [`TurboVectorStorageImpl`](crate::vector_storage::turbo::TurboVectorStorageImpl).
-pub struct ReadOnlyImmutableTurboVectorStorage<S: UniversalRead> {
-    /// Read-only single-file encoded vector blob.
-    storage: QuantizedStorage<S>,
+pub struct ReadOnlyImmutableTurboVectorStorage<B: TurboVectorBlob> {
+    /// Read-only encoded vector blob.
+    storage: B,
     /// Quantizer used to de/quantize and score; rebuilt from `(dim, distance)`.
     quantizer: TurboQuantizer,
     /// Persisted soft-deletion flags, materialized in memory.
     deleted: InMemoryBitvecFlags,
+    on_disk: bool,
     /// Distance used for scoring / query preprocessing.
     distance: Distance,
     /// Original (un-padded) vector dimensionality.
     dim: usize,
 }
 
-impl<S: UniversalRead> std::fmt::Debug for ReadOnlyImmutableTurboVectorStorage<S> {
+impl<B: TurboVectorBlob> std::fmt::Debug for ReadOnlyImmutableTurboVectorStorage<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ReadOnlyImmutableTurboVectorStorage")
             .field("dim", &self.dim)

--- a/lib/segment/src/vector_storage/turbo/read_only/immutable/read_ops.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/immutable/read_ops.rs
@@ -3,9 +3,8 @@ use std::borrow::Cow;
 use common::bitvec::BitSlice;
 use common::generic_consts::AccessPattern;
 use common::types::{PointOffsetType, ScoreType};
-use common::universal_io::{UniversalRead, UserData};
+use common::universal_io::UserData;
 use quantization::turboquant::EncodedQueryTQ;
-use quantization::{EncodedStorage, EncodedStorageWrite};
 
 use super::ReadOnlyImmutableTurboVectorStorage;
 use crate::common::operation_error::OperationResult;
@@ -13,10 +12,11 @@ use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::DenseVector;
 use crate::types::{Distance, VectorStorageDatatype};
 use crate::vector_storage::turbo::shared;
+use crate::vector_storage::turbo::turbo_vectors::TurboVectorBlob;
 use crate::vector_storage::vector_storage_base::VectorStorageRead;
 use crate::vector_storage::{DenseTQVectorStorageRead, TurboScoring};
 
-impl<S: UniversalRead> VectorStorageRead for ReadOnlyImmutableTurboVectorStorage<S> {
+impl<B: TurboVectorBlob> VectorStorageRead for ReadOnlyImmutableTurboVectorStorage<B> {
     fn size_of_available_vectors_in_bytes(&self) -> usize {
         self.available_vector_count() * self.quantized_vector_size()
     }
@@ -30,7 +30,7 @@ impl<S: UniversalRead> VectorStorageRead for ReadOnlyImmutableTurboVectorStorage
     }
 
     fn is_on_disk(&self) -> bool {
-        self.storage.is_on_disk()
+        self.on_disk
     }
 
     fn total_vector_count(&self) -> usize {
@@ -86,7 +86,7 @@ impl<S: UniversalRead> VectorStorageRead for ReadOnlyImmutableTurboVectorStorage
     }
 }
 
-impl<S: UniversalRead> DenseTQVectorStorageRead for ReadOnlyImmutableTurboVectorStorage<S> {
+impl<B: TurboVectorBlob> DenseTQVectorStorageRead for ReadOnlyImmutableTurboVectorStorage<B> {
     fn vector_dim(&self) -> usize {
         self.dim
     }
@@ -134,7 +134,7 @@ impl<S: UniversalRead> DenseTQVectorStorageRead for ReadOnlyImmutableTurboVector
     }
 }
 
-impl<S: UniversalRead> TurboScoring for ReadOnlyImmutableTurboVectorStorage<S> {
+impl<B: TurboVectorBlob> TurboScoring for ReadOnlyImmutableTurboVectorStorage<B> {
     fn preprocess_query(&self, query: DenseVector) -> EncodedQueryTQ {
         shared::preprocess_query(&self.quantizer, self.distance, query)
     }
@@ -149,14 +149,8 @@ impl<S: UniversalRead> TurboScoring for ReadOnlyImmutableTurboVectorStorage<S> {
         ids: &[PointOffsetType],
         scores: &mut [ScoreType],
     ) {
-        shared::score_query_batch(
-            &self.storage,
-            &self.quantizer,
-            self.distance,
-            query,
-            ids,
-            scores,
-        )
+        self.storage
+            .score_query_batch(&self.quantizer, self.distance, query, ids, scores);
     }
 
     fn score_internal_encoded(

--- a/lib/segment/src/vector_storage/turbo/turbo_vector_storage.rs
+++ b/lib/segment/src/vector_storage/turbo/turbo_vector_storage.rs
@@ -23,9 +23,9 @@ use common::universal_io::{IoUringFile, IoUringFs};
 use common::universal_io::{MmapFile, MmapFs, Populate, UniversalRead, UserData};
 use quantization::turboquant::EncodedQueryTQ;
 use quantization::turboquant::quantization::TurboQuantizer;
-use quantization::{EncodedStorage, EncodedStorageWrite};
 
 use super::shared::{self, DELETED_DIR_PATH, VECTORS_PATH};
+use super::turbo_vectors::TurboVectorBlob;
 use crate::common::Flusher;
 use crate::common::flags::FlagsMode;
 use crate::common::flags::bitvec_flags::BitvecFlags;
@@ -41,12 +41,12 @@ use crate::vector_storage::{
     VectorStorageRead,
 };
 
-/// Single-file TurboQuant dense vector storage over a [`UniversalRead`] backend
-/// `S` (mmap by default, io_uring on Linux). Non-appendable data, mutable
-/// deletions.
-pub struct TurboVectorStorageImpl<S: UniversalRead = MmapFile> {
-    /// Single-file encoded vectors, read through `S`.
-    storage: QuantizedStorage<S>,
+/// Single-file TurboQuant dense vector storage over the encoded-vector blob `B`
+/// — for now only its own file, read through mmap or io_uring. Non-appendable
+/// data, mutable deletions.
+pub struct TurboVectorStorageImpl<B: TurboVectorBlob> {
+    /// Encoded vectors.
+    storage: B,
 
     /// Quantizer used to de/quantize.
     quantizer: TurboQuantizer,
@@ -55,6 +55,8 @@ pub struct TurboVectorStorageImpl<S: UniversalRead = MmapFile> {
     deleted: BitvecFlags<MmapFile>,
     /// Number of vectors currently flagged as deleted.
     deleted_count: usize,
+
+    on_disk: bool,
 
     /// Distance used for scoring / query preprocessing.
     distance: Distance,
@@ -93,7 +95,9 @@ pub fn open_turbo_vector_storage_with_uring(
 
     #[cfg(target_os = "linux")]
     if with_uring {
-        match TurboVectorStorageImpl::<IoUringFile>::open_uring(path, dim, distance, populate) {
+        match TurboVectorStorageImpl::<QuantizedStorage<IoUringFile>>::open_uring(
+            path, dim, distance, populate,
+        ) {
             Ok(storage) => return Ok(VectorStorageEnum::DenseTurboUring(Box::new(storage))),
             Err(err) => {
                 log::error!("Failed to open io_uring based TurboQuant storage: {err}");
@@ -101,11 +105,13 @@ pub fn open_turbo_vector_storage_with_uring(
         }
     }
 
-    let storage = TurboVectorStorageImpl::<MmapFile>::open_mmap(path, dim, distance, populate)?;
+    let storage = TurboVectorStorageImpl::<QuantizedStorage<MmapFile>>::open_mmap(
+        path, dim, distance, populate,
+    )?;
     Ok(VectorStorageEnum::DenseTurboMemmap(Box::new(storage)))
 }
 
-impl TurboVectorStorageImpl<MmapFile> {
+impl TurboVectorStorageImpl<QuantizedStorage<MmapFile>> {
     /// Open (create-or-load) the mem-mapped single-file backend.
     pub fn open_mmap(
         path: &Path,
@@ -125,7 +131,7 @@ impl TurboVectorStorageImpl<MmapFile> {
 }
 
 #[cfg(target_os = "linux")]
-impl TurboVectorStorageImpl<IoUringFile> {
+impl TurboVectorStorageImpl<QuantizedStorage<IoUringFile>> {
     /// Open (create-or-load) the single-file io_uring backend.
     pub fn open_uring(
         path: &Path,
@@ -144,11 +150,11 @@ impl TurboVectorStorageImpl<IoUringFile> {
     }
 }
 
-impl<S: UniversalRead> TurboVectorStorageImpl<S> {
+impl<B: TurboVectorBlob> TurboVectorStorageImpl<B> {
     /// Shared tail of the backend-specific `open_*` constructors: open the
     /// deletion flags and assemble the storage.
     fn finalize(
-        storage: QuantizedStorage<S>,
+        storage: B,
         quantizer: TurboQuantizer,
         path: &Path,
         dim: usize,
@@ -169,6 +175,7 @@ impl<S: UniversalRead> TurboVectorStorageImpl<S> {
             quantizer,
             deleted,
             deleted_count,
+            on_disk: true,
             distance,
             dim,
         })
@@ -188,7 +195,7 @@ impl<S: UniversalRead> TurboVectorStorageImpl<S> {
 
     /// Drop the disk cache for the encoded vectors and deleted flags.
     pub fn clear_cache(&self) -> OperationResult<()> {
-        self.storage.clear_cache();
+        self.storage.clear_cache()?;
         self.deleted.clear_cache()?;
         Ok(())
     }
@@ -243,7 +250,7 @@ impl<S: UniversalRead> TurboVectorStorageImpl<S> {
     }
 }
 
-impl<S: UniversalRead> std::fmt::Debug for TurboVectorStorageImpl<S> {
+impl<B: TurboVectorBlob> std::fmt::Debug for TurboVectorStorageImpl<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TurboVectorStorageImpl")
             .field("dim", &self.dim)
@@ -254,7 +261,7 @@ impl<S: UniversalRead> std::fmt::Debug for TurboVectorStorageImpl<S> {
     }
 }
 
-impl<S: UniversalRead> VectorStorageRead for TurboVectorStorageImpl<S> {
+impl<B: TurboVectorBlob> VectorStorageRead for TurboVectorStorageImpl<B> {
     fn size_of_available_vectors_in_bytes(&self) -> usize {
         self.available_vector_count() * self.quantized_vector_size()
     }
@@ -268,7 +275,7 @@ impl<S: UniversalRead> VectorStorageRead for TurboVectorStorageImpl<S> {
     }
 
     fn is_on_disk(&self) -> bool {
-        self.storage.is_on_disk()
+        self.on_disk
     }
 
     fn total_vector_count(&self) -> usize {
@@ -324,7 +331,7 @@ impl<S: UniversalRead> VectorStorageRead for TurboVectorStorageImpl<S> {
     }
 }
 
-impl<S: UniversalRead> VectorStorage for TurboVectorStorageImpl<S> {
+impl<B: TurboVectorBlob> VectorStorage for TurboVectorStorageImpl<B> {
     fn insert_vector(
         &mut self,
         _key: PointOffsetType,
@@ -352,7 +359,7 @@ impl<S: UniversalRead> VectorStorage for TurboVectorStorageImpl<S> {
     }
 
     fn immutable_files(&self) -> Vec<PathBuf> {
-        self.storage.immutable_files()
+        self.storage.files()
     }
 
     fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
@@ -360,7 +367,7 @@ impl<S: UniversalRead> VectorStorage for TurboVectorStorageImpl<S> {
     }
 }
 
-impl<S: UniversalRead> TurboScoring for TurboVectorStorageImpl<S> {
+impl<B: TurboVectorBlob> TurboScoring for TurboVectorStorageImpl<B> {
     fn preprocess_query(&self, query: DenseVector) -> EncodedQueryTQ {
         Self::preprocess_query(self, query)
     }
@@ -375,14 +382,8 @@ impl<S: UniversalRead> TurboScoring for TurboVectorStorageImpl<S> {
         ids: &[PointOffsetType],
         scores: &mut [ScoreType],
     ) {
-        shared::score_query_batch(
-            &self.storage,
-            &self.quantizer,
-            self.distance,
-            query,
-            ids,
-            scores,
-        )
+        self.storage
+            .score_query_batch(&self.quantizer, self.distance, query, ids, scores);
     }
 
     fn score_internal_encoded(
@@ -398,7 +399,7 @@ impl<S: UniversalRead> TurboScoring for TurboVectorStorageImpl<S> {
     }
 }
 
-impl<S: UniversalRead> DenseTQVectorStorageRead for TurboVectorStorageImpl<S> {
+impl<B: TurboVectorBlob> DenseTQVectorStorageRead for TurboVectorStorageImpl<B> {
     fn vector_dim(&self) -> usize {
         self.dim
     }
@@ -446,7 +447,7 @@ impl<S: UniversalRead> DenseTQVectorStorageRead for TurboVectorStorageImpl<S> {
     }
 }
 
-impl<S: UniversalRead> DenseTQVectorStorage for TurboVectorStorageImpl<S> {
+impl<S: UniversalRead> DenseTQVectorStorage for TurboVectorStorageImpl<QuantizedStorage<S>> {
     fn update_from<'a>(
         &mut self,
         other_vectors: &mut impl Iterator<Item = (Cow<'a, [u8]>, bool)>,

--- a/lib/segment/src/vector_storage/turbo/turbo_vectors.rs
+++ b/lib/segment/src/vector_storage/turbo/turbo_vectors.rs
@@ -1,0 +1,100 @@
+use std::borrow::Cow;
+use std::path::PathBuf;
+
+use common::mmap::MmapFlusher;
+use common::types::{PointOffsetType, ScoreType};
+use common::universal_io::UniversalRead;
+use quantization::turboquant::EncodedQueryTQ;
+use quantization::turboquant::quantization::TurboQuantizer;
+use quantization::{EncodedStorage, EncodedStorageWrite};
+
+use super::shared;
+use crate::common::operation_error::OperationResult;
+use crate::types::Distance;
+use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
+
+pub trait TurboVectorBlob {
+    /// Backend the encoded bytes are read through.
+    type File: UniversalRead;
+
+    fn vectors_count(&self) -> usize;
+
+    fn get_vector_data(&self, key: PointOffsetType) -> Cow<'_, [u8]>;
+
+    fn for_each_in_batch<F: FnMut(usize, &[u8])>(
+        &self,
+        keys: &[PointOffsetType],
+        f: F,
+    ) -> OperationResult<()>;
+
+    fn populate(&self);
+
+    fn clear_cache(&self) -> OperationResult<()>;
+
+    fn get_vector_data_opt(&self, key: PointOffsetType) -> Option<Cow<'_, [u8]>>;
+
+    fn files(&self) -> Vec<PathBuf>;
+
+    fn flusher(&self) -> MmapFlusher;
+
+    fn score_query_batch(
+        &self,
+        quantizer: &TurboQuantizer,
+        distance: Distance,
+        query: &EncodedQueryTQ,
+        ids: &[PointOffsetType],
+        scores: &mut [ScoreType],
+    );
+}
+
+impl<S: UniversalRead> TurboVectorBlob for QuantizedStorage<S> {
+    type File = S;
+
+    fn vectors_count(&self) -> usize {
+        EncodedStorageWrite::vectors_count(self)
+    }
+
+    fn get_vector_data(&self, key: PointOffsetType) -> Cow<'_, [u8]> {
+        EncodedStorage::get_vector_data(self, key)
+    }
+
+    fn for_each_in_batch<F: FnMut(usize, &[u8])>(
+        &self,
+        keys: &[PointOffsetType],
+        f: F,
+    ) -> OperationResult<()> {
+        QuantizedStorage::for_each_in_batch(self, keys, f)
+    }
+
+    fn populate(&self) {
+        QuantizedStorage::populate(self);
+    }
+
+    fn clear_cache(&self) -> OperationResult<()> {
+        QuantizedStorage::clear_cache(self);
+        Ok(())
+    }
+
+    fn get_vector_data_opt(&self, key: PointOffsetType) -> Option<Cow<'_, [u8]>> {
+        EncodedStorage::get_vector_data_opt(self, key)
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        EncodedStorage::files(self)
+    }
+
+    fn flusher(&self) -> MmapFlusher {
+        EncodedStorageWrite::flusher(self)
+    }
+
+    fn score_query_batch(
+        &self,
+        quantizer: &TurboQuantizer,
+        distance: Distance,
+        query: &EncodedQueryTQ,
+        ids: &[PointOffsetType],
+        scores: &mut [ScoreType],
+    ) {
+        shared::score_query_batch(self, quantizer, distance, query, ids, scores);
+    }
+}

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -38,6 +38,7 @@ use crate::data_types::vectors::{
 };
 use crate::types::{Distance, IoBackend, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::dense::appendable_dense_vector_storage::AppendableMmapDenseVectorStorage;
+use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
 
 /// In case of simple vector storage, vector offset is the same as [`PointOffsetType`].
 /// But in case of multivectors, it requires an additional lookup.
@@ -636,9 +637,9 @@ pub enum VectorStorageEnum {
     DenseAppendableMemmap(Box<AppendableMmapDenseVectorStorage<VectorElementType>>),
     DenseAppendableMemmapByte(Box<AppendableMmapDenseVectorStorage<VectorElementTypeByte>>),
     DenseAppendableMemmapHalf(Box<AppendableMmapDenseVectorStorage<VectorElementTypeHalf>>),
-    DenseTurboMemmap(Box<TurboVectorStorageImpl<MmapFile>>),
+    DenseTurboMemmap(Box<TurboVectorStorageImpl<QuantizedStorage<MmapFile>>>),
     #[cfg(target_os = "linux")]
-    DenseTurboUring(Box<TurboVectorStorageImpl<IoUringFile>>),
+    DenseTurboUring(Box<TurboVectorStorageImpl<QuantizedStorage<IoUringFile>>>),
     DenseTurboAppendableMemmap(Box<AppendableMmapTurboVectorStorage>),
     SparseVolatile(VolatileSparseVectorStorage),
     SparseMmap(MmapSparseVectorStorage),


### PR DESCRIPTION
This PR does the same thing as #10474, but for TurboQuant: `TurboVectorBlob` helper trait.
Pure refactoring change.

## Illustration: without `TurboVectorBlob` (without this PR)

```rust
// ────────── Current turbo vector storages (current dev) ──────────
struct RwTurboVectorStorage<S> { storage: QuantizedStorage<S>, deleted, … } // aka TurboVectorStorageImpl
struct RoTurboVectorStorage<S> { storage: QuantizedStorage<S>, deleted, … } // aka ReadOnlyImmutableTurboVectorStorage
// Then 300 lines of boilerplate:
impl VectorStorageRead        for RwTurboVectorStorage<S> { … }
impl VectorStorage            for RwTurboVectorStorage<S> { … }
impl TurboScoring             for RwTurboVectorStorage<S> { … }
impl DenseTQVectorStorageRead for RwTurboVectorStorage<S> { … }
// And 175 lines more:
impl VectorStorageRead        for RoTurboVectorStorage<S> { … }
impl TurboScoring             for RoTurboVectorStorage<S> { … }
impl DenseTQVectorStorageRead for RoTurboVectorStorage<S> { … }
impl LiveReload               for RoTurboVectorStorage<S> { … }


// ────────── Upcoming combined vector storage (next PRs) ──────────
struct RwGraphInlineTurboVectorStorage<S> { storage: GraphVectors<u8, S>, deleted, … }
struct RoGraphInlineTurboVectorStorage<S> { storage: GraphVectors<u8, S>, deleted, … }
// Then 300 + 175 lines of a similar boilerplate again:
impl VectorStorageRead        for RwGraphInlineTurboVectorStorage<S> { … }
impl VectorStorage            for RwGraphInlineTurboVectorStorage<S> { … }
impl TurboScoring             for RwGraphInlineTurboVectorStorage<S> { … }
impl DenseTQVectorStorageRead for RwGraphInlineTurboVectorStorage<S> { … }
impl VectorStorageRead        for RoGraphInlineTurboVectorStorage<S> { … }
impl TurboScoring             for RoGraphInlineTurboVectorStorage<S> { … }
impl DenseTQVectorStorageRead for RoGraphInlineTurboVectorStorage<S> { … }
impl LiveReload               for RoGraphInlineTurboVectorStorage<S> { … }
```

## Illustration: with `TurboVectorBlob` (this PR)

```rust
// ────────── Common code ──────────
trait TurboVectorBlob {
    …
    fn score_query_batch(…);
}
struct RwTurboVectorStorage<B: TurboVectorBlob> { storage: B, on_disk, deleted, … }
struct RoTurboVectorStorage<B: TurboVectorBlob> { storage: B, on_disk, deleted, … }
// 300 + 175 lines of boilerplate written once:
impl<B: TurboVectorBlob> VectorStorageRead        for RwTurboVectorStorage<B> { … }
impl<B: TurboVectorBlob> VectorStorage            for RwTurboVectorStorage<B> { … }
impl<B: TurboVectorBlob> TurboScoring             for RwTurboVectorStorage<B> { … }
impl<B: TurboVectorBlob> DenseTQVectorStorageRead for RwTurboVectorStorage<B> { … }
impl<B: TurboVectorBlob> VectorStorageRead        for RoTurboVectorStorage<B> { … }
impl<B: TurboVectorBlob> TurboScoring             for RoTurboVectorStorage<B> { … }
impl<B: TurboVectorBlob> DenseTQVectorStorageRead for RoTurboVectorStorage<B> { … }
impl<B: TurboVectorBlob> LiveReload               for RoTurboVectorStorage<B> { … }

// ────────── Current turbo vector storages ──────────
impl TurboVectorBlob for QuantizedStorage<S> {
    /* 51 lines */
    fn score_query_batch(…) { /* run-coalescing shared::score_query_batch */ }
}
// Stays per-blob: openers and update_from.
impl RwTurboVectorStorage<QuantizedStorage<S>> { fn open_mmap, fn open_uring }
impl RoTurboVectorStorage<QuantizedStorage<S>> { fn preopen, fn open }
impl DenseTQVectorStorage for RwTurboVectorStorage<QuantizedStorage<S>> { fn update_from }

// ────────── Upcoming combined vector storage (next PRs) ──────────
impl TurboVectorBlob for GraphVectors<u8, S> { /* 60 lines, one vector at a time */ }
// Stays per-blob: openers and update_from.
impl RwTurboVectorStorage<GraphVectors<u8, S>> { fn open }
impl RoTurboVectorStorage<GraphVectors<u8, S>> { fn preopen, fn open }
impl DenseTQVectorStorage for RwTurboVectorStorage<GraphVectors<u8, S>> { fn update_from }
```
