### PR TITLE
perf: Move sync_segment_manifest off the update async path

### DIFF
--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -125,8 +125,18 @@ impl UpdateWorkers {
             // Backstop: reconcile the segment manifest with the live segment set. Registration
             // normally happens at each publication site via the `NewSegmentToken`; this wake-up is
             // the recovery path that picks up any registration that was skipped (e.g. an ignored
-            // token). No-op if already in sync.
-            if let Err(err) = segments.read().sync_segment_manifest(None) {
+            // token). No-op if already in sync.Manifest write uses fsync — keep it off the
+            // async worker.
+            let segments_for_sync = segments.clone();
+            if let Err(err) = tokio::task::spawn_blocking(move || {
+                segments_for_sync.read().sync_segment_manifest(None)
+            })
+            .await
+            .unwrap_or_else(|err| {
+                Err(OperationError::service_error(format!(
+                    "sync_segment_manifest task panicked: {err}"
+                )))
+            }) {
                 log::error!("Failed to write segment manifest: {err}");
             }
 


### PR DESCRIPTION
Found with our https://github.com/qdrant/qdrant/pull/10442 integration.

The fsync in the `sync_segment_manifest` shows as blocking code creating long polls on the update async path.

<img width="1736" height="1300" alt="manifest" src="https://github.com/user-attachments/assets/e1b79401-c40e-4fda-9103-442a1a3a2cb8" />

