### PR TITLE
fix-snapshot-names

### DIFF
--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -12,6 +12,7 @@ use shard::files::PAYLOAD_INDEX_CONFIG_FILE;
 use shard::snapshots::snapshot_data::SnapshotData;
 use shard::snapshots::snapshot_manifest::{RecoveryType, SnapshotManifest};
 use tokio::sync::OwnedRwLockReadGuard;
+use uuid::Uuid;
 
 use super::Collection;
 use crate::collection::CollectionVersion;
@@ -59,9 +60,10 @@ impl Collection {
         this_peer_id: PeerId,
     ) -> CollectionResult<SnapshotDescription> {
         let snapshot_name = format!(
-            "{}-{this_peer_id}-{}.snapshot",
+            "{}-{this_peer_id}-{}-{}.snapshot",
             self.name(),
             chrono::Utc::now().format("%Y-%m-%d-%H-%M-%S"),
+            Uuid::new_v4(),
         );
 
         // Final location of snapshot

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1229,8 +1229,9 @@ impl ShardHolder {
         }
 
         let snapshot_file_name = format!(
-            "{collection_name}-shard-{shard_id}-{}.snapshot",
+            "{collection_name}-shard-{shard_id}-{}-{}.snapshot",
             chrono::Utc::now().format("%Y-%m-%d-%H-%M-%S"),
+            uuid::Uuid::new_v4(),
         );
 
         let snapshot_temp_dir = tempfile::Builder::new()
@@ -1305,8 +1306,9 @@ impl ShardHolder {
         }
 
         let snapshot_file_name = format!(
-            "{collection_name}-shard-{shard_id}-{}.snapshot",
+            "{collection_name}-shard-{shard_id}-{}-{}.snapshot",
             chrono::Utc::now().format("%Y-%m-%d-%H-%M-%S"),
+            uuid::Uuid::new_v4(),
         );
 
         let snapshot_temp_dir = tempfile::Builder::new()


### PR DESCRIPTION
## Summary

- make collection and shard snapshot names unique within the same second
- prevent concurrent snapshot creation from overwriting an earlier archive

## Testing

- `rustfmt --check --edition 2024 lib/collection/src/collection/snapshots.rs lib/collection/src/shards/shard_holder/mod.rs`

Fixes #10554
