### PR TITLE
fix(api): cap relevance feedback items to bound quadratic pair expansion

### DIFF
--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -341,7 +341,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("ContextInputPair.negative", ""),
             ("ContextInput.pairs", ""),
             ("RelevanceFeedbackInput.target", ""),
-            ("RelevanceFeedbackInput.feedback", "length(min = 1, max = 100)"),
+            ("RelevanceFeedbackInput.feedback", ""),
             ("RelevanceFeedbackInput.strategy", ""),
             ("FeedbackStrategy.variant", ""),
             ("FeedbackItem.example", ""),

--- a/lib/api/build.rs
+++ b/lib/api/build.rs
@@ -341,7 +341,7 @@ fn configure_validation(builder: Builder) -> Builder {
             ("ContextInputPair.negative", ""),
             ("ContextInput.pairs", ""),
             ("RelevanceFeedbackInput.target", ""),
-            ("RelevanceFeedbackInput.feedback", ""),
+            ("RelevanceFeedbackInput.feedback", "length(min = 1, max = 100)"),
             ("RelevanceFeedbackInput.strategy", ""),
             ("FeedbackStrategy.variant", ""),
             ("FeedbackItem.example", ""),

--- a/lib/api/src/rest/validate.rs
+++ b/lib/api/src/rest/validate.rs
@@ -288,6 +288,15 @@ impl Validate for Expression {
     }
 }
 
