### PR TITLE
[combined-storage] Read vector methods

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph.rs
+++ b/lib/segment/src/index/hnsw_index/graph.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use common::types::{PointOffsetType, ScoredPointOffset};
@@ -19,8 +20,17 @@ use crate::common::operation_error::OperationResult;
 
 #[derive(Debug)]
 pub enum HnswGraph<S: UniversalRead> {
-    Direct(GraphLayers),
-    Batched(Box<GraphLayersBatched<S>>),
+    Direct(Arc<GraphLayers>),
+    Batched(Arc<GraphLayersBatched<S>>),
+}
+
+impl<S: UniversalRead> Clone for HnswGraph<S> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Direct(graph) => Self::Direct(Arc::clone(graph)),
+            Self::Batched(graph) => Self::Batched(Arc::clone(graph)),
+        }
+    }
 }
 
 /// Backend the writable [`HNSWIndex`][1] reads its graph links through.
@@ -57,12 +67,12 @@ impl HnswGraph<HnswLinksStorage> {
             #[cfg(target_os = "linux")]
             if Self::is_batched(&IoUringFs, dir, residency)? {
                 let graph = GraphLayersBatched::open(&IoUringFs, dir, residency)?;
-                return Ok(HnswGraph::Batched(Box::new(graph)));
+                return Ok(HnswGraph::Batched(Arc::new(graph)));
             }
         }
 
         let graph = GraphLayers::load(dir, residency, do_convert)?;
-        Ok(HnswGraph::Direct(graph))
+        Ok(HnswGraph::Direct(Arc::new(graph)))
     }
 }
 
