### PR TITLE
Support `cached` id tracker memory placement

### DIFF
--- a/docs/redoc/master/openapi.json
+++ b/docs/redoc/master/openapi.json
@@ -7232,7 +7232,7 @@
         "type": "object",
         "properties": {
           "memory": {
-            "description": "Memory placement of the point id mapping in indexed segments: `cold` keeps it on disk and reads it on demand, `pinned` keeps it in RAM. `cached` is not supported. Default: `pinned`.",
+            "description": "Memory placement of the point id mapping in indexed segments: `cold` keeps it on disk and reads it on demand, `cached` keeps it on disk but primes the page cache with it on load, `pinned` keeps it in RAM. Default: `pinned`.",
             "anyOf": [
               {
                 "$ref": "#/components/schemas/Memory"

--- a/lib/api/src/grpc/proto/collections.proto
+++ b/lib/api/src/grpc/proto/collections.proto
@@ -530,8 +530,8 @@ message PayloadStorageParams {
 
 message IdTrackerParams {
   // Memory placement of the point id mapping in indexed segments:
-  // `Cold` keeps it on disk and reads it on demand, `Pinned` keeps it in RAM.
-  // `Cached` is not supported.
+  // `Cold` keeps it on disk and reads it on demand, `Cached` keeps it on disk
+  // but primes the page cache with it on load, `Pinned` keeps it in RAM.
   optional Memory memory = 1;
 }
 

--- a/lib/api/src/grpc/qdrant.rs
+++ b/lib/api/src/grpc/qdrant.rs
@@ -1183,8 +1183,8 @@ pub struct PayloadStorageParams {
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct IdTrackerParams {
     /// Memory placement of the point id mapping in indexed segments:
-    /// `Cold` keeps it on disk and reads it on demand, `Pinned` keeps it in RAM.
-    /// `Cached` is not supported.
+    /// `Cold` keeps it on disk and reads it on demand, `Cached` keeps it on disk
+    /// but primes the page cache with it on load, `Pinned` keeps it in RAM.
     #[prost(enumeration = "Memory", optional, tag = "1")]
     pub memory: ::core::option::Option<i32>,
 }

--- a/lib/collection/src/config.rs
+++ b/lib/collection/src/config.rs
@@ -208,10 +208,10 @@ impl PayloadStorageParams {
 #[anonymize(false)]
 pub struct IdTrackerParams {
     /// Memory placement of the point id mapping in indexed segments: `cold` keeps it on disk and
-    /// reads it on demand, `pinned` keeps it in RAM. `cached` is not supported.
+    /// reads it on demand, `cached` keeps it on disk but primes the page cache with it on load,
+    /// `pinned` keeps it in RAM.
     /// Default: `pinned`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[validate(custom(function = "validate_id_tracker_memory"))]
     pub memory: Option<Memory>,
 }
 
@@ -221,21 +221,6 @@ impl IdTrackerParams {
         let IdTrackerParams { memory } = diff;
         IdTrackerParams {
             memory: memory.or(self.memory),
-        }
-    }
-}
-
-/// Reject memory placements not supported by the id tracker.
-/// `validator` unwraps `Option<Memory>` before calling, so we receive `&Memory`.
-fn validate_id_tracker_memory(memory: &Memory) -> Result<(), ValidationError> {
-    match memory {
-        Memory::Cold | Memory::Pinned => Ok(()),
-        Memory::Cached => {
-            let mut error = ValidationError::new("unsupported_memory_placement");
-            error.message = Some(std::borrow::Cow::from(
-                "`cached` memory placement is not supported for id tracker",
-            ));
-            Err(error)
         }
     }
 }

--- a/lib/segment/src/id_tracker/disk_id_tracker/lifecycle.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/lifecycle.rs
@@ -38,8 +38,9 @@ where
     }
 
     /// Open an existing disk-resident id tracker: `deleted` and `versions` are
-    /// read into RAM (small, mutated in place), the mapping stays on disk.
-    pub fn open(fs: &S::Fs, segment_path: &Path) -> OperationResult<Self> {
+    /// read into RAM (small, mutated in place), the mapping stays on disk;
+    /// `populate` says whether to prime the page cache with it.
+    pub fn open(fs: &S::Fs, segment_path: &Path, populate: Populate) -> OperationResult<Self> {
         let deleted_storage = StoredBitSlice::open(
             fs,
             deleted_path(segment_path),
@@ -71,7 +72,7 @@ where
         let internal_to_version_wrapper =
             SliceBufferedUpdateWrapper::new(internal_to_version_file.inner)?;
 
-        let reader = DiskMappingReader::open(fs, segment_path)?;
+        let reader = DiskMappingReader::open(fs, segment_path, populate)?;
 
         Ok(Self {
             path: segment_path.to_path_buf(),
@@ -158,7 +159,9 @@ where
         deleted_wrapper.flusher()()?;
         internal_to_version_wrapper.flusher()()?;
 
-        let reader = DiskMappingReader::open(fs, path)?;
+        // Just written, so cached already; the configured placement applies
+        // when the built segment is loaded.
+        let reader = DiskMappingReader::open(fs, path, Populate::No)?;
 
         Ok(Self {
             path: path.to_path_buf(),

--- a/lib/segment/src/id_tracker/disk_id_tracker/read_only/lifecycle.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/read_only/lifecycle.rs
@@ -16,11 +16,11 @@ use crate::id_tracker::immutable_id_tracker::{deleted_path, version_mapping_path
 use crate::types::SeqNumberType;
 
 impl<S: UniversalRead> ReadOnlyDiskIdTracker<S> {
-    pub(super) fn open_options() -> OpenOptions {
+    pub(super) fn open_options(populate: Populate) -> OpenOptions {
         OpenOptions {
             writeable: false,
             need_sequential: false,
-            populate: Populate::No,
+            populate,
             advice: AdviceSetting::Global,
         }
     }
@@ -37,16 +37,18 @@ impl<S: UniversalRead> ReadOnlyDiskIdTracker<S> {
 
     /// Schedule background prefetch of every file [`try_open`](Self::try_open)
     /// will read. Returns `false` (nothing scheduled) when the tracker is not
-    /// in the on-disk format.
+    /// in the on-disk format. `populate` is the placement of the per-point
+    /// data, see [`open`](Self::open).
     pub fn try_preopen(
         fs: &impl CachedReadFs<File = S>,
         segment_path: &Path,
+        populate: Populate,
     ) -> OperationResult<bool> {
-        if !DiskMappingReader::try_preopen(fs, segment_path)? {
+        if !DiskMappingReader::try_preopen(fs, segment_path, populate)? {
             return Ok(false);
         }
 
-        let options = Self::open_options();
+        let options = Self::open_options(populate);
         fs.schedule_open(&version_mapping_path(segment_path), Some(options), None);
         fs.schedule_open(
             &deleted_path(segment_path),
@@ -58,12 +60,17 @@ impl<S: UniversalRead> ReadOnlyDiskIdTracker<S> {
     }
 
     /// Open a read-only disk id tracker at `segment_path`; all per-point data
-    /// except the `is_uuid` bitmap stays on the backing store.
+    /// except the `is_uuid` bitmap stays on the backing store. A populating
+    /// `populate` primes the page cache with the mapping and versions.
     ///
     /// Errors if the segment is not in the on-disk format; use
     /// [`try_open`](Self::try_open) to probe without erroring.
-    pub fn open(fs: &impl UniversalReadFs<File = S>, segment_path: &Path) -> OperationResult<Self> {
-        Self::try_open(fs, segment_path)?.ok_or_else(|| {
+    pub fn open(
+        fs: &impl UniversalReadFs<File = S>,
+        segment_path: &Path,
+        populate: Populate,
+    ) -> OperationResult<Self> {
+        Self::try_open(fs, segment_path, populate)?.ok_or_else(|| {
             OperationError::service_error(format!(
                 "on-disk id tracker not found in segment {}",
                 segment_path.display(),
@@ -76,12 +83,13 @@ impl<S: UniversalRead> ReadOnlyDiskIdTracker<S> {
     pub fn try_open(
         fs: &impl UniversalReadFs<File = S>,
         segment_path: &Path,
+        populate: Populate,
     ) -> OperationResult<Option<Self>> {
-        let Some(reader) = DiskMappingReader::try_open(fs, segment_path)? else {
+        let Some(reader) = DiskMappingReader::try_open(fs, segment_path, populate)? else {
             return Ok(None);
         };
 
-        let options = Self::open_options();
+        let options = Self::open_options(populate);
 
         let versions = TypedStorage::<S, SeqNumberType>::new(fs.open(
             version_mapping_path(segment_path),

--- a/lib/segment/src/id_tracker/disk_id_tracker/read_only/live_reload.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/read_only/live_reload.rs
@@ -3,7 +3,7 @@
 use common::bitvec::BitVec;
 use common::stored_bitslice::StoredBitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, OkUnchanged, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, OkUnchanged, Populate, UniversalRead, UniversalReadFs};
 use futures::future::BoxFuture;
 
 use super::ReadOnlyDiskIdTracker;
@@ -45,7 +45,7 @@ impl<S: UniversalRead> ReadOnlyDiskIdTracker<S> {
         let Some(fresh) = StoredBitSlice::<S>::open(
             fs,
             deleted_path(&self.path),
-            Self::open_options(),
+            Self::open_options(Populate::No),
             Default::default(),
         )
         .ok_unchanged()?

--- a/lib/segment/src/id_tracker/disk_id_tracker/reader/lifecycle.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/reader/lifecycle.rs
@@ -21,14 +21,19 @@ use crate::id_tracker::disk_id_tracker::on_disk_format::{
 type Endian = LittleEndian;
 
 impl<S: UniversalRead> DiskMappingReader<S> {
-    fn open_options() -> OpenOptions {
+    /// Options for the `i2e`/`e2i` handles. A non-populating open still
+    /// prefetches the headers, which are read at open regardless.
+    fn open_options(populate: Populate) -> OpenOptions {
+        let populate = match populate {
+            Populate::Blocking | Populate::PreferBackground => populate,
+            Populate::Auto | Populate::No | Populate::Partial(_) => Populate::Partial(
+                ReadRange::new(0, size_of::<I2eHeader>().max(size_of::<E2iHeader>()) as u64),
+            ),
+        };
         OpenOptions {
             writeable: false,
             need_sequential: false,
-            populate: Populate::Partial(ReadRange::new(
-                0,
-                size_of::<I2eHeader>().max(size_of::<E2iHeader>()) as u64,
-            )),
+            populate,
             advice: AdviceSetting::Global,
         }
     }
@@ -46,17 +51,19 @@ impl<S: UniversalRead> DiskMappingReader<S> {
 
     /// Schedule background prefetch of every file [`try_open`](Self::try_open)
     /// will open. Returns `false` (nothing scheduled) when the mapping is not
-    /// in the on-disk format.
+    /// in the on-disk format. `populate` is the mapping placement, see
+    /// [`open`](Self::open).
     pub fn try_preopen(
         fs: &impl CachedReadFs<File = S>,
         segment_path: &Path,
+        populate: Populate,
     ) -> OperationResult<bool> {
         let i2e_path = i2e_path(segment_path);
         if !UniversalReadFileOps::exists(fs, &i2e_path)? {
             return Ok(false);
         }
 
-        let options = Self::open_options();
+        let options = Self::open_options(populate);
 
         fs.schedule_open(&i2e_path, Some(options), None);
         fs.schedule_open(&e2i_path(segment_path), Some(options), None);
@@ -75,12 +82,18 @@ impl<S: UniversalRead> DiskMappingReader<S> {
     }
 
     /// Open the reader, loading only headers, the sparse index, and the
-    /// `is_uuid` bitmap into RAM; no per-point mapping data is read.
+    /// `is_uuid` bitmap into RAM; no per-point mapping data is read. A
+    /// populating `populate` additionally primes the page cache with the
+    /// mapping files, which otherwise are paged in on demand.
     ///
     /// Errors if the segment is not in the on-disk format (`i2e` absent). Use
     /// [`try_open`](Self::try_open) to probe without erroring.
-    pub fn open(fs: &impl UniversalReadFs<File = S>, segment_path: &Path) -> OperationResult<Self> {
-        Self::try_open(fs, segment_path)?.ok_or_else(|| {
+    pub fn open(
+        fs: &impl UniversalReadFs<File = S>,
+        segment_path: &Path,
+        populate: Populate,
+    ) -> OperationResult<Self> {
+        Self::try_open(fs, segment_path, populate)?.ok_or_else(|| {
             OperationError::service_error(format!(
                 "on-disk id tracker mapping ({}) not found",
                 i2e_path(segment_path).display(),
@@ -95,8 +108,9 @@ impl<S: UniversalRead> DiskMappingReader<S> {
     pub fn try_open(
         fs: &impl UniversalReadFs<File = S>,
         segment_path: &Path,
+        populate: Populate,
     ) -> OperationResult<Option<Self>> {
-        let options = Self::open_options();
+        let options = Self::open_options(populate);
 
         let Some(i2e) = fs
             .open(i2e_path(segment_path), options, Default::default())

--- a/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
+++ b/lib/segment/src/id_tracker/disk_id_tracker/tests.rs
@@ -1,6 +1,6 @@
 use ahash::AHashMap;
 use common::types::DeferredBehavior;
-use common::universal_io::{MmapFile, MmapFs};
+use common::universal_io::{MmapFile, MmapFs, Populate};
 use rand::SeedableRng as _;
 use rand::rngs::StdRng;
 use tempfile::Builder;
@@ -169,7 +169,8 @@ fn batch_lookups_match_single() {
     let disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
     assert_batch_parity(&disk);
 
-    let read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+    let read_only =
+        ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path(), Populate::No).unwrap();
     assert_batch_parity(&read_only);
 }
 
@@ -193,7 +194,8 @@ fn read_only_matches_immutable() {
     // Writing the files also validates the on-disk format round-trips.
     let _disk = DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
 
-    let read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+    let read_only =
+        ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path(), Populate::No).unwrap();
     assert_read_parity(&immutable, &read_only);
 }
 
@@ -228,8 +230,13 @@ fn detect_and_load_selects_disk_format() {
     let disk_dir = Builder::new().prefix("disk").tempdir().unwrap();
     let _disk =
         DiskIdTracker::<MmapFile>::new(&MmapFs, disk_dir.path(), &versions, mappings).unwrap();
-    let loaded =
-        ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(&MmapFs, disk_dir.path(), None).unwrap();
+    let loaded = ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(
+        &MmapFs,
+        disk_dir.path(),
+        None,
+        Populate::No,
+    )
+    .unwrap();
     assert_eq!(loaded.name(), "read-only disk id tracker");
     assert_read_parity(&immutable, &loaded);
 
@@ -238,15 +245,24 @@ fn detect_and_load_selects_disk_format() {
     let imm_dir = Builder::new().prefix("imm").tempdir().unwrap();
     let _imm = ImmutableIdTracker::<MmapFile>::new(&MmapFs, imm_dir.path(), &versions2, mappings2)
         .unwrap();
-    let loaded =
-        ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(&MmapFs, imm_dir.path(), None).unwrap();
+    let loaded = ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(
+        &MmapFs,
+        imm_dir.path(),
+        None,
+        Populate::No,
+    )
+    .unwrap();
     assert_eq!(loaded.name(), "read-only immutable id tracker");
 
     // An empty segment (no mapping files) falls back to the appendable reader.
     let empty_dir = Builder::new().prefix("empty").tempdir().unwrap();
-    let loaded =
-        ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(&MmapFs, empty_dir.path(), None)
-            .unwrap();
+    let loaded = ReadOnlyIdTrackerEnum::<MmapFile>::detect_and_load(
+        &MmapFs,
+        empty_dir.path(),
+        None,
+        Populate::No,
+    )
+    .unwrap();
     assert_eq!(loaded.name(), "read-only appendable id tracker");
 }
 
@@ -261,7 +277,8 @@ fn is_uuid_sidecar_written_and_listed() {
     assert!(disk.files().contains(&is_uuid_file));
     assert!(disk.immutable_files().contains(&is_uuid_file));
 
-    let read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+    let read_only =
+        ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path(), Populate::No).unwrap();
     assert!(read_only.files().contains(&is_uuid_file));
 }
 
@@ -301,7 +318,8 @@ fn read_by_id_does_not_materialize_deleted_set() {
         disk.point_mappings().iter_from(None).collect()
     };
 
-    let read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+    let read_only =
+        ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path(), Populate::No).unwrap();
 
     // Point lookups must not trigger the full deleted-set materialization.
     for (external_id, offset) in live.iter().take(200) {
@@ -349,7 +367,8 @@ fn deletion_and_live_reload() {
         DiskIdTracker::<MmapFile>::new(&MmapFs, dir.path(), &versions, mappings).unwrap();
 
     // A reader opened before the deletions; it will pick them up via live_reload.
-    let mut read_only = ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path()).unwrap();
+    let mut read_only =
+        ReadOnlyDiskIdTracker::<MmapFile>::open(&MmapFs, dir.path(), Populate::No).unwrap();
     // Establish the diff baseline (a search-style access) so the next reload
     // reports only the incremental deletions, not every build-time deletion.
     let _ = read_only.deleted_point_bitslice();
@@ -441,7 +460,8 @@ fn deletion_and_live_reload_disk_cache() {
         ReadOnlyImmutableIdTracker::<DiskCache<MmapFile>>::open(&cache_fs, &immutable_path)
             .unwrap();
     let mut read_only_disk =
-        ReadOnlyDiskIdTracker::<DiskCache<MmapFile>>::open(&cache_fs, &disk_path).unwrap();
+        ReadOnlyDiskIdTracker::<DiskCache<MmapFile>>::open(&cache_fs, &disk_path, Populate::No)
+            .unwrap();
     // Establish the diff baseline (a search-style access) so the reload
     // reports only the incremental deletions, not every build-time deletion.
     let _ = read_only_disk.deleted_point_bitslice();

--- a/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
+++ b/lib/segment/src/id_tracker/id_tracker_base/read_only_tracker_enum.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use common::bitvec::BitSlice;
 use common::types::PointOffsetType;
-use common::universal_io::{CachedReadFs, UniversalRead, UniversalReadFs};
+use common::universal_io::{CachedReadFs, Populate, UniversalRead, UniversalReadFs};
 use futures::future::BoxFuture;
 
 use crate::common::operation_error::OperationResult;
@@ -23,8 +23,14 @@ pub enum ReadOnlyIdTrackerEnum<S: UniversalRead> {
 impl<S: UniversalRead> ReadOnlyIdTrackerEnum<S> {
     /// Schedule background prefetch for whichever id-tracker format is
     /// present, probing in the same order as [`Self::detect_and_load`].
-    pub fn preopen(fs: &impl CachedReadFs<File = S>, segment_path: &Path) -> OperationResult<()> {
-        if ReadOnlyDiskIdTracker::try_preopen(fs, segment_path)? {
+    /// `populate` applies to the disk-resident format only: the other formats
+    /// hold their per-point data in RAM regardless.
+    pub fn preopen(
+        fs: &impl CachedReadFs<File = S>,
+        segment_path: &Path,
+        populate: Populate,
+    ) -> OperationResult<()> {
+        if ReadOnlyDiskIdTracker::try_preopen(fs, segment_path, populate)? {
             return Ok(());
         }
         if ReadOnlyImmutableIdTracker::try_preopen(fs, segment_path)? {
@@ -40,12 +46,14 @@ impl<S: UniversalRead> ReadOnlyIdTrackerEnum<S> {
     /// Order: disk-resident (the serverless/object-storage format) first, then
     /// the in-RAM immutable format, then the appendable/mutable format (whose
     /// open tolerates absent files, i.e. a fresh or empty segment).
+    /// `populate` applies to the disk-resident format only, see [`Self::preopen`].
     pub fn detect_and_load(
         fs: &impl UniversalReadFs<File = S>,
         segment_path: &Path,
         deferred_internal_id: Option<PointOffsetType>,
+        populate: Populate,
     ) -> OperationResult<Self> {
-        if let Some(tracker) = ReadOnlyDiskIdTracker::try_open(fs, segment_path)? {
+        if let Some(tracker) = ReadOnlyDiskIdTracker::try_open(fs, segment_path, populate)? {
             return Ok(Self::DiskResident(tracker));
         }
         if let Some(tracker) = ReadOnlyImmutableIdTracker::try_open(fs, segment_path)? {

--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -63,6 +63,17 @@ fn payload_populate(config: &SegmentConfig) -> Populate {
     }
 }
 
+/// How the disk-resident id tracker's per-point data is brought into memory;
+/// the other tracker formats hold it in RAM regardless.
+fn id_tracker_populate(config: &SegmentConfig) -> Populate {
+    let memory = config.id_tracker_memory_placement().clamp_to_low_memory();
+    if memory.populate_on_open() {
+        Populate::PreferBackground
+    } else {
+        Populate::No
+    }
+}
+
 /// How one sparse vector's storage is brought into memory. Search never reads
 /// it, so it normally stays cold — except when the (non-persisted) mutable-RAM
 /// sparse index is configured: that index is rebuilt from the storage at open,
@@ -141,7 +152,7 @@ impl<S: UniversalReadExt<Fs: UniversalReadFsAsync> + 'static> ReadOnlySegment<S>
         ReadOnlyPayloadStorage::preopen(fs, segment_path.to_path_buf(), payload_storage_populate)?;
 
         // Id tracker; always loaded — every request resolves ids through it.
-        ReadOnlyIdTrackerEnum::preopen(fs, segment_path)?;
+        ReadOnlyIdTrackerEnum::preopen(fs, segment_path, id_tracker_populate(&config))?;
 
         // Vector storages
         for (vector_name, vector_config) in &config.vector_data {
@@ -255,6 +266,7 @@ impl<S: UniversalReadExt<Fs: UniversalReadFsAsync> + 'static> ReadOnlySegment<S>
             &fs,
             segment_path,
             deferred_internal_id,
+            id_tracker_populate(&config),
         )?));
 
         // Open all vector storages up front: the payload index needs them.

--- a/lib/segment/src/segment/update_only/lookup/lifecycle.rs
+++ b/lib/segment/src/segment/update_only/lookup/lifecycle.rs
@@ -121,6 +121,7 @@ impl<Fs: UniversalReadFsAsync> LookupSegment<Fs> {
             &fs,
             segment_path,
             deferred_internal_id.filter(|_| appendable),
+            WRITER_POPULATE,
         )?));
 
         let mut vector_data = HashMap::new();
@@ -174,7 +175,7 @@ impl<Fs: UniversalReadFsAsync> LookupSegment<Fs> {
         } = read_json_via(fs, segment_path.join(SEGMENT_STATE_FILE))?;
 
         ReadOnlyPayloadStorage::preopen(fs, segment_path.to_path_buf(), WRITER_POPULATE)?;
-        ReadOnlyIdTrackerEnum::preopen(fs, segment_path)?;
+        ReadOnlyIdTrackerEnum::preopen(fs, segment_path, WRITER_POPULATE)?;
 
         for (vector_name, vector_config) in &config.vector_data {
             let path = get_vector_storage_path(segment_path, vector_name);

--- a/lib/segment/src/segment_constructor/segment_builder.rs
+++ b/lib/segment/src/segment_constructor/segment_builder.rs
@@ -592,8 +592,8 @@ impl SegmentBuilder {
             let id_tracker = match id_tracker {
                 IdTrackerEnum::InMemoryIdTracker(in_memory_id_tracker) => {
                     match segment_config.id_tracker_memory_placement() {
-                        // Mapping stays on disk. `Cached` is rejected by API validation;
-                        // it defensively maps to the closest supported placement.
+                        // Mapping stays on disk; a cached placement primes the page cache
+                        // with it when the built segment is loaded.
                         Memory::Cold | Memory::Cached => {
                             let disk_id_tracker = DiskIdTracker::from_in_memory_tracker(
                                 &MmapFs,

--- a/lib/segment/src/segment_constructor/segment_constructor_base/create_segment.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/create_segment.rs
@@ -8,7 +8,7 @@ use atomic_refcell::AtomicRefCell;
 use common::defaults::log_load_timing;
 use common::is_alive_lock::IsAliveLock;
 use common::types::PointOffsetType;
-use common::universal_io::MmapFs;
+use common::universal_io::{MmapFs, Populate};
 use parking_lot::Mutex;
 use uuid::Uuid;
 
@@ -58,9 +58,19 @@ pub(super) fn create_segment(
     let deferred_internal_id = deferred_internal_id.filter(|_| appendable_flag);
 
     let id_tracker_format = IdTrackerFormat::detect_local(segment_path, appendable_flag);
+    let id_tracker_populate = Populate::from(
+        config
+            .id_tracker_memory_placement()
+            .clamp_to_low_memory()
+            .populate_on_open(),
+    );
     let started = Instant::now();
-    let id_tracker =
-        create_segment_id_tracker(id_tracker_format, segment_path, deferred_internal_id)?;
+    let id_tracker = create_segment_id_tracker(
+        id_tracker_format,
+        segment_path,
+        deferred_internal_id,
+        id_tracker_populate,
+    )?;
     log_load_timing(segment_path, "id_tracker", started);
 
     let mut vector_storages = HashMap::new();

--- a/lib/segment/src/segment_constructor/segment_constructor_base/id_tracker.rs
+++ b/lib/segment/src/segment_constructor/segment_constructor_base/id_tracker.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use atomic_refcell::AtomicRefCell;
 use common::types::PointOffsetType;
-use common::universal_io::MmapFs;
+use common::universal_io::{MmapFs, Populate};
 
 use super::sp;
 use crate::common::operation_error::OperationResult;
@@ -19,10 +19,13 @@ pub(crate) fn create_mutable_id_tracker(
     MutableIdTracker::open(segment_path, deferred_internal_id)
 }
 
+/// `populate` is the placement of the disk-resident format's mapping; the other
+/// formats hold it in RAM regardless.
 pub(crate) fn create_segment_id_tracker(
     format: IdTrackerFormat,
     segment_path: &Path,
     deferred_internal_id: Option<PointOffsetType>,
+    populate: Populate,
 ) -> OperationResult<Arc<AtomicRefCell<IdTrackerEnum>>> {
     let id_tracker = match format {
         IdTrackerFormat::Mutable => IdTrackerEnum::MutableIdTracker(create_mutable_id_tracker(
@@ -33,7 +36,7 @@ pub(crate) fn create_segment_id_tracker(
             IdTrackerEnum::ImmutableIdTracker(ImmutableIdTracker::open(&MmapFs, segment_path)?)
         }
         IdTrackerFormat::Disk => {
-            IdTrackerEnum::DiskIdTracker(DiskIdTracker::open(&MmapFs, segment_path)?)
+            IdTrackerEnum::DiskIdTracker(DiskIdTracker::open(&MmapFs, segment_path, populate)?)
         }
     };
     Ok(sp(id_tracker))

--- a/tests/openapi/test_memory_placement.py
+++ b/tests/openapi/test_memory_placement.py
@@ -150,15 +150,21 @@ def test_id_tracker_memory_placement():
     assert response.ok, response.text
     assert response.json()["result"]["config"]["params"]["id_tracker"]["memory"] == "pinned"
 
-    # The id tracker has no populate-on-open variant: `cached` is rejected
     response = request_with_validation(
         api="/collections/{collection_name}",
         method="PATCH",
         path_params={"collection_name": collection_name},
         body={"params": {"id_tracker": {"memory": "cached"}}},
     )
-    assert response.status_code == 422, response.text
-    assert "cached" in response.json()["status"]["error"]
+    assert response.ok, response.text
+
+    response = request_with_validation(
+        api="/collections/{collection_name}",
+        method="GET",
+        path_params={"collection_name": collection_name},
+    )
+    assert response.ok, response.text
+    assert response.json()["result"]["config"]["params"]["id_tracker"]["memory"] == "cached"
 
 
 def test_pinned_payload_storage_is_rejected():


### PR DESCRIPTION
Follow-up to #10597, stacked on `id-tracker-memory-placement`.

## What

`id_tracker: { memory: cached }` is now accepted. The mapping stays on disk like `cold`, but the page cache is primed with it when the segment is loaded (`Populate::Blocking` on the server's segment open, `PreferBackground` on the read-only open, mirroring how payload storage is handled there).

## How

- `DiskMappingReader::{open, try_open, try_preopen}` take a `Populate`. A non-populating open keeps prefetching just the headers, which are read at open regardless.
- `DiskIdTracker::open` and `ReadOnlyDiskIdTracker::{open, try_open, try_preopen}` take it too; the read-only tracker also applies it to its lazily read versions file. `ReadOnlyIdTrackerEnum::{preopen, detect_and_load}` forward it to the disk-resident format only, the other formats hold their data in RAM regardless.
- Segment open derives it from `SegmentConfig::id_tracker_memory_placement()`, clamped to low-memory mode: `create_segment` for the writable segment, `id_tracker_populate` next to `payload_populate` for the read-only segment.
- Unchanged: the update-only lookup segment keeps `WRITER_POPULATE` (transfers nothing), the build-time reader stays cold (the built segment is reloaded through `load_segment`), and the live-reload reopen of the deleted mask stays non-populating.
- The `cached` validator is removed; docs and the OpenAPI spec are updated.

As with the sparse index, switching an existing collection between `cold` and `cached` goes through the config mismatch optimizer, since the placement is persisted in the segment config.

## Tests

- `tests/openapi/test_memory_placement.py`: `cached` is accepted on update and echoed back.
- Disk id tracker, read-only segment, segment builder, and config mismatch tests pass; clippy `-D warnings` clean for default and `--all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
