### PR TITLE
Validate text index min_token_len is not above max_token_len

### DIFF
--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -570,9 +570,17 @@ impl Validate for super::qdrant::payload_index_params::IndexParams {
 impl Validate for super::qdrant::TextIndexParams {
     fn validate(&self) -> Result<(), ValidationErrors> {
         let super::qdrant::TextIndexParams {
+            tokenizer: _,
+            lowercase: _,
             min_token_len,
             max_token_len,
-            ..
+            on_disk: _,
+            stopwords: _,
+            phrase_matching: _,
+            stemmer: _,
+            ascii_folding: _,
+            enable_hnsw: _,
+            memory: _,
         } = self;
         validate_text_index_params(
             &min_token_len.map(|len| len as usize),

--- a/lib/api/src/grpc/validate.rs
+++ b/lib/api/src/grpc/validate.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 use common::validation::{validate_range_generic, validate_shard_different_peers};
-use segment::data_types::index::validate_integer_index_params;
+use segment::data_types::index::{validate_integer_index_params, validate_text_index_params};
 use validator::{Validate, ValidationError, ValidationErrors};
 
 use super::qdrant as grpc;
@@ -557,11 +557,27 @@ impl Validate for super::qdrant::payload_index_params::IndexParams {
             }
             grpc::payload_index_params::IndexParams::FloatIndexParams(_) => Ok(()),
             grpc::payload_index_params::IndexParams::GeoIndexParams(_) => Ok(()),
-            grpc::payload_index_params::IndexParams::TextIndexParams(_) => Ok(()),
+            grpc::payload_index_params::IndexParams::TextIndexParams(text_index_params) => {
+                text_index_params.validate()
+            }
             grpc::payload_index_params::IndexParams::BoolIndexParams(_) => Ok(()),
             grpc::payload_index_params::IndexParams::DatetimeIndexParams(_) => Ok(()),
             grpc::payload_index_params::IndexParams::UuidIndexParams(_) => Ok(()),
         }
+    }
+}
+
+impl Validate for super::qdrant::TextIndexParams {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        let super::qdrant::TextIndexParams {
+            min_token_len,
+            max_token_len,
+            ..
+        } = self;
+        validate_text_index_params(
+            &min_token_len.map(|len| len as usize),
+            &max_token_len.map(|len| len as usize),
+        )
     }
 }
 

--- a/lib/edge/ffi/src/payload_index.rs
+++ b/lib/edge/ffi/src/payload_index.rs
@@ -686,13 +686,24 @@ impl TryFrom<PayloadIndexParams> for PayloadSchemaParams {
                     stemmer,
                     enable_hnsw,
                 } = config;
