### PR TITLE
feat(audit): support audit log to stdout + losslessness

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -487,3 +487,35 @@ tls:
 #   # WARNING: Enabling this without a trusted proxy allows clients to spoof their IP.
 #   # Default: false
 #   trust_forwarded_headers: false
+#   # Write audit records to rotating files in `dir` (see above).
+#   # This is the only sink the `/audit/logs` API can read: with it disabled,
+#   # that endpoint returns an error on this peer and records are only
+#   # available wherever the other enabled sinks send them.
+#   # Default: true
+#   write_to_file: true
+#   # Write audit records to stdout, so a log collector consuming the process'
+#   # stdout receives them. Intended for stdout shipping (i.e. hybrid).
+#   # Audit records are always JSON, so with the default `logger.format: text`
+#   # the stdout stream mixes text log lines with JSON audit lines. Set
+#   # `logger.format: json` for a uniform stream.
+#   # Default: false
+#   write_to_stdout: false
+#   # What each sink does when its 128k-record queue fills up because the
+#   # destination cannot keep up. One of:
+#   #   drop  - never blocks, but audit records can be lost under sustained
+#   #           load. Drops are counted in `/telemetry` and exposed as the
+#   #           `audit_log_dropped_records_total` metric.
+#   #   block - never loses records to a full queue, but applies backpressure:
+#   #           an indefinitely stalled destination stalls writes to the DB.
+#   # Both default to `drop`, which is how Qdrant has always behaved. If every
+#   # enabled sink is set to `drop`, a warning is logged at startup because no
+#   # destination is then guaranteed to retain records under pressure.
+#   # Default: drop
+#   on_file_full: drop
+#   on_stdout_full: drop
+#
+# At least one sink must be enabled when `enabled: true` - a config with
+# audit logging on but every sink off is rejected at startup, since it would
+# leave data access unlogged while appearing to be configured. Note that
+# `write_to_file: false` alone is enough to reach that state, because
+# `write_to_stdout` defaults to false.

--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -12036,8 +12036,12 @@
           "dir",
           "log_api",
           "max_log_files",
+          "on_file_full",
+          "on_stdout_full",
           "rotation",
