### PR TITLE
fix: clear sticky optimizer error status after a successful optimization

### DIFF
--- a/lib/collection/src/shards/local_shard/optimizer_config_update_tests.rs
+++ b/lib/collection/src/shards/local_shard/optimizer_config_update_tests.rs
@@ -89,13 +89,16 @@ mod tests {
     use tokio::runtime::Handle;
     use tokio::sync::{RwLock, oneshot};
 
+    use common::counter::hardware_accumulator::HwMeasurementAcc;
+
     use super::worker_restart_hooks::{
         clear_worker_restart_hook, install_worker_restart_hook, update_handler_is_stopped,
     };
     use crate::common::adaptive_handle::AdaptiveSearchHandle;
     use crate::shards::local_shard::LocalShard;
-    use crate::shards::shard_trait::ShardOperation;
-    use crate::tests::fixtures::create_collection_config;
+    use crate::shards::shard_trait::{ShardOperation, WaitUntil};
+    use crate::tests::fixtures::{create_collection_config, upsert_operation};
+    use crate::update_handler::UpdateSignal;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn optimizer_config_update_refreshes_prevent_unoptimized_flag() {
@@ -188,6 +191,78 @@ mod tests {
         assert!(
             shard.segments.read().optimizer_errors.is_none(),
             "optimizer errors should be cleared after config update"
+        );
+
+        shard.stop_gracefully().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn successful_optimization_clears_optimizer_errors() {
+        let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+        let payload_index_schema_dir = Builder::new().prefix("qdrant-test").tempdir().unwrap();
+        let payload_index_schema_file = payload_index_schema_dir.path().join("payload-schema.json");
+        let payload_index_schema =
+            Arc::new(SaveOnDisk::load_or_init_default(payload_index_schema_file).unwrap());
+
+        let mut config = create_collection_config();
+        // Low indexing threshold, so the upsert below schedules an indexing optimization
+        config.optimizer_config.indexing_threshold = Some(2);
+
+        let update_runtime = Handle::current();
+        let search_runtime = AdaptiveSearchHandle::current_for_tests();
+        let shard = LocalShard::build(
+            0,
+            "test".to_string(),
+            collection_dir.path(),
+            Arc::new(RwLock::new(config.clone())),
+            Arc::new(Default::default()),
+            payload_index_schema,
+            update_runtime.clone(),
+            search_runtime.clone(),
+            ResourceBudget::default(),
+            config.optimizer_config.clone(),
+        )
+        .await
+        .unwrap();
+
+        // Simulate a previous (transient) optimizer failure
+        shard
+            .segments
+            .write()
+            .report_optimizer_error("test optimizer error");
+        assert!(shard.segments.read().optimizer_errors.is_some());
+
+        // Upsert enough points to schedule an indexing optimization
+        shard
+            .update(
+                upsert_operation().into(),
+                WaitUntil::Visible,
+                None,
+                HwMeasurementAcc::new(),
+            )
+            .await
+            .unwrap();
+
+        // Trigger optimizers and wait for the scheduled optimization to finish
+        shard
+            .update_sender
+            .load()
+            .send(UpdateSignal::Nop)
+            .await
+            .unwrap();
+
+        let mut cleared = false;
+        for _ in 0..100 {
+            if shard.segments.read().optimizer_errors.is_none() {
+                cleared = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        assert!(
+            cleared,
+            "optimizer error should be cleared by a successful optimization"
         );
 
         shard.stop_gracefully().await;

--- a/lib/collection/src/update_workers/optimization_worker.rs
+++ b/lib/collection/src/update_workers/optimization_worker.rs
@@ -386,6 +386,7 @@ impl UpdateWorkers {
                 let is_optimized;
                 let status;
                 let reported_error;
+                let mut clear_optimizer_errors = false;
                 match result {
                     // Success
                     Ok(Ok(optimized_points)) => {
@@ -393,6 +394,7 @@ impl UpdateWorkers {
                         status = TrackerStatus::Done;
                         reported_error = None;
                         total_optimized_points.fetch_add(optimized_points, Ordering::Relaxed);
+                        clear_optimizer_errors = true;
                         callback();
                     }
                     // Cancelled
@@ -428,6 +430,11 @@ impl UpdateWorkers {
                 if let Some(reported_error) = reported_error {
                     segments.write().report_optimizer_error(reported_error);
                     is_optimization_failed.store(true, Ordering::Relaxed);
+                } else if clear_optimizer_errors {
+                    // A successful optimization shows the optimizer recovered from a
+                    // previous (possibly transient) failure: clear the sticky error,
+                    // so the shard does not stay red until restart or config update.
+                    segments.write().optimizer_errors = None;
                 }
                 is_optimized
             });


### PR DESCRIPTION
## Summary

Fixes #10528

Once an optimization fails, the first error sticks in `SegmentHolder::optimizer_errors` and the shard reports red / `OptimizersStatus::Error` until restart or an optimizer config update (#8767). A successful optimization already proves the optimizer recovered, but the success path never cleared the sticky error.

This clears `optimizer_errors` when an optimization finishes successfully, mirroring the clear added on config update in #8767. Cancelled optimizations do not clear it, since a cancellation proves nothing about health.

## Test plan

- Added `successful_optimization_clears_optimizer_errors` next to the #8767 tests in `optimizer_config_update_tests.rs`: builds a local shard with a low indexing threshold, simulates an optimizer error, upserts points, triggers the optimizers, and waits for the error to clear.
- `cargo check -p collection --tests` passes.
- Verified the control flow with a standalone harness replicating `report_optimizer_error` plus the old vs new result handling: old keeps the shard red after a successful optimization, new clears it.
- Caveat: full `cargo test` could not run in my environment (collection codegen OOMs under a 2 GB memory limit), so the new test is compile-checked but not executed here.