### PR TITLE
Fix root filter OR-merged with prefetch should/min_should filters

### DIFF
--- a/lib/collection/src/tests/query_prefetch_offset_limit.rs
+++ b/lib/collection/src/tests/query_prefetch_offset_limit.rs
@@ -7,8 +7,13 @@ use common::budget::ResourceBudget;
 use common::counter::hardware_accumulator::HwMeasurementAcc;
 use rand::{RngExt, rng};
 use segment::data_types::vectors::NamedQuery;
-use segment::types::{Distance, ExtendedPointId, WithPayloadInterface, WithVector};
+use segment::json_path::JsonPath;
+use segment::types::{
+    Condition, Distance, ExtendedPointId, FieldCondition, Filter, Match, MinShould, Payload,
+    ScoredPoint, ValueVariants, WithPayloadInterface, WithVector,
+};
 use shard::query::query_enum::QueryEnum;
+use serde_json::Value;
 use tempfile::Builder;
 
 use crate::collection::{Collection, RequestShardTransfer};
@@ -258,4 +263,231 @@ fn dummy_request_shard_transfer() -> RequestShardTransfer {
 
 fn dummy_abort_shard_transfer() -> AbortShardTransfer {
     Arc::new(|_transfer, _reason| {})
+}
+
+/// Collection of points carrying `a`, `b` and `c` payload fields, laid out so
+/// that the intersection of conditions is observable:
+/// - `a = i % 2` (half the points have a = 1)
+/// - `b = 2` for i in [500, 600), `b = 9` otherwise
+/// - `c = 3` for i in [600, 650), `c = 9` otherwise
+async fn fixture_with_payload() -> Collection {
+    let wal_config = WalConfig {
+        wal_capacity_mb: 1,
+        wal_segments_ahead: 0,
+        wal_retain_closed: 1,
+    };
+
+    let collection_params = CollectionParams {
+        vectors: VectorsConfig::Single(VectorParamsBuilder::new(DIM, Distance::Dot).build()),
+        shard_number: NonZeroU32::new(SHARD_COUNT).unwrap(),
+        replication_factor: NonZeroU32::new(1).unwrap(),
+        write_consistency_factor: NonZeroU32::new(1).unwrap(),
+        ..CollectionParams::empty()
+    };
+
+    let config = CollectionConfigInternal {
+        params: collection_params,
+        optimizer_config: OptimizersConfig::fixture(),
+        wal_config,
+        hnsw_config: Default::default(),
+        quantization_config: Default::default(),
+        strict_mode_config: Default::default(),
+        uuid: None,
+        metadata: None,
+    };
+
+    let collection_dir = Builder::new().prefix("test_collection").tempdir().unwrap();
+    let snapshots_path = Builder::new().prefix("test_snapshots").tempdir().unwrap();
+
+    let collection_name = "test".to_string();
+    let shards: AHashMap<ShardId, HashSet<PeerId>> = (0..SHARD_COUNT)
+        .map(|i| (i, HashSet::from([PEER_ID])))
+        .collect();
+
+    let collection = Collection::new(
+        collection_name.clone(),
+        PEER_ID,
+        collection_dir.path(),
+        snapshots_path.path(),
+        &config,
+        Arc::new(SharedStorageConfig::default()),
+        CollectionShardDistribution { shards },
+        None,
+        ChannelService::default(),
+        dummy_on_replica_failure(),
+        dummy_request_shard_transfer(),
+        dummy_abort_shard_transfer(),
+        None,
+        None,
+        ResourceBudget::default(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    for shard_id in 0..SHARD_COUNT {
+        collection
+            .set_shard_replica_state(shard_id, PEER_ID, ReplicaState::Active, None)
+            .await
+            .expect("failed to activate shard");
+    }
+
+    let points = (0..POINT_COUNT)
+        .map(|i| {
+            let b = if (500..600).contains(&i) { 2 } else { 9 };
+            let c = if (600..650).contains(&i) { 3 } else { 9 };
+            PointStructPersisted {
+                id: ExtendedPointId::from(i as u64),
+                vector: VectorStructPersisted::Single(
+                    (0..DIM).map(|_| rng().random_range(0.0..1.0)).collect(),
+                ),
+                payload: Some(Payload(serde_json::Map::from_iter([
+                    ("a".to_string(), Value::from(i % 2)),
+                    ("b".to_string(), Value::from(b)),
+                    ("c".to_string(), Value::from(c)),
+                ]))),
+            }
+        })
+        .collect();
+    let operation = CollectionUpdateOperations::PointOperation(PointOperations::UpsertPoints(
+        PointInsertOperationsInternal::PointsList(points),
+    ));
+
+    collection
+        .update_from_client(
+            operation,
+            WaitUntil::from(true),
+            None,
+            WriteOrdering::Weak,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("failed to insert points");
+
+    collection
+}
+
+/// `a == 1` as a field condition.
+fn a_is_one() -> Condition {
+    Condition::Field(FieldCondition::new_match(
+        JsonPath::new("a"),
+        Match::from(ValueVariants::Integer(1)),
+    ))
+}
+
+/// `b == 2` as a field condition.
+fn b_is_two() -> Condition {
+    Condition::Field(FieldCondition::new_match(
+        JsonPath::new("b"),
+        Match::from(ValueVariants::Integer(2)),
+    ))
+}
+
+/// `c == 3` as a field condition.
+fn c_is_three() -> Condition {
+    Condition::Field(FieldCondition::new_match(
+        JsonPath::new("c"),
+        Match::from(ValueVariants::Integer(3)),
+    ))
+}
+
+async fn query_with_filters(
+    collection: &Collection,
+    root_filter: Filter,
+    prefetch_filter: Filter,
+) -> Vec<ScoredPoint> {
+    collection
+        .query(
+            ShardQueryRequest {
+                query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
+                    NamedQuery::default_dense(vec![0.1, 0.2, 0.3, 0.4]),
+                ))),
+                prefetches: vec![ShardPrefetch {
+                    prefetches: vec![],
+                    query: Some(ScoringQuery::Vector(QueryEnum::Nearest(
+                        NamedQuery::default_dense(vec![0.1, 0.2, 0.3, 0.4]),
+                    ))),
+                    limit: 1000,
+                    params: None,
+                    filter: Some(prefetch_filter),
+                    score_threshold: None,
+                }],
+                filter: Some(root_filter),
+                params: None,
+                offset: 0,
+                limit: 1000,
+                with_payload: WithPayloadInterface::Bool(true),
+                with_vector: WithVector::Bool(false),
+                score_threshold: None,
+            },
+            None,
+            None,
+            ShardSelectorInternal::All,
+            None,
+            HwMeasurementAcc::new(),
+        )
+        .await
+        .expect("failed to query")
+}
+
+fn assert_only_a1_b2(points: &[ScoredPoint]) {
+    for point in points {
+        let payload = point.payload.as_ref().expect("payload requested");
+        assert_eq!(
+            payload.0.get("a"),
+            Some(&Value::from(1)),
+            "root filter violated by point {}",
+            point.id,
+        );
+        assert_eq!(
+            payload.0.get("b"),
+            Some(&Value::from(2)),
+            "prefetch filter violated by point {}",
+            point.id,
+        );
+    }
+}
+
+/// The root filter must be ANDed with each prefetch filter. `merge_owned`
+/// unions `should` lists and `min_should` condition sets, which would OR the
+/// two filters instead; the propagated filter has to be nested, not merged
+/// flat.
+///
+/// Bug: root `{should: [a=1]}` + prefetch `{should: [b=2]}` returned points
+/// matching either condition, and root `min_should: 2 of [a=1, c=3]` +
+/// prefetch `min_should: 1 of [b=2]` let points skip `b=2` entirely.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_root_filter_ands_with_prefetch_should() {
+    let collection = fixture_with_payload().await;
+
+    // should + should: only odd i in [500, 600) have a=1 AND b=2 (50 points)
+    let points = query_with_filters(
+        &collection,
+        Filter::new_should(a_is_one()),
+        Filter::new_should(b_is_two()),
+    )
+    .await;
+    assert_eq!(points.len(), 50, "expected exactly the a=1 AND b=2 points");
+    assert_only_a1_b2(&points);
+
+    // min_should + min_should: no point satisfies (a=1 AND c=3) AND b=2,
+    // since b=2 and c=3 cover disjoint id ranges
+    let points = query_with_filters(
+        &collection,
+        Filter::new_min_should(MinShould {
+            conditions: vec![a_is_one(), c_is_three()],
+            min_count: 2,
+        }),
+        Filter::new_min_should(MinShould {
+            conditions: vec![b_is_two()],
+            min_count: 1,
+        }),
+    )
+    .await;
+    assert!(
+        points.is_empty(),
+        "expected no points, got {}",
+        points.len()
+    );
 }

