### PR TITLE
fix: prevent matrix limit overflow

### DIFF
--- a/lib/collection/src/collection/distance_matrix.rs
+++ b/lib/collection/src/collection/distance_matrix.rs
@@ -220,6 +220,7 @@ impl Collection {
 
         // Perform nearest neighbor search for each sampled point
         let mut queries = Vec::with_capacity(sampled_points.len());
+        let query_limit = limit_per_sample.saturating_add(1);
 
         for point in sampled_points {
             let vector = point
@@ -238,7 +239,7 @@ impl Collection {
                 using: using.clone(),
                 filter: Some(filter.clone()),
                 score_threshold: None,
-                limit: limit_per_sample + 1, // +1 to exclude the point itself afterward
+                limit: query_limit, // +1 to exclude the point itself afterward
                 offset: 0,
                 params: None,
                 with_vector: WithVector::Bool(false),
@@ -275,7 +276,7 @@ impl Collection {
                 scores.remove(sample_pos);
             } else {
                 // if not found pop lowest score
-                if scores.len() == limit_per_sample + 1 {
+                if scores.len() == query_limit {
                     // if we have enough results, remove the last one
                     scores.pop();
                 }
@@ -349,5 +350,10 @@ mod tests {
 
         let actual = SearchMatrixOffsetsResponse::from(response);
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn matrix_limit_max_does_not_wrap() {
+        assert_eq!(usize::MAX.saturating_add(1), usize::MAX);
     }
 }

--- a/lib/collection/src/collection/distance_matrix.rs
+++ b/lib/collection/src/collection/distance_matrix.rs
@@ -351,9 +351,4 @@ mod tests {
         let actual = SearchMatrixOffsetsResponse::from(response);
         assert_eq!(actual, expected);
     }
-
-    #[test]
-    fn matrix_limit_max_does_not_wrap() {
-        assert_eq!(usize::MAX.saturating_add(1), usize::MAX);
-    }
 }

--- a/lib/collection/tests/integration/distance_matrix_test.rs
+++ b/lib/collection/tests/integration/distance_matrix_test.rs
@@ -127,13 +127,15 @@ async fn distance_matrix_anonymous_vector() {
     }
 }
 
+use segment::types::PointIdType;
+
 #[tokio::test(flavor = "multi_thread")]
 async fn distance_matrix_max_limit() {
     let collection_dir = Builder::new().prefix("storage").tempdir().unwrap();
     let collection = simple_collection_fixture(collection_dir.path(), 1).await;
 
     let point_count = 50;
-    let ids = (0..point_count).map_into().collect();
+    let ids = (0..point_count).map(PointIdType::from).collect();
     let mut rng = SmallRng::seed_from_u64(SEED);
 
     let vectors = (0..point_count)
@@ -188,8 +190,7 @@ async fn distance_matrix_max_limit() {
     assert_eq!(matrix.sample_ids.len(), sample_size);
     assert_eq!(matrix.nearests.len(), sample_size);
     for nearest in matrix.nearests {
-        assert!(!nearest.is_empty());
-        assert!(nearest.len() < point_count as usize);
+        assert_eq!(nearest.len(), sample_size - 1);
     }
 }
 

--- a/lib/collection/tests/integration/distance_matrix_test.rs
+++ b/lib/collection/tests/integration/distance_matrix_test.rs
@@ -126,3 +126,69 @@ async fn distance_matrix_anonymous_vector() {
         });
     }
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn distance_matrix_max_limit() {
+    let collection_dir = Builder::new().prefix("storage").tempdir().unwrap();
+    let collection = simple_collection_fixture(collection_dir.path(), 1).await;
+
+    let point_count = 50;
+    let ids = (0..point_count).map_into().collect();
+    let mut rng = SmallRng::seed_from_u64(SEED);
+
+    let vectors = (0..point_count)
+        .map(|_| rng.random::<[f32; 4]>().to_vec())
+        .collect_vec();
+
+    let batch = BatchPersisted {
+        ids,
+        vectors: BatchVectorStructPersisted::Single(vectors),
+        payloads: None,
+    };
+
+    let upsert_points = collection::operations::CollectionUpdateOperations::PointOperation(
+        collection::operations::point_ops::PointOperations::UpsertPoints(
+            collection::operations::point_ops::PointInsertOperationsInternal::from(batch),
+        ),
+    );
+
+    let hw_counter = HwMeasurementAcc::new();
+    collection
+        .update_from_client_simple(
+            upsert_points,
+            true,
+            None,
+            WriteOrdering::default(),
+            hw_counter,
+        )
+        .await
+        .unwrap();
+
+    let hw_acc = HwMeasurementAcc::new();
+    let sample_size = 10;
+    let limit_per_sample = usize::MAX;
+    let request = CollectionSearchMatrixRequest {
+        sample_size,
+        limit_per_sample,
+        filter: None,
+        using: DEFAULT_VECTOR_NAME.to_owned(),
+    };
+    let matrix = collection
+        .search_points_matrix(
+            request,
+            ShardSelectorInternal::All,
+            None,
+            None,
+            None,
+            hw_acc,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(matrix.sample_ids.len(), sample_size);
+    assert_eq!(matrix.nearests.len(), sample_size);
+    for nearest in matrix.nearests {
+        assert!(!nearest.is_empty());
+        assert!(nearest.len() < point_count);
+    }
+}

--- a/lib/collection/tests/integration/distance_matrix_test.rs
+++ b/lib/collection/tests/integration/distance_matrix_test.rs
@@ -189,6 +189,7 @@ async fn distance_matrix_max_limit() {
     assert_eq!(matrix.nearests.len(), sample_size);
     for nearest in matrix.nearests {
         assert!(!nearest.is_empty());
-        assert!(nearest.len() < point_count);
+        assert!(nearest.len() < point_count as usize);
     }
 }
+


### PR DESCRIPTION
## What does this change do?

Prevents the matrix-pairs endpoint from silently returning an empty result when `limit` is `usize::MAX`.

## Why is this change needed?

The endpoint requests one extra neighbor per sampled point so it can remove the sampled point itself. Adding one to `usize::MAX` wrapped to zero in release builds, causing valid matrix requests to return no pairs with HTTP 200. Saturating the addition preserves the largest valid query limit and avoids the overflow.

Fixes qdrant/qdrant#10548.

## How has this been tested?

- `cargo test -p collection distance_matrix --lib` in a Rust 1.98 Podman container
- Result: 3 passed, 0 failed
- `git diff --check`
