### PR TITLE
feat: copy a fresh appendable segment in one async save wave

### DIFF
--- a/lib/common/common/src/universal_io/mmap/async_io.rs
+++ b/lib/common/common/src/universal_io/mmap/async_io.rs
@@ -16,7 +16,7 @@ use crate::ext::aligned_vec::ACow;
 use crate::generic_consts::AccessPattern;
 use crate::universal_io::{
     OpenOptions, UioResult, UniversalRead, UniversalReadAsync, UniversalReadFs,
-    UniversalReadFsAsync,
+    UniversalReadFsAsync, UniversalWriteFileOps, UniversalWriteFsAsync,
 };
 
 impl UniversalReadFsAsync for MmapFs {
@@ -38,5 +38,27 @@ impl UniversalReadAsync for MmapFile {
         align: usize,
     ) -> impl Future<Output = UioResult<ACow<'_>>> {
         ready(self.read_bytes(range, access_pattern, align))
+    }
+}
+
+impl UniversalWriteFsAsync for MmapFs {
+    fn create_dir_async(&self, path: PathBuf) -> impl Future<Output = UioResult<()>> + Send + '_ {
+        ready(self.create_dir(&path))
+    }
+
+    fn atomic_save_async(
+        &self,
+        path: PathBuf,
+        bytes: Vec<u8>,
+    ) -> impl Future<Output = UioResult<()>> + Send + '_ {
+        ready(self.atomic_save(&path, &bytes))
+    }
+
+    fn remove_async(&self, path: PathBuf) -> impl Future<Output = UioResult<()>> + Send + '_ {
+        ready(self.remove(&path))
+    }
+
+    fn block_on<F: Future>(&self, fut: F) -> F::Output {
+        futures::executor::block_on(fut)
     }
 }

--- a/lib/common/common/src/universal_io/mmap/async_io.rs
+++ b/lib/common/common/src/universal_io/mmap/async_io.rs
@@ -55,9 +55,4 @@ impl UniversalWriteFsAsync for MmapFs {
     async fn remove_async(&self, path: PathBuf) -> UioResult<()> {
         self.remove(&path)
     }
-
-    /// Local saves complete inline, so a wave gains nothing over a loop.
-    fn max_concurrent_saves(&self) -> usize {
-        1
-    }
 }

--- a/lib/common/common/src/universal_io/mmap/async_io.rs
+++ b/lib/common/common/src/universal_io/mmap/async_io.rs
@@ -41,24 +41,23 @@ impl UniversalReadAsync for MmapFile {
     }
 }
 