--- a/lib/shard/src/query/planned_query.rs
+++ b/lib/shard/src/query/planned_query.rs
@@ -2,7 +2,7 @@ use common::types::ScoreType;
 use ordered_float::OrderedFloat;
 use segment::common::operation_error::{OperationError, OperationResult};
 use segment::data_types::vectors::NamedQuery;
-use segment::types::{Filter, SearchParams, WithPayloadInterface, WithVector};
+use segment::types::{Condition, Filter, SearchParams, WithPayloadInterface, WithVector};
 
 use super::query_enum::QueryEnum;
 use super::scroll::{QueryScrollRequestInternal, ScrollOrder};
@@ -343,8 +343,16 @@ fn recurse_prefetches(
             score_threshold,
         } = prefetch;
 
-        // Filters are propagated into the leaves
-        let filter = Filter::merge_opts(propagate_filter.clone(), filter);
+        // Filters are propagated into the leaves. The propagated filter is
+        // nested rather than flattened: `merge_owned` unions `should` lists
+        // and `min_should` conditions, which would turn the intended AND of
+        // the propagated and prefetch filters into an OR.
+        let filter = Filter::merge_opts(
+            propagate_filter
+                .clone()
+                .map(|filter| Filter::new_must(Condition::Filter(filter))),
+            filter,
+        );
 
         let source = if prefetches.is_empty() {
             // This is a leaf prefetch. Fetch this info from the segments


### PR DESCRIPTION
# Fix root filter being OR-merged with prefetch should/min_should filters

Fixes #10594

## Problem

`recurse_prefetches` propagates the root query filter into prefetch leaves with `Filter::merge_opts`. `merge_owned` concatenates `should` lists and unions `min_should` conditions (`max(min_count)`), which turns the intended AND of the two filters into an OR:

- root `{should: [a=1]}` + prefetch `{should: [b=2]}` matched either condition;
- root `{min_should: 2 of [a=1, c=3]}` + prefetch `{min_should: 1 of [b=2]}` became "2 of 3" over the union, letting points skip the prefetch condition.

`must`/`must_not` were unaffected.

## Fix

Nest the propagated filter as `Condition::Filter` under `must` before merging, so propagation stays conjunctive for any combination of combinators. One-line behavioral change in `lib/shard/src/query/planned_query.rs`; recursion semantics (re-propagating the merged filter to deeper levels) are unchanged.

## Tests

Added `test_root_filter_ands_with_prefetch_should` in `lib/collection/src/tests/query_prefetch_offset_limit.rs` with a payload-carrying fixture:

- should+should: asserts exactly the points satisfying BOTH conditions are returned (fails on current dev, which returns the union);
- min_should+min_should: asserts the intersection over disjoint id ranges is empty (fails on current dev, which returns points skipping the prefetch condition).

## Verification

- `cargo check -p shard` passes.
- `cargo check -p collection --tests` passes.
- Full test suite not run locally (environment resource limits); the new regression test and existing prefetch tests should be run in CI.

## All Submissions

* [x] Contributions should target the `dev` branch. Did you create your branch from `dev`?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## New Feature Submissions

* [x] Does your submission pass existing tests? (checks pass; full suite in CI, see above)
* [x] Have you added tests for your feature/fix?