### PR TITLE
[AI] fix(collection): saturate offset+limit in query pagination instead of overflowing (#10501)

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -107,7 +107,7 @@ impl Collection {
 
         let max_limit = batch_request
             .iter()
-            .map(|req| req.limit + req.offset)
+            .map(|req| req.limit.saturating_add(req.offset))
             .max()
             .unwrap_or(0);
 
@@ -119,7 +119,7 @@ impl Collection {
 
         for request in batch_request.iter() {
             let mut new_request = request.clone();
-            let request_limit = new_request.limit + new_request.offset;
+            let request_limit = new_request.limit.saturating_add(new_request.offset);
 
             let is_exact = request.params.as_ref().is_some_and(|p| p.exact);
 

--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -756,7 +756,9 @@ fn intermediate_query_infos(request: &ShardQueryRequest) -> Vec<IntermediateQuer
             // Otherwise, we expect the root result
             vec![IntermediateQueryInfo {
                 scoring_query: request.query.as_ref(),
-                take: request.offset + request.limit,
+                // Use saturating_add so an unbounded user-supplied limit/offset cannot overflow
+                // (debug panic / release wraparound to a tiny take) — it clamps to usize::MAX instead.
+                take: request.offset.saturating_add(request.limit),
             }]
         }
     }

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -325,7 +325,11 @@ impl Collection {
                     .take(request.limit)
                     .collect()
             } else {
-                merged_iter.take(request.offset + request.limit).collect()
+                // Use saturating_add so an unbounded user-supplied limit/offset cannot overflow
+                // (debug panic / release wraparound to a tiny take) — it clamps to usize::MAX instead.
+                merged_iter
+                    .take(request.offset.saturating_add(request.limit))
+                    .collect()
             };
 
             top_results.push(top_res);

--- a/lib/collection/src/collection/search.rs
+++ b/lib/collection/src/collection/search.rs
@@ -78,11 +78,25 @@ impl Collection {
 
         let metadata_required = is_payload_required || with_vectors;
 
-        let sum_limits: usize = request.searches.iter().map(|s| s.limit).sum();
-        let sum_offsets: usize = request.searches.iter().map(|s| s.offset).sum();
+        // Saturating fold instead of `.sum()`/`+`/`*` so a batch with very large or
+        // usize::MAX limits/offsets can't overflow this heuristic (debug panic / release
+        // wraparound), matching the saturating_add idiom used for the per-request take() above.
+        let sum_limits: usize = request
+            .searches
+            .iter()
+            .fold(0usize, |sum, search| sum.saturating_add(search.limit));
+        let sum_offsets: usize = request
+            .searches
+            .iter()
+            .fold(0usize, |sum, search| sum.saturating_add(search.offset));
 
         // Number of records we need to retrieve to fill the search result.
-        let require_transfers = self.shards_holder.read().await.len() * (sum_limits + sum_offsets);
+        let require_transfers = self
+            .shards_holder
+            .read()
+            .await
+            .len()
+            .saturating_mul(sum_limits.saturating_add(sum_offsets));
         // Actually used number of records.
         let used_transfers = sum_limits;
 

--- a/lib/collection/src/collection_manager/segments_searcher.rs
+++ b/lib/collection/src/collection_manager/segments_searcher.rs
@@ -296,7 +296,7 @@ impl SegmentsSearcher {
             batch_request
                 .searches
                 .iter()
-                .map(|request| request.limit + request.offset)
+                .map(|request| request.limit.saturating_add(request.offset))
                 .collect(),
             &further_results,
         );

--- a/lib/collection/src/tests/query_prefetch_offset_limit.rs
+++ b/lib/collection/src/tests/query_prefetch_offset_limit.rs
@@ -20,7 +20,7 @@ use crate::operations::point_ops::{
 };
 use crate::operations::shard_selector_internal::ShardSelectorInternal;
 use crate::operations::shared_storage_config::SharedStorageConfig;
-use crate::operations::types::VectorsConfig;
+use crate::operations::types::{CoreSearchRequest, VectorsConfig};
 use crate::operations::universal_query::shard_query::{
     ScoringQuery, ShardPrefetch, ShardQueryRequest,
 };
@@ -304,6 +304,56 @@ async fn test_offset_limit_does_not_overflow() {
 
     // Normal, non-overflowing offset/limit pagination must still work.
     let points = do_query(10, 15).await;
+    assert_eq!(points.len(), 15, "expected 15 points, got {}", points.len());
+}
+
+/// Regression test for the `core_search_batch` payload-transfer heuristic in
+/// `lib/collection/src/collection/search.rs`, flagged as a follow-up gap on
+/// <https://github.com/qdrant/qdrant/issues/10501>: `sum_limits`/`sum_offsets`
+/// were computed with a plain `.sum()`/`+`/`*` instead of saturating
+/// arithmetic, so a search with an (almost) unbounded limit alongside a
+/// non-zero offset overflowed before ever reaching the per-request take().
+#[tokio::test(flavor = "multi_thread")]
+async fn test_search_batch_offset_limit_does_not_overflow() {
+    let collection = fixture().await;
+
+    let do_search = async |offset, limit| {
+        collection
+            .search(
+                CoreSearchRequest {
+                    query: QueryEnum::Nearest(NamedQuery::default_dense(vec![0.1, 0.2, 0.3, 0.4])),
+                    filter: None,
+                    params: None,
+                    limit,
+                    offset,
+                    with_payload: None,
+                    with_vector: None,
+                    score_threshold: None,
+                },
+                None,
+                None,
+                &ShardSelectorInternal::All,
+                None,
+                HwMeasurementAcc::new(),
+            )
+            .await
+            .expect("failed to search")
+    };
+
+    // `offset=1, limit=usize::MAX` used to overflow `sum_limits + sum_offsets`
+    // (and the shard-count multiplication) before the per-request take() was
+    // ever reached.
+    let points = do_search(1, usize::MAX).await;
+    assert_eq!(
+        points.len(),
+        POINT_COUNT - 1,
+        "expected {} points, got {}",
+        POINT_COUNT - 1,
+        points.len()
+    );
+
+    // Normal, non-overflowing offset/limit search must still work.
+    let points = do_search(10, 15).await;
     assert_eq!(points.len(), 15, "expected 15 points, got {}", points.len());
 }
 

--- a/lib/collection/src/tests/query_prefetch_offset_limit.rs
+++ b/lib/collection/src/tests/query_prefetch_offset_limit.rs
@@ -248,6 +248,65 @@ async fn test_limit_offset_with_prefetch() {
     assert_eq!(points.len(), 5, "expected 5 points, got {}", points.len());
 }
 
+/// Regression test for <https://github.com/qdrant/qdrant/issues/10501>.
+///
+/// `offset + limit` must not overflow `usize` when a client sends an
+/// (almost) unbounded `limit` alongside a non-zero `offset`. Before the fix,
+/// `offset.wrapping_add(limit)` wrapped around to a tiny value, so the
+/// collection-level merge silently returned an empty page instead of the
+/// remaining points.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_offset_limit_does_not_overflow() {
+    let collection = fixture().await;
+
+    let do_query = async |offset, limit| {
+        collection
+            .query(
+                ShardQueryRequest {
+                    query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
+                        NamedQuery::default_dense(vec![0.1, 0.2, 0.3, 0.4]),
+                    ))),
+                    prefetches: vec![],
+                    filter: None,
+                    params: None,
+                    offset,
+                    limit,
+                    with_payload: WithPayloadInterface::Bool(false),
+                    with_vector: WithVector::Bool(false),
+                    score_threshold: None,
+                },
+                None,
+                None,
+                ShardSelectorInternal::All,
+                None,
+                HwMeasurementAcc::new(),
+            )
+            .await
+            .expect("failed to query")
+    };
+
+    // `offset=1, limit=usize::MAX` used to overflow `offset + limit` and
+    // silently return an empty page. It must instead return the remaining
+    // `POINT_COUNT - 1` points.
+    let points = do_query(1, usize::MAX).await;
+    assert_eq!(
+        points.len(),
+        POINT_COUNT - 1,
+        "expected {} points, got {}",
+        POINT_COUNT - 1,
+        points.len()
+    );
+
+    // `offset=0` with an unbounded limit must still be clamped by the
+    // collection size, not by an overflowed take count.
+    let points = do_query(0, usize::MAX).await;
+    assert_eq!(points.len(), POINT_COUNT);
+
+    // Normal, non-overflowing offset/limit pagination must still work.
+    let points = do_query(10, 15).await;
+    assert_eq!(points.len(), 15, "expected 15 points, got {}", points.len());
+}
+
 fn dummy_on_replica_failure() -> ChangePeerFromState {
     Arc::new(move |_peer_id, _shard_id, _from_state| {})
 }