+/// Unlike the reads above, the writes are deferred to first poll, as
+/// [`UniversalWriteFsAsync`] requires.
 impl UniversalWriteFsAsync for MmapFs {
-    fn create_dir_async(&self, path: PathBuf) -> impl Future<Output = UioResult<()>> + Send + '_ {
-        ready(self.create_dir(&path))
+    async fn create_dir_async(&self, path: PathBuf) -> UioResult<()> {
+        self.create_dir(&path)
     }
 
-    fn atomic_save_async(
-        &self,
-        path: PathBuf,
-        bytes: Vec<u8>,
-    ) -> impl Future<Output = UioResult<()>> + Send + '_ {
-        ready(self.atomic_save(&path, &bytes))
+    async fn atomic_save_async(&self, path: PathBuf, bytes: Vec<u8>) -> UioResult<()> {
+        self.atomic_save(&path, &bytes)
     }
 
-    fn remove_async(&self, path: PathBuf) -> impl Future<Output = UioResult<()>> + Send + '_ {
-        ready(self.remove(&path))
+    async fn remove_async(&self, path: PathBuf) -> UioResult<()> {
+        self.remove(&path)
     }
 
-    fn block_on<F: Future>(&self, fut: F) -> F::Output {
-        futures::executor::block_on(fut)
+    /// Local saves complete inline, so a wave gains nothing over a loop.
+    fn max_concurrent_saves(&self) -> usize {
+        1
     }
 }

--- a/lib/common/common/src/universal_io/mod.rs
+++ b/lib/common/common/src/universal_io/mod.rs
@@ -35,7 +35,7 @@ pub use self::sorted_block_index::SortedBlockIndex;
 pub use self::traits::{
     CachedReadFs, Item, OpenExtra, OwnedPipeline, ReadPipeline, UniversalAppend, UniversalAppendFs,
     UniversalFlush, UniversalRead, UniversalReadAsync, UniversalReadFileOps, UniversalReadFs,
-    UniversalReadFsAsync, UniversalWrite, UniversalWriteFileOps, UserData,
+    UniversalReadFsAsync, UniversalWrite, UniversalWriteFileOps, UniversalWriteFsAsync, UserData,
 };
 pub use self::types::{
     ByteOffset, FileIndex, Flusher, ListedFile, OpenOptions, Populate, ReadBytesItem, ReadRange,

--- a/lib/common/common/src/universal_io/traits/async_io.rs
+++ b/lib/common/common/src/universal_io/traits/async_io.rs
@@ -46,30 +46,23 @@ pub trait UniversalReadFsAsync: UniversalReadFs {
 }
 
 /// The async whole-file write surface, mirroring the same operations on
-/// [`UniversalWriteFileOps`].
-///
-/// A batch of saves runs as one concurrent wave on the backend's own IO
-/// runtime instead of a thread per file; synchronous callers drive the wave
-/// through [`Self::block_on`]. Local backends resolve inline, as they do for
-/// [`UniversalReadFsAsync`].
+/// [`UniversalWriteFileOps`]: a batch of saves runs as one concurrent wave on
+/// the backend's own IO runtime instead of a thread per file.
 ///
 /// [`UniversalWriteFileOps`]: crate::universal_io::UniversalWriteFileOps
 pub trait UniversalWriteFsAsync: Send + Sync {
-    /// Create a directory. Backends without materialized directories may
-    /// treat this as a no-op.
+    /// Backends without materialized directories may treat this as a no-op.
     fn create_dir_async(&self, path: PathBuf) -> impl Future<Output = UioResult<()>> + Send + '_;
 
-    /// Atomically save `bytes` at `path` in a single write.
     fn atomic_save_async(
         &self,
         path: PathBuf,
         bytes: Vec<u8>,
     ) -> impl Future<Output = UioResult<()>> + Send + '_;
 
-    /// Remove the file at `path`.
     fn remove_async(&self, path: PathBuf) -> impl Future<Output = UioResult<()>> + Send + '_;
 
-    /// Drive a future built from this filesystem's async operations to
-    /// completion from synchronous code, on the executor those operations need.
+    /// Drive a wave of these operations from synchronous code, on the executor
+    /// they need.
     fn block_on<F: Future>(&self, fut: F) -> F::Output;
 }

--- a/lib/common/common/src/universal_io/traits/async_io.rs
+++ b/lib/common/common/src/universal_io/traits/async_io.rs
@@ -46,8 +46,15 @@ pub trait UniversalReadFsAsync: UniversalReadFs {
 }
 
 /// The async whole-file write surface, mirroring the same operations on
-/// [`UniversalWriteFileOps`]: a batch of saves runs as one concurrent wave on
-/// the backend's own IO runtime instead of a thread per file.
+/// [`UniversalWriteFileOps`]: a batch of saves runs as one concurrent wave
+/// instead of a thread per file.
+///
+/// As with [`UniversalReadFsAsync::open_async`], the futures must not depend on
+/// ambient async context, so any executor can drive them — including
+/// `futures::executor::block_on` from synchronous code. Nothing runs before the
+/// first poll, so a caller that sizes its wave by
+/// [`max_concurrent_saves`](Self::max_concurrent_saves) really does bound the
+/// in-flight saves, however it collects the futures.
 ///
 /// [`UniversalWriteFileOps`]: crate::universal_io::UniversalWriteFileOps
 pub trait UniversalWriteFsAsync: Send + Sync {
@@ -62,7 +69,8 @@ pub trait UniversalWriteFsAsync: Send + Sync {
 
     fn remove_async(&self, path: PathBuf) -> impl Future<Output = UioResult<()>> + Send + '_;
 
-    /// Drive a wave of these operations from synchronous code, on the executor
-    /// they need.
-    fn block_on<F: Future>(&self, fut: F) -> F::Output;
+    /// The backend's own save queue depth, which a caller uses to size its
+    /// wave — and with it, how many buffers it holds in memory. Backends
+    /// enforce their total in-flight saves themselves, across all callers.
+    fn max_concurrent_saves(&self) -> usize;
 }

--- a/lib/common/common/src/universal_io/traits/async_io.rs
+++ b/lib/common/common/src/universal_io/traits/async_io.rs
@@ -44,3 +44,32 @@ pub trait UniversalReadFsAsync: UniversalReadFs {
         extra: Self::OpenExtra,
     ) -> impl Future<Output = UioResult<Self::File>> + Send + '_;
 }
+
+/// The async whole-file write surface, mirroring the same operations on
+/// [`UniversalWriteFileOps`].
+///
+/// A batch of saves runs as one concurrent wave on the backend's own IO
+/// runtime instead of a thread per file; synchronous callers drive the wave
+/// through [`Self::block_on`]. Local backends resolve inline, as they do for
+/// [`UniversalReadFsAsync`].
+///
+/// [`UniversalWriteFileOps`]: crate::universal_io::UniversalWriteFileOps
+pub trait UniversalWriteFsAsync: Send + Sync {
+    /// Create a directory. Backends without materialized directories may
+    /// treat this as a no-op.
+    fn create_dir_async(&self, path: PathBuf) -> impl Future<Output = UioResult<()>> + Send + '_;
+
+    /// Atomically save `bytes` at `path` in a single write.
+    fn atomic_save_async(
+        &self,
+        path: PathBuf,
+        bytes: Vec<u8>,
+    ) -> impl Future<Output = UioResult<()>> + Send + '_;
+
+    /// Remove the file at `path`.
+    fn remove_async(&self, path: PathBuf) -> impl Future<Output = UioResult<()>> + Send + '_;
+
+    /// Drive a future built from this filesystem's async operations to
+    /// completion from synchronous code, on the executor those operations need.
+    fn block_on<F: Future>(&self, fut: F) -> F::Output;
+}

--- a/lib/common/common/src/universal_io/traits/async_io.rs
+++ b/lib/common/common/src/universal_io/traits/async_io.rs
@@ -52,9 +52,8 @@ pub trait UniversalReadFsAsync: UniversalReadFs {
 /// As with [`UniversalReadFsAsync::open_async`], the futures must not depend on
 /// ambient async context, so any executor can drive them — including
 /// `futures::executor::block_on` from synchronous code. Nothing runs before the
-/// first poll, so a caller that sizes its wave by
-/// [`max_concurrent_saves`](Self::max_concurrent_saves) really does bound the
-/// in-flight saves, however it collects the futures.
+/// first poll, so a caller that bounds its wave really does bound the in-flight
+/// saves, however it collects the futures.
 ///
 /// [`UniversalWriteFileOps`]: crate::universal_io::UniversalWriteFileOps
 pub trait UniversalWriteFsAsync: Send + Sync {
@@ -68,9 +67,4 @@ pub trait UniversalWriteFsAsync: Send + Sync {
     ) -> impl Future<Output = UioResult<()>> + Send + '_;
 
     fn remove_async(&self, path: PathBuf) -> impl Future<Output = UioResult<()>> + Send + '_;
-
-    /// The backend's own save queue depth, which a caller uses to size its
-    /// wave — and with it, how many buffers it holds in memory. Backends
-    /// enforce their total in-flight saves themselves, across all callers.
-    fn max_concurrent_saves(&self) -> usize;
 }

--- a/lib/common/common/src/universal_io/traits/mod.rs
+++ b/lib/common/common/src/universal_io/traits/mod.rs
@@ -9,7 +9,7 @@ mod write;
 use std::fmt;
 
 pub use append::{UniversalAppend, UniversalAppendFs};
-pub use async_io::{UniversalReadAsync, UniversalReadFsAsync};
+pub use async_io::{UniversalReadAsync, UniversalReadFsAsync, UniversalWriteFsAsync};
 pub use file_ops::{CachedReadFs, UniversalReadFileOps, UniversalReadFs, UniversalWriteFileOps};
 pub use open_extra::OpenExtra;
 pub use pipeline::{OwnedPipeline, ReadPipeline};

--- a/lib/common/io_bridge/src/cached/async_io.rs
+++ b/lib/common/io_bridge/src/cached/async_io.rs
@@ -74,7 +74,7 @@ where
         self.blob_fs.remove_async(path)
     }
 
-    fn block_on<F: Future>(&self, fut: F) -> F::Output {
-        self.blob_fs.runtime().block_on(fut)
+    fn max_concurrent_saves(&self) -> usize {
+        self.blob_fs.max_concurrent_saves()
     }
 }

--- a/lib/common/io_bridge/src/cached/async_io.rs
+++ b/lib/common/io_bridge/src/cached/async_io.rs
@@ -7,7 +7,9 @@ use std::path::PathBuf;
 
 use common::ext::aligned_vec::ACow;
 use common::generic_consts::AccessPattern;
-use common::universal_io::{OpenOptions, UioResult, UniversalReadAsync, UniversalReadFsAsync};
+use common::universal_io::{
+    OpenOptions, UioResult, UniversalReadAsync, UniversalReadFsAsync, UniversalWriteFsAsync,
+};
 
 use super::CachedBlobFile;
 use super::fs::CachedBlobFs;
@@ -48,5 +50,31 @@ where
         align: usize,
     ) -> impl Future<Output = UioResult<ACow<'_>>> {
         self.cache.read_bytes_async(range, access_pattern, align)
+    }
+}
+
+impl<A: AsyncAppend + Clone> UniversalWriteFsAsync for CachedBlobFs<A>
+where
+    A::Config: Clone,
+{
+    fn create_dir_async(&self, _path: PathBuf) -> impl Future<Output = UioResult<()>> + Send + '_ {
+        // No materialized directories.
+        std::future::ready(Ok(()))
+    }
+
+    fn atomic_save_async(
+        &self,
+        path: PathBuf,
+        bytes: Vec<u8>,
+    ) -> impl Future<Output = UioResult<()>> + Send + '_ {
+        self.blob_fs.save_async(path, bytes)
+    }
+
+    fn remove_async(&self, path: PathBuf) -> impl Future<Output = UioResult<()>> + Send + '_ {
+        self.blob_fs.remove_async(path)
+    }
+
+    fn block_on<F: Future>(&self, fut: F) -> F::Output {
+        self.blob_fs.runtime().block_on(fut)
     }
 }

--- a/lib/common/io_bridge/src/cached/async_io.rs
+++ b/lib/common/io_bridge/src/cached/async_io.rs
@@ -73,8 +73,4 @@ where
     fn remove_async(&self, path: PathBuf) -> impl Future<Output = UioResult<()>> + Send + '_ {
         self.blob_fs.remove_async(path)
     }
-
-    fn max_concurrent_saves(&self) -> usize {
-        self.blob_fs.max_concurrent_saves()
-    }
 }