@@ -98,13 +108,13 @@ impl<S: UniversalRead> HnswGraph<S> {
         S: 'static,
     {
         Ok(if Self::is_batched(fs, dir, residency)? {
-            HnswGraph::Batched(Box::new(GraphLayersBatched::open(fs, dir, residency)?))
+            HnswGraph::Batched(Arc::new(GraphLayersBatched::open(fs, dir, residency)?))
         } else {
             // Note that on non-borrowable backends this materializes the
             // links into heap RAM whatever the residency: `Plain` is not
             // supported by the batched view, and `Pinned` asks for
             // materialization explicitly.
-            HnswGraph::Direct(GraphLayers::load_universal(fs, dir, residency)?)
+            HnswGraph::Direct(Arc::new(GraphLayers::load_universal(fs, dir, residency)?))
         })
     }
 

--- a/lib/segment/src/index/hnsw_index/graph.rs
+++ b/lib/segment/src/index/hnsw_index/graph.rs
@@ -295,6 +295,19 @@ impl<S: UniversalRead> HnswGraph<S> {
         self.format().is_with_vectors()
     }
 
+    #[expect(dead_code, reason = "would be used in combined-storage")]
+    pub fn residency(&self) -> GraphLinksResidency {
+        match self {
+            HnswGraph::Direct(graph) => graph.residency,
+            HnswGraph::Batched(graph) => graph.residency,
+        }
+    }
+
+    #[expect(dead_code, reason = "would be used in combined-storage")]
+    pub fn is_on_disk(&self) -> bool {
+        self.residency() == GraphLinksResidency::Cold
+    }
+
     pub(super) fn as_direct(&self) -> Option<&GraphLayers> {
         match self {
             HnswGraph::Direct(graph) => Some(graph),

--- a/lib/segment/src/index/hnsw_index/graph.rs
+++ b/lib/segment/src/index/hnsw_index/graph.rs
@@ -1,7 +1,9 @@
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
+use common::ext::aligned_vec::ACow;
 use common::types::{PointOffsetType, ScoredPointOffset};
 #[cfg(not(target_os = "linux"))]
 use common::universal_io::MmapFile;
@@ -16,7 +18,8 @@ use super::graph_layers::{GraphLayers, SearchAlgorithm};
 use super::graph_layers_batched::GraphLayersBatched;
 use super::graph_links::{GraphLinks, GraphLinksFile, GraphLinksFormat, GraphLinksResidency};
 use super::point_scorer::{FilteredScorer, ScorerFilters};
-use crate::common::operation_error::OperationResult;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::types::IoBackend;
 
 #[derive(Debug)]
 pub enum HnswGraph<S: UniversalRead> {
@@ -225,11 +228,71 @@ impl<S: UniversalRead> HnswGraph<S> {
         }
     }
 
-    pub fn has_inline_vectors(&self) -> bool {
+    /// Return an error if this graph doesn't provide base vectors of said layout.
+    #[expect(dead_code, reason = "would be used in combined-storage")]
+    pub fn check_base_vector_layout_compatibility(
+        &self,
+        expected_size: usize,
+        expected_align: usize,
+    ) -> OperationResult<()> {
+        let layout = match self {
+            HnswGraph::Direct(graph) => graph.links.base_vector_layout(),
+            HnswGraph::Batched(graph) => graph.links.base_vector_layout(),
+        };
+        if let Some(layout) = layout
+            && layout.size() == expected_size
+            && layout.align() >= expected_align
+        {
+            return Ok(());
+        };
+        Err(OperationError::service_error(format!(
+            "Inline graph vector layout mismatch: expected \
+             size={expected_size} align={expected_align}, found={layout:?}",
+        )))
+    }
+
+    #[expect(dead_code, reason = "would be used in combined-storage")]
+    pub fn for_each_base_vector_in_batch<T>(
+        &self,
+        keys: &[PointOffsetType],
+        mut f: impl FnMut(usize, &[T]),
+    ) -> OperationResult<()>
+    where
+        T: bytemuck::Pod,
+    {
         match self {
-            HnswGraph::Direct(graph) => graph.links.format().is_with_vectors(),
-            HnswGraph::Batched(graph) => graph.links.is_with_vectors(),
+            HnswGraph::Direct(graph) => {
+                for (position, &point_id) in keys.iter().enumerate() {
+                    let bytes = graph.links.base_vector(point_id);
+                    f(position, &cast_vector::<T>(ACow::Borrowed(bytes))?);
+                }
+                Ok(())
+            }
+            HnswGraph::Batched(graph) => graph.links.read_base_vectors(
+                &stumpalo::Arena::new(),
+                keys,
+                align_of::<T>(),
+                |position, bytes| {
+                    f(position, &cast_vector::<T>(bytes)?);
+                    Ok(())
+                },
+            ),
         }
+    }
+
+    #[expect(dead_code, reason = "would be used in combined-storage")]
+    pub fn base_vector<T>(&self, key: PointOffsetType) -> OperationResult<Cow<'_, [T]>>
+    where
+        T: bytemuck::Pod,
+    {
+        cast_vector(match self {
+            HnswGraph::Direct(graph) => ACow::Borrowed(graph.links.base_vector(key)),
+            HnswGraph::Batched(graph) => graph.links.read_base_vector(key, align_of::<T>())?,
+        })
+    }
+
+    pub fn has_inline_vectors(&self) -> bool {
+        self.format().is_with_vectors()
     }
 
     pub(super) fn as_direct(&self) -> Option<&GraphLayers> {
@@ -243,6 +306,26 @@ impl<S: UniversalRead> HnswGraph<S> {
         match self {
             HnswGraph::Direct(graph) => graph.links.num_points(),
             HnswGraph::Batched(graph) => graph.num_points(),
+        }
+    }
+
+    pub fn format(&self) -> GraphLinksFormat {
+        match self {
+            HnswGraph::Direct(graph) => graph.links.format(),
+            HnswGraph::Batched(graph) => graph.links.format(),
+        }
+    }
+
+    #[expect(dead_code, reason = "would be used in combined-storage")]
+    pub fn io_backend(&self) -> Option<IoBackend> {
+        match self {
+            HnswGraph::Direct(_) => {
+                // Ambiguity: the graph probably *was loaded* from an mmap,
+                // but *right now* it can be either mmap or `Vec<>`.
+                // Arbitrary choice: report the former.
+                Some(IoBackend::Mmap)
+            }
+            HnswGraph::Batched(_) => IoBackend::from_universal_kind(S::kind()),
         }
     }
 
@@ -276,4 +359,11 @@ impl<S: UniversalRead> HnswGraph<S> {
             HnswGraph::Batched(graph) => graph.links.clear_cache(),
         }
     }
+}
+
+#[expect(dead_code, reason = "would be used in combined-storage")]
+fn cast_vector<T: bytemuck::Pod>(bytes: ACow<'_>) -> OperationResult<Cow<'_, [T]>> {
+    bytes.try_cast_bytemuck().map_err(|err| {
+        OperationError::service_error(format!("Misplaced inline-graph vector: {err}"))
+    })
 }

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -73,6 +73,8 @@ pub struct GraphLayers {
     pub(super) links: GraphLinks,
     pub(super) entry_points: EntryPoints,
     pub(super) visited_pool: VisitedPool,
+    #[expect(dead_code, reason = "would be used in combined-storage")]
+    pub(super) residency: GraphLinksResidency,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -651,6 +653,7 @@ impl GraphLayers {
             links: Self::load_links_universal(fs, dir, residency)?,
             entry_points: graph_data.entry_points.into_owned(),
             visited_pool: VisitedPool::new(),
+            residency,
         })
     }
 
@@ -867,6 +870,7 @@ mod tests {
             links: GraphLinks::new_from_edges(graph_links.clone(), format_param, hnsw_m).unwrap(),
             entry_points: EntryPoints::new(entry_points_num),
             visited_pool: VisitedPool::new(),
+            residency: GraphLinksResidency::Pinned,
         };
 
         let linking_idx: PointOffsetType = 7;

--- a/lib/segment/src/index/hnsw_index/graph_layers_batched.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_batched.rs
@@ -27,6 +27,8 @@ pub struct GraphLayersBatched<S: UniversalRead> {
     pub(super) links: GraphLinksFile<S>,
     pub(super) entry_points: EntryPoints,
     visited_pool: VisitedPool,
+    #[expect(dead_code, reason = "would be used in combined-storage")]
+    pub(super) residency: GraphLinksResidency,
 }
 
 impl<S: UniversalRead> std::fmt::Debug for GraphLayersBatched<S> {
@@ -54,6 +56,7 @@ impl<S: UniversalRead> GraphLayersBatched<S> {
             links: GraphLinksFile::open(file, format)?,
             entry_points: graph_data.entry_points.into_owned(),
             visited_pool: VisitedPool::new(),
+            residency,
         })
     }
 

--- a/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_builder.rs
@@ -250,6 +250,7 @@ impl GraphLayersBuilder {
             links,
             entry_points,
             visited_pool: self.visited_pool,
+            residency,
         })
     }
 
