### PR TITLE
Strict mode: saturate group and matrix effective query limits

### DIFF
--- a/lib/collection/src/operations/verification/matrix.rs
+++ b/lib/collection/src/operations/verification/matrix.rs
@@ -32,7 +32,7 @@ impl StrictModeVerification for SearchMatrixRequestInternal {
 
 impl StrictModeVerification for CollectionSearchMatrixRequest {
     fn query_limit(&self) -> Option<usize> {
-        Some(self.limit_per_sample * self.sample_size)
+        Some(self.limit_per_sample.saturating_mul(self.sample_size))
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {

--- a/lib/collection/src/operations/verification/matrix.rs
+++ b/lib/collection/src/operations/verification/matrix.rs
@@ -6,7 +6,7 @@ use crate::collection::distance_matrix::CollectionSearchMatrixRequest;
 impl StrictModeVerification for SearchMatrixRequestInternal {
     fn query_limit(&self) -> Option<usize> {
         match (self.limit, self.sample) {
-            (Some(limit), Some(sample)) => Some(limit * sample),
+            (Some(limit), Some(sample)) => Some(limit.saturating_mul(sample)),
             (Some(limit), None) => Some(limit),
             (None, Some(sample)) => Some(sample),
             (None, None) => None,
@@ -55,6 +55,18 @@ impl StrictModeVerification for CollectionSearchMatrixRequest {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn rest_matrix_query_limit_saturates_on_overflow() {
+        // (1 << 32) * (1 << 32) wraps to 0 without saturation
+        let request = SearchMatrixRequestInternal {
+            limit: Some(1 << 32),
+            sample: Some(1 << 32),
+            filter: None,
+            using: None,
+        };
+        assert_eq!(request.query_limit(), Some(usize::MAX));
+    }
 
     #[test]
     fn collection_matrix_query_limit_saturates_on_overflow() {

--- a/lib/collection/src/operations/verification/matrix.rs
+++ b/lib/collection/src/operations/verification/matrix.rs
@@ -51,3 +51,31 @@ impl StrictModeVerification for CollectionSearchMatrixRequest {
         None
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn collection_matrix_query_limit_saturates_on_overflow() {
+        // (1 << 32) * (1 << 32) wraps to 0 without saturation
+        let request = CollectionSearchMatrixRequest {
+            sample_size: 1 << 32,
+            limit_per_sample: 1 << 32,
+            filter: None,
+            using: Default::default(),
+        };
+        assert_eq!(request.query_limit(), Some(usize::MAX));
+    }
+
+    #[test]
+    fn collection_matrix_query_limit_normal_product() {
+        let request = CollectionSearchMatrixRequest {
+            sample_size: 10,
+            limit_per_sample: 3,
+            filter: None,
+            using: Default::default(),
+        };
+        assert_eq!(request.query_limit(), Some(30));
+    }
+}

--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -279,3 +279,41 @@ impl StrictModeVerification for CollectionQueryGroupsRequest {
         self.params.as_ref()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use segment::types::{WithPayloadInterface, WithVector};
+
+    use super::*;
+
+    fn groups_request(limit: usize, group_size: usize) -> CollectionQueryGroupsRequest {
+        CollectionQueryGroupsRequest {
+            prefetch: vec![],
+            query: None,
+            using: Default::default(),
+            filter: None,
+            params: None,
+            score_threshold: None,
+            with_vector: WithVector::from(false),
+            with_payload: WithPayloadInterface::Bool(false),
+            lookup_from: None,
+            group_by: "num".parse().unwrap(),
+            group_size,
+            limit,
+            with_lookup: None,
+        }
+    }
+
+    #[test]
+    fn groups_query_limit_saturates_on_overflow() {
+        // (1 << 32) * (1 << 32) wraps to 0 without saturation
+        let request = groups_request(1 << 32, 1 << 32);
+        assert_eq!(request.query_limit(), Some(usize::MAX));
+    }
+
+    #[test]
+    fn groups_query_limit_normal_product() {
+        let request = groups_request(10, 5);
+        assert_eq!(request.query_limit(), Some(50));
+    }
+}

--- a/lib/collection/src/operations/verification/query.rs
+++ b/lib/collection/src/operations/verification/query.rs
@@ -260,7 +260,7 @@ impl StrictModeVerification for CollectionQueryGroupsRequest {
     }
 
     fn query_limit(&self) -> Option<usize> {
-        Some(self.limit * self.group_size)
+        Some(self.limit.saturating_mul(self.group_size))
     }
 
     fn indexed_filter_read(&self) -> Option<&segment::types::Filter> {

--- a/lib/collection/src/operations/verification/recommend.rs
+++ b/lib/collection/src/operations/verification/recommend.rs
@@ -27,7 +27,7 @@ impl StrictModeVerification for RecommendRequestInternal {
 
 impl StrictModeVerification for RecommendGroupsRequestInternal {
     fn query_limit(&self) -> Option<usize> {
-        Some(self.group_request.limit as usize * self.group_request.group_size as usize)
+        Some((self.group_request.limit as usize).saturating_mul(self.group_request.group_size as usize))
     }
 
     fn indexed_filter_read(&self) -> Option<&Filter> {

--- a/lib/collection/src/operations/verification/search.rs
+++ b/lib/collection/src/operations/verification/search.rs
@@ -103,7 +103,7 @@ impl StrictModeVerification for SearchGroupsRequestInternal {
     }
 
     fn query_limit(&self) -> Option<usize> {
-        Some(self.group_request.limit as usize * self.group_request.group_size as usize)
+        Some((self.group_request.limit as usize).saturating_mul(self.group_request.group_size as usize))
     }
 
     fn indexed_filter_read(&self) -> Option<&Filter> {


### PR DESCRIPTION
Fixes #10560

Follow-up to #10519, which fixed `SearchMatrixRequestInternal` and the facet default. The remaining `query_limit()` impls still multiplied raw:

- `CollectionQueryGroupsRequest` (`verification/query.rs`): `limit * group_size` over `usize`. With `limit = group_size = 2^32` the product wraps to 0 and passes any `max_query_limit`; reachable from universal group queries over REST and gRPC (`uint64` proto fields).
- `CollectionSearchMatrixRequest` (`verification/matrix.rs`): `limit_per_sample * sample_size` over `usize`; reachable from the gRPC matrix endpoints (`uint64` proto fields).
- `SearchGroupsRequestInternal` / `RecommendGroupsRequestInternal` (`verification/search.rs` / `recommend.rs`): same expression over `u32` fields; cannot overflow `usize` on 64-bit, saturated for consistency and for 32-bit targets.

All four now use `saturating_mul`, so an overflowing product reads as `usize::MAX` and is rejected whenever `max_query_limit` is set.

Regression tests: unit tests for the two `usize` impls (`groups_query_limit_saturates_on_overflow`, `collection_matrix_query_limit_saturates_on_overflow`, plus normal-product cases) next to the impls.

Testing:
- `cargo check -p collection --tests` passes, including the new tests.
- `cargo test -p collection` could not run in my environment (rustc gets OOM-killed while compiling the `segment` crate, ~2 GB RAM sandbox, also at -j1). Verified instead with a standalone harness of the `query_limit` / `check_limit_opt` logic: before the fix, `limit = group_size = 2^32` wraps to 0 and bypasses `max_query_limit = 100`; after the fix the product saturates and the request is rejected.