### PR TITLE
fix(strict-mode): check prefetches of group queries

### DIFF
--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -423,6 +423,7 @@ mod test {
 
         test_query_limit(&collection).await;
         test_scroll_query_limit(&collection).await;
+        test_query_groups_prefetch(&collection).await;
         test_search_params(&collection).await;
         test_filter_read(&collection).await;
         test_filter_write(&collection).await;
@@ -471,6 +472,46 @@ mod test {
             order_by: None,
         };
         assert_strict_mode_success(request_valid_limit, collection).await;
+    }
+
+    async fn test_query_groups_prefetch(collection: &Collection) {
+        use segment::json_path::JsonPath;
+
+        use crate::operations::universal_query::collection_query::{
+            CollectionPrefetch, CollectionQueryGroupsRequest,
+        };
+
+        let groups_request = |prefetch_limit: usize| CollectionQueryGroupsRequest {
+            prefetch: vec![CollectionPrefetch {
+                prefetch: vec![],
+                query: None,
+                using: Default::default(),
+                filter: None,
+                score_threshold: None,
+                limit: prefetch_limit,
+                params: None,
+                lookup_from: None,
+            }],
+            query: None,
+            using: Default::default(),
+            filter: None,
+            params: None,
+            score_threshold: None,
+            with_vector: Default::default(),
+            with_payload: Default::default(),
+            lookup_from: None,
+            group_by: JsonPath::new(INDEXED_KEY),
+            group_size: 1,
+            limit: 2,
+            with_lookup: None,
+        };
+
+        // Group query itself is within max_query_limit (2 * 1 = 2 <= 4), but the
+        // prefetch limit (10) exceeds max_query_limit (4) and must be rejected
+        assert_strict_mode_error(groups_request(10), collection).await;
+
+        // Prefetch within the limit passes
+        assert_strict_mode_success(groups_request(4), collection).await;
     }
 
     async fn test_filter_read(collection: &Collection) {

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -512,6 +512,21 @@ mod test {
 
         // Prefetch within the limit passes
         assert_strict_mode_success(groups_request(4), collection).await;
+
+        // Nested prefetch above the limit must also be rejected, even when the
+        // outer prefetch is within it
+        let mut nested_request = groups_request(2);
+        nested_request.prefetch[0].prefetch = vec![CollectionPrefetch {
+            prefetch: vec![],
+            query: None,
+            using: Default::default(),
+            filter: None,
+            score_threshold: None,
+            limit: 10,
+            params: None,
+            lookup_from: None,
+        }];
+        assert_strict_mode_error(nested_request, collection).await;
     }
 
     async fn test_filter_read(collection: &Collection) {

--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -239,6 +239,13 @@ impl StrictModeVerification for CollectionQueryGroupsRequest {
         collection: &Collection,
         strict_mode_config: &StrictModeConfig,
     ) -> CollectionResult<()> {
+        // CollectionPrefetch.prefetch is of type CollectionPrefetch (recursive type)
+        for prefetch in &self.prefetch {
+            prefetch
+                .check_strict_mode(collection, strict_mode_config)
+                .await?;
+        }
+
         if let Some(query) = self.query.as_ref() {
             // check query can perform fullscan when not rescoring
             if self.prefetch.is_empty() {


### PR DESCRIPTION
Fixes #10520

`CollectionQueryGroupsRequest::check_custom()` never iterated the request prefetches, unlike `CollectionQueryRequest::check_custom()`. As a result, a group query with prefetches bypassed strict-mode verification on the prefetches: the prefetch `limit` was not checked against `max_query_limit`, and the prefetch query's fullscan and formula checks were skipped. `query_limit()` for group requests only reports `limit * group_size`, so prefetch reads were invisible to strict mode. Affects both REST and gRPC `query/groups`.

The fix mirrors the non-groups path: recursively `check_strict_mode` every prefetch before checking the root query and `group_by`.

Regression test (`test_query_groups_prefetch`) added in `verification/mod.rs`: a group query within `max_query_limit` but with an oversized prefetch is rejected; the same request with a prefetch within the limit passes.

Testing: same environment constraint as #10519 - the full `cargo test -p collection operations::verification` suite cannot run here (rustc gets OOM-killed compiling the `segment` crate in a ~2 GB sandbox). Verified with `cargo check -p collection --tests` (passes, includes the new test) and a standalone harness reproducing the check flow: before the fix the oversized prefetch passes verification, after the fix it is rejected, and a prefetch within the limit still passes.