### PR TITLE
Do not claim an unfinished operation when flushing

### DIFF
--- a/lib/collection/src/shards/local_shard/snapshot.rs
+++ b/lib/collection/src/shards/local_shard/snapshot.rs
@@ -11,7 +11,7 @@ use parking_lot::RwLock;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::data_types::manifest::SegmentManifest;
 use segment::entry::StorageSegmentEntry;
-use segment::types::{SegmentConfig, SnapshotFormat};
+use segment::types::{SegmentConfig, SeqNumberType, SnapshotFormat};
 use shard::files::{APPLIED_SEQ_FILE, SEGMENT_MANIFEST_FILE, SEGMENTS_PATH, WAL_PATH};
 use shard::locked_segment::LockedSegment;
 use shard::operations::OperationWithClockTag;
@@ -27,6 +27,7 @@ use wal::{Wal, WalOptions};
 
 use crate::operations::types::{CollectionError, CollectionResult};
 use crate::shards::local_shard::{LocalShard, LocalShardClocks};
+use crate::update_workers::applied_seq::AppliedSeqHandler;
 
 impl LocalShard {
     pub async fn snapshot_manifest(&self) -> CollectionResult<SnapshotManifest> {
@@ -75,7 +76,8 @@ impl LocalShard {
             )
         };
 
-        let applied_seq_path = self.applied_seq_handler.path().to_path_buf();
+        let applied_seq_handler = self.applied_seq_handler.clone();
+        let applied_seq_path = applied_seq_handler.path().to_path_buf();
 
         let tar = tar.clone();
         let temp_path = temp_path.to_path_buf();
@@ -153,6 +155,7 @@ impl LocalShard {
                     &tar.descend(Path::new(SEGMENTS_PATH))?,
                     format,
                     manifest.as_ref(),
+                    Some(&applied_seq_handler),
                 )?;
 
                 // Staging delay: widen the window between snapshotting the segments and archiving
@@ -340,12 +343,19 @@ pub fn snapshot_all_segments(
     tar: &tar_ext::BuilderExt,
     format: SnapshotFormat,
     manifest: Option<&SnapshotManifest>,
+    applied_seq_handler: Option<&AppliedSeqHandler>,
 ) -> OperationResult<()> {
     // Snapshotting may take long-running read locks on segments blocking incoming writes, do
     // this through proxied segments to allow writes to continue.
 
+    // Updates keep flowing into the proxies' shared write segment while we snapshot, so the
+    // flush inside must not claim an operation that is still being applied to it. Read here
+    // rather than at flush time: too low only costs a re-flush on the next pass.
+    let applied_up_to = applied_seq_handler.map(AppliedSeqHandler::applied_op_num);
+
     proxy_all_segments_and_apply(
         segments,
+        applied_up_to,
         segments_path,
         segment_config,
         payload_index_schema,
@@ -397,6 +407,7 @@ pub fn snapshot_all_segments(
 /// Before snapshotting all segments are forcefully flushed to ensure all data is persisted.
 pub fn proxy_all_segments_and_apply<F>(
     segments: LockedSegmentHolder,
+    applied_up_to: Option<SeqNumberType>,
     segments_path: &Path,
     segment_config: Option<SegmentConfig>,
     payload_index_schema: Arc<SaveOnDisk<PayloadIndexSchema>>,
@@ -420,7 +431,7 @@ where
     )?;
 
     // Flush all pending changes of each segment, now wrapped segments won't change anymore
-    segments_lock.flush_all(FlushMode::Sync, true)?;
+    segments_lock.flush_all_up_to(FlushMode::Sync, true, applied_up_to)?;
 
     // Apply provided function
     log::trace!("Applying function on all proxied shard segments");

--- a/lib/collection/src/shards/local_shard/snapshot_tests.rs
+++ b/lib/collection/src/shards/local_shard/snapshot_tests.rs
@@ -57,6 +57,7 @@ fn test_snapshot_all() {
         &tar,
         SnapshotFormat::Regular,
         None,
+        None,
     )
     .unwrap();
 
@@ -143,6 +144,7 @@ fn test_snapshot_includes_segment_manifest() {
         // Descend into `segments/`, mirroring how the local shard snapshot is produced.
         &tar.descend(std::path::Path::new(SEGMENTS_PATH)).unwrap(),
         SnapshotFormat::Regular,
+        None,
         None,
     )
     .unwrap();

--- a/lib/collection/src/update_handler.rs
+++ b/lib/collection/src/update_handler.rs
@@ -248,6 +248,7 @@ impl UpdateHandler {
         let clocks = self.clocks.clone();
         let flush_interval_sec = self.flush_interval_sec;
         let shard_path = self.shard_path.clone();
+        let applied_seq_handler = self.applied_seq_handler.clone();
         let (flush_tx, flush_rx) = oneshot::channel();
         self.flush_worker = Some(self.runtime_handle.spawn(UpdateWorkers::flush_worker_fn(
             segments,
@@ -257,6 +258,7 @@ impl UpdateHandler {
             flush_interval_sec,
             flush_rx,
             shard_path,
+            applied_seq_handler,
         )));
 
         self.flush_stop = Some(flush_tx);

--- a/lib/collection/src/update_workers/applied_seq.rs
+++ b/lib/collection/src/update_workers/applied_seq.rs
@@ -51,6 +51,19 @@ impl AppliedSeqHandler {
         }
     }
 
+    /// The last operation the update worker finished applying.
+    ///
+    /// Unlike [`AppliedSeqHandler::op_num`] this does not disappear for a handler running
+    /// without its file: the in-memory value is maintained either way, and a flush needs the
+    /// bound in both cases (see `StorageSegmentEntry::flusher`).
+    ///
+    /// Monotonic, and never ahead of the applied work: the update worker is serial and stores
+    /// this after an operation is applied, so the value can lag by the moment between the two.
+    /// Lagging only costs a re-flush on a later pass.
+    pub fn applied_op_num(&self) -> u64 {
+        self.op_num.load(Ordering::Relaxed)
+    }
+
     /// Get the op_num upper bound for the last_applied_seq adjusted to the persistence interval
     ///
     /// Returns None if the handler is not active.

--- a/lib/collection/src/update_workers/flush_workers.rs
+++ b/lib/collection/src/update_workers/flush_workers.rs
@@ -14,16 +14,25 @@ use tokio::sync::oneshot;
 
 use crate::shards::local_shard::LocalShardClocks;
 use crate::update_workers::UpdateWorkers;
+use crate::update_workers::applied_seq::AppliedSeqHandler;
 use crate::wal_delta::LockedWal;
 
 impl UpdateWorkers {
     /// Returns confirmed version after flush of all segments
     ///
+    /// `applied_up_to` is the last operation the update worker finished applying. This pass runs
+    /// concurrently with the update worker and can start between the phases of one operation, so
+    /// no segment may claim a version past it. See [`StorageSegmentEntry::flusher`].
+    ///
     /// # Errors
     /// Returns an error on flush failure
-    fn flush_segments(segments: LockedSegmentHolder) -> OperationResult<SeqNumberType> {
+    fn flush_segments(
+        segments: LockedSegmentHolder,
+        applied_up_to: Option<SeqNumberType>,
+    ) -> OperationResult<SeqNumberType> {
         let read_segments = segments.read();
-        let flushed_version = read_segments.flush_all(FlushMode::Background, false)?;
+        let flushed_version =
+            read_segments.flush_all_up_to(FlushMode::Background, false, applied_up_to)?;
         Ok(match read_segments.failed_operation.iter().cloned().min() {
             None => flushed_version,
             Some(failed_operation) => min(failed_operation, flushed_version),
@@ -36,6 +45,7 @@ impl UpdateWorkers {
         wal_keep_from: Arc<AtomicU64>,
         clocks: LocalShardClocks,
         shard_path: PathBuf,
+        applied_seq_handler: Arc<AppliedSeqHandler>,
     ) {
         log::trace!("Attempting flushing");
         let wal_flush_job = wal.blocking_lock().flush_async();
@@ -62,7 +72,11 @@ impl UpdateWorkers {
             return;
         }
 
-        let confirmed_version = Self::flush_segments(segments.clone());
+        // Read before capturing anything: an operation that finishes during the flush must not
+        // raise the cap for segments this pass already captured half of.
+        let applied_up_to = applied_seq_handler.applied_op_num();
+
+        let confirmed_version = Self::flush_segments(segments.clone(), Some(applied_up_to));
         let confirmed_version = match confirmed_version {
             Ok(version) => version,
             Err(err) => {
@@ -99,6 +113,7 @@ impl UpdateWorkers {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn flush_worker_fn(
         segments: LockedSegmentHolder,
         wal: LockedWal,
@@ -107,6 +122,7 @@ impl UpdateWorkers {
         flush_interval_sec: u64,
         mut stop_receiver: oneshot::Receiver<()>,
         shard_path: PathBuf,
+        applied_seq_handler: Arc<AppliedSeqHandler>,
     ) {
         loop {
             tokio::select! {
@@ -125,6 +141,7 @@ impl UpdateWorkers {
             let wal_keep_from_clone = wal_keep_from.clone();
             let clocks_clone = clocks.clone();
             let shard_path_clone = shard_path.clone();
+            let applied_seq_handler_clone = applied_seq_handler.clone();
 
             tokio::task::spawn_blocking(move || {
                 Self::flush_worker_internal(
@@ -133,6 +150,7 @@ impl UpdateWorkers {
                     wal_keep_from_clone,
                     clocks_clone,
                     shard_path_clone,
+                    applied_seq_handler_clone,
                 )
             })
             .await

--- a/lib/segment/src/entry/entry_point.rs
+++ b/lib/segment/src/entry/entry_point.rs
@@ -297,12 +297,24 @@ pub trait StorageSegmentEntry: ReadSegmentEntry + SnapshotEntry {
     /// Returns a function, which when called, will flush all pending changes to disk.
     /// If there are currently no changes to flush, returns None.
     /// If `force` is true, will return a flusher even if there are no changes to flush.
-    fn flusher(&self, force: bool) -> Option<Flusher>;
+    ///
+    /// `up_to` caps the version the flush is allowed to claim as persisted, and must be the
+    /// last operation known to be fully applied when the flusher is captured. It may still write
+    /// newer operations to disk though. One update operation writes a segment in several
+    /// separately locked phases under the same operation number, so a flush capturing the segment
+    /// between them holds only part of that operation. Claiming its version would leave the
+    /// segment at `version == persisted_version` with the rest still in memory: every later flush
+    /// skips it and the WAL acknowledge moves past the operation, dropping the rest for good
+    /// (#10402). Pass `None` only when the flush cannot race an update operation.
+    fn flusher(&self, force: bool, up_to: Option<SeqNumberType>) -> Option<Flusher>;
 
     /// Immediately flush all changes to disk and return persisted version.
     /// Blocks the current thread.
+    ///
+    /// Claims everything the segment holds, so only for flushes that cannot race an update
+    /// operation. See `flusher`.
     fn flush(&self, force: bool) -> OperationResult<SeqNumberType> {
-        if let Some(flusher) = self.flusher(force) {
+        if let Some(flusher) = self.flusher(force, None) {
             flusher()?;
         }
         Ok(self.persistent_version())

--- a/lib/segment/src/segment/entry.rs
+++ b/lib/segment/src/segment/entry.rs
@@ -397,7 +397,7 @@ impl StorageSegmentEntry for Segment {
         (*self.persisted_version.lock()).unwrap_or(0)
     }
 
-    fn flusher(&self, force: bool) -> Option<Flusher> {
+    fn flusher(&self, force: bool, up_to: Option<SeqNumberType>) -> Option<Flusher> {
         let current_persisted_version: Option<SeqNumberType> = *self.persisted_version.lock();
 
         match (self.version, current_persisted_version) {
@@ -426,7 +426,20 @@ impl StorageSegmentEntry for Segment {
             .values()
             .filter_map(|v| v.quantized_vectors.borrow().as_ref().map(|q| q.flusher()))
             .collect();
-        let state = self.get_state();
+        let mut state = self.get_state();
+        // The state captured above holds only part of `version` when the operation writing it
+        // has not finished; `up_to` is the last one that did. Persist the segment as that
+        // version, so it stays dirty for the rest of the operation and the WAL keeps the
+        // operation replayable. The clamp goes into the state file as well: reloading at the
+        // unfinished version would make the segment look clean again, with the replayed
+        // remainder in memory and nothing left to flush it.
+        if let (Some(version), Some(up_to)) = (state.version, up_to)
+            && up_to < version
+        {
+            state.version = Some(up_to);
+            // Keeps the file consistent when the segment was created by this very operation
+            state.initial_version = state.initial_version.map(|initial| initial.min(up_to));
+        }
         let segment_path = self.segment_path.clone();
         let id_tracker_mapping_flusher = self.id_tracker.borrow().mapping_flusher();
         let payload_index_flusher = self.payload_index.borrow().flusher();

--- a/lib/segment/src/segment/tests/mod.rs
+++ b/lib/segment/src/segment/tests/mod.rs
@@ -2750,6 +2750,83 @@ fn test_deleted_deferred_point_count() {
     }
 }
 
+/// A flush pass can capture a segment between the phases of ONE update operation: the points
+/// that already exist are written under one lock, the new ones under another, both carrying the
+/// same operation number. Claiming that operation's version would leave the segment at
+/// `version == persisted_version` with the second phase still in memory, so every later pass
+/// skips it while the WAL acknowledge moves past the operation. Root cause of the missing points
+/// in #10402.
+#[test]
+fn test_flush_does_not_claim_an_unfinished_operation() {
+    init_logger();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let mut segment = build_simple_segment(dir.path(), 4, Distance::Dot).unwrap();
+
+    segment
+        .upsert_point(
+            10,
+            1.into(),
+            only_default_vector(&[1.0, 0.0, 0.0, 0.0]),
+            &hw_counter,
+        )
+        .unwrap();
+
+    // Operation 10 is still being applied, so the last finished operation is 9.
+    let flusher = segment
+        .flusher(false, Some(9))
+        .expect("segment has unflushed changes");
+    flusher().expect("flush must not fail");
+
+    assert_eq!(segment.version(), 10);
+    assert_eq!(
+        segment.persistent_version(),
+        9,
+        "a flush must not claim an operation that has not finished applying",
+    );
+
+    // The segment is therefore not clean, and the next pass flushes the rest of operation 10
+    // instead of skipping it. A skip would leave the persisted version at 9.
+    assert_eq!(segment.flush(false).unwrap(), 10);
+    assert!(
+        segment.flusher(false, None).is_none(),
+        "a fully persisted segment must not be flushed again",
+    );
+}
+
+/// The clamp must reach the segment state file, not just the in-memory persisted version.
+/// A segment reloading at the operation's own version would be clean again, with the second
+/// phase replayed from the WAL into memory and nothing left to flush it.
+#[test]
+fn test_flush_of_unfinished_operation_reloads_dirty() {
+    init_logger();
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+    let mut segment = build_simple_segment(dir.path(), 4, Distance::Dot).unwrap();
+    let segment_path = segment.segment_path.clone();
+
+    segment
+        .upsert_point(
+            10,
+            1.into(),
+            only_default_vector(&[1.0, 0.0, 0.0, 0.0]),
+            &hw_counter,
+        )
+        .unwrap();
+    segment
+        .flusher(false, Some(9))
+        .expect("segment has unflushed changes")()
+    .expect("flush must not fail");
+    drop(segment);
+
+    let reloaded = load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
+
+    // Coming back at 10 would make the segment look clean, and the WAL replay of operation 10
+    // would sit in memory with nothing left to flush it.
+    assert_eq!(reloaded.version(), 9);
+    assert_eq!(reloaded.persistent_version(), 9);
+}
+
 /// A field index dropped between flusher capture and execution (a `DropIndex`
 /// racing the background flush) must not abort the rest of the flush sequence.
 ///
@@ -2788,7 +2865,7 @@ fn test_flush_survives_concurrent_field_index_drop() {
     // Capture the flushers (as the background flush thread does), then drop the
     // index before executing them.
     let flusher = segment
-        .flusher(true)
+        .flusher(true, None)
         .expect("segment has unflushed changes");
     segment
         .delete_field_index(4, &JsonPath::new("num"))

--- a/lib/shard/src/proxy_segment/segment_entry.rs
+++ b/lib/shard/src/proxy_segment/segment_entry.rs
@@ -796,10 +796,10 @@ impl StorageSegmentEntry for ProxySegment {
         self.wrapped_segment.get().read().persistent_version()
     }
 
-    fn flusher(&self, force: bool) -> Option<Flusher> {
+    fn flusher(&self, force: bool, up_to: Option<SeqNumberType>) -> Option<Flusher> {
         let wrapped_segment = self.wrapped_segment.get();
         let wrapped_segment_guard = wrapped_segment.read();
-        wrapped_segment_guard.flusher(force)
+        wrapped_segment_guard.flusher(force, up_to)
     }
 
     fn drop_data(self) -> OperationResult<()> {

--- a/lib/shard/src/segment_holder/flush.rs
+++ b/lib/shard/src/segment_holder/flush.rs
@@ -29,7 +29,26 @@ impl SegmentHolder {
     ///
     /// If there are unsaved changes after flush - detects lowest unsaved change version.
     /// If all changes are saved - returns max version.
+    ///
+    /// Claims everything the segments hold, so only for flushes that cannot run while an update
+    /// operation is being applied. Use [`SegmentHolder::flush_all_up_to`] otherwise.
     pub fn flush_all(&self, mode: FlushMode, force: bool) -> OperationResult<SeqNumberType> {
+        self.flush_all_up_to(mode, force, None)
+    }
+
+    /// [`SegmentHolder::flush_all`], but no segment may claim a version past `up_to`.
+    ///
+    /// `up_to` is the last operation known to be fully applied. The holder read lock does not
+    /// exclude an update operation, so a flush pass can start between the phases of one and
+    /// capture a segment holding only part of it. See [`StorageSegmentEntry::flusher`]. This will
+    /// also flush newer operations than `up_to`, but it won't bump the segment version past
+    /// `up_to`.
+    pub fn flush_all_up_to(
+        &self,
+        mode: FlushMode,
+        force: bool,
+        up_to: Option<SeqNumberType>,
+    ) -> OperationResult<SeqNumberType> {
         let sync = match mode {
             FlushMode::Sync => true,
             FlushMode::Background => false,
@@ -99,8 +118,16 @@ impl SegmentHolder {
         // Capture all flushers first to improve data consistency
         let flushers: Vec<_> = segment_reads
             .iter()
-            .filter_map(|read_segment| read_segment.flusher(force))
+            .filter_map(|read_segment| read_segment.flusher(force, up_to))
             .collect();
+
+        // Copy-on-write dependencies are only satisfied up to what this pass actually persists.
+        // The segments may hold more than that: `up_to` clamps them to the last fully applied
+        // operation, so an edge registered by an operation past it must outlive this pass. Were
+        // it dropped, the next pass would be free to flush the source before the destination,
+        // and a crash in between would leave the move without a durable pre-image to replay.
+        let cleanup_up_to =
+            up_to.map_or(max_applied_version, |up_to| min(max_applied_version, up_to));
 
         if sync {
             for flusher in flushers {
@@ -108,7 +135,7 @@ impl SegmentHolder {
             }
             self.flush_dependency
                 .lock()
-                .retain(|_, _, version| *version > max_applied_version);
+                .retain(|_, _, version| *version > cleanup_up_to);
         } else {
             let flush_dependency = self.flush_dependency.clone();
             *background_flush_lock = Some(
@@ -120,7 +147,7 @@ impl SegmentHolder {
                         }
                         flush_dependency
                             .lock()
-                            .retain(|_, _, version| *version > max_applied_version);
+                            .retain(|_, _, version| *version > cleanup_up_to);
                         Ok(())
                     })
                     .unwrap(),
@@ -296,7 +323,7 @@ impl SegmentHolder {
         segment_reads: Vec<RwLockReadGuard<'_, dyn StorageSegmentEntry>>,
         lock_order: Vec<SegmentId>,
     ) -> SeqNumberType {
-        // Start with the max_persisted_vesrion at the set overwrite value, which may just be 0
+        // Start with the max_persisted_version at the set overwrite value, which may just be 0
         // Any of the segments we flush may increase this if they have a higher persisted version
         // The overwrite is required to ensure we acknowledge no-op operations in WAL that didn't hit any segment
         //

--- a/lib/shard/src/segment_holder/tests.rs
+++ b/lib/shard/src/segment_holder/tests.rs
@@ -2428,3 +2428,115 @@ fn test_cow_move_prefers_uncapped_segment_over_full_deferred_staging_segment() {
         "Source copy should be deleted, the destination copy is visible",
     );
 }
+
+/// A flush pass takes only the holder read lock, so it can start between the phases of one
+/// update operation and capture a segment holding half of it. Neither that segment nor the
+/// acknowledged version may claim the operation: the segment would look fully persisted at
+/// `version == persisted_version`, every later pass would skip it, and the WAL entry that could
+/// replay the rest would be acknowledged away (#10402).
+#[test]
+fn test_flush_all_does_not_claim_an_unfinished_operation() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    // First phase of operation 10.
+    let mut segment = empty_segment(dir.path());
+    segment
+        .upsert_point(
+            10,
+            1.into(),
+            segment::data_types::vectors::only_default_vector(&[1.0, 0.0, 0.0, 0.0]),
+            &hw_counter,
+        )
+        .unwrap();
+
+    let mut holder = SegmentHolder::default();
+    holder.add_new(segment);
+
+    // Operation 10 has not finished applying, so the last finished operation is 9.
+    assert_eq!(
+        holder
+            .flush_all_up_to(FlushMode::Sync, false, Some(9))
+            .unwrap(),
+        9,
+        "the acknowledged version must leave the unfinished operation replayable",
+    );
+
+    // The segment stays unsaved, so the rest of the operation is flushed once it is applied.
+    assert_eq!(holder.flush_all(FlushMode::Sync, false).unwrap(), 10);
+}
+
+/// A copy-on-write dependency is retired once the flush pass has persisted it. A clamped pass
+/// persists only up to the last fully applied operation, so an edge registered past that bound
+/// must survive it: dropping it would let the next pass flush the source before the destination,
+/// and a crash in between leaves the move without a durable pre-image to replay.
+#[test]
+fn test_flush_up_to_keeps_cow_dependency_past_the_bound() {
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let hw_counter = HardwareCounterCell::new();
+
+    let mut source = empty_segment(dir.path());
+    source
+        .upsert_point(
+            10,
+            100.into(),
+            segment::data_types::vectors::only_default_vector(&[0.0, 0.0, 0.0, 0.0]),
+            &hw_counter,
+        )
+        .unwrap();
+    source.appendable_flag = false;
+
+    let mut holder = SegmentHolder::default();
+    let source_id = holder.add_new(source);
+    holder.add_new(empty_segment(dir.path()));
+
+    // Operation 20 moves the point out of the non-appendable segment, recording the dependency.
+    holder
+        .apply_points_with_conditional_move(
+            20,
+            &[100.into()],
+            |_, _| unreachable!("the point's segment is non-appendable, it must be moved"),
+            |_, _, _, _| {},
+            None,
+            &hw_counter,
+        )
+        .unwrap();
+    assert_eq!(
+        holder
+            .flush_dependency
+            .lock()
+            .dependencies_of(&source_id)
+            .count(),
+        1,
+        "the move should record a copy-on-write dependency",
+    );
+
+    // Operation 20 has not finished applying, so the pass persists no further than 19.
+    assert_eq!(
+        holder
+            .flush_all_up_to(FlushMode::Sync, false, Some(19))
+            .unwrap(),
+        19,
+    );
+    assert_eq!(
+        holder
+            .flush_dependency
+            .lock()
+            .dependencies_of(&source_id)
+            .count(),
+        1,
+        "the dependency of an operation past the bound is not persisted yet, it must be kept",
+    );
+
+    // Once the operation is applied, an unclamped pass persists the move and retires the edge.
+    assert_eq!(holder.flush_all(FlushMode::Sync, false).unwrap(), 20);
+    assert_eq!(
+        holder
+            .flush_dependency
+            .lock()
+            .dependencies_of(&source_id)
+            .count(),
+        0,
+        "the dependency is persisted, it must be retired",
+    );
+}

--- a/lib/shard/src/update/payload.rs
+++ b/lib/shard/src/update/payload.rs
@@ -11,7 +11,7 @@ use super::helpers::{check_unprocessed_points, points_by_filter};
 use crate::segment_holder::SegmentHolder;
 
 /// Batch size when modifying payload
-const PAYLOAD_OP_BATCH_SIZE: usize = 32;
+pub(crate) const PAYLOAD_OP_BATCH_SIZE: usize = 32;
 
 pub fn set_payload(
     segments: &SegmentHolder,

--- a/lib/shard/src/update/tests.rs
+++ b/lib/shard/src/update/tests.rs
@@ -1040,3 +1040,117 @@ fn create_field_index_flushes_cow_destinations_before_source() {
          the only remaining copy is memory-only, got {destination_persisted}",
     );
 }
+
+/// One update operation is applied to a segment in several separately locked steps, and a flush
+/// pass can land in any of the gaps. `set_payload` walks its points in chunks of
+/// [`PAYLOAD_OP_BATCH_SIZE`], each chunk taking the segment write lock on its own, so a
+/// thousand-point payload update offers 31 such gaps. The first chunk already raises the segment
+/// to the operation's version while most of its points are untouched.
+///
+/// A flush there must not claim that version. Claiming it makes the segment clean at
+/// `version == persisted_version`, so the chunks that follow are never flushed, the WAL entry
+/// that would replay them is acknowledged away, and the points come back missing after a
+/// restart. That is #10402.
+#[test]
+fn flush_between_batches_of_one_operation_keeps_the_rest_replayable() {
+    use std::sync::atomic::AtomicBool;
+
+    use common::types::DeferredBehavior;
+    use segment::segment_constructor::load_segment;
+    use uuid::Uuid;
+
+    use crate::update::payload::PAYLOAD_OP_BATCH_SIZE;
+    use crate::update::set_payload;
+
+    /// More than one batch, so the operation cannot be applied in a single locked step
+    const POINT_COUNT: u64 = PAYLOAD_OP_BATCH_SIZE as u64 + 8;
+
+    let dir = Builder::new().prefix("segment_dir").tempdir().unwrap();
+    let is_stopped = AtomicBool::new(false);
+    let hw_counter = HardwareCounterCell::new();
+
+    let mut segment = empty_segment(dir.path());
+    let segment_path = segment.segment_path.clone();
+    let ids: Vec<PointIdType> = (1..=POINT_COUNT).map(PointIdType::from).collect();
+    for id in &ids {
+        segment
+            .upsert_point(
+                1,
+                *id,
+                only_default_vector(&[1.0, 0.0, 0.0, 0.0]),
+                &hw_counter,
+            )
+            .unwrap();
+    }
+
+    let mut holder = SegmentHolder::default();
+    let segment_id = holder.add_new(segment);
+    holder.flush_all(FlushMode::Sync, true).unwrap();
+
+    // Operation 10 sets a payload on every point. This is its first batch; the update worker
+    // has not returned, so the last fully applied operation is still 9.
+    let payload = payload_json! {"city": "Berlin"};
+    set_payload(
+        &holder,
+        10,
+        &payload,
+        &ids[..PAYLOAD_OP_BATCH_SIZE],
+        &None,
+        None,
+        &hw_counter,
+    )
+    .unwrap();
+    assert_eq!(
+        holder.get(segment_id).unwrap().get().read().version(),
+        10,
+        "the first batch already carries the segment to the operation's version",
+    );
+
+    // A flush pass lands in the gap before the next batch.
+    assert_eq!(
+        holder
+            .flush_all_up_to(FlushMode::Sync, false, Some(9))
+            .unwrap(),
+        9,
+        "the acknowledged version must leave the unfinished operation replayable",
+    );
+
+    // The remaining batches of the same operation.
+    set_payload(
+        &holder,
+        10,
+        &payload,
+        &ids[PAYLOAD_OP_BATCH_SIZE..],
+        &None,
+        None,
+        &hw_counter,
+    )
+    .unwrap();
+
+    // The next pass sees operation 10 finished and must persist the rest of it. Had the pass
+    // above claimed version 10, the segment would look clean here and be skipped.
+    assert_eq!(
+        holder
+            .flush_all_up_to(FlushMode::Sync, false, Some(10))
+            .unwrap(),
+        10,
+    );
+
+    drop(holder);
+    let reloaded = load_segment(&segment_path, Uuid::nil(), None, &AtomicBool::new(false)).unwrap();
+    let hits = reloaded
+        .read_filtered(
+            None,
+            None,
+            Some(&city_filter("Berlin")),
+            &is_stopped,
+            &hw_counter,
+            DeferredBehavior::VisibleOnly,
+        )
+        .unwrap();
+    assert_eq!(
+        hits.len(),
+        POINT_COUNT as usize,
+        "every point of operation 10 must survive a restart, not just its first batch",
+    );
+}

--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -197,9 +197,11 @@ mod tests {
     fn insert_keeps_memory_state_when_persistence_fails() {
         let (mut persistence, original) = persistence_with_unwritable_path();
 
-        assert!(persistence
-            .insert("new_alias".to_string(), "new_collection".to_string())
-            .is_err());
+        assert!(
+            persistence
+                .insert("new_alias".to_string(), "new_collection".to_string())
+                .is_err()
+        );
         assert_eq!(persistence.state(), &original);
     }
 


### PR DESCRIPTION
Fixes the missing points of #10402: a flush must not claim an operation that is still being applied. Replaces #10428.

- One operation writes a segment in several separately locked steps (`set_payload` and friends walk their points in chunks of 32). A flush pass can capture a segment holding only part of it.

- Claiming that operation's version leaves the segment at `version == persisted_version`. Later passes skip it, the WAL acknowledge moves past the operation, and the rest is gone at the next restart.

- `flusher` now takes `up_to`, the last fully applied operation, and persists that version instead, in the segment state file too. The clamped segment still reports itself unsaved, so it is flushed again and holds the acknowledge back.
