### PR TITLE
Stamp `SegmentManifestState::Retiring` with the swap time

### DIFF
--- a/lib/shard/src/segment_manifest.rs
+++ b/lib/shard/src/segment_manifest.rs
@@ -39,8 +39,13 @@ pub enum SegmentManifestState {
         /// Unix seconds after which the claim is stale.
         lease_until: u64,
     },
-    /// A superseded segment that is still readable but pending removal.
-    Retiring,
+    /// A superseded segment that is still readable but pending removal. Readers on the manifest
+    /// that preceded the swap may still hold it, so its removal waits out a grace period measured
+    /// from `retired_at`.
+    Retiring {
+        /// Unix seconds of the swap that superseded the segment.
+        retired_at: u64,
+    },
 }
 
 impl SegmentManifestState {
@@ -54,7 +59,8 @@ impl SegmentManifestState {
                 holder: _,
                 lease_until: _,
             } => true,
-            SegmentManifestState::UnderConstruction | SegmentManifestState::Retiring => false,
+            SegmentManifestState::UnderConstruction
+            | SegmentManifestState::Retiring { retired_at: _ } => false,
         }
     }
 
@@ -69,7 +75,7 @@ impl SegmentManifestState {
                 holder: _,
                 lease_until: _,
             }
-            | SegmentManifestState::Retiring => false,
+            | SegmentManifestState::Retiring { retired_at: _ } => false,
         }
     }
 
@@ -83,7 +89,7 @@ impl SegmentManifestState {
                 holder: _,
                 lease_until: _,
             }
-            | SegmentManifestState::Retiring => true,
+            | SegmentManifestState::Retiring { retired_at: _ } => true,
             SegmentManifestState::Active | SegmentManifestState::UnderConstruction => false,
         }
     }
@@ -246,7 +252,7 @@ mod tests {
         let retiring = Uuid::parse_str("6ba7b811-9dad-11d1-80b4-00c04fd430c8").unwrap();
 
         let json = format!(
-            r#"{{"{active}":"active","{building}":"under_construction","{retiring}":"retiring"}}"#,
+            r#"{{"{active}":"active","{building}":"under_construction","{retiring}":{{"retiring":{{"retired_at":7}}}}}}"#,
         );
         let parsed: SegmentsManifest = serde_json::from_str(&json).unwrap();
 
@@ -255,7 +261,10 @@ mod tests {
             parsed.get(&building),
             Some(SegmentManifestState::UnderConstruction),
         );
-        assert_eq!(parsed.get(&retiring), Some(SegmentManifestState::Retiring));
+        assert_eq!(
+            parsed.get(&retiring),
+            Some(SegmentManifestState::Retiring { retired_at: 7 }),
+        );
     }
 
     #[test]
@@ -281,17 +290,17 @@ mod tests {
         assert_eq!(parsed, manifest);
     }
 
-    /// Byte-compat guard: today's writers produce bare strings for the unit states; adding
-    /// the data-carrying variant must not change how those serialize.
+    /// Byte-compat guard: the unit states serialize as bare strings; the data-carrying
+    /// variants must not change how those serialize.
     #[test]
     fn unit_states_keep_their_bare_string_form() {
         let uuid = Uuid::parse_str("6ba7b811-9dad-11d1-80b4-00c04fd430c8").unwrap();
-        let manifest: SegmentsManifest = [(uuid, SegmentManifestState::Retiring)]
+        let manifest: SegmentsManifest = [(uuid, SegmentManifestState::UnderConstruction)]
             .into_iter()
             .collect();
         assert_eq!(
             serde_json::to_string(&manifest).unwrap(),
-            r#"{"6ba7b811-9dad-11d1-80b4-00c04fd430c8":"retiring"}"#,
+            r#"{"6ba7b811-9dad-11d1-80b4-00c04fd430c8":"under_construction"}"#,
         );
     }
 
@@ -307,7 +316,7 @@ mod tests {
         };
         let previous: SegmentsManifest = [
             (kept, optimizing.clone()),
-            (gone, SegmentManifestState::Retiring),
+            (gone, SegmentManifestState::Retiring { retired_at: 7 }),
         ]
         .into_iter()
         .collect();


### PR DESCRIPTION
### What

`SegmentManifestState::Retiring` becomes `Retiring { retired_at: u64 }` (unix seconds of the swap that superseded the segment). It serializes as a tagged object, `{"retiring":{"retired_at":…}}`, the same shape as `Optimizing`.

### Why

The serverless indexer's swap marks the source segments `retiring` and publishes the rebuilt one as `active` in one manifest CAS. Read-only followers poll the manifest on their own live_reload tick (5s by default in the search worker), so for a while after the swap some of them still serve the retired segments. GC deleted those directories on the *next* mark, and on a busy shard the next mark can follow the swap within seconds. There was no bounded grace period.

With the timestamp in the mark, the GC can refuse to delete a retired segment younger than a configured minimum age. The consumer side (grace-period gate, `INDEXER_GC_RETIRING_MIN_AGE_SECS`) lives in `qdrant-serverless` and will be bumped to this revision once it lands.

### Compatibility

The bare `"retiring"` string is no longer accepted. Only the out-of-process indexer ever writes this state, and the segment manifest is behind the `write_segment_manifest` feature flag, so no production data carries the old form. Serialization of the unit states (`active`, `under_construction`) is unchanged and covered by a byte-compat test.

### Checklist

* [x] My PR targets the `dev` branch and my branch was created from `dev`.
* [x] Tests pass (`cargo test -p shard --lib segment_manifest`; the forward-compat test now parses the tagged `retiring` form).
* [x] Formatted with `cargo +nightly fmt --all`.
* [x] `cargo clippy` clean for the touched crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

