### PR TITLE
chore(deps): trim workspace tokio full to minimal features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ urlencoding = { workspace = true }
 
 config = { version = "0.15.22", default-features = false, features = ["yaml"] }
 
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["signal"] }
 tokio-util = { workspace = true }
 
 actix-cors = "0.7.1"
@@ -298,7 +298,7 @@ tap = "1.0.1"
 tar = { version = "0.4.46", default-features = false }
 tempfile = "3.27.0"
 tinyvec = { version = "1.11.0", features = ["alloc", "latest_stable_rust"] }
-tokio = { version = "1.52.3", features = ["full"] }
+tokio = { version = "1.52.3", features = ["fs", "io-std", "io-util", "macros", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["io", "io-util", "rt"] }
 tonic = { version = "0.14.6", features = ["gzip", "tls-ring"] }
 tonic-prost = { version = "0.14.6" }


### PR DESCRIPTION
Libraries only need fs/io/macros/rt/sync/time; the server binary opts into signal explicitly. Drops process/signal (and full) from edge builds where full was unifying them into every target.

Workspace: tokio full -> fs, io-std, io-util, macros, rt, rt-multi-thread, sync, time. Root qdrant bin adds signal (src/main.rs, tonic/mod.rs). Net stays available transitively via axum/tonic/reqwest for server; process has zero tokio::process users.

Verification:
- cargo check --workspace --all-targets green
- cargo clippy --workspace --all-targets -- -D warnings green
- cargo test -p wal --lib green (38 passed)
- cargo tree -p edge -f "{p} {f}" -i tokio no longer shows full/process/signal (net remains via object_store until #10145 lands; stacks with it)
- cargo fmt: only pre-existing on_disk_postings.rs diff, untouched here