### PR TITLE
Optimizations and improvements for `ConsensusStateMachine`

### DIFF
--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -1591,6 +1591,12 @@ mod tests {
             unimplemented!()
         }
 
+        fn take_dirty_collections(
+            &self,
+        ) -> std::collections::BTreeSet<collection::shards::CollectionId> {
+            std::collections::BTreeSet::new()
+        }
+
         fn apply_collections_snapshot(
             &self,
             _data: super::CollectionsSnapshot,

--- a/lib/storage/src/content_manager/consensus_manager.rs
+++ b/lib/storage/src/content_manager/consensus_manager.rs
@@ -611,8 +611,8 @@ impl<C: CollectionContainer> ConsensusManager<C> {
             }
         };
 
-        if let Some(outcome) = shadow {
-            self.shadow_compare(&outcome, &result);
+        if let Some((operation, outcome)) = shadow {
+            self.shadow_compare(&operation, &outcome, &result);
         }
 
         if let Some(on_apply) = on_apply
@@ -625,14 +625,20 @@ impl<C: CollectionContainer> ConsensusManager<C> {
         result
     }
 
-    /// Apply `operation` to the shadow state, when the shadow run is enabled
-    fn shadow_apply(&self, operation: &ConsensusOperations) -> Option<ApplyOutcome> {
+    /// Apply `operation` to the shadow state, when the shadow run is enabled.
+    ///
+    /// Hands the operation back as well, since applying it authoritatively consumes it before
+    /// the compare, which reads the collections it names.
+    fn shadow_apply(
+        &self,
+        operation: &ConsensusOperations,
+    ) -> Option<(ConsensusOperations, ApplyOutcome)> {
         let shadow = self.shadow.as_ref()?;
         let outcome = shadow
             .lock()
             .apply(&*self.toc, &self.persistent.read(), operation);
 
-        Some(outcome)
+        Some((operation.clone(), outcome))
     }
 
     /// Drop the shadow state, so the next entry builds a machine from `TableOfContent`
@@ -643,14 +649,23 @@ impl<C: CollectionContainer> ConsensusManager<C> {
     }
 
     /// Compare the shadow against what the authoritative apply left behind
-    fn shadow_compare(&self, outcome: &ApplyOutcome, result: &Result<bool, StorageError>) {
+    fn shadow_compare(
+        &self,
+        operation: &ConsensusOperations,
+        outcome: &ApplyOutcome,
+        result: &Result<bool, StorageError>,
+    ) {
         let Some(shadow) = self.shadow.as_ref() else {
             return;
         };
 
-        shadow
-            .lock()
-            .compare(&*self.toc, &self.persistent.read(), outcome, result);
+        shadow.lock().compare(
+            &*self.toc,
+            &self.persistent.read(),
+            operation,
+            outcome,
+            result,
+        );
     }
 
     // Outer `Result` is "fatal" error, inner `Result` is "transient"/"local" error.
@@ -1555,7 +1570,23 @@ mod tests {
             super::CollectionsSnapshot::default()
         }
 
-        // Only the shadow run reads the node config, and these tests never enable it
+        // Only the shadow run reads these, and these tests never enable it
+
+        fn collection_state(
+            &self,
+            _collection: &str,
+        ) -> Option<collection::collection_state::State> {
+            unimplemented!()
+        }
+
+        fn collection_names(&self) -> std::collections::BTreeSet<collection::shards::CollectionId> {
+            unimplemented!()
+        }
+
+        fn alias_mapping(&self) -> crate::content_manager::alias_mapping::AliasMapping {
+            unimplemented!()
+        }
+
         fn node_context(&self) -> crate::content_manager::consensus_state_machine::NodeContext {
             unimplemented!()
         }

--- a/lib/storage/src/content_manager/consensus_shadow/diff.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/diff.rs
@@ -4,19 +4,37 @@
 //! until the compare covers it. A divergence names the field it found, as a path into
 //! [`ClusterState`].
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::mem;
 
 use collection::collection_state;
+use collection::shards::CollectionId;
 
+use crate::content_manager::alias_mapping::AliasMapping;
 use crate::content_manager::consensus_state_machine::{ApplyOutcome, ClusterState};
 use crate::content_manager::errors::StorageResult;
+use crate::quota::QuotaConfig;
+use crate::types::{PeerAddressById, PeerMetadataById};
+
+/// Cluster state read back from `TableOfContent` for one compare.
+///
+/// Carries collection names only. Reading a collection's state is the expensive part, so
+/// [`collection`] compares one collection at a time.
+#[derive(Clone, Debug)]
+pub struct ActualState {
+    pub collections: BTreeSet<CollectionId>,
+    pub aliases: AliasMapping,
+    pub peer_address_by_id: PeerAddressById,
+    pub peer_metadata_by_id: PeerMetadataById,
+    pub cluster_metadata: HashMap<String, serde_json::Value>,
+    pub quota_config: QuotaConfig,
+}
 
 /// Fields where `shadow` differs from `actual`, leaving out the contents of collections.
 ///
 /// A collection only one side holds is reported as `collections[name]`; [`collection`] compares
 /// the two states of a collection both sides hold.
-pub fn cluster(shadow: &ClusterState, actual: &ClusterState) -> Vec<String> {
+pub fn cluster(shadow: &ClusterState, actual: &ActualState) -> Vec<String> {
     let ClusterState {
         collections,
         aliases,
@@ -26,7 +44,7 @@ pub fn cluster(shadow: &ClusterState, actual: &ClusterState) -> Vec<String> {
         quota_config,
     } = shadow;
 
-    let ClusterState {
+    let ActualState {
         collections: actual_collections,
         aliases: actual_aliases,
         peer_address_by_id: actual_peer_address_by_id,
@@ -37,10 +55,9 @@ pub fn cluster(shadow: &ClusterState, actual: &ClusterState) -> Vec<String> {
 
     let mut diff = Vec::new();
 
-    let collections: BTreeSet<_> = collections.keys().collect();
-    let actual_collections: BTreeSet<_> = actual_collections.keys().collect();
+    let collections: BTreeSet<_> = collections.keys().cloned().collect();
 
-    for collection in collections.symmetric_difference(&actual_collections) {
+    for collection in collections.symmetric_difference(actual_collections) {
         diff.push(format!("collections[{collection}]"));
     }
 
@@ -184,8 +201,8 @@ mod tests {
 
     #[test]
     fn cluster_match() {
-        let state = cluster_state();
-        let diff = cluster(&state, &state);
+        let (shadow, actual) = cluster_states();
+        let diff = cluster(&shadow, &actual);
 
         assert!(diff.is_empty(), "states match, got {diff:?}");
     }
@@ -193,18 +210,18 @@ mod tests {
     /// A collection one side does not hold is reported by name, whatever is inside it
     #[test]
     fn cluster_collection_names() {
-        let mut actual = cluster_state();
+        let (shadow, mut actual) = cluster_states();
         actual.collections.clear();
 
         assert_eq!(
-            cluster(&cluster_state(), &actual),
+            cluster(&shadow, &actual),
             [format!("collections[{COLLECTION}]")],
         );
     }
 
     #[test]
     fn cluster_every_field() {
-        let mutations: Vec<Mutation<ClusterState>> = vec![
+        let mutations: Vec<Mutation<ActualState>> = vec![
             ("aliases", |actual| actual.aliases.remove(ALIAS)),
             ("peer_address_by_id", |actual| {
                 actual.peer_address_by_id.clear();
@@ -221,33 +238,43 @@ mod tests {
         ];
 
         for (field, mutate) in mutations {
-            let mut actual = cluster_state();
+            let (shadow, mut actual) = cluster_states();
             mutate(&mut actual);
 
-            assert_eq!(
-                cluster(&cluster_state(), &actual),
-                [field],
-                "mutated {field}"
-            );
+            assert_eq!(cluster(&shadow, &actual), [field], "mutated {field}");
         }
     }
 
-    /// Cluster state with every field filled, so a mutation of one is the only difference
-    fn cluster_state() -> ClusterState {
+    /// A shadow state and the read-back matching it, both filled in every field
+    fn cluster_states() -> (ClusterState, ActualState) {
         let mut aliases = AliasMapping::default();
         aliases.insert(ALIAS.to_string(), COLLECTION.to_string());
 
-        ClusterState {
+        let peer_address_by_id =
+            HashMap::from([(PEER_ID, "http://localhost:6335".parse().expect("valid uri"))]);
+        let peer_metadata_by_id = HashMap::from([(PEER_ID, PeerMetadata::current())]);
+        let cluster_metadata = HashMap::from([("owner".to_string(), json!("qdrant"))]);
+        let quota_config = QuotaConfig::default();
+
+        let shadow = ClusterState {
             collections: HashMap::from([(COLLECTION.to_string(), collection_state(Vec::new()))]),
+            aliases: aliases.clone(),
+            peer_address_by_id: peer_address_by_id.clone(),
+            peer_metadata_by_id: peer_metadata_by_id.clone(),
+            cluster_metadata: cluster_metadata.clone(),
+            quota_config,
+        };
+
+        let actual = ActualState {
+            collections: BTreeSet::from([COLLECTION.to_string()]),
             aliases,
-            peer_address_by_id: HashMap::from([(
-                PEER_ID,
-                "http://localhost:6335".parse().expect("valid uri"),
-            )]),
-            peer_metadata_by_id: HashMap::from([(PEER_ID, PeerMetadata::current())]),
-            cluster_metadata: HashMap::from([("owner".to_string(), json!("qdrant"))]),
-            quota_config: QuotaConfig::default(),
-        }
+            peer_address_by_id,
+            peer_metadata_by_id,
+            cluster_metadata,
+            quota_config,
+        };
+
+        (shadow, actual)
     }
 
     #[test]

--- a/lib/storage/src/content_manager/consensus_shadow/diff.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/diff.rs
@@ -1,22 +1,128 @@
-//! Compare the shadow state against the state `TableOfContent` holds
+//! Compare the shadow state against the state `TableOfContent` holds.
+//!
+//! Both sides are destructured field by field, so a field added to either one stops compiling
+//! until the compare covers it. A divergence names the field it found, as a path into
+//! [`ClusterState`].
 
+use std::collections::BTreeSet;
 use std::mem;
+
+use collection::collection_state;
 
 use crate::content_manager::consensus_state_machine::{ApplyOutcome, ClusterState};
 use crate::content_manager::errors::StorageResult;
 
-/// How `shadow` differs from `actual`, `None` when the two match.
+/// Fields where `shadow` differs from `actual`, leaving out the contents of collections.
 ///
-/// Both sides are printed whole. The derived `PartialEq` covers a field added to
-/// [`ClusterState`] or to the collection state under it without anyone having to remember it.
-/// Naming the fields that differ, rather than printing everything, is worth doing once a field
-/// turns up that consensus does not decide and the compare has to skip.
-pub fn cluster(shadow: &ClusterState, actual: &ClusterState) -> Option<String> {
-    if shadow == actual {
-        return None;
+/// A collection only one side holds is reported as `collections[name]`; [`collection`] compares
+/// the two states of a collection both sides hold.
+pub fn cluster(shadow: &ClusterState, actual: &ClusterState) -> Vec<String> {
+    let ClusterState {
+        collections,
+        aliases,
+        peer_address_by_id,
+        peer_metadata_by_id,
+        cluster_metadata,
+        quota_config,
+    } = shadow;
+
+    let ClusterState {
+        collections: actual_collections,
+        aliases: actual_aliases,
+        peer_address_by_id: actual_peer_address_by_id,
+        peer_metadata_by_id: actual_peer_metadata_by_id,
+        cluster_metadata: actual_cluster_metadata,
+        quota_config: actual_quota_config,
+    } = actual;
+
+    let mut diff = Vec::new();
+
+    let collections: BTreeSet<_> = collections.keys().collect();
+    let actual_collections: BTreeSet<_> = actual_collections.keys().collect();
+
+    for collection in collections.symmetric_difference(&actual_collections) {
+        diff.push(format!("collections[{collection}]"));
     }
 
-    Some(format!("shadow {shadow:#?} against applied {actual:#?}"))
+    if aliases != actual_aliases {
+        diff.push("aliases".to_string());
+    }
+
+    if peer_address_by_id != actual_peer_address_by_id {
+        diff.push("peer_address_by_id".to_string());
+    }
+
+    if peer_metadata_by_id != actual_peer_metadata_by_id {
+        diff.push("peer_metadata_by_id".to_string());
+    }
+
+    if cluster_metadata != actual_cluster_metadata {
+        diff.push("cluster_metadata".to_string());
+    }
+
+    if quota_config != actual_quota_config {
+        diff.push("quota_config".to_string());
+    }
+
+    diff
+}
+
+/// Fields where the two states of one collection differ.
+///
+/// Both sides hold the collection: [`cluster`] compares which collections exist
+pub fn collection(
+    name: &str,
+    shadow: &collection_state::State,
+    actual: &collection_state::State,
+) -> Vec<String> {
+    let collection_state::State {
+        config,
+        shards,
+        resharding,
+        transfers,
+        shards_key_mapping,
+        payload_index_schema,
+    } = shadow;
+
+    let collection_state::State {
+        config: actual_config,
+        shards: actual_shards,
+        resharding: actual_resharding,
+        transfers: actual_transfers,
+        shards_key_mapping: actual_shards_key_mapping,
+        payload_index_schema: actual_payload_index_schema,
+    } = actual;
+
+    let mut fields = Vec::new();
+
+    if config != actual_config {
+        fields.push("config");
+    }
+
+    if shards != actual_shards {
+        fields.push("shards");
+    }
+
+    if resharding != actual_resharding {
+        fields.push("resharding");
+    }
+
+    if transfers != actual_transfers {
+        fields.push("transfers");
+    }
+
+    if shards_key_mapping != actual_shards_key_mapping {
+        fields.push("shards_key_mapping");
+    }
+
+    if payload_index_schema != actual_payload_index_schema {
+        fields.push("payload_index_schema");
+    }
+
+    fields
+        .into_iter()
+        .map(|field| format!("collections[{name}].{field}"))
+        .collect()
 }
 
 /// How the machine's decision differs from what the apply path answered.
@@ -54,43 +160,153 @@ pub fn outcome(shadow: &ApplyOutcome, actual: &StorageResult<bool>) -> Option<St
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::num::NonZeroU32;
 
+    use collection::collection_state::ShardInfo;
+    use collection::operations::cluster_ops::ReshardingDirection;
+    use collection::operations::types::PeerMetadata;
+    use collection::shards::resharding::ReshardState;
+    use collection::shards::transfer::ShardTransfer;
     use segment::types::PayloadSchemaType;
+    use serde_json::json;
+    use uuid::Uuid;
 
     use super::*;
-    use crate::content_manager::consensus_state_machine::tests::collection_state;
+    use crate::content_manager::alias_mapping::AliasMapping;
+    use crate::content_manager::consensus_state_machine::tests::{PEER_ID, collection_state};
+    use crate::quota::QuotaConfig;
 
     const COLLECTION: &str = "books";
+    const ALIAS: &str = "novels";
+
+    /// A change to one field of a state, and the field name the compare reports for it
+    type Mutation<T> = (&'static str, fn(&mut T));
 
     #[test]
     fn cluster_match() {
         let state = cluster_state();
+        let diff = cluster(&state, &state);
 
-        assert_eq!(cluster(&state, &state), None);
+        assert!(diff.is_empty(), "states match, got {diff:?}");
     }
 
-    /// A collection both sides hold, differing inside. The compare reads collection state, not
-    /// just the names.
+    /// A collection one side does not hold is reported by name, whatever is inside it
     #[test]
-    fn cluster_collection_differs() {
-        let field = "city".parse().expect("valid field name");
-
+    fn cluster_collection_names() {
         let mut actual = cluster_state();
-        actual
-            .collections
-            .get_mut(COLLECTION)
-            .expect("collection exists")
-            .payload_index_schema
-            .schema
-            .insert(field, PayloadSchemaType::Keyword.into());
+        actual.collections.clear();
 
-        assert!(cluster(&cluster_state(), &actual).is_some());
+        assert_eq!(
+            cluster(&cluster_state(), &actual),
+            [format!("collections[{COLLECTION}]")],
+        );
     }
 
+    #[test]
+    fn cluster_every_field() {
+        let mutations: Vec<Mutation<ClusterState>> = vec![
+            ("aliases", |actual| actual.aliases.remove(ALIAS)),
+            ("peer_address_by_id", |actual| {
+                actual.peer_address_by_id.clear();
+            }),
+            ("peer_metadata_by_id", |actual| {
+                actual.peer_metadata_by_id.clear();
+            }),
+            ("cluster_metadata", |actual| {
+                actual.cluster_metadata.clear();
+            }),
+            ("quota_config", |actual| {
+                actual.quota_config.enabled = !actual.quota_config.enabled;
+            }),
+        ];
+
+        for (field, mutate) in mutations {
+            let mut actual = cluster_state();
+            mutate(&mut actual);
+
+            assert_eq!(
+                cluster(&cluster_state(), &actual),
+                [field],
+                "mutated {field}"
+            );
+        }
+    }
+
+    /// Cluster state with every field filled, so a mutation of one is the only difference
     fn cluster_state() -> ClusterState {
+        let mut aliases = AliasMapping::default();
+        aliases.insert(ALIAS.to_string(), COLLECTION.to_string());
+
         ClusterState {
             collections: HashMap::from([(COLLECTION.to_string(), collection_state(Vec::new()))]),
-            ..Default::default()
+            aliases,
+            peer_address_by_id: HashMap::from([(
+                PEER_ID,
+                "http://localhost:6335".parse().expect("valid uri"),
+            )]),
+            peer_metadata_by_id: HashMap::from([(PEER_ID, PeerMetadata::current())]),
+            cluster_metadata: HashMap::from([("owner".to_string(), json!("qdrant"))]),
+            quota_config: QuotaConfig::default(),
+        }
+    }
+
+    #[test]
+    fn collection_match() {
+        let state = collection_state(Vec::new());
+        let diff = collection(COLLECTION, &state, &state);
+
+        assert!(diff.is_empty(), "states match, got {diff:?}");
+    }
+
+    #[test]
+    fn collection_every_field() {
+        let mutations: Vec<Mutation<collection_state::State>> = vec![
+            ("config", |state| {
+                state.config.params.shard_number = NonZeroU32::new(2).expect("non-zero");
+            }),
+            ("shards", |state| {
+                let replicas = HashMap::new();
+                state.shards.insert(0, ShardInfo { replicas });
+            }),
+            ("resharding", |state| {
+                let resharding =
+                    ReshardState::new(Uuid::nil(), ReshardingDirection::Up, PEER_ID, 1, None);
+                state.resharding = Some(resharding);
+            }),
+            ("transfers", |state| {
+                state.transfers.insert(ShardTransfer {
+                    shard_id: 0,
+                    to_shard_id: None,
+                    from: PEER_ID,
+                    to: PEER_ID + 1,
+                    sync: false,
+                    method: None,
+                    filter: None,
+                });
+            }),
+            ("shards_key_mapping", |state| {
+                state
+                    .shards_key_mapping
+                    .insert("keyword".into(), [0].into_iter().collect());
+            }),
+            ("payload_index_schema", |state| {
+                let field = "city".parse().expect("valid field name");
+                state
+                    .payload_index_schema
+                    .schema
+                    .insert(field, PayloadSchemaType::Keyword.into());
+            }),
+        ];
+
+        for (field, mutate) in mutations {
+            let mut actual = collection_state(Vec::new());
+            mutate(&mut actual);
+
+            assert_eq!(
+                collection(COLLECTION, &collection_state(Vec::new()), &actual),
+                [format!("collections[{COLLECTION}].{field}")],
+                "mutated {field}",
+            );
         }
     }
 }

--- a/lib/storage/src/content_manager/consensus_shadow/mod.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/mod.rs
@@ -51,6 +51,10 @@ impl ShadowStateMachine {
         persistent: &Persistent,
         operation: &ConsensusOperations,
     ) -> ApplyOutcome {
+        // Planning reads the state of every collection it touches, so what something other
+        // than consensus wrote since the last entry is read back first
+        self.resync(toc, toc.take_dirty_collections());
+
         let machine = self.machine.get_or_insert_with(|| {
             let state = scrape_cluster_state(toc, persistent);
             ConsensusStateMachine::new(state, toc.node_context())
@@ -119,6 +123,14 @@ impl ShadowStateMachine {
             return None;
         }
 
+        // Something other than consensus may have changed a collection while the entry was
+        // being applied, and what it wrote is not a divergence
+        self.resync(toc, toc.take_dirty_collections());
+
+        let Some(machine) = &self.machine else {
+            return None;
+        };
+
         let actual = scrape_actual_state(toc, persistent);
 
         let mut report = Vec::from_iter(diff::outcome(outcome, result));
@@ -145,7 +157,11 @@ impl ShadowStateMachine {
     }
 
     /// Read the state of `collections` back into the machine
-    fn resync(&mut self, toc: &impl CollectionContainer, collections: Vec<CollectionId>) {
+    fn resync(
+        &mut self,
+        toc: &impl CollectionContainer,
+        collections: impl IntoIterator<Item = CollectionId>,
+    ) {
         let Some(machine) = &mut self.machine else {
             return;
         };

--- a/lib/storage/src/content_manager/consensus_shadow/mod.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/mod.rs
@@ -103,10 +103,16 @@ impl ShadowStateMachine {
         }
 
         let actual = scrape_cluster_state(toc, persistent);
-        let answer = diff::outcome(outcome, result);
-        let state = diff::cluster(machine.state(), &actual);
 
-        let report: Vec<_> = [answer, state].into_iter().flatten().collect();
+        let mut report = Vec::from_iter(diff::outcome(outcome, result));
+        report.extend(diff::cluster(machine.state(), &actual));
+
+        // A collection only one side holds is reported by `diff::cluster`
+        for (name, shadow) in &machine.state().collections {
+            if let Some(actual) = actual.collection(name) {
+                report.extend(diff::collection(name, shadow, actual));
+            }
+        }
 
         if report.is_empty() {
             return None;
@@ -114,7 +120,7 @@ impl ShadowStateMachine {
 
         self.machine = None;
 
-        Some(report.join("; "))
+        Some(report.join(", "))
     }
 }
 

--- a/lib/storage/src/content_manager/consensus_shadow/mod.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/mod.rs
@@ -98,12 +98,24 @@ impl ShadowStateMachine {
 
         // A service error kills the consensus thread and the entry is applied again after
         // restart. What the failed apply wrote before it gave up is not something the machine
-        // predicts, and an operation it does not model leaves its state behind entirely.
-        let comparable = !matches!(result, Err(StorageError::ServiceError { .. }))
-            && !matches!(outcome, ApplyOutcome::NotCovered);
-
-        if !comparable {
+        // predicts.
+        if matches!(result, Err(StorageError::ServiceError { .. })) {
             self.machine = None;
+            return None;
+        }
+
+        let collections = compared_collections(operation, machine.state());
+
+        // An operation the machine does not model leaves the state of the collections it names
+        // behind, so those are read back instead of compared. One that names none, `RemovePeer`
+        // above all, can have changed any of them.
+        if matches!(outcome, ApplyOutcome::NotCovered) {
+            if collections.is_empty() {
+                self.machine = None;
+            } else {
+                self.resync(toc, collections);
+            }
+
             return None;
         }
 
@@ -114,7 +126,7 @@ impl ShadowStateMachine {
 
         // Reading a collection's state is the expensive part, so only the ones this operation
         // could have changed are read. A collection only one side holds is already reported.
-        for collection in compared_collections(operation, machine.state()) {
+        for collection in collections {
             let shadow = machine.state().collection(&collection);
             let actual = toc.collection_state(&collection);
 
@@ -130,6 +142,18 @@ impl ShadowStateMachine {
         self.machine = None;
 
         Some(report.join(", "))
+    }
+
+    /// Read the state of `collections` back into the machine
+    fn resync(&mut self, toc: &impl CollectionContainer, collections: Vec<CollectionId>) {
+        let Some(machine) = &mut self.machine else {
+            return;
+        };
+
+        for collection in collections {
+            let state = toc.collection_state(&collection);
+            machine.resync_collection(&collection, state);
+        }
     }
 }
 

--- a/lib/storage/src/content_manager/consensus_shadow/mod.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/mod.rs
@@ -8,10 +8,13 @@ pub mod diff;
 #[cfg(test)]
 mod tests;
 
+use collection::shards::CollectionId;
 use parking_lot::Mutex;
 use serde::Deserialize;
 
+use self::diff::ActualState;
 use crate::content_manager::CollectionContainer;
+use crate::content_manager::collection_meta_ops::CollectionMetaOperations;
 use crate::content_manager::consensus::persistent::Persistent;
 use crate::content_manager::consensus_manager::CollectionsSnapshot;
 use crate::content_manager::consensus_ops::ConsensusOperations;
@@ -62,10 +65,11 @@ impl ShadowStateMachine {
         &mut self,
         toc: &impl CollectionContainer,
         persistent: &Persistent,
+        operation: &ConsensusOperations,
         outcome: &ApplyOutcome,
         result: &StorageResult<bool>,
     ) {
-        let Some(report) = self.diff(toc, persistent, outcome, result) else {
+        let Some(report) = self.diff(toc, persistent, operation, outcome, result) else {
             return;
         };
 
@@ -84,6 +88,7 @@ impl ShadowStateMachine {
         &mut self,
         toc: &impl CollectionContainer,
         persistent: &Persistent,
+        operation: &ConsensusOperations,
         outcome: &ApplyOutcome,
         result: &StorageResult<bool>,
     ) -> Option<String> {
@@ -102,15 +107,19 @@ impl ShadowStateMachine {
             return None;
         }
 
-        let actual = scrape_cluster_state(toc, persistent);
+        let actual = scrape_actual_state(toc, persistent);
 
         let mut report = Vec::from_iter(diff::outcome(outcome, result));
         report.extend(diff::cluster(machine.state(), &actual));
 
-        // A collection only one side holds is reported by `diff::cluster`
-        for (name, shadow) in &machine.state().collections {
-            if let Some(actual) = actual.collection(name) {
-                report.extend(diff::collection(name, shadow, actual));
+        // Reading a collection's state is the expensive part, so only the ones this operation
+        // could have changed are read. A collection only one side holds is already reported.
+        for collection in compared_collections(operation, machine.state()) {
+            let shadow = machine.state().collection(&collection);
+            let actual = toc.collection_state(&collection);
+
+            if let (Some(shadow), Some(actual)) = (shadow, actual) {
+                report.extend(diff::collection(&collection, shadow, &actual));
             }
         }
 
@@ -150,9 +159,9 @@ impl ShadowMode {
     }
 }
 
-/// Read the state consensus decides on back out of the node that applied it.
+/// Read the whole cluster state back, to build a machine that starts from it.
 ///
-/// Reads the state of every collection, which is what one compare costs.
+/// Reads the state of every collection, so this runs when a machine is built, not per entry.
 pub fn scrape_cluster_state(
     toc: &impl CollectionContainer,
     persistent: &Persistent,
@@ -169,5 +178,61 @@ pub fn scrape_cluster_state(
         peer_metadata_by_id: persistent.peer_metadata_by_id.read().clone(),
         cluster_metadata: persistent.cluster_metadata.clone(),
         quota_config: toc.quota_config(),
+    }
+}
+
+/// Read back everything an entry's compare reads, leaving out the contents of collections
+pub fn scrape_actual_state(toc: &impl CollectionContainer, persistent: &Persistent) -> ActualState {
+    ActualState {
+        collections: toc.collection_names(),
+        aliases: toc.alias_mapping(),
+        peer_address_by_id: persistent.peer_address_by_id.read().clone(),
+        peer_metadata_by_id: persistent.peer_metadata_by_id.read().clone(),
+        cluster_metadata: persistent.cluster_metadata.clone(),
+        quota_config: toc.quota_config(),
+    }
+}
+
+/// Collections whose state the compare after `operation` reads.
+///
+/// Both the name the operation carries and the collection it resolves to, since planning
+/// resolves aliases and the legacy handlers do so per operation.
+fn compared_collections(
+    operation: &ConsensusOperations,
+    state: &ClusterState,
+) -> Vec<CollectionId> {
+    let ConsensusOperations::CollectionMeta(operation) = operation else {
+        return Vec::new();
+    };
+
+    let collection = match &**operation {
+        CollectionMetaOperations::CreateCollection(operation) => &operation.collection_name,
+        CollectionMetaOperations::UpdateCollection(operation) => &operation.collection_name,
+        CollectionMetaOperations::DeleteCollection(operation) => &operation.0,
+        CollectionMetaOperations::SetShardReplicaState(operation) => &operation.collection_name,
+        CollectionMetaOperations::CreateShardKey(operation) => &operation.collection_name,
+        CollectionMetaOperations::DropShardKey(operation) => &operation.collection_name,
+        CollectionMetaOperations::CreatePayloadIndex(operation) => &operation.collection_name,
+        CollectionMetaOperations::DropPayloadIndex(operation) => &operation.collection_name,
+        CollectionMetaOperations::CreateNamedVector(operation) => &operation.collection_name,
+        CollectionMetaOperations::DeleteNamedVector(operation) => &operation.collection_name,
+        CollectionMetaOperations::Resharding(collection, _) => collection,
+        CollectionMetaOperations::TransferShard(collection, _) => collection,
+
+        // Change no collection. Alias changes are covered by the compare of the whole mapping.
+        CollectionMetaOperations::ChangeAliases(_) | CollectionMetaOperations::Nop { .. } => {
+            return Vec::new();
+        }
+
+        #[cfg(feature = "staging")]
+        CollectionMetaOperations::TestSlowDown(_)
+        | CollectionMetaOperations::TestTransientError(_) => return Vec::new(),
+    };
+
+    match state.aliases.get(collection) {
+        Some(resolved) if resolved != collection => {
+            vec![collection.clone(), resolved.clone()]
+        }
+        _ => vec![collection.clone()],
     }
 }

--- a/lib/storage/src/content_manager/consensus_shadow/tests.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/tests.rs
@@ -168,6 +168,37 @@ fn not_covered_keeps_the_rest() {
     assert_eq!(shadow.apply(&nop()).as_deref(), Some("aliases"));
 }
 
+/// Recovering a partial shard snapshot rewrites the payload index schema of a collection
+/// without a consensus operation. The collection is read back, rather than reported.
+#[test]
+fn dirty_collection_resync() {
+    let shadow = Shadow::new(ShadowMode::Panic);
+
+    assert_eq!(shadow.apply(&nop()), None);
+
+    shadow.container.add_shard(0);
+    shadow.container.mark_dirty();
+
+    // Names the collection, so its state is compared
+    assert_eq!(shadow.apply(&drop_payload_index(COLLECTION)), None);
+}
+
+/// Recovery runs next to the apply, so a collection can be dirtied after the machine planned
+/// the entry and before the compare reads it back
+#[test]
+fn dirty_collection_resync_mid_apply() {
+    let shadow = Shadow::new(ShadowMode::Panic);
+
+    assert_eq!(shadow.apply(&nop()), None);
+
+    let report = shadow.apply_between(&drop_payload_index(COLLECTION), &Ok(true), |container| {
+        container.add_shard(0);
+        container.mark_dirty();
+    });
+
+    assert_eq!(report, None);
+}
+
 /// A service error kills the consensus thread, and what the failed apply wrote before it gave
 /// up is not something the machine predicts
 #[test]
@@ -317,8 +348,21 @@ impl Shadow {
         operation: &ConsensusOperations,
         result: &StorageResult<bool>,
     ) -> Option<String> {
+        self.apply_between(operation, result, |_| ())
+    }
+
+    /// Plan `operation`, let `between` change the container the way something running next to
+    /// the apply would, then compare
+    fn apply_between(
+        &self,
+        operation: &ConsensusOperations,
+        result: &StorageResult<bool>,
+        between: impl FnOnce(&Container),
+    ) -> Option<String> {
         let mut machine = self.machine.lock();
         let outcome = machine.apply(&self.container, &self.persistent, operation);
+
+        between(&self.container);
 
         machine.diff(
             &self.container,
@@ -466,6 +510,7 @@ fn container() -> Container {
             ..Default::default()
         },
         snapshots: AtomicUsize::new(0),
+        dirty_collections: Mutex::new(BTreeSet::new()),
     }
 }
 
@@ -479,11 +524,19 @@ struct Container {
     quota_config: QuotaConfig,
     /// How many times the whole state was read back, to tell a resync from a rebuild
     snapshots: AtomicUsize,
+    /// Collections changed without a consensus operation asking for it
+    dirty_collections: Mutex<BTreeSet<CollectionId>>,
 }
 
 impl Container {
     fn snapshots(&self) -> usize {
         self.snapshots.load(Ordering::Relaxed)
+    }
+
+    /// Record that the collection changed without a consensus operation, as recovering a
+    /// partial shard snapshot does
+    fn mark_dirty(&self) {
+        self.dirty_collections.lock().insert(COLLECTION.to_string());
     }
 
     /// Point another alias at the collection, as an operation the machine never saw would
@@ -526,6 +579,10 @@ impl CollectionContainer for Container {
 
     fn alias_mapping(&self) -> AliasMapping {
         self.aliases.lock().clone()
+    }
+
+    fn take_dirty_collections(&self) -> BTreeSet<CollectionId> {
+        std::mem::take(&mut self.dirty_collections.lock())
     }
 
     fn node_context(&self) -> NodeContext {

--- a/lib/storage/src/content_manager/consensus_shadow/tests.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/tests.rs
@@ -6,6 +6,7 @@
 
 use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, mpsc};
 
 use collection::collection_state;
@@ -130,10 +131,41 @@ fn rejected_by_apply_only() {
     assert!(shadow.apply_with(&nop(), &rejection).is_some());
 }
 
-/// An operation the machine does not model leaves state it cannot predict
+/// An operation the machine does not model, naming no collection, can have changed any of them
 #[test]
 fn not_covered_invalidates() {
-    invalidates(&set_replica_state(), &Ok(true));
+    invalidates(&remove_peer(), &Ok(true));
+}
+
+/// An operation the machine does not model reads the collections it names back, rather than
+/// rebuilding the machine from every collection
+#[test]
+fn not_covered_resync() {
+    let shadow = Shadow::new(ShadowMode::Panic);
+
+    // Builds the machine, the one full read of the state this test expects
+    assert_eq!(shadow.apply(&nop()), None);
+
+    shadow.container.add_shard(0);
+    assert_eq!(shadow.apply(&set_replica_state()), None);
+
+    // Names the collection, so its state is compared: the shard has to be in both by now
+    assert_eq!(shadow.apply(&drop_payload_index(COLLECTION)), None);
+
+    assert_eq!(shadow.container.snapshots(), 1);
+}
+
+/// Reading one collection back does not paper over a divergence somewhere else
+#[test]
+fn not_covered_keeps_the_rest() {
+    let shadow = Shadow::new(ShadowMode::Panic);
+
+    assert_eq!(shadow.apply(&nop()), None);
+
+    shadow.container.add_alias(OTHER_ALIAS);
+    assert_eq!(shadow.apply(&set_replica_state()), None);
+
+    assert_eq!(shadow.apply(&nop()).as_deref(), Some("aliases"));
 }
 
 /// A service error kills the consensus thread, and what the failed apply wrote before it gave
@@ -381,7 +413,12 @@ fn drop_payload_index(collection: &str) -> ConsensusOperations {
     )))
 }
 
-/// Operation the machine does not model yet
+/// Operation the machine does not model, and which names no collection
+fn remove_peer() -> ConsensusOperations {
+    ConsensusOperations::RemovePeer(PEER_ID)
+}
+
+/// Operation the machine does not model yet, naming the collection it changes
 fn set_replica_state() -> ConsensusOperations {
     let operation = SetShardReplicaState {
         collection_name: COLLECTION.to_string(),
@@ -428,6 +465,7 @@ fn container() -> Container {
             enabled: true,
             ..Default::default()
         },
+        snapshots: AtomicUsize::new(0),
     }
 }
 
@@ -439,9 +477,15 @@ struct Container {
     collections: Mutex<HashMap<CollectionId, collection_state::State>>,
     aliases: Mutex<AliasMapping>,
     quota_config: QuotaConfig,
+    /// How many times the whole state was read back, to tell a resync from a rebuild
+    snapshots: AtomicUsize,
 }
 
 impl Container {
+    fn snapshots(&self) -> usize {
+        self.snapshots.load(Ordering::Relaxed)
+    }
+
     /// Point another alias at the collection, as an operation the machine never saw would
     fn add_alias(&self, alias: &str) {
         self.aliases
@@ -464,6 +508,8 @@ impl Container {
 
 impl CollectionContainer for Container {
     fn collections_snapshot(&self) -> CollectionsSnapshot {
+        self.snapshots.fetch_add(1, Ordering::Relaxed);
+
         CollectionsSnapshot {
             collections: self.collections.lock().clone(),
             aliases: self.aliases.lock().clone(),

--- a/lib/storage/src/content_manager/consensus_shadow/tests.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/tests.rs
@@ -69,7 +69,10 @@ fn diverged_collection() {
 
     shadow.container.add_shard(0);
 
-    assert!(shadow.apply(&drop_payload_index()).is_some());
+    assert_eq!(
+        shadow.apply(&drop_payload_index()).as_deref(),
+        Some(format!("collections[{COLLECTION}].shards").as_str()),
+    );
 }
 
 /// Both sides reject a missing collection, and with the same error class
@@ -162,7 +165,7 @@ fn snapshot_invalidates() {
 
 /// The peer dies on a divergence in panic mode, which is what the consensus test suite runs
 #[test]
-#[should_panic]
+#[should_panic(expected = "aliases")]
 fn manager_panics_on_divergence() {
     let container = Arc::new(container());
     let dir = tempdir();

--- a/lib/storage/src/content_manager/consensus_shadow/tests.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/tests.rs
@@ -4,7 +4,7 @@
 //! Driving an entry through `ConsensusManager` only covers the wiring, where the one thing a
 //! test can observe is whether the peer died.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 use std::sync::{Arc, mpsc};
 
@@ -70,7 +70,23 @@ fn diverged_collection() {
     shadow.container.add_shard(0);
 
     assert_eq!(
-        shadow.apply(&drop_payload_index()).as_deref(),
+        shadow.apply(&drop_payload_index(COLLECTION)).as_deref(),
+        Some(format!("collections[{COLLECTION}].shards").as_str()),
+    );
+}
+
+/// An operation naming an alias has the collection behind it compared, under the name the two
+/// sides hold it by
+#[test]
+fn diverged_collection_under_alias() {
+    let shadow = Shadow::new(ShadowMode::Panic);
+
+    assert_eq!(shadow.apply(&nop()), None);
+
+    shadow.container.add_shard(0);
+
+    assert_eq!(
+        shadow.apply(&drop_payload_index(ALIAS)).as_deref(),
         Some(format!("collections[{COLLECTION}].shards").as_str()),
     );
 }
@@ -214,6 +230,29 @@ fn scrape_cluster_state() {
     assert_eq!(state.cluster_metadata, persistent.cluster_metadata);
 }
 
+/// The per-entry read holds the same state, with collection names in place of their state
+#[test]
+fn scrape_actual_state() {
+    let dir = tempdir();
+    let persistent = persistent(dir.path());
+    let container = container();
+
+    let state = super::scrape_actual_state(&container, &persistent);
+
+    assert_eq!(state.collections, BTreeSet::from([COLLECTION.to_string()]));
+    assert_eq!(state.aliases, *container.aliases.lock());
+    assert_eq!(state.quota_config, container.quota_config);
+    assert_eq!(
+        state.peer_address_by_id,
+        *persistent.peer_address_by_id.read(),
+    );
+    assert_eq!(
+        state.peer_metadata_by_id,
+        *persistent.peer_metadata_by_id.read(),
+    );
+    assert_eq!(state.cluster_metadata, persistent.cluster_metadata);
+}
+
 /// Shadow over a container, without the manager in between
 struct Shadow {
     machine: Mutex<ShadowStateMachine>,
@@ -249,7 +288,13 @@ impl Shadow {
         let mut machine = self.machine.lock();
         let outcome = machine.apply(&self.container, &self.persistent, operation);
 
-        machine.diff(&self.container, &self.persistent, &outcome, result)
+        machine.diff(
+            &self.container,
+            &self.persistent,
+            operation,
+            &outcome,
+            result,
+        )
     }
 }
 
@@ -324,10 +369,10 @@ fn create_payload_index(collection: &str) -> ConsensusOperations {
     )))
 }
 
-/// Covered operation naming the collection, so the compare after it reads that collection
-fn drop_payload_index() -> ConsensusOperations {
+/// Covered operation naming `collection`, so the compare after it reads that collection
+fn drop_payload_index(collection: &str) -> ConsensusOperations {
     let operation = DropPayloadIndex {
-        collection_name: COLLECTION.to_string(),
+        collection_name: collection.to_string(),
         field_name: "city".parse().expect("valid field name"),
     };
 
@@ -423,6 +468,18 @@ impl CollectionContainer for Container {
             collections: self.collections.lock().clone(),
             aliases: self.aliases.lock().clone(),
         }
+    }
+
+    fn collection_state(&self, collection: &str) -> Option<collection_state::State> {
+        self.collections.lock().get(collection).cloned()
+    }
+
+    fn collection_names(&self) -> BTreeSet<CollectionId> {
+        self.collections.lock().keys().cloned().collect()
+    }
+
+    fn alias_mapping(&self) -> AliasMapping {
+        self.aliases.lock().clone()
     }
 
     fn node_context(&self) -> NodeContext {

--- a/lib/storage/src/content_manager/consensus_shadow/tests.rs
+++ b/lib/storage/src/content_manager/consensus_shadow/tests.rs
@@ -14,7 +14,7 @@ use collection::operations::types::PeerMetadata;
 use collection::shards::CollectionId;
 use collection::shards::replica_set::replica_set_state::ReplicaState;
 use collection::shards::shard::{PeerId, ShardId};
-use raft::eraftpb::Entry as RaftEntry;
+use raft::eraftpb::{ConfState, Entry as RaftEntry, Snapshot, SnapshotMetadata};
 use segment::types::PayloadSchemaType;
 use serde_json::json;
 use tempfile::{Builder, TempDir};
@@ -25,12 +25,13 @@ use crate::content_manager::collection_meta_ops::{
     CollectionMetaOperations, CreatePayloadIndex, DropPayloadIndex, SetShardReplicaState,
 };
 use crate::content_manager::consensus::operation_sender::OperationSender;
-use crate::content_manager::consensus_manager::ConsensusManager;
+use crate::content_manager::consensus_manager::{ConsensusManager, SnapshotData};
 use crate::content_manager::consensus_state_machine::NodeContext;
 use crate::content_manager::consensus_state_machine::tests::{
     PEER_ID, collection_state, node_context,
 };
 use crate::quota::QuotaConfig;
+use crate::types::{PeerAddressById, PeerMetadataById};
 
 const COLLECTION: &str = "books";
 const ALIAS: &str = "novels";
@@ -138,6 +139,25 @@ fn invalidates(operation: &ConsensusOperations, result: &StorageResult<bool>) {
     assert_eq!(shadow.apply_with(operation, result), None);
 
     assert_eq!(shadow.apply(&nop()), None);
+}
+
+/// Snapshot recovery leaves state no operation asked for, so the machine goes and the next
+/// entry builds a new one. Here the snapshot empties the container while the machine still
+/// holds a collection and its alias.
+#[test]
+fn snapshot_invalidates() {
+    let container = Arc::new(container());
+    let dir = tempdir();
+    let manager = manager(container, ShadowMode::Panic, dir.path());
+
+    manager.apply_normal_entry(&entry(&nop())).expect("nop");
+
+    manager
+        .apply_snapshot(&snapshot())
+        .expect("snapshot applied")
+        .expect("snapshot applied");
+
+    manager.apply_normal_entry(&entry(&nop())).expect("nop");
 }
 
 /// The peer dies on a divergence in panic mode, which is what the consensus test suite runs
@@ -256,6 +276,31 @@ fn entry(operation: &ConsensusOperations) -> RaftEntry {
     RaftEntry {
         data: serde_cbor::to_vec(operation).expect("operation serialized"),
         ..Default::default()
+    }
+}
+
+/// Snapshot of an empty cluster, with this peer as its only voter
+fn snapshot() -> Snapshot {
+    let data = SnapshotData {
+        collections_data: CollectionsSnapshot::default(),
+        address_by_id: PeerAddressById::new(),
+        metadata_by_id: PeerMetadataById::new(),
+        cluster_metadata: HashMap::new(),
+        quota_config: None,
+    };
+
+    let conf_state = ConfState {
+        voters: vec![PEER_ID],
+        ..Default::default()
+    };
+
+    Snapshot {
+        data: serde_cbor::to_vec(&data).expect("snapshot serialized"),
+        metadata: Some(SnapshotMetadata {
+            conf_state: Some(conf_state),
+            index: 1,
+            term: 1,
+        }),
     }
 }
 
@@ -394,11 +439,19 @@ impl CollectionContainer for Container {
         Ok(true)
     }
 
-    // Never reached: no test recovers a snapshot, removes a peer or writes a quota config
+    fn apply_collections_snapshot(&self, data: CollectionsSnapshot) -> Result<(), StorageError> {
+        let CollectionsSnapshot {
+            collections,
+            aliases,
+        } = data;
 
-    fn apply_collections_snapshot(&self, _data: CollectionsSnapshot) -> Result<(), StorageError> {
-        unimplemented!()
+        *self.collections.lock() = collections;
+        *self.aliases.lock() = aliases;
+
+        Ok(())
     }
+
+    // Never reached: no test removes a peer or writes a quota config
 
     fn remove_peer(&self, _peer_id: PeerId) -> Result<(), StorageError> {
         unimplemented!()

--- a/lib/storage/src/content_manager/consensus_state_machine/mod.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/mod.rs
@@ -5,9 +5,9 @@
 //! state change method on `TableOfContent`, `Collection` or `ShardHolder`, which checks only that
 //! the object it touches exists and then persists the change. Every decision is made here.
 //!
-//! [`ClusterState::apply_action`] is the only way to change the state, and it cannot fail. So a
-//! rejected operation leaves the state untouched, and applying the first N actions of an operation
-//! gives the state that a crash after N writes leaves behind.
+//! [`ClusterState::apply_action`] is the only way an operation changes the state, and it cannot
+//! fail. So a rejected operation leaves the state untouched, and applying the first N actions of
+//! an operation gives the state that a crash after N writes leaves behind.
 //!
 //! Two rules every operation follows:
 //!
@@ -29,6 +29,7 @@ pub(crate) mod tests;
 
 use std::num::NonZeroU32;
 
+use collection::collection_state;
 use collection::config::{
     self, CollectionConfigInternal, CollectionParams, PayloadStorageParams, ShardingMethod,
     WalConfig,
@@ -36,6 +37,7 @@ use collection::config::{
 use collection::operations::config_diff::DiffConfig as _;
 use collection::operations::types::VectorsConfig;
 use collection::optimizers_builder::OptimizersConfig;
+use collection::shards::CollectionId;
 use collection::shards::shard::{PeerId, ShardId};
 use collection::shards::transfer::ShardTransferMethod;
 use segment::data_types::collection_defaults::CollectionConfigDefaults;
@@ -66,6 +68,23 @@ impl ConsensusStateMachine {
 
     pub fn context(&self) -> &NodeContext {
         &self.context
+    }
+
+    /// Replace the state of one collection with state read back from `TableOfContent`, `None`
+    /// removing it.
+    ///
+    /// Actions are the only way an *operation* changes the state. This is for the shadow run,
+    /// after an operation the machine does not model: the collections that operation touched
+    /// are read back, so the next one plans against what the legacy path left behind.
+    pub fn resync_collection(
+        &mut self,
+        collection: &CollectionId,
+        state: Option<collection_state::State>,
+    ) {
+        match state {
+            Some(state) => self.state.collections.insert(collection.clone(), state),
+            None => self.state.collections.remove(collection),
+        };
     }
 
     /// Plan `operation` and advance the state by the actions it returns

--- a/lib/storage/src/content_manager/consensus_state_machine/mod.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/mod.rs
@@ -178,7 +178,7 @@ impl ConsensusStateMachine {
 ///
 /// These come from this node's config, not from consensus, so two peers can read different values
 /// for the same operation. Values scraped from `StorageConfig` keep the names they have there.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct NodeContext {
     pub peer_id: PeerId,
     pub is_distributed: bool,

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/context.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/context.rs
@@ -1,0 +1,112 @@
+//! Scraping [`NodeContext`] out of this node's storage config
+
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+
+use collection::config::PayloadStorageParams;
+use collection::shards::transfer::ShardTransferMethod;
+use common::mmap;
+use segment::data_types::collection_defaults::CollectionConfigDefaults;
+
+use super::*;
+use crate::types::{PerformanceConfig, StorageConfig};
+
+#[test]
+fn from_storage_config() {
+    let expected = NodeContext {
+        peer_id: PEER_ID,
+        is_distributed: true,
+        collection_defaults: Some(collection_defaults()),
+        default_shard_transfer_method: Some(ShardTransferMethod::StreamRecords),
+        max_collections: Some(7),
+        wal: wal_config(),
+        optimizers: optimizers_config(),
+        hnsw_index: hnsw_config(),
+        payload: Some(payload_params()),
+        on_disk_payload: true,
+    };
+
+    let context = NodeContext::from_storage_config(&storage_config(), PEER_ID, true);
+
+    assert_eq!(context, expected);
+}
+
+/// Every option an operation reads is set away from its default.
+///
+/// Two pairs of read and ignored options share a type — `on_disk_payload` with
+/// `handle_collection_load_errors`, `max_collections` with `update_queue_size` — so each of the
+/// four gets a value that tells it apart from the other three.
+fn storage_config() -> StorageConfig {
+    StorageConfig {
+        collection: Some(collection_defaults()),
+        shard_transfer_method: Some(ShardTransferMethod::StreamRecords),
+        max_collections: Some(7),
+        wal: wal_config(),
+        optimizers: optimizers_config(),
+        hnsw_index: hnsw_config(),
+        payload: Some(payload_params()),
+        #[expect(deprecated)]
+        on_disk_payload: true,
+
+        storage_path: PathBuf::from("storage"),
+        snapshots_path: PathBuf::from("snapshots"),
+        snapshots_config: Default::default(),
+        temp_path: None,
+        optimizers_overwrite: None,
+        performance: PerformanceConfig {
+            max_search_threads: 1,
+            max_optimization_runtime_threads: 1,
+            update_rate_limit: None,
+            search_timeout_sec: None,
+            optimizer_cpu_budget: 0,
+            optimizer_io_budget: 0,
+            incoming_shard_transfers_limit: None,
+            outgoing_shard_transfers_limit: None,
+            async_scorer: None,
+            io_uring: None,
+            load_concurrency: Default::default(),
+        },
+        hnsw_global_config: Default::default(),
+        mmap_advice: mmap::Advice::Random,
+        low_memory_mode: Default::default(),
+        node_type: Default::default(),
+        update_queue_size: Some(9),
+        handle_collection_load_errors: false,
+        recovery_mode: None,
+        update_concurrency: NonZeroUsize::new(3),
+        quotas: None,
+    }
+}
+
+fn collection_defaults() -> CollectionConfigDefaults {
+    CollectionConfigDefaults {
+        vectors: None,
+        quantization: None,
+        shard_number: Some(3),
+        shard_number_per_node: None,
+        replication_factor: Some(2),
+        write_consistency_factor: None,
+        strict_mode: None,
+    }
+}
+
+fn wal_config() -> WalConfig {
+    WalConfig {
+        wal_capacity_mb: 16,
+        wal_segments_ahead: 1,
+        wal_retain_closed: 2,
+    }
+}
+
+fn hnsw_config() -> HnswConfig {
+    HnswConfig {
+        m: 32,
+        ..Default::default()
+    }
+}
+
+fn payload_params() -> PayloadStorageParams {
+    PayloadStorageParams {
+        memory: Some(Memory::Pinned),
+    }
+}

--- a/lib/storage/src/content_manager/consensus_state_machine/tests/mod.rs
+++ b/lib/storage/src/content_manager/consensus_state_machine/tests/mod.rs
@@ -3,6 +3,7 @@
 //! `consensus_shadow` builds collection states out of these too, so the two sides of a compare
 //! are the same shape.
 
+mod context;
 mod ops;
 mod prop;
 mod replay;

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -229,6 +229,9 @@ pub trait CollectionContainer {
     /// Node-local values operations read, from this node's storage config
     fn node_context(&self) -> NodeContext;
 
+    /// Collections that changed without a consensus operation asking for it, clearing the record
+    fn take_dirty_collections(&self) -> BTreeSet<CollectionId>;
+
     fn apply_collections_snapshot(&self, data: CollectionsSnapshot) -> Result<(), StorageError>;
 
     fn remove_peer(&self, peer_id: PeerId) -> Result<(), StorageError>;

--- a/lib/storage/src/content_manager/mod.rs
+++ b/lib/storage/src/content_manager/mod.rs
@@ -1,5 +1,10 @@
+use std::collections::BTreeSet;
+
+use collection::collection_state;
+use collection::shards::CollectionId;
 use collection::shards::shard::PeerId;
 
+use self::alias_mapping::AliasMapping;
 use self::collection_meta_ops::CollectionMetaOperations;
 use self::consensus_manager::CollectionsSnapshot;
 use self::consensus_state_machine::NodeContext;
@@ -211,6 +216,15 @@ pub trait CollectionContainer {
     ) -> Result<bool, StorageError>;
 
     fn collections_snapshot(&self) -> CollectionsSnapshot;
+
+    /// State of one collection, `None` when there is no such collection
+    fn collection_state(&self, collection: &str) -> Option<collection_state::State>;
+
+    /// Names of all collections, without reading their state
+    fn collection_names(&self) -> BTreeSet<CollectionId>;
+
+    /// Current alias mapping
+    fn alias_mapping(&self) -> AliasMapping;
 
     /// Node-local values operations read, from this node's storage config
     fn node_context(&self) -> NodeContext;

--- a/lib/storage/src/content_manager/toc/collection_container.rs
+++ b/lib/storage/src/content_manager/toc/collection_container.rs
@@ -48,6 +48,10 @@ impl CollectionContainer for TableOfContent {
             .block_on(async { self.alias_persistence.read().await.state().clone() })
     }
 
+    fn take_dirty_collections(&self) -> BTreeSet<CollectionId> {
+        std::mem::take(&mut self.dirty_collections.lock())
+    }
+
     fn node_context(&self) -> NodeContext {
         NodeContext::from_storage_config(
             &self.storage_config,

--- a/lib/storage/src/content_manager/toc/collection_container.rs
+++ b/lib/storage/src/content_manager/toc/collection_container.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
 use collection::collection::Collection;
@@ -9,6 +9,7 @@ use collection::shards::replica_set::replica_set_state::ReplicaState;
 use collection::shards::shard::PeerId;
 
 use super::TableOfContent;
+use crate::content_manager::alias_mapping::AliasMapping;
 use crate::content_manager::collection_meta_ops::*;
 use crate::content_manager::collections_ops::Checker as _;
 use crate::content_manager::consensus::operation_sender::OperationSender;
@@ -28,6 +29,23 @@ impl CollectionContainer for TableOfContent {
 
     fn collections_snapshot(&self) -> consensus_manager::CollectionsSnapshot {
         self.collections_snapshot_sync()
+    }
+
+    fn collection_state(&self, collection: &str) -> Option<collection_state::State> {
+        self.general_runtime.block_on(async {
+            let collections = self.collections.read().await;
+            Some(collections.get(collection)?.state().await)
+        })
+    }
+
+    fn collection_names(&self) -> BTreeSet<CollectionId> {
+        self.general_runtime
+            .block_on(async { self.collections.read().await.keys().cloned().collect() })
+    }
+
+    fn alias_mapping(&self) -> AliasMapping {
+        self.general_runtime
+            .block_on(async { self.alias_persistence.read().await.state().clone() })
     }
 
     fn node_context(&self) -> NodeContext {

--- a/lib/storage/src/content_manager/toc/mod.rs
+++ b/lib/storage/src/content_manager/toc/mod.rs
@@ -12,7 +12,7 @@ mod temp_directories;
 pub mod transfer;
 
 use std::cmp::max;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -110,6 +110,12 @@ pub struct TableOfContent {
     telemetry: TocTelemetryCollector,
     /// Cluster-wide resource quotas, applied to updates on top of strict mode.
     quota_manager: Arc<QuotaManager>,
+    /// Collections whose state changed without a consensus operation asking for it.
+    ///
+    /// Recovering a partial shard snapshot rewrites the payload index schema, which is part of
+    /// the state consensus decides on. The shadow run reads these collections back rather than
+    /// reporting the change as a divergence.
+    dirty_collections: parking_lot::Mutex<BTreeSet<CollectionId>>,
 }
 
 impl TableOfContent {
@@ -298,7 +304,13 @@ impl TableOfContent {
             collection_hw_metrics: DashMap::new(),
             telemetry,
             quota_manager,
+            dirty_collections: Default::default(),
         })
+    }
+
+    /// Record that `collection` changed without a consensus operation asking for it
+    pub fn mark_collection_dirty(&self, collection: &str) {
+        self.dirty_collections.lock().insert(collection.to_string());
     }
 
     /// Cluster-wide resource quotas.

--- a/src/common/snapshots.rs
+++ b/src/common/snapshots.rs
@@ -353,6 +353,12 @@ pub async fn recover_shard_snapshot_impl(
         .await?
         .await?;
 
+    // A partial recovery rewrites the payload index schema of the collection, which is part of
+    // the state consensus decides on, without an operation asking for it
+    if recovery_type.is_partial() {
+        toc.mark_collection_dirty(collection.name());
+    }
+
     let shard_holder = collection.shards_holder();
     let replicas = shard_holder
         .read()


### PR DESCRIPTION
This PR introduce some optimizations to `ConsensusStateMachine` "shadow run", so that it's feasible to run this in chaos-testing or other deployment:

- improved diff against "real" consensus state
- some optimizations to load/compare single-collection instead of full state each time
- some correctness improvements
- more tests

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you formatted your code locally using `cargo +nightly fmt --all` command prior to submission?
3. [x] Have you checked your code using `cargo clippy --workspace --all-features` command?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
