### PR TITLE
[BM25] Share the text index post-tokenization indexing path

### DIFF
--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/mutable_inverted_index.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/mutable_inverted_index.rs
@@ -108,6 +108,28 @@ impl MutableInvertedIndex {
 
         Box::new(iter)
     }
+
+    /// Index a point from its string tokens: register them in the vocabulary,
+    /// store the ordered document when positions are enabled, then index the
+    /// token set.
+    ///
+    /// Shared by the write path and read-only live reload so the two cannot
+    /// drift apart. Positions are keyed off `point_to_doc` rather than the
+    /// config flag, so an index built without them never pays for the clone.
+    pub fn index_str_tokens(
+        &mut self,
+        point_id: PointOffsetType,
+        str_tokens: impl IntoIterator<Item = impl AsRef<str>>,
+        hw_counter: &HardwareCounterCell,
+    ) -> OperationResult<()> {
+        let tokens = self.register_tokens(str_tokens);
+
+        if self.point_to_doc.is_some() {
+            self.index_document(point_id, Document::new(tokens.clone()), hw_counter)?;
+        }
+
+        self.index_tokens(point_id, TokenSet::from_iter(tokens), hw_counter)
+    }
 }
 
 impl InvertedIndex for MutableInvertedIndex {

--- a/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/inverted_index/on_disk_inverted_index/mod.rs
@@ -629,13 +629,11 @@ impl<S: UniversalRead> OnDiskInvertedIndex<S> {
         ]
     }
 
+    /// Every file of this index is written once at build time, so the full file
+    /// list is also the immutable one. Kept as a single list so a new file
+    /// cannot be added to one and forgotten in the other.
     pub fn immutable_files(&self) -> Vec<PathBuf> {
-        vec![
-            self.path.join(POSTINGS_FILE),
-            self.path.join(VOCAB_FILE),
-            self.path.join(POINT_TO_TOKENS_COUNT_FILE),
-            deleted_mask_file(&self.path, self.compact_deleted_mask, DELETED_POINTS_FILE),
-        ]
+        self.files()
     }
 
     /// No-op flusher: the on-disk state is build-time only. See the type-level

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/lifecycle.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/lifecycle.rs
@@ -6,8 +6,8 @@ use common::types::PointOffsetType;
 use common::universal_io::{MmapFs, Populate};
 
 use super::super::FullTextIndex;
+use super::super::inverted_index::InvertedIndex;
 use super::super::inverted_index::mutable_inverted_index_builder::MutableInvertedIndexBuilder;
-use super::super::inverted_index::{Document, InvertedIndex, TokenSet};
 use super::super::tokenizers::Tokenizer;
 use super::inner::MutableFullTextIndexInner;
 use super::{MutableFullTextIndex, storage_options};