--- a/lib/common/io_bridge/src/fs.rs
+++ b/lib/common/io_bridge/src/fs.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use bytes::Bytes;
 use common::universal_io::{
@@ -29,6 +29,21 @@ impl<A: AsyncRead> std::fmt::Debug for BlobFs<A> {
 impl<A: AsyncRead> BlobFs<A> {
     pub fn new(inner: A, runtime: BridgeRuntime) -> Self {
         Self { inner, runtime }
+    }
+
+    pub(crate) fn runtime(&self) -> &BridgeRuntime {
+        &self.runtime
+    }
+}
+
+impl<A: AsyncWrite> BlobFs<A> {
+    /// The single-put save as a future, for callers batching several saves.
+    pub async fn save_async(&self, path: PathBuf, bytes: Vec<u8>) -> UioResult<()> {
+        self.inner.save(&path, Bytes::from(bytes)).await
+    }
+
+    pub async fn remove_async(&self, path: PathBuf) -> UioResult<()> {
+        self.inner.remove(&path).await
     }
 }
 

--- a/lib/common/io_bridge/src/fs.rs
+++ b/lib/common/io_bridge/src/fs.rs
@@ -37,7 +37,6 @@ impl<A: AsyncRead> BlobFs<A> {
 }
 
 impl<A: AsyncWrite> BlobFs<A> {
-    /// The single-put save as a future, for callers batching several saves.
     pub async fn save_async(&self, path: PathBuf, bytes: Vec<u8>) -> UioResult<()> {
         self.inner.save(&path, Bytes::from(bytes)).await
     }

--- a/lib/common/io_bridge/src/fs.rs
+++ b/lib/common/io_bridge/src/fs.rs
@@ -30,19 +30,51 @@ impl<A: AsyncRead> BlobFs<A> {
     pub fn new(inner: A, runtime: BridgeRuntime) -> Self {
         Self { inner, runtime }
     }
-
-    pub(crate) fn runtime(&self) -> &BridgeRuntime {
-        &self.runtime
-    }
 }
 
-impl<A: AsyncWrite> BlobFs<A> {
-    pub async fn save_async(&self, path: PathBuf, bytes: Vec<u8>) -> UioResult<()> {
-        self.inner.save(&path, Bytes::from(bytes)).await
+impl<A: AsyncWrite + Clone> BlobFs<A> {
+    pub fn save_async(
+        &self,
+        path: PathBuf,
+        bytes: Vec<u8>,
+    ) -> impl Future<Output = UioResult<()>> + Send + 'static + use<A> {
+        let inner = self.inner.clone();
+        self.spawn_write(async move { inner.save(&path, Bytes::from(bytes)).await })
     }
 
-    pub async fn remove_async(&self, path: PathBuf) -> UioResult<()> {
-        self.inner.remove(&path).await
+    pub fn remove_async(
+        &self,
+        path: PathBuf,
+    ) -> impl Future<Output = UioResult<()>> + Send + 'static + use<A> {
+        let inner = self.inner.clone();
+        self.spawn_write(async move { inner.remove(&path).await })
+    }
+
+    pub fn max_concurrent_saves(&self) -> usize {
+        self.runtime.max_concurrent_writes()
+    }
+
+    /// Like the async reads, the write rides the [`BridgeRuntime`] rather than
+    /// the caller's executor, so the returned future needs no ambient reactor.
+    /// It spawns on first poll, under one of the runtime's write permits, which
+    /// cap these spawned writes across every caller.
+    fn spawn_write<F>(
+        &self,
+        op: F,
+    ) -> impl Future<Output = UioResult<()>> + Send + 'static + use<A, F>
+    where
+        F: Future<Output = UioResult<()>> + Send + 'static,
+    {
+        let handle = self.runtime.handle().clone();
+        let permit = self.runtime.acquire_write_permit();
+        async move {
+            handle
+                .spawn(async move {
+                    let _permit = permit.await;
+                    op.await
+                })
+                .await?
+        }
     }
 }
 

--- a/lib/common/io_bridge/src/fs.rs
+++ b/lib/common/io_bridge/src/fs.rs
@@ -50,14 +50,9 @@ impl<A: AsyncWrite + Clone> BlobFs<A> {
         self.spawn_write(async move { inner.remove(&path).await })
     }
 
-    pub fn max_concurrent_saves(&self) -> usize {
-        self.runtime.max_concurrent_writes()
-    }
-
     /// Like the async reads, the write rides the [`BridgeRuntime`] rather than
     /// the caller's executor, so the returned future needs no ambient reactor.
-    /// It spawns on first poll, under one of the runtime's write permits, which
-    /// cap these spawned writes across every caller.
+    /// It spawns on first poll.
     fn spawn_write<F>(
         &self,
         op: F,
@@ -66,15 +61,7 @@ impl<A: AsyncWrite + Clone> BlobFs<A> {
         F: Future<Output = UioResult<()>> + Send + 'static,
     {
         let handle = self.runtime.handle().clone();
-        let permit = self.runtime.acquire_write_permit();
-        async move {
-            handle
-                .spawn(async move {
-                    let _permit = permit.await;
-                    op.await
-                })
-                .await?
-        }
+        async move { handle.spawn(op).await? }
     }
 }
 

--- a/lib/common/io_bridge/src/runtime.rs
+++ b/lib/common/io_bridge/src/runtime.rs
@@ -3,6 +3,13 @@ use std::sync::{Arc, LazyLock};
 
 use aligned_vec::{AVec, RuntimeAlign};
 use common::universal_io::UniversalIoError;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+/// Spawned whole-object saves and removes one execution domain keeps in flight,
+/// across every caller sharing it. The blocking single-shot writes (create,
+/// append, the sync `atomic_save`) stay uncounted: queuing an append behind a
+/// segment copy would only add head-of-line blocking.
+const MAX_CONCURRENT_WRITES: usize = 8;
 
 /// Reply produced by a spawned read task and shipped back to the originating
 /// pipeline over its reply channel. The slot is the correlation id; the
@@ -34,7 +41,11 @@ impl BridgeResponse {
     }
 }
 
-pub(crate) struct BridgeRuntimeInner(tokio::runtime::Runtime);
+pub(crate) struct BridgeRuntimeInner {
+    runtime: tokio::runtime::Runtime,
+    write_permits: Arc<Semaphore>,
+    max_concurrent_writes: usize,
+}
 
 /// Cheap-to-clone owner of a dedicated Tokio runtime. Construct one explicitly
 /// with [`Self::new`] for an isolated execution domain, or call [`Self::global`]
@@ -45,7 +56,10 @@ pub(crate) struct BridgeRuntimeInner(tokio::runtime::Runtime);
 /// Work reaches the runtime in one of two ways, both routed through the runtime
 /// [`Handle`](tokio::runtime::Handle):
 /// - single reads / metadata block the caller via [`Self::block_on`];
-/// - batched reads are dispatched with [`Handle::spawn`] (see [`Self::handle`]).
+/// - batched reads and whole-object writes are dispatched with
+///   [`Handle::spawn`](tokio::runtime::Handle::spawn) (see [`Self::handle`]),
+///   so the futures handed to a caller carry no reactor requirement of their
+///   own.
 #[derive(Clone)]
 pub struct BridgeRuntime(Arc<BridgeRuntimeInner>);
 
@@ -68,7 +82,11 @@ impl BridgeRuntime {
                 description: format!("build tokio runtime: {err}"),
             })?;
 
-        Ok(Self(Arc::new(BridgeRuntimeInner(runtime))))
+        Ok(Self(Arc::new(BridgeRuntimeInner {
+            runtime,
+            write_permits: Arc::new(Semaphore::new(MAX_CONCURRENT_WRITES)),
+            max_concurrent_writes: MAX_CONCURRENT_WRITES,
+        })))
     }
 
     pub fn global() -> Self {
@@ -79,12 +97,34 @@ impl BridgeRuntime {
     /// the reactor/executor. Used for the synchronous single-read and metadata
     /// paths. Must not be called from within the runtime's own worker threads.
     pub fn block_on<F: Future>(&self, fut: F) -> F::Output {
-        self.0.0.block_on(fut)
+        self.0.runtime.block_on(fut)
     }
 
     /// Runtime handle for spawning detached tasks (the batched-read path).
     pub(crate) fn handle(&self) -> &tokio::runtime::Handle {
-        self.0.0.handle()
+        self.0.runtime.handle()
+    }
+
+    /// Spawned saves and removes this domain keeps in flight at once.
+    pub fn max_concurrent_writes(&self) -> usize {
+        self.0.max_concurrent_writes
+    }
+
+    /// Hold the returned permit for as long as a write is in flight.
+    ///
+    /// Owns only the semaphore, never the runtime: a task on this runtime must
+    /// not hold what could be the runtime's last reference, since dropping a
+    /// Tokio runtime from one of its own workers panics.
+    pub(crate) fn acquire_write_permit(
+        &self,
+    ) -> impl Future<Output = OwnedSemaphorePermit> + Send + 'static + use<> {
+        let permits = Arc::clone(&self.0.write_permits);
+        async move {
+            permits
+                .acquire_owned()
+                .await
+                .expect("the write semaphore is never closed")
+        }
     }
 }
 

--- a/lib/common/io_bridge/src/runtime.rs
+++ b/lib/common/io_bridge/src/runtime.rs
@@ -3,13 +3,6 @@ use std::sync::{Arc, LazyLock};
 
 use aligned_vec::{AVec, RuntimeAlign};
 use common::universal_io::UniversalIoError;
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
-
-/// Spawned whole-object saves and removes one execution domain keeps in flight,
-/// across every caller sharing it. The blocking single-shot writes (create,
-/// append, the sync `atomic_save`) stay uncounted: queuing an append behind a
-/// segment copy would only add head-of-line blocking.
-const MAX_CONCURRENT_WRITES: usize = 8;
 
 /// Reply produced by a spawned read task and shipped back to the originating
 /// pipeline over its reply channel. The slot is the correlation id; the
@@ -41,11 +34,7 @@ impl BridgeResponse {
     }
 }
 
-pub(crate) struct BridgeRuntimeInner {
-    runtime: tokio::runtime::Runtime,
-    write_permits: Arc<Semaphore>,
-    max_concurrent_writes: usize,
-}
+pub(crate) struct BridgeRuntimeInner(tokio::runtime::Runtime);
 
 /// Cheap-to-clone owner of a dedicated Tokio runtime. Construct one explicitly
 /// with [`Self::new`] for an isolated execution domain, or call [`Self::global`]
@@ -82,11 +71,7 @@ impl BridgeRuntime {
                 description: format!("build tokio runtime: {err}"),
             })?;
 
