### PR TITLE
Send the queue proxy batch as a pre-encoded gRPC body

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,6 +503,7 @@ dependencies = [
  "ordered-float 5.5.0",
  "parking_lot",
  "prost 0.14.4",
+ "prost-types 0.14.4",
  "prost-wkt-types",
  "rand 0.10.2",
  "schemars",

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -39,6 +39,9 @@ sparse = { path = "../sparse" }
 
 tracing = { workspace = true, optional = true }
 
+[dev-dependencies]
+prost-types = { workspace = true }
+
 [build-dependencies]
 tonic-prost-build = { workspace = true }
 common = { path = "../common/common" }

--- a/lib/api/src/grpc/mod.rs
+++ b/lib/api/src/grpc/mod.rs
@@ -8,6 +8,7 @@ pub mod dynamic_pool;
 #[path = "grpc.health.v1.rs"]
 pub mod grpc_health_v1;
 pub mod ops;
+pub mod pre_encoded;
 pub mod transport_channel_pool;
 pub mod validate;
 

--- a/lib/api/src/grpc/pre_encoded.rs
+++ b/lib/api/src/grpc/pre_encoded.rs
@@ -1,0 +1,192 @@
+//! Unary gRPC requests whose protobuf body is encoded ahead of time.
+//!
+//! The generated clients take the message by value and let `tonic` encode it while the request body
+//! is polled, which happens on the caller's async runtime. Encoding is a full pass over the message,
+//! so for a large message that is a long synchronous block on an async worker, repeated on every
+//! retry the channel pool makes.
+//!
+//! [`PreEncodedMessage`] encodes once, wherever the caller chooses, and hands `tonic` bytes to copy
+//! out. Cloning it for a retry is a refcount bump.
+
+use std::marker::PhantomData;
+
+use prost::Message;
+use prost::bytes::{BufMut, Bytes, BytesMut};
+use tonic::client::{Grpc, GrpcService};
+use tonic::codec::{BufferSettings, Codec, EncodeBuf, Encoder};
+use tonic::codegen::{Body, StdError, http};
+use tonic::{GrpcMethod, Request, Response, Status};
+use tonic_prost::ProstDecoder;
+
+use crate::grpc::qdrant::{PointsOperationResponseInternal, UpdateBatchInternal};
+
+/// Identity of `PointsInternal/UpdateBatch`, as the generated client spells it.
+///
+/// Bypassing the generated client means these no longer follow the proto automatically, so
+/// `tests::update_batch_rpc_matches_proto` checks them against the compiled descriptor set.
+const UPDATE_BATCH_SERVICE: &str = "qdrant.PointsInternal";
+const UPDATE_BATCH_METHOD: &str = "UpdateBatch";
+const UPDATE_BATCH_PATH: &str = "/qdrant.PointsInternal/UpdateBatch";
+
+/// A protobuf message that has already been encoded to its wire representation.
+///
+/// Cloning shares the encoded bytes, so retrying a request does not encode it again.
+#[derive(Clone, Debug)]
+pub struct PreEncodedMessage<M> {
+    body: Bytes,
+    _pd: PhantomData<fn() -> M>,
+}
+
+impl<M: Message> PreEncodedMessage<M> {
+    /// Encode `message`.
+    ///
+    /// This is a full pass over the message. Callers holding a large message should do it outside
+    /// an async runtime.
+    pub fn encode(message: &M) -> Self {
+        let mut body = BytesMut::with_capacity(message.encoded_len());
+        message
+            .encode(&mut body)
+            .expect("BytesMut grows on demand, so encoding into it cannot run out of space");
+
+        Self {
+            body: body.freeze(),
+            _pd: PhantomData,
+        }
+    }
+}
+
+/// [`PointsInternalClient::update_batch`] with an already-encoded request body.
+///
+/// [`PointsInternalClient::update_batch`]: crate::grpc::qdrant::points_internal_client::PointsInternalClient::update_batch
+pub async fn update_batch_pre_encoded<T>(
+    channel: T,
+    request: PreEncodedMessage<UpdateBatchInternal>,
+    max_decoding_message_size: usize,
+) -> Result<Response<PointsOperationResponseInternal>, Status>
+where
+    T: GrpcService<tonic::body::Body>,
+    T::Error: Into<StdError>,
+    T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+    <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+{
+    let mut grpc = Grpc::new(channel).max_decoding_message_size(max_decoding_message_size);
+
+    grpc.ready()
+        .await
+        .map_err(|err| Status::unknown(format!("Service was not ready: {}", err.into())))?;
+
+    let mut request = Request::new(request);
+    request
+        .extensions_mut()
+        .insert(GrpcMethod::new(UPDATE_BATCH_SERVICE, UPDATE_BATCH_METHOD));
+
+    grpc.unary(
+        request,
+        http::uri::PathAndQuery::from_static(UPDATE_BATCH_PATH),
+        PreEncodedCodec::default(),
+    )
+    .await
+}
+
+/// Writes an already-encoded request body as is, decodes the response with prost.
+struct PreEncodedCodec<M, U> {
+    _pd: PhantomData<fn() -> (M, U)>,
+}
+
+impl<M, U> Default for PreEncodedCodec<M, U> {
+    fn default() -> Self {
+        Self { _pd: PhantomData }
+    }
+}
+
+impl<M, U> Codec for PreEncodedCodec<M, U>
+where
+    M: Send + 'static,
+    U: Message + Default + Send + 'static,
+{
+    type Encode = PreEncodedMessage<M>;
+    type Decode = U;
+
+    type Encoder = PreEncodedEncoder<M>;
+    type Decoder = ProstDecoder<U>;
+
+    fn encoder(&mut self) -> Self::Encoder {
+        PreEncodedEncoder { _pd: PhantomData }
+    }
+
+    fn decoder(&mut self) -> Self::Decoder {
+        ProstDecoder::new(BufferSettings::default())
+    }
+}
+
+struct PreEncodedEncoder<M> {
+    _pd: PhantomData<fn() -> M>,
+}
+
+impl<M> Encoder for PreEncodedEncoder<M> {
+    type Item = PreEncodedMessage<M>;
+    type Error = Status;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut EncodeBuf<'_>) -> Result<(), Self::Error> {
+        // `tonic` writes the gRPC frame header around this itself.
+        dst.reserve(item.body.len());
+        dst.put_slice(&item.body);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prost_types::FileDescriptorSet;
+
+    use super::*;
+    use crate::grpc::QDRANT_DESCRIPTOR_SET;
+
+    /// The generated client derives its path and message types from the proto, this module spells
+    /// them out. Check they still agree, so renaming the RPC cannot silently break this call.
+    #[test]
+    fn update_batch_rpc_matches_proto() {
+        let descriptor_set = FileDescriptorSet::decode(QDRANT_DESCRIPTOR_SET).unwrap();
+
+        let method = descriptor_set
+            .file
+            .iter()
+            .flat_map(|file| {
+                let package = file.package();
+                file.service.iter().map(move |service| (package, service))
+            })
+            .filter(|(package, service)| {
+                format!("{package}.{}", service.name()) == UPDATE_BATCH_SERVICE
+            })
+            .flat_map(|(_, service)| &service.method)
+            .find(|method| method.name() == UPDATE_BATCH_METHOD)
+            .expect("proto defines the RPC this module calls");
+
+        assert_eq!(
+            UPDATE_BATCH_PATH,
+            format!("/{UPDATE_BATCH_SERVICE}/{UPDATE_BATCH_METHOD}"),
+        );
+        // The types `update_batch_pre_encoded` sends and decodes.
+        assert_eq!(method.input_type(), ".qdrant.UpdateBatchInternal");
+        assert_eq!(
+            method.output_type(),
+            ".qdrant.PointsOperationResponseInternal",
+        );
+        assert!(!method.client_streaming() && !method.server_streaming());
+    }
+
+    #[test]
+    fn pre_encoded_message_matches_prost() {
+        let message = UpdateBatchInternal {
+            operations: vec![],
+            wait_override: Some(1),
+        };
+
+        let pre_encoded = PreEncodedMessage::encode(&message);
+        assert_eq!(pre_encoded.body.len(), message.encoded_len());
+        assert_eq!(
+            UpdateBatchInternal::decode(pre_encoded.body.clone()).unwrap(),
+            message,
+        );
+    }
+}

--- a/lib/api/src/grpc/pre_encoded.rs
+++ b/lib/api/src/grpc/pre_encoded.rs
@@ -11,20 +11,20 @@
 use std::marker::PhantomData;
 
 use prost::Message;
-use prost::bytes::{BufMut, Bytes, BytesMut};
+use prost::bytes::{BufMut, Bytes};
 use tonic::client::{Grpc, GrpcService};
 use tonic::codec::{BufferSettings, Codec, EncodeBuf, Encoder};
 use tonic::codegen::{Body, StdError, http};
 use tonic::{GrpcMethod, Request, Response, Status};
 use tonic_prost::ProstDecoder;
 
+use crate::grpc::qdrant::points_internal_server::SERVICE_NAME;
 use crate::grpc::qdrant::{PointsOperationResponseInternal, UpdateBatchInternal};
 
 /// Identity of `PointsInternal/UpdateBatch`, as the generated client spells it.
 ///
 /// Bypassing the generated client means these no longer follow the proto automatically, so
 /// `tests::update_batch_rpc_matches_proto` checks them against the compiled descriptor set.
-const UPDATE_BATCH_SERVICE: &str = "qdrant.PointsInternal";
 const UPDATE_BATCH_METHOD: &str = "UpdateBatch";
 const UPDATE_BATCH_PATH: &str = "/qdrant.PointsInternal/UpdateBatch";
 
@@ -43,13 +43,8 @@ impl<M: Message> PreEncodedMessage<M> {
     /// This is a full pass over the message. Callers holding a large message should do it outside
     /// an async runtime.
     pub fn encode(message: &M) -> Self {
-        let mut body = BytesMut::with_capacity(message.encoded_len());
-        message
-            .encode(&mut body)
-            .expect("BytesMut grows on demand, so encoding into it cannot run out of space");
-
         Self {
-            body: body.freeze(),
+            body: Bytes::from(message.encode_to_vec()),
             _pd: PhantomData,
         }
     }
@@ -57,11 +52,13 @@ impl<M: Message> PreEncodedMessage<M> {
 
 /// [`PointsInternalClient::update_batch`] with an already-encoded request body.
 ///
+/// `grpc` is what [`PointsInternalClient::new`] wraps, configured the same way.
+///
 /// [`PointsInternalClient::update_batch`]: crate::grpc::qdrant::points_internal_client::PointsInternalClient::update_batch
+/// [`PointsInternalClient::new`]: crate::grpc::qdrant::points_internal_client::PointsInternalClient::new
 pub async fn update_batch_pre_encoded<T>(
-    channel: T,
+    mut grpc: Grpc<T>,
     request: PreEncodedMessage<UpdateBatchInternal>,
-    max_decoding_message_size: usize,
 ) -> Result<Response<PointsOperationResponseInternal>, Status>
 where
     T: GrpcService<tonic::body::Body>,
@@ -69,8 +66,6 @@ where
     T::ResponseBody: Body<Data = Bytes> + Send + 'static,
     <T::ResponseBody as Body>::Error: Into<StdError> + Send,
 {
-    let mut grpc = Grpc::new(channel).max_decoding_message_size(max_decoding_message_size);
-
     grpc.ready()
         .await
         .map_err(|err| Status::unknown(format!("Service was not ready: {}", err.into())))?;
@@ -78,7 +73,7 @@ where
     let mut request = Request::new(request);
     request
         .extensions_mut()
-        .insert(GrpcMethod::new(UPDATE_BATCH_SERVICE, UPDATE_BATCH_METHOD));
+        .insert(GrpcMethod::new(SERVICE_NAME, UPDATE_BATCH_METHOD));
 
     grpc.unary(
         request,
@@ -155,16 +150,14 @@ mod tests {
                 let package = file.package();
                 file.service.iter().map(move |service| (package, service))
             })
-            .filter(|(package, service)| {
-                format!("{package}.{}", service.name()) == UPDATE_BATCH_SERVICE
-            })
+            .filter(|(package, service)| format!("{package}.{}", service.name()) == SERVICE_NAME)
             .flat_map(|(_, service)| &service.method)
             .find(|method| method.name() == UPDATE_BATCH_METHOD)
             .expect("proto defines the RPC this module calls");
 
         assert_eq!(
             UPDATE_BATCH_PATH,
-            format!("/{UPDATE_BATCH_SERVICE}/{UPDATE_BATCH_METHOD}"),
+            format!("/{SERVICE_NAME}/{UPDATE_BATCH_METHOD}"),
         );
         // The types `update_batch_pre_encoded` sends and decodes.
         assert_eq!(method.input_type(), ".qdrant.UpdateBatchInternal");

--- a/lib/collection/src/shards/queue_proxy_shard.rs
+++ b/lib/collection/src/shards/queue_proxy_shard.rs
@@ -718,10 +718,11 @@ impl Inner {
 
         // Build the request once, moving the operations into it, so retries below never copy
         // the operation data again.
-        let request = self
-            .remote_shard
-            .build_update_batch(operations, wait, None, WriteOrdering::Weak)
-            .await?;
+        let request = Arc::new(
+            self.remote_shard
+                .build_update_batch(operations, wait, None, WriteOrdering::Weak)
+                .await?,
+        );
 
         // Transfer batch with retries and store last transferred ID
         for remaining_attempts in (0..BATCH_RETRIES).rev() {
@@ -937,7 +938,7 @@ impl ShardOperation for Inner {
 ///
 /// If cancelled - none, some or all operations of the batch may be transmitted to the remote.
 async fn transfer_batch(
-    request: &UpdateBatchInternal,
+    request: &Arc<UpdateBatchInternal>,
     remote_shard: &RemoteShard,
     hw_measurement_acc: HwMeasurementAcc,
 ) -> CollectionResult<()> {
@@ -946,7 +947,7 @@ async fn transfer_batch(
     }
 
     match remote_shard
-        .forward_update_batch(request, hw_measurement_acc.clone())
+        .forward_update_batch(Arc::clone(request), hw_measurement_acc.clone())
         .await
     {
         Ok(_) => return Ok(()),
@@ -967,13 +968,13 @@ async fn transfer_batch(
     }
 
     for operation in &request.operations {
-        let single = UpdateBatchInternal {
+        let single = Arc::new(UpdateBatchInternal {
             operations: vec![operation.clone()],
             wait_override: request.wait_override,
-        };
+        });
 
         let result = remote_shard
-            .forward_update_batch(&single, hw_measurement_acc.clone())
+            .forward_update_batch(single, hw_measurement_acc.clone())
             .await;
 
         skip_if_rejected(result, remote_shard)?;

--- a/lib/collection/src/shards/remote_shard.rs
+++ b/lib/collection/src/shards/remote_shard.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
+use api::grpc::pre_encoded::{PreEncodedMessage, update_batch_pre_encoded};
 use api::grpc::qdrant::collections_internal_client::CollectionsInternalClient;
 use api::grpc::qdrant::points_internal_client::PointsInternalClient;
 use api::grpc::qdrant::qdrant_client::QdrantClient;
@@ -41,6 +42,7 @@ use shard::scroll::ScrollRequestInternal;
 use shard::search::CoreSearchRequestBatch;
 use tokio_util::task::AbortOnDropHandle;
 use tonic::Status;
+use tonic::client::Grpc;
 use tonic::codegen::InterceptedService;
 use tonic::transport::{Channel, Uri};
 use url::Url;
@@ -147,6 +149,23 @@ impl RemoteShard {
                 let client = PointsInternalClient::new(channel);
                 let client = client.max_decoding_message_size(usize::MAX);
                 f(client)
+            })
+            .await
+            .map_err(|err| err.into())
+    }
+
+    /// Like [`Self::with_points_client`], but hands out the [`Grpc`] the generated clients wrap,
+    /// for calls they cannot express. See [`update_batch_pre_encoded`].
+    async fn with_grpc<T, O: Future<Output = Result<T, Status>>>(
+        &self,
+        f: impl Fn(Grpc<InterceptedService<Channel, PoolInterceptor>>) -> O,
+    ) -> CollectionResult<T> {
+        let current_address = self.current_address()?;
+        self.channel_service
+            .channel_pool
+            .with_channel(&current_address, |channel| {
+                let grpc = Grpc::new(channel).max_decoding_message_size(usize::MAX);
+                f(grpc)
             })
             .await
             .map_err(|err| err.into())
@@ -557,6 +576,9 @@ impl RemoteShard {
 
     /// Forward a prebuilt batch of operations
     ///
+    /// The batch is encoded once, on the blocking pool. The attempts the channel pool makes share
+    /// the encoded bytes instead of copying and encoding the batch again on the async runtime.
+    ///
     /// # Cancel safety
     ///
     /// This method is cancel safe.
@@ -564,15 +586,21 @@ impl RemoteShard {
     /// If cancelled - either none or all operations of the batch may be forwarded to the remote.
     pub async fn forward_update_batch(
         &self,
-        batch_request: &UpdateBatchInternal,
+        batch_request: Arc<UpdateBatchInternal>,
         hw_measurement_acc: HwMeasurementAcc,
     ) -> CollectionResult<UpdateResult> {
+        let encoded = AbortOnDropHandle::new(tokio::task::spawn_blocking(move || {
+            PreEncodedMessage::encode(&*batch_request)
+        }))
+        .await
+        .map_err(|err| {
+            CollectionError::service_error(format!(
+                "Failed to join update batch encode task: {err}"
+            ))
+        })?;
+
         let point_operation_response = self
-            .with_points_client(|mut client| async move {
-                client
-                    .update_batch(tonic::Request::new(batch_request.clone()))
-                    .await
-            })
+            .with_grpc(|grpc| update_batch_pre_encoded(grpc, encoded.clone()))
             .await?
             .into_inner();
 


### PR DESCRIPTION
Follow-up to #10599 (merged). Originally stacked on that branch; now rebased onto `dev`, with a
third commit adapting to the `build_update_batch` / `forward_update_batch` split that landed there.

**Rewritten.** The first version of this PR wrapped the per-attempt `batch_request.clone()` in
`spawn_blocking`. @generall called that ugly and asked whether the clone can be avoided altogether —
it can, so I dropped that commit and replaced it with this.

## Why

Each synchronous pass over a queue-proxy send batch, measured rather than assumed. Release build,
batch shaped like the reported production traffic (800 operations × 30 points × 256 dims = 26.2 MiB
of point data, 27 MiB on the wire):

| pass | cost | after #10599 |
|---|---|---|
| 1. clone WAL operations | **72.4 ms** | gone: operations are moved into the request |
| 2. build gRPC request | 22.2 ms | moved to blocking pool |
| 3. `batch_request.clone()` | **65.7 ms** | still on the async runtime, once per attempt |
| 4. protobuf encode (tonic) | 41.4 ms | still on the async runtime, once per attempt |

Pass 3 exists because `with_points_client` takes `impl Fn` and the channel pool calls that closure
once per attempt (`make_request(uri, &f, ..)` in a loop, up to `1 + DEFAULT_RETRIES`), and an `Fn`
can't move its captured value out.

Pass 4 runs inside `poll_next`. For a unary call tonic encodes the whole message in a single
synchronous `encode_item`, so a worker is blocked for the full 41 ms — and repeats it on every retry.

## What

Encode the batch once, on the blocking pool, and send those bytes.

The generated client can't take a pre-encoded body: `update_batch` is typed
`impl IntoRequest<UpdateBatchInternal>`. But its body is only

```rust
let codec = tonic_prost::ProstCodec::default();
let path = http::uri::PathAndQuery::from_static("/qdrant.PointsInternal/UpdateBatch");
self.inner.unary(req, path, codec).await
```

and we already build the client ourselves from a pooled channel, so `tonic::client::Grpc` plus a
custom codec is the supported way in. `api::grpc::pre_encoded` does those three things with a codec
whose `Encode` is the pre-encoded body — the encoder writes it through, the decoder is tonic's own
`ProstDecoder` for the response.

`forward_update_batch` now takes `Arc<UpdateBatchInternal>`: it encodes the request once in a
`spawn_blocking` task and hands the same refcounted `Bytes` to every attempt the channel pool makes,
so pass 3 is gone and pass 4 is off the runtime. The queue proxy keeps the built request in that
`Arc` across its own `BATCH_RETRIES` and for the per-operation isolation path, as #10599 set it up.
An outer retry re-encodes (still off the runtime) rather than holding proto and bytes side by side
for the whole send.

What stays on the runtime is the copy of the encoded body into tonic's send buffer: **14.9 ms** for
26.2 MiB under jemalloc, nearly all of it faulting in freshly mapped pages rather than the copy
itself (0.9 ms when the allocator hands back warm pages). `EncodeBuf` only exposes `BufMut`, so that
copy can't be avoided without changing tonic.

| | per attempt |
|---|---|
| on the runtime before | 107.2 ms |
| on the runtime after | **14.9 ms** |

## The caveat this buys

Bypassing the generated client means the RPC path and the message types stop following the proto
automatically. `update_batch_rpc_matches_proto` checks both against the compiled descriptor set, so a
rename breaks the build rather than the call.

`forward_update_batch` has exactly one caller (the queue proxy). The single-operation paths in
`remote_shard.rs` keep the generated client — those requests are small and sit on the normal
replication path.

## Verified

After rebasing onto `dev`:

- `cargo +nightly fmt --all --check`, `cargo clippy -p api -p collection --all-targets -- -D warnings` — clean.
- `cargo test -p api pre_encoded` — 2 passed.
- Consensus tests against a debug build with the CI feature set
  (`service_debug data-consistency-check staging`): `test_shard_wal_delta_transfer`,
  `test_shard_snapshot_transfer` — **8 passed**.

**No new cluster A/B.** On the cluster used for #10599 the sender's replay-phase health-check p99 was
already down to 12.8 ms, so I don't expect a large additional end-to-end delta and I'm not claiming
one. The justification is the per-pass CPU cost. Happy to run a fresh A/B before merging if you want
the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
