### PR TITLE
[combined-storage] GraphInlineDenseVectorStorage

### DIFF
--- a/lib/segment/src/index/hnsw_index/graph.rs
+++ b/lib/segment/src/index/hnsw_index/graph.rs
@@ -229,7 +229,6 @@ impl<S: UniversalRead> HnswGraph<S> {
     }
 
     /// Return an error if this graph doesn't provide base vectors of said layout.
-    #[expect(dead_code, reason = "would be used in combined-storage")]
     pub fn check_base_vector_layout_compatibility(
         &self,
         expected_size: usize,
@@ -251,7 +250,6 @@ impl<S: UniversalRead> HnswGraph<S> {
         )))
     }
 
-    #[expect(dead_code, reason = "would be used in combined-storage")]
     pub fn for_each_base_vector_in_batch<T>(
         &self,
         keys: &[PointOffsetType],
@@ -280,7 +278,6 @@ impl<S: UniversalRead> HnswGraph<S> {
         }
     }
 
-    #[expect(dead_code, reason = "would be used in combined-storage")]
     pub fn base_vector<T>(&self, key: PointOffsetType) -> OperationResult<Cow<'_, [T]>>
     where
         T: bytemuck::Pod,
@@ -295,7 +292,6 @@ impl<S: UniversalRead> HnswGraph<S> {
         self.format().is_with_vectors()
     }
 
-    #[expect(dead_code, reason = "would be used in combined-storage")]
     pub fn residency(&self) -> GraphLinksResidency {
         match self {
             HnswGraph::Direct(graph) => graph.residency,
@@ -303,7 +299,6 @@ impl<S: UniversalRead> HnswGraph<S> {
         }
     }
 
-    #[expect(dead_code, reason = "would be used in combined-storage")]
     pub fn is_on_disk(&self) -> bool {
         self.residency() == GraphLinksResidency::Cold
     }
@@ -329,7 +324,6 @@ impl<S: UniversalRead> HnswGraph<S> {
         }
     }
 
