### PR TITLE
fix(strict-mode): verify group_by field of recommend groups requests

### DIFF
--- a/lib/collection/src/operations/verification/mod.rs
+++ b/lib/collection/src/operations/verification/mod.rs
@@ -429,6 +429,7 @@ mod test {
         test_request_exact(&collection).await;
         test_search_batch_limit(&collection).await;
         test_upsert_batch_limit(&collection).await;
+        test_recommend_groups_grouping_field(&collection).await;
     }
 
     async fn test_query_limit(collection: &Collection) {
@@ -647,6 +648,38 @@ mod test {
             update_mode: None,
         });
         assert_strict_mode_success(request, collection).await;
+    }
+
+    async fn test_recommend_groups_grouping_field(collection: &Collection) {
+        use api::rest::BaseGroupRequest;
+
+        use crate::operations::types::RecommendGroupsRequestInternal;
+
+        let groups_request = |key: &str| RecommendGroupsRequestInternal {
+            positive: vec![],
+            negative: vec![],
+            strategy: None,
+            filter: None,
+            params: None,
+            with_payload: None,
+            with_vector: None,
+            score_threshold: None,
+            using: None,
+            lookup_from: None,
+            group_request: BaseGroupRequest {
+                group_by: key.parse().unwrap(),
+                group_size: 1,
+                limit: 1,
+                with_lookup: None,
+            },
+        };
+
+        // group_by on an unindexed key must be rejected when
+        // unindexed_filtering_retrieve is disabled
+        assert_strict_mode_error(groups_request(UNINDEXED_KEY), collection).await;
+
+        // group_by on an indexed key passes
+        assert_strict_mode_success(groups_request(INDEXED_KEY), collection).await;
     }
 
     async fn assert_strict_mode_error<R: StrictModeVerification>(

--- a/lib/collection/src/operations/verification/recommend.rs
+++ b/lib/collection/src/operations/verification/recommend.rs
@@ -1,7 +1,10 @@
-use segment::types::Filter;
+use segment::types::{Filter, StrictModeConfig};
 
-use super::StrictModeVerification;
-use crate::operations::types::{RecommendGroupsRequestInternal, RecommendRequestInternal};
+use super::{StrictModeVerification, check_grouping_field};
+use crate::collection::Collection;
+use crate::operations::types::{
+    CollectionResult, RecommendGroupsRequestInternal, RecommendRequestInternal,
+};
 
 impl StrictModeVerification for RecommendRequestInternal {
     fn query_limit(&self) -> Option<usize> {
@@ -26,6 +29,16 @@ impl StrictModeVerification for RecommendRequestInternal {
 }
 
 impl StrictModeVerification for RecommendGroupsRequestInternal {
+    async fn check_custom(
+        &self,
+        collection: &Collection,
+        strict_mode_config: &StrictModeConfig,
+    ) -> CollectionResult<()> {
+        // check for unindexed fields targeted by group_by
+        check_grouping_field(&self.group_request.group_by, collection, strict_mode_config)?;
+        Ok(())
+    }
+
     fn query_limit(&self) -> Option<usize> {
         Some(self.group_request.limit as usize * self.group_request.group_size as usize)
     }


### PR DESCRIPTION
Closes #10572

## What

With strict mode `unindexed_filtering_retrieve: false`, the recommend groups endpoints (`POST /collections/{name}/points/recommend/groups`, gRPC `RecommendGroups`) did not verify that the `group_by` payload field is indexed. Both sibling grouped endpoints do: search groups (`SearchGroupsRequestInternal::check_custom`) and universal query groups (`CollectionQueryGroupsRequest::check_custom`) call `check_grouping_field`, which rejects an unindexed `group_by`. `RecommendGroupsRequestInternal` had no `check_custom`, so the check was silently skipped.

## Fix

Add the same `check_custom` override for `RecommendGroupsRequestInternal`, calling `check_grouping_field` exactly like search groups does. One small change in `lib/collection/src/operations/verification/recommend.rs`.

## Tests

New case in `operations::verification::test` (`test_recommend_groups_grouping_field`): a recommend groups request grouping by an unindexed key must fail strict-mode verification, grouping by an indexed key must pass. The first assertion fails without this change (verification returned `Ok`).

`cargo check -p collection --tests` passes. I could not execute the test binary in my environment (`cargo test` exceeds available memory when linking the collection test target); the test compiles, and the fail-before behavior follows from the missing `check_custom` override. Happy to adjust if CI flags anything.