### PR TITLE
Add iteration count and time in trying to read lock log line

### DIFF
--- a/lib/shard/src/segment_holder/mod.rs
+++ b/lib/shard/src/segment_holder/mod.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::thread::JoinHandle;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use ahash::{AHashMap, AHashSet};
 use common::counter::hardware_counter::HardwareCounterCell;
@@ -985,8 +985,10 @@ impl SegmentHolder {
     fn aloha_lock_segment_read(
         segment: &'_ RwLock<dyn StorageSegmentEntry>,
     ) -> RwLockReadGuard<'_, dyn StorageSegmentEntry> {
+        let start = Instant::now();
         let mut interval = Duration::from_nanos(100);
-        loop {
+
+        for i in 0u64.. {
             if let Some(guard) = segment.try_read_for(interval) {
                 return guard;
             }
@@ -994,10 +996,14 @@ impl SegmentHolder {
             interval = interval.saturating_mul(2);
             if interval.as_secs() >= 10 {
                 log::warn!(
-                    "Trying to read-lock a segment is taking a long time. This could be a deadlock and may block new updates.",
+                    "Trying to read-lock a segment is taking a long time. This could be a deadlock and may block new updates. (waited: {:?}, attempt: {})",
+                    start.elapsed(),
+                    i + 1,
                 );
             }
         }
+
+        unreachable!("above loop is practically infinite");
     }
 
     /// Try to acquire write lock over random segment with increasing wait time.


### PR DESCRIPTION
Instrument for support cases, add iteration count and wait time to the following log line:

```log
Trying to read-lock a segment is taking a long time. This could be a deadlock and may block new updates. (waited: 10s, iteration: #20)
```

When I spot this log line it usually does not come alone. Many appear. The line does not tell us whether it's one task waiting for a very very long time, or whether it's many tasks waiting a bit more than 10 seconds that still resolve. It's an important distinction to differentiate a contended versus a dead-locked cluster.

By adding the iteration count and wait time we can see the difference.

Alternatively I could add an UUID where each loop iteration reports the same UUID, but having an iteration counter and wait time is more convenient.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?