-          "trust_forwarded_headers"
+          "trust_forwarded_headers",
+          "write_to_file",
+          "write_to_stdout"
         ],
         "properties": {
           "dir": {
@@ -12057,7 +12061,28 @@
           "log_api": {
             "type": "boolean"
           },
+          "write_to_file": {
+            "type": "boolean"
+          },
+          "write_to_stdout": {
+            "type": "boolean"
+          },
+          "on_file_full": {
+            "description": "What the file sink does when its queue is full: `drop` or `block`. Always reported when audit logging is enabled, so fleet tooling can find peers whose audit trail is lossy without scraping startup logs.",
+            "type": "string"
+          },
+          "on_stdout_full": {
+            "description": "What the stdout sink does when its queue is full: `drop` or `block`.",
+            "type": "string"
+          },
           "dir_size_bytes": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0,
+            "nullable": true
+          },
+          "stdout_dropped_records": {
+            "description": "Records the stdout sink discarded because its queue was full.  Only present when `write_to_stdout` is enabled.",
             "type": "integer",
             "format": "uint",
             "minimum": 0,

--- a/lib/storage/src/audit.rs
+++ b/lib/storage/src/audit.rs
@@ -1,13 +1,11 @@
-use std::io::Write;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
 use chrono::{DateTime, Utc};
-use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
-use tracing_appender::rolling::{RollingFileAppender, Rotation};
+use tracing_appender::non_blocking::WorkerGuard;
 
+use crate::audit_sink::{AuditSink, AuditSinkKind, OnFull, build_sinks};
 use crate::rbac::AuthType;
 
 /// Maximum length for a tracing ID extracted from request headers.
@@ -47,7 +45,7 @@ static LOG_API: OnceLock<bool> = OnceLock::new();
 // Configuration
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Deserialize, Clone, Default)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct AuditConfig {
     /// Enable audit logging.
     #[serde(default)]
@@ -77,6 +75,68 @@ pub struct AuditConfig {
     /// to the internal operation name.  Default: true.
     #[serde(default = "default_log_api")]
     pub log_api: bool,
+
+    /// If true, write audit records to rotating files in [`Self::dir`].
+    ///
+    /// This is the only sink the `/audit/logs` query API can read (for now?), so
+    /// disabling it makes audit records unqueryable through Qdrant, they are
+    /// only available wherever the other enabled sinks send them.
+    ///
+    /// Default: true
+    #[serde(default = "default_write_to_file")]
+    pub write_to_file: bool,
+
+    /// If true, write audit records to the process' stdout, so that a log
+    /// collector consuming stdout receives them.  Intended for stdout shipping
+    /// (i.e. hybrid) esp. containerized deployments.
+    ///
+    /// Note that audit records are always JSON, so with the default
+    /// `logger.format: text` the stdout stream mixes text log lines with JSON
+    /// audit lines.  Set `logger.format: json` for a uniform stream.
+    ///
+    /// Default: false
+    #[serde(default)]
+    pub write_to_stdout: bool,
+
+    /// What the file sink does when its 128k-record queue is full because the
+    /// disk cannot keep up: `drop` (default) or `block`.
+    ///
+    /// `drop` never blocks but can lose audit records under sustained load.
+    /// `block` loses nothing to a full queue, but applies backpressure to the
+    /// request path: an indefinitely stalled disk stalls writes to the
+    /// database.
+    ///
+    /// Default: `drop`
+    #[serde(default)]
+    pub on_file_full: OnFull,
+
+    /// What the stdout sink does when its 128k-record queue is full because
+    /// the consumer cannot keep up: `drop` (default) or `block`.
+    ///
+    /// Note that `block` here makes the stdout consumer, typically a log
+    /// collector, a liveness dependency of the database. While it is not
+    /// reading, writes stall.
+    ///
+    /// Default: `drop`
+    #[serde(default)]
+    pub on_stdout_full: OnFull,
+}
+
+impl Default for AuditConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            dir: default_audit_dir(),
+            rotation: AuditRotation::default(),
+            max_log_files: default_max_log_files(),
+            trust_forwarded_headers: false,
+            log_api: default_log_api(),
+            write_to_file: default_write_to_file(),
+            write_to_stdout: false,
+            on_file_full: OnFull::default(),
+            on_stdout_full: OnFull::default(),
+        }
+    }
 }
 
 fn default_audit_dir() -> PathBuf {
@@ -88,6 +148,10 @@ const fn default_max_log_files() -> usize {
 }
 
 const fn default_log_api() -> bool {
+    true
+}
+
+const fn default_write_to_file() -> bool {
     true
 }
 
@@ -150,53 +214,20 @@ pub struct AuditEvent {
 // ---------------------------------------------------------------------------
 
 struct AuditLogger {
-    writer: Mutex<NonBlocking>,
+    /// Every enabled destination. each record is fanned out to all of them.
+    sinks: Vec<AuditSink>,
 }
 
 impl AuditLogger {
-    fn new(config: &AuditConfig) -> anyhow::Result<(Self, WorkerGuard)> {
-        let AuditConfig {
-            enabled: _,
-            dir,
-            rotation,
-            max_log_files,
-            trust_forwarded_headers: _,
-            log_api: _,
-        } = config;
-
-        fs_err::create_dir_all(dir)?;
-
-        let rotation = match rotation {
-            AuditRotation::Daily => Rotation::DAILY,
-            AuditRotation::Hourly => Rotation::HOURLY,
-        };
-
-        let appender = RollingFileAppender::builder()
-            .rotation(rotation)
-            .filename_prefix("audit")
-            .filename_suffix("log")
-            .max_log_files((*max_log_files).max(1))
-            .build(dir)
-            .map_err(|err| anyhow::anyhow!("Failed to create audit log appender: {err}"))?;
-
-        // Wrap the appender in a non-blocking writer.  The actual file I/O is
-        // performed by a dedicated worker thread.  The returned `WorkerGuard`
-        // **must** be kept alive for the lifetime of the program – dropping it
-        // flushes remaining buffered events and shuts down the worker thread.
-        let (non_blocking, guard) = tracing_appender::non_blocking(appender);
-
-        Ok((
-            Self {
-                writer: Mutex::new(non_blocking),
-            },
-            guard,
-        ))
+    fn new(config: &AuditConfig) -> anyhow::Result<(Self, Vec<WorkerGuard>)> {
+        let (sinks, guards) = build_sinks(config)?;
+        Ok((Self { sinks }, guards))
     }
 
     fn write(&self, event: &AuditEvent) {
-        // Serialize to a buffer first so the entire event is sent as one
-        // atomic message to the non-blocking writer (avoids interleaved
-        // partial writes from concurrent callers).
+        // Serialize once, then hand the same bytes to every sink, sending
+        // whole record in a single write should keep concurrent callers from
+        // interleaving partial JSON
         let mut buf = match serde_json::to_vec(event) {
             Ok(buf) => buf,
             Err(err) => {
@@ -206,10 +237,13 @@ impl AuditLogger {
         };
         buf.push(b'\n');
 
-        let mut writer = self.writer.lock();
-        if let Err(err) = writer.write_all(&buf) {
-            log::error!("Failed to write audit log entry: {err}");
+        for sink in &self.sinks {
+            sink.write(&buf);
         }
+    }
+
+    fn sink(&self, kind: AuditSinkKind) -> Option<&AuditSink> {
+        self.sinks.iter().find(|sink| sink.kind() == kind)
     }
 }
 
@@ -221,12 +255,12 @@ impl AuditLogger {
 /// most once (from `main`).  If the config is `None` or `enabled` is `false`,
 /// no logger is created and all `audit_log` calls are no‑ops.
 ///
-/// Returns a [`WorkerGuard`] that **must** be held alive (typically in
-/// `main`) until the program exits.  Dropping the guard flushes any
-/// remaining buffered audit events to disk.
-pub fn init_audit_logger(config: Option<&AuditConfig>) -> anyhow::Result<Option<WorkerGuard>> {
+/// Returns the per-sink [`WorkerGuard`]s, which **must** be held alive
+/// (typically in `main`) until the program exits.  Dropping them flushes any
+/// remaining buffered audit events.
+pub fn init_audit_logger(config: Option<&AuditConfig>) -> anyhow::Result<Vec<WorkerGuard>> {
     let Some(config) = config else {
-        return Ok(None);
+        return Ok(Vec::new());
     };
 
     let AuditConfig {
@@ -236,10 +270,14 @@ pub fn init_audit_logger(config: Option<&AuditConfig>) -> anyhow::Result<Option<
         max_log_files: _,
         trust_forwarded_headers,
         log_api,
+        write_to_file,
+        write_to_stdout,
+        on_file_full: _,
+        on_stdout_full: _,
     } = config;
 
     if !enabled {
-        return Ok(None);
+        return Ok(Vec::new());
     }
 
     // Persist flags so they are available globally even outside the audit
@@ -247,14 +285,31 @@ pub fn init_audit_logger(config: Option<&AuditConfig>) -> anyhow::Result<Option<
     let _ = TRUST_FORWARDED_HEADERS.set(*trust_forwarded_headers);
     let _ = LOG_API.set(*log_api);
 
-    let (logger, guard) = AuditLogger::new(config)?;
+    let (logger, guards) = AuditLogger::new(config)?;
     AUDIT_LOGGER
         .set(logger)
         .map_err(|_| anyhow::anyhow!("Audit logger already initialised"))?;
 
-    log::info!("Audit logging enabled, writing to {}", dir.display());
+    let mut destinations = Vec::with_capacity(2);
+    if *write_to_file {
+        destinations.push(dir.display().to_string());
+    }
+    if *write_to_stdout {
+        destinations.push("stdout".to_string());
+    }
+    log::info!(
+        "Audit logging enabled, writing to {}",
+        destinations.join(" and ")
+    );
 
-    Ok(Some(guard))
+    if !*write_to_file {
+        log::warn!(
+            "Audit logging has no file sink (`audit.write_to_file` is false), \
+             so the `/audit/logs` API cannot return records from this peer",
+        );
+    }
+
+    Ok(guards)
 }
 
 /// Write an audit event.  If the audit logger was not initialised this is a
@@ -279,6 +334,13 @@ pub fn audit_trust_forwarded_headers() -> bool {
 /// Returns `true` if the audit logger is configured to log API method paths.
 pub fn audit_log_api() -> bool {
     LOG_API.get().copied().unwrap_or(false)
+}
+
+/// Number of audit records discarded by the given sink because its queue was
+/// full.  Returns `None` when audit logging is disabled or the sink is not
+/// enabled.
+pub fn audit_dropped_records(kind: AuditSinkKind) -> Option<u64> {
+    Some(AUDIT_LOGGER.get()?.sink(kind)?.dropped_records())
 }
 
 #[cfg(test)]

--- a/lib/storage/src/audit_reader.rs
+++ b/lib/storage/src/audit_reader.rs
@@ -53,6 +53,17 @@ pub fn read_local_audit_logs(
         ));
     }
 
+    // Reading is file-backed, so with no file sink there is nothing to query.
+    // Fail explicitly: returning an empty list here would be indistinguishable
+    // from "no audit records matched", which is badly misleading.
+    if !config.write_to_file {
+        return Err(StorageError::bad_request(
+            "Audit logs are not queryable on this peer: audit records are not \
+             written to files (`audit.write_to_file` is disabled)"
+                .to_string(),
+        ));
+    }
+
     let dir = &config.dir;
     if !dir.exists() {
         return Ok(Vec::new());

--- a/lib/storage/src/audit_sink.rs
+++ b/lib/storage/src/audit_sink.rs
@@ -1,0 +1,515 @@
+//! Audit log sinks
+//!
+//! An [`AuditSink`] is a single destination for serialized audit records. The
+//! audit logger owns a list of them and fans every record out to each, so a
+//! deployment can write audit files and stream the same records to stdout
+//! for a log collector to pick up.
+//!
+//! Every sink performs its file/stream I/O on a dedicated worker thread with
+//! its own bounded queue (128k records), so in normal operation the request
+//! path should never touches the destination.
+//!
+//! When a queue fills, the sink's configured [`OnFull`] policy decides
+//! between losing records and stalling the request path.  Both defaults are
+//! [`OnFull::Drop`], which preserves the behaviour Qdrant has always had 
+//! (pre 1.20?).
+//! [`OnFull::Block`] is opt-in per sink (since its somewhat anti-pattern to 
+//! Qdrant performance targets but necessary for things like SOC 2 compliance)
+//!
+//! (note that records are fanned out sequentially, so a sink configured to
+//! block holds up the sinks after it for that record)
+
+use std::io::{self, Write as _};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use itertools::Itertools as _;
+use parking_lot::Mutex;
+use serde::Deserialize;
+use tracing_appender::non_blocking::{NonBlocking, NonBlockingBuilder, WorkerGuard};
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
+
+use crate::audit::{AuditConfig, AuditRotation};
+
+/// Identifies a sink in log messages, metrics and telemetry.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum AuditSinkKind {
+    /// Rotating files in the configured audit directory.
+    File,
+    /// The process' standard output.
+    Stdout,
+}
+
+impl AuditSinkKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::File => "file",
+            Self::Stdout => "stdout",
+        }
+    }
+
+    const fn thread_name(self) -> &'static str {
+        match self {
+            Self::File => "audit-file",
+            Self::Stdout => "audit-stdout",
+        }
+    }
+
+    const fn policy_key(self) -> &'static str {
+        match self {
+            Self::File => "on_file_full",
+            Self::Stdout => "on_stdout_full",
+        }
+    }
+}
+
+/// What a sink does when its queue is full because the worker is lagging
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OnFull {
+    /// Discard the record and count it in [`AuditSink::dropped_records`].
+    /// Never blocks, but audit records can be lost under sustained load.
+    /// (default pre-1.20)
+    #[default]
+    Drop,
+    /// Block the calling thread until the worker drains. No records are lost
+    /// to a full queue at the cost of applying backpressure to the request
+    /// path. An indefinitely stalled destination stalls writes to the
+    /// database.
+    Block,
+}
+
+impl OnFull {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Drop => "drop",
+            Self::Block => "block",
+        }
+    }
+}
+
+/// One audit record destination.
+pub struct AuditSink {
+    kind: AuditSinkKind,
+    on_full: OnFull,
+    // TODO: replace `NonBlocking`, maybe with a purpose-built worker would let 
+    // us drop this mutex (the underlying crossbeam sender is `Sync`), avoid the
+    // per-record `to_vec` copy that `NonBlocking::write` performs, and support
+    // a bounded `send_timeout` instead of the lazy binary block-or-drop above
+    writer: Mutex<NonBlocking>,
+    /// Records this sink discarded because its queue was full
+    dropped: AtomicU64,
+}
+
+impl AuditSink {
+    /// Builds the rotating-file sink, meant to be durable, also what
+    // backs the `/audit/logs` query API
+    fn new_file(config: &AuditConfig, on_full: OnFull) -> anyhow::Result<(Self, WorkerGuard)> {
+        let AuditConfig {
+            enabled: _,
+            dir,
+            rotation,
+            max_log_files,
+            trust_forwarded_headers: _,
+            log_api: _,
+            write_to_file: _,
+            write_to_stdout: _,
+            on_file_full: _,
+            on_stdout_full: _,
+        } = config;
+
+        fs_err::create_dir_all(dir)?;
+
+        let rotation = match rotation {
+            AuditRotation::Daily => Rotation::DAILY,
+            AuditRotation::Hourly => Rotation::HOURLY,
+        };
+
+        let appender = RollingFileAppender::builder()
+            .rotation(rotation)
+            .filename_prefix("audit")
+            .filename_suffix("log")
+            .max_log_files((*max_log_files).max(1))
+            .build(dir)
+            .map_err(|err| anyhow::anyhow!("Failed to create audit log appender: {err}"))?;
+
+        Ok(Self::spawn(AuditSinkKind::File, on_full, appender))
+    }
+
+    fn new_stdout(on_full: OnFull) -> (Self, WorkerGuard) {
+        Self::spawn(AuditSinkKind::Stdout, on_full, io::stdout())
+    }
+
+    fn spawn<W>(kind: AuditSinkKind, on_full: OnFull, writer: W) -> (Self, WorkerGuard)
+    where
+        W: io::Write + Send + 'static,
+    {
+        // The returned `WorkerGuard` must be held for the lifetime of the
+        // program since dropping it flushes queued records and stops the worker
+        let (non_blocking, guard) = NonBlockingBuilder::default()
+            .lossy(on_full == OnFull::Drop)
+            .thread_name(kind.thread_name())
+            .finish(writer);
+
+        let sink = Self {
+            kind,
+            on_full,
+            writer: Mutex::new(non_blocking),
+            dropped: AtomicU64::new(0),
+        };
+
+        (sink, guard)
+    }
+
+    pub const fn kind(&self) -> AuditSinkKind {
+        self.kind
+    }
+
+    pub const fn on_full(&self) -> OnFull {
+        self.on_full
+    }
+
+    /// Number of records this sink has discarded due to a full queue.
+    ///
+    /// This does not cover records lost to a failed write on the worker
+    /// thread (full/disconnected disk, broken pipe): `tracing_appender`'s 
+    //  worker swallows I/O errors and keeps draining, so such losses are 
+    //  invisible here and to [`OnFull::Block`] alike.
+    //
+    // TODO: closing that hole needs a purpose-built worker (see the TODO on
+    // `AuditSink::writer`) that reports write failures back to the sink
+    pub fn dropped_records(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Write one already-serialized, newline-terminated audit record.
+    ///
+    /// `line` must be a complete record. It is handed to the worker in a
+    /// single `write_all` so concurrent callers cannot interleave partial JSON
+    pub(crate) fn write(&self, line: &[u8]) {
+        // Snapshot the queue's drop counter so we can attribute new drops to
+        // this sink. In lossy mode `write_all` reports success even when the
+        // record was discarded, so the counter is the only signal.
+        let dropped_before = self.queue_dropped();
+
+        let result = {
+            let mut writer = self.writer.lock();
+            writer.write_all(line)
+        };
+
+        if let Err(err) = result {
+            log::error!(
+                "Failed to write audit record to {} sink: {err}",
+                self.kind.as_str(),
+            );
+            return;
+        }
+
+        let newly_dropped = self.queue_dropped().saturating_sub(dropped_before);
+        if newly_dropped > 0 {
+            self.dropped.fetch_add(newly_dropped, Ordering::Relaxed);
+            // TODO: rate-limit this to prevent spam, maybe also emit a 
+            // synthetic `audit_gap` record into the sink itself so the stream
+            // declares its own gaps?
+            log::error!(
+                "Audit {} sink queue is full, discarded {newly_dropped} record(s)",
+                self.kind.as_str(),
+            );
+        }
+    }
+
+    fn queue_dropped(&self) -> u64 {
+        self.writer.lock().error_counter().dropped_lines() as u64
+    }
+}
+
+/// Build every sink enabled by `config`, together with the worker guards that
+/// must be held until shutdown.
+///
+/// Errors if audit logging is enabled but every sink is switched off.
+/// This combination would leave access to the data unlogged while looking
+/// configured, so it is rejected at startup rather than honoured.
+///
+/// Warns if every enabled sink is set to [`OnFull::Drop`], since audit
+/// records can then be lost with no durable copy anywhere.
+pub fn build_sinks(config: &AuditConfig) -> anyhow::Result<(Vec<AuditSink>, Vec<WorkerGuard>)> {
+    let AuditConfig {
+        write_to_file,
+        write_to_stdout,
+        on_file_full,
+        on_stdout_full,
+        ..
+    } = config;
+
+    // Checked against the resolved values, not against which keys the operator
+    // wrote down
+    // `write_to_file: false` on its own already leaves no sinks,
+    // because `write_to_stdout` defaults to false.
+    if !write_to_file && !write_to_stdout {
+        anyhow::bail!(
+            "Audit logging is enabled but every sink is disabled - \
+             set `audit.write_to_file` and/or `audit.write_to_stdout` to true, \
+             or set `audit.enabled: false`",
+        );
+    }
+
+    let mut sinks = Vec::new();
+    let mut guards = Vec::new();
+
+    if *write_to_file {
+        let (sink, guard) = AuditSink::new_file(config, *on_file_full)?;
+        sinks.push(sink);
+        guards.push(guard);
+    }
+
+    if *write_to_stdout {
+        let (sink, guard) = AuditSink::new_stdout(*on_stdout_full);
+        sinks.push(sink);
+        guards.push(guard);
+    }
+
+    warn_if_every_sink_is_lossy(&sinks);
+
+    Ok((sinks, guards))
+}
+
+/// Warn when no enabled sink is willing to block, so there is no destination
+/// guaranteed to retain a record under sustained load.
+///
+/// Both policies default to [`OnFull::Drop`], so this fires for any config
+/// that just sets `audit.enabled: true`
+fn warn_if_every_sink_is_lossy(sinks: &[AuditSink]) {
+    debug_assert!(!sinks.is_empty(), "callers reject a sink-less config");
+
+    if !every_sink_is_lossy(sinks) {
+        return;
+    }
+
+    let sink_list = sinks.iter().map(|sink| sink.kind().as_str()).join(" and ");
+    let keys = sinks
+        .iter()
+        .map(|sink| format!("`audit.{}`", sink.kind().policy_key()))
+        .join(" or ");
+
+    log::warn!(
+        "Audit logging may not be comprehensive: every enabled sink ({sink_list}) \
+         is set to discard records when its queue is full, so entries may be lost \
+         under sustained load. Set {keys} to `block` to guarantee no records are \
+         lost to a full queue.",
+    );
+}
+
+/// Whether no enabled sink is willing to block, i.e. no destination is
+/// guaranteed to retain a record under sustained load.
+fn every_sink_is_lossy(sinks: &[AuditSink]) -> bool {
+    !sinks.is_empty() && sinks.iter().all(|sink| sink.on_full() == OnFull::Drop)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(write_to_file: bool, write_to_stdout: bool, dir: &std::path::Path) -> AuditConfig {
+        AuditConfig {
+            enabled: true,
+            dir: dir.to_path_buf(),
+            write_to_file,
+            write_to_stdout,
+            ..AuditConfig::default()
+        }
+    }
+
+    #[test]
+    fn defaults_reproduce_legacy_behaviour() {
+        // A config that only sets `audit.enabled: true` must behave exactly
+        // like every Qdrant release (pre 1.20) before these settings existed
+        let config = AuditConfig::default();
+        assert!(config.write_to_file);
+        assert!(!config.write_to_stdout);
+        assert_eq!(config.on_file_full, OnFull::Drop);
+        assert_eq!(config.on_stdout_full, OnFull::Drop);
+        // Unrelated defaults the hand-written `Default` also has to preserve
+        assert!(config.log_api);
+        assert_eq!(config.max_log_files, 7);
+    }
+
+    #[test]
+    fn policies_are_passed_through_verbatim() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let config = AuditConfig {
+            on_file_full: OnFull::Block,
+            on_stdout_full: OnFull::Drop,
+            ..config(true, true, dir.path())
+        };
+
+        let (sinks, guards) = build_sinks(&config).unwrap();
+        assert_eq!(sinks.len(), 2);
+        assert_eq!(guards.len(), 2);
+        assert_eq!(sinks[0].kind(), AuditSinkKind::File);
+        assert_eq!(sinks[0].on_full(), OnFull::Block);
+        assert_eq!(sinks[1].kind(), AuditSinkKind::Stdout);
+        assert_eq!(sinks[1].on_full(), OnFull::Drop);
+    }
+
+    #[test]
+    fn file_sink_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let (sinks, guards) = build_sinks(&config(true, false, dir.path())).unwrap();
+        assert_eq!(sinks.len(), 1);
+        assert_eq!(guards.len(), 1);
+        assert_eq!(sinks[0].kind(), AuditSinkKind::File);
+    }
+
+    #[test]
+    fn stdout_sink_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let (sinks, guards) = build_sinks(&config(false, true, dir.path())).unwrap();
+        assert_eq!(sinks.len(), 1);
+        assert_eq!(guards.len(), 1);
+        assert_eq!(sinks[0].kind(), AuditSinkKind::Stdout);
+    }
+
+    /// The "audit may not be comprehensive" warning fires when no enabled
+    /// sink is willing to block (not just when both settings read `drop`)
+    #[test]
+    fn lossy_warning_covers_only_enabled_sinks() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let cases = [
+            // (write_to_file, on_file_full, write_to_stdout, on_stdout_full, warns)
+            // The default, legacy-equivalent config: warns.
+            (true, OnFull::Drop, false, OnFull::Drop, true),
+            (true, OnFull::Block, false, OnFull::Drop, false),
+            (true, OnFull::Drop, true, OnFull::Drop, true),
+            // One blocking sink retains the record, so no warning
+            (true, OnFull::Block, true, OnFull::Drop, false),
+            (true, OnFull::Drop, true, OnFull::Block, false),
+            // `on_file_full` is irrelevant here since file sink is disabled
+            // so the sole enabled sink dropping must still warn
+            (false, OnFull::Block, true, OnFull::Drop, true),
+            (false, OnFull::Drop, true, OnFull::Block, false),
+        ];
+
+        for (write_to_file, on_file_full, write_to_stdout, on_stdout_full, expected) in cases {
+            let config = AuditConfig {
+                on_file_full,
+                on_stdout_full,
+                ..config(write_to_file, write_to_stdout, dir.path())
+            };
+
+            let (sinks, _guards) = build_sinks(&config).unwrap();
+            assert_eq!(
+                every_sink_is_lossy(&sinks),
+                expected,
+                "write_to_file={write_to_file} ({on_file_full:?}), \
+                 write_to_stdout={write_to_stdout} ({on_stdout_full:?})",
+            );
+        }
+    }
+
+    #[test]
+    fn deserializes_policies_from_snake_case() {
+        let parsed: OnFull = serde_json::from_str("\"drop\"").unwrap();
+        assert_eq!(parsed, OnFull::Drop);
+        let parsed: OnFull = serde_json::from_str("\"block\"").unwrap();
+        assert_eq!(parsed, OnFull::Block);
+    }
+
+    #[test]
+    fn stdout_only_does_not_create_audit_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let unused = dir.path().join("should-not-be-created");
+        let (_sinks, _guards) = build_sinks(&config(false, true, &unused)).unwrap();
+        assert!(!unused.exists());
+    }
+
+    #[test]
+    fn no_sinks_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        // Enabled-but-no-sinks would leave data access unlogged while looking
+        // configured, so it must fail at startup.
+        assert!(build_sinks(&config(false, false, dir.path())).is_err());
+    }
+
+    #[test]
+    fn disabling_the_file_sink_alone_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        // `write_to_stdout` defaults to false, so `write_to_file: false` on its
+        // own already leaves no sinks
+        let config = AuditConfig {
+            write_to_file: false,
+            ..AuditConfig {
+                enabled: true,
+                dir: dir.path().to_path_buf(),
+                ..AuditConfig::default()
+            }
+        };
+        assert!(!config.write_to_stdout, "stdout must default to false");
+        assert!(build_sinks(&config).is_err());
+    }
+
+    #[test]
+    fn file_sink_creates_missing_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("does").join("not").join("exist");
+        let (sinks, _guards) = build_sinks(&config(true, false, &nested)).unwrap();
+        assert_eq!(sinks.len(), 1);
+        assert!(nested.exists());
+    }
+
+    /// E2E for a record handed to the file sink lands on disk as one JSON
+    /// line that deserializes back into an equivalent [`AuditEvent`].
+    #[test]
+    fn file_sink_round_trips_a_record() {
+        use crate::audit::{AuditEvent, AuditResult};
+        use crate::rbac::AuthType;
+
+        let dir = tempfile::tempdir().unwrap();
+
+        let event = AuditEvent {
+            timestamp: "2026-09-03T10:30:00Z".parse().unwrap(),
+            method: Some("upsert_points".to_string()),
+            api: Some("/collections/demo/points".to_string()),
+            auth_type: AuthType::ApiKey,
+            subject: None,
+            remote: Some("10.4.2.17".to_string()),
+            collection: Some("demo".to_string()),
+            tracing_id: Some("req-abc123".to_string()),
+            result: AuditResult::Ok,
+            error: None,
+        };
+
+        let mut line = serde_json::to_vec(&event).unwrap();
+        line.push(b'\n');
+
+        {
+            let (sinks, guards) = build_sinks(&config(true, false, dir.path())).unwrap();
+            sinks[0].write(&line);
+            assert_eq!(sinks[0].dropped_records(), 0);
+            // Dropping the guards flushes the worker and joins its thread.
+            drop(guards);
+        }
+
+        let log_file = fs_err::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .find(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("audit") && name.ends_with(".log"))
+            })
+            .expect("audit log file should exist");
+
+        let contents = fs_err::read_to_string(&log_file).unwrap();
+        let lines: Vec<_> = contents.lines().filter(|l| !l.trim().is_empty()).collect();
+        assert_eq!(lines.len(), 1, "expected exactly one record: {contents:?}");
+
+        let read_back: AuditEvent = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(read_back.timestamp, event.timestamp);
+        assert_eq!(read_back.method, event.method);
+        assert_eq!(read_back.api, event.api);
+        assert_eq!(read_back.collection, event.collection);
+        assert_eq!(read_back.tracing_id, event.tracing_id);
+        assert_eq!(read_back.result, event.result);
+    }
+}

