### PR TITLE
Fix proxy segment not propagating some named vector changes

### DIFF
--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -255,12 +255,11 @@ impl ProxySegment {
         // Point deletions bump the segment version, can cause index changes to be ignored
         // Lock ordering is important here and must match the flush function to prevent a deadlock
         {
-            let op_num = wrapped_segment.version();
             if !self.changed_indexes.is_empty() {
                 wrapped_segment.with_upgraded(|wrapped_segment| {
                     for (field_name, change) in self.changed_indexes.iter_ordered() {
                         debug_assert!(
-                            change.version() >= op_num,
+                            change.version() >= wrapped_segment.version(),
                             "proxied index change should have newer version than segment",
                         );
                         match change {

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -289,16 +289,18 @@ impl ProxySegment {
         }
 
         // Propagate vector name changes (between index changes and point deletions)
+        //
+        // This artificially bumps the operation version to be at least as high as the current
+        // segment version. This way we make sure the segment does not ignore the operation.
+        // Alternatively we can interleave index, vectorname and deletion changes and apply them in
+        // exactly the same order they arrive, but that requires more complex changes.
         {
             if !self.changed_vector_names.is_empty() {
                 wrapped_segment.with_upgraded(|wrapped_segment| {
                     for (vector_name, intent) in self.changed_vector_names.iter_ordered() {
                         match intent {
                             IntendedVector::Absent { version } => {
-                                // Raise operation version to at least segment version, otherwise
-                                // the operation will be ignored by segment version handling
                                 let op_num = max(*version, wrapped_segment.version());
-
                                 wrapped_segment.delete_vector_name(op_num, vector_name)?;
                             }
                             IntendedVector::Present {
@@ -306,10 +308,7 @@ impl ProxySegment {
                                 version,
                                 supersedes_wrapped,
                             } => {
-                                // Raise operation version to at least segment version, otherwise
-                                // the operation will be ignored by segment version handling
                                 let op_num = max(*version, wrapped_segment.version());
-
                                 if *supersedes_wrapped {
                                     // `create_vector_name_impl` is idempotent and would
                                     // silently keep the wrapped's stale storage. Clear it

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -6,6 +6,7 @@ mod vector_name_changes;
 mod tests;
 
 use std::borrow::Cow;
+use std::cmp::max;
 
 use ahash::AHashMap;
 use common::bitvec::BitVec;
@@ -294,24 +295,28 @@ impl ProxySegment {
                     for (vector_name, intent) in self.changed_vector_names.iter_ordered() {
                         match intent {
                             IntendedVector::Absent { version } => {
-                                wrapped_segment.delete_vector_name(*version, vector_name)?;
+                                // Raise operation version to at least segment version, otherwise
+                                // the operation will be ignored by segment version handling
+                                let op_num = max(*version, wrapped_segment.version());
+
+                                wrapped_segment.delete_vector_name(op_num, vector_name)?;
                             }
                             IntendedVector::Present {
                                 config,
                                 version,
                                 supersedes_wrapped,
                             } => {
+                                // Raise operation version to at least segment version, otherwise
+                                // the operation will be ignored by segment version handling
+                                let op_num = max(*version, wrapped_segment.version());
+
                                 if *supersedes_wrapped {
                                     // `create_vector_name_impl` is idempotent and would
                                     // silently keep the wrapped's stale storage. Clear it
                                     // first so the new schema actually takes effect.
-                                    wrapped_segment.delete_vector_name(*version, vector_name)?;
+                                    wrapped_segment.delete_vector_name(op_num, vector_name)?;
                                 }
-                                wrapped_segment.create_vector_name(
-                                    *version,
-                                    vector_name,
-                                    config,
-                                )?;
+                                wrapped_segment.create_vector_name(op_num, vector_name, config)?;
                             }
                         }
                     }

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -716,6 +716,8 @@ fn test_proxy_deferred() {
 /// `propagate_to_wrapped` must apply all pending proxy changes to the wrapped segment: a queued
 /// named vector creation and a queued payload index creation, each recorded with a higher
 /// version than the last.
+///
+/// See: <https://github.com/qdrant/qdrant/pull/10507>
 #[test]
 fn test_propagate_to_wrapped_vector_name_and_index() {
     use segment::data_types::vector_name_config::{DenseVectorConfig, VectorNameConfig};

--- a/lib/shard/src/proxy_segment/tests.rs
+++ b/lib/shard/src/proxy_segment/tests.rs
@@ -712,3 +712,78 @@ fn test_proxy_deferred() {
 
     assert_eq!(proxy_segment.available_point_count_without_deferred(), 2);
 }
+
+/// `propagate_to_wrapped` must apply all pending proxy changes to the wrapped segment: a queued
+/// named vector creation and a queued payload index creation, each recorded with a higher
+/// version than the last.
+#[test]
+fn test_propagate_to_wrapped_vector_name_and_index() {
+    use segment::data_types::vector_name_config::{DenseVectorConfig, VectorNameConfig};
+    use segment::types::Distance;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let wrapped_segment = LockedSegment::new(empty_segment(dir.path()));
+    let hw_counter = HardwareCounterCell::new();
+
+    let mut proxy_segment = ProxySegment::new(wrapped_segment.clone());
+
+    // Queue a named vector creation, then a payload index creation, each with a higher version.
+    let vector_config = VectorNameConfig::dense(DenseVectorConfig {
+        size: 4,
+        distance: Distance::Dot,
+        multivector_config: None,
+        datatype: None,
+    });
+    proxy_segment
+        .create_vector_name(10, "extra_vector", &vector_config)
+        .unwrap();
+
+    let field_name: PayloadKeyType = "color".parse().unwrap();
+    let field_schema: PayloadFieldSchema = PayloadSchemaType::Keyword.into();
+    proxy_segment
+        .create_field_index(20, &field_name, Some(&field_schema), &hw_counter)
+        .unwrap();
+
+    // Both changes are pending on the proxy, not yet visible on the wrapped segment.
+    assert!(!proxy_segment.get_vector_name_changes().is_empty());
+    assert!(!proxy_segment.get_index_changes().is_empty());
+    assert!(
+        !wrapped_segment
+            .get()
+            .read()
+            .config()
+            .vector_data
+            .contains_key("extra_vector")
+    );
+    assert!(
+        !wrapped_segment
+            .get()
+            .read()
+            .get_indexed_fields()
+            .contains_key(&field_name)
+    );
+
+    proxy_segment.propagate_to_wrapped().unwrap();
+
+    // The proxy has drained its pending changes...
+    assert!(proxy_segment.get_vector_name_changes().is_empty());
+    assert!(proxy_segment.get_index_changes().is_empty());
+
+    // ...and both changes actually landed on the wrapped segment.
+    assert!(
+        wrapped_segment
+            .get()
+            .read()
+            .config()
+            .vector_data
+            .contains_key("extra_vector")
+    );
+    assert_eq!(
+        wrapped_segment
+            .get()
+            .read()
+            .get_indexed_fields()
+            .get(&field_name),
+        Some(&field_schema),
+    );
+}


### PR DESCRIPTION
Fixes <https://github.com/qdrant/qdrant/pull/10349#discussion_r3937283800>

It appears that segment version handling bites us when propagating proxy segment changes into the real segment.

Changes are applied in a specific order: (1) index changes, (2) named vector changes, (3) deleted points.

Step (1) and (2) respect the segment version. If we apply a named vector change with an older version than the segment currently has, it is ignored. The segment version handling conflicts with the above propagation order.

For example. We first create a named vector (v=10). Then we create a payload index (v=20). When we propagate these changes we first (1) apply the payload index change which bumps the segment to v=20. Then we try to (2) apply the creation of the named vector (v=10), which is completely ignored due to the now higher segment version. This breaks data consistency.

To fix this I now artificially bump the operation version for named vector changes to not be lower than the segment version. I believe doing this is fine, because the end result after propagating all operations is exactly the same: the segment version will become the maximum of all changes.

An alternative would be to apply all changes in exactly the same order, so that operations from all three steps are interleaved in the same order they arrived. It is more complicated and I don't think it's necessary, so I chose the above instead. It's something we can revisit in the future when <https://github.com/qdrant/qdrant/pull/10349> is implemented, because it orders all operations in a single list.

Propagation of deleted points is not affected, because it works with point-level versions.

This PR adds a test showing the problem. The test fails before the fix.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