-    #[expect(dead_code, reason = "would be used in combined-storage")]
     pub fn io_backend(&self) -> Option<IoBackend> {
         match self {
             HnswGraph::Direct(_) => {
@@ -374,7 +368,6 @@ impl<S: UniversalRead> HnswGraph<S> {
     }
 }
 
-#[expect(dead_code, reason = "would be used in combined-storage")]
 fn cast_vector<T: bytemuck::Pod>(bytes: ACow<'_>) -> OperationResult<Cow<'_, [T]>> {
     bytes.try_cast_bytemuck().map_err(|err| {
         OperationError::service_error(format!("Misplaced inline-graph vector: {err}"))

--- a/lib/segment/src/index/hnsw_index/graph_layers.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers.rs
@@ -73,7 +73,6 @@ pub struct GraphLayers {
     pub(super) links: GraphLinks,
     pub(super) entry_points: EntryPoints,
     pub(super) visited_pool: VisitedPool,
-    #[expect(dead_code, reason = "would be used in combined-storage")]
     pub(super) residency: GraphLinksResidency,
 }
 

--- a/lib/segment/src/index/hnsw_index/graph_layers_batched.rs
+++ b/lib/segment/src/index/hnsw_index/graph_layers_batched.rs
@@ -27,7 +27,6 @@ pub struct GraphLayersBatched<S: UniversalRead> {
     pub(super) links: GraphLinksFile<S>,
     pub(super) entry_points: EntryPoints,
     visited_pool: VisitedPool,
-    #[expect(dead_code, reason = "would be used in combined-storage")]
     pub(super) residency: GraphLinksResidency,
 }
 

--- a/lib/segment/src/index/hnsw_index/mod.rs
+++ b/lib/segment/src/index/hnsw_index/mod.rs
@@ -7,6 +7,7 @@ pub mod build_condition_checker;
 mod config;
 mod entry_points;
 mod graph;
+pub use graph::{HnswGraph, HnswLinksStorage};
 pub mod graph_layers;
 mod graph_layers_batched;
 pub mod graph_layers_builder;

--- a/lib/segment/src/vector_storage/dense/graph_inline_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/dense/graph_inline_dense_vector_storage.rs
@@ -1,0 +1,220 @@
+use std::borrow::Cow;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+
+use common::bitvec::BitSlice;
+use common::counter::hardware_counter::HardwareCounterCell;
+use common::generic_consts::AccessPattern;
+use common::types::PointOffsetType;
+use common::universal_io::{MmapFile, MmapFs, Populate, UniversalRead, UserData};
+
+use crate::common::Flusher;
+use crate::common::flags::FlagsMode;
+use crate::common::flags::bitvec_flags::BitvecFlags;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::data_types::named_vectors::CowVector;
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::data_types::vectors::VectorRef;
+use crate::index::hnsw_index::HnswGraph;
+use crate::types::{Distance, IoBackend, VectorStorageDatatype};
+use crate::vector_storage::common::error_immutable_insert;
+use crate::vector_storage::dense::appendable_dense_vector_storage::DELETED_DIR_PATH;
+use crate::vector_storage::dense::dense_vectors::DenseVectorBlob;
+use crate::vector_storage::graph_vectors::GraphVectors;
+use crate::vector_storage::{
+    DenseVectorStorage, DenseVectorStorageRead, VectorStorage, VectorStorageRead,
+};
+
+#[derive(Debug)]
+pub struct GraphInlineDenseVectorStorage<T: PrimitiveVectorElement, S: UniversalRead> {
+    vectors: GraphVectors<T, S>,
+    deleted: BitvecFlags<MmapFile>,
+    deleted_count: usize,
+    distance: Distance,
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> GraphInlineDenseVectorStorage<T, S> {
+    pub fn open(
+        graph: HnswGraph<S>,
+        path: &Path,
+        dim: usize,
+        distance: Distance,
+    ) -> OperationResult<Self> {
+        fs_err::create_dir_all(path)?;
+        let deleted = BitvecFlags::open_or_create(
+            MmapFs,
+            &path.join(DELETED_DIR_PATH),
+            FlagsMode::from_feature_flags(),
+            Populate::from(!graph.is_on_disk()),
+        )?;
+        let deleted_count = deleted.count_trues();
+        Ok(Self {
+            vectors: GraphVectors::new(graph, dim)?,
+            deleted,
+            deleted_count,
+            distance,
+        })
+    }
+
+    pub fn populate(&self) {
+        self.vectors.populate();
+    }
+
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        self.vectors.clear_cache()?;
+        self.deleted.clear_cache()
+    }
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorStorageRead<T>
+    for GraphInlineDenseVectorStorage<T, S>
+{
+    fn vector_dim(&self) -> usize {
+        self.vectors.dim()
+    }
+
+    fn get_dense<P: AccessPattern>(&self, key: PointOffsetType) -> Cow<'_, [T]> {
+        self.vectors
+            .get_vector_opt::<P>(key)
+            .unwrap_or_else(|| panic!("vector not found: {key}"))
+    }
+
+    fn for_each_in_dense_batch<F: FnMut(usize, &[T])>(
+        &self,
+        keys: &[PointOffsetType],
+        f: F,
+    ) -> OperationResult<()> {
+        self.vectors.for_each_in_batch(keys, f)
+    }
+
+    fn read_dense_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        let (user_data, keys): (Vec<_>, Vec<_>) = keys.into_iter().unzip();
+        self.vectors.for_each_in_batch(&keys, |idx, vector| {
+            callback(
+                user_data[idx],
+                keys[idx],
+                bytemuck::cast_slice(vector).to_vec(),
+            );
+        })
+    }
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorStorage<T>
+    for GraphInlineDenseVectorStorage<T, S>
+{
+    fn update_from<'a>(
+        &mut self,
+        _other_vectors: &mut impl Iterator<Item = (Cow<'a, [T]>, bool)>,
+        _stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        Err(OperationError::service_error(
+            "Cannot merge into a graph-backed vector storage",
+        ))
+    }
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorageRead
+    for GraphInlineDenseVectorStorage<T, S>
+{
+    fn size_of_available_vectors_in_bytes(&self) -> usize {
+        self.available_vector_count() * self.vectors.dim() * std::mem::size_of::<T>()
+    }
+
+    fn distance(&self) -> Distance {
+        self.distance
+    }
+
+    fn datatype(&self) -> VectorStorageDatatype {
+        T::datatype()
+    }
+
+    fn is_on_disk(&self) -> bool {
+        self.vectors.graph().is_on_disk()
+    }
+
+    fn io_backend(&self) -> Option<IoBackend> {
+        self.vectors.graph().io_backend()
+    }
+
+    fn total_vector_count(&self) -> usize {
+        self.vectors.num_vectors()
+    }
+
+    fn get_vector<P: AccessPattern>(&self, key: PointOffsetType) -> CowVector<'_> {
+        self.get_vector_opt::<P>(key).expect("Vector not found")
+    }
+
+    fn read_vectors<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        mut callback: impl FnMut(U, PointOffsetType, CowVector<'_>),
+    ) {
+        let (user_data, keys): (Vec<_>, Vec<_>) = keys.into_iter().unzip();
+        self.vectors
+            .for_each_in_batch(&keys, |idx, vector| {
+                let vector = CowVector::from(T::slice_to_float_cow(Cow::Borrowed(vector)));
+                callback(user_data[idx], keys[idx], vector);
+            })
+            .expect("read vectors");
+    }
+
+    fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<CowVector<'_>> {
+        self.vectors
+            .get_vector_opt::<P>(key)
+            .map(|vector| CowVector::from(T::slice_to_float_cow(vector)))
+    }
+
+    fn is_deleted_vector(&self, key: PointOffsetType) -> bool {
+        self.deleted.get(key)
+    }
+
+    fn deleted_vector_count(&self) -> usize {
+        self.deleted_count
+    }
+
+    fn deleted_vector_bitslice(&self) -> &BitSlice {
+        self.deleted.get_bitslice()
+    }
+
+    fn read_vector_bytes<P: AccessPattern, U: Copy + UserData>(
+        &self,
+        keys: impl IntoIterator<Item = (U, PointOffsetType)>,
+        callback: impl FnMut(U, PointOffsetType, Vec<u8>),
+    ) -> OperationResult<()> {
+        self.read_dense_bytes::<P, U>(keys, callback)
+    }
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> VectorStorage
+    for GraphInlineDenseVectorStorage<T, S>
+{
+    fn insert_vector(
+        &mut self,
+        _key: PointOffsetType,
+        _vector: VectorRef,
+        _hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        Err(error_immutable_insert())
+    }
+
+    fn flusher(&self) -> Flusher {
+        self.deleted.flusher()
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        self.deleted.files()
+    }
+
+    fn delete_vector(&mut self, key: PointOffsetType) -> OperationResult<bool> {
+        let was_deleted = self.deleted.set(key, true);
+        if !was_deleted {
+            self.deleted_count += 1;
+        }
+        Ok(!was_deleted)
+    }
+}

--- a/lib/segment/src/vector_storage/dense/mod.rs
+++ b/lib/segment/src/vector_storage/dense/mod.rs
@@ -2,6 +2,7 @@ pub mod appendable_dense_vector_storage;
 pub mod dense_vector_storage;
 pub mod dense_vectors;
 pub mod empty_dense_vector_storage;
+pub mod graph_inline_dense_vector_storage;
 pub mod immutable_dense_vectors;
 pub mod read_only;
 pub mod update_only;

--- a/lib/segment/src/vector_storage/dense/read_only/immutable/lifecycle.rs
+++ b/lib/segment/src/vector_storage/dense/read_only/immutable/lifecycle.rs
@@ -9,11 +9,14 @@ use super::ReadOnlyImmutableDenseVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::index::hnsw_index::HnswGraph;
 use crate::types::Distance;
+use crate::vector_storage::dense::appendable_dense_vector_storage::DELETED_DIR_PATH;
 use crate::vector_storage::dense::dense_vector_storage::{DELETED_PATH, VECTORS_PATH};
 use crate::vector_storage::dense::immutable_dense_vectors::{
     ImmutableDenseVectorData, deleted_mmap_data_start,
 };
+use crate::vector_storage::graph_vectors::GraphVectors;
 
 /// Read-only mmap options: never writable, lazily paged, nothing populated.
 fn bitslice_open_options(populate: Populate) -> OpenOptions {
@@ -68,6 +71,25 @@ impl<T: PrimitiveVectorElement, S: UniversalRead>
             deleted,
             distance,
             populate,
+        })
+    }
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead>
+    ReadOnlyImmutableDenseVectorStorage<GraphVectors<T, S>>
+{
+    pub fn open_graph(
+        fs: &impl UniversalReadFs<File = S>,
+        path: &Path,
+        graph: HnswGraph<S>,
+        dim: usize,
+        distance: Distance,
+    ) -> OperationResult<Self> {
+        Ok(Self {
+            populate: Populate::from(!graph.is_on_disk()),
+            vectors: GraphVectors::new(graph, dim)?,
+            deleted: InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIR_PATH))?,
+            distance,
         })
     }
 }

--- a/lib/segment/src/vector_storage/graph_vectors.rs
+++ b/lib/segment/src/vector_storage/graph_vectors.rs
@@ -1,0 +1,141 @@
+use std::borrow::Cow;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::mem::{align_of, size_of};
+use std::path::PathBuf;
+
+use common::generic_consts::AccessPattern;
+use common::mmap::Flusher;
+use common::types::{PointOffsetType, ScoreType};
+use common::universal_io::UniversalRead;
+use quantization::turboquant::EncodedQueryTQ;
+use quantization::turboquant::quantization::TurboQuantizer;
+
+use crate::common::operation_error::OperationResult;
+use crate::data_types::primitive::PrimitiveVectorElement;
+use crate::index::hnsw_index::HnswGraph;
+use crate::types::Distance;
+use crate::vector_storage::dense::dense_vectors::DenseVectorBlob;
+use crate::vector_storage::turbo::shared::score_query_bytes;
+use crate::vector_storage::turbo::turbo_vectors::TurboVectorBlob;
+
+#[derive(Debug)]
+pub struct GraphVectors<T: PrimitiveVectorElement, S: UniversalRead> {
+    graph: HnswGraph<S>,
+    len: usize,
+    element: PhantomData<T>,
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> GraphVectors<T, S> {
+    pub fn new(graph: HnswGraph<S>, len: usize) -> OperationResult<Self> {
+        graph.check_base_vector_layout_compatibility(size_of::<T>() * len, align_of::<T>())?;
+        Ok(Self {
+            graph,
+            len,
+            element: PhantomData,
+        })
+    }
+
+    pub fn graph(&self) -> &HnswGraph<S> {
+        &self.graph
+    }
+
+    pub fn populate(&self) {
+        if let Err(err) = self.graph.populate() {
+            log::error!("Failed to populate vector storage: {err}");
+        }
+    }
+
+    pub fn clear_cache(&self) -> OperationResult<()> {
+        self.graph.clear_cache()
+    }
+
+    fn base_vector(&self, key: PointOffsetType) -> Cow<'_, [T]> {
+        self.graph
+            .base_vector(key)
+            .unwrap_or_else(|err| panic!("Failed to read base vector {key} from graph: {err}"))
+    }
+}
+
+impl<T: PrimitiveVectorElement, S: UniversalRead> DenseVectorBlob for GraphVectors<T, S> {
+    type Element = T;
+    type File = S;
+
+    fn dim(&self) -> usize {
+        self.len
+    }
+
+    fn num_vectors(&self) -> usize {
+        self.graph.num_points()
+    }
+
+    fn get_vector_opt<P: AccessPattern>(&self, key: PointOffsetType) -> Option<Cow<'_, [T]>> {
+        ((key as usize) < self.graph.num_points()).then(|| self.base_vector(key))
+    }
+
+    fn for_each_in_batch<F: FnMut(usize, &[T])>(
+        &self,
+        keys: &[PointOffsetType],
+        f: F,
+    ) -> OperationResult<()> {
+        self.graph.for_each_base_vector_in_batch(keys, f)
+    }
+}
+
+impl<S: UniversalRead> TurboVectorBlob for GraphVectors<u8, S> {
+    type File = S;
+
+    fn vectors_count(&self) -> usize {
+        self.graph.num_points()
+    }
+
+    fn get_vector_data(&self, key: PointOffsetType) -> Cow<'_, [u8]> {
+        self.base_vector(key)
+    }
+
+    fn for_each_in_batch<F: FnMut(usize, &[u8])>(
+        &self,
+        keys: &[PointOffsetType],
+        f: F,
+    ) -> OperationResult<()> {
+        self.graph.for_each_base_vector_in_batch(keys, f)
+    }
+
+    fn populate(&self) {
+        GraphVectors::populate(self);
+    }
+
+    fn clear_cache(&self) -> OperationResult<()> {
+        GraphVectors::clear_cache(self)
+    }
+
+    fn get_vector_data_opt(&self, key: PointOffsetType) -> Option<Cow<'_, [u8]>> {
+        ((key as usize) < self.graph.num_points()).then(|| self.base_vector(key))
+    }
+
+    fn files(&self) -> Vec<PathBuf> {
+        // Files are shared with the graph. Not reporting there, assuming the
+        // graph reports them.
+        Vec::new()
+    }
+
+    fn flusher(&self) -> Flusher {
+        Box::new(|| Ok(()))
+    }
+
+    fn score_query_batch(
+        &self,
+        quantizer: &TurboQuantizer,
+        distance: Distance,
+        query: &EncodedQueryTQ,
+        ids: &[PointOffsetType],
+        scores: &mut [ScoreType],
+    ) {
+        debug_assert_eq!(ids.len(), scores.len());
+        self.graph
+            .for_each_base_vector_in_batch(ids, |idx, bytes| {
+                scores[idx] = score_query_bytes(quantizer, distance, query, bytes);
+            })
+            .expect("score TQ vectors");
+    }
+}