-        Ok(Self(Arc::new(BridgeRuntimeInner {
-            runtime,
-            write_permits: Arc::new(Semaphore::new(MAX_CONCURRENT_WRITES)),
-            max_concurrent_writes: MAX_CONCURRENT_WRITES,
-        })))
+        Ok(Self(Arc::new(BridgeRuntimeInner(runtime))))
     }
 
     pub fn global() -> Self {
@@ -97,34 +82,12 @@ impl BridgeRuntime {
     /// the reactor/executor. Used for the synchronous single-read and metadata
     /// paths. Must not be called from within the runtime's own worker threads.
     pub fn block_on<F: Future>(&self, fut: F) -> F::Output {
-        self.0.runtime.block_on(fut)
+        self.0.0.block_on(fut)
     }
 
     /// Runtime handle for spawning detached tasks (the batched-read path).
     pub(crate) fn handle(&self) -> &tokio::runtime::Handle {
-        self.0.runtime.handle()
-    }
-
-    /// Spawned saves and removes this domain keeps in flight at once.
-    pub fn max_concurrent_writes(&self) -> usize {
-        self.0.max_concurrent_writes
-    }
-
-    /// Hold the returned permit for as long as a write is in flight.
-    ///
-    /// Owns only the semaphore, never the runtime: a task on this runtime must
-    /// not hold what could be the runtime's last reference, since dropping a
-    /// Tokio runtime from one of its own workers panics.
-    pub(crate) fn acquire_write_permit(
-        &self,
-    ) -> impl Future<Output = OwnedSemaphorePermit> + Send + 'static + use<> {
-        let permits = Arc::clone(&self.0.write_permits);
-        async move {
-            permits
-                .acquire_owned()
-                .await
-                .expect("the write semaphore is never closed")
-        }
+        self.0.0.handle()
     }
 }
 

--- a/lib/common/io_bridge/src/tests/mod.rs
+++ b/lib/common/io_bridge/src/tests/mod.rs
@@ -1,2 +1,4 @@
 #[cfg(test)]
+mod spawned_writes;
+#[cfg(test)]
 mod whole_read;

--- a/lib/common/io_bridge/src/tests/spawned_writes.rs
+++ b/lib/common/io_bridge/src/tests/spawned_writes.rs
@@ -1,0 +1,191 @@
+#![cfg(test)]
+
+use std::future::Future;
+use std::ops::Range;
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use common::universal_io::{ListedFile, UioResult, UniversalIoError, UniversalKind};
+use futures::stream::BoxStream;
+use tokio::sync::Semaphore;
+
+use crate::read::{AsyncRead, OffsetByteStream};
+use crate::write::AsyncWrite;
+use crate::{BlobFs, BridgeRuntime};
+
+#[derive(Clone)]
+struct Observed {
+    in_flight: Arc<AtomicUsize>,
+    peak_in_flight: Arc<AtomicUsize>,
+    /// Saves park here once counted, until the test lets them through.
+    gate: Arc<Semaphore>,
+}
+
+/// Backend whose saves need a Tokio reactor: each one parks on a timer first,
+/// which only a Tokio context can drive.
+#[derive(Clone)]
+struct TimerWriteSource {
+    observed: Observed,
+}
+
+impl TimerWriteSource {
+    fn new(gate_permits: usize) -> Self {
+        Self {
+            observed: Observed {
+                in_flight: Arc::default(),
+                peak_in_flight: Arc::default(),
+                gate: Arc::new(Semaphore::new(gate_permits)),
+            },
+        }
+    }
+}
+
+impl AsyncRead for TimerWriteSource {
+    type Config = usize;
+
+    fn open(gate_permits: &usize) -> UioResult<Self> {
+        Ok(Self::new(*gate_permits))
+    }
+
+    fn list_files(
+        &self,
+        _prefix: &Path,
+    ) -> impl Future<Output = UioResult<Vec<ListedFile>>> + Send + 'static {
+        std::future::ready(Ok(Vec::new()))
+    }
+
+    fn exists(&self, _path: &Path) -> impl Future<Output = UioResult<bool>> + Send + 'static {
+        std::future::ready(Ok(false))
+    }
+
+    fn read_range(
+        &self,
+        path: &Path,
+        _range: Range<u64>,
+    ) -> impl Future<Output = UioResult<BoxStream<'static, UioResult<Bytes>>>> + Send + 'static
+    {
+        std::future::ready(Err(UniversalIoError::NotFound { path: path.into() }))
+    }
+
+    fn read_from(
+        &self,
+        path: &Path,
+        _from: u64,
+    ) -> impl Future<Output = UioResult<(u64, OffsetByteStream)>> + Send + 'static {
+        std::future::ready(Err(UniversalIoError::NotFound { path: path.into() }))
+    }
+
+    fn len(&self, path: &Path) -> impl Future<Output = UioResult<u64>> + Send + 'static {
+        std::future::ready(Err(UniversalIoError::NotFound { path: path.into() }))
+    }
+
+    fn kind() -> UniversalKind {
+        UniversalKind::S3
+    }
+}
+
+impl AsyncWrite for TimerWriteSource {
+    fn create(&self, _path: &Path) -> impl Future<Output = UioResult<()>> + Send + 'static {
+        std::future::ready(Ok(()))
+    }
+
+    fn remove(&self, _path: &Path) -> impl Future<Output = UioResult<()>> + Send + 'static {
+        std::future::ready(Ok(()))
+    }
+
+    fn save(
+        &self,
+        _path: &Path,
+        _bytes: Bytes,
+    ) -> impl Future<Output = UioResult<()>> + Send + 'static {
+        let observed = self.observed.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+            let now = observed.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            observed.peak_in_flight.fetch_max(now, Ordering::SeqCst);
+            let _through = observed.gate.acquire().await;
+            observed.in_flight.fetch_sub(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+}
+
+fn blob_fs(gate_permits: usize) -> (BlobFs<TimerWriteSource>, Observed, BridgeRuntime) {
+    let source = TimerWriteSource::new(gate_permits);
+    let observed = source.observed.clone();
+    let runtime = BridgeRuntime::new().expect("new runtime");
+    (BlobFs::new(source, runtime.clone()), observed, runtime)
+}
+
+fn wait_until(what: &str, condition: impl Fn() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !condition() {
+        assert!(Instant::now() < deadline, "timed out waiting until {what}");
+        std::thread::sleep(Duration::from_millis(1));
+    }
+}
+
+/// The reason the write futures are spawned: a caller with no runtime of its
+/// own drives them on a bare executor, and the reactor-bound work still runs.
+#[test]
+fn a_save_resolves_on_a_bare_executor() {
+    let (fs, _observed, _runtime) = blob_fs(Semaphore::MAX_PERMITS);
+
+    futures::executor::block_on(fs.save_async("object".into(), vec![1, 2, 3]))
+        .expect("the save resolves without an ambient runtime");
+}
+
+#[test]
+fn a_remove_resolves_on_a_bare_executor() {
+    let (fs, _observed, _runtime) = blob_fs(Semaphore::MAX_PERMITS);
+
+    futures::executor::block_on(fs.remove_async("object".into()))
+        .expect("the remove resolves without an ambient runtime");
+}
+
+/// Nothing runs before the first poll, so a collected wave stays a plan.
+#[test]
+fn a_save_does_not_start_until_polled() {
+    let (fs, observed, _runtime) = blob_fs(Semaphore::MAX_PERMITS);
+
+    let save = fs.save_async("object".into(), vec![1]);
+    std::thread::sleep(Duration::from_millis(20));
+    assert_eq!(observed.peak_in_flight.load(Ordering::SeqCst), 0);
+
+    futures::executor::block_on(save).expect("the save lands once polled");
+    assert_eq!(observed.peak_in_flight.load(Ordering::SeqCst), 1);
+}
+
+/// The backend caps its own in-flight writes, so callers cannot exceed the
+/// depth by launching a wider wave.
+#[test]
+fn the_backend_caps_writes_in_flight() {
+    let (fs, observed, runtime) = blob_fs(0);
+    let depth = runtime.max_concurrent_writes();
+    let saves: Vec<_> = (0..depth * 3)
+        .map(|i| fs.save_async(format!("object-{i}").into(), vec![i as u8]))
+        .collect();
+
+    let wave =
+        std::thread::spawn(move || futures::executor::block_on(futures::future::join_all(saves)));
+
+    // Nothing completes while the gate is shut, so every admitted save stays
+    // counted: the peak is exactly what the permits let through.
+    let in_flight = observed.in_flight.clone();
+    wait_until("the permitted saves are parked at the gate", || {
+        in_flight.load(Ordering::SeqCst) >= depth
+    });
+    observed.gate.add_permits(depth * 3);
+
+    for result in wave.join().expect("the wave thread completes") {
+        result.expect("every save lands");
+    }
+    assert_eq!(
+        observed.peak_in_flight.load(Ordering::SeqCst),
+        depth,
+        "the wave fills the backend's depth and never exceeds it"
+    );
+}

