### PR TITLE
[live-reload] rotate cache file info after successful re/load

### DIFF
--- a/lib/segment/src/segment/read_only/lifecycle.rs
+++ b/lib/segment/src/segment/read_only/lifecycle.rs
@@ -217,7 +217,7 @@ impl<S: UniversalReadExt<Fs: UniversalReadFsAsync> + 'static> ReadOnlySegment<S>
     /// here must make the same placement decisions the prefetches did.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn open_via(
-        fs: CachedFs<S::Fs>,
+        mut fs: CachedFs<S::Fs>,
         raw_fs: &S::Fs,
         segment_path: &Path,
         config: SegmentConfig,
@@ -339,6 +339,8 @@ impl<S: UniversalReadExt<Fs: UniversalReadFsAsync> + 'static> ReadOnlySegment<S>
         } else {
             SegmentType::Plain
         };
+
+        fs.rotate_cache_file_info();
 
         Ok(Self {
             uuid,

--- a/lib/segment/src/segment/update_only/appendable/mod.rs
+++ b/lib/segment/src/segment/update_only/appendable/mod.rs
@@ -248,7 +248,6 @@ impl<Fs: UniversalAppendFs> AppendableSegment<Fs> {
         }
 
         // Ensure fresh new view of the files
-        self.fs.rotate_cache_file_info();
         self.fs.cache_file_info()?;
 
         let operations: Vec<MappingOperation> = points
@@ -316,6 +315,7 @@ impl<Fs: UniversalAppendFs> AppendableSegment<Fs> {
         self.id_tracker
             .set_internal_versions(&self.fs, &slots, &versions)?;
 
+        self.fs.rotate_cache_file_info();
         Ok(())
     }
 

--- a/lib/segment/src/segment/update_only/lookup/lifecycle.rs
+++ b/lib/segment/src/segment/update_only/lookup/lifecycle.rs
@@ -90,7 +90,7 @@ impl<Fs: UniversalReadFsAsync> LookupSegment<Fs> {
     /// appendable segment has a deferred track; on any other segment the
     /// cutoff is ignored.
     pub fn open_via(
-        fs: CachedFs<Fs>,
+        mut fs: CachedFs<Fs>,
         segment_path: &Path,
         config: SegmentConfig,
         deferred_internal_id: Option<PointOffsetType>,
@@ -148,6 +148,8 @@ impl<Fs: UniversalReadFsAsync> LookupSegment<Fs> {
             ));
             vector_data.insert(vector_name.clone(), Arc::new(AtomicRefCell::new(storage)));
         }
+
+        fs.rotate_cache_file_info();
 
         Ok(Self {
             fs,

--- a/lib/segment/src/segment/update_only/lookup/live_reload.rs
+++ b/lib/segment/src/segment/update_only/lookup/live_reload.rs
@@ -30,7 +30,6 @@ impl<Fs: UniversalReadFsAsync> LookupSegment<Fs> {
         } = self;
 
         // Prepare new LIST snapshot
-        fs.rotate_cache_file_info();
         fs.cache_file_info()?;
 
         // Live preload: schedule everything
@@ -61,6 +60,7 @@ impl<Fs: UniversalReadFsAsync> LookupSegment<Fs> {
                 .live_reload(fs, &deleted, &inserted, hw_counter)?;
         }
 
+        fs.rotate_cache_file_info();
         Ok(())
     }
 }


### PR DESCRIPTION
This PR fixes two things:

- after initial open, we were missing to rotate `CachedFs` info, so first reload would do unnecessary extra work.
- live-reloading lookup and appendable segments are more resilient to retries, now they only rotate cached info after successful operations.