### PR TITLE
chore(segment): make gpu dependency optional

### DIFF
--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [features]
 default = []
 testing = ["common/testing", "sparse/testing", "gpu/testing", "quantization/testing"]
-gpu = ["gpu/gpu"]
+gpu = ["dep:gpu", "gpu/gpu"]
 
 [build-dependencies]
 cc = { workspace = true }
@@ -116,7 +116,7 @@ macros = { path = "../macros" }
 posting_list = { path = "../posting_list" }
 quantization = { path = "../quantization" }
 sparse = { path = "../sparse" }
-gpu = { path = "../gpu" }
+gpu = { path = "../gpu", optional = true }
 
 tracing = { workspace = true, optional = true }
 macro_rules_attribute = "0.2.2"


### PR DESCRIPTION
## Summary

`gpu` was a mandatory dependency of `segment`, but every use is already behind `#[cfg(feature = "gpu")]` with a stub module when the feature is off. Edge builds (`default-features = false`) compiled the crate for nothing.

This PR makes it optional and wires it into the existing `gpu` feature (`gpu = ["dep:gpu", "gpu/gpu"]`). Server builds with the feature enabled are unchanged.

## Verification

- `cargo check -p segment`, `--no-default-features`, `--features gpu`
- `cargo tree -p edge -e no-dev -i gpu`: no match
- Workspace `gpu` feature still resolves

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?