--- a/lib/edge/src/read_view/ops/search.rs
+++ b/lib/edge/src/read_view/ops/search.rs
@@ -109,8 +109,11 @@ impl<H: ReadSegmentHandle> EdgeReadView<H> {
             Ok(points_by_request)
         })?;
 
-        let mut aggregator =
-            BatchResultAggregator::new(searches.iter().map(|search| search.offset + search.limit));
+        let mut aggregator = BatchResultAggregator::new(
+            searches
+                .iter()
+                .map(|search| search.offset.saturating_add(search.limit)),
+        );
         aggregator.update_point_versions(points_by_segment.iter().flatten().flatten());
 
         for points_by_request in points_by_segment {

--- a/lib/shard/src/search.rs
+++ b/lib/shard/src/search.rs
@@ -310,7 +310,9 @@ impl<'a> From<&'a CoreSearchRequest> for BatchSearchParams<'a> {
                     .unwrap_or(&WithPayloadInterface::Bool(false)),
             ),
             with_vector: with_vector.clone().unwrap_or_default(),
-            top: limit + offset,
+            // saturating_add so an unbounded user-supplied limit/offset can't overflow here
+            // either — same idiom as the collection-level merge boundaries for this issue.
+            top: limit.saturating_add(*offset),
             params: params.as_ref(),
         }
     }


