### PR TITLE
fix(segment): reject mismatched dims when averaging recommend vectors

### DIFF
--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -169,6 +169,12 @@ fn avg_vectors<'a>(
     for vector in vectors {
         match vector {
             VectorRef::Dense(vector) => {
+                if dense_count > 0 && vector.len() != avg_dense.len() {
+                    return Err(OperationError::WrongVectorDimension {
+                        expected_dim: avg_dense.len(),
+                        received_dim: vector.len(),
+                    });
+                }
                 dense_count += 1;
                 for i in 0..vector.len() {
                     if i >= avg_dense.len() {
@@ -184,15 +190,21 @@ fn avg_vectors<'a>(
             }
             VectorRef::MultiDense(vector) => {
                 multi_count += 1;
-                avg_multi = Some(avg_multi.map_or_else(
-                    || vector.to_owned(),
-                    |mut avg_multi| {
+                avg_multi = Some(match avg_multi {
+                    None => vector.to_owned(),
+                    Some(mut avg_multi) => {
+                        if avg_multi.dim != vector.dim {
+                            return Err(OperationError::WrongVectorDimension {
+                                expected_dim: avg_multi.dim,
+                                received_dim: vector.dim,
+                            });
+                        }
                         avg_multi
                             .flattened_vectors
                             .extend_from_slice(vector.flattened_vectors);
                         avg_multi
-                    },
-                ));
+                    }
+                });
             }
         }
     }
@@ -464,6 +476,42 @@ mod test {
         );
         assert!(matches!(
             result,
+            Err(OperationError::WrongVectorDimension {
+                expected_dim: 2,
+                received_dim: 3,
+            })
+        ));
+
+        // Positive vectors with different dimensions are rejected, not
+        // silently zero-padded into the average.
+        let mismatched_positives: Vec<VectorInternal> =
+            vec![vec![1.0, 0.0].into(), vec![0.0, 1.0, 2.0].into()];
+        let result = avg_vector_for_recommendation(
+            mismatched_positives.iter().map(VectorRef::from),
+            std::iter::empty().peekable(),
+        );
+        assert!(matches!(
+            result,
+            Err(OperationError::WrongVectorDimension {
+                expected_dim: 2,
+                received_dim: 3,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_avg_vectors_mismatched_dense_dims() {
+        // Same-dimension dense vectors average as before.
+        let vectors: Vec<VectorInternal> = vec![vec![1.0, 2.0].into(), vec![3.0, 4.0].into()];
+        assert_eq!(
+            avg_vectors(vectors.iter().map(VectorRef::from)).unwrap(),
+            vec![2.0, 3.0].into(),
+        );
+
+        // Mismatched dimensions are rejected, not zero-padded.
+        let vectors: Vec<VectorInternal> = vec![vec![1.0, 2.0].into(), vec![3.0, 4.0, 5.0].into()];
+        assert!(matches!(
+            avg_vectors(vectors.iter().map(VectorRef::from)),
             Err(OperationError::WrongVectorDimension {
                 expected_dim: 2,
                 received_dim: 3,

--- a/lib/segment/src/vector_storage/query/reco_query.rs
+++ b/lib/segment/src/vector_storage/query/reco_query.rs
@@ -287,7 +287,7 @@ mod test {
 
     use super::{avg_vector_for_recommendation, avg_vectors};
     use crate::common::operation_error::OperationError;
-    use crate::data_types::vectors::{VectorInternal, VectorRef};
+    use crate::data_types::vectors::{TypedMultiDenseVector, VectorInternal, VectorRef};
     use crate::vector_storage::query::{Query, RecoBestScoreQuery, RecoQuery};
 
     enum Chosen {
@@ -510,6 +510,36 @@ mod test {
 
         // Mismatched dimensions are rejected, not zero-padded.
         let vectors: Vec<VectorInternal> = vec![vec![1.0, 2.0].into(), vec![3.0, 4.0, 5.0].into()];
+        assert!(matches!(
+            avg_vectors(vectors.iter().map(VectorRef::from)),
+            Err(OperationError::WrongVectorDimension {
+                expected_dim: 2,
+                received_dim: 3,
+            })
+        ));
+    }
+
+    #[test]
+    fn test_avg_vectors_mismatched_multidense_dims() {
+        // Same-dimension multi vectors average as before.
+        let vectors: Vec<VectorInternal> = vec![
+            VectorInternal::MultiDense(TypedMultiDenseVector::new(vec![1.0, 2.0, 3.0, 4.0], 2)),
+            VectorInternal::MultiDense(TypedMultiDenseVector::new(vec![5.0, 6.0], 2)),
+        ];
+        let avg = avg_vectors(vectors.iter().map(VectorRef::from)).unwrap();
+        match avg {
+            VectorInternal::MultiDense(multi) => {
+                assert_eq!(multi.dim, 2);
+                assert_eq!(multi.flattened_vectors, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+            }
+            _ => panic!("expected multi-dense vector"),
+        }
+
+        // Mismatched multi-vector dimensions are rejected, not merged.
+        let vectors: Vec<VectorInternal> = vec![
+            VectorInternal::MultiDense(TypedMultiDenseVector::new(vec![1.0, 2.0], 2)),
+            VectorInternal::MultiDense(TypedMultiDenseVector::new(vec![1.0, 2.0, 3.0], 3)),
+        ];
         assert!(matches!(
             avg_vectors(vectors.iter().map(VectorRef::from)),
             Err(OperationError::WrongVectorDimension {


### PR DESCRIPTION
Fixes #10524

Follow-up to #10374: that fix rejected mismatched dimensions between the positive and negative averages, but `avg_vectors` itself still accepted inputs of different dimensions within the positive (or negative) set - shorter dense vectors were silently zero-padded into the average, and multi-dense vectors with different inner dims were flattened together. When the longest input matched the collection dimension, the request succeeded with a silently wrong query vector.

Now dense inputs of unequal length and multi-dense inputs of unequal inner dimension are rejected with `WrongVectorDimension`.

Regression tests added in `reco_query.rs`: mismatched positive dims rejected from `avg_vector_for_recommendation`, mismatched dense dims rejected from `avg_vectors`, equal dims unchanged.

Testing: my sandbox cannot run the full `cargo test` suite (rustc gets OOM-killed compiling `segment` with full codegen in ~2 GB RAM). Verified with `cargo check -p segment --tests` (passes, includes the new tests - confirmed the test target is really type-checked by injecting a deliberate error and watching it fail) and a standalone harness of the exact accumulation logic: before the fix `[1,0,0]` and `[1,1]` silently average to `[1.0, 0.5, 0.0]`; after the fix the input is rejected; equal dims are unchanged.