### PR TITLE
fix: stop the segment copy at the first failed save

### DIFF
--- a/lib/edge/src/update_only/lifecycle.rs
+++ b/lib/edge/src/update_only/lifecycle.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use common::counter::hardware_counter::HardwareCounterCell;
 use common::universal_io::{MmapFs, UniversalAppendFs, UniversalWriteFsAsync};
@@ -168,8 +169,9 @@ pub(crate) const COPY_CONCURRENCY: usize = 8;
 /// Copy a locally built segment directory to the backend: directories first,
 /// then every file as one whole-object save, [`COPY_CONCURRENCY`] at a time.
 ///
-/// Every save is awaited even after one fails, so nothing is left in flight and
-/// the cleanup covers every object that landed.
+/// After the first failure no further save starts, but the ones already in
+/// flight are still awaited: nothing lands after the cleanup, which covers every
+/// object that did.
 pub(crate) async fn copy_dir<F: UniversalWriteFsAsync>(
     fs: &F,
     local: &Path,
@@ -202,8 +204,12 @@ pub(crate) async fn copy_dir<F: UniversalWriteFsAsync>(
     }
 
     // Read inside the wave, so only the in-flight files are in memory.
-    let saved: Vec<(PathBuf, OperationResult<()>)> = futures::stream::iter(files)
+    let failed = &AtomicBool::new(false);
+    let saved: Vec<(PathBuf, Option<OperationResult<()>>)> = futures::stream::iter(files)
         .map(|(source, target)| async move {
+            if failed.load(Ordering::Relaxed) {
+                return (target, None);
+            }
             let result = match fs_err::read(&source) {
                 Ok(bytes) => fs
                     .atomic_save_async(target.clone(), bytes)
@@ -216,7 +222,10 @@ pub(crate) async fn copy_dir<F: UniversalWriteFsAsync>(
                     source.display()
                 ))),
             };
-            (target, result)
+            if result.is_err() {
+                failed.store(true, Ordering::Relaxed);
+            }
+            (target, Some(result))
         })
         .buffer_unordered(COPY_CONCURRENCY)
         .collect()
@@ -226,9 +235,9 @@ pub(crate) async fn copy_dir<F: UniversalWriteFsAsync>(
     let mut landed = Vec::with_capacity(saved.len());
     for (path, result) in saved {
         match result {
-            Ok(()) => landed.push(path),
-            Err(err) if first_error.is_none() => first_error = Some(err),
-            Err(_) => {}
+            Some(Ok(())) => landed.push(path),
+            Some(Err(err)) if first_error.is_none() => first_error = Some(err),
+            Some(Err(_)) | None => {}
         }
     }
     if let Some(err) = first_error {

--- a/lib/edge/src/update_only/tests.rs
+++ b/lib/edge/src/update_only/tests.rs
@@ -825,10 +825,11 @@ mod copy_dir {
     }
 
     #[test]
-    fn a_failed_save_removes_what_landed() {
-        let local = segment_like_dir(12);
+    fn a_failed_save_removes_what_landed_and_stops_the_rest() {
+        let local = segment_like_dir(COPY_CONCURRENCY * 5);
         let fs = RecordingFs::default();
-        fs.0.lock().unwrap().fail_save_at = Some(5);
+        let failing_attempt = 5;
+        fs.0.lock().unwrap().fail_save_at = Some(failing_attempt);
         let remote = Path::new("shard/segments/uuid");
 
         let err = futures::executor::block_on(copy_dir(&fs, local.path(), remote))
@@ -837,7 +838,16 @@ mod copy_dir {
         assert!(err.to_string().contains("injected save failure"), "{err}");
         let log = fs.0.lock().unwrap();
         assert_eq!(log.in_flight, 0, "no save is left in flight");
-        assert_eq!(log.saves.len(), 11, "only the failed save is missing");
+        assert!(
+            log.attempts <= failing_attempt + (COPY_CONCURRENCY - 1),
+            "only the saves already in flight finish after the failure, got {} attempts",
+            log.attempts
+        );
+        assert_eq!(
+            log.saves.len(),
+            log.attempts - 1,
+            "every attempt but the failed one landed"
+        );
         for (path, _) in &log.saves {
             assert!(
                 log.removed.contains(path),


### PR DESCRIPTION
Stacked on #10503.

`copy_dir` kept launching every remaining save after the first failure and then deleted them all: a failure at file 1 of N still cost N-1 PUTs and N-1 DELETEs. Now the first failure sets a flag, saves not yet started are skipped without reading their file, and the ones already in flight are still awaited, so the cleanup keeps covering every object that landed.

The test asserts that at most `depth - 1` further saves run after the failure and that every landed object is removed. Against the previous code it fails with 12 attempts.