@@ -127,19 +127,9 @@ impl MutableFullTextIndex {
         let str_tokens =
             FullTextIndex::tokenize_document(&self.inner.tokenizer, phrase_matching, &values);
 
-        let tokens = self.inner.inverted_index.register_tokens(&str_tokens);
-
-        if phrase_matching {
-            let document = Document::new(tokens.clone());
-            self.inner
-                .inverted_index
-                .index_document(idx, document, hw_counter)?;
-        }
-
-        let token_set = TokenSet::from_iter(tokens);
         self.inner
             .inverted_index
-            .index_tokens(idx, token_set, hw_counter)?;
+            .index_str_tokens(idx, &str_tokens, hw_counter)?;
 
         let db_document = FullTextIndex::serialize_stored_document(str_tokens, phrase_matching)?;
 

--- a/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/live_reload.rs
+++ b/lib/segment/src/index/field_index/full_text_index/mutable_text_index/read_only/live_reload.rs
@@ -9,9 +9,7 @@ use super::ReadOnlyAppendableFullTextIndex;
 use crate::common::operation_error::{OperationError, OperationResult};
 use crate::index::field_index::LiveReload;
 use crate::index::field_index::full_text_index::FullTextIndex;
-use crate::index::field_index::full_text_index::inverted_index::{
-    Document, InvertedIndex, TokenSet,
-};
+use crate::index::field_index::full_text_index::inverted_index::InvertedIndex;
 
 impl<S: UniversalRead> LiveReload for ReadOnlyAppendableFullTextIndex<S> {
     type File = S;
@@ -32,7 +30,6 @@ impl<S: UniversalRead> LiveReload for ReadOnlyAppendableFullTextIndex<S> {
     ) -> OperationResult<()> {
         self.storage.live_reload(fs)?;
 
-        let phrase_matching = self.inner.config.phrase_matching.unwrap_or_default();
         let inner = &mut self.inner;
 
         for &deleted_point in deleted_points {
@@ -48,23 +45,11 @@ impl<S: UniversalRead> LiveReload for ReadOnlyAppendableFullTextIndex<S> {
                         return Ok(true);
                     };
                     // The stored document is already tokenized, so we replay the
-                    // post-tokenization half of `MutableFullTextIndex::add_many`:
-                    // register the tokens, then index them (plus the ordered
-                    // document when phrase matching is enabled).
+                    // post-tokenization half of `MutableFullTextIndex::add_many`.
                     let str_tokens = FullTextIndex::deserialize_document(&value)?;
-                    let tokens = inner.inverted_index.register_tokens(str_tokens);
-                    if phrase_matching {
-                        inner.inverted_index.index_document(
-                            point_offset,
-                            Document::new(tokens.clone()),
-                            hw_counter,
-                        )?;
-                    }
-                    inner.inverted_index.index_tokens(
-                        point_offset,
-                        TokenSet::from_iter(tokens),
-                        hw_counter,
-                    )?;
+                    inner
+                        .inverted_index
+                        .index_str_tokens(point_offset, str_tokens, hw_counter)?;
                     Ok(true)
                 },
                 hw_counter.payload_index_io_read_counter(),

--- a/lib/segment/src/index/field_index/full_text_index/read_only/mod.rs
+++ b/lib/segment/src/index/field_index/full_text_index/read_only/mod.rs
@@ -47,16 +47,21 @@ pub enum ReadOnlyFullTextIndex<S: UniversalRead> {
 #[cfg(test)]
 mod tests {
     use common::counter::hardware_counter::HardwareCounterCell;
+    use common::sorted_slice::SortedSlice;
+    use common::types::PointOffsetType;
     use common::universal_io::{MmapFile, ReadOnly, UniversalRead, UniversalReadFileOps};
     use itertools::Itertools as _;
+    use rstest::rstest;
     use tempfile::TempDir;
 
     use super::super::FullTextIndex;
     use super::ReadOnlyFullTextIndex;
     use crate::data_types::index::{TextIndexParams, TextIndexType, TokenizerType};
-    use crate::index::field_index::{PayloadFieldIndex, PayloadFieldIndexRead, ValueIndexer};
+    use crate::index::field_index::{
+        LiveReload, PayloadFieldIndex, PayloadFieldIndexRead, ValueIndexer,
+    };
     use crate::json_path::JsonPath;
-    use crate::types::{FieldCondition, Match};
+    use crate::types::{FieldCondition, Match, MatchPhrase};
 
     fn test_config() -> TextIndexParams {
         TextIndexParams {
@@ -143,5 +148,173 @@ mod tests {
                 .collect_vec(),
             vec![1],
         );
+    }
+
+    /// The incremental `LiveReload` path must land on exactly the same state as
+    /// a fresh `open_appendable` over the post-write gridstore.
+    ///
+    /// A writer keeps mutating after the read-only view is open: one point is
+    /// deleted and two are appended. `live_reload` is handed only that delta and
+    /// replays the stored documents itself, so it re-runs the same
+    /// post-tokenization indexing the write path runs. Both token-set matching
+    /// and phrase matching are checked, because the phrase leg is the one that
+    /// depends on the ordered document being indexed as well as the token set.
+    #[rstest]
+    fn live_reload_matches_fresh_open(#[values(false, true)] phrase_matching: bool) {
+        let dir = TempDir::with_prefix("ro_fulltext_live_reload").unwrap();
+        let mut config = test_config();
+        config.phrase_matching = Some(phrase_matching);
+        let hw_counter = HardwareCounterCell::new();
+
+        let initial = [
+            serde_json::json!("the quick brown fox jumps"),
+            serde_json::json!("over the lazy dog"),
+            serde_json::json!("the brown bear sleeps"),
+        ];
+        // Appended after the read-only view is taken. The last one repeats a
+        // term so the document is not just a set of distinct tokens.
+        let appended = [
+            serde_json::json!("a lazy brown moth"),
+            serde_json::json!("the fox and the fox again"),
+        ];
+
+        let mut writer =
+            FullTextIndex::new_gridstore(dir.path().to_path_buf(), config.clone(), true)
+                .unwrap()
+                .unwrap();
+        for (idx, payload) in initial.iter().enumerate() {
+            writer
+                .add_point(idx as u32, &[payload], &hw_counter)
+                .unwrap();
+        }
+        writer.flusher()().unwrap();
+
+        type RoFs = <ReadOnly<MmapFile> as UniversalRead>::Fs;
+        let fs = RoFs::from_context(Default::default()).unwrap();
+
+        // Read-only view of points 0..=2, taken before the writer continues.
+        let mut reloaded: ReadOnlyFullTextIndex<ReadOnly<MmapFile>> =
+            ReadOnlyFullTextIndex::open_appendable(&fs, dir.path().to_path_buf(), config.clone())
+                .unwrap()
+                .unwrap();
+
+        // Writer's delta: drop point 1, append points 3 and 4.
+        writer.remove_point(1).unwrap();
+        for (offset, payload) in appended.iter().enumerate() {
+            writer
+                .add_point((3 + offset) as u32, &[payload], &hw_counter)
+                .unwrap();
+        }
+        writer.flusher()().unwrap();
+
+        let deleted: [PointOffsetType; 1] = [1];
+        let added: [PointOffsetType; 2] = [3, 4];
+        reloaded
+            .live_reload(
+                &fs,
+                &SortedSlice::new(&deleted).unwrap(),
+                &SortedSlice::new(&added).unwrap(),
+                &hw_counter,
+            )
+            .unwrap();
+
+        let fresh: ReadOnlyFullTextIndex<ReadOnly<MmapFile>> =
+            ReadOnlyFullTextIndex::open_appendable(&fs, dir.path().to_path_buf(), config)
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(
+            reloaded.count_indexed_points().unwrap(),
+            fresh.count_indexed_points().unwrap(),
+        );
+
+        let key = JsonPath::new("test");
+        let mut conditions = vec![
+            // Spans deleted, surviving and appended points.
+            FieldCondition::new_match(key.clone(), Match::new_text("brown")),
+            // Only ever present on the deleted point.
+            FieldCondition::new_match(key.clone(), Match::new_text("dog")),
+            // Only on appended points.
+            FieldCondition::new_match(key.clone(), Match::new_text("moth")),
+            // Repeated within one appended document.
+            FieldCondition::new_match(key.clone(), Match::new_text("fox")),
+            // Multi-token, so it exercises the posting intersection.
+            FieldCondition::new_match(key.clone(), Match::new_text("lazy brown")),
+        ];
+        if phrase_matching {
+            // Needs the ordered document, not just the token set: "brown fox"
+            // is adjacent in point 0 but not in point 3 ("lazy brown moth").
+            conditions.push(FieldCondition::new_match(
+                key.clone(),
+                Match::Phrase(MatchPhrase::from("brown fox")),
+            ));
+            conditions.push(FieldCondition::new_match(
+                key,
+                Match::Phrase(MatchPhrase::from("lazy brown")),
+            ));
+        }
+
+        for condition in &conditions {
+            let from_reload = reloaded
+                .filter(condition, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec();
+            let from_fresh = fresh
+                .filter(condition, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec();
+            assert_eq!(from_reload, from_fresh, "diverged for {condition:?}");
+            // The deleted point must not survive in either.
+            assert!(
+                !from_reload.contains(&1),
+                "point 1 resurrected by {condition:?}"
+            );
+        }
+
+        // Guard the fixture: the comparisons above hold vacuously if nothing
+        // matches, so pin the results that must come from the reloaded delta.
+        let key = JsonPath::new("test");
+        let expect = |condition: &FieldCondition, want: Vec<PointOffsetType>| {
+            let got = reloaded
+                .filter(condition, &hw_counter)
+                .unwrap()
+                .unwrap()
+                .collect_vec();
+            assert_eq!(got, want, "unexpected hits for {condition:?}");
+        };
+
+        // Appended point only.
+        expect(
+            &FieldCondition::new_match(key.clone(), Match::new_text("moth")),
+            vec![3],
+        );
+        // Survivor plus both appended points.
+        expect(
+            &FieldCondition::new_match(key.clone(), Match::new_text("fox")),
+            vec![0, 4],
+        );
+        // The deleted point was the only holder of this term.
+        expect(
+            &FieldCondition::new_match(key.clone(), Match::new_text("dog")),
+            vec![],
+        );
+
+        if phrase_matching {
+            // Adjacency has to survive the reload, not just term membership:
+            // point 3 has "lazy brown" adjacent, point 0 has "brown fox".
+            expect(
+                &FieldCondition::new_match(
+                    key.clone(),
+                    Match::Phrase(MatchPhrase::from("lazy brown")),
+                ),
+                vec![3],
+            );
+            expect(
+                &FieldCondition::new_match(key, Match::Phrase(MatchPhrase::from("brown fox"))),
+                vec![0],
+            );
+        }
     }
 }


### PR DESCRIPTION
Pure refactoring ahead of adding a per-point `doc_len` to the text index for BM25 scoring.

- Extract `MutableInvertedIndex::index_str_tokens`, replacing the verbatim copy of register-then-index that lived in both `add_many` and read-only `live_reload`. That block is what the `doc_len` work edits next, and two copies means a silent divergence where live-reloaded points get a different length than freshly written ones.
- The helper gates the ordered document on `point_to_doc.is_some()` instead of re-reading `config.phrase_matching`. Equivalent, since `point_to_doc` is constructed from that flag, and it drops a `tokens.clone()` if the two ever disagree.
- `immutable_files()` now delegates to `files()`. They were byte-for-byte identical, and the `doc_len` work adds a path to both; omitting one silently breaks snapshots.
- Add the missing test for `ReadOnlyAppendableFullTextIndex::live_reload`, which had no direct coverage. It asserts the incremental reload lands on the same state as a fresh `open_appendable` after a writer deletes one point and appends two, over both `phrase_matching` values. The phrase leg is the one that depends on the ordered document being indexed, not just the token set.

No behavior change. 1146 `segment` lib tests pass, including the congruence matrix across Mutable/Immutable/OnDisk with both `phrase_matching` values and the deleted and reopen axes.

The new test was checked against two mutations rather than only a green run: dropping the ordered document fails the phrase case, and skipping the reload's indexing fails both cases on the indexed-point count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)