### PR TITLE
[updater] parallelize `StoreComponents::open`

### DIFF
--- a/lib/segment/src/index/struct_payload_index/update_only/mod.rs
+++ b/lib/segment/src/index/struct_payload_index/update_only/mod.rs
@@ -9,7 +9,7 @@ use ahash::AHashMap;
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::{UniversalAppend, UniversalAppendFs};
-use rayon::iter::{IntoParallelIterator as _, ParallelIterator as _};
+use rayon::iter::{IntoParallelIterator as _, IntoParallelRefIterator, ParallelIterator as _};
 
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::UpdateOnlyFieldIndex;
@@ -41,7 +41,7 @@ impl<S: UniversalAppend + 'static> UpdateOnlyStructPayloadIndex<S> {
     /// is a config from before those types were recorded, which only the
     /// writable index can repair, by deriving them from the schema on its next
     /// open.
-    pub fn open(
+    pub fn par_open(
         fs: &impl UniversalAppendFs<AppendFile = S>,
         segment_path: &Path,
     ) -> OperationResult<Self> {
@@ -49,25 +49,30 @@ impl<S: UniversalAppend + 'static> UpdateOnlyStructPayloadIndex<S> {
         let config = PayloadConfig::load_universal(fs, &PayloadConfig::get_config_path(&path))?
             .unwrap_or_default();
 
-        let mut field_indexes = AHashMap::with_capacity(config.indices.len());
-        for (field, indexed) in config.indices.iter() {
-            if indexed.types.is_empty() {
-                return Err(OperationError::service_error(format!(
-                    "Payload index of field {field} does not record which indexes it has; \
-                     open the segment for writing once to have them derived and stored",
-                )));
-            }
+        let field_indexes = config
+            .indices
+            .par_iter()
+            .map(|(field, indexed)| {
+                if indexed.types.is_empty() {
+                    return Err(OperationError::service_error(format!(
+                        "Payload index of field {field} does not record which indexes it has; \
+                         open the segment for writing once to have them derived and stored",
+                    )));
+                }
 
-            let indexes = indexed
-                .types
-                .iter()
-                .map(|index_type| {
-                    UpdateOnlyFieldIndex::open(fs, &path, field, &indexed.schema, index_type)
-                })
-                .collect::<OperationResult<Vec<_>>>()?;
+                let indexes = indexed
+                    .types
+                    .par_iter()
+                    .map(|index_type| {
+                        UpdateOnlyFieldIndex::open(fs, &path, field, &indexed.schema, index_type)
+                    })
+                    .collect::<OperationResult<Vec<_>>>()?;
 
-            field_indexes.insert(field.clone(), indexes);
-        }
+                Ok((field.clone(), indexes))
+            })
+            .collect::<OperationResult<Vec<_>>>()?
+            .into_iter()
+            .collect();
 
         Ok(Self { field_indexes })
     }

--- a/lib/segment/src/index/struct_payload_index/update_only/tests.rs
+++ b/lib/segment/src/index/struct_payload_index/update_only/tests.rs
@@ -73,7 +73,7 @@ fn batch_reaches_every_index_of_a_field() {
         payload_json! { "f": null },
     ];
 
-    let mut index = Index::open(&MmapFs, dir.path()).unwrap();
+    let mut index = Index::par_open(&MmapFs, dir.path()).unwrap();
     index
         .par_append_many(
             &MmapFs,
@@ -129,7 +129,7 @@ fn batches_resume() {
 
     for (slot, value) in [(0, "alpha"), (1, "beta")] {
         let payload = payload_json! { "f": value };
-        let mut index = Index::open(&MmapFs, dir.path()).unwrap();
+        let mut index = Index::par_open(&MmapFs, dir.path()).unwrap();
         index
             .par_append_many(&MmapFs, [(slot, &payload)], &hw_counter)
             .unwrap();
@@ -172,7 +172,7 @@ fn segment_without_indexes_opens_empty() {
     let hw_counter = HardwareCounterCell::new();
 
     let payload = payload_json! { "f": "alpha" };
-    let mut index = Index::open(&MmapFs, dir.path()).unwrap();
+    let mut index = Index::par_open(&MmapFs, dir.path()).unwrap();
     index
         .par_append_many(&MmapFs, [(0, &payload)], &hw_counter)
         .unwrap();
@@ -185,7 +185,7 @@ fn undeclared_index_types_are_refused() {
     let dir = TempDir::with_prefix("update_only_struct_index").unwrap();
     write_config(dir.path(), vec![]);
 
-    let Err(err) = Index::open(&MmapFs, dir.path()) else {
+    let Err(err) = Index::par_open(&MmapFs, dir.path()) else {
         panic!("a field with no declared index types must be refused");
     };
     assert!(

--- a/lib/segment/src/segment/update_only/appendable/mod.rs
+++ b/lib/segment/src/segment/update_only/appendable/mod.rs
@@ -8,7 +8,9 @@ use common::counter::hardware_counter::HardwareCounterCell;
 use common::types::PointOffsetType;
 use common::universal_io::{CachedFs, CachedReadFs, UniversalAppendFs};
 use rayon::ThreadPool;
-use rayon::iter::{IntoParallelRefMutIterator as _, ParallelIterator as _};
+use rayon::iter::{
+    IntoParallelRefIterator, IntoParallelRefMutIterator as _, ParallelIterator as _,
+};
 
 use super::AppendableIdTrackerState;
 use crate::common::operation_error::OperationResult;
@@ -106,32 +108,73 @@ impl<Fs: UniversalAppendFs> VectorComponents<Fs> {
 }
 
 impl<Fs: UniversalAppendFs> StoreComponents<Fs> {
-    fn open(fs: &Fs, segment_path: &Path, config: &SegmentConfig) -> OperationResult<Self> {
-        let payload_storage = UpdateOnlyPayloadStorage::open(fs, segment_path)?;
-        let payload_indexes = UpdateOnlyStructPayloadIndex::open(fs, segment_path)?;
+    fn open(
+        fs: &Fs,
+        pool: &rayon::ThreadPool,
+        segment_path: &Path,
+        config: &SegmentConfig,
+    ) -> OperationResult<Self> {
+        let mut payload_storage = None;
+        let mut payload_indexes = None;
+        let mut dense_vectors: OperationResult<Vec<_>> = Ok(Vec::new());
+        let mut sparse_vectors: OperationResult<Vec<_>> = Ok(Vec::new());
+        pool.scope(|s| {
+            s.spawn(|_| {
+                payload_storage = Some(UpdateOnlyPayloadStorage::open(fs, segment_path));
+            });
+            s.spawn(|_| {
+                payload_indexes = Some(UpdateOnlyStructPayloadIndex::par_open(fs, segment_path));
+            });
 
-        let mut vectors =
-            Vec::with_capacity(config.vector_data.len() + config.sparse_vector_data.len());
-        for (vector_name, vector_config) in &config.vector_data {
-            let path = get_vector_storage_path(segment_path, vector_name);
-            let components = VectorComponents {
-                storage: UpdateOnlyVectorStorage::open(fs, &path, vector_config)?,
-                quantized: UpdateOnlyQuantizedVectors::open(fs.clone(), &path, vector_config)?,
-            };
-            vectors.push((vector_name.clone(), components));
-        }
-        for vector_name in config.sparse_vector_data.keys() {
-            let path = get_vector_storage_path(segment_path, vector_name);
-            let components = VectorComponents {
-                storage: UpdateOnlyVectorStorage::open_sparse(fs, &path)?,
-                quantized: None,
-            };
-            vectors.push((vector_name.clone(), components));
-        }
+            s.spawn(|_| {
+                dense_vectors = config
+                    .vector_data
+                    .par_iter()
+                    .map(|(vector_name, vector_config)| {
+                        let path = get_vector_storage_path(segment_path, vector_name);
+
+                        let (original, quantized) = rayon::join(
+                            || UpdateOnlyVectorStorage::<Fs::File>::open(fs, &path, vector_config),
+                            || {
+                                UpdateOnlyQuantizedVectors::<Fs>::open(
+                                    fs.clone(),
+                                    &path,
+                                    vector_config,
+                                )
+                            },
+                        );
+
+                        let components = VectorComponents {
+                            storage: original?,
+                            quantized: quantized?,
+                        };
+                        Ok((vector_name.clone(), components))
+                    })
+                    .collect();
+            });
+
+            s.spawn(|_| {
+                sparse_vectors = config
+                    .sparse_vector_data
+                    .par_iter()
+                    .map(|(vector_name, _config)| {
+                        let path = get_vector_storage_path(segment_path, vector_name);
+                        let components = VectorComponents {
+                            storage: UpdateOnlyVectorStorage::open_sparse(fs, &path)?,
+                            quantized: None,
+                        };
+                        Ok((vector_name.clone(), components))
+                    })
+                    .collect();
+            });
+        });
+
+        let mut vectors = dense_vectors?;
+        vectors.extend(sparse_vectors?);
 
         Ok(Self {
-            payload_storage,
-            payload_indexes,
+            payload_storage: payload_storage.expect("rayon finished")?,
+            payload_indexes: payload_indexes.expect("rayon finished")?,
             vectors,
         })
     }
@@ -179,10 +222,12 @@ impl<Fs: UniversalAppendFs> AppendableSegment<Fs> {
     /// borrow can still pass it down per call.
     fn store_components(
         &mut self,
+        pool: &rayon::ThreadPool,
     ) -> OperationResult<(&CachedFs<Fs>, &mut StoreComponents<CachedFs<Fs>>)> {
         if self.store.is_none() {
             self.store = Some(StoreComponents::open(
                 &self.fs,
+                pool,
                 &self.segment_path,
                 &self.config,
             )?);
@@ -213,7 +258,7 @@ impl<Fs: UniversalAppendFs> AppendableSegment<Fs> {
         let inserted = self.id_tracker.insert_operations(&self.fs, &operations)?;
         let (_, start_slot) = *inserted.first().expect("one slot per insert");
 
-        let (fs, store) = self.store_components()?;
+        let (fs, store) = self.store_components(pool)?;
 
         // One cell per task, off the accumulator: the cell itself is not Sync
         let hw_acc = hw_counter.new_accumulator();


### PR DESCRIPTION
Since `UniversalWriteFileOps::open_append` is not designed to work with `CachedFs` (no `OpenExtra` is accepted by design), we can't do the same `preopen` shenanigans we did for `ReadOnly` or `Lookup` segments. 

Instead, of using LIST/`CachedFs` optimization, this PR enables parallel opening within a `rayon::ThreadPool`. 

Small disclaimer: id-tracker is not included in this parallelization to honor the optimization of being able to NOT open `StoreComponents` if not necessary.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>