--- a/lib/segment/src/vector_storage/mod.rs
+++ b/lib/segment/src/vector_storage/mod.rs
@@ -1,6 +1,7 @@
 mod chunked_vectors;
 pub mod common;
 pub mod dense;
+pub mod graph_vectors;
 mod memory_reporter;
 pub mod multi_dense;
 mod prefill_deleted;

--- a/lib/segment/src/vector_storage/turbo/read_only/immutable/lifecycle.rs
+++ b/lib/segment/src/vector_storage/turbo/read_only/immutable/lifecycle.rs
@@ -5,7 +5,9 @@ use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadF
 use super::ReadOnlyImmutableTurboVectorStorage;
 use crate::common::flags::in_memory_bitvec_flags::InMemoryBitvecFlags;
 use crate::common::operation_error::OperationResult;
-use crate::types::Distance;
+use crate::index::hnsw_index::HnswGraph;
+use crate::types::{Distance, IoBackend};
+use crate::vector_storage::graph_vectors::GraphVectors;
 use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
 use crate::vector_storage::turbo::shared::{self, DELETED_DIR_PATH, VECTORS_PATH};
 
@@ -53,5 +55,29 @@ impl<S: UniversalRead> ReadOnlyImmutableTurboVectorStorage<QuantizedStorage<S>> 
             distance,
             dim,
         })
