### PR TITLE
fix(segment): return Distance::Cosine for f16 CosineMetric

### DIFF
--- a/lib/segment/src/spaces/metric_f16/simple_cosine.rs
+++ b/lib/segment/src/spaces/metric_f16/simple_cosine.rs
@@ -22,7 +22,7 @@ use crate::types::Distance;
 
 impl Metric<VectorElementTypeHalf> for CosineMetric {
     fn distance() -> Distance {
-        Distance::Dot
+        Distance::Cosine
     }
 
     fn similarity(v1: &[VectorElementTypeHalf], v2: &[VectorElementTypeHalf]) -> ScoreType {
@@ -84,5 +84,21 @@ impl Metric<VectorElementTypeHalf> for CosineMetric {
         }
 
         cosine_preprocess(vector)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_types::vectors::{VectorElementType, VectorElementTypeByte};
+
+    #[test]
+    fn test_cosine_distance_consistency() {
+        let f32_dist = <CosineMetric as Metric<VectorElementType>>::distance();
+        let u8_dist = <CosineMetric as Metric<VectorElementTypeByte>>::distance();
+        let f16_dist = <CosineMetric as Metric<VectorElementTypeHalf>>::distance();
+        assert_eq!(f16_dist, Distance::Cosine);
+        assert_eq!(f16_dist, f32_dist);
+        assert_eq!(f16_dist, u8_dist);
     }
 }


### PR DESCRIPTION
### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---

## Summary

Fixes `<CosineMetric as Metric<VectorElementTypeHalf>>::distance()` incorrectly returning `Distance::Dot` instead of `Distance::Cosine`.

## Problem

In `lib/segment/src/spaces/metric_f16/simple_cosine.rs`:
```rust
impl Metric<VectorElementTypeHalf> for CosineMetric {
    fn distance() -> Distance {
        Distance::Dot
    }
```

Both `VectorElementType` (`f32`) and `VectorElementTypeByte` (`u8`) return `Distance::Cosine`. Returning `Distance::Dot` for `VectorElementTypeHalf` (`f16`) breaks the contract of the `Metric` trait.

In `QuantizedQueryScorer`, `QuantizedCustomQueryScorer`, `QuantizedMultiQueryScorer`, and `QuantizedMultiCustomQueryScorer`, query preprocessing routes `TMetric::distance()` into `TElement::quantization_preprocess(quantization_config, distance, vector)`. Returning `Dot` falsely tags cosine queries as dot product.

## Solution

- Change `Distance::Dot` to `Distance::Cosine` in `lib/segment/src/spaces/metric_f16/simple_cosine.rs`.
- Add `test_cosine_distance_consistency` cross-type unit test to ensure `f32`, `u8`, and `f16` implementations of `CosineMetric` all agree on `Distance::Cosine`.

## Verification

- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p segment --lib` (0 warnings)
- `cargo test -p segment spaces::` (25/25 passed)
- `cargo test -p segment quantized` (47 unit + 25 integration passed)
