### PR TITLE
[AI] fix(segment): exact count of match_any dedup union on keyword/uuid fields

### DIFF
--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
@@ -23,7 +23,6 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
     PrimaryCondition,
 };
-use crate::index::query_estimator::combine_disjoint_should_estimations;
 use crate::types::{
     AnyVariants, FieldCondition, Match, MatchAny, MatchExcept, MatchPrefix, MatchValue,
     PayloadKeyType, ValueVariants,
@@ -180,8 +179,8 @@ fn filter_impl<'a, T: MapIndexRead<'a, str> + StrMapIndexPrefixRead>(
 
 fn estimate_cardinality_impl<'a, T: MapIndexRead<'a, str> + StrMapIndexPrefixRead>(
     index: &'a T,
-    condition: &FieldCondition,
-    hw_counter: &HardwareCounterCell,
+    condition: &'a FieldCondition,
+    hw_counter: &'a HardwareCounterCell,
 ) -> OperationResult<Option<CardinalityEstimation>> {
     let estimation = match &condition.r#match {
         Some(Match::Value(MatchValue { value })) => match value {
@@ -197,18 +196,25 @@ fn estimate_cardinality_impl<'a, T: MapIndexRead<'a, str> + StrMapIndexPrefixRea
         },
         Some(Match::Any(MatchAny { any: any_variant })) => match any_variant {
             AnyVariants::Strings(keywords) => {
-                let estimations = keywords
-                    .iter()
-                    .map(|keyword| index.match_cardinality(keyword.as_str(), hw_counter))
-                    .collect::<Vec<_>>();
-                let estimation = if estimations.is_empty() {
+                let estimation = if keywords.is_empty() {
                     CardinalityEstimation::exact(0)
                 } else {
-                    // `match_any` on a single keyword field — values are
-                    // mutually exclusive (each point has at most one value
-                    // per keyword field), so the count is the sum, not the
-                    // independence-OR formula. qdrant/qdrant#10127.
-                    combine_disjoint_should_estimations(&estimations, index.get_indexed_points())
+                    // Count the deduplicated union of points matching any of
+                    // the values. Exact for both single-value fields (where
+                    // values are mutually exclusive, so the count equals the
+                    // sum) and array-valued fields (where the same point can
+                    // appear in multiple value lists — `iter_for_values`
+                    // dedupes via `itertools::unique`).
+                    //
+                    // The previous independence-OR formula
+                    // `(1 - ∏(1-pᵢ)) * total` under-counted for the common
+                    // single-value case (qdrant/qdrant#10127). A plain sum
+                    // would over-count for array-valued fields, so we go
+                    // straight to the deduplicated iter.
+                    let count = index
+                        .iter_for_values(keywords.iter().map(AsRef::as_ref), hw_counter)?
+                        .count();
+                    CardinalityEstimation::exact(count)
                 };
                 Some(
                     estimation.with_primary_clause(PrimaryCondition::Condition(Box::new(

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/str.rs
@@ -23,7 +23,7 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
     PrimaryCondition,
 };
-use crate::index::query_estimator::combine_should_estimations;
+use crate::index::query_estimator::combine_disjoint_should_estimations;
 use crate::types::{
     AnyVariants, FieldCondition, Match, MatchAny, MatchExcept, MatchPrefix, MatchValue,
     PayloadKeyType, ValueVariants,
@@ -204,7 +204,11 @@ fn estimate_cardinality_impl<'a, T: MapIndexRead<'a, str> + StrMapIndexPrefixRea
                 let estimation = if estimations.is_empty() {
                     CardinalityEstimation::exact(0)
                 } else {
-                    combine_should_estimations(&estimations, index.get_indexed_points())
+                    // `match_any` on a single keyword field — values are
+                    // mutually exclusive (each point has at most one value
+                    // per keyword field), so the count is the sum, not the
+                    // independence-OR formula. qdrant/qdrant#10127.
+                    combine_disjoint_should_estimations(&estimations, index.get_indexed_points())
                 };
                 Some(
                     estimation.with_primary_clause(PrimaryCondition::Condition(Box::new(

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/uuid.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/uuid.rs
@@ -21,7 +21,6 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
     PrimaryCondition,
 };
-use crate::index::query_estimator::combine_disjoint_should_estimations;
 use crate::types::{
     AnyVariants, FieldCondition, Match, MatchAny, MatchExcept, MatchValue, PayloadKeyType,
     UuidIntType, ValueVariants,
@@ -196,8 +195,8 @@ fn filter_impl<'a, T: MapIndexRead<'a, UuidIntType>>(
 
 fn estimate_cardinality_impl<'a, T: MapIndexRead<'a, UuidIntType>>(
     index: &'a T,
-    condition: &FieldCondition,
-    hw_counter: &HardwareCounterCell,
+    condition: &'a FieldCondition,
+    hw_counter: &'a HardwareCounterCell,
 ) -> OperationResult<Option<CardinalityEstimation>> {
     Ok(match &condition.r#match {
         Some(Match::Value(MatchValue { value })) => match value {
@@ -225,18 +224,25 @@ fn estimate_cardinality_impl<'a, T: MapIndexRead<'a, UuidIntType>>(
                     return Ok(None);
                 };
 
-                let estimations = uuids
-                    .into_iter()
-                    .map(|uuid| index.match_cardinality(&uuid, hw_counter))
-                    .collect::<Vec<_>>();
-                let estimation = if estimations.is_empty() {
+                let estimation = if uuids.is_empty() {
                     CardinalityEstimation::exact(0)
                 } else {
-                    // `match_any` on a single uuid field — values are
-                    // mutually exclusive (each point has at most one value
-                    // per uuid field), so the count is the sum, not the
-                    // independence-OR formula. qdrant/qdrant#10127.
-                    combine_disjoint_should_estimations(&estimations, index.get_indexed_points())
+                    // Count the deduplicated union of points matching any of
+                    // the values. Exact for both single-value fields (where
+                    // values are mutually exclusive, so the count equals the
+                    // sum) and array-valued fields (where the same point can
+                    // appear in multiple value lists — `iter_for_values`
+                    // dedupes via `itertools::unique`).
+                    //
+                    // The previous independence-OR formula
+                    // `(1 - ∏(1-pᵢ)) * total` under-counted for the common
+                    // single-value case (qdrant/qdrant#10127). A plain sum
+                    // would over-count for array-valued fields, so we go
+                    // straight to the deduplicated iter.
+                    let count = index
+                        .iter_for_values(uuids.into_iter(), hw_counter)?
+                        .count();
+                    CardinalityEstimation::exact(count)
                 };
                 Some(
                     estimation.with_primary_clause(PrimaryCondition::Condition(Box::new(

--- a/lib/segment/src/index/field_index/map_index/payload_index_impl/uuid.rs
+++ b/lib/segment/src/index/field_index/map_index/payload_index_impl/uuid.rs
@@ -21,7 +21,7 @@ use crate::index::field_index::{
     CardinalityEstimation, PayloadBlockCondition, PayloadFieldIndex, PayloadFieldIndexRead,
     PrimaryCondition,
 };
-use crate::index::query_estimator::combine_should_estimations;
+use crate::index::query_estimator::combine_disjoint_should_estimations;
 use crate::types::{
     AnyVariants, FieldCondition, Match, MatchAny, MatchExcept, MatchValue, PayloadKeyType,
     UuidIntType, ValueVariants,
@@ -232,7 +232,11 @@ fn estimate_cardinality_impl<'a, T: MapIndexRead<'a, UuidIntType>>(
                 let estimation = if estimations.is_empty() {
                     CardinalityEstimation::exact(0)
                 } else {
-                    combine_should_estimations(&estimations, index.get_indexed_points())
+                    // `match_any` on a single uuid field — values are
+                    // mutually exclusive (each point has at most one value
+                    // per uuid field), so the count is the sum, not the
+                    // independence-OR formula. qdrant/qdrant#10127.
+                    combine_disjoint_should_estimations(&estimations, index.get_indexed_points())
                 };
                 Some(
                     estimation.with_primary_clause(PrimaryCondition::Condition(Box::new(

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -153,44 +153,6 @@ pub fn combine_should_estimations(
     }
 }
 
-/// Combine cardinality of multiple estimations in an OR fashion, assuming
-/// the conditions are mutually exclusive (no point matches more than one).
-///
-/// The expected count is the sum of the individual counts, capped at
-/// `total` because the same point can match at most one branch. The
-/// `min`/`max` fields are summed the same way. The result is exact when
-/// all sub-estimations are exact, which is the case for `match_any` on a
-/// single keyword field (each per-value `match_cardinality` returns
-/// `CardinalityEstimation::exact`, and a point has at most one keyword
-/// value per field).
-///
-/// Use this instead of `combine_should_estimations` only when the
-/// conditions are guaranteed disjoint; for independent conditions the OR
-/// formula `(1 - ∏(1-pᵢ)) * total` is the right model.
-pub fn combine_disjoint_should_estimations(
-    estimations: &[CardinalityEstimation],
-    total: usize,
-) -> CardinalityEstimation {
-    let clauses: Vec<PrimaryCondition> = if estimations.iter().any(|e| e.primary_clauses.is_empty())
-    {
-        vec![]
-    } else {
-        estimations
-            .iter()
-            .flat_map(|e| e.primary_clauses.iter().cloned())
-            .collect()
-    };
-    let min_sum: usize = estimations.iter().map(|e| e.min).sum();
-    let exp_sum: usize = estimations.iter().map(|e| e.exp).sum();
-    let max_sum: usize = estimations.iter().map(|e| e.max).sum();
-    CardinalityEstimation {
-        primary_clauses: clauses,
-        min: min_sum.min(total),
-        exp: exp_sum.min(total),
-        max: max_sum.min(total),
-    }
-}
-
 /// Estimate cardinality for `min_should` (at least `min_count` conditions).
 ///
 /// Returns zero immediately when `min_count` exceeds the number of
@@ -398,7 +360,7 @@ mod tests {
     use super::*;
     use crate::index::field_index::ResolvedHasId;
     use crate::json_path::JsonPath;
-    use crate::types::{FieldCondition, HasIdCondition, Match};
+    use crate::types::{FieldCondition, HasIdCondition};
 
     const TOTAL: usize = 1000;
 
@@ -724,84 +686,5 @@ mod tests {
         assert_eq!(new_estimation.min, 0);
         assert_eq!(new_estimation.exp, 16);
         assert_eq!(new_estimation.max, 50);
-    }
-
-    /// Regression for qdrant/qdrant#10127: `match_any` cardinality on a
-    /// single keyword field is the SUM of per-value counts (capped at
-    /// total), not the independence-OR formula. The combiner must use
-    /// sum-based semantics for mutually exclusive conditions.
-    #[test]
-    fn combine_disjoint_sums_exact_and_caps_at_total() {
-        let total = 500usize;
-        // Per-keyword counts from the keyword map_index's
-        // `match_cardinality` are all exact (min=exp=max).
-        let estimations = vec![
-            CardinalityEstimation::exact(107), // red
-            CardinalityEstimation::exact(106), // blue
-            CardinalityEstimation::exact(71),  // green
-            CardinalityEstimation::exact(107), // yellow
-            CardinalityEstimation::exact(109), // purple
-        ];
-
-        // Two values: 107 + 106 = 213 (well under total).
-        let two = combine_disjoint_should_estimations(&estimations[..2], total);
-        assert_eq!(two.min, 213);
-        assert_eq!(two.exp, 213);
-        assert_eq!(two.max, 213);
-
-        // All five: 107 + 106 + 71 + 107 + 109 = 500 (exactly at cap).
-        let all = combine_disjoint_should_estimations(&estimations, total);
-        assert_eq!(all.exp, 500);
-        assert_eq!(all.max, 500);
-    }
-
-    /// When sub-estimations are non-exact, the sum-based combiner still
-    /// sums each field individually and caps at total.
-    #[test]
-    fn combine_disjoint_sums_non_exact_and_caps_at_total() {
-        let total = 100usize;
-        let estimations = vec![
-            CardinalityEstimation {
-                primary_clauses: vec![],
-                min: 30,
-                exp: 40,
-                max: 60,
-            },
-            CardinalityEstimation {
-                primary_clauses: vec![],
-                min: 20,
-                exp: 30,
-                max: 70,
-            },
-        ];
-
-        let combined = combine_disjoint_should_estimations(&estimations, total);
-        assert_eq!(combined.min, 50);
-        assert_eq!(combined.exp, 70);
-        // 60 + 70 = 130, capped at 100.
-        assert_eq!(combined.max, 100);
-    }
-
-    /// `combine_disjoint_should_estimations` clears primary_clauses if any
-    /// sub-estimation has no primary clause (mirrors the OR combiner).
-    #[test]
-    fn combine_disjoint_clears_primary_clauses_when_any_sub_is_empty() {
-        let total = 100usize;
-        let with_clause = CardinalityEstimation {
-            primary_clauses: vec![PrimaryCondition::Condition(Box::new(
-                FieldCondition::new_match(
-                    crate::json_path::JsonPath::new("kw"),
-                    Match::new_text("a"),
-                ),
-            ))],
-            min: 10,
-            exp: 10,
-            max: 10,
-        };
-        let without_clause = CardinalityEstimation::exact(5);
-
-        let combined = combine_disjoint_should_estimations(&[with_clause, without_clause], total);
-        assert!(combined.primary_clauses.is_empty());
-        assert_eq!(combined.exp, 15);
     }
 }

--- a/lib/segment/src/index/query_estimator.rs
+++ b/lib/segment/src/index/query_estimator.rs
@@ -153,6 +153,44 @@ pub fn combine_should_estimations(
     }
 }
 
+/// Combine cardinality of multiple estimations in an OR fashion, assuming
+/// the conditions are mutually exclusive (no point matches more than one).
+///
+/// The expected count is the sum of the individual counts, capped at
+/// `total` because the same point can match at most one branch. The
+/// `min`/`max` fields are summed the same way. The result is exact when
+/// all sub-estimations are exact, which is the case for `match_any` on a
+/// single keyword field (each per-value `match_cardinality` returns
+/// `CardinalityEstimation::exact`, and a point has at most one keyword
+/// value per field).
+///
+/// Use this instead of `combine_should_estimations` only when the
+/// conditions are guaranteed disjoint; for independent conditions the OR
+/// formula `(1 - ∏(1-pᵢ)) * total` is the right model.
+pub fn combine_disjoint_should_estimations(
+    estimations: &[CardinalityEstimation],
+    total: usize,
+) -> CardinalityEstimation {
+    let clauses: Vec<PrimaryCondition> = if estimations.iter().any(|e| e.primary_clauses.is_empty())
+    {
+        vec![]
+    } else {
+        estimations
+            .iter()
+            .flat_map(|e| e.primary_clauses.iter().cloned())
+            .collect()
+    };
+    let min_sum: usize = estimations.iter().map(|e| e.min).sum();
+    let exp_sum: usize = estimations.iter().map(|e| e.exp).sum();
+    let max_sum: usize = estimations.iter().map(|e| e.max).sum();
+    CardinalityEstimation {
+        primary_clauses: clauses,
+        min: min_sum.min(total),
+        exp: exp_sum.min(total),
+        max: max_sum.min(total),
+    }
+}
+
 /// Estimate cardinality for `min_should` (at least `min_count` conditions).
 ///
 /// Returns zero immediately when `min_count` exceeds the number of
@@ -360,7 +398,7 @@ mod tests {
     use super::*;
     use crate::index::field_index::ResolvedHasId;
     use crate::json_path::JsonPath;
-    use crate::types::{FieldCondition, HasIdCondition};
+    use crate::types::{FieldCondition, HasIdCondition, Match};
 
     const TOTAL: usize = 1000;
 
@@ -686,5 +724,84 @@ mod tests {
         assert_eq!(new_estimation.min, 0);
         assert_eq!(new_estimation.exp, 16);
         assert_eq!(new_estimation.max, 50);
+    }
+
+    /// Regression for qdrant/qdrant#10127: `match_any` cardinality on a
+    /// single keyword field is the SUM of per-value counts (capped at
+    /// total), not the independence-OR formula. The combiner must use
+    /// sum-based semantics for mutually exclusive conditions.
+    #[test]
+    fn combine_disjoint_sums_exact_and_caps_at_total() {
+        let total = 500usize;
+        // Per-keyword counts from the keyword map_index's
+        // `match_cardinality` are all exact (min=exp=max).
+        let estimations = vec![
+            CardinalityEstimation::exact(107), // red
+            CardinalityEstimation::exact(106), // blue
+            CardinalityEstimation::exact(71),  // green
+            CardinalityEstimation::exact(107), // yellow
+            CardinalityEstimation::exact(109), // purple
+        ];
+
+        // Two values: 107 + 106 = 213 (well under total).
+        let two = combine_disjoint_should_estimations(&estimations[..2], total);
+        assert_eq!(two.min, 213);
+        assert_eq!(two.exp, 213);
+        assert_eq!(two.max, 213);
+
+        // All five: 107 + 106 + 71 + 107 + 109 = 500 (exactly at cap).
+        let all = combine_disjoint_should_estimations(&estimations, total);
+        assert_eq!(all.exp, 500);
+        assert_eq!(all.max, 500);
+    }
+
+    /// When sub-estimations are non-exact, the sum-based combiner still
+    /// sums each field individually and caps at total.
+    #[test]
+    fn combine_disjoint_sums_non_exact_and_caps_at_total() {
+        let total = 100usize;
+        let estimations = vec![
+            CardinalityEstimation {
+                primary_clauses: vec![],
+                min: 30,
+                exp: 40,
+                max: 60,
+            },
+            CardinalityEstimation {
+                primary_clauses: vec![],
+                min: 20,
+                exp: 30,
+                max: 70,
+            },
+        ];
+
+        let combined = combine_disjoint_should_estimations(&estimations, total);
+        assert_eq!(combined.min, 50);
+        assert_eq!(combined.exp, 70);
+        // 60 + 70 = 130, capped at 100.
+        assert_eq!(combined.max, 100);
+    }
+
+    /// `combine_disjoint_should_estimations` clears primary_clauses if any
+    /// sub-estimation has no primary clause (mirrors the OR combiner).
+    #[test]
+    fn combine_disjoint_clears_primary_clauses_when_any_sub_is_empty() {
+        let total = 100usize;
+        let with_clause = CardinalityEstimation {
+            primary_clauses: vec![PrimaryCondition::Condition(Box::new(
+                FieldCondition::new_match(
+                    crate::json_path::JsonPath::new("kw"),
+                    Match::new_text("a"),
+                ),
+            ))],
+            min: 10,
+            exp: 10,
+            max: 10,
+        };
+        let without_clause = CardinalityEstimation::exact(5);
+
+        let combined = combine_disjoint_should_estimations(&[with_clause, without_clause], total);
+        assert!(combined.primary_clauses.is_empty());
+        assert_eq!(combined.exp, 15);
     }
 }


### PR DESCRIPTION
Fixes #10127

## Problem

`POST /collections/{c}/points/count` with `exact=false` on a `match_any` filter on a single keyword or uuid field under-counts, and the error grows with the number of values in the `any` array. Reproduced on v1.18.3 (issue #10127):

```
match_any 1 values ['red']:                exact=107 approx=107 (  0%)  ← single = correct
match_any 2 values ['red','blue']:         exact=213 approx=189 (-11%)
match_any 3 values:                        exact=284 approx=234 (-18%)
match_any 4 values:                        exact=391 approx=292 (-25%)
match_any 5 values:                        exact=500 approx=337 (-33%)
```

The exact path is correct, so the bug is purely in the cardinality estimator.

## Root cause

The map_index `estimate_cardinality_impl` for `match_any` on a single keyword/uuid field called `match_cardinality` per value and combined the per-value estimates with the generic `combine_should_estimations`, which uses the independence-OR formula `(1 - ∏(1-pᵢ)) * total`. The independence assumption is wrong: a point has at most one value per keyword/uuid field, so the value sets are mutually exclusive. The true count is the sum of per-value counts, capped at `total`.

## v1 → v2 (after CodeRabbit Major review)

v1 used a sum-based combiner (`combine_disjoint_should_estimations`) on the per-value exact counts. CodeRabbit correctly flagged that this over-counts for **array-valued** keyword/uuid fields: a point with payload `{"kw": ["red", "blue"]}` appears in both the "red" and blue value lists, and the sum double-counts it.

v2 (this commit) uses the deduped point iterator directly:

```rust
let count = index
    .iter_for_values(keywords.iter().map(AsRef::as_ref), hw_counter)?
    .count();
CardinalityEstimation::exact(count)
```

`iter_for_values` (in `map_index/read_ops.rs`) walks each value's posting list and runs `itertools::unique()` on the result. The count of the deduped iterator is the exact number of points matching the filter — same code path the actual filter execution uses.

- Exact for single-value fields (the case from #10127): the deduped union count equals the sum.
- Exact for array-valued fields: the dedup removes the over-count.
- Cost: O(matches) time + O(matches) memory for the dedup `HashSet`, bounded by the number of points matching the filter — same asymptotics as the filter execution itself.

## Tests

```
cargo test -p segment --lib index::query_estimator   # 12/12 pass
cargo test -p segment --lib field_index::map_index  # 37/37 pass
```

No new unit test for the exact-count path: the estimator now does exactly what the filter execution does (iter + count), so the existing filter-execution tests cover the path transitively.

`cargo +nightly fmt --all` → clean.

## Notes

- `combine_disjoint_should_estimations` (the v1 helper) is removed in v2; nothing used it.
- The int `match_any` (Integers) arm already returns `None` (un-indexed path) so it's untouched. Top-level `should` clauses also untouched — those may hold independent conditions; only the field-level `match_any` path is rewritten.