### PR TITLE
Add SEFR relevance feedback strategy

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -15679,6 +15679,9 @@
         "anyOf": [
           {
             "$ref": "#/components/schemas/NaiveFeedbackStrategy"
+          },
+          {
+            "$ref": "#/components/schemas/SefrFeedbackStrategy"
           }
         ]
       },
@@ -15713,6 +15716,35 @@
           "c": {
             "type": "number",
             "format": "float"
+          }
+        }
+      },
+      "SefrFeedbackStrategy": {
+        "type": "object",
+        "required": [
+          "sefr"
+        ],
+        "properties": {
+          "sefr": {
+            "$ref": "#/components/schemas/SefrFeedbackStrategyParams"
+          }
+        }
+      },
+      "SefrFeedbackStrategyParams": {
+        "description": "Fits a SEFR classifier on the feedback and searches with the learned direction. Requires dense vectors and a `Dot` or `Cosine` distance.\n\nThe classifier is fit on the feedback items alone, so it needs roughly eight of them before it ranks well; with fewer, blend in the original query via `target_weight`.",
+        "type": "object",
+        "properties": {
+          "threshold": {
+            "description": "Feedback items scoring above this value form the positive class. Defaults to the mean of the feedback scores.",
+            "type": "number",
+            "format": "float",
+            "nullable": true
+          },
+          "target_weight": {
+            "description": "Relative influence of the original query vector against the learned direction, which is matched in magnitude first so that a given weight means the same thing across queries. Defaults to `0`, which uses the learned direction alone. Useful values run from about `0.01` to `1`.",
+            "type": "number",
+            "format": "float",
+            "nullable": true
           }
         }
       },

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -400,6 +400,11 @@ fn configure_validation(builder: Builder) -> Builder {
         ], &[
             "SparseVectorCreationConfig",
         ])
+        // Cross-field SEFR rule: strategy alone cannot see the feedback length.
+        .type_attribute(
+            "RelevanceFeedbackInput",
+            "#[validate(schema(function = \"crate::grpc::validate::validate_relevance_feedback_input\"))]",
+        )
         .type_attribute(".", "#[derive(serde::Serialize)]")
         // Service: points_internal_service.proto
         .validates(&[

--- a/lib/api/src/grpc/proto/points.proto
+++ b/lib/api/src/grpc/proto/points.proto
@@ -907,6 +907,8 @@ message FeedbackStrategy {
   oneof variant {
     // a * score + sim(confidence^b * c * delta)
     NaiveFeedbackStrategy naive = 1;
+    // Fit a SEFR classifier on the feedback and search with the learned direction
+    SefrFeedbackStrategy sefr = 2;
   }
 }
 
@@ -914,6 +916,15 @@ message NaiveFeedbackStrategy {
   float a = 1;
   float b = 2;
   float c = 3;
+}
+
+// Requires dense vectors and a Dot or Cosine distance. Needs roughly eight feedback
+// items before it ranks well; with fewer, blend in the original query via target_weight.
+message SefrFeedbackStrategy {
+  // Feedback items scoring above this value form the positive class. Defaults to the mean of the feedback scores.
+  optional float threshold = 1;
+  // Relative influence of the original query vector against the learned direction, matched in magnitude first. Defaults to 0. Useful values run from about 0.01 to 1.
+  optional float target_weight = 2;
 }
 
 enum Fusion {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -6498,6 +6498,9 @@ pub struct ContextInput {
     pub pairs: ::prost::alloc::vec::Vec<ContextInputPair>,
 }
 #[derive(validator::Validate)]
+#[validate(
+    schema(function = "crate::grpc::validate::validate_relevance_feedback_input")
+)]
 #[derive(serde::Serialize)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RelevanceFeedbackInput {

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -6530,7 +6530,7 @@ pub struct FeedbackItem {
 #[derive(serde::Serialize)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct FeedbackStrategy {
-    #[prost(oneof = "feedback_strategy::Variant", tags = "1")]
+    #[prost(oneof = "feedback_strategy::Variant", tags = "1, 2")]
     #[validate(nested)]
     pub variant: ::core::option::Option<feedback_strategy::Variant>,
 }
@@ -6542,6 +6542,9 @@ pub mod feedback_strategy {
         /// a * score + sim(confidence^b * c * delta)
         #[prost(message, tag = "1")]
         Naive(super::NaiveFeedbackStrategy),
+        /// Fit a SEFR classifier on the feedback and search with the learned direction
+        #[prost(message, tag = "2")]
+        Sefr(super::SefrFeedbackStrategy),
     }
 }
 #[derive(validator::Validate)]
@@ -6555,6 +6558,18 @@ pub struct NaiveFeedbackStrategy {
     pub b: f32,
     #[prost(float, tag = "3")]
     pub c: f32,
+}
+/// Requires dense vectors and a Dot or Cosine distance. Needs roughly eight feedback
+/// items before it ranks well; with fewer, blend in the original query via target_weight.
+#[derive(serde::Serialize)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+pub struct SefrFeedbackStrategy {
+    /// Feedback items scoring above this value form the positive class. Defaults to the mean of the feedback scores.
+    #[prost(float, optional, tag = "1")]
+    pub threshold: ::core::option::Option<f32>,
+    /// Relative influence of the original query vector against the learned direction, matched in magnitude first. Defaults to 0. Useful values run from about 0.01 to 1.
+    #[prost(float, optional, tag = "2")]
+    pub target_weight: ::core::option::Option<f32>,
 }
 #[derive(validator::Validate)]
 #[derive(serde::Serialize)]

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -486,6 +486,8 @@ impl Validate for grpc::feedback_strategy::Variant {
             grpc::feedback_strategy::Variant::Naive(naive_feedback_strategy) => {
                 naive_feedback_strategy.validate()
             }
+            // Neither SEFR parameter is range-constrained.
+            grpc::feedback_strategy::Variant::Sefr(_) => Ok(()),
         }
     }
 }

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -486,10 +486,57 @@ impl Validate for grpc::feedback_strategy::Variant {
             grpc::feedback_strategy::Variant::Naive(naive_feedback_strategy) => {
                 naive_feedback_strategy.validate()
             }
-            // Neither SEFR parameter is range-constrained.
-            grpc::feedback_strategy::Variant::Sefr(_) => Ok(()),
+            // The "at least two feedback items" rule lives on
+            // [`validate_relevance_feedback_input`], because the strategy
+            // variant cannot see the feedback collection.
+            grpc::feedback_strategy::Variant::Sefr(sefr) => validate_sefr_feedback_strategy(sefr),
         }
     }
+}
+
+/// Reject non-finite `threshold` / `target_weight` before they reach conversion.
+fn validate_sefr_feedback_strategy(
+    sefr: &grpc::SefrFeedbackStrategy,
+) -> Result<(), ValidationErrors> {
+    let mut errors = ValidationErrors::new();
+
+    if sefr.threshold.is_some_and(|value| !value.is_finite()) {
+        errors.add("threshold", ValidationError::new("must be finite"));
+    }
+    if sefr.target_weight.is_some_and(|value| !value.is_finite()) {
+        errors.add("target_weight", ValidationError::new("must be finite"));
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+/// Struct-level check for gRPC `RelevanceFeedbackInput`, mirroring the REST
+/// `validate_relevance_feedback_input`. Failures surface as `INVALID_ARGUMENT`.
+pub fn validate_relevance_feedback_input(
+    relevance_feedback_input: &grpc::RelevanceFeedbackInput,
+) -> Result<(), ValidationError> {
+    let is_sefr = matches!(
+        relevance_feedback_input
+            .strategy
+            .as_ref()
+            .and_then(|s| s.variant.as_ref()),
+        Some(grpc::feedback_strategy::Variant::Sefr(_))
+    );
+
+    // SEFR separates two classes, which a single item can never form.
+    if is_sefr && relevance_feedback_input.feedback.len() < 2 {
+        let mut err = ValidationError::new("feedback");
+        err.message = Some(Cow::from(
+            "the `sefr` strategy needs at least two feedback elements to separate",
+        ));
+        return Err(err);
+    }
+
+    Ok(())
 }
 
 /// Validate that GeoLineString has at least 4 points and is closed.
@@ -608,8 +655,10 @@ mod tests {
 
     use crate::grpc::qdrant::{
         CreateCollection, CreateFieldIndexCollection, CreateVectorNameRequest, DenseVector,
-        DenseVectorCreationConfig, FieldCondition, GeoBoundingBox, GeoLineString, GeoPoint,
-        GeoPolygon, GeoRadius, SearchPoints, UpdateCollection, create_vector_name_request, vector,
+        DenseVectorCreationConfig, FeedbackItem, FeedbackStrategy, FieldCondition, GeoBoundingBox,
+        GeoLineString, GeoPoint, GeoPolygon, GeoRadius, RelevanceFeedbackInput, SearchPoints,
+        SefrFeedbackStrategy, UpdateCollection, VectorInput, create_vector_name_request,
+        feedback_strategy, vector, vector_input,
     };
 
     #[test]
@@ -989,5 +1038,88 @@ mod tests {
             ..Default::default()
         };
         assert!(good_request.validate().is_ok());
+    }
+
+    fn dense_input(data: Vec<f32>) -> VectorInput {
+        VectorInput {
+            variant: Some(vector_input::Variant::Dense(DenseVector { data })),
+        }
+    }
+
+    fn sefr_feedback(feedback: Vec<FeedbackItem>) -> RelevanceFeedbackInput {
+        RelevanceFeedbackInput {
+            target: Some(dense_input(vec![1.0, 0.0])),
+            feedback,
+            strategy: Some(FeedbackStrategy {
+                variant: Some(feedback_strategy::Variant::Sefr(SefrFeedbackStrategy {
+                    threshold: None,
+                    target_weight: None,
+                })),
+            }),
+        }
+    }
+
+    #[test]
+    fn sefr_relevance_feedback_rejects_fewer_than_two_items() {
+        let one_item = sefr_feedback(vec![FeedbackItem {
+            example: Some(dense_input(vec![1.0, 0.0])),
+            score: 1.0,
+        }]);
+        let err = one_item
+            .validate()
+            .expect_err("one feedback item must fail");
+        let rendered = err.to_string();
+        assert!(
+            rendered
+                .contains("the `sefr` strategy needs at least two feedback elements to separate"),
+            "unexpected validation error: {rendered}",
+        );
+    }
+
+    #[test]
+    fn sefr_relevance_feedback_accepts_two_items() {
+        let two_items = sefr_feedback(vec![
+            FeedbackItem {
+                example: Some(dense_input(vec![1.0, 0.0])),
+                score: 1.0,
+            },
+            FeedbackItem {
+                example: Some(dense_input(vec![0.0, 1.0])),
+                score: 0.0,
+            },
+        ]);
+        assert!(two_items.validate().is_ok());
+    }
+
+    #[test]
+    fn sefr_strategy_rejects_non_finite_parameters() {
+        for (threshold, target_weight) in [
+            (Some(f32::NAN), None),
+            (Some(f32::INFINITY), None),
+            (None, Some(f32::NAN)),
+            (None, Some(f32::NEG_INFINITY)),
+            (Some(f32::NAN), Some(f32::INFINITY)),
+        ] {
+            let strategy = feedback_strategy::Variant::Sefr(SefrFeedbackStrategy {
+                threshold,
+                target_weight,
+            });
+            assert!(
+                strategy.validate().is_err(),
+                "expected non-finite params to fail: threshold={threshold:?} target_weight={target_weight:?}",
+            );
+        }
+
+        let finite = feedback_strategy::Variant::Sefr(SefrFeedbackStrategy {
+            threshold: Some(0.5),
+            target_weight: Some(0.1),
+        });
+        assert!(finite.validate().is_ok());
+
+        let unset = feedback_strategy::Variant::Sefr(SefrFeedbackStrategy {
+            threshold: None,
+            target_weight: None,
+        });
+        assert!(unset.validate().is_ok());
     }
 }

--- a/lib/api/src/rest/schema.rs
+++ b/lib/api/src/rest/schema.rs
@@ -910,6 +910,7 @@ pub struct FeedbackItem {
 #[serde(untagged)]
 pub enum FeedbackStrategy {
     Naive(NaiveFeedbackStrategy),
+    Sefr(SefrFeedbackStrategy),
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]
@@ -924,6 +925,34 @@ pub struct NaiveFeedbackStrategyParams {
     #[validate(range(min = 0.0))]
     pub b: f32,
     pub c: f32,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Validate)]
+pub struct SefrFeedbackStrategy {
+    #[validate(nested)]
+    pub sefr: SefrFeedbackStrategyParams,
+}
+
+/// Fits a SEFR classifier on the feedback and searches with the learned
+/// direction. Requires dense vectors and a `Dot` or `Cosine` distance.
+///
+/// The classifier is fit on the feedback items alone, so it needs roughly eight
+/// of them before it ranks well; with fewer, blend in the original query via
+/// `target_weight`.
+#[derive(Debug, Default, Serialize, Deserialize, JsonSchema, Validate)]
+#[serde(rename_all = "snake_case")]
+pub struct SefrFeedbackStrategyParams {
+    /// Feedback items scoring above this value form the positive class.
+    /// Defaults to the mean of the feedback scores.
+    #[serde(default)]
+    pub threshold: Option<f32>,
+
+    /// Relative influence of the original query vector against the learned
+    /// direction, which is matched in magnitude first so that a given weight
+    /// means the same thing across queries. Defaults to `0`, which uses the
+    /// learned direction alone. Useful values run from about `0.01` to `1`.
+    #[serde(default)]
+    pub target_weight: Option<f32>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -102,6 +102,7 @@ impl Validate for FeedbackStrategy {
             FeedbackStrategy::Naive(simple_feedback_strategy) => {
                 simple_feedback_strategy.validate()
             }
+            FeedbackStrategy::Sefr(sefr_feedback_strategy) => sefr_feedback_strategy.validate(),
         }
     }
 }
