### PR TITLE
Reject snapshot upload without collection config, without exposing the temp path

### DIFF
--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -185,6 +185,15 @@ impl Collection {
             }
         }
 
+        // A snapshot without a collection config is a malformed archive. Reject it
+        // explicitly: the raw IO error from `load` would embed the server-side
+        // temporary path in the API response.
+        if !CollectionConfigInternal::check(target_dir) {
+            return Err(CollectionError::bad_input(
+                "Snapshot archive does not contain a collection config",
+            ));
+        }
+
         let config = CollectionConfigInternal::load(target_dir)?;
         config.validate_and_warn();
         let configured_shards = config.params.shard_number.get();

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -386,10 +386,10 @@ impl CollectionConfigInternal {
         Ok(serde_json::from_str(&contents)?)
     }
 
-    /// Check if collection config exists
+    /// Check if collection config exists as a regular file
     pub fn check(path: &Path) -> bool {
         let config_path = path.join(COLLECTION_CONFIG_FILE);
-        config_path.exists()
+        config_path.is_file()
     }
 
     pub fn validate_and_warn(&self) {

--- a/lib/storage/src/content_manager/snapshots/recover.rs
+++ b/lib/storage/src/content_manager/snapshots/recover.rs
@@ -166,6 +166,14 @@ async fn _do_recover_from_snapshot(
     });
     restoring.await??;
 
+    // A snapshot without a collection config is a malformed archive. Reject it
+    // explicitly: the raw IO error from `load` would embed the server-side
+    // temporary path in the API response.
+    if !CollectionConfigInternal::check(tmp_collection_dir.path()) {
+        return Err(StorageError::bad_input(
+            "Snapshot archive does not contain a collection config",
+        ));
+    }
     let snapshot_config = CollectionConfigInternal::load(tmp_collection_dir.path())?;
     snapshot_config.validate_and_warn();
 

--- a/tests/openapi/test_snapshot.py
+++ b/tests/openapi/test_snapshot.py
@@ -462,9 +462,15 @@ def _assert_snapshot_upload_rejected_without_path_leak(collection_name, snapshot
 
 
 def test_upload_snapshot_without_config_is_rejected_without_path_leak(collection_name):
-    # An archive that carries no collection config (here: an empty file) is bad input.
+    # A valid empty TAR (no entries) has no collection config.
+    import io
+    import tarfile
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode='w'):
+        pass
     _assert_snapshot_upload_rejected_without_path_leak(
-        collection_name, b'', 'empty.snapshot'
+        collection_name, buf.getvalue(), 'empty.snapshot'
     )
 
 

--- a/tests/openapi/test_snapshot.py
+++ b/tests/openapi/test_snapshot.py
@@ -446,3 +446,17 @@ def test_collection_snapshot_security(collection_name):
     )
     assert response.status_code == 400
     assert response.json()["status"]["error"] == "Bad request: Invalid snapshot URI, file path must be absolute or on localhost"
+
+
+def test_upload_snapshot_without_config_is_rejected_without_path_leak(collection_name):
+    # An archive that carries no collection config (here: an empty file) is bad
+    # input, and the error must not expose the server-side temporary directory.
+    response = requests.post(
+        f"{QDRANT_HOST}/collections/{collection_name}/snapshots/upload",
+        files={'snapshot': ('empty.snapshot', b'', 'application/octet-stream')},
+        headers=qdrant_host_headers(),
+    )
+    assert response.status_code == 400
+    assert 'does not contain a collection config' in response.text
+    assert 'recovery-' not in response.text
+    assert 'config.json' not in response.text

--- a/tests/openapi/test_snapshot.py
+++ b/tests/openapi/test_snapshot.py
@@ -448,15 +448,38 @@ def test_collection_snapshot_security(collection_name):
     assert response.json()["status"]["error"] == "Bad request: Invalid snapshot URI, file path must be absolute or on localhost"
 
 
-def test_upload_snapshot_without_config_is_rejected_without_path_leak(collection_name):
-    # An archive that carries no collection config (here: an empty file) is bad
-    # input, and the error must not expose the server-side temporary directory.
+def _assert_snapshot_upload_rejected_without_path_leak(collection_name, snapshot_bytes, filename):
+    # Rejected as bad input, and the error must not expose the server-side temporary directory.
     response = requests.post(
         f"{QDRANT_HOST}/collections/{collection_name}/snapshots/upload",
-        files={'snapshot': ('empty.snapshot', b'', 'application/octet-stream')},
+        files={'snapshot': (filename, snapshot_bytes, 'application/octet-stream')},
         headers=qdrant_host_headers(),
     )
     assert response.status_code == 400
     assert 'does not contain a collection config' in response.text
     assert 'recovery-' not in response.text
     assert 'config.json' not in response.text
+
+
+def test_upload_snapshot_without_config_is_rejected_without_path_leak(collection_name):
+    # An archive that carries no collection config (here: an empty file) is bad input.
+    _assert_snapshot_upload_rejected_without_path_leak(
+        collection_name, b'', 'empty.snapshot'
+    )
+
+
+def test_upload_snapshot_with_config_directory_is_rejected_without_path_leak(collection_name):
+    # A tar whose config.json entry is a directory must be rejected the same way:
+    # exists() alone is not enough, and File::open on a directory would leak the path.
+    import io
+    import tarfile
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode='w') as tar:
+        info = tarfile.TarInfo(name='config.json')
+        info.type = tarfile.DIRTYPE
+        info.mode = 0o755
+        tar.addfile(info)
+    _assert_snapshot_upload_rejected_without_path_leak(
+        collection_name, buf.getvalue(), 'config-dir.snapshot'
+    )


### PR DESCRIPTION
Part of #10553 — the path-disclosure half only.

## Problem

Uploading an archive that carries no collection config (an empty file is the simplest case) to `POST /collections/{name}/snapshots/upload` fails in `CollectionConfigInternal::load`. The raw `fs_err` IO error is propagated as-is and ends up in the API response, exposing the server-side temporary directory:

```
Service internal error: File IO error: failed to open file `/qdrant/./storage/tmp/col-test_col-recovery-tjUgi4/config.json`: No such file or directory (os error 2)
```

## Change

Check for the config file before loading it and reject the archive as bad input with a fixed message. `recover.rs` already classifies checksum mismatches and incompatible configs as `bad_input`, so this follows the existing pattern.

Out of scope, deliberately: the other half of #10553 (malformed tar archives still surface as `500 Service internal error`).

## Test

`tests/openapi/test_snapshot.py::test_upload_snapshot_without_config_is_rejected_without_path_leak` uploads an empty archive and asserts a 400 whose body names the problem and contains no temporary path. Against v1.19.1 the same request returns the 500 quoted above (verified in docker); the new test has not been run locally, CI will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3o9eWSZNMa6WAs5F2HMZC
