### PR TITLE
chore(wal): gate wal-ctl bin deps behind feature

### DIFF
--- a/lib/wal/Cargo.toml
+++ b/lib/wal/Cargo.toml
@@ -13,6 +13,15 @@ publish = false
 [lints]
 workspace = true
 
+[[bin]]
+name = "wal-ctl"
+path = "src/bin/wal-ctl.rs"
+# Bin only; build with --features wal-ctl
+required-features = ["wal-ctl"]
+
+[features]
+wal-ctl = ["dep:docopt", "dep:env_logger"]
+
 [dependencies]
 byteorder = { workspace = true }
 crc32c = "0.6.8"
@@ -26,15 +35,18 @@ rand_distr = { workspace = true }
 # to use direct functions on FreeBSD
 rustix = { version = "1", features = ["fs"] }
 
-# Binary dependencies
-docopt = "1.1"
-env_logger = { workspace = true }
+# Bin-only and test logging
 serde = { workspace = true }
+docopt = { version = "1.1", optional = true }
+env_logger = { workspace = true, optional = true }
 
 [dev-dependencies]
 chrono = { workspace = true }
 crc = "3.4.0"
 criterion = { workspace = true }
+# Examples and tests
+docopt = "1.1"
+env_logger = { workspace = true }
 hdrhistogram = "7.5.4"
 quickcheck = "1.1.0"
 regex = "1.12.3"


### PR DESCRIPTION
## Summary

`docopt` and `env_logger` were mandatory dependencies of `wal`, but are used only by the `wal-ctl` debug binary, examples, and `cfg(test)` logging. Every consumer of `wal` as a library resolved and compiled them for nothing, including edge builds and the amalgamated `qdrant-edge` crate.

This PR makes both optional behind a new `wal-ctl` feature (`required-features` on the binary) and adds both to `[dev-dependencies]` so tests, examples, and benches keep working. The binary still builds with `cargo build -p wal --features wal-ctl`.

## Verification

- `cargo check -p wal` and `cargo check -p wal --features wal-ctl`
- `cargo test -p wal --lib` (38 passed)
- `cargo clippy -p wal --all-targets` with and without `--all-features`
- `cargo tree -p edge -e no-dev -i docopt` / `-i env_logger`: no match

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?