--- a/lib/common/io_bridge/src/tests/spawned_writes.rs
+++ b/lib/common/io_bridge/src/tests/spawned_writes.rs
@@ -5,49 +5,28 @@ use std::ops::Range;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use bytes::Bytes;
 use common::universal_io::{ListedFile, UioResult, UniversalIoError, UniversalKind};
 use futures::stream::BoxStream;
-use tokio::sync::Semaphore;
 
 use crate::read::{AsyncRead, OffsetByteStream};
 use crate::write::AsyncWrite;
 use crate::{BlobFs, BridgeRuntime};
 
-#[derive(Clone)]
-struct Observed {
-    in_flight: Arc<AtomicUsize>,
-    peak_in_flight: Arc<AtomicUsize>,
-    /// Saves park here once counted, until the test lets them through.
-    gate: Arc<Semaphore>,
-}
-
-/// Backend whose saves need a Tokio reactor: each one parks on a timer first,
-/// which only a Tokio context can drive.
-#[derive(Clone)]
+/// Backend whose saves need a Tokio reactor: each one parks on a timer, which
+/// only a Tokio context can drive.
+#[derive(Clone, Default)]
 struct TimerWriteSource {
-    observed: Observed,
-}
-
-impl TimerWriteSource {
-    fn new(gate_permits: usize) -> Self {
-        Self {
-            observed: Observed {
-                in_flight: Arc::default(),
-                peak_in_flight: Arc::default(),
-                gate: Arc::new(Semaphore::new(gate_permits)),
-            },
-        }
-    }
+    saves: Arc<AtomicUsize>,
 }
 
 impl AsyncRead for TimerWriteSource {
-    type Config = usize;
+    type Config = ();
 
-    fn open(gate_permits: &usize) -> UioResult<Self> {
-        Ok(Self::new(*gate_permits))
+    fn open(_config: &()) -> UioResult<Self> {
+        Ok(Self::default())
     }
 
     fn list_files(
@@ -101,46 +80,37 @@ impl AsyncWrite for TimerWriteSource {
         _path: &Path,
         _bytes: Bytes,
     ) -> impl Future<Output = UioResult<()>> + Send + 'static {
-        let observed = self.observed.clone();
+        let saves = self.saves.clone();
         async move {
             tokio::time::sleep(Duration::from_millis(1)).await;
-            let now = observed.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
-            observed.peak_in_flight.fetch_max(now, Ordering::SeqCst);
-            let _through = observed.gate.acquire().await;
-            observed.in_flight.fetch_sub(1, Ordering::SeqCst);
+            saves.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
     }
 }
 
-fn blob_fs(gate_permits: usize) -> (BlobFs<TimerWriteSource>, Observed, BridgeRuntime) {
-    let source = TimerWriteSource::new(gate_permits);
-    let observed = source.observed.clone();
+fn blob_fs() -> (BlobFs<TimerWriteSource>, Arc<AtomicUsize>, BridgeRuntime) {
+    let source = TimerWriteSource::default();
+    let saves = source.saves.clone();
     let runtime = BridgeRuntime::new().expect("new runtime");
-    (BlobFs::new(source, runtime.clone()), observed, runtime)
-}
-
-fn wait_until(what: &str, condition: impl Fn() -> bool) {
-    let deadline = Instant::now() + Duration::from_secs(10);
-    while !condition() {
-        assert!(Instant::now() < deadline, "timed out waiting until {what}");
-        std::thread::sleep(Duration::from_millis(1));
-    }
+    (BlobFs::new(source, runtime.clone()), saves, runtime)
 }
 
 /// The reason the write futures are spawned: a caller with no runtime of its
 /// own drives them on a bare executor, and the reactor-bound work still runs.
 #[test]
 fn a_save_resolves_on_a_bare_executor() {
-    let (fs, _observed, _runtime) = blob_fs(Semaphore::MAX_PERMITS);
+    let (fs, saves, _runtime) = blob_fs();
 
     futures::executor::block_on(fs.save_async("object".into(), vec![1, 2, 3]))
         .expect("the save resolves without an ambient runtime");
+
+    assert_eq!(saves.load(Ordering::SeqCst), 1);
 }
 
 #[test]
 fn a_remove_resolves_on_a_bare_executor() {
-    let (fs, _observed, _runtime) = blob_fs(Semaphore::MAX_PERMITS);
+    let (fs, _saves, _runtime) = blob_fs();
 
     futures::executor::block_on(fs.remove_async("object".into()))
         .expect("the remove resolves without an ambient runtime");
@@ -149,43 +119,12 @@ fn a_remove_resolves_on_a_bare_executor() {
 /// Nothing runs before the first poll, so a collected wave stays a plan.
 #[test]
 fn a_save_does_not_start_until_polled() {
-    let (fs, observed, _runtime) = blob_fs(Semaphore::MAX_PERMITS);
+    let (fs, saves, _runtime) = blob_fs();
 
     let save = fs.save_async("object".into(), vec![1]);
     std::thread::sleep(Duration::from_millis(20));
-    assert_eq!(observed.peak_in_flight.load(Ordering::SeqCst), 0);
+    assert_eq!(saves.load(Ordering::SeqCst), 0);
 
     futures::executor::block_on(save).expect("the save lands once polled");
-    assert_eq!(observed.peak_in_flight.load(Ordering::SeqCst), 1);
-}
-
-/// The backend caps its own in-flight writes, so callers cannot exceed the
-/// depth by launching a wider wave.
-#[test]
-fn the_backend_caps_writes_in_flight() {
-    let (fs, observed, runtime) = blob_fs(0);
-    let depth = runtime.max_concurrent_writes();
-    let saves: Vec<_> = (0..depth * 3)
-        .map(|i| fs.save_async(format!("object-{i}").into(), vec![i as u8]))
-        .collect();
-
-    let wave =
-        std::thread::spawn(move || futures::executor::block_on(futures::future::join_all(saves)));
-
-    // Nothing completes while the gate is shut, so every admitted save stays
-    // counted: the peak is exactly what the permits let through.
-    let in_flight = observed.in_flight.clone();
-    wait_until("the permitted saves are parked at the gate", || {
-        in_flight.load(Ordering::SeqCst) >= depth
-    });
-    observed.gate.add_permits(depth * 3);
-
-    for result in wave.join().expect("the wave thread completes") {
-        result.expect("every save lands");
-    }
-    assert_eq!(
-        observed.peak_in_flight.load(Ordering::SeqCst),
-        depth,
-        "the wave fills the backend's depth and never exceeds it"
-    );
+    assert_eq!(saves.load(Ordering::SeqCst), 1);
 }

--- a/lib/edge/src/update_only/lifecycle.rs
+++ b/lib/edge/src/update_only/lifecycle.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::universal_io::{
-    MmapFs, UioResult, UniversalAppendFs, UniversalWriteFsAsync,
+    MmapFs, UniversalAppendFs, UniversalWriteFsAsync,
 };
 use futures::StreamExt as _;
 use parking_lot::RwLock;
@@ -170,8 +170,7 @@ pub(crate) const COPY_CONCURRENCY: usize = 8;
 /// then every file as one whole-object save, [`COPY_CONCURRENCY`] at a time.
 ///
 /// Every save is awaited even after one fails, so nothing is left in flight and
-/// the cleanup covers every object that landed. Sized for a fresh appendable:
-/// the files are read into memory up front.
+/// the cleanup covers every object that landed.
 pub(crate) async fn copy_dir<F: UniversalWriteFsAsync>(
     fs: &F,
     local: &Path,
@@ -192,24 +191,33 @@ pub(crate) async fn copy_dir<F: UniversalWriteFsAsync>(
                 dirs.push(remote.join(rel));
             }
         } else if entry.file_type().is_file() {
-            let bytes = fs_err::read(path).map_err(|err| {
-                OperationError::service_error(format!("read {}: {err}", path.display()))
-            })?;
-            files.push((remote.join(rel), bytes));
+            files.push((path.to_path_buf(), remote.join(rel)));
         }
     }
 
-    // Parents before children: walkdir yields pre-order, the root goes first.
+    // walkdir is pre-order, so parents precede children.
     for dir in dirs {
         fs.create_dir_async(dir.clone()).await.map_err(|err| {
             OperationError::service_error(format!("create dir {}: {err}", dir.display()))
         })?;
     }
 
-    let saved: Vec<(std::path::PathBuf, UioResult<()>)> = futures::stream::iter(files)
-        .map(|(path, bytes)| async move {
-            let result = fs.atomic_save_async(path.clone(), bytes).await;
-            (path, result)
+    // Read inside the wave: at most COPY_CONCURRENCY files are in memory.
+    let saved: Vec<(PathBuf, OperationResult<()>)> = futures::stream::iter(files)
+        .map(|(source, target)| async move {
+            let result = match fs_err::read(&source) {
+                Ok(bytes) => fs
+                    .atomic_save_async(target.clone(), bytes)
+                    .await
+                    .map_err(|err| {
+                        OperationError::service_error(format!("save {}: {err}", target.display()))
+                    }),
+                Err(err) => Err(OperationError::service_error(format!(
+                    "read {}: {err}",
+                    source.display()
+                ))),
+            };
+            (target, result)
         })
         .buffer_unordered(COPY_CONCURRENCY)
         .collect()
@@ -220,18 +228,20 @@ pub(crate) async fn copy_dir<F: UniversalWriteFsAsync>(
     for (path, result) in saved {
         match result {
             Ok(()) => landed.push(path),
-            Err(err) if first_error.is_none() => first_error = Some((path, err)),
+            Err(err) if first_error.is_none() => first_error = Some(err),
             Err(_) => {}
         }
     }
-    if let Some((path, err)) = first_error {
+    if let Some(err) = first_error {
         for object in landed {
-            let _ = fs.remove_async(object).await;
+            if let Err(cleanup) = fs.remove_async(object.clone()).await {
+                log::warn!(
+                    "failed segment copy left {} behind: {cleanup}",
+                    object.display()
+                );
+            }
         }
-        return Err(OperationError::service_error(format!(
-            "save {}: {err}",
-            path.display()
-        )));
+        return Err(err);
     }
     Ok(())
 }

--- a/lib/edge/src/update_only/lifecycle.rs
+++ b/lib/edge/src/update_only/lifecycle.rs
@@ -148,7 +148,7 @@ where
         drop(segment);
 
         let remote = self.path.join(SEGMENTS_PATH).join(uuid.to_string());
-        self.fs.block_on(copy_dir(&self.fs, &local, &remote))?;
+        futures::executor::block_on(copy_dir(&self.fs, &local, &remote))?;
 
         let lookup = LookupSegment::<Fs>::open(self.fs.clone(), &remote, None)?;
         let writer = UpdateOnlySegmentEnum::open(
@@ -163,11 +163,9 @@ where
     }
 }
 
-/// Saves in flight at once while a segment directory is copied to the backend.
-pub(crate) const COPY_CONCURRENCY: usize = 8;
-
 /// Copy a locally built segment directory to the backend: directories first,
-/// then every file as one whole-object save, [`COPY_CONCURRENCY`] at a time.
+/// then every file as one whole-object save, as many at a time as the backend
+/// takes ([`UniversalWriteFsAsync::max_concurrent_saves`]).
 ///
 /// Every save is awaited even after one fails, so nothing is left in flight and
 /// the cleanup covers every object that landed.
@@ -202,7 +200,7 @@ pub(crate) async fn copy_dir<F: UniversalWriteFsAsync>(
         })?;
     }
 
-    // Read inside the wave: at most COPY_CONCURRENCY files are in memory.
+    // Read inside the wave, so only the in-flight files are in memory.
     let saved: Vec<(PathBuf, OperationResult<()>)> = futures::stream::iter(files)
         .map(|(source, target)| async move {
             let result = match fs_err::read(&source) {
@@ -219,7 +217,7 @@ pub(crate) async fn copy_dir<F: UniversalWriteFsAsync>(
             };
             (target, result)
         })
-        .buffer_unordered(COPY_CONCURRENCY)
+        .buffer_unordered(fs.max_concurrent_saves().max(1))
         .collect()
         .await;
 

--- a/lib/edge/src/update_only/lifecycle.rs
+++ b/lib/edge/src/update_only/lifecycle.rs
@@ -2,11 +2,10 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::mmap::AdviceSetting;
 use common::universal_io::{
-    MmapFs, OpenOptions, Populate, UniversalAppend, UniversalAppendFs, UniversalFlush as _,
-    UniversalWriteFileOps,
+    MmapFs, UioResult, UniversalAppendFs, UniversalWriteFsAsync,
 };
+use futures::StreamExt as _;
 use parking_lot::RwLock;
 use rayon::prelude::*;
 use segment::common::operation_error::{OperationError, OperationResult};
@@ -99,7 +98,7 @@ impl<Fs: UniversalAppendFs> UpdateOnlyEdgeShard<Fs> {
 
 impl<Fs> UpdateOnlyEdgeShard<Fs>
 where
-    Fs: UniversalAppendFs,
+    Fs: UniversalAppendFs + UniversalWriteFsAsync,
 {
     /// [`create_appendable`](Self::create_appendable) with `source`'s config.
     #[cfg(test)]
@@ -149,7 +148,7 @@ where
         drop(segment);
 
         let remote = self.path.join(SEGMENTS_PATH).join(uuid.to_string());
-        copy_dir_via(&self.fs, &local, &remote)?;
+        self.fs.block_on(copy_dir(&self.fs, &local, &remote))?;
 
         let lookup = LookupSegment::<Fs>::open(self.fs.clone(), &remote, None)?;
         let writer = UpdateOnlySegmentEnum::open(
@@ -164,43 +163,75 @@ where
     }
 }
 
-fn copy_dir_via<F: UniversalWriteFileOps>(
+/// Saves in flight at once while a segment directory is copied to the backend.
+pub(crate) const COPY_CONCURRENCY: usize = 8;
+
+/// Copy a locally built segment directory to the backend: directories first,
+/// then every file as one whole-object save, [`COPY_CONCURRENCY`] at a time.
+///
+/// Every save is awaited even after one fails, so nothing is left in flight and
+/// the cleanup covers every object that landed. Sized for a fresh appendable:
+/// the files are read into memory up front.
+pub(crate) async fn copy_dir<F: UniversalWriteFsAsync>(
     fs: &F,
     local: &Path,
     remote: &Path,
 ) -> OperationResult<()> {
-    let mut created = std::collections::HashSet::new();
+    let mut dirs = vec![remote.to_path_buf()];
+    let mut files = Vec::new();
     for entry in walkdir::WalkDir::new(local) {
         let entry = entry.map_err(|err| {
             OperationError::service_error(format!("walk {}: {err}", local.display()))
         })?;
-        if !entry.file_type().is_file() {
-            continue;
-        }
         let path = entry.path();
         let rel = path.strip_prefix(local).map_err(|err| {
             OperationError::service_error(format!("relativize {}: {err}", path.display()))
         })?;
-        let bytes = fs_err::read(path).map_err(|err| {
-            OperationError::service_error(format!("read {}: {err}", path.display()))
-        })?;
-        let target = remote.join(rel);
-        if let Some(parent) = target.parent()
-            && created.insert(parent.to_path_buf())
-        {
-            fs.create_dir(parent)?;
+        if entry.file_type().is_dir() {
+            if !rel.as_os_str().is_empty() {
+                dirs.push(remote.join(rel));
+            }
+        } else if entry.file_type().is_file() {
+            let bytes = fs_err::read(path).map_err(|err| {
+                OperationError::service_error(format!("read {}: {err}", path.display()))
+            })?;
+            files.push((remote.join(rel), bytes));
         }
-        // Length 0: a pre-sized file would conflict with the offset-0 append.
-        fs.create(&target, 0)?;
-        let options = OpenOptions {
-            writeable: true,
-            need_sequential: true,
-            populate: Populate::No,
-            advice: AdviceSetting::Global,
-        };
-        let mut file = fs.open_append(&target, options.for_append())?;
-        file.append(0, bytes.as_slice())?;
-        file.flusher()()?;
+    }
+
+    // Parents before children: walkdir yields pre-order, the root goes first.
+    for dir in dirs {
+        fs.create_dir_async(dir.clone()).await.map_err(|err| {
+            OperationError::service_error(format!("create dir {}: {err}", dir.display()))
+        })?;
+    }
+
+    let saved: Vec<(std::path::PathBuf, UioResult<()>)> = futures::stream::iter(files)
+        .map(|(path, bytes)| async move {
+            let result = fs.atomic_save_async(path.clone(), bytes).await;
+            (path, result)
+        })
+        .buffer_unordered(COPY_CONCURRENCY)
+        .collect()
+        .await;
+
+    let mut first_error = None;
+    let mut landed = Vec::with_capacity(saved.len());
+    for (path, result) in saved {
+        match result {
+            Ok(()) => landed.push(path),
+            Err(err) if first_error.is_none() => first_error = Some((path, err)),
+            Err(_) => {}
+        }
+    }
+    if let Some((path, err)) = first_error {
+        for object in landed {
+            let _ = fs.remove_async(object).await;
+        }
+        return Err(OperationError::service_error(format!(
+            "save {}: {err}",
+            path.display()
+        )));
     }
     Ok(())
 }

--- a/lib/edge/src/update_only/lifecycle.rs
+++ b/lib/edge/src/update_only/lifecycle.rs
@@ -2,9 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use common::counter::hardware_counter::HardwareCounterCell;
-use common::universal_io::{
-    MmapFs, UniversalAppendFs, UniversalWriteFsAsync,
-};
+use common::universal_io::{MmapFs, UniversalAppendFs, UniversalWriteFsAsync};
 use futures::StreamExt as _;
 use parking_lot::RwLock;
 use rayon::prelude::*;
@@ -163,9 +161,12 @@ where
     }
 }
 
+/// Files in flight at once while a segment directory is copied: bounds the
+/// buffers held in memory as much as the saves in progress.
+pub(crate) const COPY_CONCURRENCY: usize = 8;
+
 /// Copy a locally built segment directory to the backend: directories first,
-/// then every file as one whole-object save, as many at a time as the backend
-/// takes ([`UniversalWriteFsAsync::max_concurrent_saves`]).
+/// then every file as one whole-object save, [`COPY_CONCURRENCY`] at a time.
 ///
 /// Every save is awaited even after one fails, so nothing is left in flight and
 /// the cleanup covers every object that landed.
@@ -217,7 +218,7 @@ pub(crate) async fn copy_dir<F: UniversalWriteFsAsync>(
             };
             (target, result)
         })
-        .buffer_unordered(fs.max_concurrent_saves().max(1))
+        .buffer_unordered(COPY_CONCURRENCY)
         .collect()
         .await;
 

--- a/lib/edge/src/update_only/tests.rs
+++ b/lib/edge/src/update_only/tests.rs
@@ -674,3 +674,193 @@ fn empty_manifest_shard_bootstraps_an_appendable() {
     let follower = open_follower(dir.path());
     assert_eq!(exact_count(&follower), 1);
 }
+
+mod copy_dir {
+    use std::collections::BTreeMap;
+    use std::future::Future;
+    use std::path::{Path, PathBuf};
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
+    use std::task::{Context, Poll};
+
+    use common::universal_io::{MmapFs, UioResult, UniversalIoError, UniversalWriteFsAsync};
+
+    use crate::update_only::lifecycle::{COPY_CONCURRENCY, copy_dir};
+
+    /// Records every call and the peak number of saves in flight. Saves yield
+    /// once before completing, so the wave is observable.
+    #[derive(Default)]
+    struct Log {
+        dirs: Vec<PathBuf>,
+        saves: Vec<(PathBuf, Vec<u8>)>,
+        removed: Vec<PathBuf>,
+        in_flight: usize,
+        peak_in_flight: usize,
+        attempts: usize,
+        /// The n-th save attempt (1-based) fails instead of landing.
+        fail_save_at: Option<usize>,
+    }
+
+    #[derive(Clone, Default)]
+    struct RecordingFs(Arc<Mutex<Log>>);
+
+    struct Save {
+        fs: RecordingFs,
+        target: Option<(PathBuf, Vec<u8>)>,
+        attempt: usize,
+    }
+
+    impl Future for Save {
+        type Output = UioResult<()>;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            if self.attempt == 0 {
+                let mut log = self.fs.0.lock().unwrap();
+                log.in_flight += 1;
+                log.peak_in_flight = log.peak_in_flight.max(log.in_flight);
+                log.attempts += 1;
+                let attempt = log.attempts;
+                drop(log);
+                self.attempt = attempt;
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+            let (path, bytes) = self.target.take().expect("polled after completion");
+            let mut log = self.fs.0.lock().unwrap();
+            log.in_flight -= 1;
+            if log.fail_save_at == Some(self.attempt) {
+                return Poll::Ready(Err(UniversalIoError::Io(std::io::Error::other(
+                    "injected save failure",
+                ))));
+            }
+            log.saves.push((path, bytes));
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl UniversalWriteFsAsync for RecordingFs {
+        fn create_dir_async(
+            &self,
+            path: PathBuf,
+        ) -> impl Future<Output = UioResult<()>> + Send + '_ {
+            self.0.lock().unwrap().dirs.push(path);
+            std::future::ready(Ok(()))
+        }
+
+        fn atomic_save_async(
+            &self,
+            path: PathBuf,
+            bytes: Vec<u8>,
+        ) -> impl Future<Output = UioResult<()>> + Send + '_ {
+            Save {
+                fs: self.clone(),
+                target: Some((path, bytes)),
+                attempt: 0,
+            }
+        }
+
+        fn remove_async(&self, path: PathBuf) -> impl Future<Output = UioResult<()>> + Send + '_ {
+            self.0.lock().unwrap().removed.push(path);
+            std::future::ready(Ok(()))
+        }
+
+        fn block_on<F: Future>(&self, fut: F) -> F::Output {
+            futures::executor::block_on(fut)
+        }
+    }
+
+    fn segment_like_dir(files: usize) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        fs_err::create_dir_all(dir.path().join("vector_storage/dense")).unwrap();
+        for i in 0..files {
+            let rel = if i % 2 == 0 {
+                format!("file_{i}.bin")
+            } else {
+                format!("vector_storage/dense/chunk_{i}.mmap")
+            };
+            fs_err::write(dir.path().join(rel), vec![i as u8; 16 + i]).unwrap();
+        }
+        dir
+    }
+
+    fn tree(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+        walkdir::WalkDir::new(root)
+            .into_iter()
+            .map(|e| e.unwrap())
+            .filter(|e| e.file_type().is_file())
+            .map(|e| {
+                let rel = e.path().strip_prefix(root).unwrap().to_path_buf();
+                (rel, fs_err::read(e.path()).unwrap())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn saves_every_file_once_in_a_bounded_wave() {
+        let local = segment_like_dir(12);
+        let fs = RecordingFs::default();
+        let remote = Path::new("shard/segments/uuid");
+
+        fs.block_on(copy_dir(&fs, local.path(), remote)).unwrap();
+
+        let log = fs.0.lock().unwrap();
+        let saved: BTreeMap<PathBuf, Vec<u8>> = log
+            .saves
+            .iter()
+            .map(|(p, b)| (p.strip_prefix(remote).unwrap().to_path_buf(), b.clone()))
+            .collect();
+        assert_eq!(log.saves.len(), 12, "one save per file, no duplicates");
+        assert_eq!(saved, tree(local.path()), "same tree, same bytes");
+        assert_eq!(
+            log.peak_in_flight, COPY_CONCURRENCY,
+            "the wave fills the bound"
+        );
+        assert_eq!(
+            log.dirs.first().map(PathBuf::as_path),
+            Some(remote),
+            "the root is created first"
+        );
+        assert!(
+            log.dirs.contains(&remote.join("vector_storage/dense")),
+            "nested directories are created: {:?}",
+            log.dirs
+        );
+        assert!(log.removed.is_empty());
+    }
+
+    #[test]
+    fn a_failed_save_removes_what_landed() {
+        let local = segment_like_dir(12);
+        let fs = RecordingFs::default();
+        fs.0.lock().unwrap().fail_save_at = Some(5);
+        let remote = Path::new("shard/segments/uuid");
+
+        let err = fs
+            .block_on(copy_dir(&fs, local.path(), remote))
+            .expect_err("the injected failure surfaces");
+
+        assert!(err.to_string().contains("injected save failure"), "{err}");
+        let log = fs.0.lock().unwrap();
+        assert_eq!(log.in_flight, 0, "no save is left in flight");
+        assert_eq!(log.saves.len(), 11, "only the failed save is missing");
+        for (path, _) in &log.saves {
+            assert!(
+                log.removed.contains(path),
+                "{path:?} landed and must be removed"
+            );
+        }
+    }
+
+    #[test]
+    fn reproduces_the_tree_on_a_local_fs() {
+        let local = segment_like_dir(5);
+        let remote = tempfile::tempdir().unwrap();
+        let target = remote.path().join("segments/uuid");
+
+        MmapFs
+            .block_on(copy_dir(&MmapFs, local.path(), &target))
+            .unwrap();
+
+        assert_eq!(tree(&target), tree(local.path()));
+    }
+}

--- a/lib/edge/src/update_only/tests.rs
+++ b/lib/edge/src/update_only/tests.rs
@@ -685,7 +685,10 @@ mod copy_dir {
 
     use common::universal_io::{MmapFs, UioResult, UniversalIoError, UniversalWriteFsAsync};
 
-    use crate::update_only::lifecycle::{COPY_CONCURRENCY, copy_dir};
+    use crate::update_only::lifecycle::copy_dir;
+
+    /// The save queue depth `RecordingFs` advertises to the wave.
+    const SAVE_CONCURRENCY: usize = 4;
 
     /// Records every call and the peak number of saves in flight. Saves yield
     /// once before completing, so the wave is observable.
@@ -764,8 +767,8 @@ mod copy_dir {
             std::future::ready(Ok(()))
         }
 
-        fn block_on<F: Future>(&self, fut: F) -> F::Output {
-            futures::executor::block_on(fut)
+        fn max_concurrent_saves(&self) -> usize {
+            SAVE_CONCURRENCY
         }
     }
 
@@ -801,7 +804,7 @@ mod copy_dir {
         let fs = RecordingFs::default();
         let remote = Path::new("shard/segments/uuid");
 
-        fs.block_on(copy_dir(&fs, local.path(), remote)).unwrap();
+        futures::executor::block_on(copy_dir(&fs, local.path(), remote)).unwrap();
 
         let log = fs.0.lock().unwrap();
         let saved: BTreeMap<PathBuf, Vec<u8>> = log
@@ -812,8 +815,8 @@ mod copy_dir {
         assert_eq!(log.saves.len(), 12, "one save per file, no duplicates");
         assert_eq!(saved, tree(local.path()), "same tree, same bytes");
         assert_eq!(
-            log.peak_in_flight, COPY_CONCURRENCY,
-            "the wave fills the bound"
+            log.peak_in_flight, SAVE_CONCURRENCY,
+            "the wave fills the depth the backend asked for"
         );
         assert_eq!(
             log.dirs.first().map(PathBuf::as_path),
@@ -835,8 +838,7 @@ mod copy_dir {
         fs.0.lock().unwrap().fail_save_at = Some(5);
         let remote = Path::new("shard/segments/uuid");
 
-        let err = fs
-            .block_on(copy_dir(&fs, local.path(), remote))
+        let err = futures::executor::block_on(copy_dir(&fs, local.path(), remote))
             .expect_err("the injected failure surfaces");
 
         assert!(err.to_string().contains("injected save failure"), "{err}");
@@ -857,9 +859,7 @@ mod copy_dir {
         let remote = tempfile::tempdir().unwrap();
         let target = remote.path().join("segments/uuid");
 
-        MmapFs
-            .block_on(copy_dir(&MmapFs, local.path(), &target))
-            .unwrap();
+        futures::executor::block_on(copy_dir(&MmapFs, local.path(), &target)).unwrap();
 
         assert_eq!(tree(&target), tree(local.path()));
     }

--- a/lib/edge/src/update_only/tests.rs
+++ b/lib/edge/src/update_only/tests.rs
@@ -685,10 +685,7 @@ mod copy_dir {
 
     use common::universal_io::{MmapFs, UioResult, UniversalIoError, UniversalWriteFsAsync};
 
-    use crate::update_only::lifecycle::copy_dir;
-
-    /// The save queue depth `RecordingFs` advertises to the wave.
-    const SAVE_CONCURRENCY: usize = 4;
+    use crate::update_only::lifecycle::{COPY_CONCURRENCY, copy_dir};
 
     /// Records every call and the peak number of saves in flight. Saves yield
     /// once before completing, so the wave is observable.
@@ -766,10 +763,6 @@ mod copy_dir {
             self.0.lock().unwrap().removed.push(path);
             std::future::ready(Ok(()))
         }
-
-        fn max_concurrent_saves(&self) -> usize {
-            SAVE_CONCURRENCY
-        }
     }
 
     fn segment_like_dir(files: usize) -> tempfile::TempDir {
@@ -815,8 +808,8 @@ mod copy_dir {
         assert_eq!(log.saves.len(), 12, "one save per file, no duplicates");
         assert_eq!(saved, tree(local.path()), "same tree, same bytes");
         assert_eq!(
-            log.peak_in_flight, SAVE_CONCURRENCY,
-            "the wave fills the depth the backend asked for"
+            log.peak_in_flight, COPY_CONCURRENCY,
+            "the wave fills the bound"
         );
         assert_eq!(
             log.dirs.first().map(PathBuf::as_path),


### PR DESCRIPTION
## Why

`create_appendable` copies the locally built segment to the backend with `copy_dir_via`, which per file does `create` + `open_append` + `append(0, ..)` + flush, sequentially. At offset 0 the append is a whole-object PUT on every backend anyway, so a dozen small files cost roughly 36 sequential remote round trips.

## What

`copy_dir` replaces `copy_dir_via`: directories first (the root included, which also settles the non-recursive `create_dir` ordering raised in the #10416 review), then every file as one whole-object save, 8 in flight.

The issue suggested `atomic_save` under `pool.install(|| par_iter())`. This uses the async surface instead, because the write path below `UniversalWriteFileOps` is already async and every sync call goes through a `BridgeRuntime::block_on`: a thread per file would park a thread on each of those, while a wave of futures parks none. `create_appendable` stays synchronous and drives the whole wave with one `block_on`, so callers are unchanged.

- `UniversalWriteFsAsync` in `common` (`create_dir_async`, `atomic_save_async`, `remove_async`, `block_on`) mirrors the sync write ops the way `UniversalReadFsAsync` mirrors the read ops. Deliberately not a supertrait of `UniversalWriteFileOps`, so writer-only backends and test doubles can implement just this surface.
- `CachedBlobFs` implements it over `BlobFs`'s single-put save on the bridge runtime; directory creation stays the no-op it already is. `MmapFs` resolves inline, like its async read impl.
- Failure handling: every save is awaited even after one fails, so nothing is left in flight and the cleanup removes every object that landed. A partial copy was never visible anyway, since the caller publishes the segment in the manifest afterwards, but this keeps orphans out of the bucket.

Trade-off from the issue, unchanged: `atomic_save` bypasses the disk-cache mirror, so the `LookupSegment::open` that follows fetches the small files once instead of finding them warm.

## Tests

`update_only::tests::copy_dir`, against a recording filesystem, so no live remote backend is needed:

- `saves_every_file_once_in_a_bounded_wave`: 12 files across nested directories produce 12 saves, byte-identical to the local tree, peak concurrency exactly `COPY_CONCURRENCY`, root and nested directories created before any save.
- `a_failed_save_removes_what_landed`: the 5th save attempt fails, the other 11 still complete, nothing is left in flight, and every object that landed is removed.
- `reproduces_the_tree_on_a_local_fs`: round trip through the real `MmapFs`.

`empty_manifest_shard_bootstraps_an_appendable` covers the caller unchanged.
