### PR TITLE
fix(quantization): order binary distance scores

### DIFF
--- a/lib/quantization/src/encoded_vectors_binary.rs
+++ b/lib/quantization/src/encoded_vectors_binary.rs
@@ -860,8 +860,9 @@ impl<TBitsStoreType: BitsStoreType, TStorage: EncodedStorage>
             // So if `invert` is true we return XOR, otherwise we return (dim - XOR)
             (DistanceType::Dot | DistanceType::Cosine, true) => xor_product - zeros_count,
             (DistanceType::Dot | DistanceType::Cosine, false) => zeros_count - xor_product,
-            // This also results in exact ordering as L1 and L2 but reversed.
-            (DistanceType::L1 | DistanceType::L2, true) => zeros_count - xor_product,
+            // Keep inverted distance scores non-positive so the public distance
+            // postprocessing preserves the ordering of the search results.
+            (DistanceType::L1 | DistanceType::L2, true) => -xor_product,
             (DistanceType::L1 | DistanceType::L2, false) => xor_product - zeros_count,
         }
     }

--- a/lib/quantization/tests/integration/test_binary.rs
+++ b/lib/quantization/tests/integration/test_binary.rs
@@ -340,6 +340,10 @@ mod tests {
             .map(|(i, _)| (encoded.score_point(&query_b, i as u32, &counter), i))
             .collect();
 
+        // Inverted distance scores are postprocessed with `abs()` before being
+        // returned, so they must remain non-positive to preserve result order.
+        assert!(scores.iter().all(|(score, _)| *score <= 0.0));
+
         scores.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 
         let sorted_indices: Vec<_> = scores.into_iter().map(|(_, i)| i).collect();
@@ -601,6 +605,10 @@ mod tests {
             .enumerate()
             .map(|(i, _)| (encoded.score_point(&query_b, i as u32, &counter), i))
             .collect();
+
+        // Inverted distance scores are postprocessed with `abs()` before being
+        // returned, so they must remain non-positive to preserve result order.
+        assert!(scores.iter().all(|(score, _)| *score <= 0.0));
 
         scores.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -227,6 +227,88 @@ fn hnsw_quantized_search_test(
     }
 }
 
+fn binary_quantized_non_rescored_search_is_ordered(distance: Distance) {
+    const TOP: usize = 5;
+
+    let seed = vec![
+        vec![-0.0494680889, -1.5822200775],
+        vec![-0.5807184577, -1.3024002314],
+        vec![-0.2222844660, 1.0905684233],
+        vec![-0.5575756431, 0.6532790065],
+        vec![0.7734391689, -0.2747519016],
+    ];
+    let updated_point = vec![-0.2057184577, -1.3024002314];
+    let query: QueryVector = vec![1.3748825788, -1.0415413379].into();
+
+    let stopped = AtomicBool::new(false);
+    let hw_counter = HardwareCounterCell::new();
+    let mut rng = StdRng::seed_from_u64(42);
+    let quantization_config: QuantizationConfig = BinaryQuantizationConfig {
+        memory: None,
+        always_ram: Some(true),
+        encoding: None,
+        query_encoding: None,
+    }
+    .into();
+    let (mut segment, hnsw_index, _dirs) = build_quantized_hnsw_for_compare(
+        &seed,
+        distance,
+        &quantization_config,
+        4,
+        64,
+        0,
+        &mut rng,
+        &stopped,
+    );
+    segment
+        .upsert_point(
+            seed.len() as u64,
+            1.into(),
+            only_default_vector(&updated_point),
+            &hw_counter,
+        )
+        .unwrap();
+    let results = hnsw_index
+        .search(
+            &[&query],
+            None,
+            TOP,
+            Some(&SearchParams {
+                hnsw_ef: Some(256),
+                exact: false,
+                quantization: Some(QuantizationSearchParams {
+                    rescore: Some(false),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            &Default::default(),
+        )
+        .unwrap();
+    let scores: Vec<_> = results[0]
+        .iter()
+        .map(|result| distance.postprocess_score(result.score))
+        .collect();
+
+    assert_eq!(scores.len(), TOP);
+    assert!(
+        scores
+            .windows(2)
+            .all(|window| window[0] <= window[1] + 2e-5),
+        "{distance:?} scores were not ordered by reported distance: {scores:?}"
+    );
+}
+
+#[test]
+fn binary_quantized_non_rescored_euclid_scores_are_ordered() {
+    binary_quantized_non_rescored_search_is_ordered(Distance::Euclid);
+}
+
+#[test]
+fn binary_quantized_non_rescored_manhattan_scores_are_ordered() {
+    binary_quantized_non_rescored_search_is_ordered(Distance::Manhattan);
+}
+
 pub fn check_matches(
     query_vectors: &[QueryVector],
     segment: &Segment,

--- a/lib/segment/tests/integration/hnsw_quantized_search_test.rs
+++ b/lib/segment/tests/integration/hnsw_quantized_search_test.rs
@@ -231,14 +231,14 @@ fn binary_quantized_non_rescored_search_is_ordered(distance: Distance) {
     const TOP: usize = 5;
 
     let seed = vec![
-        vec![-0.0494680889, -1.5822200775],
-        vec![-0.5807184577, -1.3024002314],
-        vec![-0.2222844660, 1.0905684233],
-        vec![-0.5575756431, 0.6532790065],
-        vec![0.7734391689, -0.2747519016],
+        vec![-0.049_468_09, -1.582_220_1],
+        vec![-0.580_718_46, -1.302_400_2],
+        vec![-0.222_284_47, 1.090_568_4],
+        vec![-0.557_575_64, 0.653_279],
+        vec![0.773_439_17, -0.274_751_9],
     ];
-    let updated_point = vec![-0.2057184577, -1.3024002314];
-    let query: QueryVector = vec![1.3748825788, -1.0415413379].into();
+    let updated_point = vec![-0.205_718_46, -1.302_400_2];
+    let query: QueryVector = vec![1.374_882_6, -1.041_541_3].into();
 
     let stopped = AtomicBool::new(false);
     let hw_counter = HardwareCounterCell::new();


### PR DESCRIPTION
### Summary

When binary quantization is used for Euclidean or Manhattan search, inverted scores must remain non-positive because the public distance postprocessing applies `abs()`.

This change removes the dimension-dependent offset from the inverted binary L1/L2 score and adds regression coverage for both paths. The integration regression exercises the public HNSW search path with `exact=false`, `quantization.rescore=false`, and an updated vector, then verifies the postprocessed distances are ordered from smallest to largest.

Fixes #10607

### Testing

- `git diff --check`
- `cargo test -p quantization --test integration test_binary -- --nocapture` (16 matching tests passed)
- `cargo test -p segment --test integration binary_quantized_non_rescored -- --nocapture` (2 passed)
- `cargo test -p segment --test integration hnsw_quantized_search_test -- --nocapture` (27 passed)
- The regression was also run against the pre-fix scoring formula and failed with the unsorted issue output, confirming that the test detects the bug.

### Checklist

- [x] My PR targets the `dev` branch and my branch was created from `dev`.
- [x] I checked for other open pull requests for the same change.
- [x] I added focused regression coverage.
- [x] Focused Rust tests and formatting checks were run.
- [ ] The full workspace test suite was not run.

### AI disclosure

- [AI] The implementation and regression test in this commit were generated with Codex.
- Initial prompt: Implement qdrant/qdrant#10607 by fixing the binary-quantized Euclidean result ordering for rescore=false with a minimal source change and focused regression coverage. Keep the change scoped, verify available checks, and do not claim unavailable tests.