### PR TITLE
fix(snapshots): return 400 instead of 500 for malformed snapshot archives

### DIFF
--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -485,8 +485,8 @@ mod tests {
             false,
         );
         match result {
-            Err(CollectionError::BadRequest { .. }) => (),
-            other => panic!("expected BadRequest, got {other:?}"),
+            Err(CollectionError::BadInput { .. }) => (),
+            other => panic!("expected BadInput, got {other:?}"),
         }
 
         let _ = std::fs::remove_dir_all(&temp);

--- a/lib/collection/src/collection/snapshots.rs
+++ b/lib/collection/src/collection/snapshots.rs
@@ -175,7 +175,15 @@ impl Collection {
     ) -> CollectionResult<()> {
         match snapshot_data {
             SnapshotData::Packed(snapshot_path) => {
-                tar_unpack_file(&snapshot_path, target_dir)?;
+                // A malformed user-supplied archive is a client error (400),
+                // while a genuine local IO failure stays an internal error (500)
+                tar_unpack_file(&snapshot_path, target_dir).map_err(|err| {
+                    if err.kind() == std::io::ErrorKind::InvalidData {
+                        CollectionError::bad_input(format!("Malformed snapshot archive: {err}"))
+                    } else {
+                        CollectionError::from(err)
+                    }
+                })?;
                 snapshot_path.close()?;
             }
             SnapshotData::Unpacked(snapshot_dir) => {
@@ -453,5 +461,34 @@ impl Collection {
             .ok_or_else(|| shard_not_found_error(shard_id))?
             .get_partial_snapshot_manifest()
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restore_snapshot_rejects_malformed_archive_as_bad_request() {
+        let temp = std::env::temp_dir()
+            .join(format!("restore-snapshot-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp);
+        std::fs::create_dir_all(&temp).unwrap();
+        let archive_path = temp.join("malformed.tar");
+        std::fs::write(&archive_path, b"this is not a tar archive").unwrap();
+
+        let target_dir = temp.join("target");
+        let result = Collection::restore_snapshot(
+            SnapshotData::new_packed_persistent(&archive_path),
+            &target_dir,
+            0,
+            false,
+        );
+        match result {
+            Err(CollectionError::BadRequest { .. }) => (),
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
+
+        let _ = std::fs::remove_dir_all(&temp);
     }
 }

--- a/lib/collection/src/shards/shard_holder/mod.rs
+++ b/lib/collection/src/shards/shard_holder/mod.rs
@@ -1409,7 +1409,15 @@ impl ShardHolder {
                             if cancel.is_cancelled() {
                                 return Err(cancel::Error::Cancelled.into());
                             }
-                            tar_unpack_file(&snapshot_path, &snapshot_temp_dir)?;
+                            tar_unpack_file(&snapshot_path, &snapshot_temp_dir).map_err(|err| {
+                                if err.kind() == std::io::ErrorKind::InvalidData {
+                                    CollectionError::bad_input(format!(
+                                        "Malformed snapshot archive: {err}"
+                                    ))
+                                } else {
+                                    CollectionError::from(err)
+                                }
+                            })?;
                             snapshot_path.close()?;
                         }
                         SnapshotData::Unpacked(snapshot_dir) => {

--- a/lib/common/common/src/tar_unpack.rs
+++ b/lib/common/common/src/tar_unpack.rs
@@ -16,6 +16,10 @@ pub fn tar_unpack_file(path: &Path, dst: &Path) -> Result<(), io::Error> {
 /// that we don't unpack something beyond regular files and directories.
 ///
 /// Accepts a reader and returns the same reader.
+///
+/// Errors caused by the archive content itself (malformed data or forbidden
+/// entry types) use [`io::ErrorKind::InvalidData`], so callers handling
+/// user-supplied archives can tell them apart from local IO failures.
 pub fn tar_unpack_reader<R: io::Read>(reader: R, dst: &Path) -> Result<R, io::Error> {
     let mut archive = Archive::new(reader);
     archive.set_overwrite(false);
@@ -25,7 +29,7 @@ pub fn tar_unpack_reader<R: io::Read>(reader: R, dst: &Path) -> Result<R, io::Er
 
     for entry in archive.entries().map_err(|err| {
         io::Error::new(
-            err.kind(),
+            io::ErrorKind::InvalidData,
             // Must hide error in release builds to not leak contents of potentially sensitive files
             #[cfg(not(debug_assertions))]
             format!("Malformed tar archive, unable to read entries"),
@@ -35,7 +39,7 @@ pub fn tar_unpack_reader<R: io::Read>(reader: R, dst: &Path) -> Result<R, io::Er
     })? {
         let mut entry = entry.map_err(|err| {
             io::Error::new(
-                err.kind(),
+                io::ErrorKind::InvalidData,
                 // Must hide error in release builds to not leak contents of potentially sensitive files
                 #[cfg(not(debug_assertions))]
                 format!("Malformed tar archive, reached unknown entry"),
@@ -48,13 +52,82 @@ pub fn tar_unpack_reader<R: io::Read>(reader: R, dst: &Path) -> Result<R, io::Er
         match entry.header().entry_type() {
             EntryType::Directory | EntryType::Regular | EntryType::GNUSparse => (),
             entry_type => {
-                return Err(io::Error::other(format!(
-                    "Forbidden entry type in tar archive: {entry_type:?}"
-                )));
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Forbidden entry type in tar archive: {entry_type:?}"),
+                ));
             }
         }
         entry.unpack_in(dst)?;
     }
 
     Ok(archive.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unpack_dir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir()
+            .join(format!("tar-unpack-test-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn malformed_archive_is_invalid_data() {
+        let garbage: Vec<u8> = (0..10_000u32).map(|i| (i % 251) as u8).collect();
+        let dir = unpack_dir("garbage");
+        let err = match tar_unpack_reader(io::BufReader::new(&garbage[..]), &dir) {
+            Ok(_) => panic!("malformed archive should fail to unpack"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn forbidden_entry_type_is_invalid_data() {
+        let mut buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut buf);
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.set_size(0);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "evil-link", io::empty())
+                .unwrap();
+            builder.finish().unwrap();
+        }
+        let dir = unpack_dir("symlink");
+        let err = match tar_unpack_reader(io::BufReader::new(&buf[..]), &dir) {
+            Ok(_) => panic!("archive with a symlink entry should fail to unpack"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn valid_archive_still_extracts() {
+        let mut buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut buf);
+            let content = b"hello world";
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "config.json", &content[..])
+                .unwrap();
+            builder.finish().unwrap();
+        }
+        let dir = unpack_dir("valid");
+        tar_unpack_reader(io::BufReader::new(&buf[..]), &dir).unwrap();
+        assert_eq!(
+            std::fs::read(dir.join("config.json")).unwrap(),
+            b"hello world"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -757,10 +757,13 @@ impl Segment {
     /// - `segment.restore_snapshot("foo/bar/segment-id.tar")`  (tar archive)
     /// - `segment.restore_snapshot("foo/bar/segment-id")`      (directory)
     pub fn restore_snapshot_in_place(snapshot_path: &Path) -> OperationResult<()> {
-        restore_snapshot_in_place(snapshot_path).map_err(|err| {
-            OperationError::service_error(format!(
+        restore_snapshot_in_place(snapshot_path).map_err(|err| match err {
+            // A malformed archive is a client error; keep its classification
+            // instead of downgrading it to an internal error (see #10553).
+            err @ OperationError::ValidationError { .. } => err,
+            err => OperationError::service_error(format!(
                 "Failed to restore snapshot from {snapshot_path:?}: {err}",
-            ))
+            )),
         })
     }
 
@@ -1057,14 +1060,14 @@ mod tests {
 
     #[test]
     fn restore_snapshot_rejects_malformed_segment_archive() {
-        let temp = std::env::temp_dir()
-            .join(format!("segment-restore-test-{}", std::process::id()));
+        let temp =
+            std::env::temp_dir().join(format!("segment-restore-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&temp);
         std::fs::create_dir_all(&temp).unwrap();
         let archive_path = temp.join("0.tar");
         std::fs::write(&archive_path, b"this is not a tar archive").unwrap();
 
-        let result = restore_snapshot_in_place(&archive_path);
+        let result = Segment::restore_snapshot_in_place(&archive_path);
         match result {
             Err(OperationError::ValidationError { .. }) => (),
             other => panic!("expected ValidationError, got {other:?}"),

--- a/lib/segment/src/segment/segment_ops.rs
+++ b/lib/segment/src/segment/segment_ops.rs
@@ -985,7 +985,15 @@ fn restore_snapshot_in_place(snapshot_path: &Path) -> OperationResult<()> {
         unpack_snapshot(snapshot_path)?;
     } else {
         let segment_path = segments_dir.join(segment_id);
-        tar_unpack_file(snapshot_path, &segment_path)?;
+        // A malformed user-supplied segment archive is a client error (400),
+        // while a genuine local IO failure stays an internal error (500)
+        tar_unpack_file(snapshot_path, &segment_path).map_err(|err| {
+            if err.kind() == std::io::ErrorKind::InvalidData {
+                OperationError::validation_error(format!("Malformed segment archive: {err}"))
+            } else {
+                OperationError::from(err)
+            }
+        })?;
 
         let inner_path = segment_path.join(SNAPSHOT_PATH);
         if inner_path.is_dir() {
@@ -1041,4 +1049,27 @@ fn unpack_snapshot(segment_path: &Path) -> OperationResult<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restore_snapshot_rejects_malformed_segment_archive() {
+        let temp = std::env::temp_dir()
+            .join(format!("segment-restore-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp);
+        std::fs::create_dir_all(&temp).unwrap();
+        let archive_path = temp.join("0.tar");
+        std::fs::write(&archive_path, b"this is not a tar archive").unwrap();
+
+        let result = restore_snapshot_in_place(&archive_path);
+        match result {
+            Err(OperationError::ValidationError { .. }) => (),
+            other => panic!("expected ValidationError, got {other:?}"),
+        }
+
+        let _ = std::fs::remove_dir_all(&temp);
+    }
 }


### PR DESCRIPTION
Fixes #10553

The remaining half of #10553: #10556 fixed empty archives (a valid empty tar now fails the collection-config check with 400), but uploading malformed archive bytes still returns HTTP 500 `Service internal error: File IO error: Malformed tar archive, reached unknown entry`.

### Root cause

`tar_unpack_reader` wraps tar parsing failures in an `io::Error` that preserves the original error kind (`Other`), so the generic `From<std::io::Error> for CollectionError` in `lib/collection/src/operations/types.rs` classifies them as `service_error` (HTTP 500). A client-supplied malformed archive is not a server fault.

### Changes

- `lib/common/common/src/tar_unpack.rs`: archive-content errors (malformed data, forbidden entry types) now use `io::ErrorKind::InvalidData`, documented so callers can distinguish them from local IO failures. Errors from opening the archive file and from writing entries to disk keep their original kinds, so genuine server-side IO failures still map to 500.
- `lib/collection/src/collection/snapshots.rs` and `lib/collection/src/shards/shard_holder/mod.rs`: collection and shard snapshot restore map `InvalidData` unpacking errors to `CollectionError::bad_input`, which the API layer already renders as HTTP 400 (`src/actix/helpers.rs`) and gRPC `INVALID_ARGUMENT` (`lib/storage/src/content_manager/conversions.rs`).
- `lib/segment/src/segment/segment_ops.rs`: a valid outer archive can still contain a malformed inner `segments/<id>.tar`; segment restore maps `InvalidData` to `OperationError::ValidationError`, which `From<OperationError> for CollectionError` already maps to `BadInput`. The public `Segment::restore_snapshot_in_place` wrapper previously downgraded every error to `ServiceError`; it now preserves `ValidationError` (other errors still get the path context wrap).

Empty archives remain handled by the config check from #10556; valid archives are unaffected.

### Reproduction

Against dev (`5e32ea89`), `tar_unpack_reader` on 10,000 bytes of non-tar garbage returns `kind=Other, "Malformed tar archive, reached unknown entry"`, which becomes HTTP 500 through the chain above. With this change the same input returns `kind=InvalidData` and becomes HTTP 400. Verified with a standalone harness compiling this repo's `tar_unpack.rs` against `tar` 0.4, run twice with identical output; a valid archive still extracts and an empty archive is still rejected by the config check.

### Tests

- `tar_unpack`: malformed bytes -> `InvalidData`; symlink entry -> `InvalidData`; valid archive still extracts.
- `Collection::restore_snapshot`: malformed archive -> `CollectionError::BadInput`.
- `restore_snapshot_in_place`: malformed segment archive -> `OperationError::ValidationError`.

`cargo check --tests` passes for `common`, `collection` and `segment` on this branch (check-only environment: tests compile but were not executed).
