### PR TITLE
fix: saturate offset + limit in query pagination

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -107,7 +107,7 @@ impl Collection {
 
         let max_limit = batch_request
             .iter()
-            .map(|req| req.limit + req.offset)
+            .map(|req| req.limit.saturating_add(req.offset))
             .max()
             .unwrap_or(0);
 
@@ -119,7 +119,7 @@ impl Collection {
 
         for request in batch_request.iter() {
             let mut new_request = request.clone();
-            let request_limit = new_request.limit + new_request.offset;
+            let request_limit = new_request.limit.saturating_add(new_request.offset);
 
             let is_exact = request.params.as_ref().is_some_and(|p| p.exact);
 
@@ -756,7 +756,7 @@ fn intermediate_query_infos(request: &ShardQueryRequest) -> Vec<IntermediateQuer
             // Otherwise, we expect the root result
             vec![IntermediateQueryInfo {
                 scoring_query: request.query.as_ref(),
-                take: request.offset + request.limit,
+                take: request.offset.saturating_add(request.limit),
             }]
         }
     }

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -325,7 +325,7 @@ impl Collection {
                     .take(request.limit)
                     .collect()
             } else {
-                merged_iter.take(request.offset + request.limit).collect()
+                merged_iter.take(request.offset.saturating_add(request.limit)).collect()
             };
 
             top_results.push(top_res);

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -296,7 +296,7 @@ impl SegmentsSearcher {
             batch_request
                 .searches
                 .iter()
-                .map(|request| request.limit + request.offset)
+                .map(|request| request.limit.saturating_add(request.offset))
                 .collect(),
             &further_results,
         );

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -20,13 +20,14 @@ use common::counter::hardware_accumulator::HwMeasurementAcc;
 use fs_err::File;
 use itertools::Itertools;
 use segment::data_types::order_by::{Direction, OrderBy, OrderByInterface};
-use segment::data_types::vectors::VectorStructInternal;
+use segment::data_types::vectors::{NamedQuery, VectorStructInternal};
 use segment::types::{
     Condition, ExtendedPointId, FieldCondition, Filter, HasIdCondition, Payload,
     PayloadFieldSchema, PayloadSchemaType, PointIdType, WithPayloadInterface,
 };
 use serde_json::Map;
 use shard::query::{SampleInternal, ScoringQuery, ShardQueryRequest};
+use shard::query::query_enum::QueryEnum;
 use tempfile::Builder;
 
 use crate::common::{N_SHARDS, load_local_collection, simple_collection_fixture};
@@ -1107,4 +1108,79 @@ async fn test_random_sample_huge_limit_does_not_abort() {
     // Bounded by the points actually available; the request completes instead of
     // aborting.
     assert_eq!(result.len(), 3);
+}
+
+/// Regression for <https://github.com/qdrant/qdrant/issues/10501>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_query_pagination_huge_limit_does_not_wrap() {
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
+    let collection = simple_collection_fixture(collection_dir.path(), 1).await;
+
+    let batch = BatchPersisted {
+        ids: vec![1, 2, 3].into_iter().map(u64::into).collect_vec(),
+        vectors: BatchVectorStructPersisted::Single(vec![
+            vec![1.0, 0.0, 0.0, 0.0],
+            vec![0.0, 3.0, 0.0, 0.0],
+            vec![4.0, 0.0, 0.0, 0.0],
+        ]),
+        payloads: None,
+    };
+    let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::from(batch),
+    ));
+    collection
+        .update_from_client_simple(
+            insert_points,
+            true,
+            None,
+            WriteOrdering::default(),
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+
+    let make_request = |limit, offset| ShardQueryRequest {
+        prefetches: vec![],
+        query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
+            NamedQuery::default_dense(vec![1.0, 0.0, 0.0, 0.0]),
+        ))),
+        filter: None,
+        score_threshold: None,
+        limit,
+        offset,
+        params: None,
+        with_vector: false.into(),
+        with_payload: false.into(),
+    };
+
+    let control = collection
+        .query(
+            make_request(2, 1),
+            None,
+            None,
+            ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(control.len(), 2);
+
+    // offset + limit overflows usize without saturating arithmetic, wrapping the
+    // internal take to 0 and returning an empty page
+    let huge_limit = collection
+        .query(
+            make_request(usize::MAX, 1),
+            None,
+            None,
+            ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+
+    let expected = control.iter().map(|point| point.id).collect_vec();
+    let actual = huge_limit.iter().map(|point| point.id).collect_vec();
+    assert_eq!(actual, expected);
 }

--- a/lib/shard/src/search.rs
+++ b/lib/shard/src/search.rs
@@ -310,7 +310,7 @@ impl<'a> From<&'a CoreSearchRequest> for BatchSearchParams<'a> {
                     .unwrap_or(&WithPayloadInterface::Bool(false)),
             ),
             with_vector: with_vector.clone().unwrap_or_default(),
-            top: limit + offset,
+            top: limit.saturating_add(*offset),
             params: params.as_ref(),
         }
     }


### PR DESCRIPTION
## Summary

Fixes #10501

`offset + limit` overflows `usize` and wraps when the limit is huge (e.g. `offset=1, limit=18446744073709551615`), so the internal per-shard `take` becomes 0 and the query returns an empty page instead of the expected tail of the result list.

Saturating arithmetic on the query path: the per-shard `take`, the shard subsampling estimates, and the non-client merge in `search.rs`. The MMR selection side of the same theme is handled by #10502; this covers the non-MMR path.

## Test plan

- Added `test_query_pagination_huge_limit_does_not_wrap` in `collection_test.rs`: 3-point collection, `offset=1` with `limit=usize::MAX` must return the same page as the finite control `offset=1, limit=2`.
- `cargo check -p collection --tests` passes.
- Verified the overflow itself with a standalone harness replicating old vs new `take` arithmetic: old wraps to an empty page, saturating matches the control.
- Caveat: full `cargo test` could not run in my environment (collection codegen OOMs under a 2 GB memory limit), so the new test is compile-checked but not executed here.