### PR TITLE
[combined-storage] VectorStorageEnum::DenseGraphInline

### DIFF
--- a/lib/segment/benches/vector_search.rs
+++ b/lib/segment/benches/vector_search.rs
@@ -53,6 +53,7 @@ fn benchmark<const IO_URING: bool, const VECTORS: usize, const BATCH: usize>(c: 
 
     let result = match &mut storage {
         VectorStorageEnum::DenseMemmap(v) => v.update_from(&mut vectors, &DEFAULT_STOPPED),
+        VectorStorageEnum::DenseGraphInline(v) => v.update_from(&mut vectors, &DEFAULT_STOPPED),
         #[cfg(target_os = "linux")]
         VectorStorageEnum::DenseUring(v) => v.update_from(&mut vectors, &DEFAULT_STOPPED),
         _ => panic!("unexpected dense vector storage variant"),

--- a/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
+++ b/lib/segment/src/index/hnsw_index/gpu/gpu_vector_storage/mod.rs
@@ -429,6 +429,18 @@ impl GpuVectorStorage {
             VectorStorageEnum::DenseMemmapHalf(vector_storage) => {
                 Self::new_dense_f16(device, vector_storage.as_ref(), stopped)
             }
+            VectorStorageEnum::DenseGraphInline(vector_storage) => Self::new_dense_f32(
+                device,
+                vector_storage.as_ref(),
+                force_half_precision,
+                stopped,
+            ),
+            VectorStorageEnum::DenseGraphInlineByte(vector_storage) => {
+                Self::new_dense(device, vector_storage.as_ref(), stopped)
+            }
+            VectorStorageEnum::DenseGraphInlineHalf(vector_storage) => {
+                Self::new_dense_f16(device, vector_storage.as_ref(), stopped)
+            }
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(vector_storage) => Self::new_dense_f32(
                 device,
@@ -492,6 +504,9 @@ impl GpuVectorStorage {
             // back to float (or half-float, when the device supports it) and
             // upload it as a regular dense storage.
             VectorStorageEnum::DenseTurboMemmap(vector_storage) => {
+                Self::new_dense_tq(device, vector_storage.as_ref(), stopped)
+            }
+            VectorStorageEnum::DenseTurboGraphInline(vector_storage) => {
                 Self::new_dense_tq(device, vector_storage.as_ref(), stopped)
             }
             #[cfg(target_os = "linux")]

--- a/lib/segment/src/segment_constructor/batched_reader.rs
+++ b/lib/segment/src/segment_constructor/batched_reader.rs
@@ -75,6 +75,21 @@ pub(crate) fn merge_from<'a>(
             let range = target.update_from(&mut reader, stopped);
             reader.finish(range)
         }
+        VectorStorageEnum::DenseGraphInline(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_f32);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::DenseGraphInlineByte(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_byte);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::DenseGraphInlineHalf(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_half);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
         #[cfg(target_os = "linux")]
         VectorStorageEnum::DenseUring(target) => {
             let mut reader = BatchedReader::new(points, sources, read_dense_f32);
@@ -109,6 +124,11 @@ pub(crate) fn merge_from<'a>(
             reader.finish(range)
         }
         VectorStorageEnum::DenseTurboMemmap(target) => {
+            let mut reader = BatchedReader::new(points, sources, read_dense_tq);
+            let range = target.update_from(&mut reader, stopped);
+            reader.finish(range)
+        }
+        VectorStorageEnum::DenseTurboGraphInline(target) => {
             let mut reader = BatchedReader::new(points, sources, read_dense_tq);
             let range = target.update_from(&mut reader, stopped);
             reader.finish(range)
@@ -334,12 +354,15 @@ fn read_dense_f32(
     let vector = match source {
         VectorStorageEnum::DenseVolatile(v) => v.get_dense::<Sequential>(key),
         VectorStorageEnum::DenseMemmap(v) => v.get_dense::<Sequential>(key),
+        VectorStorageEnum::DenseGraphInline(v) => v.get_dense::<Sequential>(key),
         #[cfg(target_os = "linux")]
         VectorStorageEnum::DenseUring(v) => v.get_dense::<Sequential>(key),
         VectorStorageEnum::DenseAppendableMemmap(v) => v.get_dense::<Sequential>(key),
         VectorStorageEnum::EmptyDense(v) => v.get_dense::<Sequential>(key),
         VectorStorageEnum::DenseMemmapByte(_)
+        | VectorStorageEnum::DenseGraphInlineByte(_)
         | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseGraphInlineHalf(_)
         | VectorStorageEnum::DenseAppendableMemmapByte(_)
         | VectorStorageEnum::DenseAppendableMemmapHalf(_)
         | VectorStorageEnum::SparseVolatile(_)
@@ -349,6 +372,7 @@ fn read_dense_f32(
         | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
         | VectorStorageEnum::DenseTurboMemmap(_)
+        | VectorStorageEnum::DenseTurboGraphInline(_)
         | VectorStorageEnum::DenseTurboAppendableMemmap(_)
         | VectorStorageEnum::MultiDenseTurbo(_)
         | VectorStorageEnum::EmptySparse(_) => {
@@ -386,12 +410,15 @@ fn read_dense_byte(
         #[cfg(test)]
         VectorStorageEnum::DenseVolatileByte(v) => v.get_dense::<Sequential>(key),
         VectorStorageEnum::DenseMemmapByte(v) => v.get_dense::<Sequential>(key),
+        VectorStorageEnum::DenseGraphInlineByte(v) => v.get_dense::<Sequential>(key),
         #[cfg(target_os = "linux")]
         VectorStorageEnum::DenseUringByte(v) => v.get_dense::<Sequential>(key),
         VectorStorageEnum::DenseAppendableMemmapByte(v) => v.get_dense::<Sequential>(key),
         VectorStorageEnum::DenseVolatile(_)
         | VectorStorageEnum::DenseMemmap(_)
+        | VectorStorageEnum::DenseGraphInline(_)
         | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseGraphInlineHalf(_)
         | VectorStorageEnum::DenseAppendableMemmap(_)
         | VectorStorageEnum::DenseAppendableMemmapHalf(_)
         | VectorStorageEnum::SparseVolatile(_)
@@ -401,6 +428,7 @@ fn read_dense_byte(
         | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
         | VectorStorageEnum::DenseTurboMemmap(_)
+        | VectorStorageEnum::DenseTurboGraphInline(_)
         | VectorStorageEnum::DenseTurboAppendableMemmap(_)
         | VectorStorageEnum::EmptyDense(_)
         | VectorStorageEnum::MultiDenseTurbo(_)
@@ -438,12 +466,15 @@ fn read_dense_half(
         #[cfg(test)]
         VectorStorageEnum::DenseVolatileHalf(v) => v.get_dense::<Sequential>(key),
         VectorStorageEnum::DenseMemmapHalf(v) => v.get_dense::<Sequential>(key),
+        VectorStorageEnum::DenseGraphInlineHalf(v) => v.get_dense::<Sequential>(key),
         #[cfg(target_os = "linux")]
         VectorStorageEnum::DenseUringHalf(v) => v.get_dense::<Sequential>(key),
         VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.get_dense::<Sequential>(key),
         VectorStorageEnum::DenseVolatile(_)
         | VectorStorageEnum::DenseMemmap(_)
+        | VectorStorageEnum::DenseGraphInline(_)
         | VectorStorageEnum::DenseMemmapByte(_)
+        | VectorStorageEnum::DenseGraphInlineByte(_)
         | VectorStorageEnum::DenseAppendableMemmap(_)
         | VectorStorageEnum::DenseAppendableMemmapByte(_)
         | VectorStorageEnum::SparseVolatile(_)
@@ -453,6 +484,7 @@ fn read_dense_half(
         | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
         | VectorStorageEnum::DenseTurboMemmap(_)
+        | VectorStorageEnum::DenseTurboGraphInline(_)
         | VectorStorageEnum::DenseTurboAppendableMemmap(_)
         | VectorStorageEnum::EmptyDense(_)
         | VectorStorageEnum::MultiDenseTurbo(_)
@@ -488,6 +520,7 @@ fn read_dense_tq(
     let deleted = source.is_deleted_vector(key);
     let vector = match source {
         VectorStorageEnum::DenseTurboMemmap(v) => v.get_dense_tq::<Sequential>(key),
+        VectorStorageEnum::DenseTurboGraphInline(v) => v.get_dense_tq::<Sequential>(key),
         #[cfg(target_os = "linux")]
         VectorStorageEnum::DenseTurboUring(v) => v.get_dense_tq::<Sequential>(key),
         VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.get_dense_tq::<Sequential>(key),
@@ -495,6 +528,9 @@ fn read_dense_tq(
         | VectorStorageEnum::DenseMemmap(_)
         | VectorStorageEnum::DenseMemmapByte(_)
         | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseGraphInline(_)
+        | VectorStorageEnum::DenseGraphInlineByte(_)
+        | VectorStorageEnum::DenseGraphInlineHalf(_)
         | VectorStorageEnum::DenseAppendableMemmap(_)
         | VectorStorageEnum::DenseAppendableMemmapByte(_)
         | VectorStorageEnum::DenseAppendableMemmapHalf(_)
@@ -543,10 +579,14 @@ fn read_multi_tq(
         | VectorStorageEnum::DenseMemmap(_)
         | VectorStorageEnum::DenseMemmapByte(_)
         | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseGraphInline(_)
+        | VectorStorageEnum::DenseGraphInlineByte(_)
+        | VectorStorageEnum::DenseGraphInlineHalf(_)
         | VectorStorageEnum::DenseAppendableMemmap(_)
         | VectorStorageEnum::DenseAppendableMemmapByte(_)
         | VectorStorageEnum::DenseAppendableMemmapHalf(_)
         | VectorStorageEnum::DenseTurboMemmap(_)
+        | VectorStorageEnum::DenseTurboGraphInline(_)
         | VectorStorageEnum::DenseTurboAppendableMemmap(_)
         | VectorStorageEnum::SparseVolatile(_)
         | VectorStorageEnum::SparseMmap(_)
@@ -594,6 +634,9 @@ fn read_multi_f32(
         | VectorStorageEnum::DenseMemmap(_)
         | VectorStorageEnum::DenseMemmapByte(_)
         | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseGraphInline(_)
+        | VectorStorageEnum::DenseGraphInlineByte(_)
+        | VectorStorageEnum::DenseGraphInlineHalf(_)
         | VectorStorageEnum::DenseAppendableMemmap(_)
         | VectorStorageEnum::DenseAppendableMemmapByte(_)
         | VectorStorageEnum::DenseAppendableMemmapHalf(_)
@@ -602,6 +645,7 @@ fn read_multi_f32(
         | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
         | VectorStorageEnum::DenseTurboMemmap(_)
+        | VectorStorageEnum::DenseTurboGraphInline(_)
         | VectorStorageEnum::DenseTurboAppendableMemmap(_)
         | VectorStorageEnum::EmptyDense(_)
         | VectorStorageEnum::MultiDenseTurbo(_)
@@ -645,6 +689,9 @@ fn read_multi_byte(
         | VectorStorageEnum::DenseMemmap(_)
         | VectorStorageEnum::DenseMemmapByte(_)
         | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseGraphInline(_)
+        | VectorStorageEnum::DenseGraphInlineByte(_)
+        | VectorStorageEnum::DenseGraphInlineHalf(_)
         | VectorStorageEnum::DenseAppendableMemmap(_)
         | VectorStorageEnum::DenseAppendableMemmapByte(_)
         | VectorStorageEnum::DenseAppendableMemmapHalf(_)
@@ -654,6 +701,7 @@ fn read_multi_byte(
         | VectorStorageEnum::MultiDenseAppendableMemmap(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
         | VectorStorageEnum::DenseTurboMemmap(_)
+        | VectorStorageEnum::DenseTurboGraphInline(_)
         | VectorStorageEnum::DenseTurboAppendableMemmap(_)
         | VectorStorageEnum::EmptyDense(_)
         | VectorStorageEnum::MultiDenseTurbo(_)
@@ -696,6 +744,9 @@ fn read_multi_half(
         | VectorStorageEnum::DenseMemmap(_)
         | VectorStorageEnum::DenseMemmapByte(_)
         | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseGraphInline(_)
+        | VectorStorageEnum::DenseGraphInlineByte(_)
+        | VectorStorageEnum::DenseGraphInlineHalf(_)
         | VectorStorageEnum::DenseAppendableMemmap(_)
         | VectorStorageEnum::DenseAppendableMemmapByte(_)
         | VectorStorageEnum::DenseAppendableMemmapHalf(_)
@@ -705,6 +756,7 @@ fn read_multi_half(
         | VectorStorageEnum::MultiDenseAppendableMemmap(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
         | VectorStorageEnum::DenseTurboMemmap(_)
+        | VectorStorageEnum::DenseTurboGraphInline(_)
         | VectorStorageEnum::DenseTurboAppendableMemmap(_)
         | VectorStorageEnum::EmptyDense(_)
         | VectorStorageEnum::MultiDenseTurbo(_)
@@ -759,6 +811,9 @@ fn read_sparse(
         | VectorStorageEnum::DenseMemmap(_)
         | VectorStorageEnum::DenseMemmapByte(_)
         | VectorStorageEnum::DenseMemmapHalf(_)
+        | VectorStorageEnum::DenseGraphInline(_)
+        | VectorStorageEnum::DenseGraphInlineByte(_)
+        | VectorStorageEnum::DenseGraphInlineHalf(_)
         | VectorStorageEnum::DenseAppendableMemmap(_)
         | VectorStorageEnum::DenseAppendableMemmapByte(_)
         | VectorStorageEnum::DenseAppendableMemmapHalf(_)
@@ -767,6 +822,7 @@ fn read_sparse(
         | VectorStorageEnum::MultiDenseAppendableMemmapByte(_)
         | VectorStorageEnum::MultiDenseAppendableMemmapHalf(_)
         | VectorStorageEnum::DenseTurboMemmap(_)
+        | VectorStorageEnum::DenseTurboGraphInline(_)
         | VectorStorageEnum::DenseTurboAppendableMemmap(_)
         | VectorStorageEnum::MultiDenseTurbo(_)
         | VectorStorageEnum::EmptyDense(_) => {

--- a/lib/segment/src/vector_storage/memory_reporter.rs
+++ b/lib/segment/src/vector_storage/memory_reporter.rs
@@ -42,6 +42,15 @@ impl MemoryReporter for VectorStorageEnum {
             VectorStorageEnum::DenseMemmapHalf(v) => {
                 from_files_with_on_disk(v.files(), v.is_on_disk())
             }
+            VectorStorageEnum::DenseGraphInline(v) => {
+                from_files_with_on_disk(v.files(), v.is_on_disk())
+            }
+            VectorStorageEnum::DenseGraphInlineByte(v) => {
+                from_files_with_on_disk(v.files(), v.is_on_disk())
+            }
+            VectorStorageEnum::DenseGraphInlineHalf(v) => {
+                from_files_with_on_disk(v.files(), v.is_on_disk())
+            }
 
             // io_uring dense variants: always on-disk, no mmap caching
             #[cfg(target_os = "linux")]
@@ -69,6 +78,9 @@ impl MemoryReporter for VectorStorageEnum {
             }
 
             VectorStorageEnum::DenseTurboMemmap(v) => {
+                from_files_with_on_disk(v.files(), v.is_on_disk())
+            }
+            VectorStorageEnum::DenseTurboGraphInline(v) => {
                 from_files_with_on_disk(v.files(), v.is_on_disk())
             }
             #[cfg(target_os = "linux")]

--- a/lib/segment/src/vector_storage/prefill_deleted.rs
+++ b/lib/segment/src/vector_storage/prefill_deleted.rs
@@ -113,6 +113,9 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => fill_dense(&mut **v, count, &stopped),
             VectorStorageEnum::DenseMemmapByte(v) => fill_dense(&mut **v, count, &stopped),
             VectorStorageEnum::DenseMemmapHalf(v) => fill_dense(&mut **v, count, &stopped),
+            VectorStorageEnum::DenseGraphInline(v) => fill_dense(&mut **v, count, &stopped),
+            VectorStorageEnum::DenseGraphInlineByte(v) => fill_dense(&mut **v, count, &stopped),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => fill_dense(&mut **v, count, &stopped),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => fill_dense(&mut **v, count, &stopped),
@@ -130,6 +133,7 @@ impl VectorStorageEnum {
             }
 
             VectorStorageEnum::DenseTurboMemmap(v) => fill_turbo(&mut **v, count, &stopped),
+            VectorStorageEnum::DenseTurboGraphInline(v) => fill_turbo(&mut **v, count, &stopped),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => fill_turbo(&mut **v, count, &stopped),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => {

--- a/lib/segment/src/vector_storage/quantized/quantized_vectors/create.rs
+++ b/lib/segment/src/vector_storage/quantized/quantized_vectors/create.rs
@@ -84,6 +84,30 @@ impl QuantizedVectors {
                 max_threads,
                 stopped,
             ),
+            VectorStorageEnum::DenseGraphInline(v) => Self::create_impl(
+                v.as_ref(),
+                quantization_config,
+                storage_type,
+                path,
+                max_threads,
+                stopped,
+            ),
+            VectorStorageEnum::DenseGraphInlineByte(v) => Self::create_impl(
+                v.as_ref(),
+                quantization_config,
+                storage_type,
+                path,
+                max_threads,
+                stopped,
+            ),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => Self::create_impl(
+                v.as_ref(),
+                quantization_config,
+                storage_type,
+                path,
+                max_threads,
+                stopped,
+            ),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => Self::create_impl(
                 v.as_ref(),
@@ -136,6 +160,14 @@ impl QuantizedVectors {
                 stopped,
             ),
             VectorStorageEnum::DenseTurboMemmap(v) => Self::create_turbo_impl(
+                v.as_ref(),
+                quantization_config,
+                storage_type,
+                path,
+                max_threads,
+                stopped,
+            ),
+            VectorStorageEnum::DenseTurboGraphInline(v) => Self::create_turbo_impl(
                 v.as_ref(),
                 quantization_config,
                 storage_type,

--- a/lib/segment/src/vector_storage/raw_scorer.rs
+++ b/lib/segment/src/vector_storage/raw_scorer.rs
@@ -72,6 +72,9 @@ pub fn new_raw_scorer<'a>(
         VectorStorageEnum::DenseMemmap(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
         VectorStorageEnum::DenseMemmapByte(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
         VectorStorageEnum::DenseMemmapHalf(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
+        VectorStorageEnum::DenseGraphInline(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
+        VectorStorageEnum::DenseGraphInlineByte(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
+        VectorStorageEnum::DenseGraphInlineHalf(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
 
         #[cfg(target_os = "linux")]
         VectorStorageEnum::DenseUring(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
@@ -84,6 +87,9 @@ pub fn new_raw_scorer<'a>(
         VectorStorageEnum::DenseAppendableMemmapByte(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
         VectorStorageEnum::DenseAppendableMemmapHalf(vs) => raw_scorer_impl(query, vs.as_ref(), hc),
         VectorStorageEnum::DenseTurboMemmap(vs) => raw_turbo_scorer_impl(query, vs.as_ref(), hc),
+        VectorStorageEnum::DenseTurboGraphInline(vs) => {
+            raw_turbo_scorer_impl(query, vs.as_ref(), hc)
+        }
         #[cfg(target_os = "linux")]
         VectorStorageEnum::DenseTurboUring(vs) => raw_turbo_scorer_impl(query, vs.as_ref(), hc),
         VectorStorageEnum::DenseTurboAppendableMemmap(vs) => {

--- a/lib/segment/src/vector_storage/read_only/live_reload.rs
+++ b/lib/segment/src/vector_storage/read_only/live_reload.rs
@@ -19,6 +19,9 @@ impl<S: UniversalRead> LiveReload for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => s.live_preload(fs),
             VectorStorageReadEnum::DenseByte(s) => s.live_preload(fs),
             VectorStorageReadEnum::DenseHalf(s) => s.live_preload(fs),
+            VectorStorageReadEnum::DenseGraphInline(s) => s.live_preload(fs),
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => s.live_preload(fs),
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => s.live_preload(fs),
             VectorStorageReadEnum::DenseChunked(s) => s.live_preload(fs),
             VectorStorageReadEnum::DenseChunkedByte(s) => s.live_preload(fs),
             VectorStorageReadEnum::DenseChunkedHalf(s) => s.live_preload(fs),
@@ -26,6 +29,7 @@ impl<S: UniversalRead> LiveReload for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.live_preload(fs),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.live_preload(fs),
             VectorStorageReadEnum::DenseTurbo(s) => s.live_preload(fs),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => s.live_preload(fs),
             VectorStorageReadEnum::DenseTurboChunked(s) => s.live_preload(fs),
             VectorStorageReadEnum::MultiDenseTurbo(s) => s.live_preload(fs),
             VectorStorageReadEnum::Sparse(s) => s.live_preload(fs),
@@ -49,6 +53,15 @@ impl<S: UniversalRead> LiveReload for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::DenseHalf(s) => {
                 s.live_reload(fs, deleted_points, new_points, hw_counter)
             }
+            VectorStorageReadEnum::DenseGraphInline(s) => {
+                s.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => {
+                s.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => {
+                s.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
             VectorStorageReadEnum::DenseChunked(s) => {
                 s.live_reload(fs, deleted_points, new_points, hw_counter)
             }
@@ -68,6 +81,9 @@ impl<S: UniversalRead> LiveReload for VectorStorageReadEnum<S> {
                 s.live_reload(fs, deleted_points, new_points, hw_counter)
             }
             VectorStorageReadEnum::DenseTurbo(s) => {
+                s.live_reload(fs, deleted_points, new_points, hw_counter)
+            }
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => {
                 s.live_reload(fs, deleted_points, new_points, hw_counter)
             }
             VectorStorageReadEnum::DenseTurboChunked(s) => {

--- a/lib/segment/src/vector_storage/read_only/mod.rs
+++ b/lib/segment/src/vector_storage/read_only/mod.rs
@@ -9,6 +9,7 @@ use crate::vector_storage::dense::immutable_dense_vectors::ImmutableDenseVectorD
 use crate::vector_storage::dense::read_only::{
     ReadOnlyChunkedDenseVectorStorage, ReadOnlyImmutableDenseVectorStorage,
 };
+use crate::vector_storage::graph_vectors::GraphVectors;
 use crate::vector_storage::multi_dense::read_only::ReadOnlyChunkedMultiDenseVectorStorage;
 use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
 use crate::vector_storage::sparse::read_only::ReadOnlySparseVectorStorage;
@@ -26,6 +27,7 @@ mod live_reload;
 mod read_ops;
 
 type Dense<T, S> = ReadOnlyImmutableDenseVectorStorage<ImmutableDenseVectorData<T, S>>;
+type DenseInline<T, S> = ReadOnlyImmutableDenseVectorStorage<GraphVectors<T, S>>;
 
 /// Read-only counterpart of [`super::super::VectorStorageEnum`].
 ///
@@ -35,6 +37,10 @@ pub enum VectorStorageReadEnum<S: UniversalRead> {
     Dense(Box<Dense<VectorElementType, S>>),
     DenseByte(Box<Dense<VectorElementTypeByte, S>>),
     DenseHalf(Box<Dense<VectorElementTypeHalf, S>>),
+
+    DenseGraphInline(Box<DenseInline<VectorElementType, S>>),
+    DenseGraphInlineByte(Box<DenseInline<VectorElementTypeByte, S>>),
+    DenseGraphInlineHalf(Box<DenseInline<VectorElementTypeHalf, S>>),
     DenseChunked(Box<ReadOnlyChunkedDenseVectorStorage<VectorElementType, S>>),
     DenseChunkedByte(Box<ReadOnlyChunkedDenseVectorStorage<VectorElementTypeByte, S>>),
     DenseChunkedHalf(Box<ReadOnlyChunkedDenseVectorStorage<VectorElementTypeHalf, S>>),
@@ -42,6 +48,7 @@ pub enum VectorStorageReadEnum<S: UniversalRead> {
     MultiDenseChunkedByte(Box<ReadOnlyChunkedMultiDenseVectorStorage<VectorElementTypeByte, S>>),
     MultiDenseChunkedHalf(Box<ReadOnlyChunkedMultiDenseVectorStorage<VectorElementTypeHalf, S>>),
     DenseTurbo(Box<ReadOnlyImmutableTurboVectorStorage<QuantizedStorage<S>>>),
+    DenseTurboGraphInline(Box<ReadOnlyImmutableTurboVectorStorage<GraphVectors<u8, S>>>),
     DenseTurboChunked(Box<ReadOnlyChunkedTurboVectorStorage<S>>),
     MultiDenseTurbo(Box<ReadOnlyChunkedMultiTurboVectorStorage<S>>),
     Sparse(Box<ReadOnlySparseVectorStorage<S>>),
@@ -59,6 +66,15 @@ impl<S: UniversalRead> RawScorerBuilder for VectorStorageReadEnum<S> {
                 raw_scorer_impl(query, s.as_ref(), hardware_counter)
             }
             VectorStorageReadEnum::DenseHalf(s) => {
+                raw_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::DenseGraphInline(s) => {
+                raw_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => {
+                raw_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => {
                 raw_scorer_impl(query, s.as_ref(), hardware_counter)
             }
             VectorStorageReadEnum::DenseChunked(s) => {
@@ -80,6 +96,9 @@ impl<S: UniversalRead> RawScorerBuilder for VectorStorageReadEnum<S> {
                 raw_multi_scorer_impl(query, s.as_ref(), hardware_counter)
             }
             VectorStorageReadEnum::DenseTurbo(s) => {
+                raw_turbo_scorer_impl(query, s.as_ref(), hardware_counter)
+            }
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => {
                 raw_turbo_scorer_impl(query, s.as_ref(), hardware_counter)
             }
             VectorStorageReadEnum::DenseTurboChunked(s) => {

--- a/lib/segment/src/vector_storage/read_only/read_ops.rs
+++ b/lib/segment/src/vector_storage/read_only/read_ops.rs
@@ -23,6 +23,13 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => s.size_of_available_vectors_in_bytes(),
             VectorStorageReadEnum::DenseByte(s) => s.size_of_available_vectors_in_bytes(),
             VectorStorageReadEnum::DenseHalf(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseGraphInline(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => {
+                s.size_of_available_vectors_in_bytes()
+            }
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => {
+                s.size_of_available_vectors_in_bytes()
+            }
             VectorStorageReadEnum::DenseChunked(s) => s.size_of_available_vectors_in_bytes(),
             VectorStorageReadEnum::DenseChunkedByte(s) => s.size_of_available_vectors_in_bytes(),
             VectorStorageReadEnum::DenseChunkedHalf(s) => s.size_of_available_vectors_in_bytes(),
@@ -34,6 +41,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
                 s.size_of_available_vectors_in_bytes()
             }
             VectorStorageReadEnum::DenseTurbo(s) => s.size_of_available_vectors_in_bytes(),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => {
+                s.size_of_available_vectors_in_bytes()
+            }
             VectorStorageReadEnum::DenseTurboChunked(s) => s.size_of_available_vectors_in_bytes(),
             VectorStorageReadEnum::MultiDenseTurbo(s) => s.size_of_available_vectors_in_bytes(),
             VectorStorageReadEnum::Sparse(s) => s.size_of_available_vectors_in_bytes(),
@@ -45,6 +55,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => s.distance(),
             VectorStorageReadEnum::DenseByte(s) => s.distance(),
             VectorStorageReadEnum::DenseHalf(s) => s.distance(),
+            VectorStorageReadEnum::DenseGraphInline(s) => s.distance(),
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => s.distance(),
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => s.distance(),
             VectorStorageReadEnum::DenseChunked(s) => s.distance(),
             VectorStorageReadEnum::DenseChunkedByte(s) => s.distance(),
             VectorStorageReadEnum::DenseChunkedHalf(s) => s.distance(),
@@ -52,6 +65,7 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.distance(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.distance(),
             VectorStorageReadEnum::DenseTurbo(s) => s.distance(),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => s.distance(),
             VectorStorageReadEnum::DenseTurboChunked(s) => s.distance(),
             VectorStorageReadEnum::MultiDenseTurbo(s) => s.distance(),
             VectorStorageReadEnum::Sparse(s) => s.distance(),
@@ -63,6 +77,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => s.datatype(),
             VectorStorageReadEnum::DenseByte(s) => s.datatype(),
             VectorStorageReadEnum::DenseHalf(s) => s.datatype(),
+            VectorStorageReadEnum::DenseGraphInline(s) => s.datatype(),
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => s.datatype(),
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => s.datatype(),
             VectorStorageReadEnum::DenseChunked(s) => s.datatype(),
             VectorStorageReadEnum::DenseChunkedByte(s) => s.datatype(),
             VectorStorageReadEnum::DenseChunkedHalf(s) => s.datatype(),
@@ -70,6 +87,7 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.datatype(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.datatype(),
             VectorStorageReadEnum::DenseTurbo(s) => s.datatype(),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => s.datatype(),
             VectorStorageReadEnum::DenseTurboChunked(s) => s.datatype(),
             VectorStorageReadEnum::MultiDenseTurbo(s) => s.datatype(),
             VectorStorageReadEnum::Sparse(s) => s.datatype(),
@@ -81,6 +99,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => s.is_on_disk(),
             VectorStorageReadEnum::DenseByte(s) => s.is_on_disk(),
             VectorStorageReadEnum::DenseHalf(s) => s.is_on_disk(),
+            VectorStorageReadEnum::DenseGraphInline(s) => s.is_on_disk(),
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => s.is_on_disk(),
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => s.is_on_disk(),
             VectorStorageReadEnum::DenseChunked(s) => s.is_on_disk(),
             VectorStorageReadEnum::DenseChunkedByte(s) => s.is_on_disk(),
             VectorStorageReadEnum::DenseChunkedHalf(s) => s.is_on_disk(),
@@ -88,6 +109,7 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.is_on_disk(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.is_on_disk(),
             VectorStorageReadEnum::DenseTurbo(s) => s.is_on_disk(),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => s.is_on_disk(),
             VectorStorageReadEnum::DenseTurboChunked(s) => s.is_on_disk(),
             VectorStorageReadEnum::MultiDenseTurbo(s) => s.is_on_disk(),
             VectorStorageReadEnum::Sparse(s) => s.is_on_disk(),
@@ -99,6 +121,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => s.total_vector_count(),
             VectorStorageReadEnum::DenseByte(s) => s.total_vector_count(),
             VectorStorageReadEnum::DenseHalf(s) => s.total_vector_count(),
+            VectorStorageReadEnum::DenseGraphInline(s) => s.total_vector_count(),
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => s.total_vector_count(),
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => s.total_vector_count(),
             VectorStorageReadEnum::DenseChunked(s) => s.total_vector_count(),
             VectorStorageReadEnum::DenseChunkedByte(s) => s.total_vector_count(),
             VectorStorageReadEnum::DenseChunkedHalf(s) => s.total_vector_count(),
@@ -106,6 +131,7 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.total_vector_count(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.total_vector_count(),
             VectorStorageReadEnum::DenseTurbo(s) => s.total_vector_count(),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => s.total_vector_count(),
             VectorStorageReadEnum::DenseTurboChunked(s) => s.total_vector_count(),
             VectorStorageReadEnum::MultiDenseTurbo(s) => s.total_vector_count(),
             VectorStorageReadEnum::Sparse(s) => s.total_vector_count(),
@@ -117,6 +143,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => s.get_vector::<P>(key),
             VectorStorageReadEnum::DenseByte(s) => s.get_vector::<P>(key),
             VectorStorageReadEnum::DenseHalf(s) => s.get_vector::<P>(key),
+            VectorStorageReadEnum::DenseGraphInline(s) => s.get_vector::<P>(key),
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => s.get_vector::<P>(key),
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => s.get_vector::<P>(key),
             VectorStorageReadEnum::DenseChunked(s) => s.get_vector::<P>(key),
             VectorStorageReadEnum::DenseChunkedByte(s) => s.get_vector::<P>(key),
             VectorStorageReadEnum::DenseChunkedHalf(s) => s.get_vector::<P>(key),
@@ -124,6 +153,7 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.get_vector::<P>(key),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.get_vector::<P>(key),
             VectorStorageReadEnum::DenseTurbo(s) => s.get_vector::<P>(key),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => s.get_vector::<P>(key),
             VectorStorageReadEnum::DenseTurboChunked(s) => s.get_vector::<P>(key),
             VectorStorageReadEnum::MultiDenseTurbo(s) => s.get_vector::<P>(key),
             VectorStorageReadEnum::Sparse(s) => s.get_vector::<P>(key),
@@ -139,6 +169,13 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => s.read_vectors::<P, U>(keys, callback),
             VectorStorageReadEnum::DenseByte(s) => s.read_vectors::<P, U>(keys, callback),
             VectorStorageReadEnum::DenseHalf(s) => s.read_vectors::<P, U>(keys, callback),
+            VectorStorageReadEnum::DenseGraphInline(s) => s.read_vectors::<P, U>(keys, callback),
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => {
+                s.read_vectors::<P, U>(keys, callback)
+            }
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => {
+                s.read_vectors::<P, U>(keys, callback)
+            }
             VectorStorageReadEnum::DenseChunked(s) => s.read_vectors::<P, U>(keys, callback),
             VectorStorageReadEnum::DenseChunkedByte(s) => s.read_vectors::<P, U>(keys, callback),
             VectorStorageReadEnum::DenseChunkedHalf(s) => s.read_vectors::<P, U>(keys, callback),
@@ -150,6 +187,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
                 s.read_vectors::<P, U>(keys, callback)
             }
             VectorStorageReadEnum::DenseTurbo(s) => s.read_vectors::<P, U>(keys, callback),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => {
+                s.read_vectors::<P, U>(keys, callback)
+            }
             VectorStorageReadEnum::DenseTurboChunked(s) => s.read_vectors::<P, U>(keys, callback),
             VectorStorageReadEnum::MultiDenseTurbo(s) => s.read_vectors::<P, U>(keys, callback),
             VectorStorageReadEnum::Sparse(s) => s.read_vectors::<P, U>(keys, callback),
@@ -161,6 +201,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => s.get_vector_opt::<P>(key),
             VectorStorageReadEnum::DenseByte(s) => s.get_vector_opt::<P>(key),
             VectorStorageReadEnum::DenseHalf(s) => s.get_vector_opt::<P>(key),
+            VectorStorageReadEnum::DenseGraphInline(s) => s.get_vector_opt::<P>(key),
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => s.get_vector_opt::<P>(key),
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => s.get_vector_opt::<P>(key),
             VectorStorageReadEnum::DenseChunked(s) => s.get_vector_opt::<P>(key),
             VectorStorageReadEnum::DenseChunkedByte(s) => s.get_vector_opt::<P>(key),
             VectorStorageReadEnum::DenseChunkedHalf(s) => s.get_vector_opt::<P>(key),
@@ -168,6 +211,7 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.get_vector_opt::<P>(key),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.get_vector_opt::<P>(key),
             VectorStorageReadEnum::DenseTurbo(s) => s.get_vector_opt::<P>(key),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => s.get_vector_opt::<P>(key),
             VectorStorageReadEnum::DenseTurboChunked(s) => s.get_vector_opt::<P>(key),
             VectorStorageReadEnum::MultiDenseTurbo(s) => s.get_vector_opt::<P>(key),
             VectorStorageReadEnum::Sparse(s) => s.get_vector_opt::<P>(key),
@@ -179,6 +223,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => s.is_deleted_vector(key),
             VectorStorageReadEnum::DenseByte(s) => s.is_deleted_vector(key),
             VectorStorageReadEnum::DenseHalf(s) => s.is_deleted_vector(key),
+            VectorStorageReadEnum::DenseGraphInline(s) => s.is_deleted_vector(key),
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => s.is_deleted_vector(key),
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => s.is_deleted_vector(key),
             VectorStorageReadEnum::DenseChunked(s) => s.is_deleted_vector(key),
             VectorStorageReadEnum::DenseChunkedByte(s) => s.is_deleted_vector(key),
             VectorStorageReadEnum::DenseChunkedHalf(s) => s.is_deleted_vector(key),
@@ -186,6 +233,7 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.is_deleted_vector(key),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.is_deleted_vector(key),
             VectorStorageReadEnum::DenseTurbo(s) => s.is_deleted_vector(key),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => s.is_deleted_vector(key),
             VectorStorageReadEnum::DenseTurboChunked(s) => s.is_deleted_vector(key),
             VectorStorageReadEnum::MultiDenseTurbo(s) => s.is_deleted_vector(key),
             VectorStorageReadEnum::Sparse(s) => s.is_deleted_vector(key),
@@ -197,6 +245,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => s.deleted_vector_count(),
             VectorStorageReadEnum::DenseByte(s) => s.deleted_vector_count(),
             VectorStorageReadEnum::DenseHalf(s) => s.deleted_vector_count(),
+            VectorStorageReadEnum::DenseGraphInline(s) => s.deleted_vector_count(),
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => s.deleted_vector_count(),
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => s.deleted_vector_count(),
             VectorStorageReadEnum::DenseChunked(s) => s.deleted_vector_count(),
             VectorStorageReadEnum::DenseChunkedByte(s) => s.deleted_vector_count(),
             VectorStorageReadEnum::DenseChunkedHalf(s) => s.deleted_vector_count(),
@@ -204,6 +255,7 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.deleted_vector_count(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.deleted_vector_count(),
             VectorStorageReadEnum::DenseTurbo(s) => s.deleted_vector_count(),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => s.deleted_vector_count(),
             VectorStorageReadEnum::DenseTurboChunked(s) => s.deleted_vector_count(),
             VectorStorageReadEnum::MultiDenseTurbo(s) => s.deleted_vector_count(),
             VectorStorageReadEnum::Sparse(s) => s.deleted_vector_count(),
@@ -215,6 +267,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::DenseByte(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::DenseHalf(s) => s.deleted_vector_bitslice(),
+            VectorStorageReadEnum::DenseGraphInline(s) => s.deleted_vector_bitslice(),
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => s.deleted_vector_bitslice(),
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::DenseChunked(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::DenseChunkedByte(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::DenseChunkedHalf(s) => s.deleted_vector_bitslice(),
@@ -222,6 +277,7 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::DenseTurbo(s) => s.deleted_vector_bitslice(),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::DenseTurboChunked(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::MultiDenseTurbo(s) => s.deleted_vector_bitslice(),
             VectorStorageReadEnum::Sparse(s) => s.deleted_vector_bitslice(),
@@ -237,6 +293,15 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => Ok(s.with_dense_bytes_opt::<P, R>(key, f)),
             VectorStorageReadEnum::DenseByte(s) => Ok(s.with_dense_bytes_opt::<P, R>(key, f)),
             VectorStorageReadEnum::DenseHalf(s) => Ok(s.with_dense_bytes_opt::<P, R>(key, f)),
+            VectorStorageReadEnum::DenseGraphInline(s) => {
+                Ok(s.with_dense_bytes_opt::<P, R>(key, f))
+            }
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => {
+                Ok(s.with_dense_bytes_opt::<P, R>(key, f))
+            }
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => {
+                Ok(s.with_dense_bytes_opt::<P, R>(key, f))
+            }
             VectorStorageReadEnum::DenseChunked(s) => Ok(s.with_dense_bytes_opt::<P, R>(key, f)),
             VectorStorageReadEnum::DenseChunkedByte(s) => {
                 Ok(s.with_dense_bytes_opt::<P, R>(key, f))
@@ -254,6 +319,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
                 Ok(s.with_multi_bytes_opt::<P, R>(key, f))
             }
             VectorStorageReadEnum::DenseTurbo(s) => Ok(s.with_dense_tq_bytes_opt::<P, R>(key, f)),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => {
+                Ok(s.with_dense_tq_bytes_opt::<P, R>(key, f))
+            }
             VectorStorageReadEnum::DenseTurboChunked(s) => {
                 Ok(s.with_dense_tq_bytes_opt::<P, R>(key, f))
             }
@@ -275,6 +343,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(_)
             | VectorStorageReadEnum::DenseByte(_)
             | VectorStorageReadEnum::DenseHalf(_)
+            | VectorStorageReadEnum::DenseGraphInline(_)
+            | VectorStorageReadEnum::DenseGraphInlineByte(_)
+            | VectorStorageReadEnum::DenseGraphInlineHalf(_)
             | VectorStorageReadEnum::DenseChunked(_)
             | VectorStorageReadEnum::DenseChunkedByte(_)
             | VectorStorageReadEnum::DenseChunkedHalf(_)
@@ -282,6 +353,7 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             | VectorStorageReadEnum::MultiDenseChunkedByte(_)
             | VectorStorageReadEnum::MultiDenseChunkedHalf(_)
             | VectorStorageReadEnum::DenseTurbo(_)
+            | VectorStorageReadEnum::DenseTurboGraphInline(_)
             | VectorStorageReadEnum::DenseTurboChunked(_)
             | VectorStorageReadEnum::MultiDenseTurbo(_) => {
                 self.with_vector_bytes_opt::<P, _>(key, <[u8]>::to_vec)
@@ -294,6 +366,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => s.available_vector_count(),
             VectorStorageReadEnum::DenseByte(s) => s.available_vector_count(),
             VectorStorageReadEnum::DenseHalf(s) => s.available_vector_count(),
+            VectorStorageReadEnum::DenseGraphInline(s) => s.available_vector_count(),
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => s.available_vector_count(),
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => s.available_vector_count(),
             VectorStorageReadEnum::DenseChunked(s) => s.available_vector_count(),
             VectorStorageReadEnum::DenseChunkedByte(s) => s.available_vector_count(),
             VectorStorageReadEnum::DenseChunkedHalf(s) => s.available_vector_count(),
@@ -301,6 +376,7 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::MultiDenseChunkedByte(s) => s.available_vector_count(),
             VectorStorageReadEnum::MultiDenseChunkedHalf(s) => s.available_vector_count(),
             VectorStorageReadEnum::DenseTurbo(s) => s.available_vector_count(),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => s.available_vector_count(),
             VectorStorageReadEnum::DenseTurboChunked(s) => s.available_vector_count(),
             VectorStorageReadEnum::MultiDenseTurbo(s) => s.available_vector_count(),
             VectorStorageReadEnum::Sparse(s) => s.available_vector_count(),
@@ -316,6 +392,15 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
             VectorStorageReadEnum::Dense(s) => s.read_vector_bytes::<P, U>(keys, callback),
             VectorStorageReadEnum::DenseByte(s) => s.read_vector_bytes::<P, U>(keys, callback),
             VectorStorageReadEnum::DenseHalf(s) => s.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageReadEnum::DenseGraphInline(s) => {
+                s.read_vector_bytes::<P, U>(keys, callback)
+            }
+            VectorStorageReadEnum::DenseGraphInlineByte(s) => {
+                s.read_vector_bytes::<P, U>(keys, callback)
+            }
+            VectorStorageReadEnum::DenseGraphInlineHalf(s) => {
+                s.read_vector_bytes::<P, U>(keys, callback)
+            }
             VectorStorageReadEnum::DenseChunked(s) => s.read_vector_bytes::<P, U>(keys, callback),
             VectorStorageReadEnum::DenseChunkedByte(s) => {
                 s.read_vector_bytes::<P, U>(keys, callback)
@@ -333,6 +418,9 @@ impl<S: UniversalRead> VectorStorageRead for VectorStorageReadEnum<S> {
                 s.read_vector_bytes::<P, U>(keys, callback)
             }
             VectorStorageReadEnum::DenseTurbo(s) => s.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageReadEnum::DenseTurboGraphInline(s) => {
+                s.read_vector_bytes::<P, U>(keys, callback)
+            }
             VectorStorageReadEnum::DenseTurboChunked(s) => {
                 s.read_vector_bytes::<P, U>(keys, callback)
             }

--- a/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
+++ b/lib/segment/src/vector_storage/tests/test_appendable_multi_dense_vector_storage.rs
@@ -75,7 +75,10 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
             | VectorStorageEnum::DenseVolatileByte(_)
             | VectorStorageEnum::DenseVolatileHalf(_) => unreachable!(),
             VectorStorageEnum::DenseMemmap(_)
+            | VectorStorageEnum::DenseGraphInline(_)
             | VectorStorageEnum::DenseMemmapByte(_)
+            | VectorStorageEnum::DenseGraphInlineByte(_)
+            | VectorStorageEnum::DenseGraphInlineHalf(_)
             | VectorStorageEnum::DenseMemmapHalf(_) => unreachable!(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(_)
@@ -85,6 +88,7 @@ fn do_test_delete_points(vector_dim: usize, vec_count: usize, storage: &mut Vect
             | VectorStorageEnum::DenseAppendableMemmapByte(_)
             | VectorStorageEnum::DenseAppendableMemmapHalf(_)
             | VectorStorageEnum::DenseTurboMemmap(_)
+            | VectorStorageEnum::DenseTurboGraphInline(_)
             | VectorStorageEnum::DenseTurboAppendableMemmap(_) => unreachable!(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(_) => unreachable!(),

--- a/lib/segment/src/vector_storage/vector_storage_base.rs
+++ b/lib/segment/src/vector_storage/vector_storage_base.rs
@@ -19,6 +19,7 @@ use sparse::common::sparse_vector::SparseVector;
 use super::dense::dense_vector_storage::DenseVectorStorageImpl;
 use super::dense::empty_dense_vector_storage::EmptyDenseVectorStorage;
 use super::dense::volatile_dense_vector_storage::VolatileDenseVectorStorage;
+use super::graph_vectors::GraphVectors;
 use super::multi_dense::appendable_mmap_multi_dense_vector_storage::AppendableMmapMultiDenseVectorStorage;
 use super::multi_dense::volatile_multi_dense_vector_storage::VolatileMultiDenseVectorStorage;
 use super::raw_scorer::NotDeletedChecker;
@@ -36,8 +37,10 @@ use crate::data_types::vectors::{
     DenseVector, MultiDenseVectorInternal, TypedMultiDenseVector, TypedMultiDenseVectorRef,
     VectorElementType, VectorElementTypeByte, VectorElementTypeHalf, VectorInternal, VectorRef,
 };
+use crate::index::hnsw_index::HnswLinksStorage;
 use crate::types::{Distance, IoBackend, MultiVectorConfig, VectorStorageDatatype};
 use crate::vector_storage::dense::appendable_dense_vector_storage::AppendableMmapDenseVectorStorage;
+use crate::vector_storage::dense::graph_inline_dense_vector_storage::GraphInlineDenseVectorStorage;
 use crate::vector_storage::quantized::quantized_storage::QuantizedStorage;
 
 /// In case of simple vector storage, vector offset is the same as [`PointOffsetType`].
@@ -627,6 +630,14 @@ pub enum VectorStorageEnum {
     DenseMemmapByte(Box<DenseVectorStorageImpl<VectorElementTypeByte>>),
     DenseMemmapHalf(Box<DenseVectorStorageImpl<VectorElementTypeHalf>>),
 
+    DenseGraphInline(Box<GraphInlineDenseVectorStorage<VectorElementType, HnswLinksStorage>>),
+    DenseGraphInlineByte(
+        Box<GraphInlineDenseVectorStorage<VectorElementTypeByte, HnswLinksStorage>>,
+    ),
+    DenseGraphInlineHalf(
+        Box<GraphInlineDenseVectorStorage<VectorElementTypeHalf, HnswLinksStorage>>,
+    ),
+
     #[cfg(target_os = "linux")]
     DenseUring(Box<DenseVectorStorageImpl<VectorElementType, IoUringFile>>),
     #[cfg(target_os = "linux")]
@@ -638,6 +649,7 @@ pub enum VectorStorageEnum {
     DenseAppendableMemmapByte(Box<AppendableMmapDenseVectorStorage<VectorElementTypeByte>>),
     DenseAppendableMemmapHalf(Box<AppendableMmapDenseVectorStorage<VectorElementTypeHalf>>),
     DenseTurboMemmap(Box<TurboVectorStorageImpl<QuantizedStorage<MmapFile>>>),
+    DenseTurboGraphInline(Box<TurboVectorStorageImpl<GraphVectors<u8, HnswLinksStorage>>>),
     #[cfg(target_os = "linux")]
     DenseTurboUring(Box<TurboVectorStorageImpl<QuantizedStorage<IoUringFile>>>),
     DenseTurboAppendableMemmap(Box<AppendableMmapTurboVectorStorage>),
@@ -671,6 +683,9 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(_) => None,
             VectorStorageEnum::DenseMemmapByte(_) => None,
             VectorStorageEnum::DenseMemmapHalf(_) => None,
+            VectorStorageEnum::DenseGraphInline(_) => None,
+            VectorStorageEnum::DenseGraphInlineByte(_) => None,
+            VectorStorageEnum::DenseGraphInlineHalf(_) => None,
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(_) => None,
@@ -683,6 +698,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(_) => None,
             VectorStorageEnum::DenseAppendableMemmapHalf(_) => None,
             VectorStorageEnum::DenseTurboMemmap(_) => None,
+            VectorStorageEnum::DenseTurboGraphInline(_) => None,
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(_) => None,
             VectorStorageEnum::DenseTurboAppendableMemmap(_) => None,
@@ -720,6 +736,15 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseMemmapHalf(v) => {
                 VectorInternal::from(vec![1.0; v.vector_dim()])
             }
+            VectorStorageEnum::DenseGraphInline(v) => {
+                VectorInternal::from(vec![1.0; v.vector_dim()])
+            }
+            VectorStorageEnum::DenseGraphInlineByte(v) => {
+                VectorInternal::from(vec![1.0; v.vector_dim()])
+            }
+            VectorStorageEnum::DenseGraphInlineHalf(v) => {
+                VectorInternal::from(vec![1.0; v.vector_dim()])
+            }
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => VectorInternal::from(vec![1.0; v.vector_dim()]),
@@ -738,6 +763,9 @@ impl VectorStorageEnum {
                 VectorInternal::from(vec![1.0; v.vector_dim()])
             }
             VectorStorageEnum::DenseTurboMemmap(v) => {
+                VectorInternal::from(vec![1.0; v.vector_dim()])
+            }
+            VectorStorageEnum::DenseTurboGraphInline(v) => {
                 VectorInternal::from(vec![1.0; v.vector_dim()])
             }
             #[cfg(target_os = "linux")]
@@ -787,6 +815,9 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(vs) => vs.populate(),
             VectorStorageEnum::DenseMemmapByte(vs) => vs.populate(),
             VectorStorageEnum::DenseMemmapHalf(vs) => vs.populate(),
+            VectorStorageEnum::DenseGraphInline(vs) => vs.populate(),
+            VectorStorageEnum::DenseGraphInlineByte(vs) => vs.populate(),
+            VectorStorageEnum::DenseGraphInlineHalf(vs) => vs.populate(),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(vs) => vs.populate(),
@@ -799,6 +830,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(vs) => vs.populate()?,
             VectorStorageEnum::DenseAppendableMemmapHalf(vs) => vs.populate()?,
             VectorStorageEnum::DenseTurboMemmap(vs) => vs.populate()?,
+            VectorStorageEnum::DenseTurboGraphInline(vs) => vs.populate()?,
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(vs) => vs.populate()?,
             VectorStorageEnum::DenseTurboAppendableMemmap(vs) => vs.populate()?,
@@ -829,6 +861,9 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(vs) => vs.clear_cache()?,
             VectorStorageEnum::DenseMemmapByte(vs) => vs.clear_cache()?,
             VectorStorageEnum::DenseMemmapHalf(vs) => vs.clear_cache()?,
+            VectorStorageEnum::DenseGraphInline(vs) => vs.clear_cache()?,
+            VectorStorageEnum::DenseGraphInlineByte(vs) => vs.clear_cache()?,
+            VectorStorageEnum::DenseGraphInlineHalf(vs) => vs.clear_cache()?,
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(vs) => vs.clear_cache()?,
@@ -841,6 +876,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(vs) => vs.clear_cache()?,
             VectorStorageEnum::DenseAppendableMemmapHalf(vs) => vs.clear_cache()?,
             VectorStorageEnum::DenseTurboMemmap(vs) => vs.clear_cache()?,
+            VectorStorageEnum::DenseTurboGraphInline(vs) => vs.clear_cache()?,
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(vs) => vs.clear_cache()?,
             VectorStorageEnum::DenseTurboAppendableMemmap(vs) => vs.clear_cache()?,
@@ -872,6 +908,9 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => return v.get_dense_vector_layout(),
             VectorStorageEnum::DenseMemmapByte(v) => return v.get_dense_vector_layout(),
             VectorStorageEnum::DenseMemmapHalf(v) => return v.get_dense_vector_layout(),
+            VectorStorageEnum::DenseGraphInline(v) => return v.get_dense_vector_layout(),
+            VectorStorageEnum::DenseGraphInlineByte(v) => return v.get_dense_vector_layout(),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => return v.get_dense_vector_layout(),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => return v.get_dense_vector_layout(),
@@ -884,6 +923,7 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => return v.get_dense_vector_layout(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => return v.get_dense_vector_layout(),
             VectorStorageEnum::DenseTurboMemmap(v) => return v.get_dense_tq_vector_layout(),
+            VectorStorageEnum::DenseTurboGraphInline(v) => return v.get_dense_tq_vector_layout(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => return v.get_dense_tq_vector_layout(),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => {
@@ -942,6 +982,15 @@ impl VectorStorageEnum {
             VectorStorageEnum::DenseMemmapHalf(v) => {
                 insert_dense_bytes(v.as_mut(), key, bytes, hw_counter)
             }
+            VectorStorageEnum::DenseGraphInline(v) => {
+                insert_dense_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
+            VectorStorageEnum::DenseGraphInlineByte(v) => {
+                insert_dense_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
+            VectorStorageEnum::DenseGraphInlineHalf(v) => {
+                insert_dense_bytes(v.as_mut(), key, bytes, hw_counter)
+            }
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => {
@@ -966,6 +1015,9 @@ impl VectorStorageEnum {
                 insert_dense_bytes(v.as_mut(), key, bytes, hw_counter)
             }
             VectorStorageEnum::DenseTurboMemmap(v) => v.insert_tq_bytes(key, bytes, hw_counter),
+            VectorStorageEnum::DenseTurboGraphInline(v) => {
+                v.insert_tq_bytes(key, bytes, hw_counter)
+            }
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.insert_tq_bytes(key, bytes, hw_counter),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => {
@@ -1092,6 +1144,10 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmapByte(_) => Some(IoBackend::Mmap),
             VectorStorageEnum::DenseMemmapHalf(_) => Some(IoBackend::Mmap),
 
+            VectorStorageEnum::DenseGraphInline(v) => v.io_backend(),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.io_backend(),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.io_backend(),
+
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(_) => Some(IoBackend::IoUring),
             #[cfg(target_os = "linux")]
@@ -1103,6 +1159,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(_) => None,
             VectorStorageEnum::DenseAppendableMemmapHalf(_) => None,
             VectorStorageEnum::DenseTurboMemmap(_) => Some(IoBackend::Mmap),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.io_backend(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(_) => Some(IoBackend::IoUring),
             VectorStorageEnum::DenseTurboAppendableMemmap(_) => None,
@@ -1136,6 +1193,13 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => Ok(v.with_dense_bytes_opt::<P, R>(key, f)),
             VectorStorageEnum::DenseMemmapByte(v) => Ok(v.with_dense_bytes_opt::<P, R>(key, f)),
             VectorStorageEnum::DenseMemmapHalf(v) => Ok(v.with_dense_bytes_opt::<P, R>(key, f)),
+            VectorStorageEnum::DenseGraphInline(v) => Ok(v.with_dense_bytes_opt::<P, R>(key, f)),
+            VectorStorageEnum::DenseGraphInlineByte(v) => {
+                Ok(v.with_dense_bytes_opt::<P, R>(key, f))
+            }
+            VectorStorageEnum::DenseGraphInlineHalf(v) => {
+                Ok(v.with_dense_bytes_opt::<P, R>(key, f))
+            }
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => Ok(v.with_dense_bytes_opt::<P, R>(key, f)),
@@ -1154,6 +1218,9 @@ impl VectorStorageRead for VectorStorageEnum {
                 Ok(v.with_dense_bytes_opt::<P, R>(key, f))
             }
             VectorStorageEnum::DenseTurboMemmap(v) => Ok(v.with_dense_tq_bytes_opt::<P, R>(key, f)),
+            VectorStorageEnum::DenseTurboGraphInline(v) => {
+                Ok(v.with_dense_tq_bytes_opt::<P, R>(key, f))
+            }
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => Ok(v.with_dense_tq_bytes_opt::<P, R>(key, f)),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => {
@@ -1198,10 +1265,14 @@ impl VectorStorageRead for VectorStorageEnum {
             | VectorStorageEnum::DenseMemmap(_)
             | VectorStorageEnum::DenseMemmapByte(_)
             | VectorStorageEnum::DenseMemmapHalf(_)
+            | VectorStorageEnum::DenseGraphInline(_)
+            | VectorStorageEnum::DenseGraphInlineByte(_)
+            | VectorStorageEnum::DenseGraphInlineHalf(_)
             | VectorStorageEnum::DenseAppendableMemmap(_)
             | VectorStorageEnum::DenseAppendableMemmapByte(_)
             | VectorStorageEnum::DenseAppendableMemmapHalf(_)
             | VectorStorageEnum::DenseTurboMemmap(_)
+            | VectorStorageEnum::DenseTurboGraphInline(_)
             | VectorStorageEnum::DenseTurboAppendableMemmap(_)
             | VectorStorageEnum::MultiDenseVolatile(_)
             | VectorStorageEnum::MultiDenseAppendableMemmap(_)
@@ -1243,6 +1314,13 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.read_vector_bytes::<P, U>(keys, callback),
             VectorStorageEnum::DenseMemmapByte(v) => v.read_vector_bytes::<P, U>(keys, callback),
             VectorStorageEnum::DenseMemmapHalf(v) => v.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::DenseGraphInline(v) => v.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::DenseGraphInlineByte(v) => {
+                v.read_vector_bytes::<P, U>(keys, callback)
+            }
+            VectorStorageEnum::DenseGraphInlineHalf(v) => {
+                v.read_vector_bytes::<P, U>(keys, callback)
+            }
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.read_vector_bytes::<P, U>(keys, callback),
@@ -1261,6 +1339,9 @@ impl VectorStorageRead for VectorStorageEnum {
                 v.read_vector_bytes::<P, U>(keys, callback)
             }
             VectorStorageEnum::DenseTurboMemmap(v) => v.read_vector_bytes::<P, U>(keys, callback),
+            VectorStorageEnum::DenseTurboGraphInline(v) => {
+                v.read_vector_bytes::<P, U>(keys, callback)
+            }
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.read_vector_bytes::<P, U>(keys, callback),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => {
@@ -1302,6 +1383,9 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.size_of_available_vectors_in_bytes(),
             VectorStorageEnum::DenseMemmapByte(v) => v.size_of_available_vectors_in_bytes(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseGraphInline(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.size_of_available_vectors_in_bytes(),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.size_of_available_vectors_in_bytes(),
@@ -1318,6 +1402,7 @@ impl VectorStorageRead for VectorStorageEnum {
                 v.size_of_available_vectors_in_bytes()
             }
             VectorStorageEnum::DenseTurboMemmap(v) => v.size_of_available_vectors_in_bytes(),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.size_of_available_vectors_in_bytes(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.size_of_available_vectors_in_bytes(),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => {
@@ -1359,6 +1444,9 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.distance(),
             VectorStorageEnum::DenseMemmapByte(v) => v.distance(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.distance(),
+            VectorStorageEnum::DenseGraphInline(v) => v.distance(),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.distance(),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.distance(),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.distance(),
@@ -1371,6 +1459,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.distance(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.distance(),
             VectorStorageEnum::DenseTurboMemmap(v) => v.distance(),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.distance(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.distance(),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.distance(),
@@ -1400,6 +1489,9 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.datatype(),
             VectorStorageEnum::DenseMemmapByte(v) => v.datatype(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.datatype(),
+            VectorStorageEnum::DenseGraphInline(v) => v.datatype(),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.datatype(),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.datatype(),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.datatype(),
@@ -1412,6 +1504,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.datatype(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.datatype(),
             VectorStorageEnum::DenseTurboMemmap(v) => v.datatype(),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.datatype(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.datatype(),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.datatype(),
@@ -1443,6 +1536,9 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.is_on_disk(),
             VectorStorageEnum::DenseMemmapByte(v) => v.is_on_disk(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.is_on_disk(),
+            VectorStorageEnum::DenseGraphInline(v) => v.is_on_disk(),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.is_on_disk(),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.is_on_disk(),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.is_on_disk(),
@@ -1455,6 +1551,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.is_on_disk(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.is_on_disk(),
             VectorStorageEnum::DenseTurboMemmap(v) => v.is_on_disk(),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.is_on_disk(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.is_on_disk(),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.is_on_disk(),
@@ -1484,6 +1581,9 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.total_vector_count(),
             VectorStorageEnum::DenseMemmapByte(v) => v.total_vector_count(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.total_vector_count(),
+            VectorStorageEnum::DenseGraphInline(v) => v.total_vector_count(),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.total_vector_count(),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.total_vector_count(),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.total_vector_count(),
@@ -1496,6 +1596,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.total_vector_count(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.total_vector_count(),
             VectorStorageEnum::DenseTurboMemmap(v) => v.total_vector_count(),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.total_vector_count(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.total_vector_count(),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.total_vector_count(),
@@ -1525,6 +1626,9 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.get_vector::<P>(key),
             VectorStorageEnum::DenseMemmapByte(v) => v.get_vector::<P>(key),
             VectorStorageEnum::DenseMemmapHalf(v) => v.get_vector::<P>(key),
+            VectorStorageEnum::DenseGraphInline(v) => v.get_vector::<P>(key),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.get_vector::<P>(key),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.get_vector::<P>(key),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.get_vector::<P>(key),
@@ -1537,6 +1641,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.get_vector::<P>(key),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.get_vector::<P>(key),
             VectorStorageEnum::DenseTurboMemmap(v) => v.get_vector::<P>(key),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.get_vector::<P>(key),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.get_vector::<P>(key),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.get_vector::<P>(key),
@@ -1570,6 +1675,9 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.read_vectors::<P, U>(keys, callback),
             VectorStorageEnum::DenseMemmapByte(v) => v.read_vectors::<P, U>(keys, callback),
             VectorStorageEnum::DenseMemmapHalf(v) => v.read_vectors::<P, U>(keys, callback),
+            VectorStorageEnum::DenseGraphInline(v) => v.read_vectors::<P, U>(keys, callback),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.read_vectors::<P, U>(keys, callback),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.read_vectors::<P, U>(keys, callback),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.read_vectors::<P, U>(keys, callback),
@@ -1586,6 +1694,7 @@ impl VectorStorageRead for VectorStorageEnum {
                 v.read_vectors::<P, U>(keys, callback)
             }
             VectorStorageEnum::DenseTurboMemmap(v) => v.read_vectors::<P, U>(keys, callback),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.read_vectors::<P, U>(keys, callback),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.read_vectors::<P, U>(keys, callback),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => {
@@ -1623,6 +1732,9 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.get_vector_opt::<P>(key),
             VectorStorageEnum::DenseMemmapByte(v) => v.get_vector_opt::<P>(key),
             VectorStorageEnum::DenseMemmapHalf(v) => v.get_vector_opt::<P>(key),
+            VectorStorageEnum::DenseGraphInline(v) => v.get_vector_opt::<P>(key),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.get_vector_opt::<P>(key),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.get_vector_opt::<P>(key),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.get_vector_opt::<P>(key),
@@ -1635,6 +1747,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.get_vector_opt::<P>(key),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.get_vector_opt::<P>(key),
             VectorStorageEnum::DenseTurboMemmap(v) => v.get_vector_opt::<P>(key),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.get_vector_opt::<P>(key),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.get_vector_opt::<P>(key),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.get_vector_opt::<P>(key),
@@ -1664,6 +1777,9 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseMemmapByte(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseMemmapHalf(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::DenseGraphInline(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.is_deleted_vector(key),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.is_deleted_vector(key),
@@ -1676,6 +1792,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseTurboMemmap(v) => v.is_deleted_vector(key),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.is_deleted_vector(key),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.is_deleted_vector(key),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.is_deleted_vector(key),
@@ -1705,6 +1822,9 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseMemmapByte(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.deleted_vector_count(),
+            VectorStorageEnum::DenseGraphInline(v) => v.deleted_vector_count(),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.deleted_vector_count(),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.deleted_vector_count(),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.deleted_vector_count(),
@@ -1717,6 +1837,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseTurboMemmap(v) => v.deleted_vector_count(),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.deleted_vector_count(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.deleted_vector_count(),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.deleted_vector_count(),
@@ -1746,6 +1867,9 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseMemmapByte(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::DenseGraphInline(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.deleted_vector_bitslice(),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.deleted_vector_bitslice(),
@@ -1758,6 +1882,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseTurboMemmap(v) => v.deleted_vector_bitslice(),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.deleted_vector_bitslice(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.deleted_vector_bitslice(),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.deleted_vector_bitslice(),
@@ -1787,6 +1912,9 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.available_vector_count(),
             VectorStorageEnum::DenseMemmapByte(v) => v.available_vector_count(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.available_vector_count(),
+            VectorStorageEnum::DenseGraphInline(v) => v.available_vector_count(),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.available_vector_count(),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.available_vector_count(),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.available_vector_count(),
@@ -1799,6 +1927,7 @@ impl VectorStorageRead for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.available_vector_count(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.available_vector_count(),
             VectorStorageEnum::DenseTurboMemmap(v) => v.available_vector_count(),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.available_vector_count(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.available_vector_count(),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.available_vector_count(),
@@ -1835,6 +1964,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.insert_vector(key, vector, hw_counter),
             VectorStorageEnum::DenseMemmapByte(v) => v.insert_vector(key, vector, hw_counter),
             VectorStorageEnum::DenseMemmapHalf(v) => v.insert_vector(key, vector, hw_counter),
+            VectorStorageEnum::DenseGraphInline(v) => v.insert_vector(key, vector, hw_counter),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.insert_vector(key, vector, hw_counter),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.insert_vector(key, vector, hw_counter),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.insert_vector(key, vector, hw_counter),
@@ -1851,6 +1983,7 @@ impl VectorStorage for VectorStorageEnum {
                 v.insert_vector(key, vector, hw_counter)
             }
             VectorStorageEnum::DenseTurboMemmap(v) => v.insert_vector(key, vector, hw_counter),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.insert_vector(key, vector, hw_counter),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.insert_vector(key, vector, hw_counter),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => {
@@ -1892,6 +2025,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.flusher(),
             VectorStorageEnum::DenseMemmapByte(v) => v.flusher(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.flusher(),
+            VectorStorageEnum::DenseGraphInline(v) => v.flusher(),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.flusher(),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.flusher(),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.flusher(),
@@ -1904,6 +2040,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.flusher(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.flusher(),
             VectorStorageEnum::DenseTurboMemmap(v) => v.flusher(),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.flusher(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.flusher(),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.flusher(),
@@ -1933,6 +2070,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.files(),
             VectorStorageEnum::DenseMemmapByte(v) => v.files(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.files(),
+            VectorStorageEnum::DenseGraphInline(v) => v.files(),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.files(),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.files(),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.files(),
@@ -1945,6 +2085,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.files(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.files(),
             VectorStorageEnum::DenseTurboMemmap(v) => v.files(),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.files(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.files(),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.files(),
@@ -1974,6 +2115,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.immutable_files(),
             VectorStorageEnum::DenseMemmapByte(v) => v.immutable_files(),
             VectorStorageEnum::DenseMemmapHalf(v) => v.immutable_files(),
+            VectorStorageEnum::DenseGraphInline(v) => v.immutable_files(),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.immutable_files(),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.immutable_files(),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.immutable_files(),
@@ -1986,6 +2130,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.immutable_files(),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.immutable_files(),
             VectorStorageEnum::DenseTurboMemmap(v) => v.immutable_files(),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.immutable_files(),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.immutable_files(),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.immutable_files(),
@@ -2015,6 +2160,9 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseMemmap(v) => v.delete_vector(key),
             VectorStorageEnum::DenseMemmapByte(v) => v.delete_vector(key),
             VectorStorageEnum::DenseMemmapHalf(v) => v.delete_vector(key),
+            VectorStorageEnum::DenseGraphInline(v) => v.delete_vector(key),
+            VectorStorageEnum::DenseGraphInlineByte(v) => v.delete_vector(key),
+            VectorStorageEnum::DenseGraphInlineHalf(v) => v.delete_vector(key),
 
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseUring(v) => v.delete_vector(key),
@@ -2027,6 +2175,7 @@ impl VectorStorage for VectorStorageEnum {
             VectorStorageEnum::DenseAppendableMemmapByte(v) => v.delete_vector(key),
             VectorStorageEnum::DenseAppendableMemmapHalf(v) => v.delete_vector(key),
             VectorStorageEnum::DenseTurboMemmap(v) => v.delete_vector(key),
+            VectorStorageEnum::DenseTurboGraphInline(v) => v.delete_vector(key),
             #[cfg(target_os = "linux")]
             VectorStorageEnum::DenseTurboUring(v) => v.delete_vector(key),
             VectorStorageEnum::DenseTurboAppendableMemmap(v) => v.delete_vector(key),


### PR DESCRIPTION
The first step to wire up `GraphInlineDenseVectorStorage` (added in #10477).
Adds the `VectorStorageEnum::DenseGraphInline`-alike variants (for f32, f16, u8, turbo).