### PR TITLE
fix(collection): persist newest clocks before oldest clocks in LocalShardClocks

### DIFF
--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1766,15 +1766,37 @@ mod tests {
         initial_clocks.store_if_changed(shard_path).unwrap();
 
         // Simulate crash between writes when advancing to newest=20, oldest=15:
-        // With newest-first, newest is persisted to disk first, and crash prevents oldest write.
+        // Exercise `LocalShardClocks::store_if_changed`: inject a failure on the second write (oldest_clocks).
         let mut advanced_newest = ClockMap::default();
+        let mut advanced_oldest = ClockMap::default();
         advanced_newest.advance_clock(ClockTag::new(1, 1, 20));
-        advanced_newest
-            .store_if_changed(&LocalShardClocks::newest_clocks_path(shard_path))
-            .unwrap();
+        advanced_oldest.advance_clock(ClockTag::new(1, 1, 15));
+        let advanced_clocks = LocalShardClocks::new(advanced_newest, advanced_oldest);
+
+        // Inject failure on oldest_clocks path by replacing file with a directory (rename fails with EISDIR).
+        let oldest_path = LocalShardClocks::oldest_clocks_path(shard_path);
+        let oldest_backup = std::fs::read(&oldest_path).unwrap();
+        std::fs::remove_file(&oldest_path).unwrap();
+        std::fs::create_dir(&oldest_path).unwrap();
+
+        // store_if_changed writes newest (20) successfully, then fails on oldest (15).
+        assert!(advanced_clocks.store_if_changed(shard_path).is_err());
+
+        // Restore oldest_clocks.json to simulate pre-crash state on disk (tick 5).
+        std::fs::remove_dir(&oldest_path).unwrap();
+        std::fs::write(&oldest_path, &oldest_backup).unwrap();
 
         // On reboot, load clocks from disk:
         let recovered = LocalShardClocks::load(shard_path).unwrap();
+        assert_eq!(
+            recovered.newest_clocks.blocking_lock().current_tick(1, 1),
+            Some(20)
+        );
+        assert_eq!(
+            recovered.oldest_clocks.blocking_lock().current_tick(1, 1),
+            Some(5)
+        );
+
         let rec_newest = recovered.newest_clocks.blocking_lock().to_recovery_point();
         let rec_oldest = recovered.oldest_clocks.blocking_lock().to_recovery_point();
 

--- a/lib/collection/src/shards/local_shard/mod.rs
+++ b/lib/collection/src/shards/local_shard/mod.rs
@@ -1592,13 +1592,16 @@ impl LocalShardClocks {
 
     /// Persist clock maps to disk
     pub fn store_if_changed(&self, shard_path: &Path) -> CollectionResult<()> {
-        self.oldest_clocks
-            .blocking_lock()
-            .store_if_changed(&Self::oldest_clocks_path(shard_path))?;
-
+        // Persist newest before oldest: if we crash between writes, on-disk newest is ahead of
+        // oldest (preserving oldest <= newest). A stale oldest cutoff is safe and just replays
+        // more from the WAL, whereas a stale newest would make oldest > newest and reject deltas.
         self.newest_clocks
             .blocking_lock()
             .store_if_changed(&Self::newest_clocks_path(shard_path))?;
+
+        self.oldest_clocks
+            .blocking_lock()
+            .store_if_changed(&Self::oldest_clocks_path(shard_path))?;
 
         Ok(())
     }
@@ -1715,5 +1718,89 @@ fn collect_segment_memory_metadata(
             let proxy_guard = proxy.read();
             collect_segment_memory_metadata(&proxy_guard.wrapped_segment, reports);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::Builder;
+
+    use super::*;
+    use crate::operations::ClockTag;
+
+    #[test]
+    fn test_local_shard_clocks_store_order() {
+        let temp_dir = Builder::new().prefix("test_clocks").tempdir().unwrap();
+        let shard_path = temp_dir.path();
+
+        let mut newest = ClockMap::default();
+        let mut oldest = ClockMap::default();
+        newest.advance_clock(ClockTag::new(1, 1, 10));
+        oldest.advance_clock(ClockTag::new(1, 1, 5));
+
+        let clocks = LocalShardClocks::new(newest, oldest);
+        clocks.store_if_changed(shard_path).unwrap();
+
+        let loaded = LocalShardClocks::load(shard_path).unwrap();
+        let loaded_newest = loaded.newest_clocks.blocking_lock().to_recovery_point();
+        let loaded_oldest = loaded.oldest_clocks.blocking_lock().to_recovery_point();
+
+        // Oldest must not exceed newest
+        assert!(!loaded_newest.has_any_older_clocks_than(&loaded_oldest));
+    }
+
+    #[test]
+    fn test_local_shard_clocks_crash_between_writes_preserves_invariant() {
+        let temp_dir = Builder::new()
+            .prefix("test_clocks_crash")
+            .tempdir()
+            .unwrap();
+        let shard_path = temp_dir.path();
+
+        // Initial state on disk: newest=10, oldest=5
+        let mut initial_newest = ClockMap::default();
+        let mut initial_oldest = ClockMap::default();
+        initial_newest.advance_clock(ClockTag::new(1, 1, 10));
+        initial_oldest.advance_clock(ClockTag::new(1, 1, 5));
+        let initial_clocks = LocalShardClocks::new(initial_newest, initial_oldest);
+        initial_clocks.store_if_changed(shard_path).unwrap();
+
+        // Simulate crash between writes when advancing to newest=20, oldest=15:
+        // With newest-first, newest is persisted to disk first, and crash prevents oldest write.
+        let mut advanced_newest = ClockMap::default();
+        advanced_newest.advance_clock(ClockTag::new(1, 1, 20));
+        advanced_newest
+            .store_if_changed(&LocalShardClocks::newest_clocks_path(shard_path))
+            .unwrap();
+
+        // On reboot, load clocks from disk:
+        let recovered = LocalShardClocks::load(shard_path).unwrap();
+        let rec_newest = recovered.newest_clocks.blocking_lock().to_recovery_point();
+        let rec_oldest = recovered.oldest_clocks.blocking_lock().to_recovery_point();
+
+        // Invariant oldest <= newest is preserved: rec_newest is 20, rec_oldest is 5.
+        assert!(!rec_newest.has_any_older_clocks_than(&rec_oldest));
+
+        // Contrast with backwards (oldest-first) crash: if oldest=15 was written but newest remained 10,
+        // rec_oldest would exceed rec_newest (15 > 10).
+        let mut backwards_oldest = ClockMap::default();
+        backwards_oldest.advance_clock(ClockTag::new(1, 1, 15));
+        backwards_oldest
+            .store_if_changed(&LocalShardClocks::oldest_clocks_path(shard_path))
+            .unwrap();
+
+        // Reset newest on disk back to 10
+        let mut stale_newest = ClockMap::default();
+        stale_newest.advance_clock(ClockTag::new(1, 1, 10));
+        stale_newest
+            .store_if_changed(&LocalShardClocks::newest_clocks_path(shard_path))
+            .unwrap();
+
+        let broken = LocalShardClocks::load(shard_path).unwrap();
+        let broken_newest = broken.newest_clocks.blocking_lock().to_recovery_point();
+        let broken_oldest = broken.oldest_clocks.blocking_lock().to_recovery_point();
+
+        // In the broken order, newest is strictly older than oldest (invariant inverted!)
+        assert!(broken_newest.has_any_older_clocks_than(&broken_oldest));
     }
 }


### PR DESCRIPTION
### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---

## Summary

Persist `newest_clocks` before `oldest_clocks` in `LocalShardClocks::store_if_changed`.

## Problem

In `lib/collection/src/shards/local_shard/mod.rs`:
```rust
    pub fn store_if_changed(&self, shard_path: &Path) -> CollectionResult<()> {
        self.oldest_clocks
            .blocking_lock()
            .store_if_changed(&Self::oldest_clocks_path(shard_path))?;

        self.newest_clocks
            .blocking_lock()
            .store_if_changed(&Self::newest_clocks_path(shard_path))?;

        Ok(())
    }
```

`oldest_clocks` was persisted to disk before `newest_clocks`.

If a crash, power loss, or kill occurs between these two writes:
- `oldest_clocks.json` on disk is updated with the newer cutoff.
- `newest_clocks.json` on disk retains the older highest clock.
- On reboot, `LocalShardClocks::load` loads `oldest_clocks > newest_clocks`, inverting the fundamental invariant.

When this happens, any subsequent WAL delta resolution (`resolve_wal_delta` in `wal_delta.rs`) will see `recovery_point.has_any_older_clocks_than(&oldest_clocks)` and reject deltas with `WalDeltaError::Cutoff`, preventing the shard from resolving deltas.

Notice that in-memory updates (`wal_delta.rs:106-122`) already advance `newest_clocks` first and `oldest_clocks` second, and snapshots (`snapshot.rs:97-100`) capture `oldest` before `newest` because cutoffs advance newest-first.

## Solution

- Swap the persistence order in `LocalShardClocks::store_if_changed` to write `newest_clocks` first, then `oldest_clocks`.
- If a crash occurs between the writes, on-disk `newest_clocks` is ahead of `oldest_clocks` (preserving `oldest <= newest`). A stale oldest cutoff is safe and at most causes the shard to replay slightly more from the WAL.
- Add regression tests verifying the store order and proving that a crash between writes preserves the `oldest <= newest` invariant.

## Verification

- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p collection --lib` (0 warnings)
- `cargo test -p collection test_local_shard_clocks`
- `cargo test -p collection wal_delta` (25/25 passed)
- `cargo test -p collection --test integration wal_less_snapshot_clocks_test --features staging` (passed)
