### PR TITLE
Clamp MMR selection buffer to candidate count

### DIFF
--- a/lib/shard/src/query/mmr/mod.rs
+++ b/lib/shard/src/query/mmr/mod.rs
@@ -206,7 +206,7 @@ fn maximal_marginal_relevance(
         return Vec::new();
     }
 
-    let mut selected_indices = Vec::with_capacity(limit);
+    let mut selected_indices = Vec::with_capacity(limit.min(num_candidates));
     let mut remaining_indices: IndexSet<usize, ahash::RandomState> = (0..num_candidates).collect();
 
     // Select first point with highest relevance score

--- a/lib/shard/src/query/mmr/tests.rs
+++ b/lib/shard/src/query/mmr/tests.rs
@@ -394,3 +394,33 @@ fn test_mmr_multi_vector() {
         assert_eq!(multi_scored_points.len(), 3);
     }
 }
+
+#[test]
+fn test_mmr_huge_limit_does_not_panic() {
+    // A request-level limit far above the candidate count must not trigger an
+    // oversized allocation: MMR can never select more points than candidates.
+    let points = vec![
+        create_scored_point_with_vector(1.into(), vec![1.0, 0.0, 0.0], None),
+        create_scored_point_with_vector(2.into(), vec![0.0, 1.0, 0.0], None),
+        create_scored_point_with_vector(3.into(), vec![0.0, 0.0, 1.0], None),
+    ];
+
+    let mmr = MmrInternal {
+        vector: vec![1.0, 0.0, 0.0].into(),
+        using: VectorNameBuf::from(""),
+        lambda: OrderedFloat(0.5),
+        candidates_limit: 100,
+    };
+
+    let result = mmr_from_points_with_vector(
+        points,
+        mmr,
+        Distance::Dot,
+        None,
+        usize::MAX,
+        HwMeasurementAcc::new(),
+    );
+
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().len(), 3);
+}


### PR DESCRIPTION
Fixes #10563

`maximal_marginal_relevance` allocated its selection buffer with the unclamped request limit: `Vec::with_capacity(limit)` panics with `capacity overflow` for limits above `isize::MAX / 8` and can abort the process for giant-but-allocatable values. The selection can never exceed the candidate count, so the buffer is now clamped with `with_capacity(limit.min(num_candidates))`, mirroring the `LARGEST_REASONABLE_ALLOCATION_SIZE` guards in the search and grouping aggregators.

Regression test `test_mmr_huge_limit_does_not_panic` in `lib/shard/src/query/mmr/tests.rs`: panics before the fix, passes after.

Testing:
- `cargo check -p shard --tests` passes.
- `cargo test -p shard` could not run in my environment (rustc gets OOM-killed while compiling the `segment` crate, ~2 GB RAM sandbox, also at -j1). Verified instead with a standalone harness of the allocation behavior: `with_capacity(usize::MAX)` panics before the fix, the clamped allocation proceeds after, and normal limits are unchanged.