### PR DESCRIPTION
Fixes #10501.

`offset=1, limit=usize::MAX` on `/points/query` silently returned an empty page instead of the remaining points. The collection-level merge sized its take as `offset + limit`, which wraps to a tiny value on overflow instead of erroring or saturating - `lib/shard/src/query/planned_query.rs` already guarded the identical per-shard computation with `saturating_add`, but that guard didn't reach the collection-level merge boundaries.

I opened #10504 for this earlier and closed it myself once CodeRabbit's review pointed out the fix only covered the reported code path and missed a second overflow in the same file (`search.rs`'s `sum_limits`/`sum_offsets`/`require_transfers` payload-transfer heuristic). Picking it back up: fixed that spot, then wrote a regression test against `core_search_batch` (the batch-search path, not just `/points/query`) to check for more, and it caught two more overflow panics one after another - `shard/search.rs`'s `BatchSearchParams` construction, then `collection_manager/segments_searcher.rs`'s per-segment take-count map. At that point I grepped the whole workspace for the same `offset + limit` / `limit + offset` pattern and found two more untested ones: `collection/query.rs`'s auto-sharding subsampling threshold, and `edge/read_view/ops/search.rs`'s `BatchResultAggregator` sizing. All six are now `saturating_add`/`saturating_mul`, matching the existing shard-level idiom. None of this changes behavior for ordinary requests - saturating arithmetic is a no-op until the sum would actually exceed `usize::MAX`.

Tests added: extended the existing `query_prefetch_offset_limit.rs` regression test with a batch-search case (`offset=1, limit=usize::MAX` via the `#[cfg(feature = "testing")]` `search()` helper), alongside the original `/points/query` case.

### Testing
Ran the full `collection` crate test suite (265 tests, 0 failed) in a `rust:1-bookworm` container, plus `cargo clippy -p collection -p shard --lib --tests -- -D warnings` (clean) and `cargo +nightly fmt --check` (clean).

### Checklist
- [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change? (superseding my own closed #10504, no others found)
- [x] Have you formatted your code locally using `cargo +nightly fmt --all`?
- [x] Have you checked your code using `cargo clippy`?
- [x] Have you written new tests for your core changes?
- [x] Have you successfully ran tests with your changes locally?

### AI disclosure
Both commits in this PR (and the earlier #10504) were written with AI assistance, tagged `[AI]` per the contributing guide.

- `[AI] fix(collection): saturate offset+limit in query pagination instead of overflowing (#10501)` - the original #10504 commit.
- `Saturate the remaining offset+limit overflow sites (#10501)` - this session's follow-up; missed the `[AI]` tag on this one, should have carried it forward from the first commit.

Prompt/approach: given the issue text and CodeRabbit's specific finding on #10504 (the `search.rs` heuristic can still overflow), fix that spot, then write a regression test through the batch-search path rather than trusting the fix was complete, following overflow panics as the test surfaced them, then grep the workspace for any remaining instances of the same `offset + limit` pattern rather than stopping at the first two found. I read and verified each site's surrounding logic myself (traced the call chain manually and confirmed each swap is behavior-preserving for non-overflowing inputs) before including it.
