### PR TITLE
fix: sort sparse queries in legacy search APIs

### DIFF
--- a/lib/segment/src/vector_storage/query_scorer/sparse_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_metric_query_scorer.rs
@@ -96,6 +96,7 @@ impl QueryScorer for SparseMetricQueryScorer<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::data_types::vectors::VectorRef;
     use crate::vector_storage::VectorStorage;
     use crate::vector_storage::query_scorer::QueryScorer;
 
@@ -104,7 +105,7 @@ mod tests {
         let mut vector_storage = VolatileSparseVectorStorage::default();
         let stored = SparseVector::new(vec![1, 3], vec![5.0, 7.0]).unwrap();
         vector_storage
-            .insert_vector(0, (&stored).into(), &HardwareCounterCell::new())
+            .insert_vector(0, VectorRef::from(&stored), &HardwareCounterCell::new())
             .unwrap();
 
         let sorted = SparseVector::new(vec![1, 3], vec![5.0, 7.0]).unwrap();

--- a/lib/segment/src/vector_storage/query_scorer/sparse_metric_query_scorer.rs
+++ b/lib/segment/src/vector_storage/query_scorer/sparse_metric_query_scorer.rs
@@ -16,10 +16,14 @@ pub struct SparseMetricQueryScorer<'a> {
 
 impl<'a> SparseMetricQueryScorer<'a> {
     pub fn new(
-        query: SparseVector,
+        mut query: SparseVector,
         vector_storage: &'a VolatileSparseVectorStorage,
         mut hardware_counter: HardwareCounterCell,
     ) -> Self {
+        if !query.is_sorted() {
+            query.sort_by_indices();
+        }
+
         // We will count the number of intersections per pair of vectors.
         hardware_counter.set_cpu_multiplier(1);
         // We don't measure `vector_io_read` because we are dealing with a volatile storage,
@@ -86,5 +90,41 @@ impl QueryScorer for SparseMetricQueryScorer<'_> {
     type SupportsBytes = False;
     fn score_bytes(&self, enabled: Self::SupportsBytes, _: &[u8]) -> ScoreType {
         match enabled {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vector_storage::VectorStorage;
+    use crate::vector_storage::query_scorer::QueryScorer;
+
+    #[test]
+    fn unsorted_sparse_query_keeps_score() {
+        let mut vector_storage = VolatileSparseVectorStorage::default();
+        let stored = SparseVector::new(vec![1, 3], vec![5.0, 7.0]).unwrap();
+        vector_storage
+            .insert_vector(0, (&stored).into(), &HardwareCounterCell::new())
+            .unwrap();
+
+        let sorted = SparseVector::new(vec![1, 3], vec![5.0, 7.0]).unwrap();
+        let unsorted = SparseVector::new(vec![3, 1], vec![7.0, 5.0]).unwrap();
+
+        let sorted_score =
+            SparseMetricQueryScorer::new(sorted, &vector_storage, HardwareCounterCell::new())
+                .score_stored(0);
+        let unsorted_score =
+            SparseMetricQueryScorer::new(unsorted, &vector_storage, HardwareCounterCell::new())
+                .score_stored(0);
+        let mut batch_scores = [0.0];
+        SparseMetricQueryScorer::new(
+            SparseVector::new(vec![3, 1], vec![7.0, 5.0]).unwrap(),
+            &vector_storage,
+            HardwareCounterCell::new(),
+        )
+        .score_stored_batch(&[0], &mut batch_scores);
+
+        assert_eq!(sorted_score, unsorted_score);
+        assert_eq!(sorted_score, batch_scores[0]);
     }
 }


### PR DESCRIPTION
### All Submissions:

- [x] My PR targets the `dev` branch and my branch was created from `dev`.
- [x] I followed the guidelines in the [Contributing document](docs/CONTRIBUTING.md).
- [x] I checked for other open pull requests for the same update.

### Changes to Core Features:

Legacy sparse search now accepts unsorted sparse query indices and produces the same score as the equivalent sorted query. This fixes the inconsistency reported in [#9092](https://github.com/qdrant/qdrant/issues/9092).

The query is sorted once at the shared sparse scorer boundary. The query is owned there, so this avoids changing caller-owned data and covers both single search and batch scoring paths.

### Testing

- Reproduced the pre-fix failure with an unsorted sparse query. It triggered the sparse scoring sortedness assertion.
- `cargo +nightly-x86_64-pc-windows-gnu test -p segment unsorted_sparse_query_keeps_score --lib -- --nocapture`
  - Passed, including single-result and batch scoring.
- `cargo +nightly-x86_64-pc-windows-gnu test -p segment --lib`
  - 1047 passed, 14 ignored.
- `cargo +nightly-x86_64-pc-windows-gnu fmt --all -- --check`
  - Passed.
- `git diff --check`
  - Passed.
- `cargo clippy -p segment --lib --all-features -- -D warnings`
  - Could not complete on Windows because the enabled `shaderc-sys` build requires `cmake`, which is not installed. The same check was attempted in Podman, but the Linux image pull stalled.

### AI Assistance Disclosure

This commit was AI-assisted and is marked with the `[AI]` commit prefix. Initial prompt: investigate and fix Qdrant issue #9092 concerning inconsistent sparse query handling between legacy search/search_batch APIs and the newer /query flow, with reproduction, tests, self-review, and no speculative changes.

### Post-Deploy Monitoring & Validation

No additional operational monitoring is required for this internal scorer change. After merge, validate legacy sparse `search` and `search_batch` requests with both sorted and unsorted equivalent sparse vectors. Expected behavior is equal scores and no sortedness assertion failures.
