### PR TITLE
fix(validation): reject trailing dots, spaces, and Windows reserved names in collection names (#10418)

### DIFF
--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -161,12 +161,9 @@ fn check_plain_dir_name(value: &str, kind: &str) -> Result<(), ValidationError> 
     if value.ends_with('.') || value.ends_with(' ') {
         let mut err = ValidationError::new("trailing_dot_or_space");
         err.add_param(Cow::from("value"), &value);
-        err.message.replace(
-            format!(
-                "{kind} cannot end with a period or space, it is used as a directory name on disk"
-            )
-            .into(),
-        );
+        err.message.replace(Cow::from(format!(
+            "{kind} cannot end with a period or space, it is used as a directory name on disk"
+        )));
         return Err(err);
     }
 
@@ -175,7 +172,7 @@ fn check_plain_dir_name(value: &str, kind: &str) -> Result<(), ValidationError> 
         let mut err = ValidationError::new("reserved_name");
         err.add_param(Cow::from("value"), &value);
         err.message
-            .replace(format!("{kind} cannot be a reserved device name {value:?}").into());
+            .replace(Cow::from(format!("{kind} cannot be a reserved device name {value:?}")));
         return Err(err);
     }
 

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -108,11 +108,33 @@ fn check_invalid_name_chars(value: &str, kind: &str) -> Result<(), ValidationErr
     Err(err)
 }
 
-/// Reject names that are not a plain, single path component.
+/// Windows reserved device names (CON, PRN, AUX, NUL, COM1..9, LPT1..9).
+///
+/// On Windows filesystems, these names (and variants with extensions like `NUL.json`)
+/// refer to legacy system devices rather than valid directories, causing OS errors or hangs.
+const WINDOWS_RESERVED_DEVICE_NAMES: [&str; 22] = [
+    "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
+    "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+];
+
+fn is_windows_reserved_name(value: &str) -> bool {
+    let stem = match value.split_once('.') {
+        Some((stem, _)) => stem,
+        None => value,
+    };
+    WINDOWS_RESERVED_DEVICE_NAMES
+        .iter()
+        .any(|&r| r.eq_ignore_ascii_case(stem))
+}
+
+/// Reject names that are not a plain, single path component or are unsafe on disk.
 ///
 /// Name is used as the name of a storage directory on disk.
-/// It must not contain path separators or dot-segments (`.`, `..`),
-/// so that it won't be interpreted as a path.
+/// It must not contain path separators, dot-segments (`.`, `..`),
+/// trailing periods or spaces (which Windows Win32 API strips, causing
+/// dot-only strings like `...` to resolve to the parent directory itself,
+/// and trailing dots/spaces to alias existing directories),
+/// or Windows-reserved device names.
 ///
 /// `Path::file_name` is a simple way to check this: it returns the whole path
 /// only when it's a simple name with no restricted components.
@@ -126,6 +148,32 @@ fn check_plain_dir_name(value: &str, kind: &str) -> Result<(), ValidationError> 
         );
         return Err(err);
     }
+
+    // Windows strips trailing periods and spaces during path normalization.
+    // This causes strings consisting solely of dots ("...", "....") to normalize
+    // directly to the parent directory itself, as well as causing silent collisions
+    // ("name." -> "name").
+    if value.ends_with('.') || value.ends_with(' ') {
+        let mut err = ValidationError::new("trailing_dot_or_space");
+        err.add_param(Cow::from("value"), &value);
+        err.message.replace(
+            format!(
+                "{kind} cannot end with a period or space, it is used as a directory name on disk"
+            )
+            .into(),
+        );
+        return Err(err);
+    }
+
+    // Reject reserved Windows device names (CON, PRN, AUX, NUL, COM1-9, LPT1-9).
+    if is_windows_reserved_name(value) {
+        let mut err = ValidationError::new("reserved_name");
+        err.add_param(Cow::from("value"), &value);
+        err.message
+            .replace(format!("{kind} cannot be a reserved device name {value:?}").into());
+        return Err(err);
+    }
+
     Ok(())
 }
 
