### PR TITLE
Double the wait time for awaiting on consensus synchronization

### DIFF
--- a/lib/collection/src/shards/mod.rs
+++ b/lib/collection/src/shards/mod.rs
@@ -101,7 +101,7 @@ async fn await_consensus_sync(
     consensus: &dyn ShardTransferConsensus,
     channel_service: &ChannelService,
 ) {
-    let wait_until = tokio::time::Instant::now() + defaults::CONSENSUS_META_OP_WAIT;
+    let wait_until = tokio::time::Instant::now() + defaults::CONSENSUS_META_OP_WAIT * 2;
     let sync_consensus =
         timeout_at(wait_until, consensus.await_consensus_sync(channel_service)).await;
 


### PR DESCRIPTION
Doubles the timeout for awaiting consensus synchronization from 10 to 20 seconds.

Consensus itself uses a 10 second timeout after which reelection can be triggered. Doubling the time for awaiting consensus synchronization makes sure we give Raft enough time for reelection.
This also makes awaiting less sensitive to consensus lag, simply because there is more wait time.

At the same time we don't want to raise the timeout too much. Because if there is an unresponsive peer, we'll always wait for the full timeout.

Yes, 20 seconds is still quite arbitrary. But we don't have better numbers to base this upon.

### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