@@ -261,6 +262,7 @@ impl GraphLayersBuilder {
             links: GraphLinks::new_from_edges(edges, format_param, self.hnsw_m).unwrap(),
             entry_points: self.entry_points.into_inner(),
             visited_pool: self.visited_pool,
+            residency: GraphLinksResidency::Pinned,
         }
     }
 

--- a/lib/segment/src/index/hnsw_index/graph_links/links.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/links.rs
@@ -6,6 +6,7 @@
 //! through the parsed view and never touch the owning storage, so the search
 //! hot path involves no dynamic dispatch even for the `Universal` backend.
 
+use std::alloc::Layout;
 use std::borrow::Cow;
 use std::fmt::Debug;
 use std::io::Cursor;
@@ -150,6 +151,22 @@ impl GraphLinks {
         }
     }
 
+    pub fn base_vector_layout(&self) -> Option<Layout> {
+        match &self.view().compression {
+            CompressionInfo::Uncompressed { .. } => None,
+            CompressionInfo::Compressed { .. } => None,
+            CompressionInfo::CompressedWithVectors {
+                neighbors: _,
+                offsets: _,
+                hnsw_m: _,
+                bits_per_unsorted: _,
+                base_vector_layout,
+                link_vector_size: _,
+                link_vector_alignment: _,
+            } => Some(*base_vector_layout),
+        }
+    }
+
     pub fn num_points(&self) -> usize {
         self.view().reindex.len()
     }
