### PR TITLE
Fix MMR pagination with offsets (rebase of #10502 onto dev)

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -397,19 +397,13 @@ impl Collection {
                 fused
             }
             Some(ScoringQuery::Mmr(mmr)) => {
-                let available_points = intermediates
-                    .iter()
-                    .map(Vec::len)
-                    .fold(0usize, usize::saturating_add);
                 let points_with_vector = intermediates.into_iter().flatten();
 
                 let collection_params = self.collection_config.read().await.params.clone();
                 let search_runtime_handle = &self.search_runtime;
                 let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);
-                // MMR is finalized before the collection-level offset is applied below.
-                // Select enough points to cover both the offset and the requested page, but
-                // never reserve more capacity than the number of points available to MMR.
-                let mmr_limit = limit.saturating_add(*offset).min(available_points);
+                // MMR runs before the offset is applied below, so it must select the whole page.
+                let mmr_limit = limit.saturating_add(*offset);
 
                 let mut mmr_result = mmr_from_points_with_vector(
                     &collection_params,

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -397,17 +397,25 @@ impl Collection {
                 fused
             }
             Some(ScoringQuery::Mmr(mmr)) => {
+                let available_points = intermediates
+                    .iter()
+                    .map(Vec::len)
+                    .fold(0usize, usize::saturating_add);
                 let points_with_vector = intermediates.into_iter().flatten();
 
                 let collection_params = self.collection_config.read().await.params.clone();
                 let search_runtime_handle = &self.search_runtime;
                 let timeout = timeout.unwrap_or(self.shared_storage_config.search_timeout);
+                // MMR is finalized before the collection-level offset is applied below.
+                // Select enough points to cover both the offset and the requested page, but
+                // never reserve more capacity than the number of points available to MMR.
+                let mmr_limit = limit.saturating_add(*offset).min(available_points);
 
                 let mut mmr_result = mmr_from_points_with_vector(
                     &collection_params,
                     points_with_vector,
                     mmr.clone(),
-                    *limit,
+                    mmr_limit,
                     search_runtime_handle,
                     timeout,
                     hw_measurement_acc,

--- a/lib/collection/tests/integration/collection_test.rs
+++ b/lib/collection/tests/integration/collection_test.rs
@@ -19,6 +19,7 @@ use collection::shards::replica_set::replica_set_state::{ReplicaSetState, Replic
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use fs_err::File;
 use itertools::Itertools;
+use ordered_float::OrderedFloat;
 use segment::data_types::order_by::{Direction, OrderBy, OrderByInterface};
 use segment::data_types::vectors::VectorStructInternal;
 use segment::types::{
@@ -26,7 +27,7 @@ use segment::types::{
     PayloadFieldSchema, PayloadSchemaType, PointIdType, WithPayloadInterface,
 };
 use serde_json::Map;
-use shard::query::{SampleInternal, ScoringQuery, ShardQueryRequest};
+use shard::query::{MmrInternal, SampleInternal, ScoringQuery, ShardQueryRequest};
 use tempfile::Builder;
 
 use crate::common::{N_SHARDS, load_local_collection, simple_collection_fixture};
@@ -1107,4 +1108,92 @@ async fn test_random_sample_huge_limit_does_not_abort() {
     // Bounded by the points actually available; the request completes instead of
     // aborting.
     assert_eq!(result.len(), 3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mmr_pagination_applies_offset_after_rescoring() {
+    let collection_dir = Builder::new().prefix("collection").tempdir().unwrap();
+    let collection = simple_collection_fixture(collection_dir.path(), 1).await;
+
+    let batch = BatchPersisted {
+        ids: vec![0, 1, 2, 3, 4].into_iter().map(u64::into).collect_vec(),
+        vectors: BatchVectorStructPersisted::Single(vec![
+            vec![1.0, 0.0, 0.0, 0.0],
+            vec![0.9, 0.1, 0.0, 0.0],
+            vec![0.0, 1.0, 0.0, 0.0],
+            vec![-1.0, 0.0, 0.0, 0.0],
+            vec![0.0, -1.0, 0.0, 0.0],
+        ]),
+        payloads: None,
+    };
+    let insert_points = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::from(batch),
+    ));
+    collection
+        .update_from_client_simple(
+            insert_points,
+            true,
+            None,
+            WriteOrdering::default(),
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+
+    let make_request = |limit, offset| ShardQueryRequest {
+        prefetches: vec![],
+        query: Some(ScoringQuery::Mmr(MmrInternal {
+            vector: vec![1.0, 0.0, 0.0, 0.0].into(),
+            using: "".into(),
+            lambda: OrderedFloat(0.5),
+            candidates_limit: 5,
+        })),
+        filter: None,
+        score_threshold: None,
+        limit,
+        offset,
+        params: None,
+        with_vector: false.into(),
+        with_payload: false.into(),
+    };
+
+    let full = collection
+        .query(
+            make_request(5, 0),
+            None,
+            None,
+            ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+    let page = collection
+        .query(
+            make_request(2, 1),
+            None,
+            None,
+            ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+
+    let expected = full[1..3].iter().map(|point| point.id).collect_vec();
+    let actual = page.iter().map(|point| point.id).collect_vec();
+    assert_eq!(actual, expected);
+
+    let oversized_offset_page = collection
+        .query(
+            make_request(2, usize::MAX),
+            None,
+            None,
+            ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .unwrap();
+    assert!(oversized_offset_page.is_empty());
 }

--- a/lib/shard/src/query/mmr/mod.rs
+++ b/lib/shard/src/query/mmr/mod.rs
@@ -206,7 +206,7 @@ fn maximal_marginal_relevance(
         return Vec::new();
     }
 
-    let mut selected_indices = Vec::with_capacity(limit);
+    let mut selected_indices = Vec::with_capacity(limit.min(num_candidates));
     let mut remaining_indices: IndexSet<usize, ahash::RandomState> = (0..num_candidates).collect();
 
     // Select first point with highest relevance score


### PR DESCRIPTION
Rebase of #10502 onto `dev`. Same two commits, cherry-picked with `-x`, original authorship preserved.

#10502 was approved but is based on `master`, whose history has diverged from `dev` (retargeting it shows ~2400 conflicting files), so it cannot be merged as-is.

Fixes #10500 (MMR pagination applied `limit` before `offset`, short pages).
Fixes #10563 (`Vec::with_capacity(limit)` in MMR panics on huge limits; now clamped to the candidate count).

Changes are identical to the approved #10502:
- `lib/collection/src/collection/query.rs`: pass `limit.saturating_add(offset)` to the MMR selection, then skip/take.
- `lib/shard/src/query/mmr/mod.rs`: `Vec::with_capacity(limit.min(num_candidates))`.
- Regression tests from #10502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3o9eWSZNMa6WAs5F2HMZC
