### PR TITLE
fix(segment): hash only sampled candidates in facet filter-iter plan

### DIFF
--- a/lib/segment/src/segment/read_view/facet.rs
+++ b/lib/segment/src/segment/read_view/facet.rs
@@ -173,7 +173,7 @@ where
 
         if prefer_filter_iter {
             // Iterate the filter, then hash each value to get counts
-            self.visit_filter_iter(facet_index, filter, &cardinality, is_stopped, hw_counter)
+            self.visit_filter_iter(facet_index, filter, &cardinality, None, is_stopped, hw_counter)
         } else {
             // Every posting element will be checked, so materializing the entire filter
             // is cheaper than that many per-point evaluations.
@@ -258,6 +258,7 @@ where
                 facet_index,
                 &new_filter,
                 &new_cardinality,
+                Some(&candidates),
                 is_stopped,
                 hw_counter,
             )
@@ -279,11 +280,17 @@ where
     /// `iter_filtered_points` with [`DeferredBehavior::VisibleOnly`] already
     /// excludes deferred and soft-deleted points, so the yielded ids can be
     /// hashed directly.
+    ///
+    /// `candidates` restricts which values are hashed: the sampling plan must
+    /// count only the values it sampled, because a point needs just one
+    /// candidate value to pass the merged filter, and hashing every value it
+    /// carries would leak never-sampled values into the result.
     fn visit_filter_iter<F: FacetIndex>(
         &self,
         facet_index: &F,
         filter: &Filter,
         cardinality: &CardinalityEstimation,
+        candidates: Option<&HashSet<FacetValue>>,
         is_stopped: &AtomicBool,
         hw_counter: &HardwareCounterCell,
     ) -> OperationResult<HashMap<FacetValue, usize>> {
@@ -298,6 +305,11 @@ where
         facet_index.for_points_values(points, hw_counter, |_point_id, iter| {
             iter.for_each(|value| {
                 let value = value.to_owned();
+                if let Some(candidates) = candidates {
+                    if !candidates.contains(&value) {
+                        return;
+                    }
+                }
                 *hits.entry(value).or_insert(0) += 1;
             });
         })?;

--- a/lib/segment/src/segment/tests/test_facets.rs
+++ b/lib/segment/src/segment/tests/test_facets.rs
@@ -258,3 +258,76 @@ fn sampling_selective_filter_iterates_filter() {
     assert!(hits.len() < N_FILTER_ITER);
     assert_counts_exact(&segment, TAG_KEY, Some(&filter), &hits);
 }
+
+/// Fixture with multi-valued `tag`: every point carries one shared value
+/// (`common_{i % 50}`, 50 distinct) plus one point-unique value
+/// (`unique_{i}`). Points pass a candidate-merged filter via the common
+/// value, so the other value they carry must not be counted unless it was
+/// itself sampled as a candidate.
+#[cfg(not(windows))]
+fn build_segment_multi_tags_n(n: usize) -> (TempDir, Segment) {
+    let hw_counter = HardwareCounterCell::new();
+    let dir = Builder::new().prefix("facet_segment_multi").tempdir().unwrap();
+
+    let dim = 2;
+    let mut segment = build_simple_segment(dir.path(), dim, Distance::Dot).unwrap();
+    let vector: Vec<f32> = (0..dim).map(|i| i as f32 / 10.0).collect();
+    let vectors = NamedVectors::from_ref(DEFAULT_VECTOR_NAME, VectorRef::from(&vector));
+
+    let mut op = 0u64;
+    for i in 0..n {
+        let point_id = PointIdType::from(i as u64 + 1);
+        segment
+            .insert_new_vectors(point_id, op, &vectors, &hw_counter)
+            .unwrap();
+        op += 1;
+
+        let payload = payload_json! {
+            TAG_KEY: [format!("common_{}", i % 50), format!("unique_{i}")],
+            SEQ_KEY: i as f64,
+        };
+        segment
+            .set_full_payload(op, point_id, &payload, &hw_counter)
+            .unwrap();
+        op += 1;
+    }
+
+    for (key, schema) in [
+        (TAG_KEY, PayloadSchemaType::Keyword),
+        (SEQ_KEY, PayloadSchemaType::Float),
+    ] {
+        segment
+            .create_field_index(
+                op,
+                &JsonPath::new(key),
+                Some(&PayloadFieldSchema::FieldType(schema)),
+                &hw_counter,
+            )
+            .unwrap();
+        op += 1;
+    }
+
+    (dir, segment)
+}
+
+/// sampling → filter iter must count only sampled candidates. A point passes
+/// the merged filter via its `common_*` value, so hashing every value it
+/// carries leaks its `unique_*` value into the result. Candidates are capped
+/// at `sample_target = max(LIMIT * 10, 1000) = 1000`; the leak adds up to one
+/// never-sampled value per matched point (≈ 9% of 200k here) on top.
+#[cfg(not(windows))]
+#[test]
+fn sampling_selective_filter_counts_only_candidates() {
+    let (_dir, segment) = build_segment_multi_tags_n(N_FILTER_ITER);
+    let filter = seq_below(N_FILTER_ITER * 9 / 100);
+
+    let hits = run_facet(&segment, TAG_KEY, Some(filter.clone()));
+
+    assert!(!hits.is_empty());
+    assert!(
+        hits.len() <= 1000,
+        "filter-iter must hash only sampled candidates, got {} values",
+        hits.len()
+    );
+    assert_counts_exact(&segment, TAG_KEY, Some(&filter), &hits);
+}


### PR DESCRIPTION
## What

Fixes #10589

The sampling approximate-facet plan (`sampled_approximate_facet`) merges a candidate MATCH filter with the request filter, then may choose the filter-iter plan. The call-site comment says "hash candidate values out of the yielded points", but `visit_filter_iter` hashed every value of every visited point - it took no candidate set. A point needs only one candidate value to pass the merged filter, so any other values it carries on a multi-valued facet key were counted too.

The sibling plan (`visit_facet_iter` with `Some(candidates)`) counts only candidates, so the result set depended on which plan the cardinality estimator picked, and never-sampled values could flood the per-segment map (and, with high enough counts, displace sampled candidates from the merged top-k).

## Fix

`visit_filter_iter` now takes `Option<&HashSet<FacetValue>>` and hashes only candidate values when the set is provided. The sampling path passes `Some(&candidates)`; the exact path passes `None`.

## Tests

New regression test `sampling_selective_filter_counts_only_candidates` (lib/segment/src/segment/tests/test_facets.rs): 200k points with multi-valued tags (`["common_{i % 50}", "unique_{i}"]`), a selective filter forcing the sampling -> filter-iter plan, asserting the returned map holds at most `sample_target` (1000) values and that every reported count is exact. On `dev` the map additionally collects each matched point's `unique_*` value (~18k extra values at this fixture's selectivity), so the assertion fails before and passes after.

## Verification disclosure

- `cargo check -p segment` and `cargo check -p segment --tests` pass locally (rustc 1.98.1 stable).
- The test suite was NOT executed locally (sandbox resource limits); fail-before/pass-after behavior follows directly from the plan mechanics described above and should be confirmed by CI.