@@ -181,6 +198,12 @@ impl GraphLinks {
     ) -> (&[u8], LinksWithVectorsIterator<'_>) {
         let (base_vector, links, vectors) = self.view().links_with_vectors(point_id, level);
         (base_vector, links.zip(vectors))
+    }
+
+    /// See [`GraphLinksView::base_vector`].
+    #[inline]
+    pub fn base_vector(&self, point_id: PointOffsetType) -> &[u8] {
+        self.view().base_vector(point_id)
     }
 
     pub fn point_level(&self, point_id: PointOffsetType) -> usize {

--- a/lib/segment/src/index/hnsw_index/graph_links/links_file.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/links_file.rs
@@ -3,6 +3,7 @@ use std::num::NonZero;
 
 use common::bitpacking_links::{PackedLinksIterator, iterate_packed_links};
 use common::bitpacking_ordered;
+use common::ext::aligned_vec::ACow;
 use common::generic_consts::Random;
 use common::mmap::{Advice, AdviceSetting};
 use common::types::PointOffsetType;
@@ -23,6 +24,7 @@ use crate::index::hnsw_index::graph_links::view_utils::{
 use crate::index::hnsw_index::graph_links::{GraphLinksFormat, GraphLinksResidency};
 
 /// UIO-backed counterpart of [super::view::GraphLinksView].
+#[derive(Debug)]
 pub struct GraphLinksFile<S: UniversalRead> {
     file: S,
     point_count: u64,
@@ -223,6 +225,18 @@ impl<S: UniversalRead> GraphLinksFile<S> {
         Ok(find_level(u64::from(reindexed), &self.level_offsets))
     }
 
+    /// See [`super::GraphLinks::base_vector_layout`].
+    pub fn base_vector_layout(&self) -> Option<Layout> {
+        match self.compression {
+            CompressionInfo::Compressed => None,
+            CompressionInfo::CompressedWithVectors {
+                base_vector_layout,
+                link_vector_size: _,
+                link_vector_alignment: _,
+            } => Some(base_vector_layout),
+        }
+    }
+
     pub fn populate(&self) -> OperationResult<()> {
         Ok(self.file.populate()?)
     }
@@ -242,13 +256,12 @@ impl<S: UniversalRead> GraphLinksFile<S> {
         match self.compression {
             CompressionInfo::Compressed => {
                 let sorted_count = self.hnsw_m.level_m(level);
-                self.read_neighbors(arena, point_ids, level, 1, |position, _start, data| {
-                    callback(
-                        position,
-                        iterate_packed_links(data, self.bits_per_unsorted, sorted_count),
-                    );
+                let cb = |position, _start, data: ACow<'_>| {
+                    let iter = iterate_packed_links(&data, self.bits_per_unsorted, sorted_count);
+                    callback(position, iter);
                     OperationResult::Ok(())
-                })
+                };
+                self.read_entries(arena, point_ids, level, 1, None, cb)
             }
             CompressionInfo::CompressedWithVectors { .. } => self.links_with_vectors(
                 arena,
@@ -286,9 +299,9 @@ impl<S: UniversalRead> GraphLinksFile<S> {
 
         let sorted_count = self.hnsw_m.level_m(level);
         let align = std::cmp::max(base_vector_layout.align(), link_vector_alignment as usize);
-        self.read_neighbors(arena, point_ids, level, align, |position, start, data| {
+        let cb = |position, start, data: ACow<'_>| {
             let (base_vector, links, link_vectors) = parse_links_with_vectors(
-                data,
+                &data,
                 start as usize,
                 (level == 0).then_some(base_vector_layout),
                 self.bits_per_unsorted,
@@ -297,16 +310,52 @@ impl<S: UniversalRead> GraphLinksFile<S> {
                 link_vector_alignment,
             );
             callback(position, base_vector, links, link_vectors)
-        })
+        };
+        self.read_entries(arena, point_ids, level, align, None, cb)
     }
 
-    fn read_neighbors(
+    /// Read a single base vector.
+    pub fn read_base_vector(
+        &self,
+        point_id: PointOffsetType,
+        align: usize,
+    ) -> OperationResult<ACow<'_>> {
+        let (_position, (start, _end)) = self
+            .offsets
+            .read_pairs_iter(&self.file, self.offsets_offset, &[point_id as usize])?
+            .exactly_one()
+            .map_err(|_| OperationError::service_error("Expect the point"))??;
+        let start = self.neighbors_offset + start;
+        let size = self.base_vector_layout().unwrap().size() as u64;
+        Ok(self.file.read_bytes(start..start + size, Random, align)?)
+    }
+
+    /// Batched read of base vectors.
+    pub fn read_base_vectors(
+        &self,
+        arena: &stumpalo::Arena,
+        point_ids: &[PointOffsetType],
+        align: usize,
+        mut callback: impl FnMut(usize, ACow<'_>) -> OperationResult<()>,
+    ) -> OperationResult<()> {
+        self.read_entries(
+            arena,
+            point_ids,
+            0,
+            align,
+            Some(self.base_vector_layout().unwrap().size() as u64),
+            |position, _start, data| callback(position, data),
+        )
+    }
+
+    fn read_entries(
         &self,
         arena: &stumpalo::Arena,
         point_ids: &[PointOffsetType],
         level: usize,
         align: usize,
-        mut callback: impl FnMut(usize, u64, &[u8]) -> OperationResult<()>,
+        vec_size: Option<u64>, // If `Some(x)`, read only the first bytes.
+        mut callback: impl FnMut(usize, u64, ACow<'_>) -> OperationResult<()>,
     ) -> OperationResult<()> {
         // Compute an offset index for each point.
         let offset_indices = if level == 0 {
@@ -331,12 +380,13 @@ impl<S: UniversalRead> GraphLinksFile<S> {
         pairs.process_results(|pairs| {
             let items = pairs.map(|(position, (start, end))| ReadBytesItem {
                 user_data: (position, start),
-                range: self.neighbors_offset + start..self.neighbors_offset + end,
+                range: self.neighbors_offset + start
+                    ..self.neighbors_offset + vec_size.map_or(end, |len| start + len),
                 align,
             });
             for result in self.file.read_bytes_iter(items, Random)? {
                 let ((position, start), data) = result?;
-                callback(position, start, &data)?;
+                callback(position, start, data)?;
             }
             Ok(())
         })?

--- a/lib/segment/src/index/hnsw_index/graph_links/tests.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/tests.rs
@@ -113,6 +113,11 @@ fn check_links(
         assert_eq!(links.is_empty(), right.links_empty(point_id, level));
         links
     });
+    if let Some(vectors) = vectors {
+        for point_id in 0..right.num_points() as PointOffsetType {
+            vectors.assert_base_vector(point_id, 0, right.base_vector(point_id));
+        }
+    }
     for links in [&mut left, &mut right_links].iter_mut() {
         links.iter_mut().for_each(|levels| {
             levels
@@ -252,6 +257,13 @@ fn test_links_file_links<F: UniversalReadFs>(
                 )
                 .unwrap();
             }
+        }
+    }
+
+    if let Some(vectors) = &vectors {
+        for point_id in 0..links.len() as PointOffsetType {
+            let base_vector = view.read_base_vector(point_id, 1).unwrap();
+            vectors.assert_base_vector(point_id, 0, &base_vector);
         }
     }
 }

--- a/lib/segment/src/index/hnsw_index/graph_links/view.rs
+++ b/lib/segment/src/index/hnsw_index/graph_links/view.rs
@@ -295,6 +295,32 @@ impl GraphLinksView<'_> {
         }
     }
 
+    /// Base vector of a point.
+    ///
+    /// # Panics
+    ///
+    /// Panics when using a format that does not support vectors.
+    pub(super) fn base_vector(&self, point_id: PointOffsetType) -> &[u8] {
+        let idx = self.offset_idx(point_id, 0);
+        match self.compression {
+            CompressionInfo::Uncompressed { .. } => unimplemented!(),
+            CompressionInfo::Compressed { .. } => unimplemented!(),
+            CompressionInfo::CompressedWithVectors {
+                neighbors,
+                ref offsets,
+                hnsw_m: _,
+                bits_per_unsorted: _,
+                base_vector_layout,
+                link_vector_size: _,
+                link_vector_alignment: _,
+            } => {
+                let (start, _end) = offsets.read_pair(idx).unwrap();
+                let end = start as usize + base_vector_layout.size();
+                &neighbors[start as usize..end]
+            }
+        }
+    }
+
     pub(super) fn point_level(&self, point_id: PointOffsetType) -> usize {
         find_level(
             u64::from(self.reindex[point_id as usize]),

--- a/lib/segment/src/index/hnsw_index/hnsw/build.rs
+++ b/lib/segment/src/index/hnsw_index/hnsw/build.rs
@@ -1,4 +1,5 @@
 use std::ops::Deref as _;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
 
@@ -601,7 +602,7 @@ impl HNSWIndex {
             payload_index,
             config,
             path: path.to_owned(),
-            graph: HnswGraph::Direct(graph),
+            graph: HnswGraph::Direct(Arc::new(graph)),
             searches_telemetry: HNSWSearchesTelemetry::new(),
             is_on_disk,
         })


### PR DESCRIPTION
Implement methods that read vectors (without reading graph neighbors and quantized vectors) from inline-graph.
Not used in this PR, will be used in subsequent PRs.