### PR TITLE
perf: Move AppliedSeq fsync off the update async path

### DIFF
--- a/lib/collection/src/update_workers/update_worker.rs
+++ b/lib/collection/src/update_workers/update_worker.rs
@@ -185,7 +185,17 @@ impl UpdateWorkers {
                         }
                     };
 
-                    if let Err(err) = applied_seq_handler.update(op_num) {
+                    // `AppliedSeqHandler::update` may fsync every APPLIED_SEQ_SAVE_INTERVAL ops.
+                    let applied_seq_handler = applied_seq_handler.clone();
+                    if let Err(err) =
+                        tokio::task::spawn_blocking(move || applied_seq_handler.update(op_num))
+                            .await
+                            .unwrap_or_else(|join_err| {
+                                Err(CollectionError::service_error(format!(
+                                    "applied_seq update task panicked: {join_err}"
+                                )))
+                            })
+                    {
                         log::error!("Can't update last applied_seq {err}")
                     }
 


### PR DESCRIPTION
Found with our [dial9](https://github.com/qdrant/qdrant/pull/10442) integration.

The `fsync` in the `AppliedSeq` shows as blocking code creating long polls on the update async path.

<img width="1760" height="1303" alt="applied" src="https://github.com/user-attachments/assets/10eebf58-775e-42b8-a1ec-931b4c82dafe" />
