### PR TITLE
docs: update coverage instructions for the renamed coverage script

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -188,7 +188,7 @@ You can also generate coverage reports locally with the following commands
 ```bash
 cd qdrant
 cargo install cargo-llvm-cov
-./tools/coverage.sh
+./tools/unit-test-coverage.sh
 
 cd target/llvm-cov/html
 python -m http.server

--- a/tools/unit-test-coverage.sh
+++ b/tools/unit-test-coverage.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Usage: tools/coverage.sh
+# Usage: tools/unit-test-coverage.sh
 #
-# For running on low RAM machines like Github CI, Use `RUN_PER_PACKAGE=true tools/coverage.sh`
+# For running on low RAM machines like Github CI, Use `RUN_PER_PACKAGE=true tools/unit-test-coverage.sh`
 #
 # If using locally, occasionally run `cargo llvm-cov clean` to avoid bloating `target/llvm-cov-target` dir with .profraw files
 


### PR DESCRIPTION
**Document**: docs/DEVELOPMENT.md + tools/unit-test-coverage.sh

`tools/coverage.sh` was split into `tools/unit-test-coverage.sh` and `tools/integration-test-coverage.sh` in #6414, but the "Coverage reports → generate locally" steps in DEVELOPMENT.md still reference the old path (which no longer exists), and the new script's own usage header kept the old name. Updated both.

Transparency note per CONTRIBUTING "Contributing with AI": the commits here are AI-assisted (located via `git log -S coverage.sh` and verified against the rename commit); the change is a two-line docs/comment rename with no behavior change.