@@ -454,6 +502,19 @@ mod tests {
             "..",
             ".",
             "",
+            "...",
+            "....",
+            "test.",
+            "test..",
+            "test ",
+            " ",
+            "con",
+            "CON",
+            "nul",
+            "NUL",
+            "aux.json",
+            "com1",
+            "lpt1",
         ];
 
         for name in TRAVERSING_NAMES {
@@ -495,7 +556,7 @@ mod tests {
 
         // Names merely containing dots do not traverse and must stay valid, so existing
         // collections with such names remain reachable.
-        for name in ["v1.2", ".hidden", "..dots", "..."] {
+        for name in ["v1.2", ".hidden", "..dots"] {
             assert!(
                 validate_collection_name(name).is_ok(),
                 "collection name {name:?} does not traverse and must stay valid",

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -117,6 +117,11 @@ const WINDOWS_RESERVED_DEVICE_NAMES: [&str; 22] = [
     "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
 ];
 
+/// Check if a name (or its file stem before any extension) matches a reserved Windows device name.
+///
+/// Under Win32 path normalization, device names such as `CON`, `NUL`, `AUX`, `COM1..9`, and `LPT1..9`
+/// (including variants with extensions like `NUL.json` or case-insensitively like `con`) refer to legacy
+/// DOS devices and cannot be safely used as directory names on Windows filesystems.
 fn is_windows_reserved_name(value: &str) -> bool {
     let stem = match value.split_once('.') {
         Some((stem, _)) => stem,

--- a/lib/common/common/src/validation.rs
+++ b/lib/common/common/src/validation.rs
@@ -117,16 +117,16 @@ const WINDOWS_RESERVED_DEVICE_NAMES: [&str; 22] = [
     "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
 ];
 
-/// Check if a name (or its file stem before any extension) matches a reserved Windows device name.
+/// Check if a name (or its file stem before any extension or colon delimiter) matches a reserved Windows device name.
 ///
 /// Under Win32 path normalization, device names such as `CON`, `NUL`, `AUX`, `COM1..9`, and `LPT1..9`
-/// (including variants with extensions like `NUL.json` or case-insensitively like `con`) refer to legacy
-/// DOS devices and cannot be safely used as directory names on Windows filesystems.
+/// (including variants with extensions like `NUL.json`, trailing colons like `CON:`, or colon-qualified forms
+/// like `NUL:foo`) refer to legacy DOS devices and cannot be safely used as directory names on Windows filesystems.
 fn is_windows_reserved_name(value: &str) -> bool {
-    let stem = match value.split_once('.') {
-        Some((stem, _)) => stem,
-        None => value,
-    };
+    let stem = value
+        .split(['.', ':'])
+        .next()
+        .unwrap_or(value);
     WINDOWS_RESERVED_DEVICE_NAMES
         .iter()
         .any(|&r| r.eq_ignore_ascii_case(stem))
@@ -520,6 +520,10 @@ mod tests {
             "aux.json",
             "com1",
             "lpt1",
+            "NUL:foo",
+            "CON:foo",
+            "con:",
+            "com1:stream",
         ];
 
         for name in TRAVERSING_NAMES {


### PR DESCRIPTION
### Summary
Fixes #10418

While #10242 added `Path::new(value).file_name() != Some(value.as_ref())` to reject `.` and `..`, `"..."` and strings of dots still pass validation because Rust's `Path::file_name()` classifies `"..."` as a normal filename component (`Some("...")`). In fact, #10242 added a test asserting `validate_collection_name("...")` is valid.

However, under Windows Win32 path normalization:
1. Trailing periods (`.`) and spaces (` `) are stripped.
2. For `"..."`, stripping trailing periods strips all characters, causing `storage\collections\...` to resolve directly to `storage\collections\`.
3. Invoking `DELETE /collections/%2E%2E%2E` causes `safe_delete_in_tmp` to move `storage\collections\...` to `.deleted`, wiping out the entire `collections` root directory and all collections stored inside.
4. Names ending with a dot or space (e.g. `col.` or `col `) silently collide with and overwrite existing collections (`col`).
5. Windows reserved device names (`CON`, `PRN`, `AUX`, `NUL`, `COM1..9`, `LPT1..9`) cause OS errors or hangs when accessed as directories.

### Changes
- In `lib/common/common/src/validation.rs`:
  - In `check_plain_dir_name`, reject names ending with a period (`.`) or space (` `). This automatically blocks all pure-dot sequences (`...`, `....`) and prevents trailing-character aliasing.
  - Reject Windows reserved device names (`CON`, `PRN`, `AUX`, `NUL`, etc., including with file extensions).
- Update unit tests:
  - Remove `"..."` from the accepted names list.
  - Add `"..."`, `"...."`, `"test."`, `"test "`, `"CON"`, `"NUL"`, etc., to `TRAVERSING_NAMES` to verify both strict and legacy validators reject them.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
