### PR TITLE
docs: update the dead careers link to the current job board

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -30,7 +30,7 @@ If you use Qdrant or Metric Learning in your projects, we'd love to hear your st
 
 For those familiar with Rust - check out our [contribution guide](../CONTRIBUTING.md).
 If you have problems with code or architecture understanding - reach us at any time.
-Feeling confident and want to contribute more? - Come to [work with us](https://qdrant.join.com/)!
+Feeling confident and want to contribute more? - Come to [work with us](https://jobs.ashbyhq.com/qdrant.tech)!
 
 ## Core Milestones
 

--- a/docs/roadmap/roadmap-2023.md
+++ b/docs/roadmap/roadmap-2023.md
@@ -24,7 +24,7 @@ If you use Qdrant or Metric Learning in your projects, we'd love to hear your st
 
 For those familiar with Rust - check out our [contribution guide](../CONTRIBUTING.md).
 If you have problems with code or architecture understanding - reach us at any time.
-Feeling confident and want to contribute more? - Come to [work with us](https://qdrant.join.com/)!
+Feeling confident and want to contribute more? - Come to [work with us](https://jobs.ashbyhq.com/qdrant.tech)!
 
 ## Milestones
 

--- a/docs/roadmap/roadmap-2024.md
+++ b/docs/roadmap/roadmap-2024.md
@@ -32,7 +32,7 @@ If you use Qdrant or Metric Learning in your projects, we'd love to hear your st
 
 For those familiar with Rust - check out our [contribution guide](../CONTRIBUTING.md).
 If you have problems with code or architecture understanding - reach us at any time.
-Feeling confident and want to contribute more? - Come to [work with us](https://qdrant.join.com/)!
+Feeling confident and want to contribute more? - Come to [work with us](https://jobs.ashbyhq.com/qdrant.tech)!
 
 ## Core Milestones
 


### PR DESCRIPTION
**Document**: docs/roadmap/README.md (+ 2024/2023 archives)

`https://qdrant.join.com/` redirects to a 404 page; the job board now lives at `https://jobs.ashbyhq.com/qdrant.tech`. Updated the roadmap pages, archives included for consistency.

Transparency note per CONTRIBUTING "Contributing with AI": AI-assisted change (the dead redirect was verified via HTTP check).
