### PR TITLE
Reject non-finite RRF weights from gRPC

### DIFF
--- a/lib/segment/src/common/reciprocal_rank_fusion.rs
+++ b/lib/segment/src/common/reciprocal_rank_fusion.rs
@@ -67,6 +67,11 @@ pub fn rrf_scoring(
                 responses.len()
             )));
         }
+        if weights.iter().any(|w| !w.is_finite()) {
+            return Err(OperationError::validation_error(
+                "RRF weights must be finite numbers",
+            ));
+        }
         Either::Left(weights.iter().copied())
     } else {
         Either::Right(std::iter::repeat(1.0f32))
@@ -245,6 +250,23 @@ mod tests {
 
         // With a 3:1 weight ratio, we expect the count of source 1 items in the top 10 to be roughly 3 times that of source 2
         assert!(count_source_1 >= 2 * count_source_2); // Allow some variance due to tie-breaking and small sample size
+    }
+
+    #[test]
+    fn test_rrf_scoring_rejects_non_finite_weights() {
+        let responses = vec![
+            vec![make_scored_point(1, 0.9)],
+            vec![make_scored_point(2, 0.9)],
+        ];
+
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let weights = [1.0, bad];
+            let result = rrf_scoring(responses.clone(), DEFAULT_RRF_K, Some(&weights));
+            assert!(
+                result.is_err(),
+                "non-finite weight {bad} must be rejected, got {result:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #10558

`rrf_scoring` accepted NaN and infinite RRF weights from gRPC: a NaN weight turns that prefetch's scores into NaN, which `OrderedFloat` sorts above every finite score, and infinite weights dominate the ranking. Weights are now validated next to the existing length check: every weight must be finite, otherwise the request is rejected as invalid input.

Regression test `test_rrf_scoring_rejects_non_finite_weights` fails before the fix and passes after.

Testing:
- `cargo check -p segment` passes.
- `cargo test -p segment` could not run in my environment (rustc gets OOM-killed while compiling the `segment` crate, ~2 GB RAM sandbox, also at -j1). Verified instead with a standalone harness running the `rrf_scoring` logic from master: NaN weight -> NaN score that ranks first, +Inf weight with k=1 -> infinite score; after the fix both are rejected and finite weights are unchanged.