### PR TITLE
strict-mode: check distance matrix requests against max_query_limit using default sample and limit

### DIFF
--- a/lib/collection/src/operations/verification/matrix.rs
+++ b/lib/collection/src/operations/verification/matrix.rs
@@ -5,12 +5,13 @@ use crate::collection::distance_matrix::CollectionSearchMatrixRequest;
 
 impl StrictModeVerification for SearchMatrixRequestInternal {
     fn query_limit(&self) -> Option<usize> {
-        match (self.limit, self.sample) {
-            (Some(limit), Some(sample)) => Some(limit * sample),
-            (Some(limit), None) => Some(limit),
-            (None, Some(sample)) => Some(sample),
-            (None, None) => None,
-        }
+        let sample = self
+            .sample
+            .unwrap_or(CollectionSearchMatrixRequest::DEFAULT_SAMPLE);
+        let limit = self
+            .limit
+            .unwrap_or(CollectionSearchMatrixRequest::DEFAULT_LIMIT_PER_SAMPLE);
+        Some(limit * sample)
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {

--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -423,6 +423,7 @@ mod test {
 
         test_query_limit(&collection).await;
         test_scroll_query_limit(&collection).await;
+        test_matrix_query_limit(&collection).await;
         test_search_params(&collection).await;
         test_filter_read(&collection).await;
         test_filter_write(&collection).await;
@@ -479,6 +480,31 @@ mod test {
 
         let filter = filter_fixture(INDEXED_KEY);
         assert_strict_mode_success(discover_fixture(None, Some(filter), None), collection).await;
+    }
+
+    async fn test_matrix_query_limit(collection: &Collection) {
+        use api::rest::SearchMatrixRequestInternal;
+
+        fn matrix_request(
+            sample: Option<usize>,
+            limit: Option<usize>,
+        ) -> SearchMatrixRequestInternal {
+            SearchMatrixRequestInternal {
+                filter: None,
+                sample,
+                limit,
+                using: None,
+            }
+        }
+
+        // Omitted sample/limit default to 10 * 3 = 30, exceeding max_query_limit (4)
+        assert_strict_mode_error(matrix_request(None, None), collection).await;
+
+        // Explicit values exceeding the limit are rejected
+        assert_strict_mode_error(matrix_request(Some(10), Some(3)), collection).await;
+
+        // sample * limit (2 * 2 = 4) matches max_query_limit (4)
+        assert_strict_mode_success(matrix_request(Some(2), Some(2)), collection).await;
     }
 
     async fn test_search_params(collection: &Collection) {


### PR DESCRIPTION
Fixes #10539.

## What

`SearchMatrixRequestInternal::query_limit()` returned `None` when `sample` and `limit` were both omitted, skipping the `max_query_limit` check even though the server executes such requests with the defaults (sample 10, limit 3, i.e. up to 30 points of work).

Now it computes the effective values the same way the conversion does:

```rust
let sample = self.sample.unwrap_or(CollectionSearchMatrixRequest::DEFAULT_SAMPLE);
let limit = self.limit.unwrap_or(CollectionSearchMatrixRequest::DEFAULT_LIMIT_PER_SAMPLE);
Some(limit * sample)
```

This also fixes partially-omitted requests: previously `sample` alone was checked without the per-sample limit factor and vice versa.

## Tests

Added `test_matrix_query_limit` in `lib/collection/src/operations/verification/mod.rs`, mirroring the scroll/facet tests: omitted parameters (30 > 4) and explicit 10 x 3 are rejected when `max_query_limit` is 4; 2 x 2 passes.

`cargo check -p collection --tests` is green. I could not run the full test suite in my environment (limited RAM), so the suite was not executed here.