### PR TITLE
docs: fix typos and duplicated words across config help and rustdoc

### DIFF
--- a/.github/review-rules.md
+++ b/.github/review-rules.md
@@ -55,7 +55,7 @@ Rules that are intended to reduce noise in AI code review and are not considered
 - We don't mind using `.unwrap()` and `panic!()` in tests and benchmarks.
 
 - For Rust, checking whether the code compiles is out of scope of AI code review. In particular:
-  - Don't report mising imports for `size_of` or `align_of`.
+  - Don't report missing imports for `size_of` or `align_of`.
     The prelude used in Rust 1.80+ includes these functions.
   - Don't report that some method is used but not implemented for a type. Most likely, it is.
   - Some versions of the `rand` crate provide methods named `random_*`, and some provide `gen_*`, e.g., `random_range` vs `gen_range`.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -151,7 +151,7 @@ storage:
     # If `default_segment_number = 0`, will be automatically selected by the number of available CPUs
     default_segment_number: 0
 
-    # Do not create segments larger this size (in KiloBytes).
+    # Do not create segments larger than this size (in KiloBytes).
     # Large segments might require disproportionately long indexation times,
     # therefore it makes sense to limit the size of segments.
     #

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -299,7 +299,7 @@ message OptimizersConfigDiff {
   optional uint64 default_segment_number = 3;
   // Deprecated:
   //
-  // Do not create segments larger this size (in kilobytes).
+  // Do not create segments larger than this size (in kilobytes).
   // Large segments might require disproportionately long indexation times,
   // therefore it makes sense to limit the size of segments.
   //

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -809,7 +809,7 @@ pub struct OptimizersConfigDiff {
     pub default_segment_number: ::core::option::Option<u64>,
     /// Deprecated:
     ///
-    /// Do not create segments larger this size (in kilobytes).
+    /// Do not create segments larger than this size (in kilobytes).
     /// Large segments might require disproportionately long indexation times,
     /// therefore it makes sense to limit the size of segments.
     ///

--- a/lib/collection/src/operations/config_diff.rs
+++ b/lib/collection/src/operations/config_diff.rs
@@ -134,7 +134,7 @@ pub struct OptimizersConfigDiff {
     /// so that each segment would be handled evenly by one of the threads
     /// If `default_segment_number = 0`, will be automatically selected by the number of available CPUs
     pub default_segment_number: Option<usize>,
-    /// Do not create segments larger this size (in kilobytes).
+    /// Do not create segments larger than this size (in kilobytes).
     /// Large segments might require disproportionately long indexation times,
     /// therefore it makes sense to limit the size of segments.
     ///

--- a/lib/collection/src/optimizers_builder.rs
+++ b/lib/collection/src/optimizers_builder.rs
@@ -53,7 +53,7 @@ pub struct OptimizersConfig {
     /// so that each segment would be handled evenly by one of the threads.
     /// If `default_segment_number = 0`, will be automatically selected by the number of available CPUs.
     pub default_segment_number: usize,
-    /// Do not create segments larger this size (in kilobytes).
+    /// Do not create segments larger than this size (in kilobytes).
     /// Large segments might require disproportionately long indexation times,
     /// therefore it makes sense to limit the size of segments.
     ///

--- a/lib/edge/src/config/shard.rs
+++ b/lib/edge/src/config/shard.rs
@@ -49,7 +49,7 @@ pub struct EdgeConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hnsw_config: Option<HnswConfig>,
     /// Global quantization config for all vectors
-    /// Per-vector override in in `vectors[].quantization_config`
+    /// Per-vector override in `vectors[].quantization_config`
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub quantization_config: Option<QuantizationConfig>,
     /// `None` defaults to [`EdgeOptimizersConfig::default`], see [`EdgeConfig::optimizers`].

--- a/lib/segment/src/id_tracker/mutable_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/mutable_id_tracker/tests.rs
@@ -440,7 +440,7 @@ fn test_point_mappings_truncation() {
     );
     assert_eq!(fs::metadata(&mappings_path).unwrap().len(), 13);
 
-    // One entry and and one extra byte, file must be truncated
+    // One entry and one extra byte, file must be truncated
     fs::write(
         &mappings_path,
         b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x01",

--- a/lib/segment/src/json_path/mod.rs
+++ b/lib/segment/src/json_path/mod.rs
@@ -216,7 +216,7 @@ impl JsonPath {
 
     /// Check if the path will be affected by a call to `path_to_remove.value_remove(_)`.
     pub fn is_affected_by_value_remove(&self, path_to_remove: &JsonPath) -> bool {
-        // If we have, e.g., indexed field "a.b", then it is not safe to delete any of of "a",
+        // If we have, e.g., indexed field "a.b", then it is not safe to delete any of "a",
         // "a.b", or "a.b.c".
         path_to_remove.compatible(self)
     }

--- a/lib/segment/src/vector_storage/query_scorer/mod.rs
+++ b/lib/segment/src/vector_storage/query_scorer/mod.rs
@@ -113,7 +113,7 @@ fn score_multi<T: PrimitiveVectorElement, TMetric: Metric<T>>(
 /// TODO: For example
 ///
 /// - If the whole batch is less than one page - don't use prefetch
-/// - If one vector is bigger then the prefetch size - don't use prefetch
+/// - If one vector is bigger than the prefetch size - don't use prefetch
 /// - ???
 pub fn is_read_with_prefetch_efficient<O: VectorOffset>(ids: &[O]) -> bool {
     let mut min = usize::MAX;


### PR DESCRIPTION
**Files**: .github/review-rules.md, config/config.yaml, lib/collection/src/{optimizers_builder.rs, operations/config_diff.rs}, lib/api/src/grpc/{proto/collections.proto, qdrant.rs}, lib/segment/src/{vector_storage/query_scorer/mod.rs, json_path/mod.rs, id_tracker/mutable_id_tracker/tests.rs}

Comment/help-text-only fixes, no behavior changes:

- `mising` → `missing` in review-rules.md (already flagged by the repo's own codespell config)
- `Do not create segments larger this size` → `larger than this size` (config.yaml, optimizers_builder.rs, config_diff.rs, collections.proto and its generated copy qdrant.rs — kept in sync)
- `bigger then` → `bigger than` (query_scorer rustdoc)
- three duplicated-word rustdoc fixes (`override in in`, `any of of`, `and and`)

Transparency note per CONTRIBUTING "Contributing with AI": these commits are AI-assisted; each site was verified in context before patching.