+    }
+}
+
+impl<S: UniversalRead> ReadOnlyImmutableTurboVectorStorage<GraphVectors<u8, S>> {
+    pub fn open_graph(
+        fs: &impl UniversalReadFs<File = S>,
+        path: &Path,
+        graph: HnswGraph<S>,
+        dim: usize,
+        distance: Distance,
+    ) -> OperationResult<Self> {
+        let quantizer = shared::build_quantizer(dim, distance);
+        Ok(Self {
+            on_disk: graph.is_on_disk(),
+            storage: GraphVectors::new(graph, quantizer.quantized_size())?,
+            quantizer,
+            deleted: InMemoryBitvecFlags::open::<S>(fs, &path.join(DELETED_DIR_PATH))?,
+            distance,
+            dim,
+        })
+    }
+
+    pub fn io_backend(&self) -> Option<IoBackend> {
+        self.storage.graph().io_backend()
     }
 }

--- a/lib/segment/src/vector_storage/turbo/shared.rs
+++ b/lib/segment/src/vector_storage/turbo/shared.rs
@@ -90,7 +90,7 @@ pub(super) fn preprocess_query(
 /// Asymmetric score of a precomputed query against already-fetched encoded
 /// `bytes`, applying the metric sign convention. Pure: no IO, no hardware
 /// accounting.
-pub(super) fn score_query_bytes(
+pub(crate) fn score_query_bytes(
     quantizer: &TurboQuantizer,
     distance: Distance,
     query: &EncodedQueryTQ,

--- a/lib/segment/src/vector_storage/turbo/turbo_vector_storage.rs
+++ b/lib/segment/src/vector_storage/turbo/turbo_vector_storage.rs
@@ -30,11 +30,13 @@ use crate::common::Flusher;
 use crate::common::flags::FlagsMode;
 use crate::common::flags::bitvec_flags::BitvecFlags;
 use crate::common::io_uring::{IoUringFallback, use_io_uring};
-use crate::common::operation_error::{OperationResult, check_process_stopped};
+use crate::common::operation_error::{OperationError, OperationResult, check_process_stopped};
 use crate::data_types::named_vectors::CowVector;
 use crate::data_types::vectors::{DenseVector, VectorRef};
-use crate::types::{Distance, Memory, VectorStorageDatatype};
+use crate::index::hnsw_index::HnswGraph;
+use crate::types::{Distance, IoBackend, Memory, VectorStorageDatatype};
 use crate::vector_storage::common::error_immutable_insert;
+use crate::vector_storage::graph_vectors::GraphVectors;
 use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
 use crate::vector_storage::{
     DenseTQVectorStorage, DenseTQVectorStorageRead, TurboScoring, VectorStorage, VectorStorageEnum,
@@ -126,7 +128,7 @@ impl TurboVectorStorageImpl<QuantizedStorage<MmapFile>> {
             quantizer.quantized_size(),
             populate,
         )?;
-        Self::finalize(storage, quantizer, path, dim, distance, populate)
+        Self::finalize(storage, quantizer, path, dim, distance, populate, true)
     }
 }
 
@@ -146,7 +148,25 @@ impl TurboVectorStorageImpl<QuantizedStorage<IoUringFile>> {
             quantizer.quantized_size(),
             populate,
         )?;
-        Self::finalize(storage, quantizer, path, dim, distance, populate)
+        Self::finalize(storage, quantizer, path, dim, distance, populate, true)
+    }
+}
+
+impl<S: UniversalRead> TurboVectorStorageImpl<GraphVectors<u8, S>> {
+    pub fn open_graph(
+        graph: HnswGraph<S>,
+        path: &Path,
+        dim: usize,
+        distance: Distance,
+    ) -> OperationResult<Self> {
+        let on_disk = graph.is_on_disk();
+        let quantizer = shared::build_quantizer(dim, distance);
+        let storage = GraphVectors::new(graph, quantizer.quantized_size())?;
+        Self::finalize(storage, quantizer, path, dim, distance, !on_disk, on_disk)
+    }
+
+    pub fn io_backend(&self) -> Option<IoBackend> {
+        self.storage.graph().io_backend()
     }
 }
 