--- a/lib/storage/src/audit_sink.rs
+++ b/lib/storage/src/audit_sink.rs
@@ -25,7 +25,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use itertools::Itertools as _;
 use parking_lot::Mutex;
 use serde::Deserialize;
-use tracing_appender::non_blocking::{NonBlocking, NonBlockingBuilder, WorkerGuard};
+use tracing_appender::non_blocking::{ErrorCounter, NonBlocking, NonBlockingBuilder, WorkerGuard};
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 
 use crate::audit::{AuditConfig, AuditRotation};
@@ -96,8 +96,14 @@ pub struct AuditSink {
     // per-record `to_vec` copy that `NonBlocking::write` performs, and support
     // a bounded `send_timeout` instead of the lazy binary block-or-drop above
     writer: Mutex<NonBlocking>,
-    /// Records this sink discarded because its queue was full
-    dropped: AtomicU64,
+    /// Records this sink's queue discarded because it was full.
+    ///
+    /// `ErrorCounter` is a handle on the same `Arc<AtomicUsize>` that
+    /// `NonBlocking::write` increments
+    dropped: ErrorCounter,
+    /// How much of `dropped` has already been logged, so a burst of discards
+    /// produces one message rather than one per record
+    reported_dropped: AtomicU64,
 }
 
 impl AuditSink {
@@ -150,11 +156,14 @@ impl AuditSink {
             .thread_name(kind.thread_name())
             .finish(writer);
 
+        let dropped = non_blocking.error_counter();
+
         let sink = Self {
             kind,
             on_full,
             writer: Mutex::new(non_blocking),
-            dropped: AtomicU64::new(0),
+            dropped,
+            reported_dropped: AtomicU64::new(0),
         };
 
         (sink, guard)
@@ -171,14 +180,14 @@ impl AuditSink {
     /// Number of records this sink has discarded due to a full queue.
     ///
     /// This does not cover records lost to a failed write on the worker
-    /// thread (full/disconnected disk, broken pipe): `tracing_appender`'s 
-    //  worker swallows I/O errors and keeps draining, so such losses are 
+    /// thread (full/disconnected disk, broken pipe): `tracing_appender`'s
+    //  worker swallows I/O errors and keeps draining, so such losses are
     //  invisible here and to [`OnFull::Block`] alike.
     //
     // TODO: closing that hole needs a purpose-built worker (see the TODO on
     // `AuditSink::writer`) that reports write failures back to the sink
     pub fn dropped_records(&self) -> u64 {
-        self.dropped.load(Ordering::Relaxed)
+        self.dropped.dropped_lines() as u64
     }
 
     /// Write one already-serialized, newline-terminated audit record.
@@ -186,11 +195,6 @@ impl AuditSink {
     /// `line` must be a complete record. It is handed to the worker in a
     /// single `write_all` so concurrent callers cannot interleave partial JSON
     pub(crate) fn write(&self, line: &[u8]) {
-        // Snapshot the queue's drop counter so we can attribute new drops to
-        // this sink. In lossy mode `write_all` reports success even when the
-        // record was discarded, so the counter is the only signal.
-        let dropped_before = self.queue_dropped();
-
         let result = {
             let mut writer = self.writer.lock();
             writer.write_all(line)
@@ -204,21 +208,36 @@ impl AuditSink {
             return;
         }
 
-        let newly_dropped = self.queue_dropped().saturating_sub(dropped_before);
-        if newly_dropped > 0 {
-            self.dropped.fetch_add(newly_dropped, Ordering::Relaxed);
-            // TODO: rate-limit this to prevent spam, maybe also emit a 
-            // synthetic `audit_gap` record into the sink itself so the stream
-            // declares its own gaps?
-            log::error!(
-                "Audit {} sink queue is full, discarded {newly_dropped} record(s)",
-                self.kind.as_str(),
-            );
-        }
+        // In lossy mode `write_all` reports success even when the record was
+        // discarded, so the writer's counter is the only signal that it was
+        self.report_new_drops();
     }
 
-    fn queue_dropped(&self) -> u64 {
-        self.writer.lock().error_counter().dropped_lines() as u64
+    /// Log whatever the queue has discarded since the last report
+    //
+    // TODO: also emit a synthetic `audit_gap` record into the sink itself, so
+    // the stream declares its own gaps rather than only the process log?
+    fn report_new_drops(&self) {
+        let dropped = self.dropped_records();
+        let reported = self.reported_dropped.load(Ordering::Relaxed);
+
+        if dropped <= reported {
+            return;
+        }
+
+        if self
+            .reported_dropped
+            .compare_exchange(reported, dropped, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            return;
+        }
+
+        log::error!(
+            "Audit {} sink queue is full, discarded {} record(s) ({dropped} total)",
+            self.kind.as_str(),
+            dropped - reported,
+        );
     }
 }
 
@@ -405,6 +424,84 @@ mod tests {
                  write_to_stdout={write_to_stdout} ({on_stdout_full:?})",
             );
         }
+    }
+
+    /// A writer that blocks on every write until its gate is released, so a
+    /// sink's worker cannot drain and its queue fills up
+    struct StalledWriter(std::sync::Arc<Mutex<()>>);
+
+    impl io::Write for StalledWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            let _held = self.0.lock();
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Concurrent writers must not inflate the drop count.
+    /// The count is read straight off the writer's monotonic counter, so it
+    /// cannot exceed the records handed over
+    #[test]
+    fn concurrent_writes_do_not_overcount_drops() {
+        use std::sync::Arc;
+
+        let gate = Arc::new(Mutex::new(()));
+        let held = gate.lock();
+
+        // Drop policy plus a stalled writer, so a full queue discards
+        let (sink, guard) = AuditSink::spawn(
+            AuditSinkKind::Stdout,
+            OnFull::Drop,
+            StalledWriter(Arc::clone(&gate)),
+        );
+        let sink = Arc::new(sink);
+
+        let threads = 8u64;
+        let per_thread = 40_000u64;
+        let sent = threads * per_thread;
+
+        let handles: Vec<_> = (0..threads)
+            .map(|t| {
+                let sink = Arc::clone(&sink);
+                std::thread::spawn(move || {
+                    for i in 0..per_thread {
+                        sink.write(format!("{{\"t\":{t},\"i\":{i}}}\n").as_bytes());
+                    }
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let dropped = sink.dropped_records();
+
+        // The queue is far smaller than the load, so discards must have
+        // happened, else this test is not exercising the path it claims to
+        assert!(dropped > 0, "expected the queue to overflow");
+
+        // no way we could have discarded more records than were ever written
+        assert!(
+            dropped <= sent,
+            "reported {dropped} drops from only {sent} writes - count is inflated",
+        );
+
+        // the records NOT dropped are those the queue accepted, capped at its
+        // capacity plus the one the worker is blocked writing
+        let accepted = sent - dropped;
+        let capacity = tracing_appender::non_blocking::DEFAULT_BUFFERED_LINES_LIMIT as u64;
+        assert!(
+            accepted <= capacity + 1,
+            "{accepted} records accepted exceeds queue capacity {capacity} (+1 in flight)",
+        );
+
+        // Release the worker before dropping the guard, which joins it
+        drop(held);
+        drop(guard);
     }
 
     #[test]

--- a/lib/storage/src/lib.rs
+++ b/lib/storage/src/lib.rs
@@ -12,6 +12,7 @@ use types::ClusterStatus;
 
 pub mod audit;
 pub mod audit_reader;
+pub mod audit_sink;
 mod common;
 pub mod content_manager;
 #[cfg(feature = "dial9")]

--- a/src/common/metrics.rs
+++ b/src/common/metrics.rs
@@ -212,16 +212,26 @@ impl MetricsProvider for AppBuildTelemetry {
             .iter()
             .for_each(|f| f.add_metrics(metrics, prefix));
 
-        if let Some(audit) = &self.audit
-            && let Some(size) = audit.dir_size_bytes
-        {
-            metrics.push_metric(metric_family(
-                "audit_log_dir_size_bytes",
-                "size of the audit log directory on disk in bytes",
-                MetricType::GAUGE,
-                vec![gauge(size as f64, &[])],
-                prefix,
-            ));
+        if let Some(audit) = &self.audit {
+            if let Some(size) = audit.dir_size_bytes {
+                metrics.push_metric(metric_family(
+                    "audit_log_dir_size_bytes",
+                    "size of the audit log directory on disk in bytes",
+                    MetricType::GAUGE,
+                    vec![gauge(size as f64, &[])],
+                    prefix,
+                ));
+            }
+
+            if let Some(dropped) = audit.stdout_dropped_records {
+                metrics.push_metric(metric_family(
+                    "audit_log_dropped_records_total",
+                    "audit records discarded because a sink queue was full",
+                    MetricType::COUNTER,
+                    vec![counter(dropped as f64, &[("sink", "stdout")])],
+                    prefix,
+                ));
+            }
         }
 
         if let Some(system) = &self.system

--- a/src/common/telemetry_ops/app_telemetry.rs
+++ b/src/common/telemetry_ops/app_telemetry.rs
@@ -10,6 +10,8 @@ use segment::common::anonymize::Anonymize;
 use segment::types::HnswGlobalConfig;
 use serde::Serialize;
 
+use storage::audit_sink::AuditSinkKind;
+
 use crate::common::audit::{AuditConfig, AuditRotation};
 use crate::settings::Settings;
 
@@ -75,8 +77,22 @@ pub struct AuditTelemetry {
     pub max_log_files: usize,
     pub trust_forwarded_headers: bool,
     pub log_api: bool,
+    pub write_to_file: bool,
+    pub write_to_stdout: bool,
+    /// What the file sink does when its queue is full: `drop` or `block`.
+    /// Always reported when audit logging is enabled, so fleet tooling can
+    /// find peers whose audit trail is lossy without scraping startup logs.
+    #[anonymize(false)]
+    pub on_file_full: String,
+    /// What the stdout sink does when its queue is full: `drop` or `block`.
+    #[anonymize(false)]
+    pub on_stdout_full: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dir_size_bytes: Option<usize>,
+    /// Records the stdout sink discarded because its queue was full.  Only
+    /// present when `write_to_stdout` is enabled.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stdout_dropped_records: Option<usize>,
 }
 
 #[derive(Serialize, Clone, Debug, JsonSchema, Anonymize)]
@@ -144,7 +160,7 @@ fn collect_audit_telemetry(
     detail: TelemetryDetail,
 ) -> Option<AuditTelemetry> {
     let config = audit.filter(|c| c.enabled)?;
-    let dir_size_bytes = (detail.level > DetailsLevel::Level2)
+    let dir_size_bytes = (config.write_to_file && detail.level > DetailsLevel::Level2)
         .then(|| {
             common::disk::dir_disk_size(&config.dir)
                 .ok()
@@ -161,7 +177,13 @@ fn collect_audit_telemetry(
         max_log_files: config.max_log_files,
         trust_forwarded_headers: config.trust_forwarded_headers,
         log_api: config.log_api,
+        write_to_file: config.write_to_file,
+        write_to_stdout: config.write_to_stdout,
+        on_file_full: config.on_file_full.as_str().to_string(),
+        on_stdout_full: config.on_stdout_full.as_str().to_string(),
         dir_size_bytes,
+        stdout_dropped_records: storage::audit::audit_dropped_records(AuditSinkKind::Stdout)
+            .map(|dropped| dropped as usize),
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -440,8 +440,9 @@ fn main() -> anyhow::Result<()> {
 
     // If audit logging is enabled, but failed to initialize,
     // we should stop the service, as it may cause unlogged access to the data.
-    // The guard must be held alive until shutdown to flush remaining audit events.
-    let _audit_guard = common::audit::init_audit_logger(settings.audit.as_ref())
+    // The guards (one per sink) must be held alive until shutdown to flush
+    // remaining audit events.
+    let _audit_guards = common::audit::init_audit_logger(settings.audit.as_ref())
         .expect("Audit logger must be initialized if audit logging is enabled");
 
     //


### PR DESCRIPTION
Audit logging with multiple sinks, configurable stdout output and losslessness
(see #10472)

**Summary**
Audit records could previously only be written to rotating files in audit.dir. This adds a second, independent sink for stdout, so deployments can hand audit records straight to a log collector instead of scraping pod-local files. Especially useful when the volume mounted is not reachable by log shipping tooling (i.e. for Hybrid deploys).

I tried to break apart RollingFileAppender into a list of sinks (lib/storage/src/audit_sink.rs) where each sink gets its own bounded queue (128k records) and its own worker thread, so a stalled stdout consumer cannot slow the file sink.
New audit events/recs are serialized once and fanned out to every enabled sink.

Config

```yaml
audit:
  enabled: true
  write_to_file: true      # default true
  write_to_stdout: false   # default false
  on_file_full: drop       # drop | block, default drop
  on_stdout_full: drop     # drop | block, default drop
```
on_*_full controls what a sink does when its queue fills.
`drop` never blocks but can lose records under sustained load (see below), block loses nothing to a full queue but applies backpressure to the request path.


**Behaviors**
- Zero sinks is a startup error, `enabled: true` with both sinks off would leave data access unlogged while appearing configured
  - Checked against resolved values, so write_to_file: false alone trips it (write_to_stdout defaults false)
- All-lossy config warns at startup. If every enabled sink is drop, a warning names the sinks and the exact key to change
  - This fires for existing `audit.enabled: true` configs since those deployments have always been able to lose audit recs silently (see below)
- Drops should now be observable. Previously tracing-appender's lossy writer discarded records and returned Ok, so the existing error handler could never fire and nothing read its counter
  - Drops are now counted per sink, reported in `/telemetry`, and exposed as `audit_log_dropped_records_total{sink=...}`
- `/audit/logs` fails explicitly with no file sink, instead of returning `200` `{"entries": []}` (previously indistinguishable from 'no records matched")

**Lossy behaviors?**
`AuditLogger::new` built its writer as such:
https://github.com/qdrant/qdrant/blob/ce468c04f61553cee0fd5ddbe3bb3f5f58f4b0eb/lib/storage/src/audit.rs#L182-L186

That delegates to `NonBlocking::new` -> `NonBlockingBuilder::default()`, whose defaults are `is_lossy: true`
https://github.com/clia/tracing-appender/blob/3e2a7597a1a84f5b509496bd1d25b9e0e91005e7/src/lib.rs#L181-L183

while we would always opt out of lossy, I feel like defaulting to this would be anti-pattern.
At the same time, _not_ supporting configuration for this goes against SOC 2 since we do not know that:
1: whether audit logs are comprehensive AND
2: if they are not, where/when

[tokio-rs/tracing#2865](https://github.com/tokio-rs/tracing/issues/2865) (open): "Silently losing logs in a production environment is hard to diagnose, and should not be a default."