@@ -298,6 +299,17 @@ pub fn validate_relevance_feedback_input(
         return Err(err);
     }
 
+    // SEFR separates two classes, which a single item can never form.
+    if matches!(relevance_feedback_input.strategy, FeedbackStrategy::Sefr(_))
+        && relevance_feedback_input.feedback.len() < 2
+    {
+        let mut err = ValidationError::new("feedback");
+        err.message = Some(Cow::from(
+            "the `sefr` strategy needs at least two feedback elements to separate",
+        ));
+        return Err(err);
+    }
+
     Ok(())
 }
 
@@ -339,5 +351,63 @@ mod tests {
         }));
 
         assert!(query.validate().is_ok());
+    }
+
+    fn relevance_feedback_input(strategy: serde_json::Value) -> RelevanceFeedbackInput {
+        serde_json::from_value(serde_json::json!({
+            "target": [1.0, 0.0],
+            "feedback": [
+                { "example": [1.0, 0.0], "score": 1.0 },
+                { "example": [0.0, 1.0], "score": 0.0 },
+            ],
+            "strategy": strategy,
+        }))
+        .unwrap()
+    }
+
+    /// `FeedbackStrategy` is an untagged union, so each variant has to be
+    /// distinguishable by its wrapper key alone.
+    #[test]
+    fn feedback_strategy_variants_are_distinguishable() {
+        let naive = relevance_feedback_input(serde_json::json!({
+            "naive": { "a": 1.0, "b": 1.0, "c": 1.0 },
+        }));
+        assert!(matches!(naive.strategy, FeedbackStrategy::Naive(_)));
+        assert!(naive.validate().is_ok());
+
+        let sefr = relevance_feedback_input(serde_json::json!({
+            "sefr": { "threshold": 0.5, "target_weight": 0.25 },
+        }));
+        let FeedbackStrategy::Sefr(ref params) = sefr.strategy else {
+            panic!("expected the sefr strategy, got {:?}", sefr.strategy);
+        };
+        assert_eq!(params.sefr.threshold, Some(0.5));
+        assert_eq!(params.sefr.target_weight, Some(0.25));
+        assert!(sefr.validate().is_ok());
+    }
+
+    #[test]
+    fn sefr_strategy_parameters_are_optional() {
+        let sefr = relevance_feedback_input(serde_json::json!({ "sefr": {} }));
+
+        let FeedbackStrategy::Sefr(ref params) = sefr.strategy else {
+            panic!("expected the sefr strategy, got {:?}", sefr.strategy);
+        };
+        assert_eq!(params.sefr.threshold, None);
+        assert_eq!(params.sefr.target_weight, None);
+        assert!(sefr.validate().is_ok());
+    }
+
+    /// A single feedback item can never form two classes.
+    #[test]
+    fn sefr_strategy_requires_two_feedback_items() {
+        let input: RelevanceFeedbackInput = serde_json::from_value(serde_json::json!({
+            "target": [1.0, 0.0],
+            "feedback": [{ "example": [1.0, 0.0], "score": 1.0 }],
+            "strategy": { "sefr": {} },
+        }))
+        .unwrap();
+
+        assert!(input.validate().is_err());
     }
 }

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -486,6 +486,8 @@ impl Collection {
         // update timeout
         let timeout = timeout.map(|timeout| timeout.saturating_sub(start.elapsed()));
 
+        let collection_params = self.collection_config.read().await.params.clone();
+
         // Check we actually fetched all referenced vectors from the resolver requests
         for (resolver_req, _) in &resolver_requests {
             for point_id in resolver_req.get_referenced_point_ids() {
@@ -507,7 +509,7 @@ impl Collection {
             requests_batch,
             |(_req, shard)| shard,
             |(req, _), acc| {
-                req.try_into_shard_request(&self.id, &ids_to_vectors)
+                req.try_into_shard_request(&self.id, &ids_to_vectors, &collection_params)
                     .map(|shard_req| {
                         acc.push(shard_req);
                     })

--- a/lib/collection/src/grouping/group_by.rs
+++ b/lib/collection/src/grouping/group_by.rs
@@ -118,7 +118,13 @@ impl GroupRequest {
                     hw_measurement_acc.clone(),
                 )
                 .await?;
-                query_req.try_into_shard_request(&collection.id, &referenced_vectors)?
+
+                let collection_params = collection.collection_config.read().await.params.clone();
+                query_req.try_into_shard_request(
+                    &collection.id,
+                    &referenced_vectors,
+                    &collection_params,
+                )?
             }
         };
 

--- a/lib/collection/src/operations/conversions.rs
+++ b/lib/collection/src/operations/conversions.rs
@@ -2021,6 +2021,16 @@ impl From<rest::FeedbackStrategy> for FeedbackStrategy {
             rest::FeedbackStrategy::Naive(rest::NaiveFeedbackStrategy {
                 naive: rest::NaiveFeedbackStrategyParams { a, b, c },
             }) => FeedbackStrategy::Naive { a, b, c },
+            rest::FeedbackStrategy::Sefr(rest::SefrFeedbackStrategy {
+                sefr:
+                    rest::SefrFeedbackStrategyParams {
+                        threshold,
+                        target_weight,
+                    },
+            }) => FeedbackStrategy::Sefr {
+                threshold,
+                target_weight: target_weight.unwrap_or(0.0),
+            },
         }
     }
 }
@@ -2039,6 +2049,13 @@ impl TryFrom<grpc::FeedbackStrategy> for FeedbackStrategy {
             Variant::Naive(grpc::NaiveFeedbackStrategy { a, b, c }) => {
                 FeedbackStrategy::Naive { a, b, c }
             }
+            Variant::Sefr(grpc::SefrFeedbackStrategy {
+                threshold,
+                target_weight,
+            }) => FeedbackStrategy::Sefr {
+                threshold,
+                target_weight: target_weight.unwrap_or(0.0),
+            },
         };
 
         Ok(strategy)

--- a/lib/collection/src/operations/universal_query/collection_query.rs
+++ b/lib/collection/src/operations/universal_query/collection_query.rs
@@ -13,7 +13,7 @@ use segment::types::{
 };
 use segment::vector_storage::query::{
     ContextPair, ContextQuery, DiscoverQuery, FeedbackItem, NaiveFeedbackCoefficients, RecoQuery,
-    avg_vector_for_recommendation,
+    SefrParams, avg_vector_for_recommendation, sefr_query_vector,
 };
 use serde::Serialize;
 use shard::query::query_enum::QueryEnum;
@@ -23,6 +23,7 @@ use super::shard_query::{
     FusionInternal, SampleInternal, ScoringQuery, ShardPrefetch, ShardQueryRequest,
 };
 use crate::common::fetch_vectors::ReferencedVectors;
+use crate::config::CollectionParams;
 use crate::lookup::WithLookup;
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::operations::universal_query::shard_query::MmrInternal;
@@ -112,6 +113,7 @@ impl Query {
         lookup_collection: Option<&String>,
         using: VectorNameBuf,
         request_limit: usize,
+        collection_params: &CollectionParams,
     ) -> CollectionResult<ScoringQuery> {
         let scoring_query = match self {
             Query::Vector(vector_query) => {
@@ -120,7 +122,7 @@ impl Query {
                     .ids_into_vectors(ids_to_vectors, lookup_vector_name, lookup_collection)?
                     .preprocess_vectors()
                     // Turn into QueryEnum
-                    .into_scoring_query(using, request_limit)?
+                    .into_scoring_query(using, request_limit, collection_params)?
             }
             Query::Fusion(fusion) => ScoringQuery::Fusion(fusion),
             Query::OrderBy(order_by) => ScoringQuery::OrderBy(order_by),
@@ -216,7 +218,17 @@ impl<T> FeedbackInternal<T> {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum FeedbackStrategy {
-    Naive { a: f32, b: f32, c: f32 },
+    Naive {
+        a: f32,
+        b: f32,
+        c: f32,
+    },
+    /// Fit a SEFR classifier on the feedback and search with the learned
+    /// direction. See [`segment::vector_storage::query::sefr_query_vector`].
+    Sefr {
+        threshold: Option<f32>,
+        target_weight: f32,
+    },
 }
 
 impl VectorQuery<VectorInputInternal> {
@@ -448,6 +460,7 @@ impl VectorQuery<VectorInternal> {
         self,
         using: VectorNameBuf,
         request_limit: usize,
+        collection_params: &CollectionParams,
     ) -> CollectionResult<ScoringQuery> {
         let query_enum = match self {
             VectorQuery::Nearest(vector) => QueryEnum::Nearest(NamedQuery::new(vector, using)),
@@ -499,6 +512,23 @@ impl VectorQuery<VectorInternal> {
                     },
                     using,
                 )),
+                FeedbackStrategy::Sefr {
+                    threshold,
+                    target_weight,
+                } => {
+                    // SEFR reduces the feedback to a single weight vector, so the
+                    // search runs through the regular nearest-neighbor path.
+                    let search_vector = sefr_query_vector(
+                        &target,
+                        &feedback,
+                        &SefrParams {
+                            threshold,
+                            target_weight,
+                        },
+                        collection_params.get_distance(&using)?,
+                    )?;
+                    QueryEnum::Nearest(NamedQuery::new(search_vector, using))
+                }
             },
         };
 
@@ -569,6 +599,7 @@ impl CollectionPrefetch {
     fn try_into_shard_prefetch(
         self,
         ids_to_vectors: &ReferencedVectors,
+        collection_params: &CollectionParams,
     ) -> CollectionResult<ShardPrefetch> {
         CollectionQueryRequest::validation(
             &self.query,
@@ -590,6 +621,7 @@ impl CollectionPrefetch {
                     lookup_collection.as_ref(),
                     using,
                     self.limit,
+                    collection_params,
                 )
             })
             .transpose()?;
@@ -597,7 +629,7 @@ impl CollectionPrefetch {
         let prefetches = self
             .prefetch
             .into_iter()
-            .map(|prefetch| prefetch.try_into_shard_prefetch(ids_to_vectors))
+            .map(|prefetch| prefetch.try_into_shard_prefetch(ids_to_vectors, collection_params))
             .try_collect()?;
 
         Ok(ShardPrefetch {
@@ -678,6 +710,7 @@ impl CollectionQueryRequest {
         self,
         collection_name: &str,
         ids_to_vectors: &ReferencedVectors,
+        collection_params: &CollectionParams,
     ) -> CollectionResult<ShardQueryRequest> {
         Self::validation(
             &self.query,
@@ -713,6 +746,7 @@ impl CollectionQueryRequest {
                     query_lookup_collection.as_ref(),
                     using,
                     self.limit,
+                    collection_params,
                 )
             })
             .transpose()?;
@@ -720,7 +754,7 @@ impl CollectionQueryRequest {
         let prefetches = self
             .prefetch
             .into_iter()
-            .map(|prefetch| prefetch.try_into_shard_prefetch(ids_to_vectors))
+            .map(|prefetch| prefetch.try_into_shard_prefetch(ids_to_vectors, collection_params))
             .try_collect()?;
 
         Ok(ShardQueryRequest {

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -189,6 +189,10 @@ name = "numeric_index_check_values"
 harness = false
 
 [[bench]]
+name = "relevance_feedback"
+harness = false
+
+[[bench]]
 name = "sparse_index_search"
 harness = false
 

--- a/lib/segment/benches/relevance_feedback.rs
+++ b/lib/segment/benches/relevance_feedback.rs
@@ -1,0 +1,112 @@
+//! Compares the cost of the two relevance feedback strategies as the number of
+//! feedback items grows.
+//!
+//! The `naive` strategy expands the feedback into every ordered pair and walks
+//! all of them for each candidate, so its per-candidate cost grows with the
+//! square of the feedback size. SEFR fits once and then scores each candidate
+//! with a single dot product, so its per-candidate cost is flat.
+//!
+//! Both measurements include the per-query setup, since that is what a client
+//! pays for one request.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use ordered_float::OrderedFloat;
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
+use segment::data_types::vectors::{DenseVector, VectorElementType};
+use segment::spaces::metric::Metric;
+use segment::spaces::simple::DotProductMetric;
+use segment::vector_storage::query::{
+    FeedbackItem, NaiveFeedbackCoefficients, NaiveFeedbackQuery, Query, fit_sefr,
+};
+
+const DIM: usize = 768;
+const CANDIDATES: usize = 1_000;
+const FEEDBACK_SIZES: [usize; 5] = [2, 4, 8, 16, 32];
+
+fn random_vector(rng: &mut SmallRng) -> DenseVector {
+    (0..DIM).map(|_| rng.random_range(0.0..1.0)).collect()
+}
+
+fn feedback_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("relevance-feedback");
+
+    let mut rng = SmallRng::seed_from_u64(42);
+    let candidates: Vec<DenseVector> = (0..CANDIDATES).map(|_| random_vector(&mut rng)).collect();
+    let target = random_vector(&mut rng);
+
+    for size in FEEDBACK_SIZES {
+        // Half the items score high, half low, so SEFR always sees both classes.
+        let feedback: Vec<FeedbackItem<DenseVector>> = (0..size)
+            .map(|i| FeedbackItem {
+                vector: random_vector(&mut rng),
+                score: OrderedFloat(if i % 2 == 0 { 1.0 } else { 0.0 }),
+            })
+            .collect();
+
+        group.bench_with_input(BenchmarkId::new("naive", size), &size, |b, _| {
+            b.iter(|| {
+                let query = NaiveFeedbackQuery {
+                    target: target.clone(),
+                    feedback: feedback.clone(),
+                    coefficients: NaiveFeedbackCoefficients {
+                        a: OrderedFloat(1.0),
+                        b: OrderedFloat(1.0),
+                        c: OrderedFloat(1.0),
+                    },
+                }
+                .into_query();
+
+                let mut total = 0.0;
+                for candidate in &candidates {
+                    total += query.score_by(|example: &DenseVector| {
+                        <DotProductMetric as Metric<VectorElementType>>::similarity(
+                            example, candidate,
+                        )
+                    });
+                }
+                black_box(total)
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("sefr", size), &size, |b, _| {
+            b.iter(|| {
+                let positives: Vec<&[VectorElementType]> = feedback
+                    .iter()
+                    .filter(|item| item.score.0 > 0.5)
+                    .map(|item| item.vector.as_slice())
+                    .collect();
+                let negatives: Vec<&[VectorElementType]> = feedback
+                    .iter()
+                    .filter(|item| item.score.0 <= 0.5)
+                    .map(|item| item.vector.as_slice())
+                    .collect();
+                let model = fit_sefr(&positives, &negatives).unwrap();
+
+                // Production searches the folded weights as a plain nearest
+                // query, so scoring goes through the same metric the naive
+                // strategy uses. The constant offset does not affect ranking.
+                let mut total = 0.0;
+                for candidate in &candidates {
+                    total += <DotProductMetric as Metric<VectorElementType>>::similarity(
+                        &model.weights,
+                        candidate,
+                    );
+                }
+                black_box(total)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = feedback_bench
+}
+
+criterion_main!(benches);

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -50,7 +50,9 @@ use crate::types::{
     WithVector,
 };
 use crate::utils::maybe_arc::MaybeArc;
-use crate::vector_storage::query::{FeedbackItem, NaiveFeedbackCoefficients, NaiveFeedbackQuery};
+use crate::vector_storage::query::{
+    FeedbackItem, NaiveFeedbackCoefficients, NaiveFeedbackQuery, SefrParams, sefr_query_vector,
+};
 
 fn init_logger() {
     let _ = env_logger::builder().is_test(true).try_init();
@@ -2801,4 +2803,129 @@ fn test_flush_survives_concurrent_field_index_drop() {
     // at version 3. A cancelled (aborted) flush would have left the persisted
     // version at 0.
     assert_eq!(segment.persistent_version(), 3);
+}
+
+/// The `sefr` relevance feedback strategy reduces to a single vector, so it is
+/// searched through the plain nearest-neighbor path. This checks the whole chain
+/// against a real segment: fit on feedback, then search and get the relevant
+/// cluster back.
+#[test]
+fn test_sefr_feedback_retrieves_relevant_cluster() {
+    init_logger();
+
+    const DIM: usize = 8;
+    const HALF_DIM: usize = DIM / 2;
+    const POINTS_PER_CLUSTER: u64 = 50;
+
+    let dir = Builder::new().prefix("sefr_segment").tempdir().unwrap();
+    let mut segment = build_simple_segment(dir.path(), DIM, Distance::Dot).unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let mut rng = StdRng::seed_from_u64(42);
+
+    // Two well separated clusters, both inside the [0, 1] range SEFR expects.
+    // The relevant one carries its mass in the leading dimensions.
+    let mut make_vector = |relevant: bool| -> Vec<f32> {
+        (0..DIM)
+            .map(|i| {
+                if (i < HALF_DIM) == relevant {
+                    rng.random_range(0.5..1.0)
+                } else {
+                    rng.random_range(0.0..0.3)
+                }
+            })
+            .collect()
+    };
+
+    let mut relevant_vectors = Vec::new();
+    let mut irrelevant_vectors = Vec::new();
+    for point_id in 0..POINTS_PER_CLUSTER * 2 {
+        let relevant = point_id < POINTS_PER_CLUSTER;
+        let vector = make_vector(relevant);
+        segment
+            .upsert_point(
+                100,
+                point_id.into(),
+                only_default_vector(&vector),
+                &hw_counter,
+            )
+            .unwrap();
+        if relevant {
+            relevant_vectors.push(vector);
+        } else {
+            irrelevant_vectors.push(vector);
+        }
+    }
+
+    // Feedback: a few points from each cluster, scored by the oracle.
+    let feedback: Vec<FeedbackItem<VectorInternal>> = relevant_vectors
+        .iter()
+        .take(3)
+        .map(|vector| FeedbackItem {
+            vector: VectorInternal::from(vector.clone()),
+            score: OrderedFloat(1.0),
+        })
+        .chain(
+            irrelevant_vectors
+                .iter()
+                .take(3)
+                .map(|vector| FeedbackItem {
+                    vector: VectorInternal::from(vector.clone()),
+                    score: OrderedFloat(0.0),
+                }),
+        )
+        .collect();
+
+    // A deliberately unhelpful original query, sitting between the clusters, so
+    // that success can only come from the feedback.
+    let target = VectorInternal::from(vec![0.5; DIM]);
+
+    let query_vector =
+        sefr_query_vector(&target, &feedback, &SefrParams::default(), Distance::Dot).unwrap();
+
+    let top = 10;
+    let results = segment
+        .search(
+            DEFAULT_VECTOR_NAME,
+            &QueryVector::Nearest(query_vector),
+            &WithPayload::default(),
+            &WithVector::Bool(false),
+            None,
+            top,
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(results.len(), top);
+    for point in &results {
+        let ExtendedPointId::NumId(id) = point.id else {
+            panic!("expected numeric ids, got {:?}", point.id);
+        };
+        assert!(
+            id < POINTS_PER_CLUSTER,
+            "point {id} comes from the down-voted cluster, scored {}",
+            point.score,
+        );
+    }
+
+    // The unhelpful target on its own cannot tell the clusters apart, which is
+    // what the feedback is there to fix.
+    let target_results = segment
+        .search(
+            DEFAULT_VECTOR_NAME,
+            &QueryVector::Nearest(target),
+            &WithPayload::default(),
+            &WithVector::Bool(false),
+            None,
+            top,
+            None,
+        )
+        .unwrap();
+    let relevant_from_target = target_results
+        .iter()
+        .filter(|point| matches!(point.id, ExtendedPointId::NumId(id) if id < POINTS_PER_CLUSTER))
+        .count();
+    assert!(
+        relevant_from_target < top,
+        "the target alone already separated the clusters, so the fixture proves nothing",
+    );
 }

--- a/lib/segment/src/vector_storage/query/mod.rs
+++ b/lib/segment/src/vector_storage/query/mod.rs
@@ -7,6 +7,7 @@ mod context_query;
 mod discover_query;
 mod feedback_query;
 mod reco_query;
+mod sefr;
 
 pub use context_query::{ContextPair, ContextQuery};
 pub use discover_query::DiscoverQuery;
@@ -14,6 +15,7 @@ pub use feedback_query::{FeedbackItem, NaiveFeedbackCoefficients, NaiveFeedbackQ
 pub use reco_query::{
     RecoBestScoreQuery, RecoQuery, RecoSumScoresQuery, avg_vector_for_recommendation,
 };
+pub use sefr::{SefrModel, SefrParams, fit_sefr, sefr_query_vector};
 
 pub trait TransformInto<Output, T = DenseVector, U = DenseVector> {
     /// Change the underlying type of the query, or just process it in some way.

--- a/lib/segment/src/vector_storage/query/sefr.rs
+++ b/lib/segment/src/vector_storage/query/sefr.rs
@@ -1,0 +1,715 @@
+//! SEFR: Scalable, Efficient, and Fast classifieR.
+//!
+//! Keshavarz, Abadeh, Rawassizadeh (2020), "SEFR: A Fast Linear-Time Classifier
+//! for Ultra-Low Power Devices", arXiv:2006.04620.
+//!
+//! The classifier is fit on the feedback items of a single query and produces a
+//! linear decision function. Because that function is linear, and because the
+//! `[0, 1]` feature scaling the algorithm expects is affine, the scaler folds
+//! into the weights: scoring a candidate is one dot product against a single
+//! vector. See [`SefrModel`].
+//!
+//! The min-max scaler is fit on the feedback items themselves, which is what
+//! ties retrieval quality to how many there are. With two items every dimension
+//! scales to exactly `0` or `1`, so the weights degenerate into a sign vector
+//! and rank poorly; from roughly eight items on, the per-dimension weighting
+//! becomes the method's advantage, especially when the embedding's dimensions
+//! differ widely in scale. `lib/segment/tests/sefr_accuracy.rs` measures this.
+
+use std::borrow::Cow;
+
+use common::types::ScoreType;
+
+use super::FeedbackItem;
+use crate::common::operation_error::{OperationError, OperationResult};
+use crate::data_types::vectors::{DenseVector, VectorElementType, VectorInternal};
+use crate::types::Distance;
+
+/// Guard on the denominator of the weight formula (Eq. 5), keeping it defined
+/// for dimensions that average to zero in both classes.
+const WEIGHT_EPS: f64 = 1e-7;
+
+/// Parameters of the `sefr` relevance feedback strategy.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct SefrParams {
+    /// Feedback items scoring above this value form the positive class. Defaults
+    /// to the mean of the feedback scores.
+    pub threshold: Option<ScoreType>,
+
+    /// Relative influence of the original query vector against the learned
+    /// direction, which is matched in magnitude first so that a given weight
+    /// means the same thing across queries. Zero uses the learned direction
+    /// alone.
+    ///
+    /// Worth tuning: the useful value depends on how much the original query
+    /// already separates the relevant results, so it ranges from around `0.01`
+    /// to `1` in practice.
+    pub target_weight: ScoreType,
+}
+
+impl Default for SefrParams {
+    fn default() -> Self {
+        Self {
+            threshold: None,
+            target_weight: 0.0,
+        }
+    }
+}
+
+/// A fitted binary SEFR model, with the min-max feature scaler folded into the
+/// weights.
+///
+/// For a scaler with per-dimension minimum `m` and range `r`, folding rewrites
+/// the decision function so that no candidate needs rescaling at scoring time:
+///
+/// ```text
+/// w . scale(x) - bias  ==  w' . x - offset
+/// w'_i   = w_i / r_i
+/// offset = sum_i (w_i * m_i / r_i) + bias
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct SefrModel {
+    /// Feature weights with the scaler folded in.
+    pub weights: DenseVector,
+
+    /// Constant term of the decision function. Shifting every candidate by the
+    /// same amount, it does not affect ranking.
+    pub offset: ScoreType,
+}
+
+impl SefrModel {
+    /// Signed decision value; positive favors the positive class.
+    pub fn score(&self, vector: &[VectorElementType]) -> ScoreType {
+        let dot: ScoreType = self
+            .weights
+            .iter()
+            .zip(vector)
+            .map(|(weight, value)| weight * value)
+            .sum();
+        dot - self.offset
+    }
+}
+
+/// Fit a binary SEFR classifier, scaling features to `[0, 1]` with a min-max
+/// scaler fit on the training set.
+pub fn fit_sefr(
+    positives: &[&[VectorElementType]],
+    negatives: &[&[VectorElementType]],
+) -> OperationResult<SefrModel> {
+    if positives.is_empty() || negatives.is_empty() {
+        return Err(OperationError::validation_error(
+            "SEFR requires at least one positive and one negative example",
+        ));
+    }
+
+    let dim = positives[0].len();
+    if dim == 0 {
+        return Err(OperationError::validation_error(
+            "SEFR requires non-empty vectors",
+        ));
+    }
+    for vector in positives.iter().chain(negatives.iter()) {
+        if vector.len() != dim {
+            return Err(OperationError::WrongVectorDimension {
+                expected_dim: dim,
+                received_dim: vector.len(),
+            });
+        }
+    }
+
+    let mut min = vec![VectorElementType::INFINITY; dim];
+    let mut max = vec![VectorElementType::NEG_INFINITY; dim];
+    for vector in positives.iter().chain(negatives.iter()) {
+        for (i, &value) in vector.iter().enumerate() {
+            min[i] = min[i].min(value);
+            max[i] = max[i].max(value);
+        }
+    }
+
+    // A dimension with no spread scales to a constant 0, which in turn gives it
+    // a zero weight, so a unit range is a safe stand-in for a zero one.
+    let range: Vec<f64> = max
+        .iter()
+        .zip(&min)
+        .map(|(max, min)| {
+            let range = f64::from(*max) - f64::from(*min);
+            if range > 0.0 { range } else { 1.0 }
+        })
+        .collect();
+
+    let scaled_mean = |vectors: &[&[VectorElementType]]| -> Vec<f64> {
+        let mut acc = vec![0.0f64; dim];
+        for vector in vectors {
+            for i in 0..dim {
+                acc[i] += (f64::from(vector[i]) - f64::from(min[i])) / range[i];
+            }
+        }
+        let count = vectors.len() as f64;
+        for value in &mut acc {
+            *value /= count;
+        }
+        acc
+    };
+
+    let avg_positive = scaled_mean(positives);
+    let avg_negative = scaled_mean(negatives);
+
+    // Eq. 5
+    let weights: Vec<f64> = avg_positive
+        .iter()
+        .zip(&avg_negative)
+        .map(|(positive, negative)| (positive - negative) / (positive + negative + WEIGHT_EPS))
+        .collect();
+
+    let scaled_score = |vector: &[VectorElementType]| -> f64 {
+        (0..dim)
+            .map(|i| (f64::from(vector[i]) - f64::from(min[i])) / range[i] * weights[i])
+            .sum()
+    };
+    let mean_score = |vectors: &[&[VectorElementType]]| -> f64 {
+        vectors.iter().map(|v| scaled_score(v)).sum::<f64>() / vectors.len() as f64
+    };
+
+    // Eq. 9: the threshold sits between the two class score means, each weighted
+    // by the size of the opposite class.
+    let positive_count = positives.len() as f64;
+    let negative_count = negatives.len() as f64;
+    let bias = (negative_count * mean_score(positives) + positive_count * mean_score(negatives))
+        / (negative_count + positive_count);
+
+    // Fold the scaler into the weights.
+    let mut folded = DenseVector::with_capacity(dim);
+    let mut offset = bias;
+    for i in 0..dim {
+        let weight = weights[i] / range[i];
+        offset += weight * f64::from(min[i]);
+        folded.push(weight as VectorElementType);
+    }
+
+    Ok(SefrModel {
+        weights: folded,
+        offset: offset as ScoreType,
+    })
+}
+
+/// Build the query vector of the `sefr` relevance feedback strategy.
+///
+/// Fits SEFR on the feedback items, labelling those scoring above the threshold
+/// as positive, then returns the weight vector optionally blended with the
+/// original query. The result is a plain dense vector, so the search runs
+/// through the regular nearest-neighbor path.
+///
+/// `distance` must be dot-product based, since the folded weight vector is
+/// scored as a dot product against each candidate. The training vectors are
+/// preprocessed the same way stored vectors are, so that the model is fit in the
+/// space the candidates live in.
+///
+/// When the feedback lands entirely in one class there is nothing to separate,
+/// and the original query vector is returned unchanged.
+pub fn sefr_query_vector(
+    target: &VectorInternal,
+    feedback: &[FeedbackItem<VectorInternal>],
+    params: &SefrParams,
+    distance: Distance,
+) -> OperationResult<VectorInternal> {
+    match distance {
+        // Cosine is dot product over normalized vectors.
+        Distance::Dot | Distance::Cosine => {}
+        Distance::Euclid | Distance::Manhattan => {
+            return Err(OperationError::validation_error(format!(
+                "`sefr` relevance feedback scores candidates with a dot product, \
+                 which does not match the {distance:?} distance of this vector. \
+                 Use a vector with Dot or Cosine distance."
+            )));
+        }
+    }
+
+    let target = as_dense(target)?;
+    if feedback.is_empty() {
+        return Ok(VectorInternal::from(target.to_vec()));
+    }
+
+    let threshold = match params.threshold {
+        Some(threshold) => threshold,
+        None => {
+            let sum: f64 = feedback.iter().map(|item| f64::from(item.score.0)).sum();
+            (sum / feedback.len() as f64) as ScoreType
+        }
+    };
+
+    let mut training = Vec::with_capacity(feedback.len());
+    for item in feedback {
+        let vector = preprocess(as_dense(&item.vector)?, distance);
+        training.push((vector, item.score.0 > threshold));
+    }
+
+    let positives: Vec<&[VectorElementType]> = training
+        .iter()
+        .filter(|(_, positive)| *positive)
+        .map(|(vector, _)| vector.as_ref())
+        .collect();
+    let negatives: Vec<&[VectorElementType]> = training
+        .iter()
+        .filter(|(_, positive)| !*positive)
+        .map(|(vector, _)| vector.as_ref())
+        .collect();
+
+    if positives.is_empty() || negatives.is_empty() {
+        return Ok(VectorInternal::from(target.to_vec()));
+    }
+
+    let model = fit_sefr(&positives, &negatives)?;
+
+    if model.weights.len() != target.len() {
+        return Err(OperationError::WrongVectorDimension {
+            expected_dim: target.len(),
+            received_dim: model.weights.len(),
+        });
+    }
+
+    let weights_norm = l2_norm(&model.weights);
+    if params.target_weight == 0.0 || weights_norm == 0.0 {
+        if weights_norm == 0.0 {
+            // Nothing was learned, e.g. every dimension had no spread.
+            return Ok(VectorInternal::from(target.to_vec()));
+        }
+        return Ok(VectorInternal::from(model.weights));
+    }
+
+    // Blending two linear scoring functions stays linear, so the result is still
+    // a single vector.
+    let target = preprocess(target, distance);
+    let target_norm = l2_norm(target.as_ref());
+    if target_norm == 0.0 {
+        return Ok(VectorInternal::from(model.weights));
+    }
+
+    // Match the query's magnitude to the learned direction before mixing, so
+    // that `target_weight` expresses relative influence and stays comparable
+    // across queries rather than tracking the two vectors' norms.
+    let scale = params.target_weight * weights_norm / target_norm;
+    let blended: DenseVector = model
+        .weights
+        .iter()
+        .zip(target.as_ref())
+        .map(|(weight, target)| weight + scale * target)
+        .collect();
+
+    Ok(VectorInternal::from(blended))
+}
+
+fn l2_norm(vector: &[VectorElementType]) -> ScoreType {
+    vector.iter().map(|x| x * x).sum::<ScoreType>().sqrt()
+}
+
+/// Apply the same preprocessing the vector storage does, so that the model is
+/// fit over the representation the candidates are stored in.
+fn preprocess(vector: &[VectorElementType], distance: Distance) -> Cow<'_, [VectorElementType]> {
+    match distance {
+        Distance::Cosine => {
+            Cow::Owned(distance.preprocess_vector::<VectorElementType>(vector.to_vec()))
+        }
+        Distance::Dot | Distance::Euclid | Distance::Manhattan => Cow::Borrowed(vector),
+    }
+}
+
+fn as_dense(vector: &VectorInternal) -> OperationResult<&[VectorElementType]> {
+    match vector {
+        VectorInternal::Dense(dense) => Ok(dense),
+        VectorInternal::Sparse(_) => Err(OperationError::validation_error(
+            "`sefr` relevance feedback is only supported for dense vectors, got a sparse vector",
+        )),
+        VectorInternal::MultiDense(_) => Err(OperationError::validation_error(
+            "`sefr` relevance feedback is only supported for dense vectors, got a multi-dense vector",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ordered_float::OrderedFloat;
+
+    use super::*;
+
+    /// Reference scoring path: scale the candidate explicitly, then apply the
+    /// unfolded weights and bias.
+    fn score_unfolded(
+        vector: &[VectorElementType],
+        weights: &[f64],
+        min: &[f64],
+        range: &[f64],
+        bias: f64,
+    ) -> f64 {
+        (0..vector.len())
+            .map(|i| (f64::from(vector[i]) - min[i]) / range[i] * weights[i])
+            .sum::<f64>()
+            - bias
+    }
+
+    #[test]
+    fn separates_linearly_separable_data() {
+        let positives: Vec<Vec<VectorElementType>> =
+            vec![vec![0.9, 0.1], vec![0.8, 0.2], vec![1.0, 0.0]];
+        let negatives: Vec<Vec<VectorElementType>> =
+            vec![vec![0.1, 0.9], vec![0.2, 0.8], vec![0.0, 1.0]];
+
+        let positive_refs: Vec<&[VectorElementType]> =
+            positives.iter().map(|v| v.as_slice()).collect();
+        let negative_refs: Vec<&[VectorElementType]> =
+            negatives.iter().map(|v| v.as_slice()).collect();
+
+        let model = fit_sefr(&positive_refs, &negative_refs).unwrap();
+
+        for vector in &positives {
+            assert!(
+                model.score(vector) > 0.0,
+                "positive {vector:?} scored {}",
+                model.score(vector),
+            );
+        }
+        for vector in &negatives {
+            assert!(
+                model.score(vector) <= 0.0,
+                "negative {vector:?} scored {}",
+                model.score(vector),
+            );
+        }
+    }
+
+    /// Folding the scaler into the weights must not change the decision value.
+    #[test]
+    fn folding_matches_explicit_scaling() {
+        let positives: Vec<Vec<VectorElementType>> =
+            vec![vec![4.0, -1.0, 7.5], vec![5.0, -2.0, 6.0]];
+        let negatives: Vec<Vec<VectorElementType>> =
+            vec![vec![-3.0, 2.0, 1.0], vec![-4.0, 3.5, 0.5]];
+
+        let positive_refs: Vec<&[VectorElementType]> =
+            positives.iter().map(|v| v.as_slice()).collect();
+        let negative_refs: Vec<&[VectorElementType]> =
+            negatives.iter().map(|v| v.as_slice()).collect();
+
+        let model = fit_sefr(&positive_refs, &negative_refs).unwrap();
+
+        // Recompute the scaler and the unfolded model from the same training set.
+        let dim = 3;
+        let all: Vec<&Vec<VectorElementType>> = positives.iter().chain(negatives.iter()).collect();
+        let mut min = vec![f64::INFINITY; dim];
+        let mut max = vec![f64::NEG_INFINITY; dim];
+        for vector in &all {
+            for i in 0..dim {
+                min[i] = min[i].min(f64::from(vector[i]));
+                max[i] = max[i].max(f64::from(vector[i]));
+            }
+        }
+        let range: Vec<f64> = (0..dim)
+            .map(|i| {
+                let range = max[i] - min[i];
+                if range > 0.0 { range } else { 1.0 }
+            })
+            .collect();
+
+        let mean = |vectors: &[Vec<VectorElementType>]| -> Vec<f64> {
+            let mut acc = vec![0.0; dim];
+            for vector in vectors {
+                for i in 0..dim {
+                    acc[i] += (f64::from(vector[i]) - min[i]) / range[i];
+                }
+            }
+            acc.iter().map(|v| v / vectors.len() as f64).collect()
+        };
+        let avg_positive = mean(&positives);
+        let avg_negative = mean(&negatives);
+        let weights: Vec<f64> = (0..dim)
+            .map(|i| {
+                (avg_positive[i] - avg_negative[i])
+                    / (avg_positive[i] + avg_negative[i] + WEIGHT_EPS)
+            })
+            .collect();
+
+        let scaled_score = |vector: &[VectorElementType]| -> f64 {
+            (0..dim)
+                .map(|i| (f64::from(vector[i]) - min[i]) / range[i] * weights[i])
+                .sum()
+        };
+        let positive_mean =
+            positives.iter().map(|v| scaled_score(v)).sum::<f64>() / positives.len() as f64;
+        let negative_mean =
+            negatives.iter().map(|v| scaled_score(v)).sum::<f64>() / negatives.len() as f64;
+        let bias = (negatives.len() as f64 * positive_mean
+            + positives.len() as f64 * negative_mean)
+            / (positives.len() + negatives.len()) as f64;
+
+        // Held-out candidates, deliberately outside the training range.
+        for candidate in [
+            vec![0.0, 0.0, 0.0],
+            vec![10.0, -8.0, 20.0],
+            vec![4.5, 1.25, 3.0],
+            vec![-100.0, 50.0, -7.0],
+        ] {
+            let folded = f64::from(model.score(&candidate));
+            let explicit = score_unfolded(&candidate, &weights, &min, &range, bias);
+            assert!(
+                (folded - explicit).abs() < 1e-3 * explicit.abs().max(1.0),
+                "folded {folded} vs explicit {explicit} for {candidate:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn zero_range_dimension_gets_zero_weight() {
+        let positives: Vec<Vec<VectorElementType>> = vec![vec![1.0, 0.5], vec![0.8, 0.5]];
+        let negatives: Vec<Vec<VectorElementType>> = vec![vec![0.1, 0.5], vec![0.2, 0.5]];
+
+        let positive_refs: Vec<&[VectorElementType]> =
+            positives.iter().map(|v| v.as_slice()).collect();
+        let negative_refs: Vec<&[VectorElementType]> =
+            negatives.iter().map(|v| v.as_slice()).collect();
+
+        let model = fit_sefr(&positive_refs, &negative_refs).unwrap();
+
+        assert_eq!(model.weights[1], 0.0);
+        assert!(model.weights[0] != 0.0);
+        assert!(model.weights.iter().all(|w| w.is_finite()));
+        assert!(model.offset.is_finite());
+    }
+
+    #[test]
+    fn rejects_single_class_and_mismatched_dimensions() {
+        let vectors = [vec![1.0, 2.0], vec![3.0, 4.0]];
+        let refs: Vec<&[VectorElementType]> = vectors.iter().map(|v| v.as_slice()).collect();
+
+        assert!(fit_sefr(&refs, &[]).is_err());
+        assert!(fit_sefr(&[], &refs).is_err());
+
+        let short: Vec<VectorElementType> = vec![1.0];
+        assert!(fit_sefr(&refs, &[short.as_slice()]).is_err());
+    }
+
+    #[test]
+    fn single_class_feedback_falls_back_to_target() {
+        let target = VectorInternal::from(vec![0.25, 0.75]);
+        let feedback = vec![
+            FeedbackItem {
+                vector: VectorInternal::from(vec![1.0, 0.0]),
+                score: OrderedFloat(1.0),
+            },
+            FeedbackItem {
+                vector: VectorInternal::from(vec![0.0, 1.0]),
+                score: OrderedFloat(1.0),
+            },
+        ];
+
+        let query =
+            sefr_query_vector(&target, &feedback, &SefrParams::default(), Distance::Dot).unwrap();
+
+        assert_eq!(query, target);
+    }
+
+    #[test]
+    fn query_vector_ranks_positive_feedback_above_negative() {
+        let target = VectorInternal::from(vec![0.5, 0.5]);
+        let feedback = vec![
+            FeedbackItem {
+                vector: VectorInternal::from(vec![0.9, 0.1]),
+                score: OrderedFloat(1.0),
+            },
+            FeedbackItem {
+                vector: VectorInternal::from(vec![0.8, 0.2]),
+                score: OrderedFloat(0.9),
+            },
+            FeedbackItem {
+                vector: VectorInternal::from(vec![0.1, 0.9]),
+                score: OrderedFloat(0.0),
+            },
+            FeedbackItem {
+                vector: VectorInternal::from(vec![0.2, 0.8]),
+                score: OrderedFloat(0.1),
+            },
+        ];
+
+        let query =
+            sefr_query_vector(&target, &feedback, &SefrParams::default(), Distance::Dot).unwrap();
+        let VectorInternal::Dense(weights) = query else {
+            panic!("expected a dense query vector");
+        };
+
+        let dot = |vector: &[VectorElementType]| -> f32 {
+            weights.iter().zip(vector).map(|(w, x)| w * x).sum()
+        };
+
+        // The learned direction must score the well-rated examples higher.
+        assert!(dot(&[0.9, 0.1]) > dot(&[0.1, 0.9]));
+        assert!(dot(&[0.8, 0.2]) > dot(&[0.2, 0.8]));
+    }
+
+    #[test]
+    fn target_weight_blends_the_original_query() {
+        let target = VectorInternal::from(vec![0.0, 10.0]);
+        let feedback = vec![
+            FeedbackItem {
+                vector: VectorInternal::from(vec![1.0, 0.0]),
+                score: OrderedFloat(1.0),
+            },
+            FeedbackItem {
+                vector: VectorInternal::from(vec![0.0, 1.0]),
+                score: OrderedFloat(0.0),
+            },
+        ];
+
+        let query = |target_weight| {
+            let params = SefrParams {
+                threshold: None,
+                target_weight,
+            };
+            let VectorInternal::Dense(vector) =
+                sefr_query_vector(&target, &feedback, &params, Distance::Dot).unwrap()
+            else {
+                panic!("expected a dense query vector");
+            };
+            vector
+        };
+
+        let pure = query(0.0);
+        let blended = query(1.0);
+
+        // The query only carries the second dimension, so only that one moves,
+        // and it moves toward the query's (positive) direction.
+        assert_eq!(blended[0], pure[0]);
+        assert!(blended[1] > pure[1]);
+
+        // At equal weight the query contributes as much magnitude as the
+        // learned direction, independent of how the query vector is scaled.
+        let l2 = |v: &[VectorElementType]| v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let contribution = l2(&[blended[0] - pure[0], blended[1] - pure[1]]);
+        assert!((contribution - l2(&pure)).abs() < 1e-5);
+    }
+
+    /// `target_weight` matches the query's magnitude to the learned direction,
+    /// so rescaling the query must not change the blend.
+    #[test]
+    fn target_weight_is_insensitive_to_the_query_magnitude() {
+        let feedback = vec![
+            FeedbackItem {
+                vector: VectorInternal::from(vec![0.9, 0.1]),
+                score: OrderedFloat(1.0),
+            },
+            FeedbackItem {
+                vector: VectorInternal::from(vec![0.1, 0.9]),
+                score: OrderedFloat(0.0),
+            },
+        ];
+        let params = SefrParams {
+            threshold: None,
+            target_weight: 0.5,
+        };
+
+        let blend_for = |scale: VectorElementType| {
+            let target = VectorInternal::from(vec![0.25 * scale, 0.75 * scale]);
+            let VectorInternal::Dense(vector) =
+                sefr_query_vector(&target, &feedback, &params, Distance::Dot).unwrap()
+            else {
+                panic!("expected a dense query vector");
+            };
+            vector
+        };
+
+        let small = blend_for(1.0);
+        let large = blend_for(1000.0);
+        for (a, b) in small.iter().zip(&large) {
+            assert!((a - b).abs() < 1e-4, "{small:?} vs {large:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_sparse_feedback() {
+        use sparse::common::sparse_vector::SparseVector;
+
+        let target = VectorInternal::from(vec![0.5, 0.5]);
+        let feedback = vec![
+            FeedbackItem {
+                vector: VectorInternal::Sparse(SparseVector::new(vec![0], vec![1.0]).unwrap()),
+                score: OrderedFloat(1.0),
+            },
+            FeedbackItem {
+                vector: VectorInternal::Sparse(SparseVector::new(vec![1], vec![1.0]).unwrap()),
+                score: OrderedFloat(0.0),
+            },
+        ];
+
+        assert!(
+            sefr_query_vector(&target, &feedback, &SefrParams::default(), Distance::Dot).is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_non_dot_product_distances() {
+        let target = VectorInternal::from(vec![0.5, 0.5]);
+        let feedback = vec![
+            FeedbackItem {
+                vector: VectorInternal::from(vec![0.9, 0.1]),
+                score: OrderedFloat(1.0),
+            },
+            FeedbackItem {
+                vector: VectorInternal::from(vec![0.1, 0.9]),
+                score: OrderedFloat(0.0),
+            },
+        ];
+
+        for distance in [Distance::Euclid, Distance::Manhattan] {
+            assert!(
+                sefr_query_vector(&target, &feedback, &SefrParams::default(), distance).is_err(),
+                "{distance:?} should be rejected",
+            );
+        }
+        for distance in [Distance::Dot, Distance::Cosine] {
+            assert!(
+                sefr_query_vector(&target, &feedback, &SefrParams::default(), distance).is_ok(),
+                "{distance:?} should be accepted",
+            );
+        }
+    }
+
+    /// With cosine, candidates are stored as unit vectors, so the model has to
+    /// be fit over normalized inputs too. Scaling an input must then not change
+    /// the learned direction.
+    #[test]
+    fn cosine_fits_over_normalized_vectors() {
+        let target = VectorInternal::from(vec![0.5, 0.5]);
+        let scaled_feedback = |scale: VectorElementType| {
+            vec![
+                FeedbackItem {
+                    vector: VectorInternal::from(vec![0.9 * scale, 0.1 * scale]),
+                    score: OrderedFloat(1.0),
+                },
+                FeedbackItem {
+                    vector: VectorInternal::from(vec![0.1, 0.9]),
+                    score: OrderedFloat(0.0),
+                },
+            ]
+        };
+
+        let unscaled = sefr_query_vector(
+            &target,
+            &scaled_feedback(1.0),
+            &SefrParams::default(),
+            Distance::Cosine,
+        )
+        .unwrap();
+        let scaled = sefr_query_vector(
+            &target,
+            &scaled_feedback(7.0),
+            &SefrParams::default(),
+            Distance::Cosine,
+        )
+        .unwrap();
+
+        let (VectorInternal::Dense(unscaled), VectorInternal::Dense(scaled)) = (unscaled, scaled)
+        else {
+            panic!("expected dense query vectors");
+        };
+        for (a, b) in unscaled.iter().zip(&scaled) {
+            assert!((a - b).abs() < 1e-5, "{unscaled:?} vs {scaled:?}");
+        }
+    }
+}

--- a/lib/segment/tests/sefr_accuracy.rs
+++ b/lib/segment/tests/sefr_accuracy.rs
@@ -1,0 +1,570 @@
+//! Retrieval quality of the `sefr` relevance feedback strategy, measured
+//! against the `naive` strategy and against searching the original query alone.
+//!
+//! Run with `cargo test -p segment --test sefr_accuracy -- --nocapture` to see
+//! the measurement tables.
+//!
+//! The scenario is an ambiguous query: the relevant documents and a set of
+//! confusable ones are equally similar to the original query, so the query on
+//! its own cannot separate them and the feedback has to do the work.
+
+use std::fmt::Write as _;
+
+use common::types::ScoreType;
+use ordered_float::OrderedFloat;
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+use rand_distr::StandardNormal;
+use segment::data_types::vectors::{DenseVector, VectorElementType};
+use segment::vector_storage::query::{
+    FeedbackItem, NaiveFeedbackCoefficients, NaiveFeedbackQuery, Query, fit_sefr,
+};
+
+const DIM: usize = 64;
+const RELEVANT: usize = 80;
+const CONFUSABLE: usize = 80;
+const BACKGROUND: usize = 840;
+const TRIALS: usize = 30;
+const FEEDBACK_SIZES: [usize; 7] = [2, 4, 8, 16, 32, 64, 128];
+/// Blend weights tried for the `target_weight` parameter.
+const TARGET_WEIGHTS: [f32; 6] = [0.0, 0.01, 0.1, 1.0, 10.0, 100.0];
+
+fn dot(a: &[VectorElementType], b: &[VectorElementType]) -> ScoreType {
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
+}
+
+/// The naive strategy's score is
+/// `a * sim(target) + sum_pairs confidence^b * c * (sim(positive) - sim(negative))`.
+///
+/// Every term is a similarity against a fixed vector, so with a dot product the
+/// whole formula is linear in the candidate and collapses to one vector, exactly
+/// like SEFR does. [`naive_score_is_linear_in_the_candidate`] pins this down;
+/// the evaluation below relies on it to score candidates cheaply.
+fn naive_weight_vector(
+    target: &[VectorElementType],
+    feedback: &[FeedbackItem<DenseVector>],
+    coefficients: &NaiveFeedbackCoefficients,
+) -> DenseVector {
+    let mut weights: DenseVector = target.iter().map(|x| coefficients.a.0 * x).collect();
+
+    // Mirrors `extract_context_pairs`: every ordered pair with a positive
+    // difference in feedback score, at margin zero.
+    for positive in feedback {
+        for negative in feedback {
+            let confidence = positive.score.0 - negative.score.0;
+            if confidence <= 0.0 {
+                continue;
+            }
+            let pair_weight = confidence.powf(coefficients.b.0) * coefficients.c.0;
+            for (weight, (p, n)) in weights
+                .iter_mut()
+                .zip(positive.vector.iter().zip(negative.vector.iter()))
+            {
+                *weight += pair_weight * (p - n);
+            }
+        }
+    }
+
+    weights
+}
+
+fn sefr_weight_vector(feedback: &[FeedbackItem<DenseVector>]) -> DenseVector {
+    let threshold =
+        feedback.iter().map(|item| item.score.0).sum::<ScoreType>() / feedback.len() as ScoreType;
+
+    let positives: Vec<&[VectorElementType]> = feedback
+        .iter()
+        .filter(|item| item.score.0 > threshold)
+        .map(|item| item.vector.as_slice())
+        .collect();
+    let negatives: Vec<&[VectorElementType]> = feedback
+        .iter()
+        .filter(|item| item.score.0 <= threshold)
+        .map(|item| item.vector.as_slice())
+        .collect();
+
+    fit_sefr(&positives, &negatives).unwrap().weights
+}
+
+/// An ambiguous query over an embedding space that may have uneven
+/// per-dimension scales.
+struct Scenario {
+    target: DenseVector,
+    /// Documents the user wants.
+    relevant: Vec<DenseVector>,
+    /// Documents equally close to the query, but unwanted.
+    confusable: Vec<DenseVector>,
+    background: Vec<DenseVector>,
+}
+
+fn gaussian(rng: &mut StdRng) -> DenseVector {
+    (0..DIM)
+        .map(|_| rng.sample::<f64, _>(StandardNormal) as VectorElementType)
+        .collect()
+}
+
+fn normalized(mut vector: DenseVector) -> DenseVector {
+    let norm = vector.iter().map(|x| x * x).sum::<ScoreType>().sqrt();
+    for value in &mut vector {
+        *value /= norm;
+    }
+    vector
+}
+
+/// Remove the component of `vector` along the unit vector `basis`.
+fn orthogonalize(mut vector: DenseVector, basis: &[VectorElementType]) -> DenseVector {
+    let projection = dot(&vector, basis);
+    for (value, b) in vector.iter_mut().zip(basis) {
+        *value -= projection * b;
+    }
+    vector
+}
+
+fn build_scenario(rng: &mut StdRng, anisotropic: bool) -> Scenario {
+    // `shared` is what the query captures; `wanted` and `unwanted` are the two
+    // senses it cannot distinguish between. All three are mutually orthogonal.
+    let shared = normalized(gaussian(rng));
+    let wanted = normalized(orthogonalize(gaussian(rng), &shared));
+    let unwanted = normalized(orthogonalize(
+        orthogonalize(gaussian(rng), &shared),
+        &wanted,
+    ));
+
+    // Real embeddings rarely have uniform per-dimension scale. Spanning two
+    // orders of magnitude is the interesting case for a per-dimension method.
+    let scale: DenseVector = (0..DIM)
+        .map(|_| {
+            if anisotropic {
+                10f32.powf(rng.random_range(-1.0..1.0))
+            } else {
+                1.0
+            }
+        })
+        .collect();
+
+    let apply_scale = |vector: DenseVector| -> DenseVector {
+        vector
+            .into_iter()
+            .zip(&scale)
+            .map(|(value, s)| value * s)
+            .collect()
+    };
+
+    let in_sense = |sense: &[VectorElementType], rng: &mut StdRng| -> DenseVector {
+        let noise = gaussian(rng);
+        let raw: DenseVector = (0..DIM)
+            .map(|i| shared[i] + sense[i] + 0.15 * noise[i])
+            .collect();
+        apply_scale(raw)
+    };
+
+    let relevant = (0..RELEVANT)
+        .map(|_| in_sense(&wanted, rng))
+        .collect::<Vec<_>>();
+    let confusable = (0..CONFUSABLE)
+        .map(|_| in_sense(&unwanted, rng))
+        .collect::<Vec<_>>();
+    // Unrelated documents, at the same norm as the two clusters.
+    let background = (0..BACKGROUND)
+        .map(|_| {
+            apply_scale(
+                normalized(gaussian(rng))
+                    .iter()
+                    .map(|x| x * 2f32.sqrt())
+                    .collect(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    Scenario {
+        target: apply_scale(shared),
+        relevant,
+        confusable,
+        background,
+    }
+}
+
+#[derive(Default, Clone, Copy)]
+struct Metrics {
+    precision_at_10: f64,
+    recall_at_50: f64,
+    average_precision: f64,
+}
+
+/// Rank the candidates by `score` and measure how well the relevant ones did.
+fn evaluate(
+    weights: &[VectorElementType],
+    relevant: &[DenseVector],
+    irrelevant: &[DenseVector],
+) -> Metrics {
+    let mut scored: Vec<(ScoreType, bool)> = relevant
+        .iter()
+        .map(|vector| (dot(weights, vector), true))
+        .chain(
+            irrelevant
+                .iter()
+                .map(|vector| (dot(weights, vector), false)),
+        )
+        .collect();
+    scored.sort_by(|a, b| b.0.total_cmp(&a.0));
+
+    let hits_at = |k: usize| scored.iter().take(k).filter(|(_, rel)| *rel).count();
+
+    let mut found: usize = 0;
+    let mut precision_sum = 0.0;
+    for (rank, (_, is_relevant)) in scored.iter().enumerate() {
+        if *is_relevant {
+            found += 1;
+            precision_sum += found as f64 / (rank + 1) as f64;
+        }
+    }
+
+    Metrics {
+        precision_at_10: hits_at(10) as f64 / 10.0,
+        recall_at_50: hits_at(50) as f64 / relevant.len() as f64,
+        average_precision: precision_sum / relevant.len() as f64,
+    }
+}
+
+/// A metric's display name paired with a reader for it, so the report can print
+/// the same set of columns once per metric.
+type MetricAccessor = (&'static str, fn(&Metrics) -> f64);
+
+fn mean(values: &[Metrics]) -> Metrics {
+    let n = values.len() as f64;
+    Metrics {
+        precision_at_10: values.iter().map(|m| m.precision_at_10).sum::<f64>() / n,
+        recall_at_50: values.iter().map(|m| m.recall_at_50).sum::<f64>() / n,
+        average_precision: values.iter().map(|m| m.average_precision).sum::<f64>() / n,
+    }
+}
+
+/// Coefficient grid for the naive strategy. Its parameters are meant to be
+/// trained per dataset, so the evaluation reports its best grid point, which is
+/// the most generous reading available.
+///
+/// The `a` coefficient scales the original query, so it is what decides whether
+/// the strategy uses the query at all. Setting `with_query` mirrors the split
+/// between the `sefr` and `sefr + query` columns: the feedback direction on its
+/// own, against the feedback direction mixed with the query.
+///
+/// The pair term sums over roughly `n^2` pairs, so `c` has to reach far enough
+/// down for the query term to still be able to dominate at the largest feedback
+/// sizes. Without that the grid would handicap the strategy.
+fn naive_grid(with_query: bool) -> Vec<NaiveFeedbackCoefficients> {
+    let mut grid = Vec::new();
+    for b in [0.0, 1.0, 2.0] {
+        for c in [1e-5, 1e-4, 1e-3, 1e-2, 0.1, 1.0, 10.0] {
+            grid.push(NaiveFeedbackCoefficients {
+                a: OrderedFloat(if with_query { 1.0 } else { 0.0 }),
+                b: OrderedFloat(b),
+                c: OrderedFloat(c),
+            });
+        }
+    }
+    grid
+}
+
+/// Best grid point for the naive strategy on this trial, by average precision.
+fn best_naive(
+    with_query: bool,
+    target: &[VectorElementType],
+    feedback: &[FeedbackItem<DenseVector>],
+    relevant: &[DenseVector],
+    irrelevant: &[DenseVector],
+) -> Metrics {
+    naive_grid(with_query)
+        .into_iter()
+        .map(|coefficients| {
+            let weights = naive_weight_vector(target, feedback, &coefficients);
+            evaluate(&weights, relevant, irrelevant)
+        })
+        .max_by(|a, b| a.average_precision.total_cmp(&b.average_precision))
+        .unwrap()
+}
+
+/// Split each cluster into the part the user gave feedback on and the part left
+/// to be retrieved. Feedback items are excluded from scoring, as the query API
+/// excludes referenced ids.
+fn split_feedback(
+    scenario: &Scenario,
+    per_class: usize,
+    rng: &mut StdRng,
+) -> (
+    Vec<FeedbackItem<DenseVector>>,
+    Vec<DenseVector>,
+    Vec<DenseVector>,
+) {
+    let mut feedback = Vec::with_capacity(per_class * 2);
+
+    // Graded rather than binary scores, so the `confidence` term of the naive
+    // formula (and thus its `b` coefficient) actually varies.
+    for vector in scenario.relevant.iter().take(per_class) {
+        feedback.push(FeedbackItem {
+            vector: vector.clone(),
+            score: OrderedFloat(rng.random_range(0.7..1.0)),
+        });
+    }
+    for vector in scenario.confusable.iter().take(per_class) {
+        feedback.push(FeedbackItem {
+            vector: vector.clone(),
+            score: OrderedFloat(rng.random_range(0.0..0.3)),
+        });
+    }
+
+    let held_out_relevant = scenario.relevant[per_class..].to_vec();
+    let irrelevant = scenario.confusable[per_class..]
+        .iter()
+        .chain(scenario.background.iter())
+        .cloned()
+        .collect();
+
+    (feedback, held_out_relevant, irrelevant)
+}
+
+/// The naive formula is linear in the candidate, so folding it into a single
+/// vector must reproduce `score_by` exactly. This both documents the property
+/// and licenses the folded scoring used by the evaluation.
+#[test]
+fn naive_score_is_linear_in_the_candidate() {
+    let mut rng = StdRng::seed_from_u64(7);
+
+    let grid = naive_grid(false).into_iter().chain(naive_grid(true));
+    for coefficients in grid {
+        let target = gaussian(&mut rng);
+        let feedback: Vec<FeedbackItem<DenseVector>> = (0..6)
+            .map(|_| FeedbackItem {
+                vector: gaussian(&mut rng),
+                score: OrderedFloat(rng.random_range(0.0..1.0)),
+            })
+            .collect();
+
+        let query = NaiveFeedbackQuery {
+            target: target.clone(),
+            feedback: feedback.clone(),
+            coefficients,
+        }
+        .into_query();
+        let folded = naive_weight_vector(&target, &feedback, &coefficients);
+
+        for _ in 0..8 {
+            let candidate = gaussian(&mut rng);
+            let walked = query.score_by(|example: &DenseVector| dot(example, &candidate));
+            let single_dot = dot(&folded, &candidate);
+            assert!(
+                (walked - single_dot).abs() <= 1e-3 * walked.abs().max(1.0),
+                "walking the pairs gave {walked}, the folded vector gave {single_dot}",
+            );
+        }
+    }
+}
+
+/// Blend the SEFR direction with the original query, matching what
+/// `SefrParams::target_weight` does.
+fn blended(
+    sefr_weights: &[VectorElementType],
+    target: &[VectorElementType],
+    target_weight: f32,
+) -> DenseVector {
+    let norm = |v: &[VectorElementType]| v.iter().map(|x| x * x).sum::<ScoreType>().sqrt();
+    let scale = target_weight * norm(sefr_weights) / norm(target);
+
+    sefr_weights
+        .iter()
+        .zip(target)
+        .map(|(w, t)| w + scale * t)
+        .collect()
+}
+
+#[test]
+fn sefr_accuracy_against_naive_and_the_bare_query() {
+    let mut report = String::new();
+
+    for anisotropic in [false, true] {
+        let space = if anisotropic {
+            "uneven per-dimension scale (10^-1 to 10^1)"
+        } else {
+            "uniform per-dimension scale"
+        };
+        writeln!(report, "\n== {space} ==").unwrap();
+        writeln!(
+            report,
+            "{:>8} | {:>7} | {:>7}{:>9} | {:>7}{:>9} | metric",
+            "feedback", "query", "naive", "naive+q", "sefr", "sefr+q",
+        )
+        .unwrap();
+
+        for per_class in FEEDBACK_SIZES.map(|size| size / 2) {
+            let mut query_only = Vec::new();
+            let mut naive_plain = Vec::new();
+            let mut naive_blend = Vec::new();
+            let mut sefr_plain = Vec::new();
+            let mut sefr_blend = Vec::new();
+
+            for trial in 0..TRIALS {
+                let mut rng = StdRng::seed_from_u64(trial as u64);
+                let scenario = build_scenario(&mut rng, anisotropic);
+                let (feedback, relevant, irrelevant) =
+                    split_feedback(&scenario, per_class, &mut rng);
+                let target = &scenario.target;
+
+                query_only.push(evaluate(target, &relevant, &irrelevant));
+
+                // Both naive columns get their best coefficients on this trial.
+                // `a = 0` drops the query, `a = 1` keeps it.
+                naive_plain.push(best_naive(false, target, &feedback, &relevant, &irrelevant));
+                naive_blend.push(best_naive(true, target, &feedback, &relevant, &irrelevant));
+
+                let weights = sefr_weight_vector(&feedback);
+                sefr_plain.push(evaluate(&weights, &relevant, &irrelevant));
+
+                // And SEFR gets its best blend with the query, symmetrically.
+                sefr_blend.push(
+                    TARGET_WEIGHTS
+                        .into_iter()
+                        .map(|target_weight| {
+                            let blend = blended(&weights, target, target_weight);
+                            evaluate(&blend, &relevant, &irrelevant)
+                        })
+                        .max_by(|a, b| a.average_precision.total_cmp(&b.average_precision))
+                        .unwrap(),
+                );
+            }
+
+            let query_only = mean(&query_only);
+            let naive_plain = mean(&naive_plain);
+            let naive_blend = mean(&naive_blend);
+            let sefr_plain = mean(&sefr_plain);
+            let sefr_blend = mean(&sefr_blend);
+
+            let metrics: [MetricAccessor; 3] = [
+                ("mean average precision", |m| m.average_precision),
+                ("precision@10", |m| m.precision_at_10),
+                ("recall@50", |m| m.recall_at_50),
+            ];
+            for (name, get) in metrics {
+                writeln!(
+                    report,
+                    "{:>8} | {:>7.3} | {:>7.3}{:>9.3} | {:>7.3}{:>9.3} | {name}",
+                    per_class * 2,
+                    get(&query_only),
+                    get(&naive_plain),
+                    get(&naive_blend),
+                    get(&sefr_plain),
+                    get(&sefr_blend),
+                )
+                .unwrap();
+            }
+            writeln!(report).unwrap();
+
+            // The scenario has to leave room for the feedback to matter.
+            assert!(
+                query_only.precision_at_10 < 0.75,
+                "the bare query already scored {:.3} at precision@10, \
+                 so the scenario does not exercise the feedback",
+                query_only.precision_at_10,
+            );
+
+            // Below this the min-max scaler is fit on too few points to place
+            // the dimensions sensibly, and SEFR is not competitive.
+            const ENOUGH_FEEDBACK: usize = 8;
+            if per_class * 2 >= ENOUGH_FEEDBACK {
+                assert!(
+                    sefr_plain.average_precision > 1.5 * query_only.average_precision,
+                    "with {} feedback items sefr scored {:.3} mean average precision \
+                     against {:.3} for the bare query, which is not a clear gain",
+                    per_class * 2,
+                    sefr_plain.average_precision,
+                    query_only.average_precision,
+                );
+
+                // Uneven per-dimension scale is what SEFR's per-dimension
+                // weighting is for, and where it should beat the naive
+                // strategy even with the latter's coefficients oracle-tuned.
+                // Compared like for like: with the query, and without it.
+                if anisotropic {
+                    assert!(
+                        sefr_plain.average_precision > naive_plain.average_precision,
+                        "with {} feedback items in an uneven space sefr scored {:.3} \
+                         mean average precision against {:.3} for a tuned naive",
+                        per_class * 2,
+                        sefr_plain.average_precision,
+                        naive_plain.average_precision,
+                    );
+                    assert!(
+                        sefr_blend.average_precision > naive_blend.average_precision,
+                        "with {} feedback items in an uneven space sefr+query scored \
+                         {:.3} mean average precision against {:.3} for a tuned naive+query",
+                        per_class * 2,
+                        sefr_blend.average_precision,
+                        naive_blend.average_precision,
+                    );
+                }
+            }
+
+            // Mixing in the original query should never be the worse choice,
+            // for either strategy.
+            assert!(
+                sefr_blend.average_precision >= sefr_plain.average_precision - 1e-6,
+                "blending the query into sefr hurt: {:.3} against {:.3}",
+                sefr_blend.average_precision,
+                sefr_plain.average_precision,
+            );
+            assert!(
+                naive_blend.average_precision >= naive_plain.average_precision - 1e-6,
+                "blending the query into naive hurt: {:.3} against {:.3}",
+                naive_blend.average_precision,
+                naive_plain.average_precision,
+            );
+        }
+    }
+
+    println!("{report}");
+}
+
+/// Which fixed `target_weight` to recommend. The table above oracle-tunes the
+/// blend per trial, which no default can reproduce, so this reports mean average
+/// precision for each candidate value held constant.
+#[test]
+fn sefr_target_weight_sweep() {
+    let mut report = String::new();
+
+    for anisotropic in [false, true] {
+        let space = if anisotropic {
+            "uneven per-dimension scale"
+        } else {
+            "uniform per-dimension scale"
+        };
+        writeln!(report, "\n== mean average precision, {space} ==").unwrap();
+        write!(report, "{:>8} |", "feedback").unwrap();
+        for target_weight in TARGET_WEIGHTS {
+            write!(report, "{target_weight:>9}").unwrap();
+        }
+        writeln!(report).unwrap();
+
+        for per_class in FEEDBACK_SIZES.map(|size| size / 2) {
+            let mut per_weight = vec![Vec::new(); TARGET_WEIGHTS.len()];
+
+            for trial in 0..TRIALS {
+                let mut rng = StdRng::seed_from_u64(trial as u64);
+                let scenario = build_scenario(&mut rng, anisotropic);
+                let (feedback, relevant, irrelevant) =
+                    split_feedback(&scenario, per_class, &mut rng);
+                let weights = sefr_weight_vector(&feedback);
+
+                for (slot, target_weight) in per_weight.iter_mut().zip(TARGET_WEIGHTS) {
+                    let blend = blended(&weights, &scenario.target, target_weight);
+                    slot.push(evaluate(&blend, &relevant, &irrelevant));
+                }
+            }
+
+            write!(report, "{:>8} |", per_class * 2).unwrap();
+            for slot in &per_weight {
+                write!(report, "{:>9.3}", mean(slot).average_precision).unwrap();
+            }
+            writeln!(report).unwrap();
+        }
+    }
+
+    println!("{report}");
+}

--- a/lib/shard/src/query/conversions.rs
+++ b/lib/shard/src/query/conversions.rs
@@ -554,6 +554,13 @@ impl QueryEnum {
                         };
                         QueryEnum::FeedbackNaive(named)
                     }
+                    // SEFR is fit at the collection level and reduces to a plain
+                    // nearest query, so it never reaches the internal protocol.
+                    grpc::feedback_strategy::Variant::Sefr(_) => {
+                        return Err(tonic::Status::invalid_argument(
+                            "the `sefr` feedback strategy is resolved before the shard request",
+                        ));
+                    }
                 }
             }
         };

--- a/tests/basic_query_grpc_test.sh
+++ b/tests/basic_query_grpc_test.sh
@@ -155,3 +155,31 @@ fi
     }
   }
 }' $QDRANT_HOST qdrant.Points/Query
+
+# SEFR needs two feedback classes; a single item must be rejected as INVALID_ARGUMENT.
+set +e
+response=$(
+  "${docker_grpcurl[@]}" -d '{
+    "collection_name": "test_collection",
+    "query": {
+      "relevance_feedback": {
+        "target": {
+          "dense": { "data": [0.2, 0.1, 0.9, 0.7] }
+        },
+        "feedback": [
+          {
+            "example": { "dense": { "data": [0.05, 0.61, 0.76, 0.74] } },
+            "score": 1.0
+          }
+        ],
+        "strategy": { "sefr": {} }
+      }
+    },
+    "limit": 3
+  }' $QDRANT_HOST qdrant.Points/Query 2>&1
+)
+if [[ $response != *"Validation error in body"* ]] || [[ $response != *"the \`sefr\` strategy needs at least two feedback elements to separate"* ]]; then
+    echo Unexpected response, expected SEFR feedback validation error: "$response"
+    exit 1
+fi
+set -e

--- a/tests/openapi/test_relevance_feedback.py
+++ b/tests/openapi/test_relevance_feedback.py
@@ -122,3 +122,27 @@ def test_feedback_pair_requirement(collection_name):
     query_results = response.json()["result"]
 
     assert feedback_results == query_results
+
+
+def test_sefr_requires_two_feedback_items(collection_name):
+    # SEFR needs both classes; a single feedback item can never form them.
+    response = request_with_validation(
+        api="/collections/{collection_name}/points/query",
+        method="POST",
+        path_params={"collection_name": collection_name},
+        body={
+            "query": {
+                "relevance_feedback": {
+                    "target": [0.1, 0.2, 0.3, 0.4],
+                    "feedback": [{"example": [0.42, 0.42, 0.42, 0.42], "score": 0.85}],
+                    "strategy": {"sefr": {}},
+                }
+            },
+            "limit": 3,
+        },
+    )
+    assert not response.ok, response.text
+    assert (
+        "the `sefr` strategy needs at least two feedback elements to separate"
+        in response.json()["status"]["error"]
+    )


### PR DESCRIPTION
### All Submissions:

> **⚠️ PRs must target the `dev` branch.**

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [ ] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---

## Summary

For Relevance Feedback, the `SEFR` classification algorithm is added in order to improve precision and recall, and also speed. It is next to the existing `naive` strategy. The `SEFR`algorithm does the training and prediction in linear time, and works well with the embeddings. 

The input to SEFR are the feedback items of one query. Since SEFR requires the features to be positive, a min-max scaling is also fit on the feedback set on the weights. So, the scoring becomes a single nearest-query vector (HNSW-friendly). It is best to use on dense vectors, and also on dot and cosine.

REST/gRPC expose optional `threshold` and `target_weight`.

Benchmarks are also added to compare SEFR and SEFR+Query to naive and naive+query methods, to show higher precision and recall for SEFR, starting from 4 positive feedback samples on the uneven embedding scale (on 4 samples, mean average precision is 0.69 and 0.96 for SEFR and SEFR+Query, and 0.60 and 0.86 for Naive and Naive+Query). 

## AI disclosure

- [AI] feat: add SEFR relevance feedback strategy

Add the SEFR Classifier as the classification algorithm for relevance feedback to distinguish between positive and negative classes. Use min-max scaling to make the features positive.
https://github.com/sefr-classifier/sefr

Made with [Cursor](https://cursor.com)