### PR TITLE
Refactor `OnDiskMapIndex`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://qdrant.tech/"
 repository = "https://github.com/qdrant/qdrant"
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.97"
+rust-version = "1.98"
 default-run = "qdrant"
 
 [lints]

--- a/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/map_index/on_disk_map_index/lifecycle.rs
@@ -8,8 +8,7 @@ use common::mmap::AdviceSetting;
 use common::persisted_hashmap::{Key, UniversalHashMap, serialize_hashmap};
 use common::types::PointOffsetType;
 use common::universal_io::{
-    CachedReadFs, MmapFile, OkNotFound, OpenOptions, Populate, UniversalRead, UniversalReadFs,
-    UniversalWrite, read_json_via,
+    CachedReadFs, OkNotFound, OpenOptions, Populate, UniversalRead, UniversalReadFs, read_json_via,
 };
 use fs_err as fs;
 
@@ -213,13 +212,7 @@ where
     pub(crate) fn ram_usage_bytes(&self) -> usize {
         self.storage.ram_usage_bytes()
     }
-}
 
-impl<N, S> OnDiskMapIndex<N, S>
-where
-    N: MapIndexKey + Key + ?Sized,
-    S: UniversalWrite,
-{
     /// TODO: Use Fs to create config and hashmap files?
     pub fn build(
         fs: &S::Fs,
@@ -263,7 +256,7 @@ where
             build_prefix_index(path, entries.into_iter())?;
         }
 
-        OnDiskPointToValues::<N, MmapFile>::build_from_iter(
+        OnDiskPointToValues::<N, S>::build_from_iter(
             path,
             point_to_values.iter().enumerate().map(|(idx, values)| {
                 (

--- a/lib/storage/src/content_manager/alias_mapping.rs
+++ b/lib/storage/src/content_manager/alias_mapping.rs
@@ -197,9 +197,11 @@ mod tests {
     fn insert_keeps_memory_state_when_persistence_fails() {
         let (mut persistence, original) = persistence_with_unwritable_path();
 
-        assert!(persistence
-            .insert("new_alias".to_string(), "new_collection".to_string())
-            .is_err());
+        assert!(
+            persistence
+                .insert("new_alias".to_string(), "new_collection".to_string())
+                .is_err()
+        );
         assert_eq!(persistence.state(), &original);
     }
 


### PR DESCRIPTION
- The `UniversalWrite` trait is no longer needed for `OnDiskMapIndex`
- Update rust version
- Fix `cargo +nightly fmt --all`