@@ -160,6 +180,7 @@ impl<B: TurboVectorBlob> TurboVectorStorageImpl<B> {
         dim: usize,
         distance: Distance,
         populate: bool,
+        on_disk: bool,
     ) -> OperationResult<Self> {
         fs_err::create_dir_all(path)?;
         let deleted = BitvecFlags::open_or_create(
@@ -175,7 +196,7 @@ impl<B: TurboVectorBlob> TurboVectorStorageImpl<B> {
             quantizer,
             deleted,
             deleted_count,
-            on_disk: true,
+            on_disk,
             distance,
             dim,
         })
@@ -444,6 +465,18 @@ impl<B: TurboVectorBlob> DenseTQVectorStorageRead for TurboVectorStorageImpl<B> 
             &self.storage.get_vector_data(key),
             keep_rotated,
         )
+    }
+}
+
+impl<S: UniversalRead> DenseTQVectorStorage for TurboVectorStorageImpl<GraphVectors<u8, S>> {
+    fn update_from<'a>(
+        &mut self,
+        _other_vectors: &mut impl Iterator<Item = (Cow<'a, [u8]>, bool)>,
+        _stopped: &AtomicBool,
+    ) -> OperationResult<Range<PointOffsetType>> {
+        Err(OperationError::service_error(
+            "Cannot merge into a graph-backed vector storage",
+        ))
     }
 }
 


### PR DESCRIPTION
Depends on on #10474, #10475, #10476.

Implements `GraphInlineDenseVectorStorage` - a vector storage that uses graph-with-vectors as the storage. Not wired yet.