### PR TITLE
fix: token-aware text_any matching on unindexed payload fields

### DIFF
--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -1,5 +1,6 @@
 //! Contains functions for interpreting filter queries and defining if given points pass the conditions
 
+use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
@@ -56,13 +57,12 @@ fn unindexed_text_match(stored: &str, query: &str) -> bool {
 }
 
 fn unindexed_text_any_match(stored: &str, query: &str) -> bool {
-    let document_tokens = collect_unindexed_document_tokens(stored);
+    let document_tokens: HashSet<String> =
+        collect_unindexed_document_tokens(stored).into_iter().collect();
     let query_tokens = collect_unindexed_query_tokens(query);
-    query_tokens.iter().any(|query_token| {
-        document_tokens
-            .iter()
-            .any(|document_token| document_token == query_token)
-    })
+    query_tokens
+        .iter()
+        .any(|query_token| document_tokens.contains(query_token))
 }
 
 fn unindexed_phrase_match(stored: &str, phrase: &str) -> bool {

--- a/lib/segment/src/payload_storage/condition_checker.rs
+++ b/lib/segment/src/payload_storage/condition_checker.rs
@@ -55,6 +55,16 @@ fn unindexed_text_match(stored: &str, query: &str) -> bool {
     })
 }
 
+fn unindexed_text_any_match(stored: &str, query: &str) -> bool {
+    let document_tokens = collect_unindexed_document_tokens(stored);
+    let query_tokens = collect_unindexed_query_tokens(query);
+    query_tokens.iter().any(|query_token| {
+        document_tokens
+            .iter()
+            .any(|document_token| document_token == query_token)
+    })
+}
+
 fn unindexed_phrase_match(stored: &str, phrase: &str) -> bool {
     let document_tokens = collect_unindexed_document_tokens(stored);
     let phrase_tokens = collect_unindexed_query_tokens(phrase);
@@ -236,9 +246,7 @@ impl ValueChecker for Match {
                 | Value::Object(_) => false,
             },
             Match::TextAny(MatchTextAny { text_any }) => match payload {
-                Value::String(stored) => text_any
-                    .split_whitespace()
-                    .any(|token| stored.contains(token)),
+                Value::String(stored) => unindexed_text_any_match(stored, text_any),
                 Value::Null
                 | Value::Bool(_)
                 | Value::Number(_)

--- a/lib/segment/tests/integration/unindexed_text_match_test.rs
+++ b/lib/segment/tests/integration/unindexed_text_match_test.rs
@@ -1,5 +1,5 @@
 use segment::payload_storage::condition_checker::ValueChecker;
-use segment::types::{Match, MatchPhrase, MatchText};
+use segment::types::{Match, MatchPhrase, MatchText, MatchTextAny};
 use serde_json::Value;
 
 /// Regression for <https://github.com/qdrant/qdrant/issues/10182>
@@ -34,4 +34,25 @@ fn test_unindexed_phrase_requires_token_order() {
     assert!(!phrase_match("alpha beta", "alphabeta"));
     assert!(!phrase_match("good", "goodness only"));
     assert!(phrase_match("good", "goodness only good"));
+}
+
+/// Same tokenization gap as <https://github.com/qdrant/qdrant/issues/10182>,
+/// in the `text_any` matcher.
+#[test]
+fn test_unindexed_text_any_uses_token_matching() {
+    let text_any_match = |query: &str, stored: &str| {
+        Match::TextAny(MatchTextAny {
+            text_any: query.to_string(),
+        })
+        .check_match(&Value::String(stored.to_string()))
+    };
+
+    // At least one query token must appear as a whole token (lowercased),
+    // like the indexed full-text path.
+    assert!(text_any_match("hello", "Hello, world!"));
+    assert!(text_any_match("alpha beta", "foo beta bar"));
+
+    // A substring that is not a whole token must not match.
+    assert!(!text_any_match("good", "goodness only"));
+    assert!(!text_any_match("alpha beta", "gamma delta"));
 }


### PR DESCRIPTION
## Summary

Fixes #10526

`text_any` on an unindexed string field matched whitespace-split tokens as case-sensitive substrings, while the indexed full-text path tokenizes (lowercase, punctuation-aware) and matches on whole tokens. This is the same class of bug fixed for `text`/`phrase` in #10341; `text_any` was left using the old logic.

The fix adds `unindexed_text_any_match`, mirroring `unindexed_text_match` but matching on *any* shared token (the documented `text_any` semantics, matching `AnyTokens` on the indexed path).

## Test plan

- Added `test_unindexed_text_any_uses_token_matching` to `lib/segment/tests/integration/unindexed_text_match_test.rs`, next to the #10341 regression tests.
- `cargo check -p segment --tests` passes.
- Verified the behavior change with a standalone harness replicating old vs new matcher logic against indexed-path semantics (case/punctuation and substring cases).
- Caveat: full `cargo test` could not run in my environment (segment codegen OOMs under a 2 GB memory limit), so the new integration test is compile-checked but not executed here.