### PR TITLE
fix(collection): saturate offset+limit in query pagination (#10501)

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -756,7 +756,9 @@ fn intermediate_query_infos(request: &ShardQueryRequest) -> Vec<IntermediateQuer
             // Otherwise, we expect the root result
             vec![IntermediateQueryInfo {
                 scoring_query: request.query.as_ref(),
-                take: request.offset + request.limit,
+                // Use saturating_add so an unbounded user-supplied limit/offset cannot overflow
+                // (debug panic / release wraparound to a tiny take) — it clamps to usize::MAX instead.
+                take: request.offset.saturating_add(request.limit),
             }]
         }
     }

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -325,7 +325,11 @@ impl Collection {
                     .take(request.limit)
                     .collect()
             } else {
-                merged_iter.take(request.offset + request.limit).collect()
+                // Use saturating_add so an unbounded user-supplied limit/offset cannot overflow
+                // (debug panic / release wraparound to a tiny take) — it clamps to usize::MAX instead.
+                merged_iter
+                    .take(request.offset.saturating_add(request.limit))
+                    .collect()
             };
 
             top_results.push(top_res);

--- a/lib/collection/src/tests/query_prefetch_offset_limit.rs
+++ b/lib/collection/src/tests/query_prefetch_offset_limit.rs
@@ -248,6 +248,65 @@ async fn test_limit_offset_with_prefetch() {
     assert_eq!(points.len(), 5, "expected 5 points, got {}", points.len());
 }
 
+/// Regression test for <https://github.com/qdrant/qdrant/issues/10501>.
+///
+/// `offset + limit` must not overflow `usize` when a client sends an
+/// (almost) unbounded `limit` alongside a non-zero `offset`. Before the fix,
+/// `offset.wrapping_add(limit)` wrapped around to a tiny value, so the
+/// collection-level merge silently returned an empty page instead of the
+/// remaining points.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_offset_limit_does_not_overflow() {
+    let collection = fixture().await;
+
+    let do_query = async |offset, limit| {
+        collection
+            .query(
+                ShardQueryRequest {
+                    query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
+                        NamedQuery::default_dense(vec![0.1, 0.2, 0.3, 0.4]),
+                    ))),
+                    prefetches: vec![],
+                    filter: None,
+                    params: None,
+                    offset,
+                    limit,
+                    with_payload: WithPayloadInterface::Bool(false),
+                    with_vector: WithVector::Bool(false),
+                    score_threshold: None,
+                },
+                None,
+                None,
+                ShardSelectorInternal::All,
+                None,
+                HwMeasurementAcc::new(),
+            )
+            .await
+            .expect("failed to query")
+    };
+
+    // `offset=1, limit=usize::MAX` used to overflow `offset + limit` and
+    // silently return an empty page. It must instead return the remaining
+    // `POINT_COUNT - 1` points.
+    let points = do_query(1, usize::MAX).await;
+    assert_eq!(
+        points.len(),
+        POINT_COUNT - 1,
+        "expected {} points, got {}",
+        POINT_COUNT - 1,
+        points.len()
+    );
+
+    // `offset=0` with an unbounded limit must still be clamped by the
+    // collection size, not by an overflowed take count.
+    let points = do_query(0, usize::MAX).await;
+    assert_eq!(points.len(), POINT_COUNT);
+
+    // Normal, non-overflowing offset/limit pagination must still work.
+    let points = do_query(10, 15).await;
+    assert_eq!(points.len(), 15, "expected 15 points, got {}", points.len());
+}
+
 fn dummy_on_replica_failure() -> ChangePeerFromState {
     Arc::new(move |_peer_id, _shard_id, _from_state| {})
 }


### PR DESCRIPTION
Fixes #10501.

A query with `offset=1, limit=usize::MAX` returns an HTTP 200 with an empty page instead of the remaining points. The collection-level merge works out how many results to keep with `offset + limit`, and that addition wraps around to a tiny value on overflow instead of erroring or saturating, so the merge ends up taking ~0 results even though matching points exist.

`lib/shard/src/query/planned_query.rs` already guards the identical per-shard computation with `limit.saturating_add(offset)`, but that guard only covers the shard-level plan, not the two collection-level merge boundaries:

- `intermediate_query_infos` in `lib/collection/src/collection/query.rs`, which sizes the per-shard take for a plain vector/order-by query (this is the one the reported repro actually hits).
- the equivalent merge step in `lib/collection/src/collection/search.rs`, same `offset + limit` pattern, same overflow risk.

Both now use `saturating_add`, matching the existing shard-level idiom instead of a different approach.

Added a regression test next to the existing prefetch/offset/limit tests in `lib/collection/src/tests/query_prefetch_offset_limit.rs`, reusing that file's fixture: `offset=1, limit=usize::MAX` now returns the remaining points, `offset=0, limit=usize::MAX` returns the full collection, and ordinary offset/limit pagination is unaffected.

### Testing
I read through the merge/take code paths by hand to confirm `offset` and `limit` are both `usize` end to end and that `saturating_add` here can't itself cause an unbounded allocation (it only feeds an `Iterator::take`, which doesn't pre-allocate). I wasn't able to run `cargo test` in my own environment (no local Rust toolchain, and not enough free disk to build this workspace from scratch), so I haven't seen the new test run green myself — happy to fix anything CI turns up.

### Checklist
- [x] PR targets `dev` and the branch was created from `dev`.
- [x] Added a regression test for the reported case, plus a check that normal pagination still works.
- [ ] Ran `cargo +nightly fmt` / `cargo clippy` locally — couldn't, see note above; formatting matches the surrounding code by hand.

### AI disclosure
This PR (single commit) was written with AI assistance, tagged `[AI]` per your contributing guide.

Prompt/approach used: given the issue text, locate the unguarded `offset + limit` computation(s) in `lib/collection/src/collection/query.rs` and/or `search.rs`, confirm the existing `saturating_add` guard in `lib/shard/src/query/planned_query.rs` as the established pattern, apply that same pattern to the vulnerable collection-level computation(s) (not a different overflow-handling approach), add a regression test reproducing `offset=1, limit=usize::MAX` alongside a check that ordinary pagination is unaffected, and open the PR against `dev` with this disclosure. I reviewed the resulting diff and reasoning myself before pushing.