+                let min_token_len = token_len("min_token_len", min_token_len)?;
+                let max_token_len = token_len("max_token_len", max_token_len)?;
+                // Same rule the server enforces on its API: a min above max
+                // rejects every token and would silently build an empty index.
+                segment_index::validate_text_index_params(&min_token_len, &max_token_len)
+                    .map_err(|_| {
+                        EdgeError::invalid_argument(
+                            "text index: the 'min_token_len' cannot be greater than \
+                             the 'max_token_len'",
+                        )
+                    })?;
                 Ok(PayloadSchemaParams::Text(segment_index::TextIndexParams {
                     r#type: segment_index::TextIndexType::Text,
                     tokenizer: tokenizer
                         .map(segment_index::TokenizerType::from)
                         .unwrap_or_default(),
-                    min_token_len: token_len("min_token_len", min_token_len)?,
-                    max_token_len: token_len("max_token_len", max_token_len)?,
+                    min_token_len,
+                    max_token_len,
                     lowercase,
                     ascii_folding,
                     phrase_matching,

--- a/lib/segment/src/data_types/index.rs
+++ b/lib/segment/src/data_types/index.rs
@@ -310,6 +310,33 @@ pub struct TextIndexParams {
     pub enable_hnsw: Option<bool>,
 }
 
+impl Validate for TextIndexParams {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        let TextIndexParams {
+            min_token_len,
+            max_token_len,
+            ..
+        } = self;
+        validate_text_index_params(min_token_len, max_token_len)
+    }
+}
+
+pub fn validate_text_index_params(
+    min_token_len: &Option<usize>,
+    max_token_len: &Option<usize>,
+) -> Result<(), ValidationErrors> {
+    if let (Some(min), Some(max)) = (min_token_len, max_token_len)
+        && min > max
+    {
+        let mut errors = ValidationErrors::new();
+        let error =
+            ValidationError::new("the 'min_token_len' cannot be greater than the 'max_token_len'");
+        errors.add("min_token_len", error);
+        return Err(errors);
+    }
+    Ok(())
+}
+
 #[derive(Default, Debug, Deserialize, Serialize, JsonSchema, Clone, Copy, PartialEq, Hash, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Snowball {
@@ -627,6 +654,7 @@ pub struct DatetimeIndexParams {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::PayloadSchemaParams;
 
     #[test]
     fn test_stemming_algorithm_serialization() {
@@ -792,5 +820,36 @@ mod tests {
             StopwordsInterface::new_set(&[Language::English, Language::French], &["AAA"]);
 
         assert_eq!(stopwords_multiple, expected_set);
+    }
+    fn text_params(min: Option<usize>, max: Option<usize>) -> TextIndexParams {
+        TextIndexParams {
+            min_token_len: min,
+            max_token_len: max,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_text_index_params_reject_min_above_max() {
+        // A min_token_len above max_token_len rejects every token during
+        // indexing, silently building an empty full-text index. The schema
+        // validation must reject it instead.
+        let schema = PayloadSchemaParams::Text(text_params(Some(10), Some(5)));
+        assert!(schema.validate().is_err());
+    }
+
+    #[test]
+    fn test_text_index_params_accept_valid_token_lens() {
+        // Unset bounds, min < max, and min == max are all fine.
+        for (min, max) in [
+            (None, None),
+            (Some(3), None),
+            (None, Some(10)),
+            (Some(3), Some(10)),
+            (Some(5), Some(5)),
+        ] {
+            let schema = PayloadSchemaParams::Text(text_params(min, max));
+            assert!(schema.validate().is_ok(), "min={min:?} max={max:?}");
+        }
     }
 }

--- a/lib/segment/src/data_types/index.rs
+++ b/lib/segment/src/data_types/index.rs
@@ -313,9 +313,18 @@ pub struct TextIndexParams {
 impl Validate for TextIndexParams {
     fn validate(&self) -> Result<(), ValidationErrors> {
         let TextIndexParams {
+            r#type: _,
+            tokenizer: _,
             min_token_len,
             max_token_len,
-            ..
+            lowercase: _,
+            ascii_folding: _,
+            phrase_matching: _,
+            stopwords: _,
+            on_disk: _,
+            memory: _,
+            stemmer: _,
+            enable_hnsw: _,
         } = self;
         validate_text_index_params(min_token_len, max_token_len)
     }

--- a/lib/segment/src/types.rs
+++ b/lib/segment/src/types.rs
@@ -2748,7 +2748,7 @@ impl Validate for PayloadSchemaParams {
             PayloadSchemaParams::Integer(integer_index_params) => integer_index_params.validate(),
             PayloadSchemaParams::Float(_) => Ok(()),
             PayloadSchemaParams::Geo(_) => Ok(()),
-            PayloadSchemaParams::Text(_) => Ok(()),
+            PayloadSchemaParams::Text(text_index_params) => text_index_params.validate(),
             PayloadSchemaParams::Bool(_) => Ok(()),
             PayloadSchemaParams::Datetime(_) => Ok(()),
             PayloadSchemaParams::Uuid(_) => Ok(()),


### PR DESCRIPTION
Fixes #10578

## Problem

A full-text payload index created with `min_token_len` > `max_token_len` was accepted by both the REST and gRPC APIs. The token filter drops any token shorter than `min_token_len` or longer than `max_token_len`, so the inverted range rejects every token: the index builds successfully but stays empty, and all text queries on the field silently return no results.

## Fix

Reject the inverted range at request validation, mirroring the existing cross-field validation for integer index params (`validate_integer_index_params`):

- New `validate_text_index_params` helper and `impl Validate for TextIndexParams` in `lib/segment/src/data_types/index.rs`.
- Wired into the REST path (`PayloadSchemaParams::Text` in `types.rs`, previously `Ok(())`).
- Wired into the gRPC path (`impl Validate for qdrant::TextIndexParams` in `validate.rs`, previously `Ok(())`).
- Same check added to the edge FFI conversion, matching how the integer rule is enforced there.

## Tests

Added in `lib/segment/src/data_types/index.rs`:

- `test_text_index_params_reject_min_above_max` — `PayloadSchemaParams::Text` with min 10 / max 5 fails validation. On the pre-fix code this returned `Ok(())` (fail-before verified against the pre-fix `Ok(())` arm).
- `test_text_index_params_accept_valid_token_lens` — unset bounds, min < max, and min == max all pass.

## Notes

- `cargo check -p segment --tests`, `-p api --tests`, and `-p edge --tests` pass; the full test suite was not run locally (resource limits on my machine).
- The user-visible impact was confirmed by extracting the token filter into a standalone program: with min=10/max=5 every token is rejected (empty index), while a sane config indexes normally.