### PR TITLE
fix(strict-mode): honor search_allow_exact for gRPC facet requests

### DIFF
--- a/lib/collection/src/operations/verification/facet.rs
+++ b/lib/collection/src/operations/verification/facet.rs
@@ -40,7 +40,7 @@ impl StrictModeVerification for FacetParams {
     }
 
     fn request_exact(&self) -> Option<bool> {
-        None
+        Some(self.exact)
     }
 
     fn request_search_params(&self) -> Option<&SearchParams> {

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -427,6 +427,7 @@ mod test {
         test_filter_read(&collection).await;
         test_filter_write(&collection).await;
         test_request_exact(&collection).await;
+        test_facet_exact(&collection).await;
         test_search_batch_limit(&collection).await;
         test_upsert_batch_limit(&collection).await;
     }
@@ -523,6 +524,26 @@ mod test {
             exact: false,
         };
         assert_strict_mode_success(request, collection).await;
+    }
+
+    async fn test_facet_exact(collection: &Collection) {
+        use segment::data_types::facets::FacetParams;
+        use segment::json_path::JsonPath;
+
+        let facet_params = |exact: bool| FacetParams {
+            key: JsonPath::new(INDEXED_KEY),
+            limit: 1,
+            filter: None,
+            exact,
+        };
+
+        // exact = true must be rejected when strict mode disallows exact search.
+        // The gRPC facet API is verified through `FacetParams`, so this is the
+        // impl that decides whether gRPC facet requests honor search_allow_exact.
+        assert_strict_mode_error(facet_params(true), collection).await;
+
+        // exact = false (also the default) passes
+        assert_strict_mode_success(facet_params(false), collection).await;
     }
 
     async fn test_search_batch_limit(collection: &Collection) {


### PR DESCRIPTION
Fixes #10522

The gRPC facet API is verified through `FacetParams`, whose `request_exact()` returned `None`, so a gRPC facet request with `exact: true` bypassed strict mode when `search_allow_exact` was false. The REST facet API is verified through `FacetRequestInternal`, which checks the flag, so REST and gRPC disagreed. Returning `Some(self.exact)` makes both APIs enforce the setting the same way; the default `exact: false` still passes.

Regression test (`test_facet_exact`) added in `verification/mod.rs` next to `test_request_exact`.

Testing: same environment constraint as #10519 - the full `cargo test -p collection operations::verification` suite cannot run here (rustc gets OOM-killed compiling the `segment` crate in a ~2 GB sandbox). Verified with `cargo check -p collection --tests` (passes, includes the new test) and a standalone harness reproducing the check flow: before the fix gRPC accepts `exact: true` while REST rejects it; after the fix both reject it, and the default `exact: false` still passes.