### PR TITLE
Fix proxy propagate vector name versions optimizer

### DIFF
--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -1033,4 +1033,96 @@ mod tests {
              into the holder",
         );
     }
+
+    /// `finish_optimization` must apply all pending proxy changes to the optimized segment: a
+    /// queued payload index creation, a queued named vector creation, and a queued point delete,
+    /// each recorded with a higher version than the last.
+    ///
+    /// Unlike `propagate_to_wrapped` (which applies index changes before vector name changes,
+    /// see [`crate::proxy_segment::tests::test_propagate_to_wrapped_vector_name_and_index`]),
+    /// `finish_optimization` applies vector name changes *before* index changes. So the index
+    /// change is queued *first* here, at the lowest version, to check that applying the
+    /// higher-versioned vector name change afterwards, which bumps the segment version, does not
+    /// cause the index change to be silently skipped.
+    ///
+    /// See: <https://github.com/qdrant/qdrant/pull/10507>
+    #[test]
+    fn finish_optimization_propagates_index_vector_name_and_delete() {
+        use segment::data_types::vector_name_config::{DenseVectorConfig, VectorNameConfig};
+        use segment::types::{Distance, PayloadFieldSchema, PayloadKeyType, PayloadSchemaType};
+
+        let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+        let hw_counter = HardwareCounterCell::new();
+
+        let wrapped = LockedSegment::new(build_segment_1(dir.path()));
+        let mut holder = SegmentHolder::default();
+        let segment_id = holder.add_new_locked(wrapped.clone());
+
+        // Stand in for the freshly-built optimized segment: it already holds the same points
+        // `wrapped` had when the optimization started, but none of the schema changes queued
+        // below, since those only land on the proxy after the build has started.
+        let optimized_segment = build_segment_1(dir.path());
+
+        let mut proxy = ProxySegment::new(wrapped.clone());
+
+        // Queue a payload index creation, then a named vector creation, then a point delete,
+        // each with a higher version than the last.
+        let field_name: PayloadKeyType = "color".parse().unwrap();
+        let field_schema: PayloadFieldSchema = PayloadSchemaType::Keyword.into();
+        proxy
+            .create_field_index(10, &field_name, Some(&field_schema), &hw_counter)
+            .unwrap();
+
+        let vector_config = VectorNameConfig::dense(DenseVectorConfig {
+            size: 4,
+            distance: Distance::Dot,
+            multivector_config: None,
+            datatype: None,
+        });
+        proxy
+            .create_vector_name(20, "extra_vector", &vector_config)
+            .unwrap();
+
+        proxy.delete_point(30, 1.into(), &hw_counter).unwrap();
+
+        let holder = LockedSegmentHolder::new(holder);
+        let locked_proxy = LockedSegment::from(proxy);
+        holder
+            .write()
+            .replace(segment_id, locked_proxy.clone())
+            .unwrap();
+
+        finish_optimization(
+            &holder,
+            vec![locked_proxy],
+            optimized_segment,
+            &DeletedPoints::new(),
+            &[segment_id],
+            None,
+            &AtomicBool::new(false),
+            &hw_counter,
+        )
+        .unwrap();
+
+        let result_segment = holder.read().iter().next().unwrap().1.clone();
+        let result_segment = result_segment.get();
+        let result_segment = result_segment.read();
+
+        assert!(
+            result_segment
+                .config()
+                .vector_data
+                .contains_key("extra_vector"),
+            "named vector change must land on the optimized segment",
+        );
+        assert_eq!(
+            result_segment.get_indexed_fields().get(&field_name),
+            Some(&field_schema),
+            "payload index change queued before the named vector change must still land",
+        );
+        assert!(
+            !result_segment.has_point(1.into(), DeferredBehavior::WithDeferred),
+            "point delete must land on the optimized segment",
+        );
+    }
 }

--- a/lib/shard/src/optimize.rs
+++ b/lib/shard/src/optimize.rs
@@ -3,6 +3,7 @@
 //! Core optimization execution logic that is agnostic to collection-level policies.
 //! The collection layer provides the strategy via `OptimizationStrategy`.
 
+use std::cmp::max;
 use std::collections::HashSet;
 use std::debug_assert_matches;
 use std::ops::Deref;
@@ -558,25 +559,32 @@ fn finish_optimization(
 
     // Apply index changes before point deletions
     // Point deletions bump the segment version, can cause index changes to be ignored
+    //
+    // This artificially bumps the operation version to be at least as high as the current segment
+    // version. This way we make sure the segment does not ignore the operation. Alternatively we
+    // can interleave index, vector name and deletion changes and apply them in exactly the same
+    // order they arrive, but that requires more complex changes.
     for (field_name, change) in index_changes.iter_ordered() {
         match change {
             // Warn: change version might be lower than the segment version,
             // because we might already applied the change earlier in optimization.
             // Applied optimizations are not removed from `proxy_index_changes`.
             ProxyIndexChange::Create(schema, version) => {
+                let op_num = max(*version, optimized_segment.version());
                 optimized_segment.create_field_index(
-                    *version,
+                    op_num,
                     field_name,
                     Some(schema),
                     hw_counter,
                 )?;
             }
             ProxyIndexChange::Delete(version) => {
-                optimized_segment.delete_field_index(*version, field_name)?;
+                let op_num = max(*version, optimized_segment.version());
+                optimized_segment.delete_field_index(op_num, field_name)?;
             }
             ProxyIndexChange::DeleteIfIncompatible(version, schema) => {
-                optimized_segment
-                    .delete_field_index_if_incompatible(*version, field_name, schema)?;
+                let op_num = max(*version, optimized_segment.version());
+                optimized_segment.delete_field_index_if_incompatible(op_num, field_name, schema)?;
             }
         }
         check_process_stopped(stopped)?;

--- a/lib/shard/src/proxy_segment/mod.rs
+++ b/lib/shard/src/proxy_segment/mod.rs
@@ -292,8 +292,8 @@ impl ProxySegment {
         //
         // This artificially bumps the operation version to be at least as high as the current
         // segment version. This way we make sure the segment does not ignore the operation.
-        // Alternatively we can interleave index, vectorname and deletion changes and apply them in
-        // exactly the same order they arrive, but that requires more complex changes.
+        // Alternatively we can interleave index, vector name and deletion changes and apply them
+        // in exactly the same order they arrive, but that requires more complex changes.
         {
             if !self.changed_vector_names.is_empty() {
                 wrapped_segment.with_upgraded(|wrapped_segment| {


### PR DESCRIPTION
Turns out there is another case.

Similar bug to <https://github.com/qdrant/qdrant/pull/10507>, but after optimization.

Read [its](https://github.com/qdrant/qdrant/pull/10507) description for more details.

An interesting difference is that we apply proxy index and named vector changes in a different order here.

I believe this can benefit from the same "interleave" suggestion as in the other PR. And we might as well combine both variants in a single shared function. I can work on this after <https://github.com/qdrant/qdrant/pull/10349>.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
