### PR TITLE
Fix DBSF reversing ranking order for Euclidean distance metrics (#10611)

### DIFF
--- a/lib/collection/src/collection/query.rs
+++ b/lib/collection/src/collection/query.rs
@@ -386,7 +386,23 @@ impl Collection {
                             .map(|w| w.iter().map(|f| f.into_inner()).collect::<Vec<_>>());
                         rrf_scoring(intermediates, *k, weights_slice.as_deref())?
                     }
-                    FusionInternal::Dbsf => score_fusion(intermediates, ScoreFusion::dbsf()),
+                    FusionInternal::Dbsf => {
+                        let collection_params = self.collection_config.read().await.params.clone();
+                        let source_orders: Vec<Order> = request
+                            .prefetches
+                            .iter()
+                            .map(|prefetch| {
+                                shard_query::query_result_order(
+                                    prefetch.query.as_ref(),
+                                    &collection_params,
+                                )
+                                .ok()
+                                .flatten()
+                                .unwrap_or(Order::LargeBetter)
+                            })
+                            .collect();
+                        score_fusion(intermediates, ScoreFusion::dbsf_with_orders(source_orders))
+                    }
                 };
                 if let Some(&score_threshold) = score_threshold.as_ref() {
                     fused = fused

--- a/lib/segment/src/common/score_fusion.rs
+++ b/lib/segment/src/common/score_fusion.rs
@@ -16,6 +16,8 @@ pub struct ScoreFusion {
     pub weights: Vec<f32>,
     /// Final ordering of the results
     pub order: Order,
+    /// Order for each input list of scores (default: LargeBetter)
+    pub source_orders: Vec<Order>,
 }
 
 impl ScoreFusion {
@@ -26,6 +28,17 @@ impl ScoreFusion {
             norm: Normalization::Distr,
             weights: vec![],
             order: Order::LargeBetter,
+            source_orders: vec![],
+        }
+    }
+
+    pub fn dbsf_with_orders(source_orders: Vec<Order>) -> Self {
+        Self {
+            method: Aggregation::Sum,
+            norm: Normalization::Distr,
+            weights: vec![],
+            order: Order::LargeBetter,
+            source_orders,
         }
     }
 }
@@ -52,16 +65,33 @@ pub fn score_fusion(
         norm,
         weights,
         order,
+        source_orders,
     } = params;
 
     let weights = weights.into_iter().chain(iter::repeat(1.0));
 
     all_results
         .into_iter()
