### PR TITLE
fix(strict-mode): enforce max_query_limit on facet and matrix defaults

### DIFF
--- a/lib/collection/src/operations/verification/facet.rs
+++ b/lib/collection/src/operations/verification/facet.rs
@@ -6,7 +6,7 @@ use super::StrictModeVerification;
 
 impl StrictModeVerification for FacetRequestInternal {
     fn query_limit(&self) -> Option<usize> {
-        self.limit
+        Some(self.limit.unwrap_or(FacetParams::DEFAULT_LIMIT))
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {

--- a/lib/collection/src/operations/verification/matrix.rs
+++ b/lib/collection/src/operations/verification/matrix.rs
@@ -5,12 +5,15 @@ use crate::collection::distance_matrix::CollectionSearchMatrixRequest;
 
 impl StrictModeVerification for SearchMatrixRequestInternal {
     fn query_limit(&self) -> Option<usize> {
-        match (self.limit, self.sample) {
-            (Some(limit), Some(sample)) => Some(limit * sample),
-            (Some(limit), None) => Some(limit),
-            (None, Some(sample)) => Some(sample),
-            (None, None) => None,
-        }
+        // Mirror `CollectionSearchMatrixRequest::from`: unset parameters fall back
+        // to their defaults, so the effective query size always has a value.
+        Some(
+            self.limit
+                .unwrap_or(CollectionSearchMatrixRequest::DEFAULT_LIMIT_PER_SAMPLE)
+                * self
+                    .sample
+                    .unwrap_or(CollectionSearchMatrixRequest::DEFAULT_SAMPLE),
+        )
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {

--- a/lib/collection/src/operations/verification/matrix.rs
+++ b/lib/collection/src/operations/verification/matrix.rs
@@ -7,12 +7,15 @@ impl StrictModeVerification for SearchMatrixRequestInternal {
     fn query_limit(&self) -> Option<usize> {
         // Mirror `CollectionSearchMatrixRequest::from`: unset parameters fall back
         // to their defaults, so the effective query size always has a value.
+        // Saturate instead of wrapping: an overflowing product must read as a huge
+        // effective size so it is rejected whenever max_query_limit is set.
         Some(
             self.limit
                 .unwrap_or(CollectionSearchMatrixRequest::DEFAULT_LIMIT_PER_SAMPLE)
-                * self
-                    .sample
-                    .unwrap_or(CollectionSearchMatrixRequest::DEFAULT_SAMPLE),
+                .saturating_mul(
+                    self.sample
+                        .unwrap_or(CollectionSearchMatrixRequest::DEFAULT_SAMPLE),
+                ),
         )
     }
 

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -519,6 +519,14 @@ mod test {
 
         // Explicitly small enough: 1 * 2 = 2 <= max_query_limit (4)
         assert_strict_mode_success(matrix_request(Some(2), Some(1)), collection).await;
+
+        // Overflowing product (2^33 * 2^33 wraps to 0 in release mode) must
+        // still be rejected, not bypass the check
+        assert_strict_mode_error(
+            matrix_request(Some(1 << 33), Some(1 << 33)),
+            collection,
+        )
+        .await;
     }
 
     async fn test_filter_read(collection: &Collection) {

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -423,6 +423,8 @@ mod test {
 
         test_query_limit(&collection).await;
         test_scroll_query_limit(&collection).await;
+        test_facet_query_limit(&collection).await;
+        test_matrix_query_limit(&collection).await;
         test_search_params(&collection).await;
         test_filter_read(&collection).await;
         test_filter_write(&collection).await;
@@ -471,6 +473,52 @@ mod test {
             order_by: None,
         };
         assert_strict_mode_success(request_valid_limit, collection).await;
+    }
+
+    async fn test_facet_query_limit(collection: &Collection) {
+        use api::rest::FacetRequestInternal;
+        use segment::json_path::JsonPath;
+
+        let facet_request = |limit: Option<usize>| FacetRequestInternal {
+            key: JsonPath::new(INDEXED_KEY),
+            limit,
+            filter: None,
+            exact: None,
+        };
+
+        // Omitted limit falls back to the default (10), which exceeds max_query_limit (4)
+        assert_strict_mode_error(facet_request(None), collection).await;
+
+        // Explicit limit (10) exceeds max_query_limit (4)
+        assert_strict_mode_error(facet_request(Some(10)), collection).await;
+
+        // Explicit limit (4) matches max_query_limit (4)
+        assert_strict_mode_success(facet_request(Some(4)), collection).await;
+    }
+
+    async fn test_matrix_query_limit(collection: &Collection) {
+        use api::rest::SearchMatrixRequestInternal;
+
+        let matrix_request =
+            |sample: Option<usize>, limit: Option<usize>| SearchMatrixRequestInternal {
+                filter: None,
+                sample,
+                limit,
+                using: None,
+            };
+
+        // Both parameters omitted: effective size is the product of the
+        // defaults (3 * 10 = 30), which exceeds max_query_limit (4)
+        assert_strict_mode_error(matrix_request(None, None), collection).await;
+
+        // Only limit given: the omitted sample still defaults to 10 (2 * 10 = 20 > 4)
+        assert_strict_mode_error(matrix_request(None, Some(2)), collection).await;
+
+        // Only sample given: the omitted limit defaults to 3 (3 * 10 = 30 > 4)
+        assert_strict_mode_error(matrix_request(Some(10), None), collection).await;
+
+        // Explicitly small enough: 1 * 2 = 2 <= max_query_limit (4)
+        assert_strict_mode_success(matrix_request(Some(2), Some(1)), collection).await;
     }
 
     async fn test_filter_read(collection: &Collection) {


### PR DESCRIPTION
Fixes #10518

Same gap as #10382 (scroll): `query_limit()` for the REST facet and matrix request types ran before default limits were resolved, so omitted limits bypassed `max_query_limit` in strict mode:

- facet: an omitted `limit` now counts as `FacetParams::DEFAULT_LIMIT` (10).
- matrix: omitted `sample`/`limit` fall back to `DEFAULT_SAMPLE` (10) / `DEFAULT_LIMIT_PER_SAMPLE` (3), and the effective `sample * limit` is checked. Previously `(None, None)` skipped the check entirely (effective 30) and partial omission under-reported (e.g. `limit: 2`, `sample` omitted was checked as 2 but executed as 20).

The gRPC paths convert to `FacetParams`/`CollectionSearchMatrixRequest` before `check_strict_mode`, so they already enforced correctly.

Regression tests (`test_facet_query_limit`, `test_matrix_query_limit`) added next to `test_scroll_query_limit` in `verification/mod.rs`.

Testing: `cargo test -p collection operations::verification` - I could not run the full `cargo test -p collection operations::verification` suite in my environment: rustc gets OOM-killed while compiling the `segment` crate (sandbox has ~2 GB RAM; tried 3 times with -j1, no debuginfo, stripped debuginfo). Verified instead:
- `cargo check -p collection --tests` passes - the new regression tests compile.
- A standalone harness reproducing the exact `query_limit()` / `check_limit_opt` logic confirms the bug before the fix (facet without limit and matrix without sample/limit bypass `max_query_limit=4`) and correct enforcement after the fix.
- The regression tests follow the existing `test_scroll_query_limit` pattern and fixture.