+/// Artificial maximum number of feedback items in a relevance feedback query.
+///
+/// Feedback items expand into `n * (n - 1)` ordered context pairs, each holding
+/// clones of two query vectors, so an uncapped list amplifies a small request
+/// into a quadratic memory spike. Real-world feedback is human-labeled and
+/// stays in the tens, so this leaves generous headroom.
+/// Mirrors `RelevanceFeedbackInput.feedback` validation in the gRPC API.
+pub const MAX_FEEDBACK_ITEMS: usize = 100;
+
 /// Struct level validation for `FeedbackInput`
 pub fn validate_relevance_feedback_input(
     relevance_feedback_input: &RelevanceFeedbackInput,
@@ -298,12 +307,55 @@ pub fn validate_relevance_feedback_input(
         return Err(err);
     }
 
+    if relevance_feedback_input.feedback.len() > MAX_FEEDBACK_ITEMS {
+        let mut err = ValidationError::new("feedback");
+        err.message = Some(Cow::from(format!(
+            "feedback elements must not exceed {MAX_FEEDBACK_ITEMS} items"
+        )));
+        return Err(err);
+    }
+
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rest::schema::{FeedbackItem, FeedbackStrategy, NaiveFeedbackStrategy, NaiveFeedbackStrategyParams, RelevanceFeedbackInput};
+
+    fn feedback_input_with_len(len: usize) -> RelevanceFeedbackInput {
+        RelevanceFeedbackInput {
+            target: crate::rest::schema::VectorInput::DenseVector(vec![0.0; 4]),
+            feedback: (0..len)
+                .map(|i| FeedbackItem {
+                    example: crate::rest::schema::VectorInput::DenseVector(vec![0.0; 4]),
+                    score: i as f32,
+                })
+                .collect(),
+            strategy: FeedbackStrategy::Naive(NaiveFeedbackStrategy {
+                naive: NaiveFeedbackStrategyParams {
+                    a: 1.0,
+                    b: 0.0,
+                    c: 1.0,
+                },
+            }),
+        }
+    }
+
+    #[test]
+    fn relevance_feedback_rejects_too_many_items() {
+        let input = feedback_input_with_len(MAX_FEEDBACK_ITEMS + 1);
+        assert!(validate_relevance_feedback_input(&input).is_err());
+
+        let input = feedback_input_with_len(MAX_FEEDBACK_ITEMS);
+        assert!(validate_relevance_feedback_input(&input).is_ok());
+    }
+
+    #[test]
+    fn relevance_feedback_rejects_empty() {
+        let input = feedback_input_with_len(0);
+        assert!(validate_relevance_feedback_input(&input).is_err());
+    }
 
     fn formula_query_with_defaults(defaults: serde_json::Value) -> FormulaQuery {
         serde_json::from_value(serde_json::json!({

--- a/src/common/inference/query_requests_grpc.rs
+++ b/src/common/inference/query_requests_grpc.rs
@@ -321,6 +321,10 @@ fn convert_query_with_inferred(
                 strategy,
             } = feedback;
 
+            if feedback.is_empty() {
+                return Err(Status::invalid_argument("feedback must not be empty"));
+            }
+
             if feedback.len() > MAX_FEEDBACK_ITEMS {
                 return Err(Status::invalid_argument(format!(
                     "feedback elements must not exceed {MAX_FEEDBACK_ITEMS} items"
@@ -655,6 +659,19 @@ mod tests {
         let err = convert_query_with_inferred(query, &inferred).unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
         assert!(err.message().contains("must not exceed"));
+    }
+
+    #[test]
+    fn test_relevance_feedback_empty_rejected() {
+        let inferred = create_test_inferred_batch();
+        let query = grpc::Query {
+            variant: Some(api::grpc::qdrant::query::Variant::RelevanceFeedback(
+                feedback_input_with_len(0),
+            )),
+        };
+        let err = convert_query_with_inferred(query, &inferred).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("must not be empty"));
     }
 
     #[test]

--- a/src/common/inference/query_requests_grpc.rs
+++ b/src/common/inference/query_requests_grpc.rs
@@ -2,6 +2,7 @@ use api::conversions::json::json_path_from_proto;
 use api::grpc::qdrant::RecommendInput;
 use api::grpc::qdrant::query::Variant;
 use api::grpc::{InferenceUsage, qdrant as grpc};
+use api::rest::validate::MAX_FEEDBACK_ITEMS;
 use api::rest::{self, LookupLocation, RecommendStrategy};
 use collection::operations::universal_query::collection_query::{
     CollectionPrefetch, CollectionQueryGroupsRequest, CollectionQueryRequest, FeedbackInternal,
@@ -320,6 +321,12 @@ fn convert_query_with_inferred(
                 strategy,
             } = feedback;
 
+            if feedback.len() > MAX_FEEDBACK_ITEMS {
+                return Err(Status::invalid_argument(format!(
+                    "feedback elements must not exceed {MAX_FEEDBACK_ITEMS} items"
+                )));
+            }
+
             let target = target.ok_or_else(|| Status::invalid_argument("target is missing"))?;
             let target = convert_vector_input_with_inferred(target, inferred)?;
 
@@ -607,4 +614,58 @@ mod tests {
                 .contains("positive is missing"),
         );
     }
+
+    fn feedback_input_with_len(len: usize) -> grpc::RelevanceFeedbackInput {
+        let example = grpc::VectorInput {
+            variant: Some(Variant::Dense(grpc::DenseVector {
+                data: vec![1.0, 2.0, 3.0],
+            })),
+        };
+        let item = grpc::FeedbackItem {
+            example: Some(example),
+            score: 1.0,
+        };
+        grpc::RelevanceFeedbackInput {
+            target: Some(grpc::VectorInput {
+                variant: Some(Variant::Dense(grpc::DenseVector {
+                    data: vec![1.0, 2.0, 3.0],
+                })),
+            }),
+            feedback: vec![item; len],
+            strategy: Some(grpc::FeedbackStrategy {
+                variant: Some(grpc::feedback_strategy::Variant::Naive(
+                    grpc::NaiveFeedbackStrategy {
+                        a: 1.0,
+                        b: 0.5,
+                        c: 0.25,
+                    },
+                )),
+            }),
+        }
+    }
+
+    #[test]
+    fn test_relevance_feedback_over_limit_rejected() {
+        let inferred = create_test_inferred_batch();
+        let query = grpc::Query {
+            variant: Some(api::grpc::qdrant::query::Variant::RelevanceFeedback(
+                feedback_input_with_len(MAX_FEEDBACK_ITEMS + 1),
+            )),
+        };
+        let err = convert_query_with_inferred(query, &inferred).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("must not exceed"));
+    }
+
+    #[test]
+    fn test_relevance_feedback_at_limit_accepted() {
+        let inferred = create_test_inferred_batch();
+        let query = grpc::Query {
+            variant: Some(api::grpc::qdrant::query::Variant::RelevanceFeedback(
+                feedback_input_with_len(MAX_FEEDBACK_ITEMS),
+            )),
+        };
+        assert!(convert_query_with_inferred(query, &inferred).is_ok());
+    }
 }
+


### PR DESCRIPTION
Fixes #10601

`RelevanceFeedbackInput.feedback` expands into `n * (n - 1)` ordered context pairs with two vector clones each, and was only validated to be non-empty (REST; gRPC had no constraint at all). This caps it at 100 items in both APIs (artificial maximum, following the MMR `candidates_limit` precedent), and adds the missing non-empty constraint to gRPC.

- REST: `validate_relevance_feedback_input` in `lib/api/src/rest/validate.rs` rejects empty and over-limit lists with 422.
- gRPC: the query conversion in `src/common/inference/query_requests_grpc.rs` rejects empty and over-limit lists with `INVALID_ARGUMENT`, sharing the `MAX_FEEDBACK_ITEMS` constant with the REST validator.

### Tests

- REST: 101 items rejected, 100 accepted, empty rejected (cap tests fail before: no maximum).
- gRPC: over-limit, empty, and at-limit conversion tests.

`cargo check --tests` passes on this branch (check-only environment: tests compile but were not executed).