-        // normalize
-        .map(|points| match norm {
-            Normalization::MinMax => min_max_norm(points),
-            Normalization::Distr => distr_norm(points),
+        .enumerate()
+        .map(|(idx, points)| {
+            let src_order = source_orders.get(idx).copied().unwrap_or_else(|| {
+                // If order was not explicitly specified, infer from the input order of points.
+                // Qdrant search results are always ordered from best to worst.
+                // If the first point has a smaller score than the last point, smaller is better (e.g. Euclidean / Manhattan).
+                if let (Some(first), Some(last)) = (points.first(), points.last()) {
+                    if first.score < last.score {
+                        Order::SmallBetter
+                    } else {
+                        Order::LargeBetter
+                    }
+                } else {
+                    Order::LargeBetter
+                }
+            });
+            match norm {
+                Normalization::MinMax => min_max_norm(points, src_order),
+                Normalization::Distr => distr_norm(points, src_order),
+            }
         })
         // weight each list of points
         .zip(weights)
@@ -94,27 +124,41 @@ pub fn score_fusion(
 }
 
 /// Normalizes the scores of the given points between 0.0 and 1.0, using the given minimum and maximum scores as extremes.
-fn norm(mut points: Vec<ScoredPoint>, min: ScoreType, max: ScoreType) -> Vec<ScoredPoint> {
+fn norm(
+    mut points: Vec<ScoredPoint>,
+    min: ScoreType,
+    max: ScoreType,
+    order: Order,
+) -> Vec<ScoredPoint> {
     // Protect against division by zero
     if min == max {
         points.iter_mut().for_each(|p| p.score = 0.5);
         return points;
     }
 
-    points.iter_mut().for_each(|p| {
-        p.score = (p.score - min) / (max - min);
-    });
+    match order {
+        Order::LargeBetter => {
+            points.iter_mut().for_each(|p| {
+                p.score = (p.score - min) / (max - min);
+            });
+        }
+        Order::SmallBetter => {
+            points.iter_mut().for_each(|p| {
+                p.score = (max - p.score) / (max - min);
+            });
+        }
+    }
 
     points
 }
 
-pub fn min_max_norm(points: Vec<ScoredPoint>) -> Vec<ScoredPoint> {
+pub fn min_max_norm(points: Vec<ScoredPoint>, order: Order) -> Vec<ScoredPoint> {
     let (min, max) = match points.iter().map(|p| OrderedFloat(p.score)).minmax() {
         MinMaxResult::NoElements | MinMaxResult::OneElement(_) => return points,
         MinMaxResult::MinMax(min, max) => (min.0, max.0),
     };
 
-    norm(points, min, max)
+    norm(points, min, max, order)
 }
 
 /// Welford's method for stable one-pass mean and variance calculation.
@@ -146,7 +190,7 @@ fn welfords_mean_variance(points: &[ScoredPoint]) -> (f32, f32) {
 
 /// Estimates the mean and variance of the given points and normalizes them between 0.0 and 1.0, using the 3rd
 /// standard deviation as extremes.
-pub fn distr_norm(mut points: Vec<ScoredPoint>) -> Vec<ScoredPoint> {
+pub fn distr_norm(mut points: Vec<ScoredPoint>, order: Order) -> Vec<ScoredPoint> {
     if points.len() < 2 {
         if points.len() == 1 {
             points[0].score = 0.5;
@@ -160,7 +204,7 @@ pub fn distr_norm(mut points: Vec<ScoredPoint>) -> Vec<ScoredPoint> {
     let min = mean - 3.0 * std_dev;
     let max = mean + 3.0 * std_dev;
 
-    norm(points, min, max)
+    norm(points, min, max, order)
 }
 
 #[cfg(test)]
@@ -213,5 +257,86 @@ mod tests {
             assert_close(mean, naive_mean);
             assert_close(variance, naive_variance);
         }
+    }
+
+    #[test]
+    fn test_dbsf_euclid_identical_retrievers() {
+        // Reproduces Issue #10611: Fusing identical Euclidean retrievers must preserve ranking
+        let r1 = vec![point(0, 0.0), point(1, 0.2), point(2, 0.4), point(3, 0.8)];
+        let r2 = r1.clone();
+
+        // 1. With explicit source orders
+        let fused_explicit = score_fusion(
+            vec![r1.clone(), r2.clone()],
+            ScoreFusion::dbsf_with_orders(vec![Order::SmallBetter, Order::SmallBetter]),
+        );
+        let ids_explicit: Vec<u64> = fused_explicit
+            .into_iter()
+            .map(|p| match p.id {
+                PointIdType::NumId(id) => id,
+                _ => panic!("Expected NumId"),
+            })
+            .collect();
+        assert_eq!(ids_explicit, vec![0, 1, 2, 3]);
+
+        // 2. With inferred source orders (fallback when not explicitly provided)
+        let fused_inferred = score_fusion(vec![r1, r2], ScoreFusion::dbsf());
+        let ids_inferred: Vec<u64> = fused_inferred
+            .into_iter()
+            .map(|p| match p.id {
+                PointIdType::NumId(id) => id,
+                _ => panic!("Expected NumId"),
+            })
+            .collect();
+        assert_eq!(ids_inferred, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_dbsf_small_better_ordering() {
+        let points = vec![point(0, 0.1), point(1, 0.5), point(2, 0.9)];
+
+        let fused = score_fusion(
+            vec![points],
+            ScoreFusion::dbsf_with_orders(vec![Order::SmallBetter]),
+        );
+
+        assert_eq!(fused.len(), 3);
+        assert!(fused[0].score > fused[1].score);
+        assert!(fused[1].score > fused[2].score);
+        assert_eq!(fused[0].id, PointIdType::NumId(0));
+        assert_eq!(fused[1].id, PointIdType::NumId(1));
+        assert_eq!(fused[2].id, PointIdType::NumId(2));
+    }
+
+    #[test]
+    fn test_dbsf_hybrid_large_and_small_better() {
+        // Source 1 (e.g. Cosine): larger is better
+        let r_cosine = vec![point(0, 0.95), point(1, 0.50), point(2, 0.10)];
+        // Source 2 (e.g. Euclid): smaller is better
+        let r_euclid = vec![point(0, 0.05), point(1, 0.40), point(2, 0.90)];
+
+        let fused = score_fusion(
+            vec![r_cosine, r_euclid],
+            ScoreFusion::dbsf_with_orders(vec![Order::LargeBetter, Order::SmallBetter]),
+        );
+
+        let ids: Vec<u64> = fused
+            .into_iter()
+            .map(|p| match p.id {
+                PointIdType::NumId(id) => id,
+                _ => panic!("Expected NumId"),
+            })
+            .collect();
+        assert_eq!(ids, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_min_max_norm_small_better() {
+        let points = vec![point(0, 1.0), point(1, 3.0), point(2, 5.0)];
+
+        let normalized = min_max_norm(points, Order::SmallBetter);
+        assert_close(normalized[0].score, 1.0); // closest -> 1.0
+        assert_close(normalized[1].score, 0.5); // middle -> 0.5
+        assert_close(normalized[2].score, 0.0); // farthest -> 0.0
     }
 }


### PR DESCRIPTION
### All Submissions:

* [x] My PR targets the `dev` branch (not `master`) and my branch was created from `dev`.
* [x] Have you followed the guidelines in our [Contributing document](docs/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---

### Description

Fixes #10611

When fusing scores from multiple retrievers with Distribution-Based Score Fusion (DBSF), normalization (`distr_norm` and `min_max_norm`) was previously computed as $(s - min) / (max - min)$, implicitly assuming that higher raw scores always mean better similarity (`Order::LargeBetter`).

For distance metrics such as Euclidean (L2) or Manhattan, smaller values indicate closer/better points (`Order::SmallBetter`). Normalizing with $(s - min) / (max - min)$ inverted the score ordering: points with the lowest distance (best match) received normalized scores near `0.0`, while the farthest points received scores near `1.0`. Consequently, fusing identical Euclidean retrievers completely reversed the result ranking order (the worst point became top-1).

### Key Changes:
1. **`lib/segment/src/common/score_fusion.rs`**:
   - Added `source_orders: Vec<Order>` support to `ScoreFusion` with constructor `ScoreFusion::dbsf_with_orders(...)`.
   - Updated normalization routines (`norm`, `min_max_norm`, `distr_norm`) to accept the source metric `Order`.
   - When `Order::SmallBetter`, scores are normalized inversely as $(max - score) / (max - min)$ so closer points correctly receive normalized scores approaching `1.0`.
   - Added automatic fallback order detection in `score_fusion`: if explicit `source_orders` are not supplied, inspects whether the input list is ascending (`first.score < last.score`), as Qdrant searches return results pre-sorted best-to-worst.
   - Added comprehensive unit tests:
     - `test_dbsf_euclid_identical_retrievers`: verifies that fusing identical Euclidean score lists preserves ranking order.
     - `test_dbsf_small_better_ordering`: verifies single and multi-point normalization for `Order::SmallBetter`.
     - `test_dbsf_hybrid_large_and_small_better`: verifies hybrid fusion between `Order::LargeBetter` (cosine/dot) and `Order::SmallBetter` (Euclidean).
     - `test_min_max_norm_small_better`: unit tests for `min_max_norm` under both orderings.

2. **`lib/collection/src/collection/query.rs`**:
   - In `intermediates_to_final_list`, resolved prefetch source orders via `shard_query::query_result_order(prefetch.query.as_ref(), &collection_params)`.
   - Passed resolved `source_orders` to `ScoreFusion::dbsf_with_orders(source_orders)` when `Fusion::Dbsf` is invoked.

### Verification
- `cargo test -p segment -- common::score_fusion`: 5/5 unit tests passed.
- `cargo clippy -p segment -p collection -- -D warnings`: passed with 0 warnings.
- Code formatted with `rustfmt` (`--edition 2024`).