### PR TITLE
Remove msgpack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,12 +1346,12 @@ dependencies = [
  "rand_distr",
  "rayon",
  "ringbuffer",
- "rmp-serde",
  "rstest",
  "schemars",
  "segment",
  "semver",
  "serde",
+ "serde_cbor",
  "serde_json",
  "sha2 0.11.0",
  "shard",
@@ -6662,25 +6662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
-name = "rmp"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
-dependencies = [
- "rmp",
- "serde",
-]
-
-[[package]]
 name = "roaring"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7186,7 +7167,6 @@ dependencies = [
  "rand 0.10.2",
  "rand_distr",
  "rayon",
- "rmp-serde",
  "roaring",
  "rstest",
  "schemars",
@@ -7499,7 +7479,6 @@ dependencies = [
  "proptest",
  "prost 0.14.4",
  "rand 0.10.2",
- "rmp-serde",
  "rstest",
  "schemars",
  "segment",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,7 +1328,6 @@ dependencies = [
  "env_logger",
  "fnv",
  "fs-err",
- "fs4 1.1.0",
  "fs_extra",
  "futures",
  "hashring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,7 +266,6 @@ prost-for-raft = { package = "prost", version = "=0.11.9" } # version of prost u
 raft = { git = "https://github.com/tikv/raft-rs", rev = "aafb07c7bab439c6139926a77dfafc5b10e9bc84" ,features = ["prost-codec"], default-features = false }
 rand = "0.10.1"
 rand_distr = "0.6.0"
-rmp-serde = "~1.3"
 roaring = "0.11.4"
 reqwest = { version = "0.13.4", default-features = false, features = [
     "json",

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -22,8 +22,8 @@ criterion = { workspace = true }
 fs-err = { workspace = true, features = ["debug"] }
 proptest = { workspace = true }
 rand_distr = { workspace = true }
-rmp-serde = { workspace = true }
 rstest = { workspace = true }
+serde_cbor = { workspace = true }
 tar = { workspace = true }
 approx = "0.5.1"
 collection = { path = ".", features = ["testing"] }

--- a/lib/collection/Cargo.toml
+++ b/lib/collection/Cargo.toml
@@ -93,7 +93,6 @@ strum = { workspace = true }
 urlencoding = { workspace = true }
 
 tracing = { workspace = true, optional = true }
-fs4 = { workspace = true }
 
 # AWS S3 support
 object_store = { workspace = true }

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -337,9 +337,9 @@ fn test_deserialization() {
 
     let _read_obj: CollectionUpdateOperations = serde_json::from_str(&json_str).unwrap();
 
-    let crob_bytes = rmp_serde::to_vec(&insert_points).unwrap();
+    let crob_bytes = serde_cbor::to_vec(&insert_points).unwrap();
 
-    let _read_obj2: CollectionUpdateOperations = rmp_serde::from_slice(&crob_bytes).unwrap();
+    let _read_obj2: CollectionUpdateOperations = serde_cbor::from_slice(&crob_bytes).unwrap();
 }
 
 #[test]
@@ -365,9 +365,9 @@ fn test_deserialization2() {
 
     let _read_obj: CollectionUpdateOperations = serde_json::from_str(&json_str).unwrap();
 
-    let raw_bytes = rmp_serde::to_vec(&insert_points).unwrap();
+    let raw_bytes = serde_cbor::to_vec(&insert_points).unwrap();
 
-    let _read_obj2: CollectionUpdateOperations = rmp_serde::from_slice(&raw_bytes).unwrap();
+    let _read_obj2: CollectionUpdateOperations = serde_cbor::from_slice(&raw_bytes).unwrap();
 }
 
 // Request to find points sent to all shards but they might not have a particular id, so they will return an error

--- a/lib/segment/Cargo.toml
+++ b/lib/segment/Cargo.toml
@@ -29,7 +29,6 @@ humantime = { workspace = true }
 indicatif = { workspace = true }
 ndarray = "0.17.2"
 ndarray-npy = { version = "0.10.0", default-features = false }
-rmp-serde = { workspace = true }
 rand_distr = { workspace = true }
 walkdir = { workspace = true }
 rstest = { workspace = true }

--- a/lib/segment/benches/serde_formats.rs
+++ b/lib/segment/benches/serde_formats.rs
@@ -18,11 +18,6 @@ fn serde_formats_bench(c: &mut Criterion) {
         .map(|p| serde_cbor::to_vec(p).unwrap())
         .collect_vec();
 
-    let rmp_bytes = payloads
-        .iter()
-        .map(|p| rmp_serde::to_vec(p).unwrap())
-        .collect_vec();
-
     group.bench_function("serde-serialize-cbor", |b| {
         b.iter(|| {
             for payload in &payloads {
@@ -36,23 +31,6 @@ fn serde_formats_bench(c: &mut Criterion) {
         b.iter(|| {
             for bytes in &cbor_bytes {
                 let _payload: Payload = serde_cbor::from_slice(bytes).unwrap();
-            }
-        });
-    });
-
-    group.bench_function("serde-serialize-rmp", |b| {
-        b.iter(|| {
-            for payload in &payloads {
-                let vec = rmp_serde::to_vec(payload);
-                vec.unwrap();
-            }
-        });
-    });
-
-    group.bench_function("serde-deserialize-rmp", |b| {
-        b.iter(|| {
-            for bytes in &rmp_bytes {
-                let _payload: Payload = rmp_serde::from_slice(bytes).unwrap();
             }
         });
     });

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -5004,16 +5004,6 @@ mod tests {
         .unwrap();
     }
 
-    #[test]
-    #[ignore]
-    fn test_rmp_vs_cbor_deserialize() {
-        let payload = payload_json! {"payload_key": "payload_value"};
-        let raw = rmp_serde::to_vec(&payload).unwrap();
-        let de_record: Payload = serde_cbor::from_slice(&raw).unwrap();
-        eprintln!("payload = {payload:#?}");
-        eprintln!("de_record = {de_record:#?}");
-    }
-
     #[rstest]
     #[case::rfc_3339("2020-03-01T00:00:00Z")]
     #[case::rfc_3339_custom_tz("2020-03-01T00:00:00-09:00")]
@@ -5088,9 +5078,9 @@ mod tests {
     fn test_datetime_payload_type_binary_roundtrip() {
         let original = DateTimePayloadType::from_str("2024-06-15T12:30:45Z").unwrap();
 
-        // rmp-serde uses non-human-readable format
-        let binary = rmp_serde::to_vec(&original).expect("serialize");
-        let restored: DateTimePayloadType = rmp_serde::from_slice(&binary).expect("deserialize");
+        // serde_cbor uses non-human-readable format
+        let binary = serde_cbor::to_vec(&original).expect("serialize");
+        let restored: DateTimePayloadType = serde_cbor::from_slice(&binary).expect("deserialize");
 
         assert_eq!(original, restored);
     }
@@ -5109,9 +5099,9 @@ mod tests {
             lte: Some(dt_lte),
         });
 
-        // rmp-serde uses non-human-readable format
-        let binary = rmp_serde::to_vec(&range).expect("serialize");
-        let restored: RangeInterface = rmp_serde::from_slice(&binary).expect("deserialize");
+        // serde_cbor uses non-human-readable format
+        let binary = serde_cbor::to_vec(&range).expect("serialize");
+        let restored: RangeInterface = serde_cbor::from_slice(&binary).expect("deserialize");
 
         assert_eq!(range, restored);
     }

--- a/lib/shard/Cargo.toml
+++ b/lib/shard/Cargo.toml
@@ -33,7 +33,6 @@ log = { workspace = true }
 ordered-float = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }
-rmp-serde = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_cbor = { workspace = true }

--- a/lib/shard/src/wal.rs
+++ b/lib/shard/src/wal.rs
@@ -38,7 +38,6 @@ pub struct WalRawRecord<R> {
 
 impl<R: DeserializeOwned + Serialize> WalRawRecord<R> {
     pub fn new(record: &R) -> Result<Self> {
-        // ToDo: Replace back to faster rmp, once this https://github.com/serde-rs/serde/issues/2055 solved
         let record = serde_cbor::to_vec(record).map_err(|err| {
             WalError::WriteWalError(format!(
                 "Can't serialize entry, probably corrupted WAL or version mismatch: {err:?}"
@@ -61,16 +60,11 @@ impl<R: DeserializeOwned + Serialize> WalRawRecord<R> {
     where
         R: DeserializeOwned,
     {
-        let record: R = serde_cbor::from_slice(record)
-            .or_else(|cbor_err| match rmp_serde::from_slice(record) {
-                Ok(record) => Ok(record),
-                Err(_err) => Err(cbor_err), // ignore fallback error
-            })
-            .map_err(|err| {
-                WalError::ReadWalError(format!(
-                    "Can't deserialize entry, probably corrupted WAL or version mismatch: {err:?}"
-                ))
-            })?;
+        let record: R = serde_cbor::from_slice(record).map_err(|err| {
+            WalError::ReadWalError(format!(
+                "Can't deserialize entry, probably corrupted WAL or version mismatch: {err:?}"
+            ))
+        })?;
         Ok(record)
     }
 }


### PR DESCRIPTION
Removes the `rmp-serde` dependency, MessagePack is no longer produced anywhere.

* `SerdeWal::deserialize_from` decoded each record as CBOR. On failure it retried the record as msgpack. That retry existed only to read WAL entries written by v0.3.4 or older. This PR deletes it.
* the WAL writer switched from msgpack to CBOR in v0.3.5 (commit d5d8d2c40, 2021-07-11). v0.3.4 is therefore the last version that produced msgpack entries. Nothing has written them since.
* this is a decision about supported upgrades, not a dead code removal. The compat suite (`tests/e2e_tests/test_data_compatibility.py`) starts at v1.16.0. Nobody upgrades 0.3.x to 1.x in place. So no supported upgrade path can still carry a msgpack WAL.
* note for review: the retry does still work. A synthesized v0.3.4 record decodes into today's `OperationWithClockTag`. After this PR it fails shard load instead, with `Can't deserialize entry, probably corrupted WAL or version mismatch`. Hitting that needs an in place upgrade from v0.3.4, plus a WAL segment retained across four years of releases.
* the remaining usages were tests and a bench. The ignored `test_rmp_vs_cbor_deserialize` is deleted. The binary roundtrip tests move to `serde_cbor`, which is also non human readable and is the format the WAL uses. The rmp arms of the `serde_formats` bench are removed.
* `rmp-serde` and `rmp` are gone from `Cargo.lock`, nothing else depended on them
* also drops the unused `fs4` dependency from `collection`. It is still used by `wal` and `common`, so the workspace entry stays.